### PR TITLE
Avoid the `int[]` and `int[,]` allocation when tokenizing line comments and matching wildcard pattern

### DIFF
--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -1661,6 +1661,9 @@ namespace System.Management.Automation.Language
                     case '\n':
                         UngetChar();
 
+                        // Detect a line comment that disguises itself to look like the beginning of a signature block.
+                        // This could be used to hide code at the bottom of a script, since people might assume there is nothing else after the signature.
+                        //
                         // The token similarity threshold was chosen by instrumenting the tokenizer and
                         // analyzing every comment from PoshCode, Technet Script Center, and Windows.
                         //
@@ -1677,8 +1680,6 @@ namespace System.Management.Automation.Language
                         //
                         // There were only 279 (out of 269,387) comments with a similarity of 11,12,13,14, or 15.
                         // At a similarity of 16-77, there were thousands of comments per similarity bucket.
-                        //
-                        // System.IO.File.AppendAllText(@"c:\temp\signature_similarity.txt", "" + sawBeginTokenSimilarity + ":" + commentLineComparison);
 
                         const string beginSignatureTextNoSpace = "sig#beginsignatureblock\n";
                         const int beginTokenSimilarityThreshold = 10;

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -1683,9 +1683,12 @@ namespace System.Management.Automation.Language
                         const string beginSignatureTextNoSpace = "sig#beginsignatureblock\n";
                         const int beginTokenSimilarityThreshold = 10;
 
-                        // Quick exit - the comment line is more than 'threshold' longer. Therefore,
+                        const int beginTokenSimilarityUpperBound = 34; // beginSignatureTextNoSpace.Length + beginTokenSimilarityThreshold
+                        const int beginTokenSimilarityLowerBound = 14; // beginSignatureTextNoSpace.Length - beginTokenSimilarityThreshold
+
+                        // Quick exit - the comment line is more than 'threshold' longer, or is less than 'threshold' shorter. Therefore,
                         // its similarity will be over the threshold.
-                        if (commentLine.Length > (beginSignatureTextNoSpace.Length + beginTokenSimilarityThreshold))
+                        if (commentLine.Length > beginTokenSimilarityUpperBound || commentLine.Length < beginTokenSimilarityLowerBound)
                         {
                             sawBeginSig = false;
                         }


### PR DESCRIPTION
# PR Summary

Avoid the `int[]` and `int[,]` allocation when tokenizing line comments and matching wildcard pattern by
1. Reusing the same 2-dimensional integer array for processing line comments in the same `Tokenizer`.
2. Use `ArrayPool<int>` in `PatternPositionVisitor` to avoid creating transient `int[]`.

These two changes reduces the allocation of `int[]` and `int[,]` significantly in the command discovery scenario where module analysis is required. See the allocation comparison below:
(given line comment tokenizing and wildcard matching are relatively hot code path, this change could improve other scenarios too)

#### Before the change
`int[,]` -- 3.8 mb
`int[]` -- 2.3 mb

![image](https://user-images.githubusercontent.com/127450/60194699-af442480-97ee-11e9-9003-32abfbe97596.png)

#### After the change

`int[,]` -- 200 kb
`int[]` -- 280 kb

![image](https://user-images.githubusercontent.com/127450/60194929-16fa6f80-97ef-11e9-9507-154c1a858e95.png)

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
