### PR TITLE
Have console host not enter command prompt mode when using `Read-Host -Prompt`

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfacePrompt.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfacePrompt.cs
@@ -375,7 +375,7 @@ namespace Microsoft.PowerShell
                     break;
                 }
                 else
-                if (rawInputString.StartsWith(PromptCommandPrefix, StringComparison.Ordinal))
+                if (!string.IsNullOrEmpty(desc.Label) && rawInputString.StartsWith(PromptCommandPrefix, StringComparison.Ordinal))
                 {
                     processedInputString = PromptCommandMode(rawInputString, desc, out inputDone);
                 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Read-Host.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Read-Host.Tests.ps1
@@ -39,7 +39,7 @@ Describe "Read-Host Test" -tag "CI" {
     }
 
     It "Read-Host doesn't enter command prompt mode" {
-        $result = "!1" | pwsh -nop -c "Read-host -Prompt 'foo'"
+        $result = "!1" | pwsh -NoProfile -c "Read-host -Prompt 'foo'"
         $result | should -BeExactly @('foo: !1','!1')
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Read-Host.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Read-Host.Tests.ps1
@@ -9,28 +9,37 @@ Describe "Read-Host Test" -tag "CI" {
         $ps.Runspace = $rs
         $ps.Commands.Clear()
     }
+
     AfterEach {
         $ps.Commands.Clear()
     }
+
     AfterAll {
         $rs.Close()
         $rs.Dispose()
         $ps.Dispose()
     }
+
     It "Read-Host returns expected string" {
         $result = $ps.AddCommand("Read-Host").Invoke()
         $result | Should -Be $th.UI.ReadLineData
     }
+
     It "Read-Host sets the prompt correctly" {
         $result = $ps.AddScript("Read-Host -prompt myprompt").Invoke()
         $prompt = $th.ui.streams.prompt[0]
         $prompt | Should -Not -BeNullOrEmpty
         $prompt.split(":")[-1] | Should -Be myprompt
     }
+
     It "Read-Host returns a secure string when using -AsSecureString parameter" {
         $result = $ps.AddScript("Read-Host -AsSecureString").Invoke() | select-object -first 1
         $result | Should -BeOfType SecureString
-        [pscredential]::New("foo",$result).GetNEtworkCredential().Password | Should -BeExactly TEST
+        [pscredential]::New("foo",$result).GetNetworkCredential().Password | Should -BeExactly TEST
+    }
 
+    It "Read-Host doesn't enter command prompt mode" {
+        $result = "!1" | pwsh -nop -c "Read-host -Prompt 'foo'"
+        $result | should -BeExactly @('foo: !1','!1')
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Read-Host.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Read-Host.Tests.ps1
@@ -40,6 +40,13 @@ Describe "Read-Host Test" -tag "CI" {
 
     It "Read-Host doesn't enter command prompt mode" {
         $result = "!1" | pwsh -NoProfile -c "Read-host -Prompt 'foo'"
-        $result | should -BeExactly @('foo: !1','!1')
+        if ($IsWindows) {
+            # Windows write to console directly so can't capture prompt in stdout
+            $expected = @('!1','!1')
+        }
+        else {
+            $expected = @('foo: !1','!1')
+        }
+        $result | should -BeExactly $expected
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

`Read-Host` calls into `$Host.UI.Prompt()`.  However, this method is also used when the host prompts for mandatory parameters that aren't provided.  The method expects to be called when given a `FieldDescription` and if the input starts with `!` it enters `CommandPromptMode`.  In this mode, you can type `!?` to request help, for example.  However this mode is not something you can use via `Read-Host` (only if calling `$Host.UI.Prompt()` directly passing in a well constructed `FieldDescription`).  When using `Read-Host -Prompt`, the cmdlet creates a `FieldDescription` where the name is the prompt and the rest of the properties are empty.

The fix is that if `Label` is empty, we can assume it's being called from `Read-Host` rather than being called to prompt for a mandatory parameter and thus not enter `CommandPromptMode`.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/4066

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
