### PR TITLE
Use the original precision (prior-dotnet-core-3) for double/fload-to-string conversion

### DIFF
--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -305,6 +305,8 @@ namespace System.Management.Automation
         internal delegate void MemberSetValueError(SetValueException e);
 
         internal const string OrderedAttribute = "ordered";
+        internal const string DoublePrecision = "G15";
+        internal const string SinglePrecision = "G7";
 
         internal static void CreateMemberNotFoundError(PSObject pso, DictionaryEntry property, Type resultType)
         {
@@ -3311,6 +3313,17 @@ namespace System.Management.Automation
             try
             {
                 // Ignore formatProvider here, the conversion should be culture invariant.
+                var numberFormat = CultureInfo.InvariantCulture.NumberFormat;
+                if (valueToConvert is double dbl)
+                {
+                    return dbl.ToString(DoublePrecision, numberFormat);
+                }
+
+                if (valueToConvert is float sgl)
+                {
+                    return sgl.ToString(SinglePrecision, numberFormat);
+                }
+
                 return (string)Convert.ChangeType(valueToConvert, resultType, CultureInfo.InvariantCulture.NumberFormat);
             }
             catch (Exception e)

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -1269,15 +1269,12 @@ namespace System.Management.Automation
         /// </exception>
         internal static string ToString(ExecutionContext context, object obj, string separator, string format, IFormatProvider formatProvider, bool recurse, bool unravelEnumeratorOnRecurse)
         {
-            bool TryFastTrackPrimitiveTypes(object obj, out string str)
+            bool TryFastTrackPrimitiveTypes(object value, out string str)
             {
-                Type valueType = obj.GetType();
-                TypeCode code = valueType.GetTypeCode();
-
-                switch (code)
+                switch (Convert.GetTypeCode(value))
                 {
                     case TypeCode.String:
-                        str = (string)obj;
+                        str = (string)value;
                         break;
                     case TypeCode.Byte:
                     case TypeCode.SByte:
@@ -1287,23 +1284,18 @@ namespace System.Management.Automation
                     case TypeCode.UInt32:
                     case TypeCode.Int64:
                     case TypeCode.UInt64:
-                        str = obj.ToString();
-                        break;
                     case TypeCode.DateTime:
-                        DateTime dt = (DateTime)obj;
-                        str = dt.ToString(formatProvider);
-                        break;
                     case TypeCode.Decimal:
-                        Decimal dec = (Decimal)obj;
-                        str = dec.ToString(formatProvider);
+                        var formattable = (IFormattable)value;
+                        str = formattable.ToString(format, formatProvider);
                         break;
                     case TypeCode.Double:
-                        double dbl = (double)obj;
-                        str = dbl.ToString(LanguagePrimitives.DoublePrecision, formatProvider);
+                        var dbl = (double)value;
+                        str = dbl.ToString(format ?? LanguagePrimitives.DoublePrecision, formatProvider);
                         break;
                     case TypeCode.Single:
-                        float sgl = (float)obj;
-                        str = sgl.ToString(LanguagePrimitives.SinglePrecision, formatProvider);
+                        var sgl = (float)value;
+                        str = sgl.ToString(format ?? LanguagePrimitives.SinglePrecision, formatProvider);
                         break;
                     default:
                         str = null;

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -1271,9 +1271,6 @@ namespace System.Management.Automation
         {
             bool TryFastTrackPrimitiveTypes(object obj, out string str)
             {
-                str = null;
-                bool success = true;
-
                 Type valueType = obj.GetType();
                 TypeCode code = valueType.GetTypeCode();
 
@@ -1309,11 +1306,11 @@ namespace System.Management.Automation
                         str = sgl.ToString(LanguagePrimitives.SinglePrecision, formatProvider);
                         break;
                     default:
-                        success = false;
-                        break;
+                        str = null;
+                        return false;
                 }
 
-                return success;
+                return true;
             }
 
             PSObject mshObj = obj as PSObject;
@@ -1326,7 +1323,6 @@ namespace System.Management.Automation
                     return string.Empty;
                 }
 
-                // Fast-track the primitive types...
                 if (TryFastTrackPrimitiveTypes(obj, out string objString))
                 {
                     return objString;
@@ -1505,7 +1501,6 @@ namespace System.Management.Automation
             // we try the BaseObject's ToString
             object baseObject = mshObj._immediateBaseObject;
 
-            // Fast-track the primitive types...
             if (TryFastTrackPrimitiveTypes(baseObject, out string baseObjString))
             {
                 return baseObjString;

--- a/test/powershell/Language/Interop/DotNet/DotNetAPI.Tests.ps1
+++ b/test/powershell/Language/Interop/DotNet/DotNetAPI.Tests.ps1
@@ -6,8 +6,8 @@ Describe "DotNetAPI" -Tags "CI" {
     $posh_pi = 3.14159265358979
 
     It "Should be able to use static .NET classes and get a constant" {
-	[System.Math]::E  | Should -Match $posh_E.ToString()
-	[System.Math]::PI | Should -Match $posh_pi.ToString()
+	[System.Math]::E  | Should -Match $posh_E.ToString("G15")
+	[System.Math]::PI | Should -Match $posh_pi.ToString("G15")
     }
 
     It "Should be able to invoke a method" {

--- a/test/powershell/Language/Interop/DotNet/DotNetAPI.Tests.ps1
+++ b/test/powershell/Language/Interop/DotNet/DotNetAPI.Tests.ps1
@@ -2,28 +2,26 @@
 # Licensed under the MIT License.
 
 Describe "DotNetAPI" -Tags "CI" {
-    $posh_E  = 2.718281828459045
-    $posh_pi = 3.14159265358979
 
     It "Should be able to use static .NET classes and get a constant" {
-	[System.Math]::E  | Should -Match $posh_E.ToString("G15")
-	[System.Math]::PI | Should -Match $posh_pi.ToString("G15")
+        [System.Math]::E  | Should -Be 2.718281828459045
+        [System.Math]::PI | Should -Be 3.141592653589793
     }
 
     It "Should be able to invoke a method" {
-	[System.Environment]::GetEnvironmentVariable("PATH") | Should -Be $env:PATH
+	    [System.Environment]::GetEnvironmentVariable("PATH") | Should -Be $env:PATH
     }
 
     It "Should not require 'system' in front of static classes" {
-	[Environment]::CommandLine | Should -Be ([System.Environment]::CommandLine)
+	    [Environment]::CommandLine | Should -Be ([System.Environment]::CommandLine)
 
-	[Math]::E | Should -Be ([System.Math]::E)
+	    [Math]::E | Should -Be ([System.Math]::E)
     }
 
     It "Should be able to create a new instance of a .Net object" {
-	[System.Guid]$guidVal = [System.Guid]::NewGuid()
+	    [System.Guid]$guidVal = [System.Guid]::NewGuid()
 
-	$guidVal | Should -BeOfType Guid
+	    $guidVal | Should -BeOfType Guid
     }
 
     It "Should access types in System.Console" {

--- a/test/powershell/Language/Interop/DotNet/DotNetAPI.Tests.ps1
+++ b/test/powershell/Language/Interop/DotNet/DotNetAPI.Tests.ps1
@@ -9,19 +9,17 @@ Describe "DotNetAPI" -Tags "CI" {
     }
 
     It "Should be able to invoke a method" {
-	    [System.Environment]::GetEnvironmentVariable("PATH") | Should -Be $env:PATH
+        [System.Environment]::GetEnvironmentVariable("PATH") | Should -Be $env:PATH
     }
 
     It "Should not require 'system' in front of static classes" {
-	    [Environment]::CommandLine | Should -Be ([System.Environment]::CommandLine)
-
-	    [Math]::E | Should -Be ([System.Math]::E)
+        [Environment]::CommandLine | Should -Be ([System.Environment]::CommandLine)
+        [Math]::E | Should -Be ([System.Math]::E)
     }
 
     It "Should be able to create a new instance of a .Net object" {
-	    [System.Guid]$guidVal = [System.Guid]::NewGuid()
-
-	    $guidVal | Should -BeOfType Guid
+        [System.Guid]$guidVal = [System.Guid]::NewGuid()
+        $guidVal | Should -BeOfType Guid
     }
 
     It "Should access types in System.Console" {

--- a/test/powershell/Language/Parser/Conversions.Tests.ps1
+++ b/test/powershell/Language/Parser/Conversions.Tests.ps1
@@ -524,8 +524,12 @@ Describe 'float/double precision when converting to string' -Tags "CI" {
     It "<SourceType>-to-[string] conversion in PowerShell should use the precision specifier <Format>" -TestCases @(
         @{ SourceType = [double]; Format = "G15"; ValueScript = { 1.1 * 3 }; StringConversionResult = "3.3"; ToStringResult = "3.3000000000000003" }
         @{ SourceType = [double]; Format = "G15"; ValueScript = { 1.1 * 6 }; StringConversionResult = "6.6"; ToStringResult = "6.6000000000000005" }
+        @{ SourceType = [double]; Format = "G15"; ValueScript = { [System.Math]::E }; StringConversionResult = [System.Math]::E.ToString("G15"); ToStringResult = [System.Math]::E.ToString() }
+        @{ SourceType = [double]; Format = "G15"; ValueScript = { [System.Math]::PI }; StringConversionResult = [System.Math]::PI.ToString("G15"); ToStringResult = [System.Math]::PI.ToString() }
         @{ SourceType = [float];  Format = "G7";  ValueScript = { [float]$f = 1.1; ($f * 3).ToSingle([cultureinfo]::InvariantCulture) }; StringConversionResult = "3.3"; ToStringResult = "3.3000002" }
         @{ SourceType = [float];  Format = "G7";  ValueScript = { [float]$f = 1.1; ($f * 6).ToSingle([cultureinfo]::InvariantCulture) }; StringConversionResult = "6.6"; ToStringResult = "6.6000004" }
+        @{ SourceType = [float];  Format = "G7";  ValueScript = { [float]::MaxValue }; StringConversionResult = [float]::MaxValue.ToString("G7"); ToStringResult = [float]::MaxValue.ToString() }
+        @{ SourceType = [float];  Format = "G7";  ValueScript = { [float]::MinValue }; StringConversionResult = [float]::MinValue.ToString("G7"); ToStringResult = [float]::MinValue.ToString() }
     ) {
         param($SourceType, $ValueScript, $StringConversionResult, $ToStringResult)
 

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -650,8 +650,8 @@ foo``u{2195}abc
             @{ Script = "-6.5"; ExpectedValue = "-6.5"; ExpectedType = [double] }
             @{ Script = "9.12"; ExpectedValue = "9.12"; ExpectedType = [double] }
             @{ Script = ".01"; ExpectedValue = "0.01"; ExpectedType = [double] }
-            @{ Script = $([single]::MinValue); ExpectedValue = $([float]::MinValue).ToString(); ExpectedType = [double] }
-            @{ Script = $([float]::MaxValue); ExpectedValue = $([float]::MaxValue).ToString(); ExpectedType = [double] }
+            @{ Script = $([single]::MinValue); ExpectedValue = $([float]::MinValue).ToString("G7"); ExpectedType = [double] }
+            @{ Script = $([float]::MaxValue); ExpectedValue = $([float]::MaxValue).ToString("G7"); ExpectedType = [double] }
             #Exponential
             @{ Script = "0e0"; ExpectedValue = "0"; ExpectedType = [double] }
             @{ Script = "0e1"; ExpectedValue = "0"; ExpectedType = [double] }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #9779 

.NET Core changes to return "shortest roundtrippable string" by default for the `ToString()` method of `double` and `float` types. This results in `ToString()` for `double`/`float` values sometimes return a string in 17-digit/9-digit precision format. This PR updated the double/float-to-string conversion in PowerShell to continue using the old precision specifier before the change in .NET Core 3.0.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
