### PR TITLE
Revert "Bump System.Security.AccessControl from 4.6.0-preview6.19303.8 to 4.6.0-preview.19113.10 in /tools/packaging/projects/reference/Microsoft.PowerShell.Commands.Utility"

### DIFF
--- a/tools/packaging/projects/reference/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
+++ b/tools/packaging/projects/reference/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
@@ -14,6 +14,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="System.Security.AccessControl" Version="4.6.0-preview.19113.10" />
+    <PackageReference Include="System.Security.AccessControl" Version="4.6.0-preview6.19303.8" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Reverts PowerShell/PowerShell#10102

The semantic version is incorrect. It is preview when preview6 is expected.