### PR TITLE
Add IsTerminating property to ErrorRecord with tests

### DIFF
--- a/src/System.Management.Automation/engine/DefaultCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/DefaultCommandRuntime.cs
@@ -5,6 +5,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Management.Automation.Host;
+using System.Management.Automation.Runspaces;
 
 namespace System.Management.Automation
 {
@@ -46,6 +47,15 @@ namespace System.Management.Automation
         /// <param name="errorRecord">Error record instance to process.</param>
         public void WriteError(ErrorRecord errorRecord)
         {
+            // Since this ErrorRecord was passed to WriteError,
+            // that means it's a non-terminating ErrorRecord.
+            // For RemotingErrorRecord's IsTerminating is already set
+            // so we shouldn't overwrite it.
+            if (!(errorRecord is RemotingErrorRecord))
+            {
+                errorRecord.IsTerminating = false;
+            }
+
             if (errorRecord.Exception != null)
                 throw errorRecord.Exception;
             else

--- a/src/System.Management.Automation/engine/ErrorPackage.cs
+++ b/src/System.Management.Automation/engine/ErrorPackage.cs
@@ -1632,6 +1632,11 @@ namespace System.Management.Automation
 
         private bool _serializeExtendedInfo = false;
 
+        /// <summary>
+        /// Used to determine if an ErrorRecord is terminating or non-terminating.
+        /// </summary>
+        public bool IsTerminating { get; internal set; } = true;
+
         #endregion Public Properties
 
         #region Private

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -2728,6 +2728,15 @@ namespace System.Management.Automation
             else
                 errorRecord.SetInvocationInfo(MyInvocation);
 
+            // Since this ErrorRecord was passed to WriteError,
+            // that means it's a non-terminating ErrorRecord.
+            // For RemotingErrorRecord's IsTerminating is already set
+            // so we shouldn't overwrite it.
+            if (!(errorRecord is RemotingErrorRecord))
+            {
+                errorRecord.IsTerminating = false;
+            }
+
             // NOTICE-2004/06/08-JonN 959638
             ThrowIfWriteNotPermitted(true);
 

--- a/src/System.Management.Automation/engine/remoting/client/Job.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job.cs
@@ -769,6 +769,10 @@ namespace System.Management.Automation
 
         internal virtual void WriteError(ErrorRecord errorRecord)
         {
+            // Since this ErrorRecord was passed to WriteError,
+            // that means it's a non-terminating ErrorRecord.
+            errorRecord.IsTerminating = false;
+
             Error.Add(errorRecord);
             if (PropagateThrows)
             {
@@ -785,6 +789,10 @@ namespace System.Management.Automation
 
         internal void WriteError(ErrorRecord errorRecord, out Exception exceptionThrownOnCmdletThread)
         {
+            // Since this ErrorRecord was passed to WriteError,
+            // that means it's a non-terminating ErrorRecord.
+            errorRecord.IsTerminating = false;
+
             this.Error.Add(errorRecord);
             this.InvokeCmdletMethodAndWaitForResults<object>(
                     delegate (Cmdlet cmdlet)

--- a/test/powershell/Language/Scripting/TryCatch.Tests.ps1
+++ b/test/powershell/Language/Scripting/TryCatch.Tests.ps1
@@ -516,6 +516,7 @@ Describe "Test try/catch" -Tags "CI" {
             }
 
             [int]$a.ToString() | Should -Be 42
+            $a.IsTerminating | Should -BeTrue
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
@@ -29,6 +29,9 @@ Describe "Write-Error Tests" -Tags "CI" {
         #InvocationInfo verification
         $e.InvocationInfo | Should -Not -BeNullOrEmpty
         $e.InvocationInfo.MyCommand.Name | Should -BeNullOrEmpty
+
+        #IsTerminating verification
+        $e.IsTerminating | Should -BeFalse
     }
 
     It "Should be works with all parameters" {
@@ -66,6 +69,9 @@ Describe "Write-Error Tests" -Tags "CI" {
         #InvocationInfo verification
         $e.InvocationInfo | Should -Not -BeNullOrEmpty
         $e.InvocationInfo.MyCommand.Name | Should -BeNullOrEmpty
+
+        #IsTerminating verification
+        $e.IsTerminating | Should -BeFalse
     }
 
     It "Should be works with all parameters" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

An experiment at adding an `IsTerminating` property to `ErrorRecord`:

```
PS /Users/tyler/Code/PowerShell/PowerShell> throw "I'm terminating"

I'm terminating
At line:1 char:1
+ throw "I'm terminating"
+ ~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : OperationStopped: (I'm terminating:String) [], RuntimeException
+ FullyQualifiedErrorId : I'm terminating

PS /Users/tyler/Code/PowerShell/PowerShell> $Error[0].IsTerminating
True

PS /Users/tyler/Code/PowerShell/PowerShell> Write-Error "I'm not terminating"

Write-Error "I'm not terminating" : I'm not terminating
+ CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
+ FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException

PS /Users/tyler/Code/PowerShell/PowerShell> $Error[0].IsTerminating
False
```

## PR Context

As a user, I want a clean and simple way to differentiate between terminating and non-terminating errors.

This PR helps bootstrap that effort by adding an `IsTerminating` property to `ErrorRecord` and setting where it makes sense.

This does _not_ change the formatting of an ErrorRecord. That is out of scope and requires a PM to approve what that will look like so in the meantime, this will provide the property that we can take advantage of later.

cc @vexx32 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
