### PR TITLE
Add support for `-l` to pwsh so that it is compatible with POSIX shell expectations

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -745,7 +745,7 @@ namespace Microsoft.PowerShell
                 }
                 else if (MatchSwitch(switchKey, "loadprofile", "l"))
                 {
-                    // do nothing as we load profile by default, but this is needed to be compatible with POSIX shell expectations
+                    _skipUserInit = false;
                 }
                 else if (MatchSwitch(switchKey, "noprofile", "nop"))
                 {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -173,28 +173,29 @@ namespace Microsoft.PowerShell
         private const int MaxPipePathLengthMacOS = 104;
 
         internal static string[] validParameters = {
-            "version",
-            "nologo",
-            "noexit",
 #if STAMODE
             "sta",
             "mta",
 #endif
-            "noprofile",
-            "noninteractive",
-            "inputformat",
-            "outputformat",
-            "windowstyle",
-            "encodedcommand",
-            "configurationname",
-            "file",
-            "executionpolicy",
             "command",
-            "settingsfile",
+            "configurationname",
+            "custompipename",
+            "encodedcommand",
+            "executionpolicy",
+            "file",
             "help",
-            "workingdirectory",
+            "inputformat",
+            "loadprofile",
+            "noexit",
+            "nologo",
+            "noninteractive",
+            "noprofile",
+            "outputformat",
             "removeworkingdirectorytrailingcharacter",
-            "custompipename"
+            "settingsfile",
+            "version",
+            "windowstyle",
+            "workingdirectory"
         };
 
         internal CommandLineParameterParser(PSHostUserInterface hostUI, string bannerText, string helpText)
@@ -741,6 +742,10 @@ namespace Microsoft.PowerShell
                 {
                     _noExit = true;
                     noexitSeen = true;
+                }
+                else if (MatchSwitch(switchKey, "loadprofile", "l"))
+                {
+                    // do nothing as we load profile by default, but this is needed to be compatible with POSIX shell expectations
                 }
                 else if (MatchSwitch(switchKey, "noprofile", "nop"))
                 {

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -225,7 +225,7 @@ All parameters are case-insensitive.</value>
     Present an interactive prompt to the user. Inverse for NonInteractive parameter.
 
 -LoadProfile | -l
-    Load the PowerShell profiles.  This is the default behavior even if this is not specified.
+    Load the PowerShell profiles. This is the default behavior even if this is not specified.
 
 -NoExit | -noe
     Does not exit after running startup commands.

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -131,7 +131,7 @@ Type 'help' to get help.</value>
                   [-ConfigurationName &lt;string&gt;] [-CustomPipeName &lt;string&gt;]
                   [-EncodedCommand &lt;Base64EncodedCommand&gt;]
                   [-ExecutionPolicy &lt;ExecutionPolicy&gt;] [-InputFormat {Text | XML}]
-                  [-Interactive] [-NoExit] [-NoLogo] [-NonInteractive] [-NoProfile]
+                  [-Interactive] [-LoadProfile] [-NoExit] [-NoLogo] [-NonInteractive] [-NoProfile]
                   [-OutputFormat {Text | XML}] [-Version] [-WindowStyle &lt;style&gt;]
                   [-WorkingDirectory &lt;directoryPath&gt;]
 
@@ -176,11 +176,11 @@ All parameters are case-insensitive.</value>
     Example: pwsh -ConfigurationName AdminRoles
 
 -CustomPipeName
-    Specifies the name to use for an additional IPC server (named pipe) used for debugging 
+    Specifies the name to use for an additional IPC server (named pipe) used for debugging
     and other cross-process communication. This offers a predictable mechanism for connecting
     to other PowerShell instances. Typically used with the CustomPipeName parameter on Enter-PSHostProcess.
 
-    Example: 
+    Example:
     # PowerShell instance 1
     pwsh -CustomPipeName mydebugpipe
     # PowerShell instance 2
@@ -223,6 +223,9 @@ All parameters are case-insensitive.</value>
 
 -Interactive | -i
     Present an interactive prompt to the user. Inverse for NonInteractive parameter.
+
+-LoadProfile | -l
+    Load the PowerShell profiles.  This is the default behavior even if this is not specified.
 
 -NoExit | -noe
     Does not exit after running startup commands.

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -250,8 +250,8 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             if (Test-Path $profile) {
                 Remove-Item -Path "$profile.backup" -ErrorAction SilentlyContinue
                 Rename-Item -Path $profile -NewName "$profile.backup"
-                Set-Content -Path $profile -Value "'profile-loaded'" -Force
             }
+            Set-Content -Path $profile -Value "'profile-loaded'" -Force
         }
 
         AfterAll {
@@ -267,6 +267,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
         ){
             param($switch)
 
+            Get-Content $profile -Raw | Should -Not -BeNullOrEmpty
             & pwsh $switch -c exit | Should -BeExactly "profile-loaded"
         }
     }

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -269,8 +269,14 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
         ){
             param($switch)
 
-            Get-Content $profile -Raw | Should -Not -BeNullOrEmpty
-            & pwsh $switch -c exit | Should -BeExactly "profile-loaded"
+            if (Test-Path $profile) {
+                & pwsh $switch -command exit | Should -BeExactly "profile-loaded"
+            }
+            else {
+                # In CI, may not be able to write to $profile location, so just verify that the switch is accepted
+                # and no error message is in the output
+                & pwsh $switch -command exit *>&1 | Should -BeNullOrEmpty
+            }
         }
     }
 

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -245,6 +245,33 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
         }
     }
 
+    Context "-LoadProfile Commandline switch" {
+        BeforeAll {
+            if (Test-Path $profile) {
+                Remove-Item -Path "$profile.backup" -ErrorAction SilentlyContinue
+                Rename-Item -Path $profile -NewName "$profile.backup"
+                Set-Content -Path $profile -Value "'profile-loaded'" -Force
+            }
+        }
+
+        AfterAll {
+            if (Test-Path "$profile.backup") {
+                Remove-Item -Path $profile -ErrorAction SilentlyContinue
+                Rename-Item -Path "$profile.backup" -NewName $profile
+            }
+        }
+
+        It "Verifies pwsh will accept <switch> switch" -TestCases @(
+            @{ switch = "-l"},
+            @{ switch = "-loadprofile"}
+        ){
+            param($switch)
+
+            & pwsh $switch -c exit | Should -BeExactly "profile-loaded"
+        }
+    }
+
+
     Context "-SettingsFile Commandline switch" {
 
         BeforeAll {

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -251,12 +251,14 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
                 Remove-Item -Path "$profile.backup" -ErrorAction SilentlyContinue
                 Rename-Item -Path $profile -NewName "$profile.backup"
             }
+
             Set-Content -Path $profile -Value "'profile-loaded'" -Force
         }
 
         AfterAll {
+            Remove-Item -Path $profile -ErrorAction SilentlyContinue
+
             if (Test-Path "$profile.backup") {
-                Remove-Item -Path $profile -ErrorAction SilentlyContinue
                 Rename-Item -Path "$profile.backup" -NewName $profile
             }
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

POSIX shells have a `-l` switch to indicate it is a login shell which will process profiles.  However, PowerShell by default already loads the profile and requires `-noprofile` to explicitly not load it.  To make pwsh compatible with other tools (like VSCode) that expects a `-l` switch, the change is to add `-loadprofile` aliased as `-l` so that it doesn't complain about that switch which is a no-op since we load the profile by default.

Also sorted the switches alphabetically in the code.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/3600

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] https://github.com/MicrosoftDocs/PowerShell-Docs/pull/4261
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
