### PR TITLE
Make UseAbbreviationExpansion and TempDrive non-experimental features

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -173,12 +173,8 @@ namespace System.Management.Automation
                     powershell
                         .AddCommandWithPreferenceSetting("Get-Command", typeof(GetCommandCommand))
                         .AddParameter("All")
-                        .AddParameter("Name", commandName);
-
-                    if (ExperimentalFeature.IsEnabled("PSUseAbbreviationExpansion"))
-                    {
-                        powershell.AddParameter("UseAbbreviationExpansion");
-                    }
+                        .AddParameter("Name", commandName)
+                        .AddParameter("UseAbbreviationExpansion");
 
                     if (moduleName != null)
                     {

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -106,12 +106,6 @@ namespace System.Management.Automation
                     name: "PSImplicitRemotingBatching",
                     description: "Batch implicit remoting proxy commands to improve performance"),
                 new ExperimentalFeature(
-                    name: "PSUseAbbreviationExpansion",
-                    description: "Allow tab completion of cmdlets and functions by abbreviation"),
-                new ExperimentalFeature(
-                    name: "PSTempDrive",
-                    description: "Create TEMP: PS Drive mapped to user's temporary directory path"),
-                new ExperimentalFeature(
                     name: "PSCommandNotFoundSuggestion",
                     description: "Recommend potential commands based on fuzzy search on a CommandNotFoundException"),
             };

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -364,7 +364,6 @@ namespace Microsoft.PowerShell.Commands
         /// This means it matches cmdlets where the uppercase characters for the noun match
         /// the given characters.  i.e., g-sgc would match Get-SomeGreatCmdlet.
         /// </summary>
-        [Experimental("PSUseAbbreviationExpansion", ExperimentAction.Show)]
         [Parameter(ValueFromPipelineByPropertyName = true, ParameterSetName = "AllCommandSet")]
         public SwitchParameter UseAbbreviationExpansion { get; set; }
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1088,18 +1088,15 @@ namespace Microsoft.PowerShell.Commands
                 }
             }
 
-            if (ExperimentalFeature.IsEnabled("PSTempDrive"))
-            {
-                PSDriveInfo newPSDriveInfo =
-                    new PSDriveInfo(
-                        DriveNames.TempDrive,
-                        ProviderInfo,
-                        Path.GetTempPath(),
-                        SessionStateStrings.TempDriveDescription,
-                        credential: null,
-                        displayRoot: null);
-                results.Add(newPSDriveInfo);
-            }
+            results.Add(
+                new PSDriveInfo(
+                    DriveNames.TempDrive,
+                    ProviderInfo,
+                    Path.GetTempPath(),
+                    SessionStateStrings.TempDriveDescription,
+                    credential: null,
+                    displayRoot: null)
+            );
 
             return results;
         }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -10,33 +10,16 @@ Describe "TabCompletion" -Tags CI {
         $res.CompletionMatches[0].CompletionText | Should -BeExactly 'Get-Command'
     }
 
-    Context "ExperimentalFeatures" {
+    It 'Should complete abbreviated cmdlet' {
+        $res = (TabExpansion2 -inputScript 'i-psdf' -cursorColumn 'pschr'.Length).CompletionMatches.CompletionText
+        $res | Should -HaveCount 1
+        $res | Should -BeExactly 'Import-PowerShellDataFile'
+    }
 
-        BeforeAll {
-            $configFilePath = Join-Path $testdrive "useabbreviationexpansion.json"
-
-            @"
-            {
-                "ExperimentalFeatures": [
-                  "PSUseAbbreviationExpansion"
-                ]
-            }
-"@ > $configFilePath
-
-        }
-
-        It 'Should complete abbreviated cmdlet' {
-            $res = pwsh -noprofile -settingsfile $configFilePath -c "(TabExpansion2 -inputScript 'i-psdf' -cursorColumn 'pschr'.Length).CompletionMatches.CompletionText"
-            $res | Should -HaveCount 1
-            $res | Should -BeExactly 'Import-PowerShellDataFile'
-        }
-
-        It 'Should complete abbreviated function' {
-            $res = pwsh -noprofile -settingsfile $configFilePath -c "(TabExpansion2 -inputScript 'pschrl' -cursorColumn 'pschr'.Length).CompletionMatches.CompletionText"
-            $res.Count | Should -BeGreaterOrEqual 1
-            $res | Should -BeExactly 'PSConsoleHostReadLine'
-        }
-
+    It 'Should complete abbreviated function' {
+        $res = (TabExpansion2 -inputScript 'pschrl' -cursorColumn 'pschr'.Length).CompletionMatches.CompletionText
+        $res.Count | Should -BeGreaterOrEqual 1
+        $res | Should -BeExactly 'PSConsoleHostReadLine'
     }
 
     It 'Should complete native exe' -Skip:(!$IsWindows) {

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -466,7 +466,7 @@ Describe "TabCompletion" -Tags CI {
                 @{ inputStr = '$host.UI.WriteD'; expected = 'WriteDebugLine('; setup = $null }
                 @{ inputStr = '$MaximumHistoryCount.'; expected = 'CompareTo('; setup = $null }
                 @{ inputStr = '$A=[datetime]::now;$A.'; expected = 'Date'; setup = $null }
-                @{ inputStr = 'try { 1/0 } catch {};$error[0].'; expected = 'CategoryInfo'; setup = $null }
+                @{ inputStr = '$e=$null;try { 1/0 } catch {$e=$_};$e.'; expected = 'CategoryInfo'; setup = $null }
                 @{ inputStr = '$x= gps pwsh;$x.*pm'; expected = 'NPM'; setup = $null }
                 @{ inputStr = 'function Get-ScrumData {}; Get-Scrum'; expected = 'Get-ScrumData'; setup = $null }
                 @{ inputStr = 'function write-output {param($abcd) $abcd};Write-Output -a'; expected = '-abcd'; setup = $null }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-PSDrive.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-PSDrive.Tests.ps1
@@ -58,26 +58,10 @@ Describe "Get-PSDrive" -Tags "CI" {
     }
 }
 
-Describe "Experimental Feature Temp: drive" -Tag Feature {
-    BeforeAll {
-        $configFilePath = Join-Path $testdrive "experimentalfeature.json"
-
-        @"
-        {
-            "ExperimentalFeatures": [
-              "PSTempDrive"
-            ]
-        }
-"@ > $configFilePath
-    }
-
-    It "TEMP: drive exists if experimental feature is enabled" {
-        $res = pwsh -outputformat xml -settingsfile $configFilePath -command "Get-PSDrive Temp"
+Describe "Temp: drive" -Tag Feature {
+    It "TEMP: drive exists" {
+        $res = Get-PSDrive Temp
         $res.Name | Should -BeExactly "Temp"
         $res.Root | Should -BeExactly ([System.IO.Path]::GetTempPath())
-    }
-
-    It "TEMP: drive does not exist if experimental feature is not enabled" {
-        { Get-PSDrive Temp -ErrorAction Stop } | Should -Throw -ErrorId "GetLocationNoMatchingDrive,Microsoft.PowerShell.Commands.GetPSDriveCommand"
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

As discussed in @PowerShell/powershell-committee, we are taking the Abbreviation Expansion and TempDrive experimental features out of experimental status.

Removed all the experimental feature wrappers.  Also updated an unrelated tab-completion test for ErrorRecord to be more reliable.  It seems that sometimes an error shows up in $error that is not what the test expects.  So fix is to check against the specific exception we expect rather than the top of the $error stack as that might change between the test and using $error[0].

Some manual perf tests using `Get-Command` and `TabExpansion2` indicates that abbreviation expansion doesn't add any noticeable perf difference.  Most of the time seems to be enumerating the commands available.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/4216

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [X] [Documentation needed] https://github.com/MicrosoftDocs/PowerShell-Docs/pull/4422(https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
