### PR TITLE
Revert "Bump System.Security.Principal.Windows from 4.6.0-preview6.19303.8 to 4.6.0-preview.19113.10 in /tools/packaging/projects/reference/System.Management.Automation"

### DIFF
--- a/tools/packaging/projects/reference/System.Management.Automation/System.Management.Automation.csproj
+++ b/tools/packaging/projects/reference/System.Management.Automation/System.Management.Automation.csproj
@@ -10,6 +10,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="1.0.0" />
     <PackageReference Include="System.Security.AccessControl" Version="4.6.0-preview.19113.10" />
-    <PackageReference Include="System.Security.Principal.Windows" Version="4.6.0-preview.19113.10" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="4.6.0-preview6.19303.8" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Reverts PowerShell/PowerShell#10101

The semantic version is incorrect. It is preview when preview6 is expected.