### PR TITLE
Add support to ternary operator

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -6994,8 +6994,8 @@ namespace System.Management.Automation
         public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
         {
             return (bool)ternaryExpressionAst.Condition.Accept(this) &&
-                   (bool)ternaryExpressionAst.IfOperand.Accept(this) &&
-                   (bool)ternaryExpressionAst.ElseOperand.Accept(this);
+                   (bool)ternaryExpressionAst.IfTrue.Accept(this) &&
+                   (bool)ternaryExpressionAst.IfFalse.Accept(this);
         }
 
         public object VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -6991,6 +6991,13 @@ namespace System.Management.Automation
             return expr != null && (bool)expr.Accept(this);
         }
 
+        public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
+        {
+            return (bool)ternaryExpressionAst.Condition.Accept(this) &&
+                   (bool)ternaryExpressionAst.IfOperand.Accept(this) &&
+                   (bool)ternaryExpressionAst.ElseOperand.Accept(this);
+        }
+
         public object VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)
         {
             return (bool)binaryExpressionAst.Left.Accept(this) && (bool)binaryExpressionAst.Right.Accept(this);

--- a/src/System.Management.Automation/engine/parser/AstVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/AstVisitor.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Reflection;
 using System.Reflection.Emit;
 
 namespace System.Management.Automation.Language
@@ -171,6 +170,9 @@ namespace System.Management.Automation.Language
 
         /// <summary/>
         object VisitDynamicKeywordStatement(DynamicKeywordStatementAst dynamicKeywordAst);
+
+        /// <summary/>
+        object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst) => null;
     }
 
 #if DEBUG
@@ -312,6 +314,8 @@ namespace System.Management.Automation.Language
         public override AstVisitAction VisitConfigurationDefinition(ConfigurationDefinitionAst ast) { return CheckParent(ast); }
 
         public override AstVisitAction VisitDynamicKeywordStatement(DynamicKeywordStatementAst ast) { return CheckParent(ast); }
+
+        public override AstVisitAction VisitTernaryExpression(TernaryExpressionAst ast) => CheckParent(ast);
     }
 
     /// <summary>
@@ -544,6 +548,8 @@ namespace System.Management.Automation.Language
         public override AstVisitAction VisitConfigurationDefinition(ConfigurationDefinitionAst ast) { return Check(ast); }
 
         public override AstVisitAction VisitDynamicKeywordStatement(DynamicKeywordStatementAst ast) { return Check(ast); }
+
+        public override AstVisitAction VisitTernaryExpression(TernaryExpressionAst ast) { return Check(ast); }
     }
 
     /// <summary>
@@ -680,5 +686,7 @@ namespace System.Management.Automation.Language
         public virtual object VisitTypeDefinition(TypeDefinitionAst typeDefinitionAst) { return null; }
         /// <summary/>
         public virtual object VisitFunctionMember(FunctionMemberAst functionMemberAst) { return null; }
+        /// <summary/>
+        public virtual object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst) { return null; }
     }
 }

--- a/src/System.Management.Automation/engine/parser/AstVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/AstVisitor.cs
@@ -150,6 +150,8 @@ namespace System.Management.Automation.Language
     /// <summary/>
     public interface ICustomAstVisitor2 : ICustomAstVisitor
     {
+        private object DefaultVisit(Ast ast) => null;
+
         /// <summary/>
         object VisitTypeDefinition(TypeDefinitionAst typeDefinitionAst);
 
@@ -172,7 +174,7 @@ namespace System.Management.Automation.Language
         object VisitDynamicKeywordStatement(DynamicKeywordStatementAst dynamicKeywordAst);
 
         /// <summary/>
-        object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst) => null;
+        object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst) => DefaultVisit(ternaryExpressionAst);
     }
 
 #if DEBUG

--- a/src/System.Management.Automation/engine/parser/CharTraits.cs
+++ b/src/System.Management.Automation/engine/parser/CharTraits.cs
@@ -376,11 +376,16 @@ namespace System.Management.Automation.Language
 
         // Return true if the character ends the current number token.  This allows the tokenizer
         // to scan '7z' as a single token, but '7+' as 2 tokens.
-        internal static bool ForceStartNewTokenAfterNumber(this char c)
+        internal static bool ForceStartNewTokenAfterNumber(this char c, bool forceEndNumberOnTernaryOperatorChars)
         {
             if (c < 128)
             {
-                return (s_traits[c] & CharTraits.ForceStartNewTokenAfterNumber) != 0;
+                if ((s_traits[c] & CharTraits.ForceStartNewTokenAfterNumber) != 0)
+                {
+                    return true;
+                }
+
+                return forceEndNumberOnTernaryOperatorChars && (c == '?' || c == ':');
             }
 
             return c.IsDash();

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -4991,8 +4991,8 @@ namespace System.Management.Automation.Language
                         Compile(ternaryExpressionAst.Condition),
                         s_getCurrentPipe),
                     CaptureAstContext.Condition).Convert(typeof(bool)),
-                Expression.Assign(tmp, Compile(ternaryExpressionAst.IfOperand).Convert(typeof(object))),
-                Expression.Assign(tmp, Compile(ternaryExpressionAst.ElseOperand).Convert(typeof(object))));
+                Expression.Assign(tmp, Compile(ternaryExpressionAst.IfTrue).Convert(typeof(object))),
+                Expression.Assign(tmp, Compile(ternaryExpressionAst.IfFalse).Convert(typeof(object))));
 
             return Expression.Block(new[] { tmp }, expr, tmp);
         }

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -4983,18 +4983,16 @@ namespace System.Management.Automation.Language
 
         public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
         {
-            var tmp = NewTemp(typeof(object), "result");
-
-            var expr = Expression.IfThenElse(
+            var expr = Expression.Condition(
                 CaptureAstResults(
                     CallAddPipe(
                         Compile(ternaryExpressionAst.Condition),
                         s_getCurrentPipe),
                     CaptureAstContext.Condition).Convert(typeof(bool)),
-                Expression.Assign(tmp, Compile(ternaryExpressionAst.IfTrue).Convert(typeof(object))),
-                Expression.Assign(tmp, Compile(ternaryExpressionAst.IfFalse).Convert(typeof(object))));
+                Compile(ternaryExpressionAst.IfTrue).Convert(typeof(object)),
+                Compile(ternaryExpressionAst.IfFalse).Convert(typeof(object)));
 
-            return Expression.Block(new[] { tmp }, expr, tmp);
+            return expr;
         }
 
         public object VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -1932,6 +1932,14 @@ namespace System.Management.Automation.Language
             CaptureAstContext context,
             MergeRedirectExprs generateRedirectExprs = null)
         {
+            return CaptureAstResults(Compile(ast), context, generateRedirectExprs);
+        }
+
+        private Expression CaptureAstResults(
+            Expression genCode,
+            CaptureAstContext context,
+            MergeRedirectExprs generateRedirectExprs = null)
+        {
             Expression result;
 
             // We'll generate code like:
@@ -1966,7 +1974,7 @@ namespace System.Management.Automation.Language
                 generateRedirectExprs(exprs, finallyExprs);
             }
 
-            exprs.Add(Compile(ast));
+            exprs.Add(genCode);
 
             switch (context)
             {
@@ -4971,6 +4979,22 @@ namespace System.Management.Automation.Language
                     PSBinaryOperationBinder.Get(ExpressionType.Equal, ignoreCase, scalarCompare: true))),
                 lhs.Cast(typeof(object)),
                 rhs.Cast(typeof(object)));
+        }
+
+        public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
+        {
+            var tmp = NewTemp(typeof(object), "result");
+
+            var expr = Expression.IfThenElse(
+                CaptureAstResults(
+                    CallAddPipe(
+                        Compile(ternaryExpressionAst.Condition),
+                        s_getCurrentPipe),
+                    CaptureAstContext.Condition).Convert(typeof(bool)),
+                Expression.Assign(tmp, Compile(ternaryExpressionAst.IfOperand).Convert(typeof(object))),
+                Expression.Assign(tmp, Compile(ternaryExpressionAst.ElseOperand).Convert(typeof(object))));
+
+            return Expression.Block(new[] { tmp }, expr, tmp);
         }
 
         public object VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -1932,14 +1932,6 @@ namespace System.Management.Automation.Language
             CaptureAstContext context,
             MergeRedirectExprs generateRedirectExprs = null)
         {
-            return CaptureAstResults(Compile(ast), context, generateRedirectExprs);
-        }
-
-        private Expression CaptureAstResults(
-            Expression genCode,
-            CaptureAstContext context,
-            MergeRedirectExprs generateRedirectExprs = null)
-        {
             Expression result;
 
             // We'll generate code like:
@@ -1974,7 +1966,7 @@ namespace System.Management.Automation.Language
                 generateRedirectExprs(exprs, finallyExprs);
             }
 
-            exprs.Add(genCode);
+            exprs.Add(Compile(ast));
 
             switch (context)
             {
@@ -4984,9 +4976,7 @@ namespace System.Management.Automation.Language
         public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
         {
             var expr = Expression.Condition(
-                CaptureAstResults(
-                    CallAddPipe(Compile(ternaryExpressionAst.Condition), s_getCurrentPipe),
-                    CaptureAstContext.Condition),
+                Compile(ternaryExpressionAst.Condition).Convert(typeof(bool)),
                 Compile(ternaryExpressionAst.IfTrue).Convert(typeof(object)),
                 Compile(ternaryExpressionAst.IfFalse).Convert(typeof(object)));
 

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -4985,10 +4985,8 @@ namespace System.Management.Automation.Language
         {
             var expr = Expression.Condition(
                 CaptureAstResults(
-                    CallAddPipe(
-                        Compile(ternaryExpressionAst.Condition),
-                        s_getCurrentPipe),
-                    CaptureAstContext.Condition).Convert(typeof(bool)),
+                    CallAddPipe(Compile(ternaryExpressionAst.Condition), s_getCurrentPipe),
+                    CaptureAstContext.Condition),
                 Compile(ternaryExpressionAst.IfTrue).Convert(typeof(object)),
                 Compile(ternaryExpressionAst.IfFalse).Convert(typeof(object)));
 

--- a/src/System.Management.Automation/engine/parser/ConstantValues.cs
+++ b/src/System.Management.Automation/engine/parser/ConstantValues.cs
@@ -15,7 +15,7 @@ namespace System.Management.Automation.Language
      * There is a number of similarities between these two classes, and changes (fixes) in this code
      * may need to be reflected in that class and vice versa
      */
-    internal class IsConstantValueVisitor : ICustomAstVisitor
+    internal class IsConstantValueVisitor : ICustomAstVisitor2
     {
         public static bool IsConstant(Ast ast, out object constantValue, bool forAttribute = false, bool forRequires = false)
         {
@@ -130,6 +130,20 @@ namespace System.Management.Automation.Language
 
         public object VisitInvokeMemberExpression(InvokeMemberExpressionAst invokeMemberExpressionAst) { return false; }
 
+        public object VisitTypeDefinition(TypeDefinitionAst typeDefinitionAst) { return false; }
+
+        public object VisitPropertyMember(PropertyMemberAst propertyMemberAst) { return false; }
+
+        public object VisitFunctionMember(FunctionMemberAst functionMemberAst) { return false; }
+
+        public object VisitBaseCtorInvokeMemberExpression(BaseCtorInvokeMemberExpressionAst baseCtorInvokeMemberExpressionAst) { return false; }
+
+        public object VisitUsingStatement(UsingStatementAst usingStatement) { return false; }
+
+        public object VisitConfigurationDefinition(ConfigurationDefinitionAst configurationDefinitionAst) { return false; }
+
+        public object VisitDynamicKeywordStatement(DynamicKeywordStatementAst dynamicKeywordAst) { return false; }
+
         public object VisitStatementBlock(StatementBlockAst statementBlockAst)
         {
             if (statementBlockAst.Traps != null) return false;
@@ -170,6 +184,13 @@ namespace System.Management.Automation.Language
             }
 
             return false;
+        }
+
+        public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
+        {
+            return (bool)ternaryExpressionAst.Condition.Accept(this) &&
+                   (bool)ternaryExpressionAst.IfOperand.Accept(this) &&
+                   (bool)ternaryExpressionAst.ElseOperand.Accept(this);
         }
 
         public object VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)
@@ -300,7 +321,7 @@ namespace System.Management.Automation.Language
         }
     }
 
-    internal class ConstantValueVisitor : ICustomAstVisitor
+    internal class ConstantValueVisitor : ICustomAstVisitor2
     {
         internal bool AttributeArgument { get; set; }
         internal bool RequiresArgument { get; set; }
@@ -400,6 +421,21 @@ namespace System.Management.Automation.Language
 
         public object VisitInvokeMemberExpression(InvokeMemberExpressionAst invokeMemberExpressionAst) { return AutomationNull.Value; }
 
+        public object VisitTypeDefinition(TypeDefinitionAst typeDefinitionAst) { return AutomationNull.Value; }
+
+        public object VisitPropertyMember(PropertyMemberAst propertyMemberAst) { return AutomationNull.Value; }
+
+        public object VisitFunctionMember(FunctionMemberAst functionMemberAst) { return AutomationNull.Value; }
+
+        public object VisitBaseCtorInvokeMemberExpression(BaseCtorInvokeMemberExpressionAst baseCtorInvokeMemberExpressionAst) { return AutomationNull.Value; }
+
+        public object VisitUsingStatement(UsingStatementAst usingStatement) { return AutomationNull.Value; }
+
+        public object VisitConfigurationDefinition(ConfigurationDefinitionAst configurationDefinitionAst) { return AutomationNull.Value; }
+
+        public object VisitDynamicKeywordStatement(DynamicKeywordStatementAst dynamicKeywordAst) { return AutomationNull.Value; }
+
+
         public object VisitStatementBlock(StatementBlockAst statementBlockAst)
         {
             CheckIsConstant(statementBlockAst, "Caller to verify ast is constant");
@@ -410,6 +446,12 @@ namespace System.Management.Automation.Language
         {
             CheckIsConstant(pipelineAst, "Caller to verify ast is constant");
             return pipelineAst.GetPureExpression().Accept(this);
+        }
+
+        public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
+        {
+            CheckIsConstant(ternaryExpressionAst, "Caller to verify ast is constant");
+            return CompileAndInvoke(ternaryExpressionAst);
         }
 
         public object VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)

--- a/src/System.Management.Automation/engine/parser/ConstantValues.cs
+++ b/src/System.Management.Automation/engine/parser/ConstantValues.cs
@@ -189,8 +189,8 @@ namespace System.Management.Automation.Language
         public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
         {
             return (bool)ternaryExpressionAst.Condition.Accept(this) &&
-                   (bool)ternaryExpressionAst.IfOperand.Accept(this) &&
-                   (bool)ternaryExpressionAst.ElseOperand.Accept(this);
+                   (bool)ternaryExpressionAst.IfTrue.Accept(this) &&
+                   (bool)ternaryExpressionAst.IfFalse.Accept(this);
         }
 
         public object VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)

--- a/src/System.Management.Automation/engine/parser/ConstantValues.cs
+++ b/src/System.Management.Automation/engine/parser/ConstantValues.cs
@@ -451,7 +451,11 @@ namespace System.Management.Automation.Language
         public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
         {
             CheckIsConstant(ternaryExpressionAst, "Caller to verify ast is constant");
-            return CompileAndInvoke(ternaryExpressionAst);
+
+            object condition = ternaryExpressionAst.Condition.Accept(this);
+            return LanguagePrimitives.IsTrue(condition)
+                ? ternaryExpressionAst.IfTrue.Accept(this)
+                : ternaryExpressionAst.IfFalse.Accept(this);
         }
 
         public object VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -6449,12 +6449,22 @@ namespace System.Management.Automation.Language
 
                 componentAsts.Add(condition);
                 Token token = PeekToken();
+
+                // Skip newlines before question mark token to support (ternary operator)line continuance when
+                // the quetion-mark tokens start the next line of script
+                if (token.Kind == TokenKind.NewLine && _tokenizer.IsTernaryContinuance(token.Extent))
+                {
+                    SkipNewlines();
+                    token = PeekToken();
+                }
+
                 if (token.Kind != TokenKind.QuestionMark)
                 {
                     return condition;
                 }
 
                 SkipToken();
+                SkipNewlines();
 
                 ExpressionAst ifOperand = ExpressionRule();
                 if (ifOperand == null)
@@ -6493,6 +6503,8 @@ namespace System.Management.Automation.Language
 
                     return new ErrorExpressionAst(ExtentOf(condition, Before(token)), componentAsts);
                 }
+
+                SkipNewlines();
 
                 ExpressionAst elseOperand = ExpressionRule();
                 if (elseOperand == null)

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -6444,14 +6444,12 @@ namespace System.Management.Automation.Language
             {
                 SetTokenizerMode(TokenizerMode.Expression);
 
-                List<Ast> componentAsts = new List<Ast>();
                 ExpressionAst condition = BinaryExpressionRule(endNumberOnTernaryOpChars);
                 if (condition == null)
                 {
                     return null;
                 }
 
-                componentAsts.Add(condition);
                 Token token = PeekToken();
 
                 // Skip newlines before question mark token to support (ternary operator)line continuance when the
@@ -6490,22 +6488,21 @@ namespace System.Management.Automation.Language
                         token.Text);
                     ifTrue = new ErrorExpressionAst(extent);
                 }
-                else
-                {
-                    componentAsts.Add(ifTrue);
-                }
 
                 SkipNewlines();
 
                 token = NextToken();
                 if (token.Kind != TokenKind.Colon)
                 {
+                    var componentAsts = new List<Ast>() { condition };
+
                     // ErrorRecovery: we have done the expression parsing and should try parsing something else.
                     UngetToken(token);
 
                     // Don't bother reporting this error if we already reported an empty 'IfTrue' operand error.
                     if (!(ifTrue is ErrorExpressionAst))
                     {
+                        componentAsts.Add(ifTrue);
                         ReportIncompleteInput(
                             token.Extent,
                             nameof(ParserStrings.MissingColonInTernaryExpression),

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -6426,6 +6426,12 @@ namespace System.Management.Automation.Language
 
         #region Expressions
 
+        /// <summary>Parse an expression.</summary>
+        /// <param name="endNumberOnTernaryOpChars">
+        /// When it's known for sure that we are expecting an expression, allowing a generic token like '12?' or '12:' is
+        /// not useful. In those cases, we force to start a new token upon seeing '?' and ':' when scanning for a number
+        /// by setting this parameter to true, hoping to find a ternary expression.
+        /// </param>
         private ExpressionAst ExpressionRule(bool endNumberOnTernaryOpChars = false)
         {
             // G  expression:
@@ -6472,9 +6478,6 @@ namespace System.Management.Automation.Language
                 SkipNewlines();
 
                 // We have seen the ternary operator '?' and now expecting the 'IfFalse' expression.
-                // Allowing a generic token like '12?' or '12:' is not useful in the current situation,
-                // so we force to start a new token upon seeing '?' and ':' when scanning for a number,
-                // hoping to find a ternary expression.
                 ExpressionAst ifTrue = ExpressionRule(endNumberOnTernaryOpChars: true);
                 if (ifTrue == null)
                 {
@@ -6536,6 +6539,12 @@ namespace System.Management.Automation.Language
             }
         }
 
+        /// <summary>Parse a binary expression.</summary>
+        /// <param name="endNumberOnTernaryOpChars">
+        /// When it's known for sure that we are expecting an expression, allowing a generic token like '12?' or '12:' is
+        /// not useful. In those cases, we force to start a new token upon seeing '?' and ':' when scanning for a number
+        /// by setting this parameter to true, hoping to find a ternary expression.
+        /// </param>
         private ExpressionAst BinaryExpressionRule(bool endNumberOnTernaryOpChars = false)
         {
             // G  binary-expression:
@@ -6613,9 +6622,6 @@ namespace System.Management.Automation.Language
                     SkipNewlines();
 
                     // We have seen a binary operator token and now expecting the right-hand-side expression.
-                    // Allowing a generic token like '12?' or '12:' is not useful in the current situation,
-                    // so we force to start a new token upon seeing '?' and ':' when scanning for a number,
-                    // hoping to find a ternary expression.
                     expr = ArrayLiteralRule(endNumberOnTernaryOpChars: true);
                     if (expr == null)
                     {
@@ -6698,6 +6704,12 @@ namespace System.Management.Automation.Language
                     new CommandParameterAst(paramToken.Extent, paramToken.ParameterName, null, paramToken.Extent)});
         }
 
+        /// <summary>Parse an array literal expression.</summary>
+        /// <param name="endNumberOnTernaryOpChars">
+        /// When it's known for sure that we are expecting an expression, allowing a generic token like '12?' or '12:' is
+        /// not useful. In those cases, we force to start a new token upon seeing '?' and ':' when scanning for a number
+        /// by setting this parameter to true, hoping to find a ternary expression.
+        /// </param>
         private ExpressionAst ArrayLiteralRule(bool endNumberOnTernaryOpChars = false)
         {
             // G  array-literal-expression:
@@ -6726,9 +6738,6 @@ namespace System.Management.Automation.Language
                 SkipNewlines();
 
                 // We have seen a comma token and now expecting an expression as an array element.
-                // Allowing a generic token like '12?' or '12:' is not useful in the current situation,
-                // so we force to start a new token upon seeing '?' and ':' when scanning for a number,
-                // hoping to find a ternary expression.
                 lastExpr = UnaryExpressionRule(endNumberOnTernaryOpChars: true);
                 if (lastExpr == null)
                 {
@@ -6751,6 +6760,12 @@ namespace System.Management.Automation.Language
             return new ArrayLiteralAst(ExtentOf(firstExpr, lastExpr), arrayValues);
         }
 
+        /// <summary>Parse an unary expression.</summary>
+        /// <param name="endNumberOnTernaryOpChars">
+        /// When it's known for sure that we are expecting an expression, allowing a generic token like '12?' or '12:' is
+        /// not useful. In those cases, we force to start a new token upon seeing '?' and ':' when scanning for a number
+        /// by setting this parameter to true, hoping to find a ternary expression.
+        /// </param>
         private ExpressionAst UnaryExpressionRule(bool endNumberOnTernaryOpChars = false)
         {
             // G  unary-expression:
@@ -6822,9 +6837,6 @@ namespace System.Management.Automation.Language
                 SkipNewlines();
 
                 // We have seen a unary operator token and now expecting an expression.
-                // Allowing a generic token like '12?' or '12:' is not useful in the current situation,
-                // so we force to start a new token upon seeing '?' and ':' when scanning for a number,
-                // hoping to find a ternary expression.
                 child = UnaryExpressionRule(endNumberOnTernaryOpChars: true);
                 if (child != null)
                 {
@@ -6865,8 +6877,7 @@ namespace System.Management.Automation.Language
                 {
                     SkipNewlines();
 
-                    // We are now expecting a child expression. Allowing a generic token like '12?' or '12:' is not useful in the current situation,
-                    // so we force to start a new token upon seeing '?' and ':' when scanning for a number, hoping to find a ternary expression.
+                    // We are now expecting a child expression.
                     child = UnaryExpressionRule(endNumberOnTernaryOpChars: true);
                     if (child == null)
                     {
@@ -6900,8 +6911,7 @@ namespace System.Management.Automation.Language
                         token = PeekToken();
                         if (token.Kind != TokenKind.NewLine && token.Kind != TokenKind.Comma)
                         {
-                            // We are now expecting a child expression. Allowing a generic token like '12?' or '12:' is not useful in the current situation,
-                            // so we force to start a new token upon seeing '?' and ':' when scanning for a number, hoping to find a ternary expression.
+                            // We are now expecting a child expression.
                             child = UnaryExpressionRule(endNumberOnTernaryOpChars: true);
                             if (child != null)
                             {

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -6426,7 +6426,7 @@ namespace System.Management.Automation.Language
 
         #region Expressions
 
-        private ExpressionAst ExpressionRule(bool endNumbeOnTernaryOpChars = false)
+        private ExpressionAst ExpressionRule(bool endNumberOnTernaryOpChars = false)
         {
             // G  expression:
             // G      logical-expression
@@ -6445,7 +6445,7 @@ namespace System.Management.Automation.Language
                 SetTokenizerMode(TokenizerMode.Expression);
 
                 List<Ast> componentAsts = new List<Ast>();
-                ExpressionAst condition = BinaryExpressionRule(endNumbeOnTernaryOpChars);
+                ExpressionAst condition = BinaryExpressionRule(endNumberOnTernaryOpChars);
                 if (condition == null)
                 {
                     return null;
@@ -6477,7 +6477,7 @@ namespace System.Management.Automation.Language
                 // Allowing a generic token like '12?' or '12:' is not useful in the current situation,
                 // so we force to start a new token upon seeing '?' and ':' when scanning for a number,
                 // hoping to find a ternary expression.
-                ExpressionAst ifTrue = ExpressionRule(endNumbeOnTernaryOpChars: true);
+                ExpressionAst ifTrue = ExpressionRule(endNumberOnTernaryOpChars: true);
                 if (ifTrue == null)
                 {
                     // ErrorRecovery: create an error expression to fill out the ast and keep parsing.
@@ -6517,7 +6517,7 @@ namespace System.Management.Automation.Language
 
                 SkipNewlines();
 
-                ExpressionAst ifFalse = ExpressionRule(endNumbeOnTernaryOpChars: true);
+                ExpressionAst ifFalse = ExpressionRule(endNumberOnTernaryOpChars: true);
                 if (ifFalse == null)
                 {
                     // ErrorRecovery: create an error expression to fill out the ast and keep parsing.
@@ -6539,7 +6539,7 @@ namespace System.Management.Automation.Language
             }
         }
 
-        private ExpressionAst BinaryExpressionRule(bool endNumbeOnTernaryOpChars = false)
+        private ExpressionAst BinaryExpressionRule(bool endNumberOnTernaryOpChars = false)
         {
             // G  binary-expression:
             // G      bitwise-expression
@@ -6582,7 +6582,7 @@ namespace System.Management.Automation.Language
                 SetTokenizerMode(TokenizerMode.Expression);
 
                 ExpressionAst lhs, rhs;
-                ExpressionAst expr = ArrayLiteralRule(endNumbeOnTernaryOpChars);
+                ExpressionAst expr = ArrayLiteralRule(endNumberOnTernaryOpChars);
 
                 if (expr == null)
                 {
@@ -6619,7 +6619,7 @@ namespace System.Management.Automation.Language
                     // Allowing a generic token like '12?' or '12:' is not useful in the current situation,
                     // so we force to start a new token upon seeing '?' and ':' when scanning for a number,
                     // hoping to find a ternary expression.
-                    expr = ArrayLiteralRule(endNumbeOnTernaryOpChars: true);
+                    expr = ArrayLiteralRule(endNumberOnTernaryOpChars: true);
                     if (expr == null)
                     {
                         // ErrorRecovery: create an error expression to fill out the ast and keep parsing.
@@ -6701,13 +6701,13 @@ namespace System.Management.Automation.Language
                     new CommandParameterAst(paramToken.Extent, paramToken.ParameterName, null, paramToken.Extent)});
         }
 
-        private ExpressionAst ArrayLiteralRule(bool endNumbeOnTernaryOpChars = false)
+        private ExpressionAst ArrayLiteralRule(bool endNumberOnTernaryOpChars = false)
         {
             // G  array-literal-expression:
             // G      unary-expression
             // G      unary-expression   ','    new-lines:opt   array-literal-expression
 
-            ExpressionAst lastExpr = UnaryExpressionRule(endNumbeOnTernaryOpChars);
+            ExpressionAst lastExpr = UnaryExpressionRule(endNumberOnTernaryOpChars);
             if (lastExpr == null)
             {
                 return null;
@@ -6732,7 +6732,7 @@ namespace System.Management.Automation.Language
                 // Allowing a generic token like '12?' or '12:' is not useful in the current situation,
                 // so we force to start a new token upon seeing '?' and ':' when scanning for a number,
                 // hoping to find a ternary expression.
-                lastExpr = UnaryExpressionRule(endNumbeOnTernaryOpChars: true);
+                lastExpr = UnaryExpressionRule(endNumberOnTernaryOpChars: true);
                 if (lastExpr == null)
                 {
                     // ErrorRecovery: create an error expression for the ast and break.
@@ -6754,7 +6754,7 @@ namespace System.Management.Automation.Language
             return new ArrayLiteralAst(ExtentOf(firstExpr, lastExpr), arrayValues);
         }
 
-        private ExpressionAst UnaryExpressionRule(bool endNumbeOnTernaryOpChars = false)
+        private ExpressionAst UnaryExpressionRule(bool endNumberOnTernaryOpChars = false)
         {
             // G  unary-expression:
             // G      primary-expression
@@ -6785,18 +6785,18 @@ namespace System.Management.Automation.Language
             ExpressionAst expr = null;
             Token token;
             bool oldAllowSignedNumbers = _tokenizer.AllowSignedNumbers;
-            bool oldForceEndNumberOnTernaryOperators = _tokenizer.ForceEndNumbeOnTernaryOpChars;
+            bool oldForceEndNumberOnTernaryOperators = _tokenizer.ForceEndNumberOnTernaryOpChars;
             try
             {
                 _tokenizer.AllowSignedNumbers = true;
-                _tokenizer.ForceEndNumbeOnTernaryOpChars = endNumbeOnTernaryOpChars;
+                _tokenizer.ForceEndNumberOnTernaryOpChars = endNumberOnTernaryOpChars;
 
                 if (_ungotToken != null)
                 {
                     bool needResync = _ungotToken.Kind == TokenKind.Minus;
                     if (!needResync)
                     {
-                        needResync = endNumbeOnTernaryOpChars && _ungotToken.Kind == TokenKind.Generic;
+                        needResync = endNumberOnTernaryOpChars && _ungotToken.Kind == TokenKind.Generic;
                     }
 
                     if (needResync)
@@ -6810,7 +6810,7 @@ namespace System.Management.Automation.Language
             finally
             {
                 _tokenizer.AllowSignedNumbers = oldAllowSignedNumbers;
-                _tokenizer.ForceEndNumbeOnTernaryOpChars = oldForceEndNumberOnTernaryOperators;
+                _tokenizer.ForceEndNumberOnTernaryOpChars = oldForceEndNumberOnTernaryOperators;
             }
 
             ExpressionAst child;
@@ -6828,7 +6828,7 @@ namespace System.Management.Automation.Language
                 // Allowing a generic token like '12?' or '12:' is not useful in the current situation,
                 // so we force to start a new token upon seeing '?' and ':' when scanning for a number,
                 // hoping to find a ternary expression.
-                child = UnaryExpressionRule(endNumbeOnTernaryOpChars: true);
+                child = UnaryExpressionRule(endNumberOnTernaryOpChars: true);
                 if (child != null)
                 {
                     if (token.Kind == TokenKind.Comma)
@@ -6870,7 +6870,7 @@ namespace System.Management.Automation.Language
 
                     // We are now expecting a child expression. Allowing a generic token like '12?' or '12:' is not useful in the current situation,
                     // so we force to start a new token upon seeing '?' and ':' when scanning for a number, hoping to find a ternary expression.
-                    child = UnaryExpressionRule(endNumbeOnTernaryOpChars: true);
+                    child = UnaryExpressionRule(endNumberOnTernaryOpChars: true);
                     if (child == null)
                     {
                         // ErrorRecovery: We have a list of attributes, and we know it's not before a param statement,
@@ -6905,7 +6905,7 @@ namespace System.Management.Automation.Language
                         {
                             // We are now expecting a child expression. Allowing a generic token like '12?' or '12:' is not useful in the current situation,
                             // so we force to start a new token upon seeing '?' and ':' when scanning for a number, hoping to find a ternary expression.
-                            child = UnaryExpressionRule(endNumbeOnTernaryOpChars: true);
+                            child = UnaryExpressionRule(endNumberOnTernaryOpChars: true);
                             if (child != null)
                             {
                                 expr = new ConvertExpressionAst(ExtentOf(lastAttribute, child),

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -5824,7 +5824,7 @@ namespace System.Management.Automation.Language
 
                 // Skip newlines before pipe tokens to support (pipe)line continuance when pipe
                 // tokens start the next line of script
-                if (nextToken.Kind == TokenKind.NewLine && _tokenizer.IsPipeContinuance(nextToken.Extent))
+                if (nextToken.Kind == TokenKind.NewLine && _tokenizer.IsPipeContinuation(nextToken.Extent))
                 {
                     SkipNewlines();
                     nextToken = PeekToken();
@@ -6459,7 +6459,7 @@ namespace System.Management.Automation.Language
                 //     $varName1 -eq $varName2
                 //         ? <do-something-if-true>
                 //         : <do-something-if-false>
-                if (token.Kind == TokenKind.NewLine && _tokenizer.IsTernaryContinuance(token.Extent))
+                if (token.Kind == TokenKind.NewLine && _tokenizer.IsTernaryContinuation(token.Extent))
                 {
                     SkipNewlines();
                     token = PeekToken();
@@ -6500,7 +6500,7 @@ namespace System.Management.Automation.Language
                 token = NextToken();
                 if (token.Kind != TokenKind.Colon)
                 {
-                    // ErrorRecovery: we have done the expression parsing and should tr parsing something else.
+                    // ErrorRecovery: we have done the expression parsing and should try parsing something else.
                     UngetToken(token);
 
                     // Don't bother reporting this error if we already reported an empty 'IfTrue' operand error.

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -6477,8 +6477,8 @@ namespace System.Management.Automation.Language
                 // Allowing a generic token like '12?' or '12:' is not useful in the current situation,
                 // so we force to start a new token upon seeing '?' and ':' when scanning for a number,
                 // hoping to find a ternary expression.
-                ExpressionAst ifOperand = ExpressionRule(endNumbeOnTernaryOpChars: true);
-                if (ifOperand == null)
+                ExpressionAst ifTrue = ExpressionRule(endNumbeOnTernaryOpChars: true);
+                if (ifTrue == null)
                 {
                     // ErrorRecovery: create an error expression to fill out the ast and keep parsing.
                     IScriptExtent extent = After(token);
@@ -6488,11 +6488,11 @@ namespace System.Management.Automation.Language
                         nameof(ParserStrings.ExpectedValueExpression),
                         ParserStrings.ExpectedValueExpression,
                         token.Text);
-                    ifOperand = new ErrorExpressionAst(extent);
+                    ifTrue = new ErrorExpressionAst(extent);
                 }
                 else
                 {
-                    componentAsts.Add(ifOperand);
+                    componentAsts.Add(ifTrue);
                 }
 
                 SkipNewlines();
@@ -6503,8 +6503,8 @@ namespace System.Management.Automation.Language
                     // ErrorRecovery: we have done the expression parsing and should tr parsing something else.
                     UngetToken(token);
 
-                    // Don't bother reporting this error if we already reported an empty if-operand error.
-                    if (!(ifOperand is ErrorExpressionAst))
+                    // Don't bother reporting this error if we already reported an empty 'IfTrue' operand error.
+                    if (!(ifTrue is ErrorExpressionAst))
                     {
                         ReportIncompleteInput(
                             token.Extent,
@@ -6517,8 +6517,8 @@ namespace System.Management.Automation.Language
 
                 SkipNewlines();
 
-                ExpressionAst elseOperand = ExpressionRule(endNumbeOnTernaryOpChars: true);
-                if (elseOperand == null)
+                ExpressionAst ifFalse = ExpressionRule(endNumbeOnTernaryOpChars: true);
+                if (ifFalse == null)
                 {
                     // ErrorRecovery: create an error expression to fill out the ast and keep parsing.
                     IScriptExtent extent = After(token);
@@ -6528,10 +6528,10 @@ namespace System.Management.Automation.Language
                         nameof(ParserStrings.ExpectedValueExpression),
                         ParserStrings.ExpectedValueExpression,
                         token.Text);
-                    elseOperand = new ErrorExpressionAst(extent);
+                    ifFalse = new ErrorExpressionAst(extent);
                 }
 
-                return new TernaryExpressionAst(ExtentOf(condition, elseOperand), condition, ifOperand, elseOperand);
+                return new TernaryExpressionAst(ExtentOf(condition, ifFalse), condition, ifTrue, ifFalse);
             }
             finally
             {

--- a/src/System.Management.Automation/engine/parser/PreOrderVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/PreOrderVisitor.cs
@@ -186,6 +186,9 @@ namespace System.Management.Automation.Language
 
         /// <summary/>
         public virtual AstVisitAction VisitDynamicKeywordStatement(DynamicKeywordStatementAst dynamicKeywordStatementAst) { return AstVisitAction.Continue; }
+
+        /// <summary/>
+        public virtual AstVisitAction VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst) { return AstVisitAction.Continue; }
     }
 
     /// <summary>

--- a/src/System.Management.Automation/engine/parser/SafeValues.cs
+++ b/src/System.Management.Automation/engine/parser/SafeValues.cs
@@ -208,8 +208,8 @@ namespace System.Management.Automation.Language
         public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
         {
             return (bool)ternaryExpressionAst.Condition.Accept(this) &&
-                   (bool)ternaryExpressionAst.IfOperand.Accept(this) &&
-                   (bool)ternaryExpressionAst.ElseOperand.Accept(this);
+                   (bool)ternaryExpressionAst.IfTrue.Accept(this) &&
+                   (bool)ternaryExpressionAst.IfFalse.Accept(this);
         }
 
         public object VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)

--- a/src/System.Management.Automation/engine/parser/SafeValues.cs
+++ b/src/System.Management.Automation/engine/parser/SafeValues.cs
@@ -646,14 +646,9 @@ namespace System.Management.Automation.Language
 
         public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
         {
-            if (s_context != null)
-            {
-                return Compiler.GetExpressionValue(ternaryExpressionAst, true, s_context, null);
-            }
-            else
-            {
-                throw PSTraceSource.NewArgumentException("ast");
-            }
+            return s_context != null
+                ? Compiler.GetExpressionValue(ternaryExpressionAst, true, s_context, null)
+                : throw PSTraceSource.NewArgumentException("ast");
         }
 
         public object VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)
@@ -666,28 +661,18 @@ namespace System.Management.Automation.Language
 
         public object VisitUnaryExpression(UnaryExpressionAst unaryExpressionAst)
         {
-            if (s_context != null)
-            {
-                return Compiler.GetExpressionValue(unaryExpressionAst, true, s_context, null);
-            }
-            else
-            {
-                throw PSTraceSource.NewArgumentException("ast");
-            }
+            return s_context != null
+                ? Compiler.GetExpressionValue(unaryExpressionAst, true, s_context, null)
+                : throw PSTraceSource.NewArgumentException("ast");
         }
 
         public object VisitConvertExpression(ConvertExpressionAst convertExpressionAst)
         {
             // at this point, we know we're safe because we checked both the type and the child,
             // so now we can just call the compiler and indicate that it's trusted (at this point)
-            if (s_context != null)
-            {
-                return Compiler.GetExpressionValue(convertExpressionAst, true, s_context, null);
-            }
-            else
-            {
-                throw PSTraceSource.NewArgumentException("ast");
-            }
+            return s_context != null
+                ? Compiler.GetExpressionValue(convertExpressionAst, true, s_context, null)
+                : throw PSTraceSource.NewArgumentException("ast");
         }
 
         public object VisitConstantExpression(ConstantExpressionAst constantExpressionAst)

--- a/src/System.Management.Automation/engine/parser/SafeValues.cs
+++ b/src/System.Management.Automation/engine/parser/SafeValues.cs
@@ -647,9 +647,12 @@ namespace System.Management.Automation.Language
 
         public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
         {
-            return s_context != null
-                ? Compiler.GetExpressionValue(ternaryExpressionAst, true, s_context, null)
-                : throw PSTraceSource.NewArgumentException("ast");
+            if (s_context == null)
+            {
+                throw PSTraceSource.NewArgumentException("ast");
+            }
+
+            return Compiler.GetExpressionValue(ternaryExpressionAst, true, s_context, null);
         }
 
         public object VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)
@@ -662,18 +665,24 @@ namespace System.Management.Automation.Language
 
         public object VisitUnaryExpression(UnaryExpressionAst unaryExpressionAst)
         {
-            return s_context != null
-                ? Compiler.GetExpressionValue(unaryExpressionAst, true, s_context, null)
-                : throw PSTraceSource.NewArgumentException("ast");
+            if (s_context == null)
+            {
+                throw PSTraceSource.NewArgumentException("ast");
+            }
+
+            return Compiler.GetExpressionValue(unaryExpressionAst, true, s_context, null);
         }
 
         public object VisitConvertExpression(ConvertExpressionAst convertExpressionAst)
         {
             // at this point, we know we're safe because we checked both the type and the child,
             // so now we can just call the compiler and indicate that it's trusted (at this point)
-            return s_context != null
-                ? Compiler.GetExpressionValue(convertExpressionAst, true, s_context, null)
-                : throw PSTraceSource.NewArgumentException("ast");
+            if (s_context == null)
+            {
+                throw PSTraceSource.NewArgumentException("ast");
+            }
+
+            return Compiler.GetExpressionValue(convertExpressionAst, true, s_context, null);
         }
 
         public object VisitConstantExpression(ConstantExpressionAst constantExpressionAst)

--- a/src/System.Management.Automation/engine/parser/SafeValues.cs
+++ b/src/System.Management.Automation/engine/parser/SafeValues.cs
@@ -36,7 +36,7 @@ using System.Management.Automation.Internal;
 
 namespace System.Management.Automation.Language
 {
-    internal class IsSafeValueVisitor : ICustomAstVisitor
+    internal class IsSafeValueVisitor : ICustomAstVisitor2
     {
         public static bool IsAstSafe(Ast ast, GetSafeValueVisitor.SafeValueContext safeValueContext)
         {
@@ -142,6 +142,20 @@ namespace System.Management.Automation.Language
 
         public object VisitInvokeMemberExpression(InvokeMemberExpressionAst invokeMemberExpressionAst) { return false; }
 
+        public object VisitTypeDefinition(TypeDefinitionAst typeDefinitionAst) { return false; }
+
+        public object VisitPropertyMember(PropertyMemberAst propertyMemberAst) { return false; }
+
+        public object VisitFunctionMember(FunctionMemberAst functionMemberAst) { return false; }
+
+        public object VisitBaseCtorInvokeMemberExpression(BaseCtorInvokeMemberExpressionAst baseCtorInvokeMemberExpressionAst) { return false; }
+
+        public object VisitUsingStatement(UsingStatementAst usingStatement) { return false; }
+
+        public object VisitConfigurationDefinition(ConfigurationDefinitionAst configurationDefinitionAst) { return false; }
+
+        public object VisitDynamicKeywordStatement(DynamicKeywordStatementAst dynamicKeywordAst) { return false; }
+
         public object VisitIndexExpression(IndexExpressionAst indexExpressionAst)
         {
             return (bool)indexExpressionAst.Index.Accept(this) && (bool)indexExpressionAst.Target.Accept(this);
@@ -189,6 +203,13 @@ namespace System.Management.Automation.Language
         {
             var expr = pipelineAst.GetPureExpression();
             return expr != null && (bool)expr.Accept(this);
+        }
+
+        public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
+        {
+            return (bool)ternaryExpressionAst.Condition.Accept(this) &&
+                   (bool)ternaryExpressionAst.IfOperand.Accept(this) &&
+                   (bool)ternaryExpressionAst.ElseOperand.Accept(this);
         }
 
         public object VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)
@@ -334,7 +355,7 @@ namespace System.Management.Automation.Language
      * except in the case of handling the unary operator
      * ExecutionContext is provided to ensure we can resolve variables
      */
-    internal class GetSafeValueVisitor : ICustomAstVisitor
+    internal class GetSafeValueVisitor : ICustomAstVisitor2
     {
         internal enum SafeValueContext
         {
@@ -433,6 +454,20 @@ namespace System.Management.Automation.Language
         public object VisitBlockStatement(BlockStatementAst blockStatementAst) { throw PSTraceSource.NewArgumentException("ast"); }
 
         public object VisitInvokeMemberExpression(InvokeMemberExpressionAst invokeMemberExpressionAst) { throw PSTraceSource.NewArgumentException("ast"); }
+
+        public object VisitTypeDefinition(TypeDefinitionAst typeDefinitionAst) { throw PSTraceSource.NewArgumentException("ast"); }
+
+        public object VisitPropertyMember(PropertyMemberAst propertyMemberAst) { throw PSTraceSource.NewArgumentException("ast"); }
+
+        public object VisitFunctionMember(FunctionMemberAst functionMemberAst) { throw PSTraceSource.NewArgumentException("ast"); }
+
+        public object VisitBaseCtorInvokeMemberExpression(BaseCtorInvokeMemberExpressionAst baseCtorInvokeMemberExpressionAst) { throw PSTraceSource.NewArgumentException("ast"); }
+
+        public object VisitUsingStatement(UsingStatementAst usingStatement) { throw PSTraceSource.NewArgumentException("ast"); }
+
+        public object VisitConfigurationDefinition(ConfigurationDefinitionAst configurationDefinitionAst) { throw PSTraceSource.NewArgumentException("ast"); }
+
+        public object VisitDynamicKeywordStatement(DynamicKeywordStatementAst dynamicKeywordAst) { throw PSTraceSource.NewArgumentException("ast"); }
 
         //
         // This is similar to logic used deep in the engine for slicing something that can be sliced
@@ -607,6 +642,18 @@ namespace System.Management.Automation.Language
             }
 
             throw PSTraceSource.NewArgumentException("ast");
+        }
+
+        public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
+        {
+            if (s_context != null)
+            {
+                return Compiler.GetExpressionValue(ternaryExpressionAst, true, s_context, null);
+            }
+            else
+            {
+                throw PSTraceSource.NewArgumentException("ast");
+            }
         }
 
         public object VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)

--- a/src/System.Management.Automation/engine/parser/SafeValues.cs
+++ b/src/System.Management.Automation/engine/parser/SafeValues.cs
@@ -383,6 +383,7 @@ namespace System.Management.Automation.Language
             throw PSTraceSource.NewArgumentException("ast");
         }
 
+        [ThreadStatic]
         private static ExecutionContext s_context;
 
         public object VisitErrorStatement(ErrorStatementAst errorStatementAst) { throw PSTraceSource.NewArgumentException("ast"); }

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -2326,6 +2326,11 @@ namespace System.Management.Automation
             return dynamicKeywordAst.CommandElements[0].Accept(this);
         }
 
+        object ICustomAstVisitor2.VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
+        {
+            return InferTypes(ternaryExpressionAst.IfOperand).Concat(InferTypes(ternaryExpressionAst.ElseOperand));
+        }
+
         private static CommandBaseAst GetPreviousPipelineCommand(CommandAst commandAst)
         {
             var pipe = (PipelineAst)commandAst.Parent;

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -2328,7 +2328,7 @@ namespace System.Management.Automation
 
         object ICustomAstVisitor2.VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
         {
-            return InferTypes(ternaryExpressionAst.IfOperand).Concat(InferTypes(ternaryExpressionAst.ElseOperand));
+            return InferTypes(ternaryExpressionAst.IfTrue).Concat(InferTypes(ternaryExpressionAst.IfFalse));
         }
 
         private static CommandBaseAst GetPreviousPipelineCommand(CommandAst commandAst)

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -7148,10 +7148,10 @@ namespace System.Management.Automation.Language
         /// </summary>
         public override Ast Copy()
         {
-            var newCondition = CopyElement(Condition);
-            var newIfClause = CopyElement(IfTrue);
-            var newElseClause = CopyElement(IfFalse);
-            return new TernaryExpressionAst(this.Extent, newCondition, newIfClause, newElseClause);
+            var newCondition = CopyElement(this.Condition);
+            var newIfTrue = CopyElement(this.IfTrue);
+            var newIfFalse = CopyElement(this.IfFalse);
+            return new TernaryExpressionAst(this.Extent, newCondition, newIfTrue, newIfFalse);
         }
 
         #region Visitors

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -7108,24 +7108,24 @@ namespace System.Management.Automation.Language
         /// </summary>
         /// <param name="extent">The extent of the expression.</param>
         /// <param name="condition">The condition operand.</param>
-        /// <param name="ifClause">The if clause.</param>
-        /// <param name="elseClause">The else clause.</param>
-        public TernaryExpressionAst(IScriptExtent extent, ExpressionAst condition, ExpressionAst ifClause, ExpressionAst elseClause)
+        /// <param name="ifTrue">The if clause.</param>
+        /// <param name="ifFalse">The else clause.</param>
+        public TernaryExpressionAst(IScriptExtent extent, ExpressionAst condition, ExpressionAst ifTrue, ExpressionAst ifFalse)
             : base(extent)
         {
-            if (condition == null || ifClause == null || elseClause == null)
+            if (condition == null || ifTrue == null || ifFalse == null)
             {
-                throw PSTraceSource.NewArgumentNullException(condition == null ? nameof(condition) : ifClause == null ? nameof(ifClause) : nameof(elseClause));
+                throw PSTraceSource.NewArgumentNullException(condition == null ? nameof(condition) : ifTrue == null ? nameof(ifTrue) : nameof(ifFalse));
             }
 
             Condition = condition;
             SetParent(condition);
 
-            IfOperand = ifClause;
-            SetParent(ifClause);
+            IfTrue = ifTrue;
+            SetParent(ifTrue);
 
-            ElseOperand = elseClause;
-            SetParent(elseClause);
+            IfFalse = ifFalse;
+            SetParent(ifFalse);
         }
 
         /// <summary>
@@ -7136,12 +7136,12 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The ast for the if-operand of the ternary expression. The property is never null.
         /// </summary>
-        public ExpressionAst IfOperand { get; }
+        public ExpressionAst IfTrue { get; }
 
         /// <summary>
         /// The ast for the else-operand of the ternary expression. The property is never null.
         /// </summary>
-        public ExpressionAst ElseOperand { get; }
+        public ExpressionAst IfFalse { get; }
 
         /// <summary>
         /// Copy the TernaryExpressionAst instance.
@@ -7149,8 +7149,8 @@ namespace System.Management.Automation.Language
         public override Ast Copy()
         {
             var newCondition = CopyElement(Condition);
-            var newIfClause = CopyElement(IfOperand);
-            var newElseClause = CopyElement(ElseOperand);
+            var newIfClause = CopyElement(IfTrue);
+            var newElseClause = CopyElement(IfFalse);
             return new TernaryExpressionAst(this.Extent, newCondition, newIfClause, newElseClause);
         }
 
@@ -7173,9 +7173,9 @@ namespace System.Management.Automation.Language
                 if (action == AstVisitAction.Continue)
                     action = Condition.InternalVisit(visitor2);
                 if (action == AstVisitAction.Continue)
-                    action = IfOperand.InternalVisit(visitor2);
+                    action = IfTrue.InternalVisit(visitor2);
                 if (action == AstVisitAction.Continue)
-                    action = ElseOperand.InternalVisit(visitor2);
+                    action = IfFalse.InternalVisit(visitor2);
             }
 
             return visitor.CheckForPostAction(this, action);

--- a/src/System.Management.Automation/engine/parser/token.cs
+++ b/src/System.Management.Automation/engine/parser/token.cs
@@ -413,6 +413,9 @@ namespace System.Management.Automation.Language
         /// <summary>The PS class base class and implemented interfaces operator ':'. Also used in base class ctor calls.</summary>
         Colon = 99,
 
+        /// <summary>The ternary operator '?'.</summary>
+        QuestionMark = 100,
+
         #endregion Operators
 
         #region Keywords
@@ -655,7 +658,10 @@ namespace System.Management.Automation.Language
         /// </summary>
         CaseSensitiveOperator = 0x00000400,
 
-        // Unused = 0x00000800,
+        /// <summary>
+        /// The token is a ternary operator '?'.
+        /// </summary>
+        TernaryOperator = 0x00000800,
 
         /// <summary>
         /// The operators '&amp;', '|', and the member access operators ':' and '::'.
@@ -847,7 +853,7 @@ namespace System.Management.Automation.Language
             /*                  Shl */ TokenFlags.BinaryOperator | TokenFlags.BinaryPrecedenceComparison | TokenFlags.CanConstantFold,
             /*                  Shr */ TokenFlags.BinaryOperator | TokenFlags.BinaryPrecedenceComparison | TokenFlags.CanConstantFold,
             /*                Colon */ TokenFlags.SpecialOperator | TokenFlags.DisallowedInRestrictedMode,
-            /*     Reserved slot 2  */ TokenFlags.None,
+            /*         QuestionMark */ TokenFlags.TernaryOperator | TokenFlags.DisallowedInRestrictedMode,
             /*     Reserved slot 3  */ TokenFlags.None,
             /*     Reserved slot 4  */ TokenFlags.None,
             /*     Reserved slot 5  */ TokenFlags.None,

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -721,7 +721,7 @@ namespace System.Management.Automation.Language
 
         internal TokenizerMode Mode { get; set; }
         internal bool AllowSignedNumbers { get; set; }
-        internal bool ForceEndNumbeOnTernaryOpChars { get; set; }
+        internal bool ForceEndNumberOnTernaryOpChars { get; set; }
         internal bool WantSimpleName { get; set; }
         internal bool InWorkflowContext { get; set; }
         internal List<Token> TokenList { get; set; }
@@ -4119,7 +4119,7 @@ namespace System.Management.Automation.Language
 
             if (!c.ForceStartNewToken())
             {
-                if (!InExpressionMode() || !c.ForceStartNewTokenAfterNumber(ForceEndNumbeOnTernaryOpChars))
+                if (!InExpressionMode() || !c.ForceStartNewTokenAfterNumber(ForceEndNumberOnTernaryOpChars))
                 {
                     notNumber = true;
                 }

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -1343,23 +1343,21 @@ namespace System.Management.Automation.Language
             return true;
         }
 
-        internal bool IsPipeContinuance(IScriptExtent extent)
+        internal bool IsPipeContinuation(IScriptExtent extent)
         {
             // If the first non-whitespace & non-comment (regular or block) character following a newline is a pipe, we have
-            // pipe continuance.
-            return extent.EndOffset < _script.Length &&
-                   ContinuanceAfterExtent(extent, continuanceChar: '|', skipComment: true);
+            // pipe continuation.
+            return extent.EndOffset < _script.Length && ContinuationAfterExtent(extent, continuationChar: '|');
         }
 
-        internal bool IsTernaryContinuance(IScriptExtent extent)
+        internal bool IsTernaryContinuation(IScriptExtent extent)
         {
             // If the first non-whitespace character following a newline is a question mark, we have
-            // ternary continuance
-            return extent.EndOffset < _script.Length &&
-                   ContinuanceAfterExtent(extent, continuanceChar: '?', skipComment: false);
+            // ternary continuation.
+            return extent.EndOffset < _script.Length && ContinuationAfterExtent(extent, continuationChar: '?');
         }
 
-        private bool ContinuanceAfterExtent(IScriptExtent extent, char continuanceChar, bool skipComment)
+        private bool ContinuationAfterExtent(IScriptExtent extent, char continuationChar)
         {
             bool lastNonWhitespaceIsNewline = true;
             int i = extent.EndOffset;
@@ -1382,7 +1380,7 @@ namespace System.Management.Automation.Language
                 {
                     if (lastNonWhitespaceIsNewline)
                     {
-                        // blank or whitespace-only lines are not allowed in automatic line continuance
+                        // blank or whitespace-only lines are not allowed in automatic line continuation
                         return false;
                     }
 
@@ -1394,7 +1392,7 @@ namespace System.Management.Automation.Language
                 {
                     if (lastNonWhitespaceIsNewline)
                     {
-                        // blank or whitespace-only lines are not allowed in automatic line continuance
+                        // blank or whitespace-only lines are not allowed in automatic line continuation
                         return false;
                     }
 
@@ -1405,27 +1403,24 @@ namespace System.Management.Automation.Language
 
                 lastNonWhitespaceIsNewline = false;
 
-                if (skipComment)
+                if (c == '#')
                 {
-                    if (c == '#')
-                    {
-                        // SkipLineComment will return the position after the comment end
-                        // which is either at the end of the file, or a cr or lf.
-                        i = SkipLineComment(i + 1);
-                        continue;
-                    }
-
-                    if (c == '<' && _script[i + 1] == '#')
-                    {
-                        i = SkipBlockComment(i + 2);
-                        continue;
-                    }
+                    // SkipLineComment will return the position after the comment end
+                    // which is either at the end of the file, or a cr or lf.
+                    i = SkipLineComment(i + 1);
+                    continue;
                 }
 
-                return c == continuanceChar;
+                if (c == '<' && _script[i + 1] == '#')
+                {
+                    i = SkipBlockComment(i + 2);
+                    continue;
+                }
+
+                return c == continuationChar;
             }
 
-            return _script[_script.Length - 1] == continuanceChar;
+            return _script[_script.Length - 1] == continuationChar;
         }
 
         private int SkipLineComment(int i)

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -721,6 +721,7 @@ namespace System.Management.Automation.Language
 
         internal TokenizerMode Mode { get; set; }
         internal bool AllowSignedNumbers { get; set; }
+        internal bool ForceEndNumbeOnTernaryOpChars { get; set; }
         internal bool WantSimpleName { get; set; }
         internal bool InWorkflowContext { get; set; }
         internal List<Token> TokenList { get; set; }
@@ -4118,7 +4119,7 @@ namespace System.Management.Automation.Language
 
             if (!c.ForceStartNewToken())
             {
-                if (!InExpressionMode() || !c.ForceStartNewTokenAfterNumber())
+                if (!InExpressionMode() || !c.ForceStartNewTokenAfterNumber(ForceEndNumbeOnTernaryOpChars))
                 {
                     notNumber = true;
                 }

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -3858,7 +3858,7 @@ namespace System.Management.Automation.Language
                 firstChar == '.' || (firstChar >= '0' && firstChar <= '9')
                 || (AllowSignedNumbers && (firstChar == '+' || firstChar.IsDash())), "Number must start with '.', '-', or digit.");
 
-            ReadOnlySpan<char> strNum = ScanNumberHelper(firstChar, out NumberFormat format, out NumberSuffixFlags suffix, out bool real, out long multiplier);
+            string strNum = ScanNumberHelper(firstChar, out NumberFormat format, out NumberSuffixFlags suffix, out bool real, out long multiplier);
 
             // the token is not a number. i.e. 77z.exe
             if (strNum == null)
@@ -3900,7 +3900,7 @@ namespace System.Management.Automation.Language
         /// OR
         /// Return the string format of the number.
         /// </returns>
-        private ReadOnlySpan<char> ScanNumberHelper(char firstChar, out NumberFormat format, out NumberSuffixFlags suffix, out bool real, out long multiplier)
+        private string ScanNumberHelper(char firstChar, out NumberFormat format, out NumberSuffixFlags suffix, out bool real, out long multiplier)
         {
             format = NumberFormat.Decimal;
             suffix = NumberSuffixFlags.None;
@@ -4129,7 +4129,7 @@ namespace System.Management.Automation.Language
                 sb[0] = '-';
             }
 
-            return GetStringAndRelease(sb).AsSpan();
+            return GetStringAndRelease(sb);
         }
 
         #endregion Numbers
@@ -4953,7 +4953,7 @@ namespace System.Management.Automation.Language
                     if (InExpressionMode() && (char.IsDigit(c1) || c1 == '.'))
                     {
                         // check if the next token is actually a number
-                        ReadOnlySpan<char> strNum = ScanNumberHelper(c, out NumberFormat format, out NumberSuffixFlags suffix, out bool real, out long multiplier);
+                        string strNum = ScanNumberHelper(c, out _, out _, out _, out _);
                         // rescan characters after the check
                         _currentIndex = _tokenStart;
                         c = GetChar();
@@ -4983,6 +4983,9 @@ namespace System.Management.Automation.Language
                     }
 
                     return this.NewToken(TokenKind.Colon);
+
+                case '?' when InExpressionMode():
+                    return this.NewToken(TokenKind.QuestionMark);
 
                 case '\0':
                     if (AtEof())

--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -1500,4 +1500,7 @@ ModuleVersion : Version of module to import. If used, ModuleName must represent 
   <data name="ClassesNotAllowedInConstrainedLanguage" xml:space="preserve">
     <value>Class keyword is not allowed in ConstrainedLanguage mode.</value>
   </data>
+  <data name="MissingColonInTernaryExpression" xml:space="preserve">
+    <value>Missing ':' in the ternary expression.</value>
+  </data>
 </root>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add support to ternary operator `<condition> ? <if-true> : <if-false>`. It results in a `TernaryExpressionAst`.

## PR Context

Ternary operator has lower precedence than binary operator, so you can write `$a -eq $b ? "Hello World" : [int]::MaxValue`.

Implicit line continuance for `?` is supported, so you can write
```
$PSEdition -eq 'Core'
    ? "PowerShell Core"
    : "Windows PowerShell"
```

Today, `1?2:3` is parsed as a command name as `1?2:3` is considered as a generic token by the tokenizer.
We don't want to break that, but in certain situation, we know we are expecting an expression and a generic token like `1?2:3` is not useful. In those cases, we want to make the ternary operator chars `?` and `:` to force ending a number token scan.
A new bool field `ForceEndNumbeOnTernaryOpChars` is added to `Tokenizer` and used when scanning number tokens. When the tokenizer is current in `Expression` mode, `ForceEndNumbeOnTernaryOpChars` is `true`, and the current char is `?` or `:`, we force ending the number token.
With this, we are able to write `$a -gt 2?[int]::MaxValue:3`, `${true}?3:1`, and `-not 1?2:3`.

Characters `?` and `:` are valid chars for a variable name, so `$varName?2:3` will be parsed as a variable. In order to write concise ternary expression with a variable condition, you can do this: `${varName}?2:3`.

### This PR is a draft, not finished yet

Send out the draft PR to start collecting feedback.
Also, exercise the CI builds to find regressions.
Pending work:
1. Finish examining all visitor usages, and update appropriately. Example, `VariableAnalysis` needs to be updated to account for the ternary operator.
2. Examine if `UpdatePosition` is correctly called at the right place.
2. Add many tests.

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
