### PR TITLE
Add -Raw switch to Select-String for convenience

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -297,7 +297,7 @@ namespace Microsoft.PowerShell.Commands
     /// </summary>
     [Cmdlet(VerbsCommon.Select, "String", DefaultParameterSetName = ParameterSetFile, HelpUri = "https://go.microsoft.com/fwlink/?LinkID=113388")]
     [OutputType(typeof(bool), typeof(MatchInfo), ParameterSetName = new[] { ParameterSetFile, ParameterSetObject, ParameterSetLiteralFile })]
-    [OutputType(typeof(bool), typeof(string), ParameterSetName = new[] { ParameterSetFileRaw, ParameterSetObjectRaw, ParameterSetLiteralFileRaw })]
+    [OutputType(typeof(string), ParameterSetName = new[] { ParameterSetFileRaw, ParameterSetObjectRaw, ParameterSetLiteralFileRaw })]
     public sealed class SelectStringCommand : PSCmdlet
     {
         private const string ParameterSetFile = "File";

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -295,7 +295,7 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// A cmdlet to search through strings and files for particular patterns.
     /// </summary>
-    [Cmdlet(VerbsCommon.Select, "String", DefaultParameterSetName = "File", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=113388")]
+    [Cmdlet(VerbsCommon.Select, "String", DefaultParameterSetName = "FileQuiet", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=113388")]
     [OutputType(typeof(MatchInfo), typeof(bool), typeof(string))]
     public sealed class SelectStringCommand : PSCmdlet
     {
@@ -972,7 +972,8 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Gets or sets the current pipeline object.
         /// </summary>
-        [Parameter(ValueFromPipeline = true, Mandatory = true, ParameterSetName = "Object")]
+        [Parameter(ValueFromPipeline = true, Mandatory = true, ParameterSetName = "ObjectQuiet")]
+        [Parameter(ValueFromPipeline = true, Mandatory = true, ParameterSetName = "ObjectRaw")]
         [AllowNull]
         [AllowEmptyString]
         public PSObject InputObject
@@ -995,7 +996,8 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets files to read from.
         /// Globbing is done on these.
         /// </summary>
-        [Parameter(Position = 1, Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = "File")]
+        [Parameter(Position = 1, Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = "FileQuiet")]
+        [Parameter(Position = 1, Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = "FileRaw")]
         [FileinfoToString]
         public string[] Path { get; set; }
 
@@ -1003,7 +1005,8 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets literal files to read from.
         /// Globbing is not done on these.
         /// </summary>
-        [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = "LiteralFile")]
+        [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = "LiteralFileQuiet")]
+        [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = "LiteralFileRaw")]
         [FileinfoToString]
         [Alias("PSPath", "LP")]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
@@ -1023,7 +1026,9 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets a value indicating if only string values containing matched lines should be returned.
         /// If not (default) return MatchInfo (or bool objects, when Quiet is passed).
         /// </summary>
-        [Parameter]
+        [Parameter(Mandatory = true, ParameterSetName = "ObjectRaw")]
+        [Parameter(Mandatory = true, ParameterSetName = "FileRaw")]
+        [Parameter(Mandatory = true, ParameterSetName = "LiteralFileRaw")]
         public SwitchParameter Raw { get; set; }
 
         /// <summary>
@@ -1043,7 +1048,9 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets a value indicating if the cmdlet will stop processing at the first successful match and
         /// return true.  If both List and Quiet parameters are given, an exception is thrown.
         /// </summary>
-        [Parameter]
+        [Parameter(ParameterSetName = "ObjectQuiet")]
+        [Parameter(ParameterSetName = "FileQuiet")]
+        [Parameter(ParameterSetName = "LiteralFileQuiet")]
         public SwitchParameter Quiet { get; set; }
 
         /// <summary>
@@ -1441,8 +1448,7 @@ namespace Microsoft.PowerShell.Commands
                 return false;
             }
 
-            // Quiet should override Raw
-            if (!Quiet && Raw)
+            if (Raw)
             {
                 foreach (MatchInfo match in contextTracker.EmitQueue)
                 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -296,8 +296,8 @@ namespace Microsoft.PowerShell.Commands
     /// A cmdlet to search through strings and files for particular patterns.
     /// </summary>
     [Cmdlet(VerbsCommon.Select, "String", DefaultParameterSetName = ParameterSetFile, HelpUri = "https://go.microsoft.com/fwlink/?LinkID=113388")]
-    [OutputType(typeof(bool), typeof(MatchInfo), ParameterSetName = new string[] { ParameterSetFile, ParameterSetObject, ParameterSetLiteralFile } )]
-    [OutputType(typeof(bool), typeof(string), ParameterSetName = new string[] { ParameterSetFileRaw, ParameterSetObjectRaw, ParameterSetLiteralFileRaw } )]
+    [OutputType(typeof(bool), typeof(MatchInfo), ParameterSetName = new[] { ParameterSetFile, ParameterSetObject, ParameterSetLiteralFile })]
+    [OutputType(typeof(bool), typeof(string), ParameterSetName = new[] { ParameterSetFileRaw, ParameterSetObjectRaw, ParameterSetLiteralFileRaw })]
     public sealed class SelectStringCommand : PSCmdlet
     {
         private const string ParameterSetFile = "File";

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -295,10 +295,18 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// A cmdlet to search through strings and files for particular patterns.
     /// </summary>
-    [Cmdlet(VerbsCommon.Select, "String", DefaultParameterSetName = "File", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=113388")]
-    [OutputType(typeof(MatchInfo), typeof(bool), typeof(string))]
+    [Cmdlet(VerbsCommon.Select, "String", DefaultParameterSetName = ParameterSetFile, HelpUri = "https://go.microsoft.com/fwlink/?LinkID=113388")]
+    [OutputType(typeof(bool), typeof(MatchInfo), ParameterSetName = new string[] { ParameterSetFile, ParameterSetObject, ParameterSetLiteralFile } )]
+    [OutputType(typeof(bool), typeof(string), ParameterSetName = new string[] { ParameterSetFileRaw, ParameterSetObjectRaw, ParameterSetLiteralFileRaw } )]
     public sealed class SelectStringCommand : PSCmdlet
     {
+        private const string ParameterSetFile = "File";
+        private const string ParameterSetFileRaw = "FileRaw";
+        private const string ParameterSetObject = "Object";
+        private const string ParameterSetObjectRaw = "ObjectRaw";
+        private const string ParameterSetLiteralFile = "LiteralFile";
+        private const string ParameterSetLiteralFileRaw = "LiteralFileRaw";
+
         /// <summary>
         /// A generic circular buffer.
         /// </summary>
@@ -972,8 +980,8 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Gets or sets the current pipeline object.
         /// </summary>
-        [Parameter(ValueFromPipeline = true, Mandatory = true, ParameterSetName = "Object")]
-        [Parameter(ValueFromPipeline = true, Mandatory = true, ParameterSetName = "ObjectRaw")]
+        [Parameter(ValueFromPipeline = true, Mandatory = true, ParameterSetName = ParameterSetObject)]
+        [Parameter(ValueFromPipeline = true, Mandatory = true, ParameterSetName = ParameterSetObjectRaw)]
         [AllowNull]
         [AllowEmptyString]
         public PSObject InputObject
@@ -996,8 +1004,8 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets files to read from.
         /// Globbing is done on these.
         /// </summary>
-        [Parameter(Position = 1, Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = "File")]
-        [Parameter(Position = 1, Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = "FileRaw")]
+        [Parameter(Position = 1, Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = ParameterSetFile)]
+        [Parameter(Position = 1, Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = ParameterSetFileRaw)]
         [FileinfoToString]
         public string[] Path { get; set; }
 
@@ -1005,8 +1013,8 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets literal files to read from.
         /// Globbing is not done on these.
         /// </summary>
-        [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = "LiteralFile")]
-        [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = "LiteralFileRaw")]
+        [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = ParameterSetLiteralFile)]
+        [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = ParameterSetLiteralFileRaw)]
         [FileinfoToString]
         [Alias("PSPath", "LP")]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
@@ -1026,9 +1034,9 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets a value indicating if only string values containing matched lines should be returned.
         /// If not (default) return MatchInfo (or bool objects, when Quiet is passed).
         /// </summary>
-        [Parameter(Mandatory = true, ParameterSetName = "ObjectRaw")]
-        [Parameter(Mandatory = true, ParameterSetName = "FileRaw")]
-        [Parameter(Mandatory = true, ParameterSetName = "LiteralFileRaw")]
+        [Parameter(Mandatory = true, ParameterSetName = ParameterSetObjectRaw)]
+        [Parameter(Mandatory = true, ParameterSetName = ParameterSetFileRaw)]
+        [Parameter(Mandatory = true, ParameterSetName = ParameterSetLiteralFileRaw)]
         public SwitchParameter Raw { get; set; }
 
         /// <summary>
@@ -1048,9 +1056,9 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets a value indicating if the cmdlet will stop processing at the first successful match and
         /// return true.  If both List and Quiet parameters are given, an exception is thrown.
         /// </summary>
-        [Parameter(ParameterSetName = "Object")]
-        [Parameter(ParameterSetName = "File")]
-        [Parameter(ParameterSetName = "LiteralFile")]
+        [Parameter(ParameterSetName = ParameterSetObject)]
+        [Parameter(ParameterSetName = ParameterSetFile)]
+        [Parameter(ParameterSetName = ParameterSetLiteralFile)]
         public SwitchParameter Quiet { get; set; }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -295,7 +295,7 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// A cmdlet to search through strings and files for particular patterns.
     /// </summary>
-    [Cmdlet(VerbsCommon.Select, "String", DefaultParameterSetName = "FileQuiet", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=113388")]
+    [Cmdlet(VerbsCommon.Select, "String", DefaultParameterSetName = "File", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=113388")]
     [OutputType(typeof(MatchInfo), typeof(bool), typeof(string))]
     public sealed class SelectStringCommand : PSCmdlet
     {
@@ -972,7 +972,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Gets or sets the current pipeline object.
         /// </summary>
-        [Parameter(ValueFromPipeline = true, Mandatory = true, ParameterSetName = "ObjectQuiet")]
+        [Parameter(ValueFromPipeline = true, Mandatory = true, ParameterSetName = "Object")]
         [Parameter(ValueFromPipeline = true, Mandatory = true, ParameterSetName = "ObjectRaw")]
         [AllowNull]
         [AllowEmptyString]
@@ -996,7 +996,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets files to read from.
         /// Globbing is done on these.
         /// </summary>
-        [Parameter(Position = 1, Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = "FileQuiet")]
+        [Parameter(Position = 1, Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = "File")]
         [Parameter(Position = 1, Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = "FileRaw")]
         [FileinfoToString]
         public string[] Path { get; set; }
@@ -1005,7 +1005,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets literal files to read from.
         /// Globbing is not done on these.
         /// </summary>
-        [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = "LiteralFileQuiet")]
+        [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = "LiteralFile")]
         [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = "LiteralFileRaw")]
         [FileinfoToString]
         [Alias("PSPath", "LP")]
@@ -1048,9 +1048,9 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets a value indicating if the cmdlet will stop processing at the first successful match and
         /// return true.  If both List and Quiet parameters are given, an exception is thrown.
         /// </summary>
-        [Parameter(ParameterSetName = "ObjectQuiet")]
-        [Parameter(ParameterSetName = "FileQuiet")]
-        [Parameter(ParameterSetName = "LiteralFileQuiet")]
+        [Parameter(ParameterSetName = "Object")]
+        [Parameter(ParameterSetName = "File")]
+        [Parameter(ParameterSetName = "LiteralFile")]
         public SwitchParameter Quiet { get; set; }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -1191,7 +1191,9 @@ namespace Microsoft.PowerShell.Commands
         private int _postContext = 0;
 
         // When we are in Raw mode or pre- and postcontext are zero, use the _noContextTracker, since we will not be needing trackedLines.
-        private IContextTracker GetContextTracker() => (Raw || (_preContext == 0 && _postContext == 0)) ? _noContextTracker : new ContextTracker(_preContext, _postContext);
+        private IContextTracker GetContextTracker() => (Raw || (_preContext == 0 && _postContext == 0)) 
+            ? _noContextTracker 
+            : new ContextTracker(_preContext, _postContext);
 
         // This context tracker is only used for strings which are piped
         // directly into the cmdlet. File processing doesn't need

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -1183,7 +1183,7 @@ namespace Microsoft.PowerShell.Commands
         private int _postContext = 0;
 
         // When we are in Raw mode or pre- and postcontext are zero, use the _noContextTracker, since we will not be needing trackedLines.
-        private IContextTracker GetContextTracker() => (Raw || _preContext == 0 && _postContext == 0) ? _noContextTracker : new ContextTracker(_preContext, _postContext);
+        private IContextTracker GetContextTracker() => (Raw || (_preContext == 0 && _postContext == 0)) ? _noContextTracker : new ContextTracker(_preContext, _postContext);
 
         // This context tracker is only used for strings which are piped
         // directly into the cmdlet. File processing doesn't need

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -1455,7 +1455,6 @@ namespace Microsoft.PowerShell.Commands
                     WriteObject(match.Line);
                 }
             }
-            // If -quiet is specified but not -list return true on first match
             else if (Quiet && !List)
             {
                 WriteObject(true);

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -76,7 +76,7 @@ Describe "Select-String" -Tags "CI" {
 	    $secondMatch = $testinputone | Select-String -pattern "goodbye" -n
 
 	    $equal = @(Compare-Object $firstMatch $secondMatch).Length -eq 0
-	    $equal | Should -Be True
+	    $equal | Should -BeTrue
 	}
 
 	It "Should return a string type when -Raw is used" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -68,7 +68,7 @@ Describe "Select-String" -Tags "CI" {
 	}
 
 	it "Should return an array of non matching strings when the switch of NotMatch is used and the string do not match" {
-	    $testinputone | Select-String -Pattern "goodbye" -NotMatch | Should -Be "hello", "hello"
+	    $testinputone | Select-String -Pattern "goodbye" -NotMatch | Should -BeExactly "hello", "Hello"
 	}
 
 	it "Should return the same as NotMatch" {
@@ -115,13 +115,13 @@ Describe "Select-String" -Tags "CI" {
 	It "Should return the name of the file and the string that 'string' is found if there is only one lines that has a match" {
 	    $expected = $testInputFile + ":1:This is a text string, and another string"
 
-	    Select-String $testInputFile -Pattern "string" | Should -Be $expected
+	    Select-String $testInputFile -Pattern "string" | Should -BeExactly $expected
 	}
 
 	It "Should return all strings where 'second' is found in testfile1 if there is only one lines that has a match" {
 	    $expected = $testInputFile + ":2:This is the second line"
 
-	    Select-String $testInputFile  -Pattern "second"| Should -Be $expected
+	    Select-String $testInputFile  -Pattern "second"| Should -BeExactly $expected
 	}
 
 	It "Should return all strings where 'in' is found in testfile1 pattern switch is not required" {
@@ -130,10 +130,10 @@ Describe "Select-String" -Tags "CI" {
 	    $expected3 = "This is the third line"
 	    $expected4 = "This is the fourth line"
 
-	    (Select-String in $testInputFile)[0].Line | Should -Be $expected1
-	    (Select-String in $testInputFile)[1].Line | Should -Be $expected2
-	    (Select-String in $testInputFile)[2].Line | Should -Be $expected3
-	    (Select-String in $testInputFile)[3].Line | Should -Be $expected4
+	    (Select-String in $testInputFile)[0].Line | Should -BeExactly $expected1
+	    (Select-String in $testInputFile)[1].Line | Should -BeExactly $expected2
+	    (Select-String in $testInputFile)[2].Line | Should -BeExactly $expected3
+	    (Select-String in $testInputFile)[3].Line | Should -BeExactly $expected4
 	    (Select-String in $testInputFile)[4].Line | Should -BeNullOrEmpty
 	}
 
@@ -192,15 +192,15 @@ Describe "Select-String" -Tags "CI" {
 	    $expected4 = "This is the fourth line"
 
 	    (Select-String in $testInputFile -Raw)[0] | Should -BeExactly $expected1
-	    (Select-String in $testInputFile -Raw)[1] | Should -Be $expected2
-	    (Select-String in $testInputFile -Raw)[2] | Should -Be $expected3
-	    (Select-String in $testInputFile -Raw)[3] | Should -Be $expected4
+	    (Select-String in $testInputFile -Raw)[1] | Should -BeExactly $expected2
+	    (Select-String in $testInputFile -Raw)[2] | Should -BeExactly $expected3
+	    (Select-String in $testInputFile -Raw)[3] | Should -BeExactly $expected4
 	    (Select-String in $testInputFile -Raw)[4] | Should -BeNullOrEmpty
 	}
 
 	It "Should ignore -Context parameter when -Raw is used." {
 		$expected = "This is the second line"
-		Select-String second $testInputFile -Raw -Context 2,2 | Should -Be $expected
+		Select-String second $testInputFile -Raw -Context 2,2 | Should -BeExactly $expected
 	}
     }
     Push-Location $currentDirectory

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -191,7 +191,7 @@ Describe "Select-String" -Tags "CI" {
 	    $expected3 = "This is the third line"
 	    $expected4 = "This is the fourth line"
 
-	    (Select-String in $testInputFile -Raw)[0] | Should -Be $expected1
+	    (Select-String in $testInputFile -Raw)[0] | Should -BeExactly $expected1
 	    (Select-String in $testInputFile -Raw)[1] | Should -Be $expected2
 	    (Select-String in $testInputFile -Raw)[2] | Should -Be $expected3
 	    (Select-String in $testInputFile -Raw)[3] | Should -Be $expected4

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-Describe "Select-String" -Tags "CI","SLS" {
+Describe "Select-String" -Tags "CI" {
     $nl = [Environment]::NewLine
     $currentDirectory = $pwd.Path
     Context "String actions" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -83,6 +83,10 @@ Describe "Select-String" -Tags "CI" {
 		$result = $testinputtwo | Select-String -Pattern "hello" -CaseSensitive -Raw
 		$result | Should -BeOfType "System.String"
 	}
+
+	It "Should return ParameterBindingException when -Raw and -Quiet are used together" {
+		{ $testinputone | Select-String -Pattern "hello" -Raw -Quiet -ErrorAction Stop } | Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+	}
     }
 
     Context "Filesystem actions" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-Describe "Select-String" -Tags "CI" {
+Describe "Select-String" -Tags "CI","SLS" {
     $nl = [Environment]::NewLine
     $currentDirectory = $pwd.Path
     Context "String actions" {
@@ -77,6 +77,11 @@ Describe "Select-String" -Tags "CI" {
 
 	    $equal = @(Compare-Object $firstMatch $secondMatch).Length -eq 0
 	    $equal | Should -Be True
+	}
+
+	it "Should return a string type when -Raw is used" {
+		$result = $testinputtwo | Select-String -Pattern "hello" -CaseSensitive -Raw
+		,$result | Should -BeOfType "System.String"
 	}
     }
 
@@ -174,6 +179,24 @@ Describe "Select-String" -Tags "CI" {
 	    $expected  = "testfile1.txt:5:No matches"
 
 	    Select-String 'matc*' $testInputFile -ca | Should -Match $expected
+	}
+
+	It "Should return all strings where 'in' is found in testfile1, when -Raw is used." {
+	    $expected1 = "This is a text string, and another string"
+	    $expected2 = "This is the second line"
+	    $expected3 = "This is the third line"
+	    $expected4 = "This is the fourth line"
+
+	    (Select-String in $testInputFile -Raw)[0] | Should -Be $expected1
+	    (Select-String in $testInputFile -Raw)[1] | Should -Be $expected2
+	    (Select-String in $testInputFile -Raw)[2] | Should -Be $expected3
+	    (Select-String in $testInputFile -Raw)[3] | Should -Be $expected4
+	    (Select-String in $testInputFile -Raw)[4] | Should -BeNullOrEmpty
+	}
+
+	It "Should ignore -Context parameter when -Raw is used." {
+		$expected = "This is the second line"
+		Select-String second $testInputFile -Raw -Context 2,2 | Should -Be $expected
 	}
     }
     Push-Location $currentDirectory

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -79,9 +79,9 @@ Describe "Select-String" -Tags "CI" {
 	    $equal | Should -Be True
 	}
 
-	it "Should return a string type when -Raw is used" {
+	It "Should return a string type when -Raw is used" {
 		$result = $testinputtwo | Select-String -Pattern "hello" -CaseSensitive -Raw
-		,$result | Should -BeOfType "System.String"
+		$result | Should -BeOfType "System.String"
 	}
     }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Resolves #7713 
This adds a `-Raw` switch parameter to Select-String, for convenience. 

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
This is my first PR to the PowerShell repo, so I picked this tiny issue. As to why this switch is desirable has already been discussed thoroughly in the issue. 

~~The approach I've taken does not introduce new parameter sets, even though -Raw is not compatible with -Quiet and -Context.~~ In the case -Raw is used together with -Context, the latter is ignored. To me, it would not make sense to have context lines when all we want is matched lines. ~~In the case -Raw is used together with -Quiet, Quiet takes precedence, because the choice for precedence seemed somewhat arbitrary and it was easier to implement this way. One might argue that respecting a users whish for -Quiet behaviour is more important than returning strings in that case.~~
_Edit: after discussion, -Raw and -Quiet were put in separate parametersets._

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.

I'm unsure about this part below ⬇️ . I think you could say this is a backwards compatible breaking change. It introduces a new feature, but does not break existing functionality. Please advise.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/4537
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
