### PR TITLE
Use a static cache for `PSVersionInfo.PSVersion` to avoid casting `SemanticVersion` to `Version` every time accessing that property

### DIFF
--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -58,7 +58,7 @@ namespace System.Management.Automation
         private static readonly Version s_psV4Version = new Version(4, 0);
         private static readonly Version s_psV5Version = new Version(5, 0);
         private static readonly Version s_psV51Version = new Version(5, 1, NTVerpVars.PRODUCTBUILD, NTVerpVars.PRODUCTBUILD_QFE);
-        private static readonly SemanticVersion s_psV6Version = new SemanticVersion(6, 0, 0, null, null);
+        private static readonly SemanticVersion s_psV6Version = new SemanticVersion(6, 0, 0, preReleaseLabel: null, buildLabel: null);
         private static readonly SemanticVersion s_psSemVersion;
         private static readonly Version s_psVersion;
 

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -122,7 +122,7 @@ namespace System.Management.Automation
         {
             var result = (Hashtable)s_psVersionTable.Clone();
             // Downlevel systems don't support SemanticVersion, but Version is most likely good enough anyway.
-            result[PSVersionInfo.PSVersionName] = PSVersion;
+            result[PSVersionInfo.PSVersionName] = s_psVersionCache;
             return result;
         }
 

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -59,8 +59,8 @@ namespace System.Management.Automation
         private static readonly Version s_psV5Version = new Version(5, 0);
         private static readonly Version s_psV51Version = new Version(5, 1, NTVerpVars.PRODUCTBUILD, NTVerpVars.PRODUCTBUILD_QFE);
         private static readonly SemanticVersion s_psV6Version = new SemanticVersion(6, 0, 0, null, null);
-        private static readonly SemanticVersion s_psCurrentVersion;
-        private static readonly Version s_psVersionCache;
+        private static readonly SemanticVersion s_psSemVersion;
+        private static readonly Version s_psVersion;
 
         /// <summary>
         /// A constant to track current PowerShell Edition.
@@ -99,13 +99,13 @@ namespace System.Management.Automation
                 rawGitCommitId = mainVersion;
             }
 
-            s_psCurrentVersion = new SemanticVersion(mainVersion);
-            s_psVersionCache = (Version)s_psCurrentVersion;
+            s_psSemVersion = new SemanticVersion(mainVersion);
+            s_psVersion = (Version)s_psSemVersion;
 
-            s_psVersionTable[PSVersionInfo.PSVersionName] = s_psCurrentVersion;
+            s_psVersionTable[PSVersionInfo.PSVersionName] = s_psSemVersion;
             s_psVersionTable[PSVersionInfo.PSEditionName] = PSEditionValue;
             s_psVersionTable[PSGitCommitIdName] = rawGitCommitId;
-            s_psVersionTable[PSCompatibleVersionsName] = new Version[] { s_psV1Version, s_psV2Version, s_psV3Version, s_psV4Version, s_psV5Version, s_psV51Version, s_psV6Version, s_psVersionCache };
+            s_psVersionTable[PSCompatibleVersionsName] = new Version[] { s_psV1Version, s_psV2Version, s_psV3Version, s_psV4Version, s_psV5Version, s_psV51Version, s_psV6Version, s_psVersion };
             s_psVersionTable[PSVersionInfo.SerializationVersionName] = new Version(InternalSerializer.DefaultVersion);
             s_psVersionTable[PSVersionInfo.PSRemotingProtocolVersionName] = RemotingConstants.ProtocolVersion;
             s_psVersionTable[PSVersionInfo.WSManStackVersionName] = GetWSManStackVersion();
@@ -122,7 +122,7 @@ namespace System.Management.Automation
         {
             var result = (Hashtable)s_psVersionTable.Clone();
             // Downlevel systems don't support SemanticVersion, but Version is most likely good enough anyway.
-            result[PSVersionInfo.PSVersionName] = s_psVersionCache;
+            result[PSVersionInfo.PSVersionName] = s_psVersion;
             return result;
         }
 
@@ -173,7 +173,7 @@ namespace System.Management.Automation
         {
             get
             {
-                return s_psVersionCache;
+                return s_psVersion;
             }
         }
 
@@ -272,9 +272,9 @@ namespace System.Management.Automation
 
         internal static bool IsValidPSVersion(Version version)
         {
-            if (version.Major == s_psCurrentVersion.Major)
+            if (version.Major == s_psSemVersion.Major)
             {
-                return version.Minor == s_psCurrentVersion.Minor;
+                return version.Minor == s_psSemVersion.Minor;
             }
 
             if (version.Major == s_psV6Version.Major)
@@ -329,7 +329,7 @@ namespace System.Management.Automation
 
         internal static SemanticVersion PSCurrentVersion
         {
-            get { return s_psCurrentVersion; }
+            get { return s_psSemVersion; }
         }
 
         #endregion

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading;
 
 using Microsoft.Win32;
 

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -60,8 +60,8 @@ namespace System.Management.Automation
         private static readonly Version s_psV5Version = new Version(5, 0);
         private static readonly Version s_psV51Version = new Version(5, 1, NTVerpVars.PRODUCTBUILD, NTVerpVars.PRODUCTBUILD_QFE);
         private static readonly SemanticVersion s_psV6Version = new SemanticVersion(6, 0, 0, null, null);
-        private static readonly SemanticVersion s_psV7Version;
-        private static Version s_psVersionCache;
+        private static readonly SemanticVersion s_psCurrentVersion;
+        private static readonly Version s_psVersionCache;
 
         /// <summary>
         /// A constant to track current PowerShell Edition.
@@ -100,12 +100,13 @@ namespace System.Management.Automation
                 rawGitCommitId = mainVersion;
             }
 
-            s_psV7Version = new SemanticVersion(mainVersion);
+            s_psCurrentVersion = new SemanticVersion(mainVersion);
+            s_psVersionCache = (Version)s_psCurrentVersion;
 
-            s_psVersionTable[PSVersionInfo.PSVersionName] = s_psV7Version;
+            s_psVersionTable[PSVersionInfo.PSVersionName] = s_psCurrentVersion;
             s_psVersionTable[PSVersionInfo.PSEditionName] = PSEditionValue;
             s_psVersionTable[PSGitCommitIdName] = rawGitCommitId;
-            s_psVersionTable[PSCompatibleVersionsName] = new Version[] { s_psV1Version, s_psV2Version, s_psV3Version, s_psV4Version, s_psV5Version, s_psV51Version, s_psV6Version, s_psV7Version };
+            s_psVersionTable[PSCompatibleVersionsName] = new Version[] { s_psV1Version, s_psV2Version, s_psV3Version, s_psV4Version, s_psV5Version, s_psV51Version, s_psV6Version, s_psVersionCache };
             s_psVersionTable[PSVersionInfo.SerializationVersionName] = new Version(InternalSerializer.DefaultVersion);
             s_psVersionTable[PSVersionInfo.PSRemotingProtocolVersionName] = RemotingConstants.ProtocolVersion;
             s_psVersionTable[PSVersionInfo.WSManStackVersionName] = GetWSManStackVersion();
@@ -173,13 +174,6 @@ namespace System.Management.Automation
         {
             get
             {
-                if (s_psVersionCache == null)
-                {
-                    // Ideally, we only do one conversion for 'PSVersion' and use the cached value afterwards.
-                    var version = (Version)(SemanticVersion)s_psVersionTable[PSVersionInfo.PSVersionName];
-                    Interlocked.CompareExchange(ref s_psVersionCache, version, null);
-                }
-
                 return s_psVersionCache;
             }
         }
@@ -279,9 +273,9 @@ namespace System.Management.Automation
 
         internal static bool IsValidPSVersion(Version version)
         {
-            if (version.Major == s_psV7Version.Major)
+            if (version.Major == s_psCurrentVersion.Major)
             {
-                return version.Minor == s_psV7Version.Minor;
+                return version.Minor == s_psCurrentVersion.Minor;
             }
 
             if (version.Major == s_psV6Version.Major)
@@ -334,9 +328,9 @@ namespace System.Management.Automation
             get { return s_psV6Version; }
         }
 
-        internal static SemanticVersion PSV7Version
+        internal static SemanticVersion PSCurrentVersion
         {
-            get { return s_psV7Version; }
+            get { return s_psCurrentVersion; }
         }
 
         #endregion


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Use a static cache for `PSVersionInfo.PSVersion` to avoid casting `SemanticVersion` to `Version` every time accessing that property

The work was initially aimed to avoid the ~40 ms CPU spent in the implicit conversion from `SemanticVersion` to `Version` during startup.
The implicit conversion would warp the `Version` instance to `PSObject` and add 2 `NoteProperty` to it (see the code snippet below). 
The ETS related operations is quite slow so the thought was it would be great if we can avoid it.

**However**, it turns out this is a problem **only for preview versions of PowerShell**, **not a problem for official releases**, because official releases won't have the `PreviewLabel` or `BuildLabel` and thus the ETS operations won't kick in during the implicit conversion from `SemanticVersion` to `Version`.

The only perf related change in this PR is to add a cache for `PSVersionInfo.PSVersion`, so it doesn't create a new `Version` instance every time it's accessed.
There is barely noticeable change for the warm startup scenario, but given `PSVesionInfo.PSVersion` is used a lot in the code base, the cache would potentially bring benefits by reducing allocation of `Version` instances in a relatively long running powershell process.

Changes:
1. add a cache for `PSVersionInfo.PSVersion`
2. use `s_psVersionTable` directly instead of calling `GetPSVersionTable()`
3. add `readonly` when applicable.

![image](https://user-images.githubusercontent.com/127450/60360979-d555fa00-9991-11e9-9709-7d96f47331b0.png)

https://github.com/PowerShell/PowerShell/blob/f3a3922285cfd231c270d287c743b131b062443b/src/System.Management.Automation/engine/PSVersionInfo.cs#L588-L603



## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
