### PR TITLE
Display Duration when displaying `HistoryInfo`

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -342,9 +342,26 @@ namespace System.Management.Automation.Runspaces
             yield return new FormatViewDefinition("history",
                 TableControl.Create()
                     .AddHeader(Alignment.Right, width: 4)
+                    .AddHeader(Alignment.Right, label: "Duration", width: 12)
                     .AddHeader()
                     .StartRowDefinition()
                         .AddPropertyColumn("Id")
+                        .AddScriptBlockColumn(@"
+                                if ($_.Duration.TotalHours -ge 10) {
+                                    return ""{0}:{1:mm}:{1:ss}.{1:fff}"" -f [int]$_.Duration.TotalHours, $_.Duration
+                                }
+                                elseif ($_.Duration.TotalHours -ge 1) {
+                                    $formatString = ""h\:mm\:ss\.fff""
+                                }
+                                elseif ($_.Duration.TotalMinutes -ge 1) {
+                                    $formatString = ""m\:ss\.fff""
+                                } 
+                                else {
+                                    $formatString = ""s\.fff""
+                                }
+
+                                $_.Duration.ToString($formatString)
+                              ")
                         .AddPropertyColumn("CommandLine")
                     .EndRowDefinition()
                 .EndTable());


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes #9518

Displays the Duration information anytime a `HistoryInfo` object is displayed e.g. as the output of `Get-History`.  The output avoids extraneous 0 placeholder digits:
```
  Id     Duration CommandLine
  --     -------- -----------
   1        0.538 ipconfig
   2        0.140 git --version
   3        3.524 dir
   4        0.128 ghy
   5       11.033 start-sleep 11
   6        0.061 ghy
   7     1:05.020 Start-Sleep 65
   8        0.036 ghy
   9    10:23.014 Start-Sleep 623
  10        0.046 ghy
  11  1:01:55.033 Start-Sleep 3715
```
The formatting as implemented will handle up to 4 days, 3hrs, 59min, 59secs, 999 msecs.  It does this by displaying total hours greater than 24.  Consequently, the max value that can be displayed non-truncated is:
```
  Id     Duration CommandLine
  --     -------- -----------
  12 99:59:59.999 .\reallyReallyReallySlowScript.ps1
```
This should handle the **vast** majority of interactice command durations.  
## PR Context

`Duration` was added as a convenience property to `HistoryInfo` objects however the majority of users will never know this exists unless it is displayed by default.  Given the narrow width required for the extra column (13 extra chars in width) and the fact that it is useful information for users to be able to see, I believe it is worth it to display this property by default.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)

I did not see any tests for the formatted display of `HistoryInfo` objects.