### PR TITLE
Consider DBNull.Value and NullString.Value the same as $null

### DIFF
--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -1065,11 +1065,19 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Internal routine that determines if an object meets any of our criteria for null.
+        /// Internal routine that determines if an object meets any of our criteria for true null.
         /// </summary>
         /// <param name="obj">The object to test.</param>
         /// <returns>True if the object is null.</returns>
         internal static bool IsNull(object obj) => obj == null || obj == AutomationNull.Value;
+
+        /// <summary>
+        /// Internal routine that determines if an object meets any of our criteria for null.
+        /// This method additionally checks for <see cref="NullString.Value"/> and <see cref="DBNull.Value"/>
+        /// </summary>
+        /// <param name="obj">The object to test.</param>
+        /// <returns>True if the object is null.</returns>
+        internal static bool IsNullLike(object obj) => IsNull(obj) || obj == DBNull.Value || obj == NullString.Value;
 
         /// <summary>
         /// Auxiliary for the cases where we want a new PSObject or null.

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -629,8 +629,7 @@ namespace System.Management.Automation
                 formatProvider = CultureInfo.InvariantCulture;
             }
 
-            var culture = formatProvider as CultureInfo;
-            if (culture == null)
+            if (!(formatProvider is CultureInfo culture))
             {
                 throw PSTraceSource.NewArgumentException("formatProvider");
             }
@@ -640,7 +639,7 @@ namespace System.Management.Automation
 
             if (first == null)
             {
-                if (second == null || second == DBNull.Value || second == NullString.Value)
+                if (IsNullLike(second))
                 {
                     return true;
                 }
@@ -650,7 +649,7 @@ namespace System.Management.Automation
 
             if (second == null)
             {
-                if (first == DBNull.Value || first == NullString.Value)
+                if (IsNullLike(first))
                 {
                     return true;
                 }
@@ -731,7 +730,7 @@ namespace System.Management.Automation
                 float f => Math.Sign(f) < 0 ? -i : i,
                 double d => Math.Sign(d) < 0 ? -i : i,
                 decimal m => Math.Sign(m) < 0 ? -i : i,
-                _ => value == DBNull.Value || value == NullString.Value ? 0 : i
+                _ => IsNullLike(value) ? 0 : i
             };
         }
 
@@ -990,7 +989,7 @@ namespace System.Management.Automation
         public static bool IsTrue(object obj)
         {
             // null is a valid argument - it converts to false...
-            if (IsNull(obj) || obj == DBNull.Value || obj == NullString.Value)
+            if (IsNullLike(obj))
             {
                 return false;
             }
@@ -1077,7 +1076,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="obj">The object to test.</param>
         /// <returns>True if the object is null.</returns>
-        internal static bool IsNullLike(object obj) => IsNull(obj) || obj == DBNull.Value || obj == NullString.Value;
+        internal static bool IsNullLike(object obj) => obj == DBNull.Value || obj == NullString.Value || IsNull(obj);
 
         /// <summary>
         /// Auxiliary for the cases where we want a new PSObject or null.

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -990,8 +990,10 @@ namespace System.Management.Automation
         public static bool IsTrue(object obj)
         {
             // null is a valid argument - it converts to false...
-            if (obj == null || obj == AutomationNull.Value)
+            if (IsNull(obj) || obj == DBNull.Value || obj == NullString.Value)
+            {
                 return false;
+            }
 
             obj = PSObject.Base(obj);
 

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -1068,7 +1068,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="obj">The object to test.</param>
         /// <returns>True if the object is null.</returns>
-        internal static bool IsNull(object obj) => obj == null || obj == AutomationNull.Value;
+        public static bool IsNull(object obj) => obj == null || obj == AutomationNull.Value;
 
         /// <summary>
         /// Internal routine that determines if an object meets any of our criteria for null.
@@ -1076,7 +1076,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="obj">The object to test.</param>
         /// <returns>True if the object is null.</returns>
-        internal static bool IsNullLike(object obj) => obj == DBNull.Value || obj == NullString.Value || IsNull(obj);
+        public static bool IsNullLike(object obj) => obj == DBNull.Value || obj == NullString.Value || IsNull(obj);
 
         /// <summary>
         /// Auxiliary for the cases where we want a new PSObject or null.

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -629,7 +629,8 @@ namespace System.Management.Automation
                 formatProvider = CultureInfo.InvariantCulture;
             }
 
-            if (!(formatProvider is CultureInfo culture))
+            var culture = formatProvider as CultureInfo;
+            if (culture == null)
             {
                 throw PSTraceSource.NewArgumentException("formatProvider");
             }
@@ -639,22 +640,12 @@ namespace System.Management.Automation
 
             if (first == null)
             {
-                if (IsNullLike(second))
-                {
-                    return true;
-                }
-
-                return false;
+                return IsNullLike(second);
             }
 
             if (second == null)
             {
-                if (IsNullLike(first))
-                {
-                    return true;
-                }
-
-                return false; // first is not null
+                return IsNullLike(first);
             }
 
             string secondString;
@@ -714,7 +705,7 @@ namespace System.Management.Automation
         /// Helper method for [Try]Compare to determine object ordering with null.
         /// </summary>
         /// <param name="value">The numeric value to compare to null.</param>
-        /// <param name="numberIsRightHandSide">True if the number to compare is on the right hand side if the comparison.</param>
+        /// <param name="numberIsRightHandSide">True if the number to compare is on the right hand side in the comparison.</param>
         private static int CompareObjectToNull(object value, bool numberIsRightHandSide)
         {
             var i = numberIsRightHandSide ? -1 : 1;
@@ -783,7 +774,8 @@ namespace System.Management.Automation
         {
             formatProvider ??= CultureInfo.InvariantCulture;
 
-            if (!(formatProvider is CultureInfo culture))
+            var culture = formatProvider as CultureInfo;
+            if (culture == null)
             {
                 throw PSTraceSource.NewArgumentException(nameof(formatProvider));
             }
@@ -803,7 +795,8 @@ namespace System.Management.Automation
 
             if (first is string firstString)
             {
-                if (!(second is string secondString))
+                var secondString = second as string;
+                if (secondString == null)
                 {
                     try
                     {

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -3108,15 +3108,17 @@ namespace System.Management.Automation
             return AutomationNull.Value;
         }
 
-        private static bool ConvertClassToBool(object valueToConvert,
-                                               Type resultType,
-                                               bool recursion,
-                                               PSObject originalValueToConvert,
-                                               IFormatProvider formatProvider,
-                                               TypeTable backupTable)
+        private static bool ConvertClassToBool(
+            object valueToConvert,
+            Type resultType,
+            bool recursion,
+            PSObject originalValueToConvert,
+            IFormatProvider formatProvider,
+            TypeTable backupTable)
         {
             typeConversion.WriteLine("Converting ref to boolean.");
-            return valueToConvert != null;
+            // Both NullString and DBNull should be treated the same as true nulls for the purposes of this conversion.
+            return !IsNullLike(valueToConvert);
         }
 
         private static bool ConvertValueToBool(object valueToConvert,

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -4711,10 +4711,11 @@ namespace System.Management.Automation
         {
             PSObject valueAsPsObj;
             Type originalType;
-            if (valueToConvert == null || valueToConvert == AutomationNull.Value)
+
+            if (IsNull(valueToConvert))
             {
-                valueAsPsObj = null;
                 originalType = typeof(Null);
+                valueAsPsObj = null;
             }
             else
             {

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -3028,13 +3028,22 @@ namespace System.Management.Automation.Language
             if (target.Value == null)
             {
                 return new DynamicMetaObject(
-                    arg.Value == null ? ExpressionCache.BoxedTrue : ExpressionCache.BoxedFalse,
+                    arg.Value == null || arg.Value == DBNull.Value || arg.Value == NullString.Value
+                        ? ExpressionCache.BoxedTrue
+                        : ExpressionCache.BoxedFalse,
                     target.CombineRestrictions(arg));
             }
 
             var enumerable = PSEnumerableBinder.IsEnumerable(target);
             if (enumerable == null && arg.Value == null)
             {
+                if (target.Value == DBNull.Value || target.Value == NullString.Value)
+                {
+                    return new DynamicMetaObject(
+                        ExpressionCache.BoxedTrue,
+                        target.CombineRestrictions(arg));
+                }
+
                 return new DynamicMetaObject(
                     ExpressionCache.BoxedFalse,
                     target.CombineRestrictions(arg));
@@ -3051,13 +3060,22 @@ namespace System.Management.Automation.Language
             if (target.Value == null)
             {
                 return new DynamicMetaObject(
-                    arg.Value == null ? ExpressionCache.BoxedFalse : ExpressionCache.BoxedTrue,
+                    arg.Value == null || arg.Value == DBNull.Value || arg.Value == NullString.Value
+                        ? ExpressionCache.BoxedFalse
+                        : ExpressionCache.BoxedTrue,
                     target.CombineRestrictions(arg));
             }
 
             var enumerable = PSEnumerableBinder.IsEnumerable(target);
             if (enumerable == null && arg.Value == null)
             {
+                if (target.Value == DBNull.Value || target.Value == NullString.Value)
+                {
+                    return new DynamicMetaObject(
+                        ExpressionCache.BoxedFalse,
+                        target.CombineRestrictions(arg));
+                }
+
                 return new DynamicMetaObject(ExpressionCache.BoxedTrue,
                     target.CombineRestrictions(arg));
             }

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -3037,15 +3037,10 @@ namespace System.Management.Automation.Language
             var enumerable = PSEnumerableBinder.IsEnumerable(target);
             if (enumerable == null && arg.Value == null)
             {
-                if (LanguagePrimitives.IsNullLike(target.Value))
-                {
-                    return new DynamicMetaObject(
-                        ExpressionCache.BoxedTrue,
-                        target.CombineRestrictions(arg));
-                }
-
                 return new DynamicMetaObject(
-                    ExpressionCache.BoxedFalse,
+                    LanguagePrimitives.IsNullLike(target.Value)
+                        ? ExpressionCache.BoxedTrue
+                        : ExpressionCache.BoxedFalse,
                     target.CombineRestrictions(arg));
             }
 
@@ -3069,14 +3064,10 @@ namespace System.Management.Automation.Language
             var enumerable = PSEnumerableBinder.IsEnumerable(target);
             if (enumerable == null && arg.Value == null)
             {
-                if (LanguagePrimitives.IsNullLike(target.Value))
-                {
-                    return new DynamicMetaObject(
-                        ExpressionCache.BoxedFalse,
-                        target.CombineRestrictions(arg));
-                }
-
-                return new DynamicMetaObject(ExpressionCache.BoxedTrue,
+                return new DynamicMetaObject(
+                    LanguagePrimitives.IsNullLike(target.Value)
+                        ? ExpressionCache.BoxedFalse
+                        : ExpressionCache.BoxedTrue,
                     target.CombineRestrictions(arg));
             }
 

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -3028,7 +3028,7 @@ namespace System.Management.Automation.Language
             if (target.Value == null)
             {
                 return new DynamicMetaObject(
-                    arg.Value == null || arg.Value == DBNull.Value || arg.Value == NullString.Value
+                    LanguagePrimitives.IsNullLike(arg.Value)
                         ? ExpressionCache.BoxedTrue
                         : ExpressionCache.BoxedFalse,
                     target.CombineRestrictions(arg));
@@ -3037,7 +3037,7 @@ namespace System.Management.Automation.Language
             var enumerable = PSEnumerableBinder.IsEnumerable(target);
             if (enumerable == null && arg.Value == null)
             {
-                if (target.Value == DBNull.Value || target.Value == NullString.Value)
+                if (LanguagePrimitives.IsNullLike(target.Value))
                 {
                     return new DynamicMetaObject(
                         ExpressionCache.BoxedTrue,
@@ -3060,7 +3060,7 @@ namespace System.Management.Automation.Language
             if (target.Value == null)
             {
                 return new DynamicMetaObject(
-                    arg.Value == null || arg.Value == DBNull.Value || arg.Value == NullString.Value
+                    LanguagePrimitives.IsNullLike(arg.Value)
                         ? ExpressionCache.BoxedFalse
                         : ExpressionCache.BoxedTrue,
                     target.CombineRestrictions(arg));
@@ -3069,7 +3069,7 @@ namespace System.Management.Automation.Language
             var enumerable = PSEnumerableBinder.IsEnumerable(target);
             if (enumerable == null && arg.Value == null)
             {
-                if (target.Value == DBNull.Value || target.Value == NullString.Value)
+                if (LanguagePrimitives.IsNullLike(target.Value))
                 {
                     return new DynamicMetaObject(
                         ExpressionCache.BoxedFalse,

--- a/test/powershell/Language/Scripting/NullRepresentatives.Tests.ps1
+++ b/test/powershell/Language/Scripting/NullRepresentatives.Tests.ps1
@@ -28,19 +28,17 @@ Describe 'Null Representatives' -Tags 'CI' {
     }
 
     Context 'Comparisons with other null representatives' {
-        BeforeAll {
-            $TestValues = @(
-                @{ LHS = { [AutomationNull]::Value }; RHS = { [DBNull]::Value } }
-                @{ LHS = { [AutomationNull]::Value }; RHS = { [NullString]::Value } }
-                @{ LHS = { [DBNull]::Value }; RHS = { [NullString]::Value } }
-            )
-        }
+        <#
+            The only unequal null-representatives are NullString and DBNull.
+            AutomationNull and $null are always considered equal already, so therefore NullString compares as
+            true with both of them, as does DBNull.
 
-        It '<LHS> should not be equal to <RHS>' -TestCases $TestValues {
-            param($LHS, $RHS)
-
-            $LHS.InvokeReturnAsIs() -eq $RHS.InvokeReturnAsIs() | Should -BeFalse
-            $RHS.InvokeReturnAsIs() -eq $RHS.InvokeReturnAsIs() | Should -BeFalse
+            However, as NullString and DBNull have different purposes, it makes more sense to consider them unequal
+            when directly compared with each other.
+        #>
+        It 'DBNull should not be equal to NullString' {
+            [DBNull]::Value -eq [NullString]::Value | Should -BeFalse
+            [NullString]::Value -eq [DBNull]::Value | Should -BeFalse
         }
     }
 

--- a/test/powershell/Language/Scripting/NullRepresentatives.Tests.ps1
+++ b/test/powershell/Language/Scripting/NullRepresentatives.Tests.ps1
@@ -58,6 +58,12 @@ Describe 'Null Representatives' -Tags 'CI' {
             [bool]($Value.InvokeReturnAsIs()) | Should -BeFalse
         }
 
+        It '-not <Value> should be $true' -TestCases $TestValues {
+            param($Value)
+
+            -not $Value.InvokeReturnAsIs() | Should -BeTrue
+        }
+
         It '<Value> should be treated as $false by Where-Object' -TestCases $TestValues {
             param($Value)
 

--- a/test/powershell/Language/Scripting/NullRepresentatives.Tests.ps1
+++ b/test/powershell/Language/Scripting/NullRepresentatives.Tests.ps1
@@ -1,0 +1,46 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+using namespace System.Management.Automation.Internal
+
+Describe 'Null Representatives' -Tags 'CI' {
+
+    Context 'Comparisons with $null' {
+        BeforeAll {
+            $TestValues = @(
+                @{ Value = { [AutomationNull]::Value } }
+                @{ Value = { [DBNull]::Value } }
+                @{ Value = { [NullString]::Value } }
+            )
+        }
+
+        It '<Value> should be equivalent to $null (RHS: $null)' -TestCases $TestValues {
+            param($Value)
+
+            $Value.InvokeReturnAsIs() -eq $null | Should -BeTrue
+        }
+
+        It '$null should be equivalent to <Value> (LHS: $null)' -TestCases $TestValues {
+            param($Value)
+
+            $null -eq $Value.InvokeReturnAsIs() | Should -BeTrue
+        }
+    }
+
+    Context 'Comparisons with other null representatives' {
+        BeforeAll {
+            $TestValues = @(
+                @{ LHS = { [AutomationNull]::Value }; RHS = { [DBNull]::Value } }
+                @{ LHS = { [AutomationNull]::Value }; RHS = { [NullString]::Value } }
+                @{ LHS = { [DBNull]::Value }; RHS = { [NullString]::Value } }
+            )
+        }
+
+        It '<LHS> should not be equal to <RHS>' -TestCases $TestValues {
+            param($LHS, $RHS)
+
+            $LHS.InvokeReturnAsIs() -eq $RHS.InvokeReturnAsIs() | Should -BeFalse
+            $RHS.InvokeReturnAsIs() -eq $RHS.InvokeReturnAsIs() | Should -BeFalse
+        }
+    }
+}

--- a/test/powershell/Language/Scripting/NullRepresentatives.Tests.ps1
+++ b/test/powershell/Language/Scripting/NullRepresentatives.Tests.ps1
@@ -48,7 +48,7 @@ Describe 'Null Representatives' -Tags 'CI' {
                 @{ Value = $null }
                 @{ Value = [DBNull]::Value }
                 @{ Value = [NullString]::Value }
-                @{ Value = [System.Management.Automation.AutomationNull]::Value }
+                @{ Value = [AutomationNull]::Value }
             )
         }
 

--- a/test/powershell/Language/Scripting/NullRepresentatives.Tests.ps1
+++ b/test/powershell/Language/Scripting/NullRepresentatives.Tests.ps1
@@ -64,4 +64,20 @@ Describe 'Null Representatives' -Tags 'CI' {
             100 | Where-Object { $Value.InvokeReturnAsIs() } | Should -BeNullOrEmpty
         }
     }
+
+    Context 'Collection Comparisons' {
+        BeforeAll {
+            $NullArray = $null, $null, [DBNull]::Value, $null, $null, [NullString]::Value
+        }
+
+        It '<Value> should correctly filter the array and return <ExpectedCount> results' {
+            param($Value, $ExpectedCount)
+
+            $NullArray -eq $Value | Should -HaveCount $ExpectedCount
+        } -TestCases @(
+            @{ Value = $null; ExpectedCount = 6 }
+            @{ Value = [DBNull]::Value; ExpectedCount = 5 }
+            @{ Value = [NullString]::Value; ExpectedCount = 5 }
+        )
+    }
 }

--- a/test/powershell/Language/Scripting/NullRepresentatives.Tests.ps1
+++ b/test/powershell/Language/Scripting/NullRepresentatives.Tests.ps1
@@ -45,23 +45,23 @@ Describe 'Null Representatives' -Tags 'CI' {
     Context 'Casting Behaviour' {
         BeforeAll {
             $TestValues = @(
-                @{ Value = $null }
-                @{ Value = [DBNull]::Value }
-                @{ Value = [NullString]::Value }
-                @{ Value = [AutomationNull]::Value }
+                @{ Value = { $null } }
+                @{ Value = { [DBNull]::Value } }
+                @{ Value = { [NullString]::Value } }
+                @{ Value = { [AutomationNull]::Value } }
             )
         }
 
         It '<Value> should cast to $false' -TestCases $TestValues {
             param($Value)
 
-            [bool]$Value | Should -BeFalse
+            [bool]($Value.InvokeReturnAsIs()) | Should -BeFalse
         }
 
         It '<Value> should be treated as $false by Where-Object' -TestCases $TestValues {
             param($Value)
 
-            100 | Where-Object { $Value } | Should -BeNullOrEmpty
+            100 | Where-Object { $Value.InvokeReturnAsIs() } | Should -BeNullOrEmpty
         }
     }
 }

--- a/test/powershell/Language/Scripting/NullRepresentatives.Tests.ps1
+++ b/test/powershell/Language/Scripting/NullRepresentatives.Tests.ps1
@@ -43,4 +43,27 @@ Describe 'Null Representatives' -Tags 'CI' {
             $RHS.InvokeReturnAsIs() -eq $RHS.InvokeReturnAsIs() | Should -BeFalse
         }
     }
+
+    Context 'Casting Behaviour' {
+        BeforeAll {
+            $TestValues = @(
+                @{ Value = $null }
+                @{ Value = [DBNull]::Value }
+                @{ Value = [NullString]::Value }
+                @{ Value = [System.Management.Automation.AutomationNull]::Value }
+            )
+        }
+
+        It '<Value> should cast to $false' -TestCases $TestValues {
+            param($Value)
+
+            [bool]$Value | Should -BeFalse
+        }
+
+        It '<Value> should be treated as $false by Where-Object' -TestCases $TestValues {
+            param($Value)
+
+            100 | Where-Object { $Value } | Should -BeNullOrEmpty
+        }
+    }
 }

--- a/test/powershell/engine/Basic/SemanticVersion.Tests.ps1
+++ b/test/powershell/engine/Basic/SemanticVersion.Tests.ps1
@@ -109,8 +109,8 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
                 @{ lhs = $v1_0_0_alpha; rhs = $v1_0_0_alpha2 }
                 @{ lhs = $v1_0_0_alpha; rhs = $v1_0_0 }
                 @{ lhs = $v1_0_0_beta; rhs = $v1_0_0 }
-                @{ lhs = $v2_1_0; rhs = "3.0"}
-                @{ lhs = "1.5"; rhs = $v2_1_0}
+                @{ lhs = $v2_1_0; rhs = "3.0" }
+                @{ lhs = "1.5"; rhs = $v2_1_0 }
             )
         }
 
@@ -176,38 +176,39 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
     Context "Error handling" {
 
         It "<name>: '<version>'" -TestCases @(
-            @{ name = "Missing parts: 'null'";       errorId = "PSArgumentNullException";expectedResult = $false; version = $null  }
-            @{ name = "Missing parts: 'NullString'"; errorId = "PSArgumentNullException";expectedResult = $false; version = [NullString]::Value }
-            @{ name = "Missing parts: 'EmptyString'";errorId = "FormatException";    expectedResult = $false; version = "" }
-            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "-" }
-            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "." }
-            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "+" }
-            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "-alpha" }
-            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1..0" }
-            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1.0.-alpha" }
-            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1.0.+alpha" }
-            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1.0.0-alpha+" }
-            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1.0.0-+" }
-            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1.0.0+-" }
-            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1.0.0+" }
-            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1.0.0-" }
-            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1.0.0." }
-            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1.0." }
-            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1.0.." }
-            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = ".0.0" }
-            @{ name = "Range check of versions";     errorId = "FormatException";    expectedResult = $false; version = "-1.0.0"  }
-            @{ name = "Range check of versions";     errorId = "FormatException";    expectedResult = $false; version = "1.-1.0"  }
-            @{ name = "Range check of versions";     errorId = "FormatException";    expectedResult = $false; version = "1.0.-1"  }
-            @{ name = "Format errors";               errorId = "FormatException";    expectedResult = $false; version = "aa.0.0"  }
-            @{ name = "Format errors";               errorId = "FormatException";    expectedResult = $false; version = "1.bb.0"  }
-            @{ name = "Format errors";               errorId = "FormatException";    expectedResult = $false; version = "1.0.cc"  }
+            @{ name = "Missing parts: 'null'"; errorId = "PSArgumentNullException"; expectedResult = $false; version = $null }
+            @{ name = "Missing parts: 'NullString'"; errorId = "PSArgumentNullException"; expectedResult = $false; version = [NullString]::Value }
+            @{ name = "Missing parts: 'EmptyString'"; errorId = "FormatException"; expectedResult = $false; version = "" }
+            @{ name = "Missing parts"; errorId = "FormatException"; expectedResult = $false; version = "-" }
+            @{ name = "Missing parts"; errorId = "FormatException"; expectedResult = $false; version = "." }
+            @{ name = "Missing parts"; errorId = "FormatException"; expectedResult = $false; version = "+" }
+            @{ name = "Missing parts"; errorId = "FormatException"; expectedResult = $false; version = "-alpha" }
+            @{ name = "Missing parts"; errorId = "FormatException"; expectedResult = $false; version = "1..0" }
+            @{ name = "Missing parts"; errorId = "FormatException"; expectedResult = $false; version = "1.0.-alpha" }
+            @{ name = "Missing parts"; errorId = "FormatException"; expectedResult = $false; version = "1.0.+alpha" }
+            @{ name = "Missing parts"; errorId = "FormatException"; expectedResult = $false; version = "1.0.0-alpha+" }
+            @{ name = "Missing parts"; errorId = "FormatException"; expectedResult = $false; version = "1.0.0-+" }
+            @{ name = "Missing parts"; errorId = "FormatException"; expectedResult = $false; version = "1.0.0+-" }
+            @{ name = "Missing parts"; errorId = "FormatException"; expectedResult = $false; version = "1.0.0+" }
+            @{ name = "Missing parts"; errorId = "FormatException"; expectedResult = $false; version = "1.0.0-" }
+            @{ name = "Missing parts"; errorId = "FormatException"; expectedResult = $false; version = "1.0.0." }
+            @{ name = "Missing parts"; errorId = "FormatException"; expectedResult = $false; version = "1.0." }
+            @{ name = "Missing parts"; errorId = "FormatException"; expectedResult = $false; version = "1.0.." }
+            @{ name = "Missing parts"; errorId = "FormatException"; expectedResult = $false; version = ".0.0" }
+            @{ name = "Range check of versions"; errorId = "FormatException"; expectedResult = $false; version = "-1.0.0" }
+            @{ name = "Range check of versions"; errorId = "FormatException"; expectedResult = $false; version = "1.-1.0" }
+            @{ name = "Range check of versions"; errorId = "FormatException"; expectedResult = $false; version = "1.0.-1" }
+            @{ name = "Format errors"; errorId = "FormatException"; expectedResult = $false; version = "aa.0.0" }
+            @{ name = "Format errors"; errorId = "FormatException"; expectedResult = $false; version = "1.bb.0" }
+            @{ name = "Format errors"; errorId = "FormatException"; expectedResult = $false; version = "1.0.cc" }
         ) {
             param($version, $expectedResult, $errorId)
             { [SemanticVersion]::new($version) } | Should -Throw -ErrorId $errorId
-            if ($version -eq $null) {
+            if ([LanguagePrimitives]::IsNull($version)) {
                 # PowerShell convert $null to Empty string
                 { [SemanticVersion]::Parse($version) } | Should -Throw -ErrorId "FormatException"
-            } else {
+            }
+            else {
                 { [SemanticVersion]::Parse($version) } | Should -Throw -ErrorId $errorId
             }
             $semVer = $null


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Closes #9561 

- Adds `LanguagePrimitives.IsNullLike()` method to account for `DBNull.Value` and `NullString.Value` so that they can be considered the same as a null value where sensible in PowerShell.
- Updates `-ne` and `-eq` binders to treat `DBNull.Value` and `NullString.Value` as equal to null/AutomationNull.
- Update code paths for comparing objects in LanguagePrimitives to ensure consistency with how the `-eq` and `-ne` binders work when calling LanguagePrimitives methods to do the comparisons.
- Make `LanguagePrimitives.IsNull()` and `LanguagePrimitives.IsNullLike()` public methods.
- Added tests for null behaviours in `NullRepresentatives.Tests.ps1`

## PR Context

DBNull.Value and NullString.Value are generally considered to be equivalent to null, and it makes the most sense to have PowerShell recognise them as such instead of treating them as strange class objects. See linked issue for more details.

/cc @daxian-dbw 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
