### PR TITLE
Use IPGlobalProperties on all platforms

### DIFF
--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -522,12 +522,6 @@ namespace System.Management.Automation
             return Unix.NativeMethods.SetDate(&tm) == 0;
         }
 
-        // Hostname in this context seems to be the FQDN
-        internal static string NonWindowsGetHostName()
-        {
-            return Unix.NativeMethods.GetFullyQualifiedName() ?? string.Empty;
-        }
-
         internal static bool NonWindowsIsSameFileSystemItem(string pathOne, string pathTwo)
         {
             return Unix.NativeMethods.IsSameFileSystemItem(pathOne, pathTwo);
@@ -689,10 +683,6 @@ namespace System.Management.Automation
 
                 [DllImport(psLib, CharSet = CharSet.Ansi)]
                 internal static extern uint GetCurrentThreadId();
-
-                [DllImport(psLib, CharSet = CharSet.Ansi, SetLastError = true)]
-                [return: MarshalAs(UnmanagedType.LPStr)]
-                internal static extern string GetFullyQualifiedName();
 
                 // This is a struct tm from <time.h>
                 [StructLayout(LayoutKind.Sequential)]

--- a/src/System.Management.Automation/utils/PsUtils.cs
+++ b/src/System.Management.Automation/utils/PsUtils.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Management.Automation.Language;
+using System.Net.NetworkInformation;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -206,21 +207,7 @@ namespace System.Management.Automation
 
         internal static string GetHostName()
         {
-            // Note: non-windows CoreCLR does not support System.Net yet
-            if (Platform.IsWindows)
-            {
-                return WinGetHostName();
-            }
-            else
-            {
-                return Platform.NonWindowsGetHostName();
-            }
-        }
-
-        internal static string WinGetHostName()
-        {
-            System.Net.NetworkInformation.IPGlobalProperties ipProperties =
-                System.Net.NetworkInformation.IPGlobalProperties.GetIPGlobalProperties();
+            IPGlobalProperties ipProperties = IPGlobalProperties.GetIPGlobalProperties();
 
             string hostname = ipProperties.HostName;
             if (!string.IsNullOrEmpty(ipProperties.DomainName))

--- a/src/System.Management.Automation/utils/PsUtils.cs
+++ b/src/System.Management.Automation/utils/PsUtils.cs
@@ -210,9 +210,13 @@ namespace System.Management.Automation
             IPGlobalProperties ipProperties = IPGlobalProperties.GetIPGlobalProperties();
 
             string hostname = ipProperties.HostName;
-            if (!string.IsNullOrEmpty(ipProperties.DomainName))
+            string domainName = ipProperties.DomainName;
+
+            // CoreFX on Unix calls GLibc getdomainname()
+            // which returns "(none)" if a domain name is not set by setdomainname()
+            if (!string.IsNullOrEmpty(domainName) && !domainName.Equals("(none)", StringComparison.Ordinal))
             {
-                hostname = hostname + "." + ipProperties.DomainName;
+                hostname = hostname + "." + domainName;
             }
 
             return hostname;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

On Windows we use System.Net.NetworkInformation.IPGlobalProperties.GetIPGlobalProperties to get computer name and domain name. The API was ported so we can remove P/Invokes for Unix-es.

[On Unix CoreFX](https://github.com/dotnet/corefx/blob/a10890f4ffe0fadf090c922578ba0e606ebdd16c/src/Common/src/System/Net/NetworkInformation/HostInformationPal.Unix.cs#L16) ([then](https://github.com/dotnet/corefx/blob/a6f76f4f620cbe74821c6445af3f13e048361658/src/Common/src/Interop/Unix/System.Native/Interop.GetDomainName.cs#L15) and [then](https://github.com/dotnet/corefx/blob/dda3289ce64a68613057758f53c20cc4768548de/src/Native/Unix/System.Native/pal_networking.c#L401)) calls GLibc getdomainname() which returns "(none)" if a domain name is not set by setdomainname(). (See https://access.redhat.com/solutions/352963) So we ignore the value.

## PR Context

Related #9526.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
