### PR TITLE
Special case the posix locale in WildcardPattern

### DIFF
--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -142,7 +142,11 @@ namespace System.Management.Automation
                 {
                     stringComparison = Options.HasFlag(WildcardOptions.CultureInvariant)
                         ? StringComparison.InvariantCultureIgnoreCase
-                        : StringComparison.CurrentCultureIgnoreCase;
+                        : CultureInfo.CurrentCulture.Name.Equals("en-US-POSIX", StringComparison.OrdinalIgnoreCase)
+                            // The collation behavior of the POSIX locale (also known as the C locale) is case sensitive.
+                            // For this specific locale, we use 'OrdinalIgnoreCase'.
+                            ? StringComparison.OrdinalIgnoreCase
+                            : StringComparison.CurrentCultureIgnoreCase;
                 }
                 else
                 {

--- a/test/powershell/Language/Parser/LanguageAndParser.TestFollowup.Tests.ps1
+++ b/test/powershell/Language/Parser/LanguageAndParser.TestFollowup.Tests.ps1
@@ -304,13 +304,29 @@ Describe "Hash expression with if statement as value" -Tags "CI" {
     }
 }
 
-Describe "Hashtable is case insensitive" -Tag CI {
-    It "When current culture is en-US-POSIX" -Skip:($IsWindows) {
+Describe "Support case-insensitive comparison in Posix locale" -Tag CI {
+    It "Hashtable is case insensitive" -Skip:($IsWindows) {
         try {
             $oldCulture = [System.Globalization.CultureInfo]::CurrentCulture
             [System.Globalization.CultureInfo]::CurrentCulture = [System.Globalization.CultureInfo]::new('en-US-POSIX')
 
             @{h=1}.H | Should -Be 1 -Because 'hashtables should be case insensitive in en-US-POSIX culture'
+        }
+        finally {
+            [System.Globalization.CultureInfo]::CurrentCulture = $oldCulture
+        }
+    }
+
+    It "Wildcard support case-insensitive matching" -Skip:($IsWindows) {
+        try {
+            $oldCulture = [System.Globalization.CultureInfo]::CurrentCulture
+            [System.Globalization.CultureInfo]::CurrentCulture = [System.Globalization.CultureInfo]::new('en-US-POSIX')
+
+            $wildcard1 = [WildcardPattern]::new("AbC*", [System.Management.Automation.WildcardOptions]::IgnoreCase)
+            $wildcard1.IsMatch("abcd") | Should -BeTrue
+
+            $wildcard2 = [WildcardPattern]::new("DeF", [System.Management.Automation.WildcardOptions]::IgnoreCase);
+            $wildcard2.IsMatch("def") | Should -BeTrue
         }
         finally {
             [System.Globalization.CultureInfo]::CurrentCulture = $oldCulture


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #10177
Special case the posix locale in WildcardPattern.
When `WildcardOptions.IgnoreCase` is specified and the current culture is `en-us-POSIX`, we use `StringComparison.OrdinalIgnoreCase` instead of `StringComparison.CurrentCultureIgnoreCase`, because the Posix culture compares in case-sensitive manner only.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
