### PR TITLE
Revert "Bump System.Security.Cryptography.Pkcs from 4.6.0-preview6.19303.8 to 4.6.0-preview.19113.10"

### DIFF
--- a/src/System.Management.Automation/System.Management.Automation.csproj
+++ b/src/System.Management.Automation/System.Management.Automation.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="System.Management" Version="4.6.0-preview.19113.10" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.6.0-preview6.19303.8" />
     <PackageReference Include="System.Security.AccessControl" Version="4.6.0-preview6.19303.8" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.6.0-preview.19113.10" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.6.0-preview6.19303.8" />
     <PackageReference Include="System.Security.Permissions" Version="4.6.0-preview6.19303.8" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.6.0-preview.19113.10" />
     <!-- the following package(s) are from the powershell org -->


### PR DESCRIPTION
Reverts PowerShell/PowerShell#10107

The semantic version is incorrect. It is preview when preview6 is expected.