### PR TITLE
Implement Cleanup { } Function Block

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
@@ -2819,15 +2819,16 @@ function Get-PSImplicitRemotingClientSideParameters
 
             $positionalArguments.AddRange($args)
 
-            $clientSideParameters = Get-PSImplicitRemotingClientSideParameters $PSBoundParameters ${8}
+            $clientSideParameters = Get-PSImplicitRemotingClientSideParameters $PSBoundParameters ${9}
 
-            $scriptCmd = {{ & $script:InvokeCommand `
-                            @clientSideParameters `
-                            -HideComputerName `
-                            -Session (Get-PSImplicitRemotingSession -CommandName '{0}') `
-                            -Arg ('{0}', $PSBoundParameters, $positionalArguments) `
-                            -Script {{ param($name, $boundParams, $unboundParams) & $name @boundParams @unboundParams }} `
-                         }}
+            $scriptCmd = {{
+                & $script:InvokeCommand `
+                    @clientSideParameters `
+                    -HideComputerName `
+                    -Session (Get-PSImplicitRemotingSession -CommandName '{0}') `
+                    -Arg ('{0}', $PSBoundParameters, $positionalArguments) `
+                    -Script {{ param($name, $boundParams, $unboundParams) & $name @boundParams @unboundParams }} `
+            }}
 
             $steppablePipeline = $scriptCmd.GetSteppablePipeline($myInvocation.CommandOrigin)
             $steppablePipeline.Begin($myInvocation.ExpectingInput, $ExecutionContext)
@@ -2839,6 +2840,8 @@ function Get-PSImplicitRemotingClientSideParameters
     Process {{ {6} }}
 
     End {{ {7} }}
+
+    Cleanup {{ {8} }}
 
     # .ForwardHelpTargetName {1}
     # .ForwardHelpCategory {5}
@@ -2865,7 +2868,8 @@ function Get-PSImplicitRemotingClientSideParameters
                 /* 5 */ commandMetadata.WrappedCommandType,
                 /* 6 */ ProxyCommand.GetProcess(commandMetadata),
                 /* 7 */ ProxyCommand.GetEnd(commandMetadata),
-                /* 8 */ commandMetadata.WrappedAnyCmdlet);
+                /* 8 */ ProxyCommand.GetCleanup(commandMetadata),
+                /* 9 */ commandMetadata.WrappedAnyCmdlet);
         }
 
         private static void GenerateCommandProxy(TextWriter writer, IEnumerable<CommandMetadata> listOfCommandMetadata)

--- a/src/System.Management.Automation/engine/CommandMetadata.cs
+++ b/src/System.Management.Automation/engine/CommandMetadata.cs
@@ -869,8 +869,11 @@ process
 
 end
 {{{5}}}
+
+cleanup
+{{{6}}}
 <#
-{6}
+{7}
 #>
 ",
                 GetDecl(),
@@ -879,6 +882,7 @@ end
                 GetBeginBlock(),
                 GetProcessBlock(),
                 GetEndBlock(),
+                GetCleanupBlock(),
                 CodeGeneration.EscapeBlockCommentContent(helpComment));
 
             return result;
@@ -1101,6 +1105,17 @@ end
             return @"
     try {
         $steppablePipeline.End()
+    } catch {
+        throw
+    }
+";
+        }
+
+        internal string GetCleanupBlock()
+        {
+            return @"
+    try {
+        $steppablePipeline.Dispose()
     } catch {
         throw
     }

--- a/src/System.Management.Automation/engine/CommandProcessorBase.cs
+++ b/src/System.Management.Automation/engine/CommandProcessorBase.cs
@@ -663,82 +663,13 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Executes the appropriate disposal methods for script commands.
-        /// <see cref="DlrScriptCommandProcessor"/> is itself a command processor, so interpreted functions cannot be
-        /// reliably disposed without also disposing the entire command processor. Instead, it implements its own
-        /// <see cref="DlrScriptCommandProcessor.InvokeCleanupBlock"/> method to perform the same function as its
-        /// compiled counterpart <see cref="PSScriptCmdlet.Dispose"/>, which is a proper IDisposable implementation.
+        /// Virtual method to be overridden by a command processor type that handles script functions, such as
+        /// <see cref="DlrScriptCommandProcessor"/>.
+        /// The base implementation does nothing.
         /// </summary>
-        internal virtual void CleanupScriptCommand()
+        protected virtual void CleanupScriptCommand()
         {
-            var scriptCmdlet = Command as PSScriptCmdlet;
-            var scriptProcessor = this as DlrScriptCommandProcessor;
-
-            if (scriptCmdlet == null && scriptProcessor == null)
-            {
-                return;
-            }
-
-            bool isStopping = ExceptionHandlingOps.SuspendStoppingPipeline(Context);
-            Pipe oldErrorOutputPipe = Context.ShellFunctionErrorOutputPipe;
-            CommandProcessorBase oldCurrentCommandProcessor = Context.CurrentCommandProcessor;
-
-            try
-            {
-                if (this.RedirectShellErrorOutputPipe || Context.ShellFunctionErrorOutputPipe != null)
-                {
-                    Context.ShellFunctionErrorOutputPipe = CommandRuntime.ErrorOutputPipe;
-                }
-
-                Context.CurrentCommandProcessor = this;
-                SetCurrentScopeToExecutionScope();
-
-                using (CommandRuntime.AllowThisCommandToWrite(true))
-                using (ParameterBinderBase.bindingTracer.TraceScope("CALLING Cleanup"))
-                {
-                    if (scriptCmdlet != null)
-                    {
-                        scriptCmdlet.Dispose();
-                    }
-                    else if (scriptProcessor != null)
-                    {
-                        scriptProcessor.InvokeCleanupBlock();
-                    }
-                }
-            }
-            catch (Exception e)
-            {
-                throw ManageInvocationException(e);
-            }
-            finally
-            {
-                OnRestorePreviousScope();
-
-                Context.ShellFunctionErrorOutputPipe = oldErrorOutputPipe;
-                Context.CurrentCommandProcessor = oldCurrentCommandProcessor;
-                ExceptionHandlingOps.RestoreStoppingPipeline(Context, isStopping);
-
-                // Destroy the local scope at this point if there is one...
-                if (_useLocalScope && CommandScope != null)
-                {
-                    CommandSessionState.RemoveScope(CommandScope);
-                }
-
-                // and restore the previous scope...
-                if (_previousScope != null)
-                {
-                    // Restore the scope but use the same session state instance we
-                    // got it from because the command may have changed the execution context
-                    // session state...
-                    CommandSessionState.CurrentScope = _previousScope;
-                }
-
-                // Restore the previous session state
-                if (_previousCommandSessionState != null)
-                {
-                    Context.EngineSessionState = _previousCommandSessionState;
-                }
-            }
+            // Do nothing -- subclasses may use.
         }
 
         /// <summary>
@@ -1031,7 +962,63 @@ namespace System.Management.Automation
                     }
                     finally
                     {
-                        if (Command is IDisposable disposableCommand)
+                        if (Command is PSScriptCmdlet scriptCmdlet)
+                        {
+                            bool isStopping = ExceptionHandlingOps.SuspendStoppingPipeline(Context);
+                            Pipe oldErrorOutputPipe = Context.ShellFunctionErrorOutputPipe;
+                            CommandProcessorBase oldCurrentCommandProcessor = Context.CurrentCommandProcessor;
+
+                            try
+                            {
+                                if (this.RedirectShellErrorOutputPipe || Context.ShellFunctionErrorOutputPipe != null)
+                                {
+                                    Context.ShellFunctionErrorOutputPipe = CommandRuntime.ErrorOutputPipe;
+                                }
+
+                                Context.CurrentCommandProcessor = this;
+                                SetCurrentScopeToExecutionScope();
+
+                                using (CommandRuntime.AllowThisCommandToWrite(permittedToWriteToPipeline: true))
+                                using (ParameterBinderBase.bindingTracer.TraceScope("CALLING Cleanup"))
+                                {
+                                    scriptCmdlet.Dispose();
+                                }
+                            }
+                            catch (Exception e)
+                            {
+                                throw ManageInvocationException(e);
+                            }
+                            finally
+                            {
+                                OnRestorePreviousScope();
+
+                                Context.ShellFunctionErrorOutputPipe = oldErrorOutputPipe;
+                                Context.CurrentCommandProcessor = oldCurrentCommandProcessor;
+                                ExceptionHandlingOps.RestoreStoppingPipeline(Context, isStopping);
+
+                                // Destroy the local scope at this point if there is one...
+                                if (_useLocalScope && CommandScope != null)
+                                {
+                                    CommandSessionState.RemoveScope(CommandScope);
+                                }
+
+                                // and restore the previous scope...
+                                if (_previousScope != null)
+                                {
+                                    // Restore the scope but use the same session state instance we
+                                    // got it from because the command may have changed the execution context
+                                    // session state...
+                                    CommandSessionState.CurrentScope = _previousScope;
+                                }
+
+                                // Restore the previous session state
+                                if (_previousCommandSessionState != null)
+                                {
+                                    Context.EngineSessionState = _previousCommandSessionState;
+                                }
+                            }
+                        }
+                        else if (Command is IDisposable disposableCommand)
                         {
                             disposableCommand.Dispose();
                         }

--- a/src/System.Management.Automation/engine/CommandProcessorBase.cs
+++ b/src/System.Management.Automation/engine/CommandProcessorBase.cs
@@ -609,7 +609,6 @@ namespace System.Management.Automation
         /// </summary>
         internal void DoComplete()
         {
-            Pipe oldErrorOutputPipe = _context.ShellFunctionErrorOutputPipe;
             CommandProcessorBase oldCurrentCommandProcessor = _context.CurrentCommandProcessor;
             try
             {
@@ -640,31 +639,43 @@ namespace System.Management.Automation
             }
             finally
             {
-                OnRestorePreviousScope();
+                RestorePreviousScope();
 
-                _context.ShellFunctionErrorOutputPipe = oldErrorOutputPipe;
                 _context.CurrentCommandProcessor = oldCurrentCommandProcessor;
+            }
+        }
 
-                // Destroy the local scope at this point if there is one...
-                if (_useLocalScope && CommandScope != null)
+        /// <summary>
+        /// Executes the appropriate disposal methods for script commands.
+        /// <see cref="DlrScriptCommandProcessor"/> is itself a command processor, so interpreted functions cannot be
+        /// reliably disposed without also disposing the entire command processor. Instead, it implements its own
+        /// <see cref="DlrScriptCommandProcessor.InvokeCleanupBlock"/> method to perform the same function as its
+        /// compiled counterpart <see cref="PSScriptCmdlet.Dispose"/>, which is a proper IDisposable implementation.
+        /// </summary>
+        internal virtual void CleanupScriptCommands()
+        {
+            try
+            {
+                if (Command is PSScriptCmdlet scriptCmdlet)
                 {
-                    CommandSessionState.RemoveScope(CommandScope);
+                    using (commandRuntime.AllowThisCommandToWrite(true))
+                    using (ParameterBinderBase.bindingTracer.TraceScope("CALLING Dispose"))
+                    {
+                        scriptCmdlet.Dispose();
+                    }
                 }
-
-                // and the previous scope...
-                if (_previousScope != null)
+                else if (this is DlrScriptCommandProcessor scriptProcessor)
                 {
-                    // Restore the scope but use the same session state instance we
-                    // got it from because the command may have changed the execution context
-                    // session state...
-                    CommandSessionState.CurrentScope = _previousScope;
+                    using (commandRuntime.AllowThisCommandToWrite(true))
+                    using (ParameterBinderBase.bindingTracer.TraceScope("CALLING Dispose"))
+                    {
+                        scriptProcessor.InvokeCleanupBlock();
+                    }
                 }
-
-                // Restore the previous session state
-                if (_previousCommandSessionState != null)
-                {
-                    Context.EngineSessionState = _previousCommandSessionState;
-                }
+            }
+            catch (Exception e)
+            {
+                throw ManageInvocationException(e);
             }
         }
 
@@ -940,21 +951,77 @@ namespace System.Management.Automation
         private void Dispose(bool disposing)
         {
             if (_disposed)
-                return;
-
-            if (disposing)
             {
-                // 2004/03/05-JonN Look into using metadata to check
-                // whether IDisposable is implemented, in order to avoid
-                // this expensive reflection cast.
-                IDisposable id = Command as IDisposable;
-                if (id != null)
-                {
-                    id.Dispose();
-                }
+                return;
             }
 
-            _disposed = true;
+            try
+            {
+                if (disposing)
+                {
+                    Pipe oldErrorOutputPipe = _context.ShellFunctionErrorOutputPipe;
+                    CommandProcessorBase oldCurrentCommandProcessor = _context.CurrentCommandProcessor;
+
+                    bool isStopping = false;
+                    try
+                    {
+                        if (this.RedirectShellErrorOutputPipe || _context.ShellFunctionErrorOutputPipe != null)
+                        {
+                            _context.ShellFunctionErrorOutputPipe = this.commandRuntime.ErrorOutputPipe;
+                        }
+
+                        _context.CurrentCommandProcessor = this;
+                        isStopping = ExceptionHandlingOps.SuspendStoppingPipeline(Context);
+                        SetCurrentScopeToExecutionScope();
+
+                        // This is a no-op for compiled cmdlets
+                        CleanupScriptCommands();
+                    }
+                    finally
+                    {
+                        ExceptionHandlingOps.RestoreStoppingPipeline(Context, isStopping);
+                        OnRestorePreviousScope();
+
+                        _context.ShellFunctionErrorOutputPipe = oldErrorOutputPipe;
+                        _context.CurrentCommandProcessor = oldCurrentCommandProcessor;
+
+                        // Destroy the local scope at this point if there is one...
+                        if (_useLocalScope && CommandScope != null)
+                        {
+                            CommandSessionState.RemoveScope(CommandScope);
+                        }
+
+                        // and the previous scope...
+                        if (_previousScope != null)
+                        {
+                            // Restore the scope but use the same session state instance we
+                            // got it from because the command may have changed the execution context
+                            // session state...
+                            CommandSessionState.CurrentScope = _previousScope;
+                        }
+
+                        // Restore the previous session state
+                        if (_previousCommandSessionState != null)
+                        {
+                            Context.EngineSessionState = _previousCommandSessionState;
+                        }
+
+                        this.CommandRuntime.RemoveVariableListsInPipe();
+
+                        // 2004/03/05-JonN Look into using metadata to check
+                        // whether IDisposable is implemented, in order to avoid
+                        // this expensive reflection cast.
+                        if (Command is IDisposable id)
+                        {
+                            id.Dispose();
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                _disposed = true;
+            }
         }
 
         #endregion IDispose

--- a/src/System.Management.Automation/engine/CommandProcessorBase.cs
+++ b/src/System.Management.Automation/engine/CommandProcessorBase.cs
@@ -366,7 +366,10 @@ namespace System.Management.Automation
         {
             OnRestorePreviousScope();
 
-            Context.EngineSessionState = _previousCommandSessionState;
+            if (_previousCommandSessionState != null)
+            {
+                Context.EngineSessionState = _previousCommandSessionState;
+            }
 
             if (_previousScope != null)
             {
@@ -659,6 +662,58 @@ namespace System.Management.Automation
                 {
                     Context.EngineSessionState = _previousCommandSessionState;
                 }
+            }
+        }
+
+        protected virtual void HandleScopedAction(Action action, string traceMessage)
+        {
+            Pipe oldErrorOutputPipe = Context.ShellFunctionErrorOutputPipe;
+            CommandProcessorBase oldCurrentCommandProcessor = Context.CurrentCommandProcessor;
+
+            try
+            {
+                // On V1 the output pipe was redirected to the command's output pipe only when it
+                // was already redirected. This is the original comment explaining this behaviour:
+                //
+                //      NTRAID#Windows Out of Band Releases-926183-2005-12-15
+                //      MonadTestHarness has a bad dependency on an artifact of the current implementation
+                //      The following code only redirects the output pipe if it's already redirected
+                //      to preserve the artifact. The test suites need to be fixed and then this
+                //      the check can be removed and the assignment always done.
+                //
+                // However, this makes the hosting APIs behave differently than commands executed
+                // from the command-line host (for example, see bugs Win7:415915 and Win7:108670).
+                // The RedirectShellErrorOutputPipe flag is used by the V2 hosting API to force the
+                // redirection.
+                if (this.RedirectShellErrorOutputPipe || Context.ShellFunctionErrorOutputPipe != null)
+                {
+                    Context.ShellFunctionErrorOutputPipe = CommandRuntime.ErrorOutputPipe;
+                }
+
+                Context.CurrentCommandProcessor = this;
+                using (CommandRuntime.AllowThisCommandToWrite(permittedToWriteToPipeline: true))
+                using (ParameterBinderBase.bindingTracer.TraceScope(traceMessage))
+                {
+                    SetCurrentScopeToExecutionScope();
+                    action();
+                }
+            }
+            catch (Exception e)
+            {
+                throw ManageInvocationException(e);
+            }
+            finally
+            {
+                Context.ShellFunctionErrorOutputPipe = oldErrorOutputPipe;
+                Context.CurrentCommandProcessor = oldCurrentCommandProcessor;
+
+                // Destroy the local scope at this point if there is one...
+                if (_useLocalScope && CommandScope != null)
+                {
+                    CommandSessionState.RemoveScope(CommandScope);
+                }
+
+                RestorePreviousScope();
             }
         }
 
@@ -965,57 +1020,13 @@ namespace System.Management.Automation
                         if (Command is PSScriptCmdlet scriptCmdlet)
                         {
                             bool isStopping = ExceptionHandlingOps.SuspendStoppingPipeline(Context);
-                            Pipe oldErrorOutputPipe = Context.ShellFunctionErrorOutputPipe;
-                            CommandProcessorBase oldCurrentCommandProcessor = Context.CurrentCommandProcessor;
-
                             try
                             {
-                                if (this.RedirectShellErrorOutputPipe || Context.ShellFunctionErrorOutputPipe != null)
-                                {
-                                    Context.ShellFunctionErrorOutputPipe = CommandRuntime.ErrorOutputPipe;
-                                }
-
-                                Context.CurrentCommandProcessor = this;
-                                SetCurrentScopeToExecutionScope();
-
-                                using (CommandRuntime.AllowThisCommandToWrite(permittedToWriteToPipeline: true))
-                                using (ParameterBinderBase.bindingTracer.TraceScope("CALLING Cleanup"))
-                                {
-                                    scriptCmdlet.Dispose();
-                                }
-                            }
-                            catch (Exception e)
-                            {
-                                throw ManageInvocationException(e);
+                                HandleScopedAction(() => scriptCmdlet.Dispose(), traceMessage: "CALLING Cleanup");
                             }
                             finally
                             {
-                                OnRestorePreviousScope();
-
-                                Context.ShellFunctionErrorOutputPipe = oldErrorOutputPipe;
-                                Context.CurrentCommandProcessor = oldCurrentCommandProcessor;
                                 ExceptionHandlingOps.RestoreStoppingPipeline(Context, isStopping);
-
-                                // Destroy the local scope at this point if there is one...
-                                if (_useLocalScope && CommandScope != null)
-                                {
-                                    CommandSessionState.RemoveScope(CommandScope);
-                                }
-
-                                // and restore the previous scope...
-                                if (_previousScope != null)
-                                {
-                                    // Restore the scope but use the same session state instance we
-                                    // got it from because the command may have changed the execution context
-                                    // session state...
-                                    CommandSessionState.CurrentScope = _previousScope;
-                                }
-
-                                // Restore the previous session state
-                                if (_previousCommandSessionState != null)
-                                {
-                                    Context.EngineSessionState = _previousCommandSessionState;
-                                }
                             }
                         }
                         else if (Command is IDisposable disposableCommand)

--- a/src/System.Management.Automation/engine/CommandProcessorBase.cs
+++ b/src/System.Management.Automation/engine/CommandProcessorBase.cs
@@ -669,7 +669,7 @@ namespace System.Management.Automation
         /// <see cref="DlrScriptCommandProcessor.InvokeCleanupBlock"/> method to perform the same function as its
         /// compiled counterpart <see cref="PSScriptCmdlet.Dispose"/>, which is a proper IDisposable implementation.
         /// </summary>
-        internal virtual void CleanupScriptCommands()
+        internal virtual void CleanupScriptCommand()
         {
             var scriptCmdlet = Command as PSScriptCmdlet;
             var scriptProcessor = this as DlrScriptCommandProcessor;
@@ -685,7 +685,7 @@ namespace System.Management.Automation
 
             if (this.RedirectShellErrorOutputPipe || Context.ShellFunctionErrorOutputPipe != null)
             {
-                Context.ShellFunctionErrorOutputPipe = this.commandRuntime.ErrorOutputPipe;
+                Context.ShellFunctionErrorOutputPipe = commandRuntime.ErrorOutputPipe;
             }
 
             try
@@ -693,21 +693,17 @@ namespace System.Management.Automation
                 Context.CurrentCommandProcessor = this;
                 SetCurrentScopeToExecutionScope();
 
-                if (scriptCmdlet != null)
+                using (commandRuntime.AllowThisCommandToWrite(true))
+                using (ParameterBinderBase.bindingTracer.TraceScope("CALLING Cleanup"))
                 {
-                    using (commandRuntime.AllowThisCommandToWrite(true))
-                    using (ParameterBinderBase.bindingTracer.TraceScope("CALLING Cleanup"))
+                    if (scriptCmdlet != null)
                     {
                         scriptCmdlet.Dispose();
+                        return;
                     }
-                }
-                else
-                {
-                    using (commandRuntime.AllowThisCommandToWrite(true))
-                    using (ParameterBinderBase.bindingTracer.TraceScope("CALLING Cleanup"))
+
+                    if (scriptProcessor != null)
                     {
-                        // scriptProcessor cannot be null here if scriptCmdlet is null (we would have hit the early
-                        // return in that case).
                         scriptProcessor.InvokeCleanupBlock();
                     }
                 }
@@ -1030,15 +1026,13 @@ namespace System.Management.Automation
             {
                 if (disposing)
                 {
-                    // This method handles script commands' `cleanup {}` blocks. It is a no-op for compiled cmdlets.
-                    CleanupScriptCommands();
+                    // This method handles script commands' `cleanup {}` blocks.
+                    // It is a no-op for non-disposable commands.
+                    CleanupScriptCommand();
 
-                    // 2004/03/05-JonN Look into using metadata to check
-                    // whether IDisposable is implemented, in order to avoid
-                    // this expensive reflection cast.
-                    if (Command is IDisposable id)
+                    if (Command is IDisposable disposableCommand)
                     {
-                        id.Dispose();
+                        disposableCommand.Dispose();
                     }
                 }
             }

--- a/src/System.Management.Automation/engine/CommandProcessorBase.cs
+++ b/src/System.Management.Automation/engine/CommandProcessorBase.cs
@@ -654,21 +654,44 @@ namespace System.Management.Automation
         /// </summary>
         internal virtual void CleanupScriptCommands()
         {
+            var scriptCmdlet = Command as PSScriptCmdlet;
+            var scriptProcessor = this as DlrScriptCommandProcessor;
+
+            if (scriptCmdlet == null && scriptProcessor == null)
+            {
+                return;
+            }
+
+            bool isStopping = ExceptionHandlingOps.SuspendStoppingPipeline(Context);
+            Pipe oldErrorOutputPipe = Context.ShellFunctionErrorOutputPipe;
+            CommandProcessorBase oldCurrentCommandProcessor = Context.CurrentCommandProcessor;
+
+            if (this.RedirectShellErrorOutputPipe || Context.ShellFunctionErrorOutputPipe != null)
+            {
+                Context.ShellFunctionErrorOutputPipe = this.commandRuntime.ErrorOutputPipe;
+            }
+
+            Context.CurrentCommandProcessor = this;
+
             try
             {
-                if (Command is PSScriptCmdlet scriptCmdlet)
+                SetCurrentScopeToExecutionScope();
+
+                if (scriptCmdlet != null)
                 {
                     using (commandRuntime.AllowThisCommandToWrite(true))
-                    using (ParameterBinderBase.bindingTracer.TraceScope("CALLING Dispose"))
+                    using (ParameterBinderBase.bindingTracer.TraceScope("CALLING Cleanup"))
                     {
                         scriptCmdlet.Dispose();
                     }
                 }
-                else if (this is DlrScriptCommandProcessor scriptProcessor)
+                else
                 {
                     using (commandRuntime.AllowThisCommandToWrite(true))
-                    using (ParameterBinderBase.bindingTracer.TraceScope("CALLING Dispose"))
+                    using (ParameterBinderBase.bindingTracer.TraceScope("CALLING Cleanup"))
                     {
+                        // scriptProcessor cannot be null here if scriptCmdlet is null (we would have hit the early
+                        // return in that case).
                         scriptProcessor.InvokeCleanupBlock();
                     }
                 }
@@ -676,6 +699,15 @@ namespace System.Management.Automation
             catch (Exception e)
             {
                 throw ManageInvocationException(e);
+            }
+            finally
+            {
+                OnRestorePreviousScope();
+
+                Context.ShellFunctionErrorOutputPipe = oldErrorOutputPipe;
+                Context.CurrentCommandProcessor = oldCurrentCommandProcessor;
+
+                ExceptionHandlingOps.RestoreStoppingPipeline(Context, isStopping);
             }
         }
 
@@ -959,39 +991,20 @@ namespace System.Management.Automation
             {
                 if (disposing)
                 {
-                    Pipe oldErrorOutputPipe = _context.ShellFunctionErrorOutputPipe;
-                    CommandProcessorBase oldCurrentCommandProcessor = _context.CurrentCommandProcessor;
-
-                    bool isStopping = false;
                     try
                     {
-                        if (this.RedirectShellErrorOutputPipe || _context.ShellFunctionErrorOutputPipe != null)
-                        {
-                            _context.ShellFunctionErrorOutputPipe = this.commandRuntime.ErrorOutputPipe;
-                        }
-
-                        _context.CurrentCommandProcessor = this;
-                        isStopping = ExceptionHandlingOps.SuspendStoppingPipeline(Context);
-                        SetCurrentScopeToExecutionScope();
-
-                        // This is a no-op for compiled cmdlets
+                        // This method handles script commands' `cleanup {}` blocks. It is a no-op for compiled cmdlets.
                         CleanupScriptCommands();
                     }
                     finally
                     {
-                        ExceptionHandlingOps.RestoreStoppingPipeline(Context, isStopping);
-                        OnRestorePreviousScope();
-
-                        _context.ShellFunctionErrorOutputPipe = oldErrorOutputPipe;
-                        _context.CurrentCommandProcessor = oldCurrentCommandProcessor;
-
                         // Destroy the local scope at this point if there is one...
                         if (_useLocalScope && CommandScope != null)
                         {
                             CommandSessionState.RemoveScope(CommandScope);
                         }
 
-                        // and the previous scope...
+                        // and restore the previous scope...
                         if (_previousScope != null)
                         {
                             // Restore the scope but use the same session state instance we
@@ -1005,8 +1018,6 @@ namespace System.Management.Automation
                         {
                             Context.EngineSessionState = _previousCommandSessionState;
                         }
-
-                        this.CommandRuntime.RemoveVariableListsInPipe();
 
                         // 2004/03/05-JonN Look into using metadata to check
                         // whether IDisposable is implemented, in order to avoid

--- a/src/System.Management.Automation/engine/CommandProcessorBase.cs
+++ b/src/System.Management.Automation/engine/CommandProcessorBase.cs
@@ -665,7 +665,7 @@ namespace System.Management.Automation
             }
         }
 
-        protected virtual void HandleScopedAction(Action action, string traceMessage)
+        protected virtual void HandleScopedAction<T>(Action<T> action, T state, string traceMessage)
         {
             Pipe oldErrorOutputPipe = Context.ShellFunctionErrorOutputPipe;
             CommandProcessorBase oldCurrentCommandProcessor = Context.CurrentCommandProcessor;
@@ -695,7 +695,7 @@ namespace System.Management.Automation
                 using (ParameterBinderBase.bindingTracer.TraceScope(traceMessage))
                 {
                     SetCurrentScopeToExecutionScope();
-                    action();
+                    action(state);
                 }
             }
             catch (Exception e)
@@ -1022,7 +1022,10 @@ namespace System.Management.Automation
                             bool isStopping = ExceptionHandlingOps.SuspendStoppingPipeline(Context);
                             try
                             {
-                                HandleScopedAction(() => scriptCmdlet.Dispose(), traceMessage: "CALLING Cleanup");
+                                HandleScopedAction(
+                                    (cmdlet) => cmdlet.Dispose(),
+                                    scriptCmdlet,
+                                    traceMessage: "CALLING Cleanup");
                             }
                             finally
                             {

--- a/src/System.Management.Automation/engine/EventManager.cs
+++ b/src/System.Management.Automation/engine/EventManager.cs
@@ -1845,6 +1845,11 @@ namespace System.Management.Automation
         internal const string OnScriptBlockInvoke = "PowerShell.OnScriptBlockInvoke";
 
         /// <summary>
+        /// Called during invocation of cleanup{} for script commands.
+        /// </summary>
+        internal const string OnScriptCommandCleanup = "PowerShell.OnScriptCommandCleanup";
+
+        /// <summary>
         /// Called during scriptblock invocation.
         /// </summary>
         internal const string GetCommandInfoParameterMetadata = "PowerShell.GetCommandInfoParameterMetadata";

--- a/src/System.Management.Automation/engine/ProxyCommand.cs
+++ b/src/System.Management.Automation/engine/ProxyCommand.cs
@@ -247,6 +247,30 @@ namespace System.Management.Automation
             return commandMetadata.GetEndBlock();
         }
 
+        /// <summary>
+        /// This method constructs a string representing the dispose block of the command
+        /// specified by <paramref name="commandMetadata"/>. The returned string only contains the
+        /// script, it is not enclosed in "cleanup { }".
+        /// </summary>
+        /// <param name="commandMetadata">
+        /// An instance of CommandMetadata representing a command.
+        /// </param>
+        /// <returns>
+        /// A string representing the end block of the command.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// If <paramref name="commandMetadata"/> is null.
+        /// </exception>
+        public static string GetCleanup(CommandMetadata commandMetadata)
+        {
+            if (commandMetadata == null)
+            {
+                throw PSTraceSource.NewArgumentNullException(nameof(commandMetadata));
+            }
+
+            return commandMetadata.GetCleanupBlock();
+        }
+
         private static T GetProperty<T>(PSObject obj, string property) where T : class
         {
             T result = null;

--- a/src/System.Management.Automation/engine/ScriptCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/ScriptCommandProcessor.cs
@@ -628,8 +628,15 @@ namespace System.Management.Automation
             }
         }
 
+        private bool _cleanupCompleted;
+
         internal void InvokeCleanupBlock()
         {
+            if (_cleanupCompleted)
+            {
+                return;
+            }
+
             if (!_scriptBlock.HasCleanupBlock)
             {
                 ScriptBlock.LogScriptBlockEnd(_scriptBlock, Context.CurrentRunspace.InstanceId);
@@ -671,6 +678,8 @@ namespace System.Management.Automation
                 }
 
                 ScriptBlock.LogScriptBlockEnd(_scriptBlock, Context.CurrentRunspace.InstanceId);
+
+                _cleanupCompleted = true;
             }
         }
 

--- a/src/System.Management.Automation/engine/ScriptCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/ScriptCommandProcessor.cs
@@ -637,7 +637,7 @@ namespace System.Management.Automation
             bool isStopping = ExceptionHandlingOps.SuspendStoppingPipeline(Context);
             try
             {
-                HandleScopedAction(() => InvokeCleanupBlock(), traceMessage: "CALLING Cleanup");
+                HandleScopedAction((processor) => processor.InvokeCleanupBlock(), this, traceMessage: "CALLING Cleanup");
             }
             finally
             {

--- a/src/System.Management.Automation/engine/ScriptCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/ScriptCommandProcessor.cs
@@ -630,6 +630,63 @@ namespace System.Management.Automation
 
         private bool _cleanupCompleted;
 
+        protected override void CleanupScriptCommand()
+        {
+            bool isStopping = ExceptionHandlingOps.SuspendStoppingPipeline(Context);
+            Pipe oldErrorOutputPipe = Context.ShellFunctionErrorOutputPipe;
+            CommandProcessorBase oldCurrentCommandProcessor = Context.CurrentCommandProcessor;
+
+            try
+            {
+                if (this.RedirectShellErrorOutputPipe || Context.ShellFunctionErrorOutputPipe != null)
+                {
+                    Context.ShellFunctionErrorOutputPipe = CommandRuntime.ErrorOutputPipe;
+                }
+
+                Context.CurrentCommandProcessor = this;
+                SetCurrentScopeToExecutionScope();
+
+                using (CommandRuntime.AllowThisCommandToWrite(permittedToWriteToPipeline: true))
+                using (ParameterBinderBase.bindingTracer.TraceScope("CALLING Cleanup"))
+                {
+                    InvokeCleanupBlock();
+                }
+            }
+            catch (Exception e)
+            {
+                throw ManageInvocationException(e);
+            }
+            finally
+            {
+                OnRestorePreviousScope();
+
+                Context.ShellFunctionErrorOutputPipe = oldErrorOutputPipe;
+                Context.CurrentCommandProcessor = oldCurrentCommandProcessor;
+                ExceptionHandlingOps.RestoreStoppingPipeline(Context, isStopping);
+
+                // Destroy the local scope at this point if there is one...
+                if (_useLocalScope && CommandScope != null)
+                {
+                    CommandSessionState.RemoveScope(CommandScope);
+                }
+
+                // and restore the previous scope...
+                if (_previousScope != null)
+                {
+                    // Restore the scope but use the same session state instance we
+                    // got it from because the command may have changed the execution context
+                    // session state...
+                    CommandSessionState.CurrentScope = _previousScope;
+                }
+
+                // Restore the previous session state
+                if (_previousCommandSessionState != null)
+                {
+                    Context.EngineSessionState = _previousCommandSessionState;
+                }
+            }
+        }
+
         internal void InvokeCleanupBlock()
         {
             if (_cleanupCompleted)

--- a/src/System.Management.Automation/engine/ScriptCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/ScriptCommandProcessor.cs
@@ -408,7 +408,9 @@ namespace System.Management.Automation
 
             if (_scriptBlock.HasEndBlock)
             {
-                var endBlock = _runOptimizedCode ? _scriptBlock.EndBlock : _scriptBlock.UnoptimizedEndBlock;
+                Action<FunctionContext> endBlock = _runOptimizedCode
+                    ? _scriptBlock.EndBlock
+                    : _scriptBlock.UnoptimizedEndBlock;
                 if (this.CommandRuntime.InputPipe.ExternalReader == null)
                 {
                     if (IsPipelineInputExpected())
@@ -697,6 +699,7 @@ namespace System.Management.Automation
             if (!_scriptBlock.HasCleanupBlock)
             {
                 ScriptBlock.LogScriptBlockEnd(_scriptBlock, Context.CurrentRunspace.InstanceId);
+                _cleanupCompleted = true;
                 return;
             }
 

--- a/src/System.Management.Automation/engine/debugger/Breakpoint.cs
+++ b/src/System.Management.Automation/engine/debugger/Breakpoint.cs
@@ -531,15 +531,16 @@ namespace System.Management.Automation
 
             // Not found.  First, we check if the line/column is before any real code.  If so, we'll
             // move the breakpoint to the first interesting sequence point (could be a dynamicparam,
-            // begin, process, or end block.)
+            // begin, process, end, or cleanup block.)
             if (scriptBlock != null)
             {
                 var ast = scriptBlock.Ast;
                 var bodyAst = ((IParameterMetadataProvider)ast).Body;
-                if ((bodyAst.DynamicParamBlock == null || bodyAst.DynamicParamBlock.Extent.IsAfter(Line, Column)) &&
-                    (bodyAst.BeginBlock == null || bodyAst.BeginBlock.Extent.IsAfter(Line, Column)) &&
-                    (bodyAst.ProcessBlock == null || bodyAst.ProcessBlock.Extent.IsAfter(Line, Column)) &&
-                    (bodyAst.EndBlock == null || bodyAst.EndBlock.Extent.IsAfter(Line, Column)))
+                if ((bodyAst.DynamicParamBlock == null || bodyAst.DynamicParamBlock.Extent.IsAfter(Line, Column))
+                    && (bodyAst.BeginBlock == null || bodyAst.BeginBlock.Extent.IsAfter(Line, Column))
+                    && (bodyAst.ProcessBlock == null || bodyAst.ProcessBlock.Extent.IsAfter(Line, Column))
+                    && (bodyAst.EndBlock == null || bodyAst.EndBlock.Extent.IsAfter(Line, Column))
+                    && (bodyAst.CleanupBlock == null || bodyAst.CleanupBlock.Extent.IsAfter(Line, Column)))
                 {
                     SetBreakpoint(functionContext, 0);
                     return true;

--- a/src/System.Management.Automation/engine/hostifaces/LocalPipeline.cs
+++ b/src/System.Management.Automation/engine/hostifaces/LocalPipeline.cs
@@ -1295,8 +1295,12 @@ namespace System.Management.Automation.Runspaces
 
         internal void EnterCriticalSection()
         {
-            Interlocked.Increment(ref _criticalSectionDepth);
-            _criticalSectionSemaphore.Wait(millisecondsTimeout: 0);
+            // Increment the depth value. If we were not previously in a critical section (depth is now 1),
+            // also take out the semaphore.
+            if (Interlocked.Increment(ref _criticalSectionDepth) == 1)
+            {
+                _criticalSectionSemaphore.Wait();
+            }
         }
 
         internal void ExitCriticalSection()

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -2023,6 +2023,7 @@ namespace System.Management.Automation.Language
                 scriptBlock.BeginBlock = CompileTree(_beginBlockLambda, compileInterpretChoice);
                 scriptBlock.ProcessBlock = CompileTree(_processBlockLambda, compileInterpretChoice);
                 scriptBlock.EndBlock = CompileTree(_endBlockLambda, compileInterpretChoice);
+                scriptBlock.CleanupBlock = CompileTree(_cleanupBlockLambda, compileInterpretChoice);
                 scriptBlock.LocalsMutableTupleType = LocalVariablesTupleType;
                 scriptBlock.LocalsMutableTupleCreator = MutableTuple.TupleCreator(LocalVariablesTupleType);
                 scriptBlock.NameToIndexMap = nameToIndexMap;
@@ -2033,6 +2034,7 @@ namespace System.Management.Automation.Language
                 scriptBlock.UnoptimizedBeginBlock = CompileTree(_beginBlockLambda, compileInterpretChoice);
                 scriptBlock.UnoptimizedProcessBlock = CompileTree(_processBlockLambda, compileInterpretChoice);
                 scriptBlock.UnoptimizedEndBlock = CompileTree(_endBlockLambda, compileInterpretChoice);
+                scriptBlock.UnoptimizedCleanupBlock = CompileTree(_cleanupBlockLambda, compileInterpretChoice);
                 scriptBlock.UnoptimizedLocalsMutableTupleType = LocalVariablesTupleType;
                 scriptBlock.UnoptimizedLocalsMutableTupleCreator = MutableTuple.TupleCreator(LocalVariablesTupleType);
             }
@@ -2218,6 +2220,7 @@ namespace System.Management.Automation.Language
         private Expression<Action<FunctionContext>> _beginBlockLambda;
         private Expression<Action<FunctionContext>> _processBlockLambda;
         private Expression<Action<FunctionContext>> _endBlockLambda;
+        private Expression<Action<FunctionContext>> _cleanupBlockLambda;
 
         private readonly List<LoopGotoTargets> _loopTargets = new List<LoopGotoTargets>();
         private bool _generatingWhileOrDoLoop;
@@ -2460,6 +2463,12 @@ namespace System.Management.Automation.Language
                 }
 
                 _endBlockLambda = CompileNamedBlock(scriptBlockAst.EndBlock, funcName, rootForDefiningTypesAndUsings);
+            }
+
+            if (scriptBlockAst.CleanupBlock != null)
+            {
+                _cleanupBlockLambda = CompileNamedBlock(scriptBlockAst.CleanupBlock, funcName + "<Cleanup>", rootForDefiningTypesAndUsings);
+                rootForDefiningTypesAndUsings = null;
             }
 
             return null;

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -2463,6 +2463,7 @@ namespace System.Management.Automation.Language
                 }
 
                 _endBlockLambda = CompileNamedBlock(scriptBlockAst.EndBlock, funcName, rootForDefiningTypesAndUsings);
+                rootForDefiningTypesAndUsings = null;
             }
 
             if (scriptBlockAst.CleanupBlock != null)

--- a/src/System.Management.Automation/engine/parser/SemanticChecks.cs
+++ b/src/System.Management.Automation/engine/parser/SemanticChecks.cs
@@ -404,10 +404,11 @@ namespace System.Management.Automation.Language
                     ParserStrings.ParamBlockNotAllowedInMethod);
             }
 
-            if (body.BeginBlock != null ||
-                body.ProcessBlock != null ||
-                body.DynamicParamBlock != null ||
-                !body.EndBlock.Unnamed)
+            if (body.BeginBlock != null
+                || body.ProcessBlock != null
+                || body.CleanupBlock != null
+                || body.DynamicParamBlock != null
+                || !body.EndBlock.Unnamed)
             {
                 _parser.ReportError(Parser.ExtentFromFirstOf(body.DynamicParamBlock, body.BeginBlock, body.ProcessBlock, body.EndBlock),
                     nameof(ParserStrings.NamedBlockNotAllowedInMethod),

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -721,6 +721,7 @@ namespace System.Management.Automation
             var beginBlock = scriptBlockAst.BeginBlock;
             var processBlock = scriptBlockAst.ProcessBlock;
             var endBlock = scriptBlockAst.EndBlock;
+            var cleanupBlock = scriptBlockAst.CleanupBlock;
 
             // The following is used when we don't find OutputType, which is checked elsewhere.
             if (beginBlock != null)
@@ -736,6 +737,11 @@ namespace System.Management.Automation
             if (endBlock != null)
             {
                 res.AddRange(InferTypes(endBlock));
+            }
+
+            if (cleanupBlock != null)
+            {
+                res.AddRange(InferTypes(cleanupBlock));
             }
 
             return res;

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -739,11 +739,6 @@ namespace System.Management.Automation
                 res.AddRange(InferTypes(endBlock));
             }
 
-            if (cleanupBlock != null)
-            {
-                res.AddRange(InferTypes(cleanupBlock));
-            }
-
             return res;
         }
 

--- a/src/System.Management.Automation/engine/parser/VariableAnalysis.cs
+++ b/src/System.Management.Automation/engine/parser/VariableAnalysis.cs
@@ -965,6 +965,11 @@ namespace System.Management.Automation.Language
                 scriptBlockAst.EndBlock.Accept(this);
             }
 
+            if (scriptBlockAst.CleanupBlock != null)
+            {
+                scriptBlockAst.CleanupBlock.Accept(this);
+            }
+
             _currentBlock.FlowsTo(_exitBlock);
 
             return null;

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -2038,7 +2038,6 @@ namespace System.Management.Automation.Language
                     || blockName == TokenKind.Dynamicparam));
         }
 
-
         // Used by the debugger for command breakpoints
         internal IScriptExtent OpenCurlyExtent { get; }
 

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -1932,10 +1932,7 @@ namespace System.Management.Automation.Language
         {
             // Validate the block name.  If the block is unnamed, it must be an End block (for a function)
             // or Process block (for a filter).
-            if (!blockName.HasTrait(TokenFlags.ScriptBlockBlockName)
-                || (unnamed && (blockName == TokenKind.Begin
-                    || blockName == TokenKind.Cleanup
-                    || blockName == TokenKind.Dynamicparam)))
+            if (HasInvalidBlockName(blockName, unnamed))
             {
                 throw PSTraceSource.NewArgumentException(nameof(blockName));
             }
@@ -2032,6 +2029,15 @@ namespace System.Management.Automation.Language
             var statementBlock = new StatementBlockAst(statementBlockExtent, newStatements, newTraps);
             return new NamedBlockAst(this.Extent, this.BlockKind, statementBlock, this.Unnamed);
         }
+
+        private static bool HasInvalidBlockName(TokenKind blockName, bool unnamed)
+        {
+            return !blockName.HasTrait(TokenFlags.ScriptBlockBlockName)
+                || (unnamed && (blockName == TokenKind.Begin
+                    || blockName == TokenKind.Cleanup
+                    || blockName == TokenKind.Dynamicparam));
+        }
+
 
         // Used by the debugger for command breakpoints
         internal IScriptExtent OpenCurlyExtent { get; }

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -848,6 +848,84 @@ namespace System.Management.Automation.Language
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="ScriptBlockAst"/> class.
+        /// This construction uses explicitly named begin/process/end/dispose blocks.
+        /// </summary>
+        /// <param name="extent">The extent of the script block.</param>
+        /// <param name="usingStatements">The list of using statments, may be null.</param>
+        /// <param name="attributes">The set of attributes for the script block.</param>
+        /// <param name="paramBlock">The ast for the param block, may be null.</param>
+        /// <param name="beginBlock">The ast for the begin block, may be null.</param>
+        /// <param name="processBlock">The ast for the process block, may be null.</param>
+        /// <param name="endBlock">The ast for the end block, may be null.</param>
+        /// <param name="cleanupBlock">The ast for the cleanup block, may be null.</param>
+        /// <param name="dynamicParamBlock">The ast for the dynamicparam block, may be null.</param>
+        /// <exception cref="PSArgumentNullException">
+        /// If <paramref name="extent"/> is null.
+        /// </exception>
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "param")]
+        public ScriptBlockAst(
+            IScriptExtent extent,
+            IEnumerable<UsingStatementAst> usingStatements,
+            IEnumerable<AttributeAst> attributes,
+            ParamBlockAst paramBlock,
+            NamedBlockAst beginBlock,
+            NamedBlockAst processBlock,
+            NamedBlockAst endBlock,
+            NamedBlockAst cleanupBlock,
+            NamedBlockAst dynamicParamBlock)
+            : base(extent)
+        {
+            SetUsingStatements(usingStatements);
+
+            if (attributes != null)
+            {
+                this.Attributes = new ReadOnlyCollection<AttributeAst>(attributes.ToArray());
+                SetParents(Attributes);
+            }
+            else
+            {
+                this.Attributes = s_emptyAttributeList;
+            }
+
+            if (paramBlock != null)
+            {
+                this.ParamBlock = paramBlock;
+                SetParent(paramBlock);
+            }
+
+            if (beginBlock != null)
+            {
+                this.BeginBlock = beginBlock;
+                SetParent(beginBlock);
+            }
+
+            if (processBlock != null)
+            {
+                this.ProcessBlock = processBlock;
+                SetParent(processBlock);
+            }
+
+            if (endBlock != null)
+            {
+                this.EndBlock = endBlock;
+                SetParent(endBlock);
+            }
+
+            if (cleanupBlock != null)
+            {
+                this.CleanupBlock = cleanupBlock;
+                SetParent(cleanupBlock);
+            }
+
+            if (dynamicParamBlock != null)
+            {
+                this.DynamicParamBlock = dynamicParamBlock;
+                SetParent(dynamicParamBlock);
+            }
+        }
+
+        /// <summary>
         /// Construct a ScriptBlockAst that uses explicitly named begin/process/end blocks.
         /// </summary>
         /// <param name="extent">The extent of the script block.</param>
@@ -873,6 +951,35 @@ namespace System.Management.Automation.Language
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="ScriptBlockAst"/> class.
+        /// This construction uses explicitly named begin/process/end/dispose blocks.
+        /// </summary>
+        /// <param name="extent">The extent of the script block.</param>
+        /// <param name="usingStatements">The list of using statments, may be null.</param>
+        /// <param name="paramBlock">The ast for the param block, may be null.</param>
+        /// <param name="beginBlock">The ast for the begin block, may be null.</param>
+        /// <param name="processBlock">The ast for the process block, may be null.</param>
+        /// <param name="endBlock">The ast for the end block, may be null.</param>
+        /// <param name="cleanupBlock">The ast for the dispose block, may be null.</param>
+        /// <param name="dynamicParamBlock">The ast for the dynamicparam block, may be null.</param>
+        /// <exception cref="PSArgumentNullException">
+        /// If <paramref name="extent"/> is null.
+        /// </exception>
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "param")]
+        public ScriptBlockAst(
+            IScriptExtent extent,
+            IEnumerable<UsingStatementAst> usingStatements,
+            ParamBlockAst paramBlock,
+            NamedBlockAst beginBlock,
+            NamedBlockAst processBlock,
+            NamedBlockAst endBlock,
+            NamedBlockAst cleanupBlock,
+            NamedBlockAst dynamicParamBlock)
+            : this(extent, usingStatements, null, paramBlock, beginBlock, processBlock, endBlock, cleanupBlock, dynamicParamBlock)
+        {
+        }
+
+        /// <summary>
         /// Construct a ScriptBlockAst that uses explicitly named begin/process/end blocks.
         /// </summary>
         /// <param name="extent">The extent of the script block.</param>
@@ -892,6 +999,33 @@ namespace System.Management.Automation.Language
                               NamedBlockAst endBlock,
                               NamedBlockAst dynamicParamBlock)
             : this(extent, null, paramBlock, beginBlock, processBlock, endBlock, dynamicParamBlock)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScriptBlockAst"/> class.
+        /// This construction uses explicitly named begin/process/end/dispose blocks.
+        /// </summary>
+        /// <param name="extent">The extent of the script block.</param>
+        /// <param name="paramBlock">The ast for the param block, may be null.</param>
+        /// <param name="beginBlock">The ast for the begin block, may be null.</param>
+        /// <param name="processBlock">The ast for the process block, may be null.</param>
+        /// <param name="endBlock">The ast for the end block, may be null.</param>
+        /// <param name="cleanupBlock">The ast for the dispose block, may be null.</param>
+        /// <param name="dynamicParamBlock">The ast for the dynamicparam block, may be null.</param>
+        /// <exception cref="PSArgumentNullException">
+        /// If <paramref name="extent"/> is null.
+        /// </exception>
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "param")]
+        public ScriptBlockAst(
+            IScriptExtent extent,
+            ParamBlockAst paramBlock,
+            NamedBlockAst beginBlock,
+            NamedBlockAst processBlock,
+            NamedBlockAst endBlock,
+            NamedBlockAst cleanupBlock,
+            NamedBlockAst dynamicParamBlock)
+            : this(extent, null, paramBlock, beginBlock, processBlock, endBlock, cleanupBlock, dynamicParamBlock)
         {
         }
 
@@ -1100,6 +1234,11 @@ namespace System.Management.Automation.Language
         public NamedBlockAst EndBlock { get; }
 
         /// <summary>
+        /// Gets the ast representing the dispose block for a script block, or null if no dispose block was specified.
+        /// </summary>
+        public NamedBlockAst CleanupBlock { get; private set; }
+
+        /// <summary>
         /// The ast representing the dynamicparam block for a script block, or null if no dynamicparam block was specified.
         /// </summary>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Param")]
@@ -1178,17 +1317,25 @@ namespace System.Management.Automation.Language
             var newBeginBlock = CopyElement(this.BeginBlock);
             var newProcessBlock = CopyElement(this.ProcessBlock);
             var newEndBlock = CopyElement(this.EndBlock);
+            var newCleanupBlock = CopyElement(this.CleanupBlock);
             var newDynamicParamBlock = CopyElement(this.DynamicParamBlock);
             var newAttributes = CopyElements(this.Attributes);
             var newUsingStatements = CopyElements(this.UsingStatements);
 
-            var scriptBlockAst = new ScriptBlockAst(this.Extent, newUsingStatements, newAttributes, newParamBlock, newBeginBlock, newProcessBlock,
-                                                    newEndBlock, newDynamicParamBlock)
+            return new ScriptBlockAst(
+                this.Extent,
+                newUsingStatements,
+                newAttributes,
+                newParamBlock,
+                newBeginBlock,
+                newProcessBlock,
+                newEndBlock,
+                newCleanupBlock,
+                newDynamicParamBlock)
             {
                 IsConfiguration = this.IsConfiguration,
                 ScriptRequirements = this.ScriptRequirements
             };
-            return scriptBlockAst;
         }
 
         internal string ToStringForSerialization()
@@ -1350,18 +1497,37 @@ namespace System.Management.Automation.Language
                 }
             }
 
-            if (action == AstVisitAction.Continue && ParamBlock != null)
-                action = ParamBlock.InternalVisit(visitor);
-            if (action == AstVisitAction.Continue && DynamicParamBlock != null)
-                action = DynamicParamBlock.InternalVisit(visitor);
-            if (action == AstVisitAction.Continue && BeginBlock != null)
-                action = BeginBlock.InternalVisit(visitor);
-            if (action == AstVisitAction.Continue && ProcessBlock != null)
-                action = ProcessBlock.InternalVisit(visitor);
-            if (action == AstVisitAction.Continue && EndBlock != null)
-                action = EndBlock.InternalVisit(visitor);
+            if (!ShouldContinueAfterVisit(visitor, ParamBlock, ref action))
+            {
+                return visitor.CheckForPostAction(this, action);
+            }
+
+            if (!ShouldContinueAfterVisit(visitor, DynamicParamBlock, ref action))
+            {
+                return visitor.CheckForPostAction(this, action);
+            }
+
+            if (!ShouldContinueAfterVisit(visitor, BeginBlock, ref action))
+            {
+                return visitor.CheckForPostAction(this, action);
+            }
+
+            if (!ShouldContinueAfterVisit(visitor, ProcessBlock, ref action))
+            {
+                return visitor.CheckForPostAction(this, action);
+            }
+
+            if (!ShouldContinueAfterVisit(visitor, EndBlock, ref action))
+            {
+                return visitor.CheckForPostAction(this, action);
+            }
+
+            ShouldContinueAfterVisit(visitor, CleanupBlock, ref action);
             return visitor.CheckForPostAction(this, action);
         }
+
+        internal static bool ShouldContinueAfterVisit(AstVisitor visitor, Ast ast, ref AstVisitAction action)
+            => ast == null || (action = ast.InternalVisit(visitor)) == AstVisitAction.Continue;
 
         #endregion Visitors
 
@@ -1564,9 +1730,12 @@ namespace System.Management.Automation.Language
 
         internal PipelineAst GetSimplePipeline(bool allowMultiplePipelines, out string errorId, out string errorMsg)
         {
-            if (BeginBlock != null || ProcessBlock != null || DynamicParamBlock != null)
+            if (BeginBlock != null
+                || ProcessBlock != null
+                || CleanupBlock != null
+                || DynamicParamBlock != null)
             {
-                errorId = "CanConvertOneClauseOnly";
+                errorId = nameof(AutomationExceptions.CanConvertOneClauseOnly);
                 errorMsg = AutomationExceptions.CanConvertOneClauseOnly;
                 return null;
             }
@@ -1732,7 +1901,7 @@ namespace System.Management.Automation.Language
     public class NamedBlockAst : Ast
     {
         /// <summary>
-        /// Construct the ast for a begin, process, end, or dynamic param block.
+        /// Construct the ast for a begin, process, end, cleanup, or dynamic param block.
         /// </summary>
         /// <param name="extent">
         /// The extent of the block.  If <paramref name="unnamed"/> is false, the extent includes
@@ -1744,6 +1913,7 @@ namespace System.Management.Automation.Language
         /// <item><see cref="TokenKind.Begin"/></item>
         /// <item><see cref="TokenKind.Process"/></item>
         /// <item><see cref="TokenKind.End"/></item>
+        /// <item><see cref="TokenKind.Cleanup"/></item>
         /// <item><see cref="TokenKind.Dynamicparam"/></item>
         /// </list>
         /// </param>
@@ -1763,7 +1933,9 @@ namespace System.Management.Automation.Language
             // Validate the block name.  If the block is unnamed, it must be an End block (for a function)
             // or Process block (for a filter).
             if (!blockName.HasTrait(TokenFlags.ScriptBlockBlockName)
-                || (unnamed && (blockName == TokenKind.Begin || blockName == TokenKind.Dynamicparam)))
+                || (unnamed && (blockName == TokenKind.Begin
+                    || blockName == TokenKind.Cleanup
+                    || blockName == TokenKind.Dynamicparam)))
             {
                 throw PSTraceSource.NewArgumentException(nameof(blockName));
             }
@@ -1821,6 +1993,7 @@ namespace System.Management.Automation.Language
         /// <item><see cref="TokenKind.Begin"/></item>
         /// <item><see cref="TokenKind.Process"/></item>
         /// <item><see cref="TokenKind.End"/></item>
+        /// <item><see cref="TokenKind.Cleanup"/></item>
         /// <item><see cref="TokenKind.Dynamicparam"/></item>
         /// </list>
         /// </summary>

--- a/src/System.Management.Automation/engine/parser/token.cs
+++ b/src/System.Management.Automation/engine/parser/token.cs
@@ -661,7 +661,7 @@ namespace System.Management.Automation.Language
         Keyword = 0x00000010,
 
         /// <summary>
-        /// The token one of the keywords that is a part of a script block: 'begin', 'process', 'end', or 'dynamicparam'.
+        /// The token one of the keywords that is a part of a script block: 'begin', 'process', 'end', 'cleanup', or 'dynamicparam'.
         /// </summary>
         ScriptBlockBlockName = 0x00000020,
 

--- a/src/System.Management.Automation/engine/parser/token.cs
+++ b/src/System.Management.Automation/engine/parser/token.cs
@@ -587,6 +587,8 @@ namespace System.Management.Automation.Language
 
         /// <summary>The 'default' keyword</summary>
         Default = 169,
+        /// <summary>The 'cleanup' keyword.</summary>
+        Cleanup = 170,
 
         #endregion Keywords
     }
@@ -948,6 +950,7 @@ namespace System.Management.Automation.Language
             /*               Hidden */ TokenFlags.Keyword,
             /*                 Base */ TokenFlags.Keyword,
             /*              Default */ TokenFlags.Keyword,
+            /*              Cleanup */ TokenFlags.Keyword | TokenFlags.ScriptBlockBlockName,
 
             #endregion Flags for keywords
         };
@@ -1147,6 +1150,7 @@ namespace System.Management.Automation.Language
             /*               Hidden */ "hidden",
             /*                 Base */ "base",
             /*              Default */ "default",
+            /*              Cleanup */ "cleanup",
 
             #endregion Text for keywords
         };
@@ -1154,10 +1158,12 @@ namespace System.Management.Automation.Language
 #if DEBUG
         static TokenTraits()
         {
-            Diagnostics.Assert(s_staticTokenFlags.Length == ((int)TokenKind.Default + 1),
-                               "Table size out of sync with enum - _staticTokenFlags");
-            Diagnostics.Assert(s_tokenText.Length == ((int)TokenKind.Default + 1),
-                               "Table size out of sync with enum - _tokenText");
+            Diagnostics.Assert(
+                s_staticTokenFlags.Length == ((int)TokenKind.Cleanup + 1),
+                "Table size out of sync with enum - _staticTokenFlags");
+            Diagnostics.Assert(
+                s_tokenText.Length == ((int)TokenKind.Cleanup + 1),
+                "Table size out of sync with enum - _tokenText");
             // Some random assertions to make sure the enum and the traits are in sync
             Diagnostics.Assert(GetTraits(TokenKind.Begin) == (TokenFlags.Keyword | TokenFlags.ScriptBlockBlockName),
                                "Table out of sync with enum - flags Begin");

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -625,7 +625,7 @@ namespace System.Management.Automation.Language
         /*A*/    "configuration",           "public",           "private",          "static",                     /*A*/
         /*B*/    "interface",               "enum",             "namespace",        "module",                     /*B*/
         /*C*/    "type",                    "assembly",         "command",          "hidden",                     /*C*/
-        /*D*/    "base",                    "default",                                                            /*D*/
+        /*D*/    "base",                    "default",          "cleanup",                                        /*D*/
         };
 
         private static readonly TokenKind[] s_keywordTokenKind = new TokenKind[] {
@@ -641,7 +641,7 @@ namespace System.Management.Automation.Language
         /*A*/    TokenKind.Configuration,   TokenKind.Public,   TokenKind.Private,  TokenKind.Static,             /*A*/
         /*B*/    TokenKind.Interface,       TokenKind.Enum,     TokenKind.Namespace,TokenKind.Module,             /*B*/
         /*C*/    TokenKind.Type,            TokenKind.Assembly, TokenKind.Command,  TokenKind.Hidden,             /*C*/
-        /*D*/    TokenKind.Base,            TokenKind.Default,                                                    /*D*/
+        /*D*/    TokenKind.Base,            TokenKind.Default,  TokenKind.Cleanup,                                /*D*/
         };
 
         internal static readonly string[] _operatorText = new string[] {

--- a/src/System.Management.Automation/engine/pipeline.cs
+++ b/src/System.Management.Automation/engine/pipeline.cs
@@ -626,6 +626,10 @@ namespace System.Management.Automation.Internal
                             commandRequestingUpstreamCommandsToStop = stopUpstreamCommandsException.RequestingCommandProcessor;
                         }
                     }
+                    finally
+                    {
+                        commandProcessor.Dispose();
+                    }
 
                     EtwActivity.SetActivityId(commandProcessor.PipelineActivityId);
 
@@ -1306,7 +1310,6 @@ namespace System.Management.Automation.Internal
                         // pipeline failure and continue disposing cmdlets.
                         try
                         {
-                            commandProcessor.CommandRuntime.RemoveVariableListsInPipe();
                             commandProcessor.Dispose();
                         }
                         // 2005/04/13-JonN: The only vaguely plausible reason
@@ -1315,12 +1318,16 @@ namespace System.Management.Automation.Internal
                         // exemption.
                         catch (Exception e) // Catch-all OK, 3rd party callout.
                         {
+                            if (_firstTerminatingError != null)
+                            {
+                                _firstTerminatingError.Throw();
+                            }
+
                             InvocationInfo myInvocation = null;
                             if (commandProcessor.Command != null)
                                 myInvocation = commandProcessor.Command.MyInvocation;
 
-                            ProviderInvocationException pie =
-                                e as ProviderInvocationException;
+                            ProviderInvocationException pie = e as ProviderInvocationException;
                             if (pie != null)
                             {
                                 e = new CmdletProviderInvocationException(

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -316,6 +316,8 @@ namespace System.Management.Automation
 
         internal Dictionary<string, int> NameToIndexMap { get; set; }
 
+        #region Named Blocks
+
         internal Action<FunctionContext> DynamicParamBlock { get; set; }
 
         internal Action<FunctionContext> UnoptimizedDynamicParamBlock { get; set; }
@@ -331,8 +333,12 @@ namespace System.Management.Automation
         internal Action<FunctionContext> EndBlock { get; set; }
 
         internal Action<FunctionContext> UnoptimizedEndBlock { get; set; }
+
         internal Action<FunctionContext> CleanupBlock { get; set; }
+
         internal Action<FunctionContext> UnoptimizedCleanupBlock { get; set; }
+
+        #endregion Named Blocks
 
         internal IScriptExtent[] SequencePoints { get; set; }
 

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -12,11 +12,9 @@ using System.Management.Automation.Language;
 using System.Management.Automation.Runspaces;
 using System.Management.Automation.Tracing;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
-using System.Threading.Tasks;
 #if LEGACYTELEMETRY
 using Microsoft.PowerShell.Telemetry.Internal;
 #endif
@@ -35,6 +33,7 @@ namespace System.Management.Automation
         Begin,
         Process,
         End,
+        Cleanup,
         ProcessBlockOnly,
     }
 
@@ -247,6 +246,7 @@ namespace System.Management.Automation
 
                 if (scriptBlockAst.BeginBlock != null
                     || scriptBlockAst.ProcessBlock != null
+                    || scriptBlockAst.CleanupBlock != null
                     || scriptBlockAst.ParamBlock != null
                     || scriptBlockAst.DynamicParamBlock != null
                     || scriptBlockAst.ScriptRequirements != null
@@ -331,6 +331,8 @@ namespace System.Management.Automation
         internal Action<FunctionContext> EndBlock { get; set; }
 
         internal Action<FunctionContext> UnoptimizedEndBlock { get; set; }
+        internal Action<FunctionContext> CleanupBlock { get; set; }
+        internal Action<FunctionContext> UnoptimizedCleanupBlock { get; set; }
 
         internal IScriptExtent[] SequencePoints { get; set; }
 
@@ -753,7 +755,7 @@ namespace System.Management.Automation
         {
             errorHandler ??= (_ => null);
 
-            if (HasBeginBlock || HasProcessBlock)
+            if (HasBeginBlock || HasProcessBlock || HasCleanupBlock)
             {
                 return errorHandler(AutomationExceptions.CanConvertOneClauseOnly);
             }
@@ -891,7 +893,10 @@ namespace System.Management.Automation
             Parser parser = new Parser();
 
             var ast = AstInternal;
-            if (HasBeginBlock || HasProcessBlock || ast.Body.ParamBlock != null)
+            if (HasBeginBlock
+                || HasProcessBlock
+                || HasCleanupBlock
+                || ast.Body.ParamBlock != null)
             {
                 Ast errorAst = ast.Body.BeginBlock ?? (Ast)ast.Body.ProcessBlock ?? ast.Body.ParamBlock;
                 parser.ReportError(
@@ -976,7 +981,8 @@ namespace System.Management.Automation
         {
             if ((clauseToInvoke == ScriptBlockClauseToInvoke.Begin && !HasBeginBlock)
                 || (clauseToInvoke == ScriptBlockClauseToInvoke.Process && !HasProcessBlock)
-                || (clauseToInvoke == ScriptBlockClauseToInvoke.End && !HasEndBlock))
+                || (clauseToInvoke == ScriptBlockClauseToInvoke.End && !HasEndBlock)
+                || (clauseToInvoke == ScriptBlockClauseToInvoke.Cleanup && !HasCleanupBlock))
             {
                 return;
             }
@@ -1362,7 +1368,7 @@ namespace System.Management.Automation
         private Action<FunctionContext> GetCodeToInvoke(ref bool optimized, ScriptBlockClauseToInvoke clauseToInvoke)
         {
             if (clauseToInvoke == ScriptBlockClauseToInvoke.ProcessBlockOnly
-                && (HasBeginBlock || (HasEndBlock && HasProcessBlock)))
+                && (HasBeginBlock || HasCleanupBlock || (HasEndBlock && HasProcessBlock)))
             {
                 throw PSTraceSource.NewInvalidOperationException(AutomationExceptions.ScriptBlockInvokeOnOneClauseOnly);
             }
@@ -1379,6 +1385,8 @@ namespace System.Management.Automation
                         return _scriptBlockData.ProcessBlock;
                     case ScriptBlockClauseToInvoke.End:
                         return _scriptBlockData.EndBlock;
+                    case ScriptBlockClauseToInvoke.Cleanup:
+                        return _scriptBlockData.CleanupBlock;
                     default:
                         return HasProcessBlock ? _scriptBlockData.ProcessBlock : _scriptBlockData.EndBlock;
                 }
@@ -1392,6 +1400,8 @@ namespace System.Management.Automation
                     return _scriptBlockData.UnoptimizedProcessBlock;
                 case ScriptBlockClauseToInvoke.End:
                     return _scriptBlockData.UnoptimizedEndBlock;
+                case ScriptBlockClauseToInvoke.Cleanup:
+                    return _scriptBlockData.UnoptimizedCleanupBlock;
                 default:
                     return HasProcessBlock ? _scriptBlockData.UnoptimizedProcessBlock : _scriptBlockData.UnoptimizedEndBlock;
             }
@@ -2147,11 +2157,17 @@ namespace System.Management.Automation
 
         internal Action<FunctionContext> UnoptimizedEndBlock { get => _scriptBlockData.UnoptimizedEndBlock; }
 
+        internal Action<FunctionContext> CleanupBlock { get => _scriptBlockData.CleanupBlock; }
+
+        internal Action<FunctionContext> UnoptimizedCleanupBlock { get => _scriptBlockData.UnoptimizedCleanupBlock; }
+
         internal bool HasBeginBlock { get => AstInternal.Body.BeginBlock != null; }
 
         internal bool HasProcessBlock { get => AstInternal.Body.ProcessBlock != null; }
 
         internal bool HasEndBlock { get => AstInternal.Body.EndBlock != null; }
+
+        internal bool HasCleanupBlock { get => AstInternal.Body.CleanupBlock != null; }
     }
 
     [Serializable]
@@ -2514,18 +2530,134 @@ namespace System.Management.Automation
                 return;
             }
 
-            this.DisposingEvent.SafeInvoke(this, EventArgs.Empty);
-            commandRuntime = null;
-            currentObjectInPipeline = null;
-            _input.Clear();
-            // _scriptBlock = null;
-            // _localsTuple = null;
-            // _functionContext = null;
+            ExecutionContext currentContext = LocalPipeline.GetExecutionContextFromTLS();
+            if (Context != currentContext && _scriptBlock.HasCleanupBlock)
+            {
+                // Something went wrong; Dispose{} is being called from the wrong thread.
+                // Create an event to call it from the correct thread.
+                InvokeCleanupInOriginalContext();
+                return;
+            }
 
-            base.InternalDispose(true);
-            _disposed = true;
+            var oldOutputPipe = _functionContext?._outputPipe;
+
+            try
+            {
+                if (_scriptBlock.HasCleanupBlock)
+                {
+                    var disposeBlock = _runOptimized ? _scriptBlock.CleanupBlock : _scriptBlock.UnoptimizedCleanupBlock;
+                    if (_functionContext != null)
+                    {
+                        _functionContext._outputPipe = new Pipe
+                        {
+                            NullPipe = true
+                        };
+                    }
+
+                    RunClause(
+                        disposeBlock,
+                        AutomationNull.Value,
+                        AutomationNull.Value);
+                }
+            }
+            finally
+            {
+                if (_functionContext != null)
+                {
+                    _functionContext._outputPipe = oldOutputPipe;
+                }
+
+                this.DisposingEvent.SafeInvoke(this, EventArgs.Empty);
+
+                commandRuntime = null;
+                currentObjectInPipeline = null;
+                _input.Clear();
+
+                base.InternalDispose(true);
+                _disposed = true;
+            }
         }
 
         #endregion IDispose
+
+        #region Eventing for Cleanup
+
+        private void InvokeCleanupInOriginalContext()
+        {
+            Context.Events.SubscribeEvent(
+                    source: null,
+                    eventName: PSEngineEvent.OnScriptCommandCleanup,
+                    sourceIdentifier: PSEngineEvent.OnScriptCommandCleanup,
+                    data: null,
+                    handlerDelegate: new PSEventReceivedEventHandler(OnCleanupInvocationEventHandler),
+                    supportEvent: true,
+                    forwardEvent: false,
+                    shouldQueueAndProcessInExecutionThread: true,
+                    maxTriggerCount: 1);
+
+            var cleanupInvocationEventArgs = new CleanupInvocationEventArgs(this);
+
+            Context.Events.GenerateEvent(
+                sourceIdentifier: PSEngineEvent.OnScriptCommandCleanup,
+                sender: null,
+                args: new object[] { cleanupInvocationEventArgs },
+                extraData: null,
+                processInCurrentThread: true,
+                waitForCompletionInCurrentThread: true);
+        }
+
+        /// <summary>
+        /// Handles OnDisposeInvoke event, this is called by the event manager.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="args">
+        /// Arguments to be passed to the event, which must be of type
+        /// <see cref="CleanupInvocationEventArgs"/>
+        /// </param>
+        private static void OnCleanupInvocationEventHandler(object sender, PSEventArgs args)
+        {
+            var eventArgs = (object)args.SourceEventArgs as CleanupInvocationEventArgs;
+            Diagnostics.Assert(
+                eventArgs?.ScriptCmdlet != null,
+                $"Event Arguments to {nameof(OnCleanupInvocationEventHandler)} should not be null");
+
+            bool wasAlreadyStopping = ExceptionHandlingOps.SuspendStoppingPipeline(eventArgs.ScriptCmdlet.Context);
+            try
+            {
+                eventArgs.ScriptCmdlet.Dispose();
+            }
+            finally
+            {
+                ExceptionHandlingOps.RestoreStoppingPipeline(eventArgs.ScriptCmdlet.Context, wasAlreadyStopping);
+            }
+        }
+
+        #endregion Eventing for Cleanup
+    }
+
+    /// <summary>
+    /// Defines Event arguments passed to OnDisposeInvocationEventHandler.
+    /// </summary>
+    internal sealed class CleanupInvocationEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CleanupInvocationEventArgs"/> class.
+        /// </summary>
+        /// <param name="cmdlet">The command processor to dispose.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="cmdlet"/> is null.</exception>
+        internal CleanupInvocationEventArgs(PSScriptCmdlet cmdlet)
+        {
+            if (cmdlet == null)
+            {
+                throw new ArgumentNullException(nameof(cmdlet));
+            }
+
+            ScriptCmdlet = cmdlet;
+        }
+
+        /// <summary>
+        /// Gets the script cmdlet to be disposed.
+        /// </summary>
+        internal PSScriptCmdlet ScriptCmdlet { get; }
     }
 }

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -1578,11 +1578,13 @@ namespace System.Management.Automation
 
         internal static bool SuspendStoppingPipeline(ExecutionContext context)
         {
-            LocalPipeline lpl = (LocalPipeline)context.CurrentRunspace.GetCurrentlyRunningPipeline();
-            if (lpl != null)
+            var pipeline = (LocalPipeline)context.CurrentRunspace.GetCurrentlyRunningPipeline();
+            if (pipeline != null)
             {
-                bool oldIsStopping = lpl.Stopper.IsStopping;
-                lpl.Stopper.IsStopping = false;
+                bool oldIsStopping = pipeline.Stopper.IsStopping;
+                pipeline.Stopper.IsStopping = false;
+                pipeline.Stopper.EnterCriticalRegion();
+
                 return oldIsStopping;
             }
 
@@ -1591,10 +1593,11 @@ namespace System.Management.Automation
 
         internal static void RestoreStoppingPipeline(ExecutionContext context, bool oldIsStopping)
         {
-            LocalPipeline lpl = (LocalPipeline)context.CurrentRunspace.GetCurrentlyRunningPipeline();
-            if (lpl != null)
+            var pipeline = (LocalPipeline)context.CurrentRunspace.GetCurrentlyRunningPipeline();
+            if (pipeline != null)
             {
-                lpl.Stopper.IsStopping = oldIsStopping;
+                pipeline.Stopper.IsStopping = oldIsStopping;
+                pipeline.Stopper.ExitCriticalRegion();
             }
         }
 

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -1448,7 +1448,9 @@ namespace System.Management.Automation
 
             // If no handler was found, return without changing the current result.
             if (handler == -1)
-            { return; }
+            {
+                return;
+            }
 
             // New handler was found.
             //  - If new-rank is less than current-rank -- meaning the new handler is more specific,

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -1447,7 +1447,8 @@ namespace System.Management.Automation
             int handler = FindMatchingHandlerByType(exception.GetType(), types);
 
             // If no handler was found, return without changing the current result.
-            if (handler == -1) { return; }
+            if (handler == -1)
+            { return; }
 
             // New handler was found.
             //  - If new-rank is less than current-rank -- meaning the new handler is more specific,
@@ -1583,7 +1584,7 @@ namespace System.Management.Automation
             {
                 bool oldIsStopping = pipeline.Stopper.IsStopping;
                 pipeline.Stopper.IsStopping = false;
-                pipeline.Stopper.EnterCriticalRegion();
+                pipeline.Stopper.EnterCriticalSection();
 
                 return oldIsStopping;
             }
@@ -1597,7 +1598,7 @@ namespace System.Management.Automation
             if (pipeline != null)
             {
                 pipeline.Stopper.IsStopping = oldIsStopping;
-                pipeline.Stopper.ExitCriticalRegion();
+                pipeline.Stopper.ExitCriticalSection();
             }
         }
 

--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -497,7 +497,7 @@ The correct form is: foreach ($a in $b) {...}</value>
     <value>Script command clause '{0}' has already been defined.</value>
   </data>
   <data name="MissingNamedBlocks" xml:space="preserve">
-    <value>unexpected token '{0}', expected 'begin', 'process', 'end', or 'dynamicparam'.</value>
+    <value>unexpected token '{0}', expected 'begin', 'process', 'end', 'cleanup', or 'dynamicparam'.</value>
   </data>
   <data name="MissingEndCurlyBrace" xml:space="preserve">
     <value>Missing closing '}' in statement block or type definition.</value>

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -67,6 +67,8 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             }
 
             end {}
+
+            cleanup {}
         }
 '@
         $functionDefinition>$functionDefinitionFile

--- a/test/powershell/Language/Parser/Parsing.Tests.ps1
+++ b/test/powershell/Language/Parser/Parsing.Tests.ps1
@@ -148,17 +148,21 @@ Describe 'named blocks parsing' -Tags "CI" {
     ShouldBeParseError 'begin' MissingNamedStatementBlock 5
     ShouldBeParseError 'process' MissingNamedStatementBlock 7
     ShouldBeParseError 'end' MissingNamedStatementBlock 3
+    ShouldBeParseError 'cleanup' MissingNamedStatementBlock 7
     ShouldBeParseError 'dynamicparam' MissingNamedStatementBlock 12
     ShouldBeParseError 'begin process {}' MissingNamedStatementBlock 6 -CheckColumnNumber
     ShouldBeParseError 'end process {}' MissingNamedStatementBlock 4 -CheckColumnNumber
+    ShouldBeParseError 'cleanup process {}' MissingNamedStatementBlock 8 -CheckColumnNumber
     ShouldBeParseError 'dynamicparam process {}' MissingNamedStatementBlock 13 -CheckColumnNumber
     ShouldBeParseError 'process begin {}' MissingNamedStatementBlock 8 -CheckColumnNumber
-    ShouldBeParseError 'begin process end' MissingNamedStatementBlock,MissingNamedStatementBlock,MissingNamedStatementBlock 6,14,18 -CheckColumnNumber
+    ShouldBeParseError 'begin process end cleanup' MissingNamedStatementBlock, MissingNamedStatementBlock, MissingNamedStatementBlock, MissingNamedStatementBlock 6, 14, 18, 26 -CheckColumnNumber
 
     Test-Ast 'begin' 'begin' 'begin'
     Test-Ast 'begin end' 'begin end' 'begin' 'end'
     Test-Ast 'begin end process' 'begin end process' 'begin' 'end' 'process'
     Test-Ast 'begin {} end' 'begin {} end' 'begin {}' 'end'
+    Test-Ast 'begin process end cleanup' 'begin process end cleanup' 'begin' 'cleanup' 'end' 'process'
+    Test-Ast 'begin {} process end cleanup {}' 'begin {} process end cleanup {}' 'begin {}' 'cleanup {}' 'end' 'process'
 }
 
 #

--- a/test/powershell/Language/Scripting/PipelineBehaviour.Tests.ps1
+++ b/test/powershell/Language/Scripting/PipelineBehaviour.Tests.ps1
@@ -1,0 +1,122 @@
+Describe 'Function Pipeline Behaviour' -Tag 'CI' {
+
+    Context 'Output from Named Blocks' {
+
+        $Cases = @(
+            @{ Script = { begin { 10 } }; ExpectedResult = 10 }
+            @{ Script = { process { 15 } }; ExpectedResult = 15 }
+            @{ Script = { end { 22 } }; ExpectedResult = 22 }
+        )
+        It 'permits output from named block: <Script>' -TestCases $Cases {
+            param($Script, $ExpectedResult)
+
+            & $Script | Should -Be $ExpectedResult
+        }
+
+        It 'does not permit output from cleanup {}' {
+            & { cleanup { 11 } } | Should -BeNullOrEmpty
+        }
+
+        It 'passes output for begin, then process, then end' {
+            $Script = {
+                process { "PROCESS" }
+                begin { "BEGIN" }
+                end { "END" }
+            }
+
+            & $Script | Should -Be @( "BEGIN", "PROCESS", "END" )
+        }
+
+    }
+
+    Context 'Output Behaviour on Error States' {
+
+        BeforeAll {
+            $powershell = $null
+        }
+
+        AfterEach {
+            if ($powershell) {
+                $powershell.Dispose()
+                $powershell = $null
+            }
+        }
+
+        It 'does not execute End {} if the pipeline is halted during Process {}' {
+            # We don't need Should -Not -Throw as if this reaches end{} and throws the test will fail anyway.
+            1..10 |
+                & {
+                    begin { "BEGIN" }
+                    process { "PROCESS $_" }
+                    end { "END"; throw "This should not be reached." }
+                } |
+                Select-Object -First 3 |
+                Should -Be @( "BEGIN", "PROCESS 1", "PROCESS 2" )
+        }
+
+        It 'still executes Cleanup {} if the pipeline is halted' {
+            $Script = {
+                1..10 |
+                    & {
+                        process { $_ }
+                        cleanup { throw "Cleanup block hit." }
+                } |
+                    Select-Object -First 1
+            }
+            $Script | Should -Throw -ExpectedMessage "Cleanup block hit."
+        }
+
+        It 'still executes Cleanup {} when StopProcessing() is triggered mid-pipeline' {
+            $script = @"
+                function test {
+                    begin {}
+                    process {
+                        Start-Sleep -Seconds 10
+                    }
+                    end {}
+                    cleanup {
+                        Write-Information "CLEANUP"
+                    }
+
+                }
+"@
+            $powershell = [powershell]::Create()
+            $powershell.AddScript($script).AddStatement().AddCommand('test') > $null
+
+            $asyncResult = $powershell.BeginInvoke()
+            Start-Sleep -Seconds 2
+            $powershell.Stop()
+
+            $powershell.EndInvoke($asyncResult) > $null
+            $powershell.Streams.Information[0].MessageData | Should -BeExactly "CLEANUP"
+        }
+
+        It 'still completes Cleanup {} execution when StopProcessing() is triggered mid-Cleanup {}' {
+            $script = @"
+                function test {
+                    begin {}
+                    process {
+                        "PROCESS"
+                    }
+                    end {}
+                    cleanup {
+                        Start-Sleep -Seconds 10
+                        Write-Information "CLEANUP"
+                    }
+
+                }
+"@
+            $powershell = [powershell]::Create()
+            $powershell.AddScript($script).AddStatement().AddCommand('test') > $null
+
+            $asyncResult = $powershell.BeginInvoke()
+            Start-Sleep -Seconds 2
+            $powershell.Stop()
+
+            $output = $powershell.EndInvoke($asyncResult)
+
+            $output | Should -Be "PROCESS"
+            $powershell.Streams.Information[0].MessageData | Should -BeExactly "CLEANUP"
+        }
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Adds a new `cleanup` keyword and named block for both script commands and advanced functions.

RFC: https://github.com/PowerShell/PowerShell-RFC/pull/207

## Changes

- Added `cleanup {}` function block, including all necessary AST changes to `ScriptBlockAst`, new token type, tokenizer changes, etc.
- Modifies pipeline command handling to automatically call any command's `Dispose()` implementation (including the new `cleanup {}` block type) immediately after `end {}`/`EndProcessing()` is called, so as to dispose of function resources as soon as a function's task in the pipeline is complete.
- Added handling to `Dispose()` method in the `CommandProcessorBase` to call the `Dispose()` methods for script cmdlets and functions as well.
- Utilised existing `IDisposable` implementation to call the `cleanup {}` script block during that code path for script cmdlets. Simple functions (utilising `DlrScriptCommandProcessor`) already inherit the `Dispose()` implementation from `CommandProcessorBase` so a method was added to handle their disposal by calling their `cleanup{}` blocks.

### Cleanup { } behaviour

- Success output is silently _swallowed_ in the Cleanup step.
- Data sent to other streams will function normally (verbose, information, error, etc.)
- The Cleanup step is intended to occupy an unskippable step specifically for logging & cleanup purposes to improve the reliability of script commands.
- All errors that occur within a Cleanup block are propagated as per normal function operation.
- _Un-caught_ terminating errors that occur during a `cleanup {}` step will skip the remainder of that Cleanup block but will **not** prevent subsequent cmdlets' own `Cleanup {}` steps from being invoked, nor interrupt any disposal of the overall pipeline.
- If a script cmdlet or function is disposed from a different thread, the method will instead invoke the method via an event triggered on the original thread, to avoid issues with scripts being invoked on the wrong thread.

## PR Context

For functions and script cmdlets that utilise pipeline input, there is currently _no possible way_ to reliably utilise a resource that should be timely disposed. Resources can be disposed by the pipeline, but typically this does not occur until the completion of _all_ commands in the pipeline.

For scripts and modules that interact with external resources, this can still become problematic. This PR attempts to address this gap and bring script cmdlets closer to parity with compiled cmdlets, which are perfectly capable of simply implementing `IDisposable` and taking necessary actions there.

Fix https://github.com/PowerShell/PowerShell/issues/6673

EditorSyntax PR: https://github.com/PowerShell/EditorSyntax/pull/186

## Open / Complicated Questions

- What is the desired behaviour when a terminating error is thrown from _both_ `cleanup{}` and another function block (i.e., a terminating error is thrown during `begin`, `process`, or `end`, and when `cleanup` is invoked, it _also_ throws a terminating error).
  - Current behaviour in the PR: surface the error from `cleanup` (this is the same as what would happen in C# if you throw both from `try` and `finally`, from what I can tell, in that you can only catch / see the error from the `finally`), but both errors still surface in `$error`.
- Locking / critical code section behaviour (see @rjmholt's concerns in https://github.com/PowerShell/PowerShell/pull/9900#discussion_r425992361)

## Additional Asks

- [ ] [Add tests for cmdlets that implement IDisposable to verify their current and future behaviour](https://github.com/PowerShell/PowerShell/pull/9900#discussion_r426008654)

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)