### PR TITLE
Revert "Bump System.Threading.AccessControl from 4.6.0-preview6.19303.8 to 4.6.0-preview.19113.10"

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
+++ b/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
@@ -56,7 +56,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.1.0" />
-    <PackageReference Include="System.Threading.AccessControl" Version="4.6.0-preview.19113.10" />
+    <PackageReference Include="System.Threading.AccessControl" Version="4.6.0-preview6.19303.8" />
     <PackageReference Include="NJsonSchema" Version="10.0.21" />
   </ItemGroup>
 


### PR DESCRIPTION
Reverts PowerShell/PowerShell#10106

The semantic version is incorrect. It is preview when preview6 is expected.