### PR TITLE
Use Environment.NewLine instead of  Crlf

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -1043,7 +1043,7 @@ namespace Microsoft.PowerShell
             foreach (string s in Enum.GetNames(typeof(Serialization.DataFormat)))
             {
                 sb.Append(s);
-                sb.Append(ConsoleHostUserInterface.Crlf);
+                sb.Append(Environment.NewLine);
             }
 
             ++i;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
@@ -2562,7 +2562,7 @@ namespace Microsoft.PowerShell
             {
                 if (newLine)
                 {
-                    WriteConsole(consoleHandle, ConsoleHostUserInterface.Crlf);
+                    WriteConsole(consoleHandle, Environment.NewLine);
                 }
 
                 return;
@@ -2591,7 +2591,7 @@ namespace Microsoft.PowerShell
 
                     if (newLine)
                     {
-                        var endOfLine = ConsoleHostUserInterface.Crlf.AsSpan();
+                        var endOfLine = Environment.NewLine.AsSpan();
                         var endOfLineLength = endOfLine.Length;
                         Span<char> outBufferLine = stackalloc char[outBuffer.Length + endOfLineLength];
                         outBuffer.CopyTo(outBufferLine);

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -712,7 +712,7 @@ namespace Microsoft.PowerShell
 
                 if (newLine)
                 {
-                    _parent.OutputSerializer.Serialize(Crlf);
+                    _parent.OutputSerializer.Serialize(Environment.NewLine);
                 }
             }
             else
@@ -1152,7 +1152,7 @@ namespace Microsoft.PowerShell
                 sb.Append(s);
                 if (++count != lines.Count)
                 {
-                    sb.Append(Crlf);
+                    sb.Append(Environment.NewLine);
                 }
             }
 
@@ -1344,7 +1344,7 @@ namespace Microsoft.PowerShell
             {
                 Dbg.Assert(writer == _parent.ErrorSerializer.textWriter, "writers should be the same");
 
-                _parent.ErrorSerializer.Serialize(value + Crlf);
+                _parent.ErrorSerializer.Serialize(value + Environment.NewLine);
             }
             else
             {
@@ -1612,7 +1612,7 @@ namespace Microsoft.PowerShell
 #if UNIX
                     if (keyInfo.Key == ConsoleKey.Enter)
 #else
-                if (s.EndsWith(Crlf, StringComparison.Ordinal))
+                if (s.EndsWith(Environment.NewLine, StringComparison.Ordinal))
 #endif
                     {
                         result = ReadLineResult.endedOnEnter;
@@ -1620,7 +1620,7 @@ namespace Microsoft.PowerShell
                         // We're intercepting characters, so we need to echo the newline
                         Console.Out.WriteLine();
 #else
-                    s = s.Remove(s.Length - Crlf.Length);
+                    s = s.Remove(s.Length - Environment.NewLine.Length);
 #endif
                         break;
                     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Replace ConsoleHostUserInterface.Crlf with Environment.NewLine that is more right name for portable code.

## PR Context

Requested in #6882 by @daxian-dbw 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
