### PR TITLE
Fix test password generation rule to meet Windows complexity requirements

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Service.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Service.Tests.ps1
@@ -10,18 +10,7 @@ Describe "Set/New/Remove-Service cmdlet tests" -Tags "Feature", "RequireAdminOnW
         }
         if ($IsWindows) {
             $userName = "testuserservices"
-            $numbers = "0123456789"
-            $lowercase = "abcdefghijklmnopqrstuvwxyz"
-            $uppercase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-            $symbols = "!`"#$%&'()*+,-./:;<=>?[\]^_``"
-            $Password = [string]::Empty
-            # Windows password complexity rule requires minimum 8 characters and using at least 3 of the
-            # buckets above, so we just pick one from each bucket twice
-            1..2 | ForEach-Object {
-                $Password += $numbers[(Get-Random $numbers.Length)] + $lowercase[(Get-Random $lowercase.Length)] +
-                    $uppercase[(Get-Random $uppercase.Length)] + $symbols[(Get-Random $symbols.Length)]
-            }
-            $testPass = [Net.NetworkCredential]::new("", $Password).SecurePassword
+            $testPass = [Net.NetworkCredential]::new("", (New-ComplexPassword)).SecurePassword
             $creds    = [pscredential]::new(".\$userName", $testPass)
             $SecurityDescriptorSddl = 'D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;SU)'
             $WrongSecurityDescriptorSddl = 'D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BB)(A;;CCLCSWLOCRRC;;;SU)'

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Service.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Service.Tests.ps1
@@ -10,8 +10,18 @@ Describe "Set/New/Remove-Service cmdlet tests" -Tags "Feature", "RequireAdminOnW
         }
         if ($IsWindows) {
             $userName = "testuserservices"
-            $Password = ([char[]]([char]33..[char]95) + ([char[]]([char]97..[char]126)) + 0..9 | Sort-Object {Get-Random})[0..12] -join ''
-            $testPass = (New-Object -TypeName Net.NetworkCredential("", $Password)).SecurePassword
+            $numbers = "0123456789"
+            $lowercase = "abcdefghijklmnopqrstuvwxyz"
+            $uppercase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+            $symbols = "!`"#$%&'()*+,-./:;<=>?[\]^_``"
+            $Password = [string]::Empty
+            # Windows password complexity rule requires minimum 8 characters and using at least 3 of the
+            # buckets above, so we just pick one from each bucket twice
+            1..2 | ForEach-Object {
+                $Password += $numbers[(Get-Random $numbers.Length)] + $lowercase[(Get-Random $lowercase.Length)] +
+                    $uppercase[(Get-Random $uppercase.Length)] + $symbols[(Get-Random $symbols.Length)]
+            }
+            $testPass = [Net.NetworkCredential]::new("", $Password).SecurePassword
             $creds    = [pscredential]::new(".\$userName", $testPass)
             $SecurityDescriptorSddl = 'D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;SU)'
             $WrongSecurityDescriptorSddl = 'D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BB)(A;;CCLCSWLOCRRC;;;SU)'

--- a/test/tools/Modules/HelpersCommon/HelpersCommon.psd1
+++ b/test/tools/Modules/HelpersCommon/HelpersCommon.psd1
@@ -23,6 +23,7 @@ FunctionsToExport = @(
         'Enable-Testhook'
         'Get-RandomFileName'
         'New-RandomHexString'
+        'New-ComplexPassword'
         'Send-VstsLogFile'
         'Set-TesthookResult'
         'Start-NativeExecution'

--- a/test/tools/Modules/HelpersCommon/HelpersCommon.psm1
+++ b/test/tools/Modules/HelpersCommon/HelpersCommon.psm1
@@ -344,3 +344,22 @@ function Test-CanWriteToPsHome
 
     $script:CanWriteToPsHome
 }
+
+# Creates a password meeting Windows complexity rules
+function New-ComplexPassword
+{
+    $numbers = "0123456789"
+    $lowercase = "abcdefghijklmnopqrstuvwxyz"
+    $uppercase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    $symbols = "~!@#$%^&*_-+=``|\(){}[]:;`"'<>,.?/"
+    $password = [string]::Empty
+    # Windows password complexity rule requires minimum 8 characters and using at least 3 of the
+    # buckets above, so we just pick one from each bucket twice.
+    # https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/password-must-meet-complexity-requirements
+    1..2 | ForEach-Object {
+        $Password += $numbers[(Get-Random $numbers.Length)] + $lowercase[(Get-Random $lowercase.Length)] +
+            $uppercase[(Get-Random $uppercase.Length)] + $symbols[(Get-Random $symbols.Length)]
+    }
+
+    $password
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The Windows password complexity rule (which is enabled in AzDevOps) requires a minimum 8 character password that contains at least 3 of 5 buckets:

1. number
2. lowercase
3. uppercase
4. symbol
5. unicode

We can skip the unicode character and just pick a random character out of the first 4 buckets twice to have a password meeting the requirement.
The previous code was completely random so it would randomly generate a password that didn't meet the complexity requirement and thus fail to create the test account causing subsequent tests to fail.

## PR Context

Nightly Windows build broke.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
