### PR TITLE
Enable recursion into OneDrive

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -7878,13 +7878,8 @@ namespace Microsoft.PowerShell.Commands
             internal uint nFileSizeLow;
             internal uint dwReserved0;
             internal uint dwReserved1;
-            private fixed char _cFileName[MAX_PATH];
-            private fixed char _cAlternateFileName[14];
-
-            internal ReadOnlySpan<char> cFileName
-            {
-                get { fixed (char* c = _cFileName) return new ReadOnlySpan<char>(c, MAX_PATH); }
-            }
+            internal fixed char cFileName[MAX_PATH];
+            internal fixed char cAlternateFileName[14];
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The current logic of `Get-ChildItem -Recurse` for the FileSystemProvider is that if it's a symlink, we don't recurse into it unless `-FollowSymLink` is specified.  However, OneDrive reparse points aren't symlinks (in that they don't link to the local filesystem).  There is another flag (on Windows) to indicate if the reparse point is a named surrogate which means it IS a symlink.  So the fix is to check for this flag and if it's not a named surrogate (aka symlink), it is ok to recurse into it.

Manually verified with OneDrive.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/9461

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
