### PR TITLE
Revert "Bump System.Text.Encoding.CodePages from 4.6.0-preview6.19303.8 to 4.6.0-preview.19113.10"

### DIFF
--- a/src/System.Management.Automation/System.Management.Automation.csproj
+++ b/src/System.Management.Automation/System.Management.Automation.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="System.Security.AccessControl" Version="4.6.0-preview6.19303.8" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.6.0-preview.19113.10" />
     <PackageReference Include="System.Security.Permissions" Version="4.6.0-preview6.19303.8" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.6.0-preview.19113.10" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.6.0-preview6.19303.8" />
     <!-- the following package(s) are from the powershell org -->
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="1.0.0" />
     <PackageReference Include="Microsoft.PowerShell.Native" Version="7.0.0-preview.1" />


### PR DESCRIPTION
Reverts PowerShell/PowerShell#10112

The semantic version is incorrect. It is preview when preview6 is expected.