### PR TITLE
Get-Command should not throw with white space argument

### DIFF
--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -599,9 +599,7 @@ namespace Microsoft.PowerShell.Commands
         {
             _commandType = CommandTypes.Cmdlet | CommandTypes.Function | CommandTypes.Filter | CommandTypes.Alias | CommandTypes.Configuration;
 
-            Collection<string> commandNames = new Collection<string>();
-            commandNames.Add("*");
-            AccumulateMatchingCommands(commandNames);
+            AccumulateMatchingCommands(new string[] { "*" });
         }
 
         private bool IsNounVerbMatch(CommandInfo command)
@@ -681,13 +679,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         private void AccumulateMatchingCommands()
         {
-            Collection<string> commandNames =
-                SessionStateUtilities.ConvertArrayToCollection<string>(this.Name);
-
-            if (commandNames.Count == 0)
-            {
-                commandNames.Add("*");
-            }
+            var commandNames = Name.Length == 0 ? new string[] { "*" } : Name;
 
             AccumulateMatchingCommands(commandNames);
         }
@@ -726,6 +718,11 @@ namespace Microsoft.PowerShell.Commands
             {
                 try
                 {
+                    if (commandName.AsSpan().Trim().IsEmpty)
+                    {
+                        continue;
+                    }
+
                     // Determine if the command name is module-qualified, and search
                     // available modules for the command.
                     string moduleName;

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -679,7 +679,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         private void AccumulateMatchingCommands()
         {
-            var commandNames = (Name != null && Name.Length != 0) ? Name : new string[] { "*" };
+            var commandNames = string.IsNullOrEmpty(Name) ? new string[] { "*" } : Name;
 
             AccumulateMatchingCommands(commandNames);
         }

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -679,7 +679,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         private void AccumulateMatchingCommands()
         {
-            var commandNames = Name != null && Name.Length != 0 ? Name : new string[] { "*" };
+            var commandNames = (Name != null && Name.Length != 0) ? Name : new string[] { "*" };
 
             AccumulateMatchingCommands(commandNames);
         }

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -679,7 +679,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         private void AccumulateMatchingCommands()
         {
-            var commandNames = Name.Length == 0 ? new string[] { "*" } : Name;
+            var commandNames = Name != null && Name.Length != 0 ? Name : new string[] { "*" };
 
             AccumulateMatchingCommands(commandNames);
         }

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -714,14 +714,11 @@ namespace Microsoft.PowerShell.Commands
                 options |= SearchResolutionOptions.ResolveFunctionPatterns;
             }
 
-            foreach (string commandName in commandNames)
+            foreach (string name in commandNames)
             {
                 try
                 {
-                    if (commandName.AsSpan().Trim().IsEmpty)
-                    {
-                        continue;
-                    }
+                    string commandName = name.Trim();
 
                     // Determine if the command name is module-qualified, and search
                     // available modules for the command.

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Command.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Command.Tests.ps1
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+
 Describe "Get-Command Tests" -Tags "CI" {
     BeforeAll {
         function TestGetCommand-DynamicParametersDCR
@@ -28,7 +29,7 @@ Describe "Get-Command Tests" -Tags "CI" {
                      "return1" {
                         $attr = [System.Management.Automation.ParameterAttribute]::new()
                         $attr.Mandatory = $true
-				        $dynamicParameter = [System.Management.Automation.RuntimeDefinedParameter]::new("OneString",[string],$attr)
+                        $dynamicParameter = [System.Management.Automation.RuntimeDefinedParameter]::new("OneString",[string],$attr)
                         $dynamicParamDictionary.Add("OneString",$dynamicParameter)
                         break
                     }
@@ -262,5 +263,9 @@ Describe "Get-Command Tests" -Tags "CI" {
         $results = Get-Command -Verb get -Noun content -encoding UTF8 -Synop
         VerifyDynamicParametersExist -cmdlet $results[0] -parameterNames $paramName
         VerifyParameterType -cmdlet $results[0] -parameterName $paramName -ParameterType System.Text.Encoding
+    }
+
+    It "Get-Command `" `" does not throw" -Pending {
+        Get-Command " " | Should -Not -Throw
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #10148

- Skip whitespace arguments
- Remove unneeded collection allocation

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
