### PR TITLE
Add more Extra variables to be allowed to be referenced in module manifest

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -448,16 +448,14 @@ namespace Microsoft.PowerShell.Commands
         /// Extra variables that are allowed to be referenced in module manifest file.
         /// </summary>
         private static readonly string[] s_extraAllowedVariables = new string[] {
-            SpecialVariables.PSScriptRoot,
-            SpecialVariables.PSHome,
-            SpecialVariables.PSEdition,
-            SpecialVariables.PSCulture,
-            SpecialVariables.PSUICulture,
-            SpecialVariables.IsCoreCLR,
+            SpecialVariables.EnabledExperimentalFeatures,
+            SpecialVariables.Home,
             SpecialVariables.IsLinux,
             SpecialVariables.IsMacOS,
             SpecialVariables.IsWindows,
-            SpecialVariables.EnabledExperimentalFeatures
+            SpecialVariables.PSEdition,
+            SpecialVariables.PSHome,
+            SpecialVariables.PSScriptRoot
         };
 
         /// <summary>

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -447,7 +447,18 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Extra variables that are allowed to be referenced in module manifest file.
         /// </summary>
-        private static readonly string[] s_extraAllowedVariables = new string[] { SpecialVariables.PSScriptRoot, SpecialVariables.PSEdition, SpecialVariables.EnabledExperimentalFeatures };
+        private static readonly string[] s_extraAllowedVariables = new string[] {
+            SpecialVariables.PSScriptRoot,
+            SpecialVariables.PSHome,
+            SpecialVariables.PSEdition,
+            SpecialVariables.PSCulture,
+            SpecialVariables.PSUICulture,
+            SpecialVariables.IsCoreCLR,
+            SpecialVariables.IsLinux,
+            SpecialVariables.IsMacOS,
+            SpecialVariables.IsWindows,
+            SpecialVariables.EnabledExperimentalFeatures
+        };
 
         /// <summary>
         /// Load and execute the manifest psd1 file or a localized manifest psd1 file.

--- a/test/powershell/engine/Module/TestModuleManifest.Tests.ps1
+++ b/test/powershell/engine/Module/TestModuleManifest.Tests.ps1
@@ -140,6 +140,38 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
         $module.NestedModules | Should -HaveCount 1
         $module.NestedModules.Name | Should -BeExactly "Foo"
     }
+
+    It "module manifest containing Special Variables" {
+        
+        Set-Content -Path $testModulePath -Value @'
+@{
+    ModuleVersion     = "1.2.3"
+    PrivateData = @{
+        PSScriptRoot = "$PSScriptRoot"
+        PSHome = "$PSHome"
+        PSEdition = "$PSEdition"
+        PSCulture  = "$PSCulture"
+        PSUICulture = "$PSUICulture"
+        IsCoreCLR = "$IsCoreCLR"
+        IsWindows = "$IsWindows"
+        IsLinux = "$IsLinux"
+        IsMacOS = "$IsMacOS"
+        EnabledExperimentalFeatures = "$EnabledExperimentalFeatures"
+    }
+}
+'@
+        $module = Test-ModuleManifest -Path $testModulePath
+        $module.PrivateData.PSScriptRoot | Should -Not -BeNullOrEmpty
+        $module.PrivateData.PSHome | Should -Not -BeNullOrEmpty
+        $module.PrivateData.PSEdition | Should -BeExactly "$PSEdition"
+        $module.PrivateData.PSCulture | Should -BeExactly "$PSCulture"
+        $module.PrivateData.PSUICulture | Should -BeExactly "$PSUICulture"
+        $module.PrivateData.IsCoreCLR | Should -BeExactly "$IsCoreCLR"
+        $module.PrivateData.IsWindows | Should -BeExactly "$IsWindows"
+        $module.PrivateData.IsLinux | Should -BeExactly "$IsLinux"
+        $module.PrivateData.IsMacOS | Should -BeExactly "$IsMacOS"
+        $module.PrivateData.EnabledExperimentalFeatures | Should -BeExactly "$EnabledExperimentalFeatures"
+    }
 }
 
 Describe "Tests for circular references in required modules" -tags "CI" {

--- a/test/powershell/engine/Module/TestModuleManifest.Tests.ps1
+++ b/test/powershell/engine/Module/TestModuleManifest.Tests.ps1
@@ -147,30 +147,30 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
 @{
     ModuleVersion     = "1.2.3"
     PrivateData = @{
-        PSScriptRoot = "$PSScriptRoot"
-        PSHome = "$PSHome"
-        PSEdition = "$PSEdition"
-        PSCulture  = "$PSCulture"
-        PSUICulture = "$PSUICulture"
-        IsCoreCLR = "$IsCoreCLR"
-        IsWindows = "$IsWindows"
+        EnabledExperimentalFeatures = "$EnabledExperimentalFeatures"
+        Home = "$Home"
         IsLinux = "$IsLinux"
         IsMacOS = "$IsMacOS"
-        EnabledExperimentalFeatures = "$EnabledExperimentalFeatures"
+        IsWindows = "$IsWindows"
+        PSCulture  = "$PSCulture"
+        PSUICulture = "$PSUICulture"
+        PSEdition = "$PSEdition"
+        PSHome = "$PSHome"
+        PSScriptRoot = "$PSScriptRoot"
     }
 }
 '@
         $module = Test-ModuleManifest -Path $testModulePath
-        $module.PrivateData.PSScriptRoot | Should -Not -BeNullOrEmpty
-        $module.PrivateData.PSHome | Should -Not -BeNullOrEmpty
-        $module.PrivateData.PSEdition | Should -BeExactly "$PSEdition"
-        $module.PrivateData.PSCulture | Should -BeExactly "$PSCulture"
-        $module.PrivateData.PSUICulture | Should -BeExactly "$PSUICulture"
-        $module.PrivateData.IsCoreCLR | Should -BeExactly "$IsCoreCLR"
-        $module.PrivateData.IsWindows | Should -BeExactly "$IsWindows"
+        $module.PrivateData.EnabledExperimentalFeatures | Should -BeExactly "$EnabledExperimentalFeatures"
+        $module.PrivateData.Home | Should -Not -BeNullOrEmpty
         $module.PrivateData.IsLinux | Should -BeExactly "$IsLinux"
         $module.PrivateData.IsMacOS | Should -BeExactly "$IsMacOS"
-        $module.PrivateData.EnabledExperimentalFeatures | Should -BeExactly "$EnabledExperimentalFeatures"
+        $module.PrivateData.IsWindows | Should -BeExactly "$IsWindows"
+        $module.PrivateData.PSCulture | Should -BeExactly "$PSCulture"
+        $module.PrivateData.PSUICulture | Should -BeExactly "$PSUICulture"
+        $module.PrivateData.PSEdition | Should -BeExactly "$PSEdition"
+        $module.PrivateData.PSHome | Should -Not -BeNullOrEmpty
+        $module.PrivateData.PSScriptRoot | Should -Not -BeNullOrEmpty
     }
 }
 

--- a/test/powershell/engine/Module/TestModuleManifest.Tests.ps1
+++ b/test/powershell/engine/Module/TestModuleManifest.Tests.ps1
@@ -141,7 +141,7 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
         $module.NestedModules.Name | Should -BeExactly "Foo"
     }
 
-    It "module manifest containing Special Variables" {
+    It "module manifest containing some Special Variables are allowed" {
         
         Set-Content -Path $testModulePath -Value @'
 @{


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Module Manifest can contain the following special variables : PSScriptRoot, PSEdition and EnabledExperimentalFeatures.

The aim of this PR is to extend the allowed variable list to :
- PSHome
- PSCulture,
- PSUICulture,
- IsCoreCLR,
- IsLinux,
- IsMacOS,
- IsWindow

## PR Context

As a PowerShell developper, I deal with cross platform and cross language, to allow more special variables let me handle more heterogeneous within the module manifest.

This PR is a followup of 
- [Allow automatic variable Is* inside PowerShell module manifest file](https://github.com/PowerShell/PowerShell/issues/9386)
- [Current module manifest schema is not adequate to properly support cross-platform modules](https://github.com/PowerShell/PowerShell/issues/5541)

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [] Not Applicable
    - **OR**
    - [X] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
