### PR TITLE
Revert "Bump System.Configuration.ConfigurationManager from 4.6.0-preview6.19303.8 to 4.6.0-preview.19113.10"

### DIFF
--- a/src/System.Management.Automation/System.Management.Automation.csproj
+++ b/src/System.Management.Automation/System.Management.Automation.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <!-- the following package(s) are from https://github.com/dotnet/corefx -->
     <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="4.6.0-preview6.19303.8" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0-preview.19113.10" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0-preview6.19303.8" />
     <PackageReference Include="System.DirectoryServices" Version="4.6.0-preview.19113.10" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.6.0-preview6.19303.8" />
     <PackageReference Include="System.Management" Version="4.6.0-preview.19113.10" />


### PR DESCRIPTION
Reverts PowerShell/PowerShell#10111

The semantic version is incorrect. It is preview when preview6 is expected.