### PR TITLE
Formatting: handle XTPUSHSGR/XTPOPSGR sequences

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
@@ -2686,12 +2686,14 @@ namespace Microsoft.PowerShell
             var start = offset;
 
             // First, check for the CSI:
-            if ((str[offset] == (char) 0x1b) && (str.Length > (offset + 1)) && (str[offset + 1] == '[')) // C0 CSI
+            if ((str[offset] == (char)0x1b) && (str.Length > (offset + 1)) && (str[offset + 1] == '['))
             {
+                // C0 CSI
                 offset += 2;
             }
-            else if (str[offset] == (char) 0x9b) // C1 CSI
+            else if (str[offset] == (char)0x9b)
             {
+                // C1 CSI
                 offset += 1;
             }
             else
@@ -2702,13 +2704,17 @@ namespace Microsoft.PowerShell
             }
 
             if (offset >= str.Length)
+            {
                 return 0;
+            }
 
             // Next, handle possible numeric arguments:
             char c;
-            do {
+            do
+            {
                 c = str[offset++];
-            } while ((offset < str.Length) && (char.IsDigit(c) || c == ';'));
+            }
+            while ((offset < str.Length) && (char.IsDigit(c) || c == ';'));
 
             // Finally, handle the command characters for the specific sequences we
             // handle:
@@ -2722,13 +2728,19 @@ namespace Microsoft.PowerShell
                 // Maybe XTPUSHSGR or XTPOPSGR, but we need to read another char. Offset
                 // is already positioned on the next char (or past the end).
                 if (offset >= str.Length)
+                {
                     return 0;
+                }
 
+                // '{' : XTPUSHSGR
+                // '}' : XTPOPSGR
+                // 'p' : alias for XTPUSHSGR
+                // 'q' : alias for XTPOPSGR
                 c = str[offset++];
-                if ((c == '{') || // XTPUSHSGR
-                    (c == '}') || // XTPOPSGR
-                    (c == 'p') || // alias for XTPUSHSGR
-                    (c == 'q'))   // alias for XTPOPSGR
+                if ((c == '{') ||
+                    (c == '}') ||
+                    (c == 'p') ||
+                    (c == 'q'))
                 {
                     return offset - start;
                 }

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -822,7 +822,7 @@ Describe "Console host api tests" -Tag CI {
         {
             @{InputObject = "$esc[31mabc"; Length = 8; Name = "Escape at start - no virtual term support"}
             @{InputObject = "$esc[31mabc$esc[0m"; Length = 12; Name = "Escape at start and end - no virtual term support"}
-            @{InputObject = "${csi}31mabc"; Length = 7; Name = "C1 CSI at start - no virtual term support - no virtual term support"}
+            @{InputObject = "${csi}31mabc"; Length = 7; Name = "C1 CSI at start - no virtual term support"}
             @{InputObject = "${csi}31mabc${csi}0m"; Length = 10; Name = "C1 CSI at start and end - no virtual term support"}
             @{InputObject = "abc${csi}m"; Length = 5; Name = "C1 CSI, no params - no virtual term support"}
             @{InputObject = "abc${csi}#{"; Length = 6; Name = "C1 CSI, XTPUSHSGR - no virtual term support"}

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -795,7 +795,7 @@ public enum ShowWindowCommands : int
 }
 
 Describe "Console host api tests" -Tag CI {
-    Context "String escape sequences" {
+    Context "String escape and control sequences" {
         $esc = [char]0x1b
         $csi = [char]0x9b
         $testCases =

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -797,6 +797,7 @@ public enum ShowWindowCommands : int
 Describe "Console host api tests" -Tag CI {
     Context "String escape sequences" {
         $esc = [char]0x1b
+        $csi = [char]0x9b
         $testCases =
             @{InputObject = "abc"; Length = 3; Name = "No escapes"},
             @{InputObject = "${esc} [31mabc"; Length = 9; Name = "Malformed escape - extra space"},
@@ -807,11 +808,29 @@ Describe "Console host api tests" -Tag CI {
         {
             @{InputObject = "$esc[31mabc"; Length = 3; Name = "Escape at start"}
             @{InputObject = "$esc[31mabc$esc[0m"; Length = 3; Name = "Escape at start and end"}
+            @{InputObject = "${csi}31mabc"; Length = 3; Name = "C1 CSI at start"}
+            @{InputObject = "${csi}31mabc${csi}0m"; Length = 3; Name = "C1 CSI at start and end"}
+            @{InputObject = "abc${csi}m"; Length = 3; Name = "C1 CSI, no params"}
+            @{InputObject = "abc${csi}#{"; Length = 3; Name = "C1 CSI, XTPUSHSGR"}
+            @{InputObject = "abc${csi}#}"; Length = 3; Name = "C1 CSI, XTPOPSGR"}
+            @{InputObject = "abc${csi}#p"; Length = 3; Name = "C1 CSI, XTPUSHSGR (alias)"}
+            @{InputObject = "abc${csi}#q"; Length = 3; Name = "C1 CSI, XTPOPSGR (alias)"}
+            @{InputObject = "abc${esc}[0#p"; Length = 3; Name = "XTPUSHSGR, with param"}
+            @{InputObject = "${esc}[0;1#qabc"; Length = 3; Name = "XTPOPSGR, with multiple params"}
         }
         else
         {
             @{InputObject = "$esc[31mabc"; Length = 8; Name = "Escape at start - no virtual term support"}
             @{InputObject = "$esc[31mabc$esc[0m"; Length = 12; Name = "Escape at start and end - no virtual term support"}
+            @{InputObject = "${csi}31mabc"; Length = 7; Name = "C1 CSI at start - no virtual term support - no virtual term support"}
+            @{InputObject = "${csi}31mabc${csi}0m"; Length = 10; Name = "C1 CSI at start and end - no virtual term support"}
+            @{InputObject = "abc${csi}m"; Length = 5; Name = "C1 CSI, no params - no virtual term support"}
+            @{InputObject = "abc${csi}#{"; Length = 6; Name = "C1 CSI, XTPUSHSGR - no virtual term support"}
+            @{InputObject = "abc${csi}#}"; Length = 6; Name = "C1 CSI, XTPOPSGR - no virtual term support"}
+            @{InputObject = "abc${csi}#p"; Length = 6; Name = "C1 CSI, XTPUSHSGR (alias) - no virtual term support"}
+            @{InputObject = "abc${csi}#q"; Length = 6; Name = "C1 CSI, XTPOPSGR (alias) - no virtual term support"}
+            @{InputObject = "abc${esc}[0#p"; Length = 8; Name = "XTPUSHSGR, with param - no virtual term support"}
+            @{InputObject = "${esc}[0;1#qabc"; Length = 10; Name = "XTPOPSGR, with multiple params - no virtual term support"}
         }
 
         It "Should properly calculate buffer cell width of '<Name>'" -TestCases $testCases {


### PR DESCRIPTION
# PR Summary

The RawUI's `LengthInBufferCells` needs to treat VT control sequences as zero-width for the purpose of determining string length.

Previously, it only handled SGR (Select Graphics Rendition) sequences (which do things like set fg color, bg color, etc.).

I'm currently adding support for some new control sequences in the microsoft/terminal project: XTPUSHSGR and XTPOPSGR. Initial WIP PR [here](https://github.com/microsoft/terminal/pull/1978).

Summarized descriptions of XTPUSHSGR and XTPOPSGR from XTerm's [ctlseqs](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html) documentation:

```
CSI # {
CSI Ps ; Ps # {
          Push video attributes onto stack (XTPUSHSGR), xterm.

CSI # }   Pop video attributes from stack (XTPOPSGR), xterm.  Popping
          restores the video-attributes which were saved using XTPUSHSGR
          to their previous state.
CSI # p
CSI Ps ; Ps # p
          Push video attributes onto stack (XTPUSHSGR), xterm.  This is
          an alias for CSI # {.

CSI # q   Pop video attributes from stack (XTPOPSGR), xterm.  This is an
          alias for CSI # }.
```

The scenario enabled by these sequences is composability (see [Issue 1796](https://github.com/microsoft/terminal/issues/1796)).

I'd like to support these sequences in PowerShell, similarly to SGR sequences, to enable better SGR content composability.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
