### PR TITLE
Suppress PossibleIncorrectUsageOfAssignmentOperator rule violation

### DIFF
--- a/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
+++ b/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
@@ -550,7 +550,7 @@ Describe "Verify approved aliases list" -Tags "CI" {
             Select-Object -Property Name, @{
                 Name = 'ConfirmImpact'
                 Expression = {
-                    if ($t = $_.ImplementingType) {
+                    if (($t = $_.ImplementingType)) {
                         $t.GetCustomAttributes($true).Where{$_.TypeId.Name -eq 'CmdletAttribute'}.ConfirmImpact
                     }
                 }


### PR DESCRIPTION
# PR Summary

Wrap expression in extra parenthesis for implicit supression of PossibleIncorrectUsageOfAssignmentOperator rule.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
