### PR TITLE
Add fast path for wildcard patterns that contains no wildcard characters

### DIFF
--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -143,37 +143,40 @@ namespace System.Management.Automation
         /// <returns>True on success, false otherwise.</returns>
         private void Init()
         {
-            if (_isMatch == null)
+            if (_isMatch != null)
             {
-                if (Pattern.Length == 1 && Pattern[0] == '*')
-                {
-                    _isMatch = s_matchAll;
-                }
-                else if (Pattern.IndexOfAny(s_specialChars) == -1)
-                {
-                    // No special characters present in the pattern, so we can just do a string comparison.
-                    StringComparison stringComparison;
-                    if (Options.HasFlag(WildcardOptions.IgnoreCase))
-                    {
-                        stringComparison = Options.HasFlag(WildcardOptions.CultureInvariant)
-                            ? StringComparison.InvariantCultureIgnoreCase
-                            : StringComparison.CurrentCultureIgnoreCase;
-                    }
-                    else
-                    {
-                        stringComparison = Options.HasFlag(WildcardOptions.CultureInvariant)
-                            ? StringComparison.InvariantCulture
-                            : StringComparison.CurrentCulture;
-                    }
+                return;
+            }
 
-                    _isMatch = str => string.Equals(str, Pattern, stringComparison);
+            if (Pattern.Length == 1 && Pattern[0] == '*')
+            {
+                _isMatch = s_matchAll;
+                return;
+            }
+
+            if (Pattern.IndexOfAny(s_specialChars) == -1)
+            {
+                // No special characters present in the pattern, so we can just do a string comparison.
+                StringComparison stringComparison;
+                if (Options.HasFlag(WildcardOptions.IgnoreCase))
+                {
+                    stringComparison = Options.HasFlag(WildcardOptions.CultureInvariant)
+                        ? StringComparison.InvariantCultureIgnoreCase
+                        : StringComparison.CurrentCultureIgnoreCase;
                 }
                 else
                 {
-                    var matcher = new WildcardPatternMatcher(this);
-                    _isMatch = matcher.IsMatch;
+                    stringComparison = Options.HasFlag(WildcardOptions.CultureInvariant)
+                        ? StringComparison.InvariantCulture
+                        : StringComparison.CurrentCulture;
                 }
+
+                _isMatch = str => string.Equals(str, Pattern, stringComparison);
+                return;
             }
+
+            var matcher = new WildcardPatternMatcher(this);
+            _isMatch = matcher.IsMatch;
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -50,34 +50,22 @@ namespace System.Management.Automation
     /// </summary>
     public sealed class WildcardPattern
     {
-        //
         // char that escapes special chars
-        //
         private const char escapeChar = '`';
 
-        //
         // we convert a wildcard pattern to a predicate
-        //
         private Predicate<string> _isMatch;
 
-        //
         // chars that are considered special in a wildcard pattern
-        //
-        private readonly static char[] s_specialChars = new char[] { '*', '?', '[', ']', '`' };
+        private static readonly char[] s_specialChars = new char[] { '*', '?', '[', ']', '`' };
 
-        //
         // static match-all delegate that is shared by all WildcardPattern instances
-        //
-        private readonly static Predicate<string> s_matchAll = _ => true;
+        private static readonly Predicate<string> s_matchAll = _ => true;
 
-        //
         // wildcard pattern
-        //
         internal string Pattern { get; }
 
-        //
         // options that control match behavior
-        //
         internal WildcardOptions Options { get; } = WildcardOptions.None;
 
         /// <summary>

--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -57,7 +57,7 @@ namespace System.Management.Automation
         private Predicate<string> _isMatch;
 
         // chars that are considered special in a wildcard pattern
-        private static readonly char[] s_specialChars = new char[] { '*', '?', '[', ']', '`' };
+        private static readonly char[] s_specialChars = new[] { '*', '?', '[', ']', '`' };
 
         // static match-all delegate that is shared by all WildcardPattern instances
         private static readonly Predicate<string> s_matchAll = _ => true;

--- a/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
+++ b/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
@@ -1039,11 +1039,7 @@ namespace System.Management.Automation
 
                 string moduleName = Path.Combine(applicationBase, defaultMshSnapinInfo.AssemblyName + ".dll");
 
-                if (File.Exists(moduleName))
-                {
-                    moduleName = Path.Combine(applicationBase, defaultMshSnapinInfo.AssemblyName + ".dll");
-                }
-                else
+                if (!File.Exists(moduleName))
                 {
                     moduleName = defaultMshSnapinInfo.AssemblyName;
                 }


### PR DESCRIPTION
# PR Summary

At many places in the code base, PowerShell uses `WildcardPattern` for strings that don't really contain any wildcard characters. For example, `Import-Module` use `WildcardPattern` for entries of `ExposedFunctions`, `ExposedCmdlets`, `ExposedAlias` and etc. even if those entries contain no wildcard characters. In that case, `WildcardPattern.IsMatch` essentially should just do a string comparison, but we are go through the same code path that handles real wildcard patterns, while results in unnecessary cycles and allocations.

This PR adds a fast path for `WildcardPattern.IsMatch(string)` for that case -- simply do a string comparison when the pattern string contains no special characters (wildcard characters `*`, `?`, `[`, `]` and the escape character backtick `).

The following is the the memory allocation when the module analysis is triggered.
As is shown, `int32[]` allocation drops drastically, and also the type `PatternPositionVisitor` is completely avoided.
This is because the pattern matching happens in module analysis (e.g. `ModuleIntrinsics.ExportModuleMembers`) are now going through the fast path.

![image](https://user-images.githubusercontent.com/127450/60305002-ffef7680-98ef-11e9-8b47-f33f8766202e.png)

Also, `WildcardPattern.IsMatch` is about 2x faster in steady state when the pattern string contains no wildcard characters:

#### Before the change

```
PS:1> $p = [WildcardPattern]::new("abcdefghi")
PS:18> Measure-Command { foreach ($i in 1..100000) { $p.IsMatch("abc") } }

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 103
Ticks             : 1030111
TotalDays         : 1.19225810185185E-06
TotalHours        : 2.86141944444444E-05
TotalMinutes      : 0.00171685166666667
TotalSeconds      : 0.1030111
TotalMilliseconds : 103.0111
```

#### After the change
```
PS:1> $p = [WildcardPattern]::new("abcdefghi")
PS:31> Measure-Command { foreach ($i in 1..100000) { $p.IsMatch("abc") } }

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 59
Ticks             : 594633
TotalDays         : 6.88232638888889E-07
TotalHours        : 1.65175833333333E-05
TotalMinutes      : 0.000991055
TotalSeconds      : 0.0594633
TotalMilliseconds : 59.4633
```

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
