### PR TITLE
 Fix null reference when module is null in hosting scenarios

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertFromMarkdownCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertFromMarkdownCommand.cs
@@ -66,17 +66,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void BeginProcessing()
         {
-            // If we have the moduleInfo then store are module scope variable
-            if (this.CommandInfo.Module != null)
-            {
-                _mdOption = this.CommandInfo.Module?.SessionState.PSVariable.GetValue("PSMarkdownOptionInfo", new PSMarkdownOptionInfo()) as PSMarkdownOptionInfo;
-                _mdOption = _mdOption ?? new PSMarkdownOptionInfo();
-            }
-            else // If we don't have a moduleInfo, like in PowerShell hosting scenarios, use a concurrent dictionary.
-            {
-                Guid currentRunspaceId = this.CommandInfo.Context.CurrentRunspace.InstanceId;
-                _mdOption = PSMarkdownOptionInfoCache.Get(currentRunspaceId);
-            }
+            _mdOption = PSMarkdownOptionInfoCache.Get(this.CommandInfo);
 
             bool? supportsVT100 = this.Host?.UI.SupportsVirtualTerminal;
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertFromMarkdownCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertFromMarkdownCommand.cs
@@ -66,12 +66,8 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void BeginProcessing()
         {
-            _mdOption = this.CommandInfo.Module.SessionState.PSVariable.GetValue("PSMarkdownOptionInfo", new PSMarkdownOptionInfo()) as PSMarkdownOptionInfo;
-
-            if (_mdOption == null)
-            {
-                throw new InvalidOperationException();
-            }
+            _mdOption = this.CommandInfo.Module?.SessionState.PSVariable.GetValue("PSMarkdownOptionInfo", new PSMarkdownOptionInfo()) as PSMarkdownOptionInfo;
+            _mdOption = _mdOption ?? new PSMarkdownOptionInfo();
 
             bool? supportsVT100 = this.Host?.UI.SupportsVirtualTerminal;
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertFromMarkdownCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertFromMarkdownCommand.cs
@@ -66,7 +66,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void BeginProcessing()
         {
-            string currentRunspaceId = this.CommandInfo.Context.CurrentRunspace.InstanceId.ToString();
+            Guid currentRunspaceId = this.CommandInfo.Context.CurrentRunspace.InstanceId;
             _mdOption = PSMarkdownOptionInfoCache.Get(currentRunspaceId);
 
             bool? supportsVT100 = this.Host?.UI.SupportsVirtualTerminal;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertFromMarkdownCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertFromMarkdownCommand.cs
@@ -66,8 +66,17 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void BeginProcessing()
         {
-            Guid currentRunspaceId = this.CommandInfo.Context.CurrentRunspace.InstanceId;
-            _mdOption = PSMarkdownOptionInfoCache.Get(currentRunspaceId);
+            // If we have the moduleInfo then store are module scope variable
+            if (this.CommandInfo.Module != null)
+            {
+                _mdOption = this.CommandInfo.Module?.SessionState.PSVariable.GetValue("PSMarkdownOptionInfo", new PSMarkdownOptionInfo()) as PSMarkdownOptionInfo;
+                _mdOption = _mdOption ?? new PSMarkdownOptionInfo();
+            }
+            else // If we don't have a moduleInfo, like in PowerShell hosting scenarios, use a concurrent dictionary.
+            {
+                Guid currentRunspaceId = this.CommandInfo.Context.CurrentRunspace.InstanceId;
+                _mdOption = PSMarkdownOptionInfoCache.Get(currentRunspaceId);
+            }
 
             bool? supportsVT100 = this.Host?.UI.SupportsVirtualTerminal;
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertFromMarkdownCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertFromMarkdownCommand.cs
@@ -66,8 +66,8 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void BeginProcessing()
         {
-            _mdOption = this.CommandInfo.Module?.SessionState.PSVariable.GetValue("PSMarkdownOptionInfo", new PSMarkdownOptionInfo()) as PSMarkdownOptionInfo;
-            _mdOption = _mdOption ?? new PSMarkdownOptionInfo();
+            string currentRunspaceId = this.CommandInfo.Context.CurrentRunspace.InstanceId.ToString();
+            _mdOption = PSMarkdownOptionInfoCache.Get(currentRunspaceId);
 
             bool? supportsVT100 = this.Host?.UI.SupportsVirtualTerminal;
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MarkdownOptionCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MarkdownOptionCommands.cs
@@ -261,6 +261,14 @@ namespace Microsoft.PowerShell.Commands
         }
     }
 
+    /// <summary>
+    /// The class manages whether we should use a module scope variable or concurrent dictionary for storing the set PSMarkdownOptions.
+    /// When we have a moduleInfo available we use the module scope variable.
+    /// In case of built-in modules, they are loaded as snapins when we are hosting PowerShell.
+    /// We use runspace Id as the key for the concurrent dictionary to have the functionality of separate settings per runspace.
+    /// Force loading the module does not unload the nested modules and hence we cannot use IModuleAssemblyCleanup to remove items from the dictionary.
+    /// Because of these reason, we continue using module scope variable when moduleInfo is available.
+    /// </summary>
     internal static class PSMarkdownOptionInfoCache
     {
         private static ConcurrentDictionary<Guid, PSMarkdownOptionInfo> markdownOptionInfoCache;
@@ -302,7 +310,7 @@ namespace Microsoft.PowerShell.Commands
                 return optionInfo;
             }
 
-            // If we don't have a moduleInfo, like in PowerShell hosting scenarios, use a concurrent dictionary.
+            // If we don't have a moduleInfo, like in PowerShell hosting scenarios with modules loaded as snapins, use a concurrent dictionary.
             return markdownOptionInfoCache.AddOrUpdate(Runspace.DefaultRunspace.InstanceId, optionInfo, (key, oldvalue) => optionInfo);
         }
     }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MarkdownOptionCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MarkdownOptionCommands.cs
@@ -297,7 +297,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 // no option cache so cache and return the default PSMarkdownOptionInfo
                 var newOptionInfo = new PSMarkdownOptionInfo();
-                return markdownOptionInfoCache.GetOrAdd(Runspace.DefaultRunspace.InstanceId, (key) => newOptionInfo);
+                return markdownOptionInfoCache.GetOrAdd(Runspace.DefaultRunspace.InstanceId, newOptionInfo);
             }
         }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MarkdownOptionCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MarkdownOptionCommands.cs
@@ -174,7 +174,7 @@ namespace Microsoft.PowerShell.Commands
                     break;
             }
 
-            string currentRunspaceId = this.CommandInfo.Context.CurrentRunspace.InstanceId.ToString();
+            Guid currentRunspaceId = this.CommandInfo.Context.CurrentRunspace.InstanceId;
 
             // If the option is already set once for this runspace, then update it or set it.
             var setOption = PSMarkdownOptionInfoCache.Set(currentRunspaceId, mdOptionInfo);
@@ -260,21 +260,21 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void EndProcessing()
         {
-            string currentRunspaceId = this.CommandInfo.Context.CurrentRunspace.InstanceId.ToString();
+            Guid currentRunspaceId = this.CommandInfo.Context.CurrentRunspace.InstanceId;
             WriteObject(PSMarkdownOptionInfoCache.Get(currentRunspaceId));
         }
     }
 
     internal static class PSMarkdownOptionInfoCache
     {
-        private static ConcurrentDictionary<string, PSMarkdownOptionInfo> markdownOptionInfoCache;
+        private static ConcurrentDictionary<Guid, PSMarkdownOptionInfo> markdownOptionInfoCache;
 
         static PSMarkdownOptionInfoCache()
         {
-            markdownOptionInfoCache = new ConcurrentDictionary<string, PSMarkdownOptionInfo>();
+            markdownOptionInfoCache = new ConcurrentDictionary<Guid, PSMarkdownOptionInfo>();
         }
 
-        internal static PSMarkdownOptionInfo Get(string runspaceId)
+        internal static PSMarkdownOptionInfo Get(Guid runspaceId)
         {
             if (markdownOptionInfoCache.TryGetValue(runspaceId, out PSMarkdownOptionInfo cachedOption))
             {
@@ -289,7 +289,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        internal static PSMarkdownOptionInfo Set(string runspaceId, PSMarkdownOptionInfo optionInfo)
+        internal static PSMarkdownOptionInfo Set(Guid runspaceId, PSMarkdownOptionInfo optionInfo)
         {
             return markdownOptionInfoCache.AddOrUpdate(runspaceId, optionInfo, (key, oldvalue) => optionInfo);
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/MarkdownCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/MarkdownCmdlets.Tests.ps1
@@ -549,22 +549,26 @@ bool function()`n{`n}
 
     Context "Hosted PowerShell scenario" {
         It 'ConvertFrom-Markdown gets expected out when run in hosted powershell' {
-            $pool = [runspacefactory]::CreateRunspacePool(1, 2, $Host)
-            $pool.Open()
 
-            $ps = [powershell]::Create()
-            $ps.RunspacePool = $pool
-            $ps.AddScript( {
-                    try {
-                        $output =  '# test' | ConvertFrom-Markdown
-                        $output.Html | Should -BeExactly '<h1 id="test">test</h1>'
-                    } catch {
-                        $_ | Out-Default
-                    }
-                }) | Out-Null
+            try {
+                $pool = [runspacefactory]::CreateRunspacePool(1, 2, $Host)
+                $pool.Open()
 
-            $ps.Invoke()
-            $ps.Dispose()
+                $ps = [powershell]::Create()
+                $ps.RunspacePool = $pool
+                $ps.AddScript( {
+                        try {
+                            $output = '# test' | ConvertFrom-Markdown
+                            $output.Html.trim() | Should -BeExactly '<h1 id="test">test</h1>'
+                        } catch {
+                            throw $_
+                        }
+                    })
+
+                $ps.Invoke()
+            } finally {
+                $ps.Dispose()
+            }
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/MarkdownCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/MarkdownCmdlets.Tests.ps1
@@ -434,36 +434,6 @@ bool function()`n{`n}
             $options.EmphasisBold | Should -BeExactly "[1m"
             $options.EmphasisItalics | Should -BeExactly "[36m"
         }
-
-        It "Verify PSMarkdownOptionInfo is defined in module scope" {
-
-            $PSMarkdownOptionInfo | Should -BeNullOrEmpty
-
-            $mod = Get-Module Microsoft.PowerShell.Utility
-            $options =  & $mod { $PSMarkdownOptionInfo }
-
-            $options.Header1 | Should -BeExactly "[7m"
-            $options.Header2 | Should -BeExactly "[4;93m"
-            $options.Header3 | Should -BeExactly "[4;94m"
-            $options.Header4 | Should -BeExactly "[4;95m"
-            $options.Header5 | Should -BeExactly "[4;96m"
-            $options.Header6 | Should -BeExactly "[4;97m"
-
-            if($IsMacOS)
-            {
-                $options.Code | Should -BeExactly "[107;95m"
-            }
-            else
-            {
-                $options.Code | Should -BeExactly "[48;2;155;155;155;38;2;30;30;30m"
-            }
-
-
-            $options.Link | Should -BeExactly "[4;38;5;117m"
-            $options.Image | Should -BeExactly "[33m"
-            $options.EmphasisBold | Should -BeExactly "[1m"
-            $options.EmphasisItalics | Should -BeExactly "[36m"
-        }
     }
 
     Context "Show-Markdown tests" {
@@ -548,7 +518,8 @@ bool function()`n{`n}
     }
 
     Context "Hosted PowerShell scenario" {
-        It 'ConvertFrom-Markdown gets expected out when run in hosted powershell' {
+
+        It 'ConvertFrom-Markdown gets expected output when run in hosted powershell' {
 
             try {
                 $pool = [runspacefactory]::CreateRunspacePool(1, 2, $Host)
@@ -559,14 +530,82 @@ bool function()`n{`n}
                 $ps.AddScript( {
                         try {
                             $output = '# test' | ConvertFrom-Markdown
-                            $output.Html.trim() | Should -BeExactly '<h1 id="test">test</h1>'
+                            $output.Html.trim()
                         } catch {
                             throw $_
                         }
                     })
 
-                $ps.Invoke()
+                $output = $ps.Invoke()
+
+                $output | Should -BeExactly '<h1 id="test">test</h1>'
             } finally {
+                $ps.Dispose()
+            }
+        }
+
+        It 'Get-MarkdownOption gets default values when run in hosted powershell' {
+
+            try {
+                $ps = [powershell]::Create()
+                $ps.AddScript( {
+                    Get-MarkdownOption -ErrorAction Stop
+                })
+
+                $options = $ps.Invoke()
+
+                $options.Header1 | Should -BeExactly "[7m"
+                $options.Header2 | Should -BeExactly "[4;93m"
+                $options.Header3 | Should -BeExactly "[4;94m"
+                $options.Header4 | Should -BeExactly "[4;95m"
+                $options.Header5 | Should -BeExactly "[4;96m"
+                $options.Header6 | Should -BeExactly "[4;97m"
+
+                if ($IsMacOS) {
+                    $options.Code | Should -BeExactly "[107;95m"
+                } else {
+                    $options.Code | Should -BeExactly "[48;2;155;155;155;38;2;30;30;30m"
+                }
+
+                $options.Link | Should -BeExactly "[4;38;5;117m"
+                $options.Image | Should -BeExactly "[33m"
+                $options.EmphasisBold | Should -BeExactly "[1m"
+                $options.EmphasisItalics | Should -BeExactly "[36m"
+            }
+            finally {
+                $ps.Dispose()
+            }
+        }
+
+        It 'Set-MarkdownOption sets values when run in hosted powershell' {
+
+            try {
+                $ps = [powershell]::Create()
+                $ps.AddScript( {
+                    Set-MarkdownOption -Header1Color '[93m' -ErrorAction Stop -PassThru
+                })
+
+                $options = $ps.Invoke()
+
+                $options.Header1 | Should -BeExactly "[93m"
+                $options.Header2 | Should -BeExactly "[4;93m"
+                $options.Header3 | Should -BeExactly "[4;94m"
+                $options.Header4 | Should -BeExactly "[4;95m"
+                $options.Header5 | Should -BeExactly "[4;96m"
+                $options.Header6 | Should -BeExactly "[4;97m"
+
+                if ($IsMacOS) {
+                    $options.Code | Should -BeExactly "[107;95m"
+                } else {
+                    $options.Code | Should -BeExactly "[48;2;155;155;155;38;2;30;30;30m"
+                }
+
+                $options.Link | Should -BeExactly "[4;38;5;117m"
+                $options.Image | Should -BeExactly "[33m"
+                $options.EmphasisBold | Should -BeExactly "[1m"
+                $options.EmphasisItalics | Should -BeExactly "[36m"
+            }
+            finally {
                 $ps.Dispose()
             }
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/MarkdownCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/MarkdownCmdlets.Tests.ps1
@@ -546,4 +546,25 @@ bool function()`n{`n}
             }
         }
     }
+
+    Context "Hosted PowerShell scenario" {
+        It 'ConvertFrom-Markdown gets expected out when run in hosted powershell' {
+            $pool = [runspacefactory]::CreateRunspacePool(1, 2, $Host)
+            $pool.Open()
+
+            $ps = [powershell]::Create()
+            $ps.RunspacePool = $pool
+            $ps.AddScript( {
+                    try {
+                        $output =  '# test' | ConvertFrom-Markdown
+                        $output.Html | Should -BeExactly '<h1 id="test">test</h1>'
+                    } catch {
+                        $_ | Out-Default
+                    }
+                }) | Out-Null
+
+            $ps.Invoke()
+            $ps.Dispose()
+        }
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/MarkdownCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/MarkdownCmdlets.Tests.ps1
@@ -527,13 +527,9 @@ bool function()`n{`n}
 
                 $ps = [powershell]::Create()
                 $ps.RunspacePool = $pool
-                $ps.AddScript( {
-                        try {
-                            $output = '# test' | ConvertFrom-Markdown
-                            $output.Html.trim()
-                        } catch {
-                            throw $_
-                        }
+                $ps.AddScript({
+                        $output = '# test' | ConvertFrom-Markdown
+                        $output.Html.trim()
                     })
 
                 $output = $ps.Invoke()
@@ -554,6 +550,7 @@ bool function()`n{`n}
 
                 $options = $ps.Invoke()
 
+                $options | Should -Not -BeNullOrEmpty
                 $options.Header1 | Should -BeExactly "[7m"
                 $options.Header2 | Should -BeExactly "[4;93m"
                 $options.Header3 | Should -BeExactly "[4;94m"
@@ -587,6 +584,7 @@ bool function()`n{`n}
 
                 $options = $ps.Invoke()
 
+                $options | Should -Not -BeNullOrEmpty
                 $options.Header1 | Should -BeExactly "[93m"
                 $options.Header2 | Should -BeExactly "[4;93m"
                 $options.Header3 | Should -BeExactly "[4;94m"


### PR DESCRIPTION
# PR Summary
Fixes #9390 

If the `CommandInfo.Module` is null, then default to a new `PSMarkdownOptionInfo`.

## PR Context

In hosting scenarios as module are loaded as snapins, the `CommandInfo.Module` is null. In those cases we default back to default `PSMarkdownOptionInfo`.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
