### PR TITLE
Fix Get-Runspace runspace object format Type column

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -983,7 +983,7 @@ namespace System.Management.Automation.Runspaces
                     }
                   ")
                         .AddScriptBlockColumn(@"
-                    if ($_.ConnectionInfo -is [System.Management.Automation.Runspaces.WSManConnectionInfo])
+                    if ($null -ne $_.ConnectionInfo)
                     {
                       ""Remote""
                     }

--- a/src/System.Management.Automation/engine/hostifaces/History.cs
+++ b/src/System.Management.Automation/engine/hostifaces/History.cs
@@ -1119,7 +1119,7 @@ namespace Microsoft.PowerShell.Commands
                 try
                 {
                     // Indicate to the system that we are in nested prompt mode, since we are emulating running the command at the prompt.
-                    // This ensures that the command being run as nested runs in the correct language mode, because CreatePipelineProcessor()
+                    // This ensures that the command being run as nested runs in the correct language mode, because CreatePipelineProcessor() 
                     // always forces CommandOrigin to Internal for nested running commands, and Command.CreateCommandProcessor() forces Internal
                     // commands to always run in FullLanguage mode unless in a nested prompt.
                     if (localRunspace != null)

--- a/src/System.Management.Automation/engine/hostifaces/History.cs
+++ b/src/System.Management.Automation/engine/hostifaces/History.cs
@@ -1119,7 +1119,7 @@ namespace Microsoft.PowerShell.Commands
                 try
                 {
                     // Indicate to the system that we are in nested prompt mode, since we are emulating running the command at the prompt.
-                    // This ensures that the command being run as nested runs in the correct language mode, because CreatePipelineProcessor() 
+                    // This ensures that the command being run as nested runs in the correct language mode, because CreatePipelineProcessor()
                     // always forces CommandOrigin to Internal for nested running commands, and Command.CreateCommandProcessor() forces Internal
                     // commands to always run in FullLanguage mode unless in a nested prompt.
                     if (localRunspace != null)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

This addresses issue #9341.

<!-- Summarize your PR between here and the checklist. -->

Any runspace that uses a RunspaceConnectionInfo object is a remote (proxy) runspace, and should be marked 'Remote' instead of 'Local'.  Currently only WSMan runspaces are marked 'Remote', and this change fixes that.

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
