### PR TITLE
Update to Pester 4.8.0, revert workaround for long paths

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -566,7 +566,7 @@ function Restore-PSPester
         [ValidateNotNullOrEmpty()]
         [string] $Destination = ([IO.Path]::Combine((Split-Path (Get-PSOptions -DefaultToNew).Output), "Modules"))
     )
-    Save-Module -Name Pester -Path $Destination -Repository PSGallery -RequiredVersion "4.4.4"
+    Save-Module -Name Pester -Path $Destination -Repository PSGallery -RequiredVersion "4.8.0"
 }
 
 function Compress-TestContent {

--- a/test/powershell/Language/Scripting/Requires.Tests.ps1
+++ b/test/powershell/Language/Scripting/Requires.Tests.ps1
@@ -45,11 +45,11 @@ Describe "#requires -Modules" -Tags "CI" {
         $sep = [System.IO.Path]::DirectorySeparatorChar
         $altSep = [System.IO.Path]::AltDirectorySeparatorChar
 
-        $scriptPath = Join-Path (Resolve-FilePath $TestDrive) 'script.ps1'
+        $scriptPath = Join-Path $TestDrive 'script.ps1'
 
         $moduleName = 'Banana'
         $moduleVersion = '0.12.1'
-        $moduleDirPath = Join-Path (Resolve-FilePath $TestDrive) 'modules'
+        $moduleDirPath = Join-Path $TestDrive 'modules'
         New-Item -Path $moduleDirPath -ItemType Directory
         $modulePath = "$moduleDirPath${sep}$moduleName"
         New-Item -Path $modulePath -ItemType Directory
@@ -62,7 +62,7 @@ Describe "#requires -Modules" -Tags "CI" {
     Context "Requiring non-existent modules" {
         BeforeAll {
             $badName = 'ModuleThatDoesNotExist'
-            $badPath = Join-Path (Resolve-FilePath $TestDrive) 'ModuleThatDoesNotExist'
+            $badPath = Join-Path $TestDrive 'ModuleThatDoesNotExist'
             $version = '1.0'
             $testCases = @(
                 @{ ModuleRequirement = "'$badName'"; Scenario = 'name' }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -149,7 +149,7 @@ Describe "Get-Module with CompatiblePSEditions-checked paths" -Tag "CI" {
             @{ Editions = $null; ModuleName = "NeitherModule" }
         )
 
-        $basePath = Join-Path (Resolve-FilePath $TestDrive) "EditionCompatibleModules"
+        $basePath = Join-Path $TestDrive "EditionCompatibleModules"
         New-TestModules -TestCases $successCases -BaseDir $basePath
         New-TestModules -TestCases $failCases -BaseDir $basePath
 
@@ -242,7 +242,7 @@ Describe "Import-Module from CompatiblePSEditions-checked paths" -Tag "CI" {
             @{ Editions = $null; ModuleName = "NeitherModule"; Result = $true }
         )
 
-        $basePath = Join-Path (Resolve-FilePath $TestDrive) "EditionCompatibleModules"
+        $basePath = Join-Path $TestDrive "EditionCompatibleModules"
         New-TestModules -TestCases $successCases -BaseDir $basePath
         New-TestModules -TestCases $failCases -BaseDir $basePath
 
@@ -387,8 +387,6 @@ Describe "Get-Module nested module behaviour with Edition checking" -Tag "Featur
             $testCases = $list
         }
 
-        $resolvedTestDrive = Resolve-FilePath $TestDrive
-
         # Define nested script module
         $scriptModuleName = "NestedScriptModule"
         $scriptModuleFile = "$scriptModuleName.psm1"
@@ -398,7 +396,7 @@ Describe "Get-Module nested module behaviour with Edition checking" -Tag "Featur
         $binaryModuleName = "NestedBinaryModule"
         $binaryModuleFile = "$binaryModuleName.dll"
         $binaryModuleContent = 'public static class TestBinaryModuleClass { public static bool Test() { return true; } }'
-        $binaryModuleSourcePath = Join-Path $resolvedTestDrive $binaryModuleFile
+        $binaryModuleSourcePath = Join-Path $TestDrive $binaryModuleFile
         Add-Type -OutputAssembly $binaryModuleSourcePath -TypeDefinition $binaryModuleContent
 
         # Define root module definition
@@ -409,8 +407,8 @@ Describe "Get-Module nested module behaviour with Edition checking" -Tag "Featur
         # Module directory structure: $TestDrive/$compatibility/$guid/$moduleName/{module parts}
         $compatibleDir = "Compatible"
         $incompatibleDir = "Incompatible"
-        $compatiblePath = Join-Path $resolvedTestDrive $compatibleDir
-        $incompatiblePath = Join-Path $resolvedTestDrive $incompatibleDir
+        $compatiblePath = Join-Path $TestDrive $compatibleDir
+        $incompatiblePath = Join-Path $TestDrive $incompatibleDir
 
         foreach ($basePath in $compatiblePath,$incompatiblePath)
         {
@@ -431,7 +429,7 @@ Describe "Get-Module nested module behaviour with Edition checking" -Tag "Featur
             # Create the module directory
             $guid = New-Guid
             $compatibilityDir = $incompatibleDir
-            $containingDir = Join-Path $resolvedTestDrive $compatibilityDir $guid
+            $containingDir = Join-Path $TestDrive $compatibilityDir $guid
             $moduleName = "CpseTestModule"
             $moduleBase = Join-Path $containingDir $moduleName
             New-Item -Path $moduleBase -ItemType Directory
@@ -561,7 +559,7 @@ Describe "Get-Module nested module behaviour with Edition checking" -Tag "Featur
             # Create the module directory
             $guid = New-Guid
             $compatibilityDir = $compatibleDir
-            $containingDir = Join-Path $resolvedTestDrive $compatibilityDir $guid
+            $containingDir = Join-Path $TestDrive $compatibilityDir $guid
             $moduleName = "CpseTestModule"
             $moduleBase = Join-Path $containingDir $moduleName
             New-Item -Path $moduleBase -ItemType Directory
@@ -692,8 +690,6 @@ Describe "Import-Module nested module behaviour with Edition checking" -Tag "Fea
             $testCases = $list
         }
 
-        $resolvedTestDrive = Resolve-FilePath $TestDrive
-
         # Define nested script module
         $scriptModuleName = "NestedScriptModule"
         $scriptModuleFile = "$scriptModuleName.psm1"
@@ -707,8 +703,8 @@ Describe "Import-Module nested module behaviour with Edition checking" -Tag "Fea
         # Module directory structure: $TestDrive/$compatibility/$guid/$moduleName/{module parts}
         $compatibleDir = "Compatible"
         $incompatibleDir = "Incompatible"
-        $compatiblePath = Join-Path $resolvedTestDrive $compatibleDir
-        $incompatiblePath = Join-Path $resolvedTestDrive $incompatibleDir
+        $compatiblePath = Join-Path $TestDrive $compatibleDir
+        $incompatiblePath = Join-Path $TestDrive $incompatibleDir
 
         foreach ($basePath in $compatiblePath,$incompatiblePath)
         {
@@ -729,7 +725,7 @@ Describe "Import-Module nested module behaviour with Edition checking" -Tag "Fea
             # Create the module directory
             $guid = New-Guid
             $compatibilityDir = $incompatibleDir
-            $containingDir = Join-Path $resolvedTestDrive $compatibilityDir $guid
+            $containingDir = Join-Path $TestDrive $compatibilityDir $guid
             $moduleName = "CpseTestModule"
             $moduleBase = Join-Path $containingDir $moduleName
             New-Item -Path $moduleBase -ItemType Directory
@@ -819,7 +815,7 @@ Describe "Import-Module nested module behaviour with Edition checking" -Tag "Fea
             # Create the module directory
             $guid = New-Guid
             $compatibilityDir = $compatibleDir
-            $containingDir = Join-Path $resolvedTestDrive $compatibilityDir $guid
+            $containingDir = Join-Path $TestDrive $compatibilityDir $guid
             $moduleName = "CpseTestModule"
             $moduleBase = Join-Path $containingDir $moduleName
             New-Item -Path $moduleBase -ItemType Directory

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Command.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Command.Tests.ps1
@@ -228,7 +228,7 @@ Describe "Get-Command Tests" -Tags "CI" {
         $results = Get-Command $fullPath
 
         $results.Name | Should -BeExactly $tempFile
-        $results.Definition | Should -BeExactly (Resolve-FilePath $fullPath)
+        $results.Definition | Should -BeExactly $fullPath
     }
 
     It "Two dynamic parameters are created properly" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -6,36 +6,34 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
     BeforeAll {
         $originalPSModulePath = $env:PSModulePath
 
-        $resolvedTestDrive = Resolve-FilePath $TestDrive
+        New-Item -ItemType Directory -Path "$testdrive\Modules\Foo\1.1" -Force > $null
+        New-Item -ItemType Directory -Path "$testdrive\Modules\Foo\2.0" -Force > $null
+        New-Item -ItemType Directory -Path "$testdrive\Modules\Bar\Download" -Force > $null
+        New-Item -ItemType Directory -Path "$testdrive\Modules\Zoo\Too" -Force > $null
+        New-Item -ItemType Directory -Path "$testdrive\Modules\Az" -Force > $null
 
-        New-Item -ItemType Directory -Path "$resolvedTestDrive\Modules\Foo\1.1" -Force > $null
-        New-Item -ItemType Directory -Path "$resolvedTestDrive\Modules\Foo\2.0" -Force > $null
-        New-Item -ItemType Directory -Path "$resolvedTestDrive\Modules\Bar\Download" -Force > $null
-        New-Item -ItemType Directory -Path "$resolvedTestDrive\Modules\Zoo\Too" -Force > $null
-        New-Item -ItemType Directory -Path "$resolvedTestDrive\Modules\Az" -Force > $null
+        New-ModuleManifest -Path "$testdrive\Modules\Foo\1.1\Foo.psd1" -ModuleVersion 1.1
+        New-ModuleManifest -Path "$testdrive\Modules\Foo\2.0\Foo.psd1" -ModuleVersion 2.0
+        New-ModuleManifest -Path "$testdrive\Modules\Bar\Bar.psd1"
+        New-ModuleManifest -Path "$testdrive\Modules\Zoo\Zoo.psd1"
+        New-ModuleManifest -Path "$testdrive\Modules\Az\Az.psd1" -ModuleVersion 1.1
 
-        New-ModuleManifest -Path "$resolvedTestDrive\Modules\Foo\1.1\Foo.psd1" -ModuleVersion 1.1
-        New-ModuleManifest -Path "$resolvedTestDrive\Modules\Foo\2.0\Foo.psd1" -ModuleVersion 2.0
-        New-ModuleManifest -Path "$resolvedTestDrive\Modules\Bar\Bar.psd1"
-        New-ModuleManifest -Path "$resolvedTestDrive\Modules\Zoo\Zoo.psd1"
-        New-ModuleManifest -Path "$resolvedTestDrive\Modules\Az\Az.psd1" -ModuleVersion 1.1
-
-        New-Item -ItemType File -Path "$resolvedTestDrive\Modules\Foo\1.1\Foo.psm1" > $null
-        New-Item -ItemType File -Path "$resolvedTestDrive\Modules\Foo\2.0\Foo.psm1" > $null
-        New-Item -ItemType File -Path "$resolvedTestDrive\Modules\Bar\Bar.psm1" > $null
-        New-Item -ItemType File -Path "$resolvedTestDrive\Modules\Bar\Download\Download.psm1" > $null
-        New-Item -ItemType File -Path "$resolvedTestDrive\Modules\Zoo\Zoo.psm1" > $null
-        New-Item -ItemType File -Path "$resolvedTestDrive\Modules\Zoo\Too\Zoo.psm1" > $null
-        New-Item -ItemType File -Path "$resolvedTestDrive\Modules\Az\Az.psm1" > $null
+        New-Item -ItemType File -Path "$testdrive\Modules\Foo\1.1\Foo.psm1" > $null
+        New-Item -ItemType File -Path "$testdrive\Modules\Foo\2.0\Foo.psm1" > $null
+        New-Item -ItemType File -Path "$testdrive\Modules\Bar\Bar.psm1" > $null
+        New-Item -ItemType File -Path "$testdrive\Modules\Bar\Download\Download.psm1" > $null
+        New-Item -ItemType File -Path "$testdrive\Modules\Zoo\Zoo.psm1" > $null
+        New-Item -ItemType File -Path "$testdrive\Modules\Zoo\Too\Zoo.psm1" > $null
+        New-Item -ItemType File -Path "$testdrive\Modules\Az\Az.psm1" > $null
 
         $fullyQualifiedPathTestCases = @(
-            @{ ModPath = "$resolvedTestDrive/Modules\Foo"; Name = 'Foo'; Version = '2.0'; Count = 1 }
-            @{ ModPath = "$resolvedTestDrive\Modules/Foo\1.1/Foo.psd1"; Name = 'Foo'; Version = '1.1'; Count = 1 }
-            @{ ModPath = "$resolvedTestDrive\Modules/Bar.psd1"; Name = 'Bar'; Version = '0.0'; Count = 1 }
-            @{ ModPath = "$resolvedTestDrive\Modules\Zoo\Too\Zoo.psm1"; Name = 'Zoo'; Version = '0.0'; Count = 1 }
+            @{ ModPath = "$TestDrive/Modules\Foo"; Name = 'Foo'; Version = '2.0'; Count = 1 }
+            @{ ModPath = "$TestDrive\Modules/Foo\1.1/Foo.psd1"; Name = 'Foo'; Version = '1.1'; Count = 1 }
+            @{ ModPath = "$TestDrive\Modules/Bar.psd1"; Name = 'Bar'; Version = '0.0'; Count = 1 }
+            @{ ModPath = "$TestDrive\Modules\Zoo\Too\Zoo.psm1"; Name = 'Zoo'; Version = '0.0'; Count = 1 }
         )
 
-        $env:PSModulePath = Join-Path $resolvedTestDrive "Modules"
+        $env:PSModulePath = Join-Path $testdrive "Modules"
     }
 
     AfterAll {
@@ -80,11 +78,11 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
         $modules[7].Version | Should -Be "2.0"
         $modules[8].ModuleType | Should -BeExactly "Script"
         $modules[9].ModuleType | Should -BeExactly "Script"
-        $modules[9].Path | Should -BeExactly (Resolve-Path "$resolvedTestDrive\Modules\Zoo\Too\Zoo.psm1").Path
+        $modules[9].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Too\Zoo.psm1").Path
         $modules[10].ModuleType | Should -BeExactly "Manifest"
-        $modules[10].Path | Should -BeExactly (Resolve-Path "$resolvedTestDrive\Modules\Zoo\Zoo.psd1").Path
+        $modules[10].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Zoo.psd1").Path
         $modules[11].ModuleType | Should -BeExactly "Script"
-        $modules[11].Path | Should -BeExactly (Resolve-Path "$resolvedTestDrive\Modules\Zoo\Zoo.psm1").Path
+        $modules[11].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Zoo.psm1").Path
     }
 
     It "Get-Module <Name> -ListAvailable -All" {
@@ -93,14 +91,14 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
         $modules = $modules | Sort-Object -Property Name, Path
         $modules.Name -join "," | Should -BeExactly "Download,Zoo,Zoo,Zoo"
 
-        $modules[0].Path | Should -BeExactly (Resolve-Path "$resolvedTestDrive\Modules\Bar\Download\Download.psm1").Path
-        $modules[1].Path | Should -BeExactly (Resolve-Path "$resolvedTestDrive\Modules\Zoo\Too\Zoo.psm1").Path
-        $modules[2].Path | Should -BeExactly (Resolve-Path "$resolvedTestDrive\Modules\Zoo\Zoo.psd1").Path
-        $modules[3].Path | Should -BeExactly (Resolve-Path "$resolvedTestDrive\Modules\Zoo\Zoo.psm1").Path
+        $modules[0].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Bar\Download\Download.psm1").Path
+        $modules[1].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Too\Zoo.psm1").Path
+        $modules[2].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Zoo.psd1").Path
+        $modules[3].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Zoo.psm1").Path
     }
 
     It "Get-Module <Path> -ListAvailable" {
-        $modules = Get-Module "$resolvedTestDrive\Modules\*" -ListAvailable
+        $modules = Get-Module "$testdrive\Modules\*" -ListAvailable
         $modules.Count | Should -Be 5
         $modules = $modules | Sort-Object -Property Name, Version
         $modules.Name -join "," | Should -BeExactly "Az,Bar,Foo,Foo,Zoo"
@@ -109,11 +107,11 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
     }
 
     It "Get-Module <Path> -ListAvailable -All" {
-        $modules = Get-Module "$resolvedTestDrive\Modules\*" -ListAvailable -All
+        $modules = Get-Module "$testdrive\Modules\*" -ListAvailable -All
         $modules.Count | Should -Be 6
         $modules = $modules | Sort-Object -Property Name, Path
         $modules.Name -join "," | Should -BeExactly "Az,Bar,Foo,Foo,Zoo,Zoo"
-        $modules[4].Path | Should -BeExactly (Resolve-Path "$resolvedTestDrive\Modules\Zoo\Too\Zoo.psm1").Path
+        $modules[4].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Too\Zoo.psm1").Path
     }
 
     It "Get-Module -FullyQualifiedName <FullyQualifiedName> -ListAvailable" {
@@ -130,7 +128,7 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
         $modules.Name | Should -BeExactly "Zoo"
         $modules.ExportedFunctions.Count | Should -Be 0 -Because 'No exports were defined'
 
-        New-ModuleManifest -Path "$resolvedTestDrive\Modules\Zoo\Zoo.psd1" -FunctionsToExport 'Test-ZooFunction'
+        New-ModuleManifest -Path "$testdrive\Modules\Zoo\Zoo.psd1" -FunctionsToExport 'Test-ZooFunction'
 
         $modules = Get-Module -Name 'Zoo' -ListAvailable -Refresh
         $modules | Should -HaveCount 1
@@ -155,17 +153,17 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
     Context "PSEdition" {
 
         BeforeAll {
-            New-Item -ItemType Directory -Path "$resolvedTestDrive\Modules\DesktopOnlyModule" -Force > $null
-            New-Item -ItemType Directory -Path "$resolvedTestDrive\Modules\CoreOnlyModule" -Force > $null
-            New-Item -ItemType Directory -Path "$resolvedTestDrive\Modules\CoreAndDesktopModule" -Force > $null
+            New-Item -ItemType Directory -Path "$testdrive\Modules\DesktopOnlyModule" -Force > $null
+            New-Item -ItemType Directory -Path "$testdrive\Modules\CoreOnlyModule" -Force > $null
+            New-Item -ItemType Directory -Path "$testdrive\Modules\CoreAndDesktopModule" -Force > $null
 
-            New-ModuleManifest -Path "$resolvedTestDrive\Modules\DesktopOnlyModule\DesktopOnlyModule.psd1" -CompatiblePSEditions Desktop
-            New-ModuleManifest -Path "$resolvedTestDrive\Modules\CoreOnlyModule\CoreOnlyModule.psd1" -CompatiblePSEditions Core
-            New-ModuleManifest -Path "$resolvedTestDrive\Modules\CoreAndDesktopModule\CoreAndDesktopModule.psd1" -CompatiblePSEditions Core, Desktop
+            New-ModuleManifest -Path "$testdrive\Modules\DesktopOnlyModule\DesktopOnlyModule.psd1" -CompatiblePSEditions Desktop
+            New-ModuleManifest -Path "$testdrive\Modules\CoreOnlyModule\CoreOnlyModule.psd1" -CompatiblePSEditions Core
+            New-ModuleManifest -Path "$testdrive\Modules\CoreAndDesktopModule\CoreAndDesktopModule.psd1" -CompatiblePSEditions Core, Desktop
 
-            New-Item -ItemType File -Path "$resolvedTestDrive\Modules\DesktopOnlyModule\DesktopOnlyModule.psm1" > $null
-            New-Item -ItemType File -Path "$resolvedTestDrive\Modules\CoreOnlyModule\CoreOnlyModule.psm1" > $null
-            New-Item -ItemType File -Path "$resolvedTestDrive\Modules\CoreAndDesktopModule\CoreAndDesktopModule.psm1" > $null
+            New-Item -ItemType File -Path "$testdrive\Modules\DesktopOnlyModule\DesktopOnlyModule.psm1" > $null
+            New-Item -ItemType File -Path "$testdrive\Modules\CoreOnlyModule\CoreOnlyModule.psm1" > $null
+            New-Item -ItemType File -Path "$testdrive\Modules\CoreAndDesktopModule\CoreAndDesktopModule.psm1" > $null
         }
 
         It "Get-Module -PSEdition <CompatiblePSEditions> -ListAvailable" -TestCases @(
@@ -181,7 +179,7 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
 
     Context "Module analysis shouldn't load assembly" {
         BeforeAll {
-            $tempModulePath = Join-Path $resolvedTestDrive "TempModules"
+            $tempModulePath = Join-Path $TestDrive "TempModules"
             $testModuleDir = Join-Path $tempModulePath "MyModuelTest"
             $moduleManifest = Join-Path $testModuleDir "MyModuelTest.psd1"
             $assemblyPath = Join-Path $testModuleDir "MyModuelTestCommandAssembly.dll"
@@ -230,8 +228,7 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
 Describe 'Get-Module -ListAvailable with path' -Tags "CI" {
     BeforeAll {
         $moduleName = 'Banana'
-        $resolvedTestDrive = Resolve-FilePath $TestDrive
-        $modulePath = Join-Path $resolvedTestDrive $moduleName
+        $modulePath = Join-Path $TestDrive $moduleName
         $v1 = '1.2.3'
         $v2 = '4.8.3'
         $v1DirPath = Join-Path $modulePath $v1

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -248,10 +248,10 @@ Describe 'Get-Module -ListAvailable with path' -Tags "CI" {
 
         $modules | Should -HaveCount 2
         $modules[0].Name | Should -BeExactly $moduleName
-        $modules[0].Path | Should -BeExactly (Resolve-FilePath $manifestV1Path)
+        $modules[0].Path | Should -BeExactly $manifestV1Path
         $modules[0].Version | Should -Be $v1
         $modules[1].Name | Should -BeExactly $moduleName
-        $modules[1].Path | Should -BeExactly (Resolve-FilePath $manifestV2Path)
+        $modules[1].Path | Should -BeExactly $manifestV2Path
         $modules[1].Version | Should -Be $v2
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -173,7 +173,7 @@ Describe "Import-Module for Binary Modules" -Tags 'CI' {
             $job | Remove-Job -ErrorAction Ignore
         }
 
-        $assemblyLocation | Should -BeExactly (Resolve-FilePath $TestModulePath)
+        $assemblyLocation | Should -BeExactly $TestModulePath
         $cmdletOutput | Should -BeExactly "BinaryModuleCmdlet1 exported by the ModuleCmdlets module."
     }
 
@@ -218,7 +218,7 @@ Describe "Import-Module for Binary Modules" -Tags 'CI' {
         $module.ModuleType.ToString() | Should -Be 'Manifest'
         $module.ExportedCmdlets['Test-BinaryModuleCmdlet1'] | Should -Be 'Test-BinaryModuleCmdlet1'
         $module.NestedModules | Should -Not -BeNullOrEmpty
-        $location | Should -Be (Resolve-FilePath $exe)
+        $location | Should -Be $exe
     }
 
     It "PS should try to load the assembly from assembly name if file path doesn't exist" {
@@ -258,7 +258,7 @@ Describe "Import-Module for Binary Modules" -Tags 'CI' {
 
         # Use a different pwsh so that we do not have the PSScheduledJob module already loaded.
         $loadedAssemblyLocation = pwsh -noprofile -c "Import-Module $destPath -Force; [Microsoft.PowerShell.ScheduledJob.AddJobTriggerCommand].Assembly.Location"
-        $loadedAssemblyLocation | Should -BeLike "$(Resolve-FilePath $TestDrive)*\Microsoft.PowerShell.ScheduledJob.dll"
+        $loadedAssemblyLocation | Should -BeLike "$TestDrive*\Microsoft.PowerShell.ScheduledJob.dll"
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/ModuleManifest.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/ModuleManifest.Tests.ps1
@@ -57,13 +57,12 @@ function New-ModuleFromLayout
 Describe "Manifest required module autoloading from module path with simple names" -Tags "CI" {
     BeforeAll {
         $prevModulePath = $env:PSModulePath
-        $resolvedTestDrive = Resolve-FilePath $TestDrive
-        $env:PSModulePath = $resolvedTestDrive + [System.IO.Path]::PathSeparator + $env:PSModulePath
+        $env:PSModulePath = ($TestDrive -as [string]) + [System.IO.Path]::PathSeparator + $env:PSModulePath
 
         $mainModule = 'mainmod'
         $requiredModule = 'reqmod'
 
-        New-ModuleFromLayout -BaseDir $resolvedTestDrive -Layout @{
+        New-ModuleFromLayout -BaseDir $TestDrive -Layout @{
             $mainModule = @{
                 "$mainModule.psd1" = @{
                     RequiredModules = $requiredModule
@@ -77,7 +76,7 @@ Describe "Manifest required module autoloading from module path with simple name
 
     AfterAll {
         $env:PSModulePath = $prevModulePath
-        Remove-Module $mainModule,$requiredModule -ErrorAction SilentlyContinue
+        Get-Module $mainModule,$requiredModule | Remove-Module
     }
 
     It "Importing main module loads required modules successfully" {
@@ -95,14 +94,12 @@ Describe "Manifest required module autoloading with relative path to dir" -Tags 
         $mainModule = 'mainmod'
         $requiredModule = 'reqmod'
 
-        $resolvedTestDrive = Resolve-FilePath $TestDrive
-
-        $mainModPath = Join-Path $resolvedTestDrive $mainModule
+        $mainModPath = Join-Path $TestDrive $mainModule
 
         # Test to ensure that we treat backslashes as path separators on UNIX and vice-versa
         $altSep = [System.IO.Path]::AltDirectorySeparatorChar
 
-        New-ModuleFromLayout -BaseDir $resolvedTestDrive -Layout @{
+        New-ModuleFromLayout -BaseDir $TestDrive -Layout @{
             $mainModule = @{
                 "$mainModule.psd1" = @{
                     RequiredModules = "..${altSep}$requiredModule"
@@ -133,15 +130,13 @@ Describe "Manifest required module autoloading with relative path to manifest" -
         $mainModule = 'mainmod'
         $requiredModule = 'reqmod'
 
-        $resolvedTestDrive = Resolve-FilePath $TestDrive
-
-        $mainModPath = Join-Path $resolvedTestDrive $mainModule "$mainModule.psd1"
+        $mainModPath = Join-Path $TestDrive $mainModule "$mainModule.psd1"
 
         # Test to ensure that we treat backslashes as path separators on UNIX and vice-versa
         $altSep = [System.IO.Path]::AltDirectorySeparatorChar
         $sep = [System.IO.Path]::DirectorySeparatorChar
 
-        New-ModuleFromLayout -BaseDir $resolvedTestDrive -Layout @{
+        New-ModuleFromLayout -BaseDir $TestDrive -Layout @{
             $mainModule = @{
                 "$mainModule.psd1" = @{
                     RequiredModules = "..${altSep}$requiredModule${sep}$requiredModule.psd1"
@@ -172,18 +167,16 @@ Describe "Manifest required module autoloading with absolute path to dir" -Tags 
         $mainModule = 'mainmod'
         $requiredModule = 'reqmod'
 
-        $resolvedTestDrive = Resolve-FilePath $TestDrive
-
-        $mainModPath = Join-Path $resolvedTestDrive $mainModule "$mainModule.psd1"
+        $mainModPath = Join-Path $TestDrive $mainModule "$mainModule.psd1"
 
         # Test to ensure that we treat backslashes as path separators on UNIX and vice-versa
         $altSep = [System.IO.Path]::AltDirectorySeparatorChar
         $sep = [System.IO.Path]::DirectorySeparatorChar
 
-        New-ModuleFromLayout -BaseDir $resolvedTestDrive -Layout @{
+        New-ModuleFromLayout -BaseDir $TestDrive -Layout @{
             $mainModule = @{
                 "$mainModule.psd1" = @{
-                    RequiredModules = "$resolvedTestDrive${altSep}$requiredModule${sep}"
+                    RequiredModules = "$TestDrive${altSep}$requiredModule${sep}"
                 }
             }
             $requiredModule = @{
@@ -211,18 +204,16 @@ Describe "Manifest required module autoloading with absolute path to manifest" -
         $mainModule = 'mainmod'
         $requiredModule = 'reqmod'
 
-        $resolvedTestDrive = Resolve-FilePath $TestDrive
-
-        $mainModPath = Join-Path $resolvedTestDrive $mainModule "$mainModule.psd1"
+        $mainModPath = Join-Path $TestDrive $mainModule "$mainModule.psd1"
 
         # Test to ensure that we treat backslashes as path separators on UNIX and vice-versa
         $altSep = [System.IO.Path]::AltDirectorySeparatorChar
         $sep = [System.IO.Path]::DirectorySeparatorChar
 
-        New-ModuleFromLayout -BaseDir $resolvedTestDrive -Layout @{
+        New-ModuleFromLayout -BaseDir $TestDrive -Layout @{
             $mainModule = @{
                 "$mainModule.psd1" = @{
-                    RequiredModules = "$resolvedTestDrive${altSep}$requiredModule${sep}$requiredModule.psd1"
+                    RequiredModules = "$TestDrive${altSep}$requiredModule${sep}$requiredModule.psd1"
                 }
             }
             $requiredModule = @{

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Convert-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Convert-Path.Tests.ps1
@@ -14,7 +14,7 @@ Describe "Convert-Path tests" -Tag CI {
     }
 
     It "Convert-Path supports pipelined input by property name" {
-        Get-Item -Path $TestDrive | Convert-Path | Should -BeExactly (Resolve-FilePath $TestDrive)
+        Get-Item -Path $TestDrive | Convert-Path | Should -BeExactly $TestDrive
     }
 
     It "Convert-Path without arguments is an error" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Convert-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Convert-Path.Tests.ps1
@@ -14,7 +14,7 @@ Describe "Convert-Path tests" -Tag CI {
     }
 
     It "Convert-Path supports pipelined input by property name" {
-        Get-Item -Path $TestDrive | Convert-Path | Should -BeExactly $TestDrive
+        Get-Item -Path $TestDrive | Convert-Path | Should -BeExactly "$TestDrive"
     }
 
     It "Convert-Path without arguments is an error" {

--- a/test/tools/Modules/HelpersCommon/HelpersCommon.psm1
+++ b/test/tools/Modules/HelpersCommon/HelpersCommon.psm1
@@ -344,8 +344,3 @@ function Test-CanWriteToPsHome
 
     $script:CanWriteToPsHome
 }
-
-# This resolves a short path on Windows to the long path
-function Resolve-FilePath($path) {
-    ([System.IO.FileInfo]::new($path)).FullName
-}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
