### PR TITLE
Cleanup LocationGlobber and related code

### DIFF
--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -1389,12 +1389,8 @@ namespace System.Management.Automation
         /// True if the command name is either a provider-qualified or PowerShell drive-qualified
         /// path. False otherwise.
         /// </returns>
-        private static bool IsQualifiedPSPath(string commandName)
+        private static bool IsQualifiedPSPath(ReadOnlySpan<char> commandName)
         {
-            Dbg.Assert(
-                !string.IsNullOrEmpty(commandName),
-                "The caller should have verified the commandName");
-
             bool result =
                 LocationGlobber.IsAbsolutePath(commandName) ||
                 LocationGlobber.IsProviderQualifiedPath(commandName) ||

--- a/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
@@ -243,7 +243,6 @@ namespace System.Management.Automation
             string originalPath = path;
             string driveName = null;
             ProviderInfo provider = null;
-            string providerId = null;
 
             switch (originalPath)
             {
@@ -282,9 +281,9 @@ namespace System.Management.Automation
                 provider = CurrentLocation.Provider;
                 CurrentDrive = provider.HiddenDrive;
             }
-            else if (LocationGlobber.IsProviderQualifiedPath(path, out providerId))
+            else if (LocationGlobber.IsProviderQualifiedPath(path, out ReadOnlySpan<char> providerId))
             {
-                provider = GetSingleProvider(providerId);
+                provider = GetSingleProvider(providerId.ToString());
                 CurrentDrive = provider.HiddenDrive;
             }
             else
@@ -384,13 +383,13 @@ namespace System.Management.Automation
                 string currentPath = path;
                 try
                 {
-                    string providerName = null;
-                    currentPathisProviderQualifiedPath = LocationGlobber.IsProviderQualifiedPath(resolvedPath.Path, out providerName);
+                    currentPathisProviderQualifiedPath = LocationGlobber.IsProviderQualifiedPath(resolvedPath.Path, out ReadOnlySpan<char> tempProviderName);
                     if (currentPathisProviderQualifiedPath)
                     {
                         // The path should be the provider-qualified path without the provider ID
                         // or ::
                         string providerInternalPath = LocationGlobber.RemoveProviderQualifier(resolvedPath.Path);
+                        string providerName = tempProviderName.ToString();
 
                         try
                         {

--- a/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
@@ -272,10 +272,7 @@ namespace System.Management.Automation
             PSDriveInfo previousWorkingDrive = CurrentDrive;
 
             // First check to see if the path is a home path
-            if (LocationGlobber.IsHomePath(path))
-            {
-                path = Globber.GetHomeRelativePath(path);
-            }
+            path = Globber.GetHomeRelativePath(path);
 
             if (LocationGlobber.IsProviderDirectPath(path))
             {

--- a/src/System.Management.Automation/engine/SessionStateNavigation.cs
+++ b/src/System.Management.Automation/engine/SessionStateNavigation.cs
@@ -256,7 +256,7 @@ namespace System.Management.Automation
             {
                 isProviderQualified = true;
 
-                // remove the qualifier
+                // remove the qualifier with '::' trail
                 result = path.Slice(qualifier.Length + 2);
             }
             else

--- a/src/System.Management.Automation/engine/SessionStateNavigation.cs
+++ b/src/System.Management.Automation/engine/SessionStateNavigation.cs
@@ -172,9 +172,9 @@ namespace System.Management.Automation
 
                 bool isProviderQualified = false;
                 bool isDriveQualified = false;
-                string pathNoQualifier = RemoveQualifier(path, provider, Globber, out ReadOnlySpan<char> qualifier, out isProviderQualified, out isDriveQualified);
+                ReadOnlySpan<char> pathNoQualifier = RemoveQualifier(path, provider, Globber, out ReadOnlySpan<char> qualifier, out isProviderQualified, out isDriveQualified);
 
-                string result = GetParentPath(provider, pathNoQualifier, root, context);
+                string result = GetParentPath(provider, pathNoQualifier.ToString(), root, context);
 
                 if (!qualifier.IsEmpty && !string.IsNullOrEmpty(result))
                 {
@@ -241,13 +241,13 @@ namespace System.Management.Automation
         /// <returns>
         /// The path without the qualifier.
         /// </returns>
-        private static string RemoveQualifier(string path, ProviderInfo provider, LocationGlobber globber, out ReadOnlySpan<char> qualifier, out bool isProviderQualified, out bool isDriveQualified)
+        private static ReadOnlySpan<char> RemoveQualifier(ReadOnlySpan<char> path, ProviderInfo provider, LocationGlobber globber, out ReadOnlySpan<char> qualifier, out bool isProviderQualified, out bool isDriveQualified)
         {
             Dbg.Diagnostics.Assert(
                 path != null,
                 "Path should be verified by the caller");
 
-            string result = path;
+            ReadOnlySpan<char> result = path;
             qualifier = null;
             isProviderQualified = false;
             isDriveQualified = false;
@@ -257,7 +257,7 @@ namespace System.Management.Automation
                 isProviderQualified = true;
 
                 // remove the qualifier
-                result = path.Substring(qualifier.Length + 2);
+                result = path.Slice(qualifier.Length + 2);
             }
             else
             {
@@ -270,11 +270,11 @@ namespace System.Management.Automation
                     // Porting note: on non-windows there is no colon for qualified paths
                     if (provider.VolumeSeparatedByColon)
                     {
-                        result = path.Substring(tempQualifier.Length + 1);
+                        result = path.Slice(tempQualifier.Length + 1);
                     }
                     else
                     {
-                        result = path.Substring(tempQualifier.Length);
+                        result = path.Slice(tempQualifier.Length);
                     }
                 }
             }

--- a/src/System.Management.Automation/engine/SessionStateNavigation.cs
+++ b/src/System.Management.Automation/engine/SessionStateNavigation.cs
@@ -172,7 +172,7 @@ namespace System.Management.Automation
 
                 bool isProviderQualified = false;
                 bool isDriveQualified = false;
-                string pathNoQualifier = RemoveQualifier(path, provider, out ReadOnlySpan<char> qualifier, out isProviderQualified, out isDriveQualified);
+                string pathNoQualifier = RemoveQualifier(path, provider, Globber, out ReadOnlySpan<char> qualifier, out isProviderQualified, out isDriveQualified);
 
                 string result = GetParentPath(provider, pathNoQualifier, root, context);
 
@@ -189,7 +189,7 @@ namespace System.Management.Automation
             }
         }
 
-        private string AddQualifier(ReadOnlySpan<char> path, ProviderInfo provider, ReadOnlySpan<char> qualifier, bool isProviderQualified, bool isDriveQualified)
+        private static string AddQualifier(ReadOnlySpan<char> path, ProviderInfo provider, ReadOnlySpan<char> qualifier, bool isProviderQualified, bool isDriveQualified)
         {
             string result;
 
@@ -226,6 +226,9 @@ namespace System.Management.Automation
         /// <param name="provider">
         /// The provider that should handle the RemoveQualifier call.
         /// </param>
+        /// <param name="globber">
+        /// The globber to check that the path is absolute.
+        /// </param>
         /// <param name="qualifier">
         /// Returns the qualifier of the path.
         /// </param>
@@ -238,7 +241,7 @@ namespace System.Management.Automation
         /// <returns>
         /// The path without the qualifier.
         /// </returns>
-        private string RemoveQualifier(string path, ProviderInfo provider, out ReadOnlySpan<char> qualifier, out bool isProviderQualified, out bool isDriveQualified)
+        private static string RemoveQualifier(string path, ProviderInfo provider, LocationGlobber globber, out ReadOnlySpan<char> qualifier, out bool isProviderQualified, out bool isDriveQualified)
         {
             Dbg.Diagnostics.Assert(
                 path != null,
@@ -258,7 +261,7 @@ namespace System.Management.Automation
             }
             else
             {
-                if (Globber.IsAbsolutePath(path, out string tempQualifier))
+                if (globber.IsAbsolutePath(path, out string tempQualifier))
                 {
                     isDriveQualified = true;
                     qualifier = tempQualifier.AsSpan();

--- a/src/System.Management.Automation/engine/SessionStateNavigation.cs
+++ b/src/System.Management.Automation/engine/SessionStateNavigation.cs
@@ -190,34 +190,30 @@ namespace System.Management.Automation
             }
         }
 
-        private string AddQualifier(string path, ProviderInfo provider, string qualifier, bool isProviderQualified, bool isDriveQualified)
+        private string AddQualifier(ReadOnlySpan<char> path, ProviderInfo provider, ReadOnlySpan<char> qualifier, bool isProviderQualified, bool isDriveQualified)
         {
-            string result = path;
+            string result;
 
-            string formatString = "{1}";
             if (isProviderQualified)
             {
-                formatString = "{0}::{1}";
+                result = string.Concat(qualifier, "::", path);
             }
             else if (isDriveQualified)
             {
                 // Porting note: on non-windows filesystem paths, there should be no colon in the path
                 if (provider.VolumeSeparatedByColon)
                 {
-                    formatString = "{0}:{1}";
+                    result = string.Concat(qualifier, ":", path);
                 }
                 else
                 {
-                    formatString = "{0}{1}";
+                    result = string.Concat(qualifier, path);
                 }
             }
-
-            result =
-                string.Format(
-                    System.Globalization.CultureInfo.InvariantCulture,
-                    formatString,
-                    qualifier,
-                    path);
+            else
+            {
+                result = path.ToString();
+            }
 
             return result;
         }

--- a/src/System.Management.Automation/engine/SessionStateNavigation.cs
+++ b/src/System.Management.Automation/engine/SessionStateNavigation.cs
@@ -254,17 +254,13 @@ namespace System.Management.Automation
             isProviderQualified = false;
             isDriveQualified = false;
 
-            if (LocationGlobber.IsProviderQualifiedPath(path, out qualifier))
+            if (LocationGlobber.IsProviderQualifiedPath(path, out ReadOnlySpan<char> tempQualifier))
             {
                 isProviderQualified = true;
 
-                int index = path.IndexOf("::", StringComparison.Ordinal);
-
-                if (index != -1)
-                {
-                    // remove the qualifier
-                    result = path.Substring(index + 2);
-                }
+                // remove the qualifier
+                result = path.Substring(tempQualifier.Length + 2);
+                qualifier = tempQualifier.ToString();
             }
             else
             {

--- a/src/System.Management.Automation/engine/SessionStateStrings.cs
+++ b/src/System.Management.Automation/engine/SessionStateStrings.cs
@@ -51,7 +51,7 @@ namespace System.Management.Automation
         /// <summary>
         /// The character used in a path to indicate the home location.
         /// </summary>
-        internal const string HomePath = "~";
+        internal const char HomePath = '~';
 
         /// <summary>
         /// Name of the global variable table in Variable scopes of session state.

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -4928,7 +4928,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         // Note: we don't use IO.Path.IsPathRooted as this deals with "invalid" i.e. unnormalized paths
-        private static bool IsAbsolutePath(string path)
+        private static bool IsAbsolutePath(ReadOnlySpan<char> path)
         {
             bool result = false;
 

--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -1405,7 +1405,8 @@ namespace System.Management.Automation
                     s_tracer.WriteLine("providerId = {0}", providerId.ToString());
 #endif
                 }
-            } while (false);
+            }
+            while (false);
 
             return result;
         }
@@ -1419,7 +1420,7 @@ namespace System.Management.Automation
         /// alternate path separator) in order for PowerShell to be slash agnostic.
         /// </remarks>
         /// <param name="path">
-        /// The path used in the determination
+        /// The path used in the determination.
         /// </param>
         /// <returns>
         /// Returns true if we're on a single root filesystem and the path is absolute.
@@ -1437,10 +1438,10 @@ namespace System.Management.Automation
         /// Determines if the given path is relative or absolute.
         /// </summary>
         /// <param name="path">
-        /// The path used in the determination
+        /// The path used in the determination.
         /// </param>
         /// <returns>
-        /// true if the path is an absolute path, false otherwise.
+        /// True if the path is an absolute path, false otherwise.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// If <paramref name="path"/> is null.
@@ -1515,14 +1516,14 @@ namespace System.Management.Automation
         /// Determines if the given path is relative or absolute.
         /// </summary>
         /// <param name="path">
-        /// The path used in the determination
+        /// The path used in the determination.
         /// </param>
         /// <param name="driveName">
         /// If the path is absolute, this out parameter will be the
         /// drive name of the drive that is referenced.
         /// </param>
         /// <returns>
-        /// true if the path is an absolute path, false otherwise.
+        /// True if the path is an absolute path, false otherwise.
         /// </returns>
         internal bool IsAbsolutePath(ReadOnlySpan<char> path, out string driveName)
         {

--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -4516,16 +4516,10 @@ namespace System.Management.Automation
 
             bool result = false;
 
-            if (IsProviderQualifiedPath(path))
+            if (IsProviderQualifiedPath(path, out string providerId))
             {
                 // Strip off the provider portion of the path
-
-                int index = path.IndexOf(StringLiterals.ProviderPathSeparator, StringComparison.Ordinal);
-
-                if (index != -1)
-                {
-                    path = path.Substring(index + StringLiterals.ProviderPathSeparator.Length);
-                }
+                path = path.Substring(providerId.Length + StringLiterals.ProviderPathSeparator.Length);
             }
 
             if (path.IndexOf(StringLiterals.HomePath, StringComparison.Ordinal) == 0)

--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -1359,16 +1359,15 @@ namespace System.Management.Automation
         /// <exception cref="ArgumentNullException">
         /// If <paramref name="path"/> is null.
         /// </exception>
-        internal static bool IsProviderQualifiedPath(string path, out string providerId)
+        internal static bool IsProviderQualifiedPath(string path, out ReadOnlySpan<char> providerId)
         {
             // Verify parameters
-
             if (path == null)
             {
                 throw PSTraceSource.NewArgumentNullException(nameof(path));
             }
 
-            providerId = null;
+            providerId = ReadOnlySpan<char>.Empty;
             bool result = false;
 
             do
@@ -1376,7 +1375,6 @@ namespace System.Management.Automation
                 if (path.Length == 0)
                 {
                     // The current working directory is specified
-
                     result = false;
                     break;
                 }
@@ -1387,7 +1385,6 @@ namespace System.Management.Automation
                     // The .\ prefix basically escapes anything that follows
                     // so treat it as a relative path no matter what comes
                     // after it.
-
                     result = false;
                     break;
                 }
@@ -1397,7 +1394,6 @@ namespace System.Management.Automation
                 {
                     // If there is no : then the path is relative to the
                     // current working drive
-
                     result = false;
                     break;
                 }
@@ -1405,16 +1401,15 @@ namespace System.Management.Automation
                 // If the :: is the first two character in the path then we
                 // must assume that it is part of the path, and not
                 // delimiting the drive name.
-
                 if (index > 0)
                 {
                     result = true;
 
                     // Get the provider ID
-
-                    providerId = path.Substring(0, index);
-
-                    s_tracer.WriteLine("providerId = {0}", providerId);
+                    providerId = path.AsSpan().Slice(0, index);
+#if DEBUG
+                    s_tracer.WriteLine("providerId = {0}", providerId.ToString());
+#endif
                 }
             } while (false);
 
@@ -4515,7 +4510,7 @@ namespace System.Management.Automation
 
             bool result = false;
 
-            if (IsProviderQualifiedPath(path, out string providerId))
+            if (IsProviderQualifiedPath(path, out ReadOnlySpan<char> providerId))
             {
                 // Strip off the provider portion of the path
                 path = path.Substring(providerId.Length + StringLiterals.ProviderPathSeparator.Length);

--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -4518,13 +4518,8 @@ namespace System.Management.Automation
         /// <exception cref="ArgumentNullException">
         /// If <paramref name="path"/> is null.
         /// </exception>
-        internal static bool IsProviderDirectPath(string path)
+        internal static bool IsProviderDirectPath(ReadOnlySpan<char> path)
         {
-            if (path == null)
-            {
-                throw PSTraceSource.NewArgumentNullException(nameof(path));
-            }
-
             return path.StartsWith(StringLiterals.DefaultRemotePathPrefix, StringComparison.Ordinal) ||
                    path.StartsWith(StringLiterals.AlternateRemotePathPrefix, StringComparison.Ordinal);
         }

--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -4485,16 +4485,19 @@ namespace System.Management.Automation
                 path = path.Slice(providerId.Length + StringLiterals.ProviderPathSeparator.Length);
             }
 
-            if (path.Length != 0 && path[0] == StringLiterals.HomePath)
+            var length = path.Length;
+            if (length != 0 && path[0] == StringLiterals.HomePath)
             {
-                // Support the single "~"
-                if (path.Length == 1)
+                if (length == 1)
+                {
+                    // Support the single "~"
                     result = true;
-                // Support "~/" or "~\"
-                else if ((path.Length > 1) &&
-                        (path[1] == '\\' ||
-                         path[1] == '/'))
+                }
+                else if ((length > 1) && (path[1] == '\\' || path[1] == '/'))
+                {
+                    // Support "~/" or "~\"
                     result = true;
+                }
             }
 
             return result;

--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -4475,22 +4475,17 @@ namespace System.Management.Automation
         /// <exception cref="ArgumentNullException">
         /// Is <paramref name="path"/> is null.
         /// </exception>
-        internal static bool IsHomePath(string path)
+        internal static bool IsHomePath(ReadOnlySpan<char> path)
         {
-            if (path == null)
-            {
-                throw PSTraceSource.NewArgumentNullException(nameof(path));
-            }
-
             bool result = false;
 
             if (IsProviderQualifiedPath(path, out ReadOnlySpan<char> providerId))
             {
                 // Strip off the provider portion of the path
-                path = path.Substring(providerId.Length + StringLiterals.ProviderPathSeparator.Length);
+                path = path.Slice(providerId.Length + StringLiterals.ProviderPathSeparator.Length);
             }
 
-            if (path.StartsWith(StringLiterals.HomePath))
+            if (path.Length != 0 && path[0] == StringLiterals.HomePath)
             {
                 // Support the single "~"
                 if (path.Length == 1)

--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -4565,21 +4565,13 @@ namespace System.Management.Automation
             {
                 ProviderInfo provider = _sessionState.Drive.Current.Provider;
 
-                if (IsProviderQualifiedPath(path))
+                if (IsProviderQualifiedPath(path, out ReadOnlySpan<char> providerId))
                 {
-                    // Strip off the provider portion of the path
-
-                    int index = path.IndexOf(StringLiterals.ProviderPathSeparator, StringComparison.Ordinal);
-
-                    if (index != -1)
+                    if (!providerId.IsEmpty)
                     {
-                        // Since the provider was specified store it and remove it
-                        // from the path.
-
-                        string providerName = path.Substring(0, index);
-
-                        provider = _sessionState.Internal.GetSingleProvider(providerName);
-                        path = path.Substring(index + StringLiterals.ProviderPathSeparator.Length);
+                        // Since the provider was specified store it and remove it from the path.
+                        path = path.Substring(providerId.Length + StringLiterals.ProviderPathSeparator.Length);
+                        provider = _sessionState.Internal.GetSingleProvider(providerId.ToString());
                     }
                 }
 

--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -1337,7 +1337,7 @@ namespace System.Management.Automation
         /// <exception cref="ArgumentNullException">
         /// If <paramref name="path"/> is null.
         /// </exception>
-        internal static bool IsProviderQualifiedPath(string path)
+        internal static bool IsProviderQualifiedPath(ReadOnlySpan<char> path)
         {
             return IsProviderQualifiedPath(path, out _);
         }
@@ -1359,14 +1359,8 @@ namespace System.Management.Automation
         /// <exception cref="ArgumentNullException">
         /// If <paramref name="path"/> is null.
         /// </exception>
-        internal static bool IsProviderQualifiedPath(string path, out ReadOnlySpan<char> providerId)
+        internal static bool IsProviderQualifiedPath(ReadOnlySpan<char> path, out ReadOnlySpan<char> providerId)
         {
-            // Verify parameters
-            if (path == null)
-            {
-                throw PSTraceSource.NewArgumentNullException(nameof(path));
-            }
-
             providerId = ReadOnlySpan<char>.Empty;
             bool result = false;
 
@@ -1406,7 +1400,7 @@ namespace System.Management.Automation
                     result = true;
 
                     // Get the provider ID
-                    providerId = path.AsSpan().Slice(0, index);
+                    providerId = path.Slice(0, index);
 #if DEBUG
                     s_tracer.WriteLine("providerId = {0}", providerId.ToString());
 #endif

--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -1356,9 +1356,6 @@ namespace System.Management.Automation
         /// <returns>
         /// True if the path is a provider path, false otherwise.
         /// </returns>
-        /// <exception cref="ArgumentNullException">
-        /// If <paramref name="path"/> is null.
-        /// </exception>
         internal static bool IsProviderQualifiedPath(ReadOnlySpan<char> path, out ReadOnlySpan<char> providerId)
         {
             providerId = ReadOnlySpan<char>.Empty;
@@ -1443,9 +1440,6 @@ namespace System.Management.Automation
         /// <returns>
         /// True if the path is an absolute path, false otherwise.
         /// </returns>
-        /// <exception cref="ArgumentNullException">
-        /// If <paramref name="path"/> is null.
-        /// </exception>
         internal static bool IsAbsolutePath(ReadOnlySpan<char> path)
         {
             bool result = false;
@@ -4472,9 +4466,6 @@ namespace System.Management.Automation
         /// True if the path contains a ~ at the beginning of the path or immediately
         /// following a provider designator ("provider::")
         /// </returns>
-        /// <exception cref="ArgumentNullException">
-        /// Is <paramref name="path"/> is null.
-        /// </exception>
         internal static bool IsHomePath(ReadOnlySpan<char> path)
         {
             bool result = false;

--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -4522,7 +4522,7 @@ namespace System.Management.Automation
                 path = path.Substring(providerId.Length + StringLiterals.ProviderPathSeparator.Length);
             }
 
-            if (path.IndexOf(StringLiterals.HomePath, StringComparison.Ordinal) == 0)
+            if (path.StartsWith(StringLiterals.HomePath))
             {
                 // Support the single "~"
                 if (path.Length == 1)
@@ -4622,7 +4622,7 @@ namespace System.Management.Automation
                     }
                 }
 
-                if (path.IndexOf(StringLiterals.HomePath, StringComparison.Ordinal) == 0)
+                if (path.StartsWith(StringLiterals.HomePath))
                 {
                     // Strip of the ~ and the \ or / if present
 

--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -189,17 +189,12 @@ namespace System.Management.Automation
                 TraceFilters(context);
 
                 // First check to see if the path starts with a ~ (home)
-
-                if (IsHomePath(path))
+                using (s_pathResolutionTracer.TraceScope("Resolving HOME relative path."))
                 {
-                    using (s_pathResolutionTracer.TraceScope("Resolving HOME relative path."))
-                    {
-                        path = GetHomeRelativePath(path);
-                    }
+                    path = GetHomeRelativePath(path);
                 }
 
                 // Now determine how to parse the path
-
                 bool isProviderDirectPath = IsProviderDirectPath(path);
                 bool isProviderQualifiedPath = IsProviderQualifiedPath(path);
                 if (isProviderDirectPath || isProviderQualifiedPath)
@@ -1230,12 +1225,9 @@ namespace System.Management.Automation
             drive = null;
 
             // First check to see if the path starts with a ~ (home)
-            if (IsHomePath(path))
+            using (s_pathResolutionTracer.TraceScope("Resolving HOME relative path."))
             {
-                using (s_pathResolutionTracer.TraceScope("Resolving HOME relative path."))
-                {
-                    path = GetHomeRelativePath(path);
-                }
+                path = GetHomeRelativePath(path);
             }
 
             // Now check to see if it is a provider-direct path (starts with // or \\)
@@ -4578,6 +4570,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Generates the path for the home location for a provider when given a
         /// path starting with ~ or "provider:~" followed by a relative path.
+        /// Otherwise return unchanged argument.
         /// </summary>
         /// <param name="path">
         /// The path to generate into a home path.

--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -1339,8 +1339,7 @@ namespace System.Management.Automation
         /// </exception>
         internal static bool IsProviderQualifiedPath(string path)
         {
-            string providerId = null;
-            return IsProviderQualifiedPath(path, out providerId);
+            return IsProviderQualifiedPath(path, out _);
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- Exclude extra IsHomePath() calls
- Make AddQualifier() and RemoveQualifier() static
- Make close code being span-based to reduce allocations

## PR Context

First motivation was to exclude extra IsHomePath() calls. 
LocationGlobber code is based on string operations and so it is a source of a huge amount of memory allocations. Then some low level methods was optimized with using ReadOnlySpan-s to reduce allocations and increase performance. This will later help to further optimize the performance of this code.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
