### PR TITLE
Revert "Bump System.IO.Packaging from 4.6.0-preview6.19303.8 to 4.6.0-preview.19113.10"

### DIFF
--- a/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
+++ b/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
@@ -18,7 +18,7 @@
     <!-- the following package(s) are from https://github.com/dotnet/fxdac -->
     <PackageReference Include="System.Data.SqlClient" Version="4.7.0-preview.19113.10" />
     <!-- the following package(s) are from https://github.com/dotnet/corefx -->
-    <PackageReference Include="System.IO.Packaging" Version="4.6.0-preview.19113.10" />
+    <PackageReference Include="System.IO.Packaging" Version="4.6.0-preview6.19303.8" />
     <PackageReference Include="System.Net.Http.WinHttpHandler" Version="4.6.0-preview6.19303.8" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.6.0-preview.19113.10" />
     <!-- the following package(s) are from https://github.com/dotnet/wcf -->


### PR DESCRIPTION
Reverts PowerShell/PowerShell#10108

The semantic version is incorrect. It is `preview` when `preview6` is expected.