### PR TITLE
Make `Foreach-Object` 2x faster by reducing unnecessary allocations and boxing

### DIFF
--- a/Settings.StyleCop
+++ b/Settings.StyleCop
@@ -155,6 +155,7 @@
           <Value>rs</Value>
           <Value>ps</Value>
           <Value>op</Value>
+          <Value>sb</Value>
         </CollectionProperty>
       </AnalyzerSettings>
     </Analyzer>

--- a/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
@@ -3484,7 +3484,7 @@ namespace System.Management.Automation
                         validParameterSets);
             }
 
-            s_tracer.WriteLine("aParameterWasBound = {0}", aParameterWasBound.ToString());
+            s_tracer.WriteLine("aParameterWasBound = {0}", aParameterWasBound);
             return aParameterWasBound;
         }
 

--- a/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
@@ -3484,7 +3484,7 @@ namespace System.Management.Automation
                         validParameterSets);
             }
 
-            s_tracer.WriteLine("aParameterWasBound = {0}", aParameterWasBound);
+            s_tracer.WriteLine("aParameterWasBound = {0}", aParameterWasBound.ToString());
             return aParameterWasBound;
         }
 

--- a/src/System.Management.Automation/engine/CommandInfo.cs
+++ b/src/System.Management.Automation/engine/CommandInfo.cs
@@ -442,8 +442,11 @@ namespace System.Management.Automation
                 // that can mess up the runspace our CommandInfo object came from.
 
                 var runspace = (RunspaceBase)_context.CurrentRunspace;
-                if (!runspace.RunActionIfNoRunningPipelinesWithThreadCheck(
-                        () => GetMergedCommandParameterMetadata(out result)))
+                if (runspace.CanRunActionInCurrentPipeline())
+                {
+                    GetMergedCommandParameterMetadata(out result);
+                }
+                else
                 {
                     _context.Events.SubscribeEvent(
                             source: null,

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -809,6 +809,7 @@ namespace System.Management.Automation
 
         private static readonly ConcurrentDictionary<ConfigScope, ConcurrentDictionary<string, PolicyBase>> s_cachedPoliciesFromRegistry =
             new ConcurrentDictionary<ConfigScope, ConcurrentDictionary<string, PolicyBase>>();
+
         private static readonly Func<ConfigScope, ConcurrentDictionary<string, PolicyBase>> s_subCacheCreationDelegate =
             key => new ConcurrentDictionary<string, PolicyBase>(StringComparer.OrdinalIgnoreCase);
 

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -806,8 +806,11 @@ namespace System.Management.Automation
             {nameof(UpdatableHelp), @"Software\Policies\Microsoft\PowerShellCore\UpdatableHelp"},
             {nameof(ConsoleSessionConfiguration), @"Software\Policies\Microsoft\PowerShellCore\ConsoleSessionConfiguration"}
         };
-        private static readonly ConcurrentDictionary<Tuple<ConfigScope, string>, PolicyBase> s_cachedPoliciesFromRegistry =
-            new ConcurrentDictionary<Tuple<ConfigScope, string>, PolicyBase>();
+
+        private static readonly ConcurrentDictionary<ConfigScope, ConcurrentDictionary<string, PolicyBase>> s_cachedPoliciesFromRegistry =
+            new ConcurrentDictionary<ConfigScope, ConcurrentDictionary<string, PolicyBase>>();
+        private static readonly Func<ConfigScope, ConcurrentDictionary<string, PolicyBase>> s_subCacheCreationDelegate =
+            key => new ConcurrentDictionary<string, PolicyBase>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// The implementation of fetching a specific kind of policy setting from the given configuration scope.
@@ -915,6 +918,8 @@ namespace System.Management.Automation
         private static T GetPolicySettingFromGPO<T>(ConfigScope[] preferenceOrder) where T : PolicyBase, new()
         {
             PolicyBase policy = null;
+            string policyName = typeof(T).Name;
+
             foreach (ConfigScope scope in preferenceOrder)
             {
                 if (InternalTestHooks.BypassGroupPolicyCaching)
@@ -923,13 +928,10 @@ namespace System.Management.Automation
                 }
                 else
                 {
-                    var key = Tuple.Create(scope, typeof(T).Name);
-                    if (!s_cachedPoliciesFromRegistry.TryGetValue(key, out policy))
+                    var subordinateCache = s_cachedPoliciesFromRegistry.GetOrAdd(scope, s_subCacheCreationDelegate);
+                    if (!subordinateCache.TryGetValue(policyName, out policy))
                     {
-                        lock (s_cachedPoliciesFromRegistry)
-                        {
-                            policy = s_cachedPoliciesFromRegistry.GetOrAdd(key, tuple => GetPolicySettingFromGPOImpl<T>(tuple.Item1));
-                        }
+                        policy = subordinateCache.GetOrAdd(policyName, key => GetPolicySettingFromGPOImpl<T>(scope));
                     }
                 }
 

--- a/src/System.Management.Automation/engine/hostifaces/ConnectionBase.cs
+++ b/src/System.Management.Automation/engine/hostifaces/ConnectionBase.cs
@@ -971,30 +971,17 @@ namespace System.Management.Automation.Runspaces
             }
         }
 
-        internal bool RunActionIfNoRunningPipelinesWithThreadCheck(Action action)
+        internal bool CanRunActionInCurrentPipeline()
         {
-            bool ranit = false;
-            bool shouldRunAction = false;
             lock (_pipelineListLock)
             {
                 // If we have no running pipeline, or if the currently running pipeline is
                 // the same as the current thread, then execute the action.
 
                 var pipelineRunning = _currentlyRunningPipeline as PipelineBase;
-                if (pipelineRunning == null ||
-                    Thread.CurrentThread.Equals(pipelineRunning.NestedPipelineExecutionThread))
-                {
-                    shouldRunAction = true;
-                }
+                return pipelineRunning == null || 
+                    Thread.CurrentThread == pipelineRunning.NestedPipelineExecutionThread;
             }
-
-            if (shouldRunAction)
-            {
-                action();
-                ranit = true;
-            }
-
-            return ranit;
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/hostifaces/ConnectionBase.cs
+++ b/src/System.Management.Automation/engine/hostifaces/ConnectionBase.cs
@@ -977,7 +977,6 @@ namespace System.Management.Automation.Runspaces
             {
                 // If we have no running pipeline, or if the currently running pipeline is
                 // the same as the current thread, then execute the action.
-
                 var pipelineRunning = _currentlyRunningPipeline as PipelineBase;
                 return pipelineRunning == null || 
                     Thread.CurrentThread == pipelineRunning.NestedPipelineExecutionThread;

--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -7,13 +7,12 @@ using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
 using System.Management.Automation.Configuration;
+using System.Management.Automation.Internal;
 using System.Management.Automation.Runspaces;
 using System.Security;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-
-using Microsoft.PowerShell.Commands;
 
 namespace System.Management.Automation.Host
 {
@@ -927,7 +926,10 @@ namespace System.Management.Automation.Host
         /// </summary>
         internal static TranscriptionOption GetSystemTranscriptOption(TranscriptionOption currentTranscript)
         {
-            var transcription = Utils.GetPolicySetting<Transcription>(Utils.SystemWideThenCurrentUserConfig);
+            var transcription = InternalTestHooks.BypassGroupPolicyCaching
+                ? Utils.GetPolicySetting<Transcription>(Utils.SystemWideThenCurrentUserConfig)
+                : s_transcriptionSettingCache.Value;
+
             if (transcription != null)
             {
                 // If we have an existing system transcript for this process, use that.
@@ -948,6 +950,9 @@ namespace System.Management.Automation.Host
 
         internal static TranscriptionOption systemTranscript = null;
         private static object s_systemTranscriptLock = new Object();
+        private static Lazy<Transcription> s_transcriptionSettingCache = new Lazy<Transcription>(
+            () => Utils.GetPolicySetting<Transcription>(Utils.SystemWideThenCurrentUserConfig),
+            isThreadSafe: true);
 
         private static TranscriptionOption GetTranscriptOptionFromSettings(Transcription transcriptConfig, TranscriptionOption currentTranscript)
         {

--- a/src/System.Management.Automation/engine/lang/scriptblock.cs
+++ b/src/System.Management.Automation/engine/lang/scriptblock.cs
@@ -975,7 +975,8 @@ namespace System.Management.Automation
                 try
                 {
                     var runspace = (RunspaceBase)context.CurrentRunspace;
-                    shouldGenerateEvent = !runspace.RunActionIfNoRunningPipelinesWithThreadCheck(() =>
+                    if (runspace.CanRunActionInCurrentPipeline())
+                    {
                         InvokeWithPipeImpl(
                             useLocalScope,
                             functionsToDefine,
@@ -986,7 +987,12 @@ namespace System.Management.Automation
                             scriptThis,
                             outputPipe,
                             invocationInfo,
-                            args));
+                            args);
+                    }
+                    else
+                    {
+                        shouldGenerateEvent = true;
+                    }
                 }
                 finally
                 {

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -1949,7 +1949,7 @@ namespace System.Management.Automation
                 // When invoking, log the creation of the script block if it has suspicious content
                 bool forceLogCreation = scriptBlock._scriptBlockData.HasSuspiciousContent;
 
-                // We delay logging the creation util the 'Start' so that we can be sure we've
+                // We delay logging the creation until the 'Start' so that we can be sure we've
                 // properly analyzed the script block's security.
                 LogScriptBlockCreation(scriptBlock, forceLogCreation);
             }

--- a/stylecop.json
+++ b/stylecop.json
@@ -25,7 +25,7 @@
         },
         "namingRules" : {
             "allowCommonHungarianPrefixes" : true,
-            "allowedHungarianPrefixes" : [ "n", "r", "l", "i", "io", "is", "fs", "lp", "dw", "h", "rs", "ps", "op" ]
+            "allowedHungarianPrefixes" : [ "n", "r", "l", "i", "io", "is", "fs", "lp", "dw", "h", "rs", "ps", "op", "sb" ]
         },
         "maintainabilityRules" : {
             "topLevelTypes" : [


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Make `Foreach-Object` 2x faster by reducing unnecessary allocations and boxing.

1. Memory profiling of `$null = 1..3e5 | % { 1+1 }` shows huge allocation of ``System.Tuple`2`` and the boxed enum type `S.M.A.ConfigScope`. (See below)
They are resulted by the policy setting cache we chose for GPO: `ConcurrentDictionary<Tuple<ConfigScope, string>, PolicyBase>`. Every time we query for the GPO policy settings, an instance of `Tuple<ConfigScope, string>` has to be created. The created `Tuple` object is also short-living, only for the querying purpose. When the tuple is used as a key for querying, the enum value gets boxed for equality comparison and hash code calculation, because ``Tuple`2`` uses `EqualityComparer<object>.Default` as the comparer which treat items of the tuple as `object` (see [``Tuple`2.Equals()``](https://source.dot.net/#System.Private.CoreLib/shared/System/Tuple.cs,219) and [``Tuple`2.GetHashCode()``](https://source.dot.net/#System.Private.CoreLib/shared/System/Tuple.cs,259)).
To avoid those unnecessary allocations, the cache for GPO is changed to `ConcurrentDictionary<ConfigScope, ConcurrentDictionary<string, PolicyBase>>` to avoid using `Tuple` as the key.

2. Add code in `CompiledScriptBlock.cs` to skip calling `LogScriptBlockCreation` when logging is skipped.

3. Add a secondary cache for `ScriptBlockLogging` setting in `CompiledScriptBlock.cs` and a secondary cache for `Transcription` setting in `MshHostUserInterface.cs`, because they are used very frequently.

4. Memory profiling shows `28 mb` allocation of `System.Boolean`. This is caused by passing a bool value to a `object` type parameter when writing tracing message in `ParameterBinder`.

5. Memory profiling shows `28 mb` allocation of a closure class `<>c_DisplayClass55_0`. This is caused by [this piece of code](https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/engine/lang/scriptblock.cs#L978-L989). This is a hot code path and thus results in a lot allocation of the auto-generated closure. The `RunActionIfNoRunningPipelinesWithThreadCheck` method is refactored to avoid passing a delegate around.

#### Before the changes

![image](https://user-images.githubusercontent.com/127450/60524110-d55f3e00-9ca0-11e9-93c7-578545f3db99.png)

```
PS> Measure-Command { 1..1e5 | % { 1+1 } > $null }

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 508
Ticks             : 5085940
TotalDays         : 5.88650462962963E-06
TotalHours        : 0.000141276111111111
TotalMinutes      : 0.00847656666666667
TotalSeconds      : 0.508594
TotalMilliseconds : 508.594
```

#### After the changes

![image](https://user-images.githubusercontent.com/127450/60528874-41926f80-9caa-11e9-852a-fbec2baebb55.png)

```
PS> Measure-Command { 1..1e5 | % { 1+1 } > $null }

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 254
Ticks             : 2545267
TotalDays         : 2.94591087962963E-06
TotalHours        : 7.07018611111111E-05
TotalMinutes      : 0.00424211166666667
TotalSeconds      : 0.2545267
TotalMilliseconds : 254.5267
```

### BUT ...

```
PS> Measure-Command { 1..1e5 | & { process { 1+1 } } > $null }

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 42
Ticks             : 426360
TotalDays         : 4.93472222222222E-07
TotalHours        : 1.18433333333333E-05
TotalMinutes      : 0.0007106
TotalSeconds      : 0.042636
TotalMilliseconds : 42.636
```

`Foreach-Object` is still 4 - 6 times slower than a filter function. This is mainly because:
1. `Foreach-Object` requires parameter binding for pipeline input while a filter function like the above one doesn't.
2. `Foreach-Object` calls into `ScriptBlock.InvokeUsingCmdlet` over and over again for every pipeline input. `InvokeUsingCmdlet` needs to do necessary setups/cleanup before/after invoking the script block and `Foreach-Object` has to pay that tax over and over again. While for a filter, the setup and cleanup is done only once because the invocation stays in the same function.
3. `Foreach-Object` runs the script block in the current scope so the compilation of the script block is un-optimized. While for a filter function, it runs in its own local scope and optimization is turned on.

### Next Step

Investigate to avoid unnecessary parameter binding for pipeline objects by using binders.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
