### PR TITLE
Speed up WildcardPattern.IsMatch if an pattern ends with asterisk

### DIFF
--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -184,8 +184,8 @@ namespace System.Management.Automation
             if (index == Pattern.Length - 1 && Pattern[index] == '*')
             {
                 // No special characters present in the pattern before last position and last character is asterisk.
-                var patternWithoutAsterisk = Pattern.Substring(0, index);
-                _isMatch = str => str.StartsWith(patternWithoutAsterisk, GetStringComparison());
+                var patternWithoutAsterisk = Pattern.AsMemory().Slice(0, index);
+                _isMatch = str => str.AsSpan().StartsWith(patternWithoutAsterisk.Span, GetStringComparison());
                 return;
             }
 

--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -167,44 +167,26 @@ namespace System.Management.Automation
                 return;
             }
 
-            if (Pattern.Length == 1)
+            if (Pattern.Length == 1 && Pattern[0] == '*')
             {
-                switch (Pattern[0])
-                {
-                    case '*':
-                        _isMatch = s_matchAll;
-                        return;
-                    case '?':
-                    case '[':
-                    case ']':
-                    case '`':
-                        break;
-                    default:
-                        // No special characters present in the pattern, so we can just do a string comparison.
-                        _isMatch = str => string.Equals(str, Pattern, GetStringComparison());
-                        return;
-                }
+                _isMatch = s_matchAll;
+                return;
             }
 
-            if (Pattern.Length > 1 && Pattern.AsSpan().Slice(0, Pattern.Length - 1).IndexOfAny(s_specialChars) == -1)
+            int index = Pattern.IndexOfAny(s_specialChars);
+            if (index == -1)
             {
-                switch (Pattern[Pattern.Length - 1])
-                {
-                    case '*':
-                        // No special characters present in the pattern before last position and last character is asterisk.
-                        var patternWithoutAsterisk = Pattern.Substring(0, Pattern.Length - 1);
-                        _isMatch = str => str.StartsWith(patternWithoutAsterisk, GetStringComparison());
-                        return;
-                    case '?':
-                    case '[':
-                    case ']':
-                    case '`':
-                        break;
-                    default:
-                        // No special characters present in the pattern, so we can just do a string comparison.
-                        _isMatch = str => string.Equals(str, Pattern, GetStringComparison());
-                        return;
-                }
+                // No special characters present in the pattern, so we can just do a string comparison.
+                _isMatch = str => string.Equals(str, Pattern, GetStringComparison());
+                return;
+            }
+
+            if (index == Pattern.Length - 1 && Pattern[index] == '*')
+            {
+                // No special characters present in the pattern before last position and last character is asterisk.
+                var patternWithoutAsterisk = Pattern.Substring(0, Pattern.Length - 1);
+                _isMatch = str => str.StartsWith(patternWithoutAsterisk, GetStringComparison());
+                return;
             }
 
             var matcher = new WildcardPatternMatcher(this);

--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -143,11 +143,6 @@ namespace System.Management.Automation
         /// <returns>True on success, false otherwise.</returns>
         private void Init()
         {
-            if (_isMatch != null)
-            {
-                return;
-            }
-
             StringComparison GetStringComparison()
             {
                 StringComparison stringComparison;
@@ -165,6 +160,11 @@ namespace System.Management.Automation
                 }
 
                 return stringComparison;
+            }
+
+            if (_isMatch != null)
+            {
+                return;
             }
 
             if (Pattern.Length == 1)

--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -184,7 +184,7 @@ namespace System.Management.Automation
             if (index == Pattern.Length - 1 && Pattern[index] == '*')
             {
                 // No special characters present in the pattern before last position and last character is asterisk.
-                var patternWithoutAsterisk = Pattern.Substring(0, Pattern.Length - 1);
+                var patternWithoutAsterisk = Pattern.Substring(0, index);
                 _isMatch = str => str.StartsWith(patternWithoutAsterisk, GetStringComparison());
                 return;
             }

--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -63,7 +63,7 @@ namespace System.Management.Automation
         private static readonly Predicate<string> s_matchAll = _ => true;
 
         // wildcard pattern
-        internal string Pattern { get; private set; }
+        internal string Pattern { get; }
 
         // options that control match behavior
         internal WildcardOptions Options { get; } = WildcardOptions.None;

--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -63,7 +63,7 @@ namespace System.Management.Automation
         private static readonly Predicate<string> s_matchAll = _ => true;
 
         // wildcard pattern
-        internal string Pattern { get; }
+        internal string Pattern { get; private set; }
 
         // options that control match behavior
         internal WildcardOptions Options { get; } = WildcardOptions.None;
@@ -176,7 +176,7 @@ namespace System.Management.Automation
                         return;
                     case '?':
                     case '[':
-                    case  ']':
+                    case ']':
                     case '`':
                         break;
                     default:
@@ -192,11 +192,12 @@ namespace System.Management.Automation
                 {
                     case '*':
                         // No special characters present in the pattern before last position and last character is asterisk.
-                        _isMatch = str => str.StartsWith(Pattern, GetStringComparison());
+                        var patternWithoutAsterisk = Pattern.Substring(0, Pattern.Length - 1);
+                        _isMatch = str => str.StartsWith(patternWithoutAsterisk, GetStringComparison());
                         return;
                     case '?':
                     case '[':
-                    case  ']':
+                    case ']':
                     case '`':
                         break;
                     default:


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Follow up on #10020 to add another fast path for `WildcardPattern.IsMatch` when an pattern ends with asterisk like `text*`.
In case of patterns like `text*`, `StartsWith(...)` method is used to check for if it's a match.

## PR Context

The main motivation was to complete the optimization of this code once we touched it.
However, this is a public code and should be improved.

As for the hot ways, my most important expectation was for path processing like `dir *`. In reality, test below shows a perf win of only about 1%.
```powershell
$a = dir -Recurse C:\Windows\System32\p*
```
Debug shows that globbing code does all works and then send filtered list child items to WindcardPattern.IsMatch() ! 
This way the engine almost always works with small collections and we don't see huge wins from fixes in WindcardPattern.IsMatch().

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
