### PR TITLE
Make sure we always return an object in command searcher

### DIFF
--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -565,7 +565,7 @@ namespace System.Management.Automation
             }
 
             provider = null;
-            return null;
+            return new Collection<string>();
         }
 
         private static bool checkPath(string path, string commandName)

--- a/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
+++ b/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
@@ -208,7 +208,7 @@ Describe "Command Discovery tests" -Tags "CI" {
 
     Context "error cases" {
         It 'Get-Command "less `"-PsPage %db?B of %DoesNotExist:`"" should throw Drive not found' {
-            {Get-Command -Name "less `"-PsPage %db?B of %DoesNotExist:`""} | Should -Throw -ErrorId 'DriveNotFound' -because "The drive 'DoesNotExist:' should not exist"
+            {Get-Command -Name "less `"-PsPage %db?B of %DoesNotExist:`""} | Should -Throw -ErrorId 'DriveNotFound' -Because "The drive 'DoesNotExist:' should not exist"
         }
     }
 }

--- a/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
+++ b/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
@@ -205,4 +205,10 @@ Describe "Command Discovery tests" -Tags "CI" {
             }
         }
     }
+
+    Context "error cases" {
+        It 'Get-Command "less `"-PsPage %db?B of %DoesNotExist:`"" should throw Drive not found' {
+            {Get-Command -Name "less `"-PsPage %db?B of %DoesNotExist:`""} | Should -Throw -ErrorId 'DriveNotFound' -because "The drive 'DoesNotExist:' should not exist"
+        }
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Make sure we always return an object in command searcher

## PR Context

Fixes #9396 

Reviewing the code returning an empty object should not cause an issue.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
