### PR TITLE
WIP: Make module intrinsics code thread safe by using a ConcurrentBag instead of a Collection to prevent errors that surface in PSSA

### DIFF
--- a/src/System.Management.Automation/cimSupport/cmdletization/ScriptWriter.cs
+++ b/src/System.Management.Automation/cimSupport/cmdletization/ScriptWriter.cs
@@ -20,6 +20,7 @@ using System.Management.Automation;
 using System.Management.Automation.Language;
 using Microsoft.PowerShell.Commands;
 using Dbg = System.Management.Automation.Diagnostics;
+using System.Collections.Concurrent;
 
 namespace Microsoft.PowerShell.Cmdletization
 {
@@ -2194,8 +2195,8 @@ Microsoft.PowerShell.Core\Export-ModuleMember -Function '{1}' -Alias '*'
                 return;
             }
 
-            moduleInfo.DeclaredAliasExports = new Collection<string>();
-            moduleInfo.DeclaredFunctionExports = new Collection<string>();
+            moduleInfo.DeclaredAliasExports = new ConcurrentBag<string>();
+            moduleInfo.DeclaredFunctionExports = new ConcurrentBag<string>();
 
             IEnumerable<CommonCmdletMetadata> cmdletMetadatas = Enumerable.Empty<CommonCmdletMetadata>();
             if (_cmdletizationMetadata.Class.InstanceCmdlets != null)

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
@@ -2680,7 +2681,7 @@ namespace Microsoft.PowerShell.Commands
 
                 if (exportedFunctions != null)
                 {
-                    manifestInfo.DeclaredFunctionExports = new Collection<string>();
+                    manifestInfo.DeclaredFunctionExports = new ConcurrentBag<string>();
 
                     if (exportedFunctions.Count > 0)
                     {
@@ -2708,7 +2709,7 @@ namespace Microsoft.PowerShell.Commands
 
                 if (exportedCmdlets != null)
                 {
-                    manifestInfo.DeclaredCmdletExports = new Collection<string>();
+                    manifestInfo.DeclaredCmdletExports = new ConcurrentBag<string>();
 
                     if (exportedCmdlets.Count > 0)
                     {
@@ -2736,7 +2737,7 @@ namespace Microsoft.PowerShell.Commands
 
                 if (exportedAliases != null)
                 {
-                    manifestInfo.DeclaredAliasExports = new Collection<string>();
+                    manifestInfo.DeclaredAliasExports = new ConcurrentBag<string>();
 
                     if (exportedAliases.Count > 0)
                     {
@@ -2764,7 +2765,7 @@ namespace Microsoft.PowerShell.Commands
 
                 if (exportedVariables != null)
                 {
-                    manifestInfo.DeclaredVariableExports = new Collection<string>();
+                    manifestInfo.DeclaredVariableExports = new ConcurrentBag<string>();
 
                     if (exportedVariables.Count > 0)
                     {
@@ -3500,7 +3501,10 @@ namespace Microsoft.PowerShell.Commands
                             }
 
                             ss.Internal.ExportedVariables.Clear();
-                            ss.Internal.ExportedVariables.AddRange(updated);
+                            foreach(var psVariable in updated)
+                            {
+                                ss.Internal.ExportedVariables.Add(psVariable);
+                            }
                         }
                     }
                 }
@@ -3618,7 +3622,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        private static void UpdateCommandCollection<T>(List<T> list, List<WildcardPattern> patterns) where T : CommandInfo
+        private static void UpdateCommandCollection<T>(ConcurrentBag<T> list, List<WildcardPattern> patterns) where T : CommandInfo
         {
             List<T> updated = new List<T>();
             foreach (T element in list)
@@ -3630,10 +3634,13 @@ namespace Microsoft.PowerShell.Commands
             }
 
             list.Clear();
-            list.AddRange(updated);
+            foreach (T updatedElement in updated)
+            {
+                list.Add(updatedElement);
+            }
         }
 
-        private static void UpdateCommandCollection(Collection<string> list, List<WildcardPattern> patterns)
+        private static void UpdateCommandCollection(ConcurrentBag<string> list, List<WildcardPattern> patterns)
         {
             if (list == null)
             {

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -3501,7 +3501,7 @@ namespace Microsoft.PowerShell.Commands
                             }
 
                             ss.Internal.ExportedVariables.Clear();
-                            foreach(var psVariable in updated)
+                            foreach (var psVariable in updated)
                             {
                                 ss.Internal.ExportedVariables.Add(psVariable);
                             }

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -1540,7 +1540,7 @@ namespace System.Management.Automation
             inputList.Clear();
             inputList.AddRange(output);
             input.Clear();
-            foreach(T inputItem in inputList)
+            foreach (T inputItem in inputList)
             {
                 input.Add(inputItem);
             }

--- a/src/System.Management.Automation/engine/Modules/PSModuleInfo.cs
+++ b/src/System.Management.Automation/engine/Modules/PSModuleInfo.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
@@ -520,10 +521,10 @@ namespace System.Management.Automation
             internal set;
         }
 
-        internal Collection<string> DeclaredFunctionExports = null;
-        internal Collection<string> DeclaredCmdletExports = null;
-        internal Collection<string> DeclaredAliasExports = null;
-        internal Collection<string> DeclaredVariableExports = null;
+        internal ConcurrentBag<string> DeclaredFunctionExports = null;
+        internal ConcurrentBag<string> DeclaredCmdletExports = null;
+        internal ConcurrentBag<string> DeclaredAliasExports = null;
+        internal ConcurrentBag<string> DeclaredVariableExports = null;
 
         internal List<string> DetectedFunctionExports = new List<string>();
         internal List<string> DetectedCmdletExports = new List<string>();
@@ -806,7 +807,7 @@ namespace System.Management.Automation
         /// some cmdlets come from the module and others come from the nested
         /// module. We need to consolidate the list so it can properly be constrained.
         /// </summary>
-        internal List<CmdletInfo> CompiledExports
+        internal ConcurrentBag<CmdletInfo> CompiledExports
         {
             get
             {
@@ -828,7 +829,7 @@ namespace System.Management.Automation
             }
         }
 
-        private readonly List<CmdletInfo> _compiledExports = new List<CmdletInfo>();
+        private readonly ConcurrentBag<CmdletInfo> _compiledExports = new ConcurrentBag<CmdletInfo>();
 
         /// <summary>
         /// Add AliasInfo to the fixed exports list...

--- a/src/System.Management.Automation/engine/Modules/PSModuleInfo.cs
+++ b/src/System.Management.Automation/engine/Modules/PSModuleInfo.cs
@@ -521,10 +521,10 @@ namespace System.Management.Automation
             internal set;
         }
 
-        internal ConcurrentBag<string> DeclaredFunctionExports = null;
-        internal ConcurrentBag<string> DeclaredCmdletExports = null;
-        internal ConcurrentBag<string> DeclaredAliasExports = null;
-        internal ConcurrentBag<string> DeclaredVariableExports = null;
+        internal ConcurrentBag<string> DeclaredFunctionExports;
+        internal ConcurrentBag<string> DeclaredCmdletExports;
+        internal ConcurrentBag<string> DeclaredAliasExports;
+        internal ConcurrentBag<string> DeclaredVariableExports;
 
         internal List<string> DetectedFunctionExports = new List<string>();
         internal List<string> DetectedCmdletExports = new List<string>();

--- a/src/System.Management.Automation/engine/Modules/RemoteDiscoveryHelper.cs
+++ b/src/System.Management.Automation/engine/Modules/RemoteDiscoveryHelper.cs
@@ -29,14 +29,14 @@ namespace System.Management.Automation
     {
         #region PSRP
 
-        private static Collection<string> RehydrateHashtableKeys(PSObject pso, string propertyName)
+        private static ConcurrentBag<string> RehydrateHashtableKeys(PSObject pso, string propertyName)
         {
             var rehydrationFlags = DeserializingTypeConverter.RehydrationFlags.NullValueOk |
                                    DeserializingTypeConverter.RehydrationFlags.MissingPropertyOk;
             Hashtable hashtable = DeserializingTypeConverter.GetPropertyValue<Hashtable>(pso, propertyName, rehydrationFlags);
             if (hashtable == null)
             {
-                return new Collection<string>();
+                return new ConcurrentBag<string>();
             }
             else
             {
@@ -47,7 +47,7 @@ namespace System.Management.Automation
                     .Select(k => k.ToString())
                     .Where(s => s != null)
                     .ToList();
-                return new Collection<string>(list);
+                return new ConcurrentBag<string>(list);
             }
         }
 

--- a/src/System.Management.Automation/engine/SessionStateAliasAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateAliasAPIs.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Management.Automation.Runspaces;
 
@@ -110,7 +111,7 @@ namespace System.Management.Automation
         /// <summary>
         /// List of aliases to export from this session state object...
         /// </summary>
-        internal List<AliasInfo> ExportedAliases { get; } = new List<AliasInfo>();
+        internal ConcurrentBag<AliasInfo> ExportedAliases { get; } = new ConcurrentBag<AliasInfo>();
 
         /// <summary>
         /// Gets the value of the specified alias from the alias table.

--- a/src/System.Management.Automation/engine/SessionStateFunctionAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateFunctionAPIs.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Management.Automation.Language;
 using System.Management.Automation.Runspaces;
@@ -102,7 +103,7 @@ namespace System.Management.Automation
         /// <summary>
         /// List of functions/filters to export from this session state object...
         /// </summary>
-        internal List<FunctionInfo> ExportedFunctions { get; } = new List<FunctionInfo>();
+        internal ConcurrentBag<FunctionInfo> ExportedFunctions { get; } = new ConcurrentBag<FunctionInfo>();
 
         internal bool UseExportList { get; set; } = false;
 

--- a/src/System.Management.Automation/engine/SessionStateVariableAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateVariableAPIs.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Management.Automation.Internal;
@@ -1871,7 +1872,7 @@ namespace System.Management.Automation
         /// <summary>
         /// List of variables to export from this session state object...
         /// </summary>
-        internal List<PSVariable> ExportedVariables { get; } = new List<PSVariable>();
+        internal ConcurrentBag<PSVariable> ExportedVariables { get; } = new ConcurrentBag<PSVariable>();
 
         #endregion variables
     }


### PR DESCRIPTION
# PR Summary

This avoids errors being thrown when `PSScriptAnalyzer` executes concurrent `Test-ModuleManifest` calls
The issues were reported in the following issues and the stack traces all pointed to PowerShell's code

- https://github.com/PowerShell/PSScriptAnalyzer/issues/901
- https://github.com/PowerShell/PSScriptAnalyzer/issues/900
- https://github.com/PowerShell/PSScriptAnalyzer/issues/902

The bug is very hard to repro, the best example was [this](https://github.com/PowerShell/PSScriptAnalyzer/issues/902#issuecomment-470757602) one and one needs a fast machine as I found that once I attached the debugger to PowerShell it was not happening any more on my dev machine so I had to spin up a 16 core Azure development VM to repro whilst still having the debugger attached...
I verified that this fix makes the concurrency errors not surface any more. The errors were surfacing in all recent version of PowerShell (5.1, 6.2, 7.0-preview1) and PSScriptAnalyzer (1.18.0, 1.17.1, 1.16.1). This PR will resolve the issue going forwards. To make PSScriptAnalyzer cope with it better when version older than PS v7 are used, PSScriptAnalyzer will probably use some retry logic as proposed in [this](https://github.com/PowerShell/PSScriptAnalyzer/pull/1257) PR.
cc @JamesWTruher  @Jaykul @LaurentDardenne 

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
