### PR TITLE
Fix `#requires -version` for pwsh 7 to include 6.1 and 6.2 in `PSCompatibleVersions`

### DIFF
--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -59,6 +59,8 @@ namespace System.Management.Automation
         private static readonly Version s_psV5Version = new Version(5, 0);
         private static readonly Version s_psV51Version = new Version(5, 1, NTVerpVars.PRODUCTBUILD, NTVerpVars.PRODUCTBUILD_QFE);
         private static readonly SemanticVersion s_psV6Version = new SemanticVersion(6, 0, 0, preReleaseLabel: null, buildLabel: null);
+        private static readonly SemanticVersion s_psV61Version = new SemanticVersion(6, 1, 0, preReleaseLabel: null, buildLabel: null);
+        private static readonly SemanticVersion s_psV62Version = new SemanticVersion(6, 2, 0, preReleaseLabel: null, buildLabel: null);
         private static readonly SemanticVersion s_psSemVersion;
         private static readonly Version s_psVersion;
 
@@ -105,7 +107,7 @@ namespace System.Management.Automation
             s_psVersionTable[PSVersionInfo.PSVersionName] = s_psSemVersion;
             s_psVersionTable[PSVersionInfo.PSEditionName] = PSEditionValue;
             s_psVersionTable[PSGitCommitIdName] = rawGitCommitId;
-            s_psVersionTable[PSCompatibleVersionsName] = new Version[] { s_psV1Version, s_psV2Version, s_psV3Version, s_psV4Version, s_psV5Version, s_psV51Version, s_psV6Version, s_psVersion };
+            s_psVersionTable[PSCompatibleVersionsName] = new Version[] { s_psV1Version, s_psV2Version, s_psV3Version, s_psV4Version, s_psV5Version, s_psV51Version, s_psV6Version, s_psV61Version, s_psV62Version, s_psVersion };
             s_psVersionTable[PSVersionInfo.SerializationVersionName] = new Version(InternalSerializer.DefaultVersion);
             s_psVersionTable[PSVersionInfo.PSRemotingProtocolVersionName] = RemotingConstants.ProtocolVersion;
             s_psVersionTable[PSVersionInfo.WSManStackVersionName] = GetWSManStackVersion();

--- a/test/powershell/Host/PSVersionTable.Tests.ps1
+++ b/test/powershell/Host/PSVersionTable.Tests.ps1
@@ -22,6 +22,10 @@ Describe "PSVersionTable" -Tags "CI" {
             $expectedGitCommitIdPattern = "^$mainVersionPattern$"
             $unexpectectGitCommitIdPattern = $fullVersionPattern
         }
+
+        $powerShellVersions = "1.0", "2.0", "3.0", "4.0", "5.0", "5.1", "6.0", "6.1", "6.2", "7.0"
+        $powerShellCompatibleVersions = $PSVersionTable.PSCompatibleVersions |
+            ForEach-Object {$_.ToString(2).SubString(0,3)}
     }
 
     It "Should have version table entries" {
@@ -156,6 +160,18 @@ Describe "PSVersionTable" -Tags "CI" {
         } finally {
             $PSVersionTable.Add("PSVersion", $VersionValue)
             $PSVersionTable.Add("PSEdition", $EditionValue)
+        }
+    }
+
+    It "Verify PSCompatibleVersions has an entry for all known versions of PowerShell" {
+        foreach ($version in $powerShellVersions) {
+            $version | Should -BeIn $powerShellCompatibleVersions
+        }
+    }
+
+    It "Verify PSCompatibleVersions has no unknown PowerShell entries" {
+        foreach ($version in $powerShellCompatibleVersions) {
+            $version | Should -BeIn $powerShellVersions
         }
     }
 }

--- a/test/powershell/Language/Scripting/Requires.Tests.ps1
+++ b/test/powershell/Language/Scripting/Requires.Tests.ps1
@@ -36,6 +36,29 @@ Describe "Requires tests" -Tags "CI" {
             { $ps.AddScript("#requires").Invoke(@(), $settings) } | Should -Not -Throw
         }
     }
+
+    Context "Version checks" {
+        BeforeAll {
+            $currentVersion = $PSVersionTable.PSVersion
+
+            $files = "6.1", "6.2" | ForEach-Object { New-Item -Path (Join-Path $TestDrive "vers$_.ps1") -Value "#requires -version $_" }
+
+            $filesTestCase = @(
+                @{ Name = "Check for version 6.1" ; File = $files[0] }
+                @{ Name = "Check for version 6.2" ; File = $files[1] }
+            )
+        }
+
+        It "<Name>" -TestCase $filesTestCase {
+            param( $Name, $File)
+
+            if ($currentVersion -notmatch '^7') {
+                Set-ItResult -Skipped -Because "Test not valid for current version - $currentVersion"
+            }
+
+            { . $file } | Should -Not -Throw
+        }
+    }
 }
 
 Describe "#requires -Modules" -Tags "CI" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixed bug when pwsh 7.x is used and a script has a `#requires -version 6.2`

Updated `PSCompatibleVersions` to include 6.1 and 6.2

## PR Context

Fixes #9938

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: #9938
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
