### PR TITLE
Fix WebListener for .NET Core 3.0

### DIFF
--- a/test/tools/WebListener/Program.cs
+++ b/test/tools/WebListener/Program.cs
@@ -33,6 +33,7 @@ namespace mvc
             WebHost.CreateDefaultBuilder()
                 .UseStartup<Startup>().UseKestrel(options =>
                 {
+                   options.AllowSynchronousIO = true;
                    options.Listen(IPAddress.Loopback, int.Parse(args[2]));
                    options.Listen(IPAddress.Loopback, int.Parse(args[3]), listenOptions =>
                    {
@@ -68,12 +69,6 @@ namespace mvc
                        listenOptions.UseHttps(httpsOption);
                    });
                 })
-#if !UNIX
-                .UseHttpSys(options =>
-                {
-                    options.AllowSynchronousIO = true;
-                })
-#endif
                 .Build();
     }
 }

--- a/test/tools/WebListener/Startup.cs
+++ b/test/tools/WebListener/Startup.cs
@@ -28,7 +28,8 @@ namespace mvc
         {
             services.AddMvc(options => {
                 options.EnableEndpointRouting = false;
-            });
+            })
+            .AddNewtonsoftJson();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/test/tools/WebListener/WebListener.csproj
+++ b/test/tools/WebListener/WebListener.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0-preview4-19216-03" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.1" />
   </ItemGroup>
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes WebListener for .NET Core 3.0 and ASP.NET Core 3.0. This is done by removing the windows specific configuration of HttpSys and using Newtonsoft JSON. 

## PR Context

related to #9425 

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [X] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
