### PR TITLE
WIP: Correct completions for quoting and escaping

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -234,8 +234,8 @@ namespace System.Management.Automation
             // and either the argument is quoted or
             // the argument matches a keyword and that keyword is NOT in the list of keywords to exclude from adding an ampersand.
             bool needAmpersand = addAmpersandIfNecessary &&
-                name[0].IsSingleQuote() || name[0].IsDoubleQuote() ||
-                Tokenizer.IsKeyword(name) && !s_keywordsToExcludeFromAddingAmpersand.Contains(name);
+                (name[0].IsSingleQuote() || name[0].IsDoubleQuote() ||
+                Tokenizer.IsKeyword(name) && !s_keywordsToExcludeFromAddingAmpersand.Contains(name));
 
             // It's useless to call ForEach-Object (foreach) as the first command of a pipeline. For example:
             //     PS C:\> fore<tab>  --->   PS C:\> foreach   (expected, use as the keyword)

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -228,7 +228,7 @@ namespace System.Management.Automation
             }
 
             syntax = string.IsNullOrEmpty(syntax) ? name : syntax;
-            name = CodeGeneration.QuoteArgument(name, quote == string.Empty ? (char)0 : quote[0], false);
+            name = CodeGeneration.QuoteArgument(name, quote, false);
 
             // determine if an ampersand is needed, if adding an ampersand (`&`) is enabled,
             // and either the argument is quoted or
@@ -436,7 +436,7 @@ namespace System.Management.Automation
                 foreach (dynamic moduleInfo in psObjects)
                 {
                     var listItemText = moduleInfo.Name.ToString();
-                    var completionText = CodeGeneration.QuoteArgument(listItemText, quote == string.Empty ? (char)0 : quote[0]);
+                    var completionText = CodeGeneration.QuoteArgument(listItemText, quote);
                     var toolTip = "Description: " + moduleInfo.Description.ToString() + "\r\nModuleType: "
                                   + moduleInfo.ModuleType.ToString() + "\r\nPath: "
                                   + moduleInfo.Path.ToString();
@@ -1671,7 +1671,7 @@ namespace System.Management.Automation
                 {
                     if (wordToComplete.Equals(value, StringComparison.OrdinalIgnoreCase))
                     {
-                        string completionText = quote == string.Empty ? value : quote + value + quote;
+                        string completionText = CodeGeneration.QuoteArgument(value, quote);
                         fullMatch = new CompletionResult(completionText, value, CompletionResultType.ParameterValue, value);
                         continue;
                     }
@@ -1689,7 +1689,7 @@ namespace System.Management.Automation
 
                 enumList.Sort();
                 result.AddRange(from entry in enumList
-                                let completionText = quote == string.Empty ? entry : quote + entry + quote
+                                let completionText = CodeGeneration.QuoteArgument(entry, quote)
                                 select new CompletionResult(completionText, entry, CompletionResultType.ParameterValue, entry));
 
                 result.Add(CompletionResult.Null);
@@ -1728,7 +1728,7 @@ namespace System.Management.Automation
 
                         if (wordToComplete.Equals(value, StringComparison.OrdinalIgnoreCase))
                         {
-                            string completionText = quote == string.Empty ? value : quote + value + quote;
+                            string completionText = CodeGeneration.QuoteArgument(value, quote);
                             fullMatch = new CompletionResult(completionText, value, CompletionResultType.ParameterValue, value);
                             continue;
                         }
@@ -1748,7 +1748,7 @@ namespace System.Management.Automation
                     foreach (string entry in setList)
                     {
                         string realEntry = entry;
-                        string completionText = CodeGeneration.QuoteArgument(entry, quote == string.Empty ? (char)0 : quote[0]);
+                        string completionText = CodeGeneration.QuoteArgument(entry, quote);
 
                         result.Add(new CompletionResult(completionText, entry, CompletionResultType.ParameterValue, entry));
                     }
@@ -2884,7 +2884,7 @@ namespace System.Management.Automation
                     foreach (dynamic eventLog in psObjects)
                     {
                         var listItemText = eventLog.Log.ToString();
-                        var completionText = CodeGeneration.QuoteArgument(listItemText, quote == string.Empty ? (char)0 : quote[0]);
+                        var completionText = CodeGeneration.QuoteArgument(listItemText, quote);
 
                         if (pattern.IsMatch(listItemText))
                         {
@@ -2963,7 +2963,7 @@ namespace System.Management.Automation
                 foreach (dynamic psJob in psObjects)
                 {
                     var listItemText = psJob.Name;
-                    var completionText = CodeGeneration.QuoteArgument(listItemText, quote == string.Empty ? (char)0 : quote[0]);
+                    var completionText = CodeGeneration.QuoteArgument(listItemText, quote);
 
                     result.Add(new CompletionResult(completionText, listItemText, CompletionResultType.ParameterValue, listItemText));
                 }
@@ -3026,7 +3026,7 @@ namespace System.Management.Automation
                 foreach (dynamic psJob in psObjects)
                 {
                     var listItemText = psJob.Name;
-                    var completionText = CodeGeneration.QuoteArgument(listItemText, quote == string.Empty ? (char)0 : quote[0]);
+                    var completionText = CodeGeneration.QuoteArgument(listItemText, quote);
 
                     result.Add(new CompletionResult(completionText, listItemText, CompletionResultType.ParameterValue, listItemText));
                 }
@@ -3157,7 +3157,7 @@ namespace System.Management.Automation
 
                     uniqueSet.Add(listItemText);
 
-                    var completionText = CodeGeneration.QuoteArgument(listItemText, quote == string.Empty ? (char)0 : quote[0]);
+                    var completionText = CodeGeneration.QuoteArgument(listItemText, quote);
                     result.Add(new CompletionResult(completionText, listItemText, CompletionResultType.ParameterValue, listItemText));
                 }
 
@@ -3191,7 +3191,7 @@ namespace System.Management.Automation
             foreach (dynamic providerInfo in psObjects)
             {
                 var listItemText = providerInfo.Name;
-                var completionText = CodeGeneration.QuoteArgument(listItemText, quote == string.Empty ? (char)0 : quote[0]);
+                var completionText = CodeGeneration.QuoteArgument(listItemText, quote);
 
                 result.Add(new CompletionResult(completionText, listItemText, CompletionResultType.ParameterValue, listItemText));
             }
@@ -3227,7 +3227,7 @@ namespace System.Management.Automation
                 foreach (dynamic driveInfo in psObjects)
                 {
                     var listItemText = driveInfo.Name;
-                    var completionText = CodeGeneration.QuoteArgument(listItemText, quote == string.Empty ? (char)0 : quote[0]);
+                    var completionText = CodeGeneration.QuoteArgument(listItemText, quote);
 
                     result.Add(new CompletionResult(completionText, listItemText, CompletionResultType.ParameterValue, listItemText));
                 }
@@ -3266,7 +3266,7 @@ namespace System.Management.Automation
                     foreach (dynamic serviceInfo in psObjects)
                     {
                         var listItemText = serviceInfo.DisplayName;
-                        var completionText = CodeGeneration.QuoteArgument(listItemText, quote == string.Empty ? (char)0 : quote[0]);
+                        var completionText = CodeGeneration.QuoteArgument(listItemText, quote);
 
                         result.Add(new CompletionResult(completionText, listItemText, CompletionResultType.ParameterValue, listItemText));
                     }
@@ -3285,7 +3285,7 @@ namespace System.Management.Automation
                     foreach (dynamic serviceInfo in psObjects)
                     {
                         var listItemText = serviceInfo.Name;
-                        var completionText = CodeGeneration.QuoteArgument(listItemText, quote == string.Empty ? (char)0 : quote[0]);
+                        var completionText = CodeGeneration.QuoteArgument(listItemText, quote);
 
                         result.Add(new CompletionResult(completionText, listItemText, CompletionResultType.ParameterValue, listItemText));
                     }
@@ -3320,7 +3320,7 @@ namespace System.Management.Automation
             foreach (dynamic variable in psObjects)
             {
                 var listItemText = variable.Name;
-                var completionText = CodeGeneration.QuoteArgument(listItemText, quote == string.Empty ? (char)0 : quote[0], false);
+                var completionText = CodeGeneration.QuoteArgument(listItemText, quote, false);
 
                 result.Add(new CompletionResult(completionText, listItemText, CompletionResultType.ParameterValue, listItemText));
             }
@@ -3358,7 +3358,7 @@ namespace System.Management.Automation
                     foreach (dynamic aliasInfo in psObjects)
                     {
                         var listItemText = aliasInfo.Name;
-                        var completionText = CodeGeneration.QuoteArgument(listItemText, quote == string.Empty ? (char)0 : quote[0]);
+                        var completionText = CodeGeneration.QuoteArgument(listItemText, quote);
 
                         result.Add(new CompletionResult(completionText, listItemText, CompletionResultType.ParameterValue, listItemText));
                     }
@@ -3409,7 +3409,7 @@ namespace System.Management.Automation
             foreach (dynamic trace in psObjects)
             {
                 var listItemText = trace.Name;
-                var completionText = CodeGeneration.QuoteArgument(listItemText, quote == string.Empty ? (char)0 : quote[0]);
+                var completionText = CodeGeneration.QuoteArgument(listItemText, quote);
 
                 result.Add(new CompletionResult(completionText, listItemText, CompletionResultType.ParameterValue, listItemText));
             }
@@ -3941,8 +3941,7 @@ namespace System.Management.Automation
                     if (sharePattern.IsMatch(share))
                     {
                         string shareFullPath = "\\\\" + server + "\\" + share;
-                        string completionText = CodeGeneration.QuoteArgument(shareFullPath,
-                            quote == string.Empty ? (char)0 : quote[0], useLiteralPath);
+                        string completionText = CodeGeneration.QuoteArgument(shareFullPath, quote, useLiteralPath);
 
                         results.Add(new CompletionResult(completionText, share, CompletionResultType.ProviderContainer, shareFullPath));
                     }
@@ -4191,7 +4190,7 @@ namespace System.Management.Automation
                             completionText = completionText.Substring(index + 2);
                         }
 
-                        completionText = CodeGeneration.QuoteArgument(completionText, quote == string.Empty ? (char)0 : quote[0], useLiteralPath);
+                        completionText = CodeGeneration.QuoteArgument(completionText, quote, useLiteralPath);
 
                         if (isFileSystem)
                         {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -228,30 +228,12 @@ namespace System.Management.Automation
             }
 
             syntax = string.IsNullOrEmpty(syntax) ? name : syntax;
-            bool needAmpersand;
+            name = CodeGeneration.QuoteArgument(name, quote == string.Empty ? (char)0 : quote[0], false);
 
-            if (CompletionRequiresQuotes(name, false))
-            {
-                needAmpersand = quote == string.Empty && addAmpersandIfNecessary;
-                string quoteInUse = quote == string.Empty ? "'" : quote;
-                if (quoteInUse == "'")
-                {
-                    name = name.Replace("'", "''");
-                }
-                else
-                {
-                    name = name.Replace("`", "``");
-                    name = name.Replace("$", "`$");
-                }
-
-                name = quoteInUse + name + quoteInUse;
-            }
-            else
-            {
-                needAmpersand = quote == string.Empty && addAmpersandIfNecessary &&
-                                Tokenizer.IsKeyword(name) && !s_keywordsToExcludeFromAddingAmpersand.Contains(name);
-                name = quote + name + quote;
-            }
+            bool needAmpersand = addAmpersandIfNecessary &&
+                name[0].IsSingleQuote() || name[0].IsDoubleQuote() ||
+                // at this point, name is unquoted, if it is a keyword, it will need an ampersand
+                Tokenizer.IsKeyword(name) && !s_keywordsToExcludeFromAddingAmpersand.Contains(name);
 
             // It's useless to call ForEach-Object (foreach) as the first command of a pipeline. For example:
             //     PS C:\> fore<tab>  --->   PS C:\> foreach   (expected, use as the keyword)
@@ -451,23 +433,11 @@ namespace System.Management.Automation
             {
                 foreach (dynamic moduleInfo in psObjects)
                 {
-                    var completionText = moduleInfo.Name.ToString();
-                    var listItemText = completionText;
+                    var listItemText = moduleInfo.Name.ToString();
+                    var completionText = CodeGeneration.QuoteArgument(listItemText, quote == string.Empty ? (char)0 : quote[0]);
                     var toolTip = "Description: " + moduleInfo.Description.ToString() + "\r\nModuleType: "
                                   + moduleInfo.ModuleType.ToString() + "\r\nPath: "
                                   + moduleInfo.Path.ToString();
-
-                    if (CompletionRequiresQuotes(completionText, false))
-                    {
-                        var quoteInUse = quote == string.Empty ? "'" : quote;
-                        if (quoteInUse == "'")
-                            completionText = completionText.Replace("'", "''");
-                        completionText = quoteInUse + completionText + quoteInUse;
-                    }
-                    else
-                    {
-                        completionText = quote + completionText + quote;
-                    }
 
                     result.Add(new CompletionResult(completionText, listItemText, CompletionResultType.ParameterValue, toolTip));
                 }
@@ -1776,24 +1746,7 @@ namespace System.Management.Automation
                     foreach (string entry in setList)
                     {
                         string realEntry = entry;
-                        string completionText = entry;
-                        if (quote == string.Empty)
-                        {
-                            if (CompletionRequiresQuotes(entry, false))
-                            {
-                                realEntry = CodeGeneration.EscapeSingleQuotedStringContent(entry);
-                                completionText = "'" + realEntry + "'";
-                            }
-                        }
-                        else
-                        {
-                            if (quote.Equals("'", StringComparison.OrdinalIgnoreCase))
-                            {
-                                realEntry = CodeGeneration.EscapeSingleQuotedStringContent(entry);
-                            }
-
-                            completionText = quote + realEntry + quote;
-                        }
+                        string completionText = CodeGeneration.QuoteArgument(entry, quote == string.Empty ? (char)0 : quote[0]);
 
                         result.Add(new CompletionResult(completionText, entry, CompletionResultType.ParameterValue, entry));
                     }
@@ -2928,20 +2881,8 @@ namespace System.Management.Automation
                 {
                     foreach (dynamic eventLog in psObjects)
                     {
-                        var completionText = eventLog.Log.ToString();
-                        var listItemText = completionText;
-
-                        if (CompletionRequiresQuotes(completionText, false))
-                        {
-                            var quoteInUse = quote == string.Empty ? "'" : quote;
-                            if (quoteInUse == "'")
-                                completionText = completionText.Replace("'", "''");
-                            completionText = quoteInUse + completionText + quoteInUse;
-                        }
-                        else
-                        {
-                            completionText = quote + completionText + quote;
-                        }
+                        var listItemText = eventLog.Log.ToString();
+                        var completionText = CodeGeneration.QuoteArgument(listItemText, quote == string.Empty ? (char)0 : quote[0]);
 
                         if (pattern.IsMatch(listItemText))
                         {
@@ -3019,20 +2960,8 @@ namespace System.Management.Automation
 
                 foreach (dynamic psJob in psObjects)
                 {
-                    var completionText = psJob.Name;
-                    var listItemText = completionText;
-
-                    if (CompletionRequiresQuotes(completionText, false))
-                    {
-                        var quoteInUse = quote == string.Empty ? "'" : quote;
-                        if (quoteInUse == "'")
-                            completionText = completionText.Replace("'", "''");
-                        completionText = quoteInUse + completionText + quoteInUse;
-                    }
-                    else
-                    {
-                        completionText = quote + completionText + quote;
-                    }
+                    var listItemText = psJob.Name;
+                    var completionText = CodeGeneration.QuoteArgument(listItemText, quote == string.Empty ? (char)0 : quote[0]);
 
                     result.Add(new CompletionResult(completionText, listItemText, CompletionResultType.ParameterValue, listItemText));
                 }
@@ -3094,20 +3023,8 @@ namespace System.Management.Automation
 
                 foreach (dynamic psJob in psObjects)
                 {
-                    var completionText = psJob.Name;
-                    var listItemText = completionText;
-
-                    if (CompletionRequiresQuotes(completionText, false))
-                    {
-                        var quoteInUse = quote == string.Empty ? "'" : quote;
-                        if (quoteInUse == "'")
-                            completionText = completionText.Replace("'", "''");
-                        completionText = quoteInUse + completionText + quoteInUse;
-                    }
-                    else
-                    {
-                        completionText = quote + completionText + quote;
-                    }
+                    var listItemText = psJob.Name;
+                    var completionText = CodeGeneration.QuoteArgument(listItemText, quote == string.Empty ? (char)0 : quote[0]);
 
                     result.Add(new CompletionResult(completionText, listItemText, CompletionResultType.ParameterValue, listItemText));
                 }
@@ -3230,31 +3147,15 @@ namespace System.Management.Automation
                 var uniqueSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 foreach (dynamic process in psObjects)
                 {
-                    var completionText = process.Name;
-                    var listItemText = completionText;
-
-                    if (uniqueSet.Contains(completionText))
-                        continue;
-
-                    uniqueSet.Add(completionText);
-                    if (CompletionRequiresQuotes(completionText, false))
-                    {
-                        var quoteInUse = quote == string.Empty ? "'" : quote;
-                        if (quoteInUse == "'")
-                            completionText = completionText.Replace("'", "''");
-                        completionText = quoteInUse + completionText + quoteInUse;
-                    }
-                    else
-                    {
-                        completionText = quote + completionText + quote;
-                    }
+                    var listItemText = process.Name;
 
                     // on macOS, system processes names will be empty if PowerShell isn't run as `sudo`
-                    if (string.IsNullOrEmpty(listItemText))
-                    {
+                    if (string.IsNullOrEmpty(listItemText) || uniqueSet.Contains(listItemText))
                         continue;
-                    }
 
+                    uniqueSet.Add(listItemText);
+
+                    var completionText = CodeGeneration.QuoteArgument(listItemText, quote == string.Empty ? (char)0 : quote[0]);
                     result.Add(new CompletionResult(completionText, listItemText, CompletionResultType.ParameterValue, listItemText));
                 }
 
@@ -3287,20 +3188,8 @@ namespace System.Management.Automation
 
             foreach (dynamic providerInfo in psObjects)
             {
-                var completionText = providerInfo.Name;
-                var listItemText = completionText;
-
-                if (CompletionRequiresQuotes(completionText, false))
-                {
-                    var quoteInUse = quote == string.Empty ? "'" : quote;
-                    if (quoteInUse == "'")
-                        completionText = completionText.Replace("'", "''");
-                    completionText = quoteInUse + completionText + quoteInUse;
-                }
-                else
-                {
-                    completionText = quote + completionText + quote;
-                }
+                var listItemText = providerInfo.Name;
+                var completionText = CodeGeneration.QuoteArgument(listItemText, quote == string.Empty ? (char)0 : quote[0]);
 
                 result.Add(new CompletionResult(completionText, listItemText, CompletionResultType.ParameterValue, listItemText));
             }
@@ -3335,20 +3224,8 @@ namespace System.Management.Automation
             {
                 foreach (dynamic driveInfo in psObjects)
                 {
-                    var completionText = driveInfo.Name;
-                    var listItemText = completionText;
-
-                    if (CompletionRequiresQuotes(completionText, false))
-                    {
-                        var quoteInUse = quote == string.Empty ? "'" : quote;
-                        if (quoteInUse == "'")
-                            completionText = completionText.Replace("'", "''");
-                        completionText = quoteInUse + completionText + quoteInUse;
-                    }
-                    else
-                    {
-                        completionText = quote + completionText + quote;
-                    }
+                    var listItemText = driveInfo.Name;
+                    var completionText = CodeGeneration.QuoteArgument(listItemText, quote == string.Empty ? (char)0 : quote[0]);
 
                     result.Add(new CompletionResult(completionText, listItemText, CompletionResultType.ParameterValue, listItemText));
                 }
@@ -3386,20 +3263,8 @@ namespace System.Management.Automation
                 {
                     foreach (dynamic serviceInfo in psObjects)
                     {
-                        var completionText = serviceInfo.DisplayName;
-                        var listItemText = completionText;
-
-                        if (CompletionRequiresQuotes(completionText, false))
-                        {
-                            var quoteInUse = quote == string.Empty ? "'" : quote;
-                            if (quoteInUse == "'")
-                                completionText = completionText.Replace("'", "''");
-                            completionText = quoteInUse + completionText + quoteInUse;
-                        }
-                        else
-                        {
-                            completionText = quote + completionText + quote;
-                        }
+                        var listItemText = serviceInfo.DisplayName;
+                        var completionText = CodeGeneration.QuoteArgument(listItemText, quote == string.Empty ? (char)0 : quote[0]);
 
                         result.Add(new CompletionResult(completionText, listItemText, CompletionResultType.ParameterValue, listItemText));
                     }
@@ -3417,20 +3282,8 @@ namespace System.Management.Automation
                 {
                     foreach (dynamic serviceInfo in psObjects)
                     {
-                        var completionText = serviceInfo.Name;
-                        var listItemText = completionText;
-
-                        if (CompletionRequiresQuotes(completionText, false))
-                        {
-                            var quoteInUse = quote == string.Empty ? "'" : quote;
-                            if (quoteInUse == "'")
-                                completionText = completionText.Replace("'", "''");
-                            completionText = quoteInUse + completionText + quoteInUse;
-                        }
-                        else
-                        {
-                            completionText = quote + completionText + quote;
-                        }
+                        var listItemText = serviceInfo.Name;
+                        var completionText = CodeGeneration.QuoteArgument(listItemText, quote == string.Empty ? (char)0 : quote[0]);
 
                         result.Add(new CompletionResult(completionText, listItemText, CompletionResultType.ParameterValue, listItemText));
                     }
@@ -3464,29 +3317,8 @@ namespace System.Management.Automation
 
             foreach (dynamic variable in psObjects)
             {
-                var effectiveQuote = quote;
-                var completionText = variable.Name;
-                var listItemText = completionText;
-
-                // Handle special characters ? and * in variable names
-                if (completionText.IndexOfAny(Utils.Separators.StarOrQuestion) != -1)
-                {
-                    effectiveQuote = "'";
-                    completionText = completionText.Replace("?", "`?");
-                    completionText = completionText.Replace("*", "`*");
-                }
-
-                if (!completionText.Equals("$", StringComparison.Ordinal) && CompletionRequiresQuotes(completionText, false))
-                {
-                    var quoteInUse = effectiveQuote == string.Empty ? "'" : effectiveQuote;
-                    if (quoteInUse == "'")
-                        completionText = completionText.Replace("'", "''");
-                    completionText = quoteInUse + completionText + quoteInUse;
-                }
-                else
-                {
-                    completionText = effectiveQuote + completionText + effectiveQuote;
-                }
+                var listItemText = variable.Name;
+                var completionText = CodeGeneration.QuoteArgument(listItemText, quote == string.Empty ? (char)0 : quote[0], false);
 
                 result.Add(new CompletionResult(completionText, listItemText, CompletionResultType.ParameterValue, listItemText));
             }
@@ -3523,20 +3355,8 @@ namespace System.Management.Automation
                 {
                     foreach (dynamic aliasInfo in psObjects)
                     {
-                        var completionText = aliasInfo.Name;
-                        var listItemText = completionText;
-
-                        if (CompletionRequiresQuotes(completionText, false))
-                        {
-                            var quoteInUse = quote == string.Empty ? "'" : quote;
-                            if (quoteInUse == "'")
-                                completionText = completionText.Replace("'", "''");
-                            completionText = quoteInUse + completionText + quoteInUse;
-                        }
-                        else
-                        {
-                            completionText = quote + completionText + quote;
-                        }
+                        var listItemText = aliasInfo.Name;
+                        var completionText = CodeGeneration.QuoteArgument(listItemText, quote == string.Empty ? (char)0 : quote[0]);
 
                         result.Add(new CompletionResult(completionText, listItemText, CompletionResultType.ParameterValue, listItemText));
                     }
@@ -3586,20 +3406,8 @@ namespace System.Management.Automation
 
             foreach (dynamic trace in psObjects)
             {
-                var completionText = trace.Name;
-                var listItemText = completionText;
-
-                if (CompletionRequiresQuotes(completionText, false))
-                {
-                    var quoteInUse = quote == string.Empty ? "'" : quote;
-                    if (quoteInUse == "'")
-                        completionText = completionText.Replace("'", "''");
-                    completionText = quoteInUse + completionText + quoteInUse;
-                }
-                else
-                {
-                    completionText = quote + completionText + quote;
-                }
+                var listItemText = trace.Name;
+                var completionText = CodeGeneration.QuoteArgument(listItemText, quote == string.Empty ? (char)0 : quote[0]);
 
                 result.Add(new CompletionResult(completionText, listItemText, CompletionResultType.ParameterValue, listItemText));
             }
@@ -4115,6 +3923,7 @@ namespace System.Management.Automation
             var wordToComplete = context.WordToComplete;
             var quote = HandleDoubleAndSingleQuote(ref wordToComplete);
             var results = new List<CompletionResult>();
+            var useLiteralPath = context.GetOption("LiteralPaths", @default: false);
 
             // First, try to match \\server\share
             var shareMatch = Regex.Match(wordToComplete, "^\\\\\\\\([^\\\\]+)\\\\([^\\\\]*)$");
@@ -4130,12 +3939,10 @@ namespace System.Management.Automation
                     if (sharePattern.IsMatch(share))
                     {
                         string shareFullPath = "\\\\" + server + "\\" + share;
-                        if (quote != string.Empty)
-                        {
-                            shareFullPath = quote + shareFullPath + quote;
-                        }
+                        string completionText = CodeGeneration.QuoteArgument(shareFullPath,
+                            quote == string.Empty ? (char)0 : quote[0], useLiteralPath);
 
-                        results.Add(new CompletionResult(shareFullPath, shareFullPath, CompletionResultType.ProviderContainer, shareFullPath));
+                        results.Add(new CompletionResult(completionText, share, CompletionResultType.ProviderContainer, shareFullPath));
                     }
                 }
             }
@@ -4149,7 +3956,6 @@ namespace System.Management.Automation
                                           !Regex.Match(wordToComplete, @"^~[\\/]+.*").Success &&
                                           !executionContext.LocationGlobber.IsAbsolutePath(wordToComplete, out _));
                 var relativePaths = context.GetOption("RelativePaths", @default: defaultRelative);
-                var useLiteralPath = context.GetOption("LiteralPaths", @default: false);
 
                 if (useLiteralPath && LocationGlobber.StringContainsGlobCharacters(wordToComplete))
                 {
@@ -4383,41 +4189,7 @@ namespace System.Management.Automation
                             completionText = completionText.Substring(index + 2);
                         }
 
-                        if (CompletionRequiresQuotes(completionText, !useLiteralPath))
-                        {
-                            var quoteInUse = quote == string.Empty ? "'" : quote;
-                            if (quoteInUse == "'")
-                            {
-                                completionText = completionText.Replace("'", "''");
-                            }
-                            else
-                            {
-                                // When double quote is in use, we have to escape the backtip and '$' even when using literal path
-                                //   Get-Content -LiteralPath ".\a``g.txt"
-                                completionText = completionText.Replace("`", "``");
-                                completionText = completionText.Replace("$", "`$");
-                            }
-
-                            if (!useLiteralPath)
-                            {
-                                if (quoteInUse == "'")
-                                {
-                                    completionText = completionText.Replace("[", "`[");
-                                    completionText = completionText.Replace("]", "`]");
-                                }
-                                else
-                                {
-                                    completionText = completionText.Replace("[", "``[");
-                                    completionText = completionText.Replace("]", "``]");
-                                }
-                            }
-
-                            completionText = quoteInUse + completionText + quoteInUse;
-                        }
-                        else if (quote != string.Empty)
-                        {
-                            completionText = quote + completionText + quote;
-                        }
+                        completionText = CodeGeneration.QuoteArgument(completionText, quote == string.Empty ? (char)0 : quote[0], useLiteralPath);
 
                         if (isFileSystem)
                         {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4569,9 +4569,6 @@ namespace System.Management.Automation
         }
 
         private static readonly string[] s_variableScopes = new string[] { "Global:", "Local:", "Script:", "Private:" };
-        private static readonly char[] s_charactersRequiringQuotes = new char[] {
-            '-', '`', '&', '@', '\'', '"', '#', '{', '}', '(', ')', '$', ',', ';', '|', '<', '>', ' ', '.', '\\', '/', '\t', '^',
-        };
 
         internal static List<CompletionResult> CompleteVariable(CompletionContext context)
         {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -6472,32 +6472,6 @@ namespace System.Management.Automation
             return false;
         }
 
-        private static bool CompletionRequiresQuotes(string completion, bool escape)
-        {
-            // If the tokenizer sees the completion as more than two tokens, or if there is some error, then
-            // some form of quoting is necessary (if it's a variable, we'd need ${}, filenames would need [], etc.)
-
-            Language.Token[] tokens;
-            ParseError[] errors;
-            Language.Parser.ParseInput(completion, out tokens, out errors);
-
-            char[] charToCheck = escape ? new[] { '$', '[', ']', '`' } : new[] { '$', '`' };
-
-            // Expect no errors and 2 tokens (1 is for our completion, the other is eof)
-            // Or if the completion is a keyword, we ignore the errors
-            bool requireQuote = !(errors.Length == 0 && tokens.Length == 2);
-            if ((!requireQuote && tokens[0] is StringToken) ||
-                (tokens.Length == 2 && (tokens[0].TokenFlags & TokenFlags.Keyword) != 0))
-            {
-                requireQuote = false;
-                var value = tokens[0].Text;
-                if (value.IndexOfAny(charToCheck) != -1)
-                    requireQuote = true;
-            }
-
-            return requireQuote;
-        }
-
         private static bool ProviderSpecified(string path)
         {
             var index = path.IndexOf(':');

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4690,7 +4690,7 @@ namespace System.Management.Automation
             else
             {
                 provider = wordToComplete.Substring(0, colon + 1);
-                if (s_variableScopes.Contains(provider, StringComparer.OrdinalIgnoreCase))
+                if (colon == 0 || s_variableScopes.Contains(provider, StringComparer.OrdinalIgnoreCase))
                 {
                     pattern = "variable:" + wordToComplete.Substring(colon + 1) + "*";
                 }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4402,7 +4402,7 @@ namespace System.Management.Automation
 
                     if (wildcardPattern.IsMatch(userPath))
                     {
-                        var completedName = prefix + GenerateVariableCompletionText(userPath, colon != -1);
+                        var completedName = GenerateVariableCompletionText(userPath, prefix, colon != -1);
                         var tooltip = userPath;
                         var ast = astTarget;
 
@@ -4498,8 +4498,8 @@ namespace System.Management.Automation
                             }
                         }
 
-                        AddUniqueVariable(hashedResults, results, prefix +
-                            GenerateVariableCompletionText(provider + name, colon != -1), name, tooltip);
+                        AddUniqueVariable(hashedResults, results,
+                            GenerateVariableCompletionText(provider + name, prefix, colon != -1), name, tooltip);
                     }
                 }
             }
@@ -4519,7 +4519,7 @@ namespace System.Management.Automation
                         if (!string.IsNullOrEmpty(name))
                         {
                             name = "env:" + name;
-                            AddUniqueVariable(hashedResults, results, prefix + GenerateVariableCompletionText(name), name, "[string]" + name);
+                            AddUniqueVariable(hashedResults, results, GenerateVariableCompletionText(name, prefix), name, "[string]" + name);
                         }
                     }
                 }
@@ -4531,7 +4531,8 @@ namespace System.Management.Automation
             {
                 if (wildcardPattern.IsMatch(specialVariable))
                 {
-                    AddUniqueVariable(hashedResults, results, prefix + GenerateVariableCompletionText(specialVariable, colon != -1), specialVariable, specialVariable);
+                    AddUniqueVariable(hashedResults, results, 
+                        GenerateVariableCompletionText(specialVariable, prefix, colon != -1), specialVariable, specialVariable);
                 }
             }
 
@@ -4554,7 +4555,7 @@ namespace System.Management.Automation
                             if (name != null && !string.IsNullOrWhiteSpace(name) && name.Length > 1)
                             {
                                 var tooltip = string.IsNullOrEmpty(driveInfo.Description) ? name : driveInfo.Description;
-                                AddUniqueVariable(hashedResults, results, prefix + GenerateVariableCompletionText(name + ':'), name, tooltip);
+                                AddUniqueVariable(hashedResults, results, GenerateVariableCompletionText(name + ':', prefix), name, tooltip);
                             }
                         }
                     }
@@ -4565,7 +4566,7 @@ namespace System.Management.Automation
                 {
                     if (scopePattern.IsMatch(scope))
                     {
-                        AddUniqueVariable(hashedResults, results, prefix + GenerateVariableCompletionText(scope), scope, scope);
+                        AddUniqueVariable(hashedResults, results, GenerateVariableCompletionText(scope, prefix), scope, scope);
                     }
                 }
             }
@@ -4582,12 +4583,12 @@ namespace System.Management.Automation
             }
         }
 
-        private static string GenerateVariableCompletionText(string value)
+        private static string GenerateVariableCompletionText(string value, string prefix)
         {
-            return GenerateVariableCompletionText(value, true);
+            return GenerateVariableCompletionText(value, prefix, true);
         }
 
-        private static string GenerateVariableCompletionText(string value, bool hasProvider)
+        private static string GenerateVariableCompletionText(string value, string prefix, bool hasProvider)
         {
             if (string.IsNullOrEmpty(value))
             {
@@ -4616,9 +4617,9 @@ namespace System.Management.Automation
 
             // note add a leading `:` if no provider is part of the completion, but completion contains `:`
             // or specifically for an unbraced variable that starts with a `?` (but is more than just a `?`)
-            return braceVariable ?
+            return prefix + (braceVariable ?
                 "{" + CodeGeneration.EscapeVariableName((hasProvider || !hasColon ? string.Empty : ":") + value) + "}" :
-                (hasProvider || !(startsWithQM || hasColon) ? string.Empty : ":") + value;
+                (hasProvider || !(startsWithQM || hasColon) ? string.Empty : ":") + value);
         }
 
         private class FindVariablesVisitor : AstVisitor

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -6300,34 +6300,20 @@ namespace System.Management.Automation
 
         internal static string HandleDoubleAndSingleQuote(ref string wordToComplete)
         {
-            string quote = string.Empty;
-
-            if (!string.IsNullOrEmpty(wordToComplete) && (wordToComplete[0].IsSingleQuote() || wordToComplete[0].IsDoubleQuote()))
+            if (!string.IsNullOrEmpty(wordToComplete))
             {
-                char frontQuote = wordToComplete[0];
-                int length = wordToComplete.Length;
-
-                if (length == 1)
+                char firstChar = wordToComplete[0];
+                if (firstChar.IsSingleQuote() || firstChar.IsDoubleQuote())
                 {
-                    wordToComplete = string.Empty;
-                    quote = frontQuote.IsSingleQuote() ? "'" : "\"";
-                }
-                else if (length > 1)
-                {
-                    if ((wordToComplete[length - 1].IsDoubleQuote() && frontQuote.IsDoubleQuote()) || (wordToComplete[length - 1].IsSingleQuote() && frontQuote.IsSingleQuote()))
-                    {
-                        wordToComplete = wordToComplete.Substring(1, length - 2);
-                        quote = frontQuote.IsSingleQuote() ? "'" : "\"";
-                    }
-                    else if (!wordToComplete[length - 1].IsDoubleQuote() && !wordToComplete[length - 1].IsSingleQuote())
-                    {
-                        wordToComplete = wordToComplete.Substring(1);
-                        quote = frontQuote.IsSingleQuote() ? "'" : "\"";
-                    }
+                    int length = wordToComplete.Length;
+                    wordToComplete = length == 1 ? string.Empty :
+                        (firstChar.IsSingleQuote() ? wordToComplete[length - 1].IsSingleQuote() : wordToComplete[length - 1].IsDoubleQuote()) ?
+                            wordToComplete.Substring(1, length - 2) : wordToComplete.Substring(1);
+                    return firstChar.IsSingleQuote() ? "'" : "\"";
                 }
             }
 
-            return quote;
+            return string.Empty;
         }
 
         internal static bool IsSplattedVariable(Ast targetExpr)

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -6588,14 +6588,8 @@ namespace System.Management.Automation
                         continue;
                     }
 
-                    var completionText = memberInfo.Name;
-
-                    // Handle scenarios like this: $aa | add-member 'a b' 23; $aa.a<tab>
-                    if (completionText.IndexOfAny(s_charactersRequiringQuotes) != -1)
-                    {
-                        completionText = completionText.Replace("'", "''");
-                        completionText = "'" + completionText + "'";
-                    }
+                    // QuoteMemberName handles scenarios like this: $aa | add-member 'a b' 23; $aa.a<tab>
+                    var completionText = CodeGeneration.QuoteMemberName(memberInfo.Name);
 
                     var isMethod = memberInfo is PSMethodInfo;
                     if (isMethod)
@@ -6638,14 +6632,8 @@ namespace System.Management.Automation
 
                         if (pattern.IsMatch(key))
                         {
-                            // Handle scenarios like this: $hashtable["abc#d"] = 100; $hashtable.ab<tab>
-                            if (key.IndexOfAny(s_charactersRequiringQuotes) != -1)
-                            {
-                                key = key.Replace("'", "''");
-                                key = "'" + key + "'";
-                            }
-
-                            results.Add(new CompletionResult(key, key, CompletionResultType.Property, key));
+                            // QuoteMemberName handles scenarios like this: $hashtable["abc#d"] = 100; $hashtable.ab<tab>
+                            results.Add(new CompletionResult(CodeGeneration.QuoteMemberName(key), key, CompletionResultType.Property, key));
                         }
                     }
                 }

--- a/src/System.Management.Automation/engine/lang/codegen.cs
+++ b/src/System.Management.Automation/engine/lang/codegen.cs
@@ -137,5 +137,123 @@ namespace System.Management.Automation.Language
                 "'" + EscapeSingleQuotedStringContent(value) + "'" :
                 value;
         }
+
+        /// <summary>
+        /// Quote an argument, if needed, or if specifically requested, escaping characters accordingly,
+        /// handling escaping of wildcard patterns when argument is not already taken literally.
+        /// For example: QuoteArgument(userContent, quoteInUse, isLiteralArgument)
+        /// </summary>
+        /// <param name="value">The content to be used as an argument value taken literally.</param>
+        /// <param name="quoteInUse">The character to be quoted with.</param>
+        /// <param name="isLiteralArgument">Treat the argument as taken literally, wildcard escaping not required.</param>
+        /// <returns>Content quoted and escaped if required for use as an argument value.</returns>
+        public static string QuoteArgument(string value, char quoteInUse, bool isLiteralArgument)
+        {
+            return string.IsNullOrEmpty(value) ?
+                string.Empty :
+                QuoteArgument(isLiteralArgument ? value : WildcardPattern.Escape(value), quoteInUse);
+        }
+
+        /// <summary>
+        /// Quote an argument, if needed, or if specifically requested, escaping characters accordingly
+        /// For example: QuoteArgument(userContent, quoteInUse)
+        /// </summary>
+        /// <param name="value">The content to be used as an argument value taken literally.</param>
+        /// <param name="quoteInUse">The character to be quoted with.</param>
+        /// <returns>Content quoted and escaped if required for use as an argument value.</returns>
+        public static string QuoteArgument(string value, char quoteInUse)
+        {
+            if (string.IsNullOrEmpty(value))
+                return string.Empty;
+
+            char quoteToUse = quoteInUse;
+            if (quoteToUse == 0)
+                if (ShouldArgumentNotBeBareword(value))
+                    // argument value not compatible with bareword
+                    quoteToUse = '\'';
+                else
+                    // return unmodified argument value
+                    return value;
+
+            // quote and escape argument as needed
+            return quoteToUse + (quoteToUse.IsDoubleQuote() ? EscapeDoubleQuotedStringContent(value) :
+                EscapeSingleQuotedStringContent(value)) + quoteToUse;
+        }
+
+        // brute force method to determine when an argument's value cannot be used bareword
+        private static bool ShouldArgumentNotBeBareword(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return false;
+
+            // Rules for bareword arguments:
+            //   characters that cannot be in the first position: '@','#','<','>'
+            //   Pattern that cannot be in the first position: /[1-6]>/
+            bool requiresQuote = "@#<>".Contains(value[0]) ||
+                value.Length > 1 && '1' <= value[0] && value[0] <= '6' && value[1] == '>';
+
+            if (!requiresQuote)
+            {
+                bool lastCharWasDollar = false;
+                foreach (char c in value)
+                {
+                    //   Characters that cannot appear anywhere 
+                    //     ForceStartNewToken
+                    //     IsSingleQuote
+                    //     IsDoubleQuote
+                    if (c.ForceStartNewToken() || c.IsSingleQuote() || c.IsDoubleQuote() || c == '`')
+                    {
+                        requiresQuote = true;
+                        break;
+                    }
+                    if (lastCharWasDollar)
+                        //   IsVariableStart characters cannot appear after a `$`
+                        // note `{` and `(` is handled by ForceStartNewToken()
+                        if (c.IsVariableStart())
+                        {
+                            requiresQuote = true;
+                            break;
+                        }
+                    lastCharWasDollar = c == '$';
+                }
+            }
+            return requiresQuote;
+        }
+
+        /// <summary>
+        /// Escapes content so that it is safe for inclusion in a double-quoted string.
+        /// For example: "\"" + EscapeDoubleQuotedStringContent(userContent) + "\""
+        /// </summary>
+        /// <param name="value">The content to be included in a double-quoted string.</param>
+        /// <returns>Content with all backticks and double-quotes, and only valid variable `$` escaped.</returns>
+        public static string EscapeDoubleQuotedStringContent(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return string.Empty;
+
+            StringBuilder sb = new StringBuilder(value.Length);
+            bool lastCharWasDollar = false;
+            foreach (char c in value)
+            {
+                if (lastCharWasDollar)
+                {
+                    if (c.IsVariableStart() || c == '{' || c == '(')
+                        sb.Append('`');
+                    sb.Append('$');
+                }
+                lastCharWasDollar = c == '$';
+                if (!lastCharWasDollar)
+                {
+                    sb.Append(c);
+                    if (c.IsDoubleQuote() || c == '`')
+                        // double-up quotes & backticks to escape them
+                        sb.Append(c);
+                }
+            }
+            if (lastCharWasDollar)
+                sb.Append('$');
+
+            return sb.ToString();
+        }
     }
 }

--- a/src/System.Management.Automation/engine/lang/codegen.cs
+++ b/src/System.Management.Automation/engine/lang/codegen.cs
@@ -123,13 +123,11 @@ namespace System.Management.Automation.Language
             bool requiresQuote = !name[0].IsIdentifierStart();
             if (!requiresQuote)
             {
-                // Use an enumerator, skipping the first character which has already been
-                // evaluated with different rules, to determine if any remaining characters are 
+                // Step through remainder of name to determine if any remaining characters are 
                 // not an indentifier successive character.
-                CharEnumerator ce_name = name.GetEnumerator();
-                for (ce_name.MoveNext(); ce_name.MoveNext();)
+                for (int i = 1, nameLength = name.Length; i < nameLength; i++)
                 {
-                    if (!ce_name.Current.IsIdentifierFollow())
+                    if (!name[i].IsIdentifierFollow())
                     {
                         requiresQuote = true;
                         break;
@@ -203,7 +201,7 @@ namespace System.Management.Automation.Language
             // - Characters that cannot be at start of argument: '@','#','<','>'
             // - Patterns that cannot be at start of argument: 
             // - - /[1-6]>/
-            // - - /<IsDash>(<IsDash>$|[_<IsIdentifierStart>])/
+            // - - /<IsDash>(<IsDash>$|[<IsIdentifierStart>])/
             var firstChar = value[0];
             var length = value.Length;
             bool requiresQuote = "@#<>".Contains(firstChar) ||
@@ -213,13 +211,14 @@ namespace System.Management.Automation.Language
             if (!requiresQuote)
             {
                 bool lastCharWasDollar = false;
-                foreach (char c in value)
+                for (int i = 0; i < length; i++)
                 {
                     // - Characters that cannot appear anywhere:
                     // - - ForceStartNewToken
                     // - - IsSingleQuote
                     // - - IsDoubleQuote
                     // - - Backtick ('\`')
+                    char c = value[i];
                     if (c.ForceStartNewToken() || c.IsSingleQuote() || c.IsDoubleQuote() || c == '`')
                     {
                         requiresQuote = true;
@@ -254,10 +253,12 @@ namespace System.Management.Automation.Language
                 return string.Empty;
             }
 
-            StringBuilder sb = new StringBuilder(value.Length);
+            int valueLength = value.Length;
+            StringBuilder sb = new StringBuilder(valueLength);
             bool lastCharWasDollar = false;
-            foreach (char c in value)
+            for (int i = 0; i < valueLength; i++)
             {
+                char c = value[i];
                 if (lastCharWasDollar)
                 {
                     if (c.IsVariableStart() || c == '{' || c == '(')

--- a/src/System.Management.Automation/engine/lang/codegen.cs
+++ b/src/System.Management.Automation/engine/lang/codegen.cs
@@ -197,9 +197,14 @@ namespace System.Management.Automation.Language
 
             // Rules for allowable bareword arguments:
             // - Characters that cannot be at start of argument: '@','#','<','>'
-            // - Pattern that cannot be at start of argument: /[1-6]>/
-            bool requiresQuote = "@#<>".Contains(value[0]) ||
-                (value.Length > 1 && (uint)(value[0] - '1') <= 5 && value[1] == '>');
+            // - Patterns that cannot be at start of argument: 
+            // - - /[1-6]>/
+            // - - /<IsDash>(<IsDash>$|[_<IsIdentifierStart>])/
+            var firstChar = value[0];
+            var length = value.Length;
+            bool requiresQuote = "@#<>".Contains(firstChar) ||
+                length > 1 && ((uint)(firstChar - '1') <= 5 && value[1] == '>' ||
+                firstChar.IsDash() && (value[1].IsIdentifierStart() || (length == 2 && value[1].IsDash())));
 
             if (!requiresQuote)
             {

--- a/src/System.Management.Automation/engine/lang/codegen.cs
+++ b/src/System.Management.Automation/engine/lang/codegen.cs
@@ -106,5 +106,36 @@ namespace System.Management.Automation.Language
                 .Replace("}", "`}")
                 .Replace("{", "`{");
         }
+
+        /// <summary>
+        /// Single-quote and escape a member name if it requires quoting, otherwise passing it unmodified.
+        /// For example: QuoteMemberName(userContent)
+        /// </summary>
+        /// <param name="value">The content to be used as a member name in a member access.</param>
+        /// <returns>Content quoted and escaped if required for use as a member name.</returns>
+        public static string QuoteMemberName(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return string.Empty;
+
+            // determine if any character is not a standard indentifier character
+            bool requiresQuote = !value[0].IsIdentifierStart();
+            if (!requiresQuote)
+            {
+                foreach (char c in value.Substring(1))
+                {
+                    if (!c.IsIdentifierFollow())
+                    {
+                        requiresQuote = true;
+                        break;
+                    }
+                }
+            }
+
+            // quote the content if required.
+            return requiresQuote ?
+                "'" + EscapeSingleQuotedStringContent(value) + "'" :
+                value;
+        }
     }
 }

--- a/src/System.Management.Automation/engine/lang/codegen.cs
+++ b/src/System.Management.Automation/engine/lang/codegen.cs
@@ -147,12 +147,12 @@ namespace System.Management.Automation.Language
         /// <param name="quoteInUse">The character to be quoted with.</param>
         /// <param name="isLiteralArgument">Treat the argument as taken literally, wildcard escaping not required.</param>
         /// <returns>Content quoted and escaped if required for use as an argument value.</returns>
-        public static string QuoteArgument(string value, char quoteInUse, bool isLiteralArgument)
-        {
-            return string.IsNullOrEmpty(value) ?
+        public static string QuoteArgument(string value, char quoteInUse, bool isLiteralArgument) =>
+            // WildcardPattern.Escape() fails to escape the escape character, so we use Replace() first
+            // but not all CMDLets will process the fully escaped result correctly.
+            string.IsNullOrEmpty(value) ?
                 string.Empty :
-                QuoteArgument(isLiteralArgument ? value : WildcardPattern.Escape(value), quoteInUse);
-        }
+                QuoteArgument(isLiteralArgument ? value : WildcardPattern.Escape(value.Replace("`", "``")), quoteInUse);
 
         /// <summary>
         /// Quote an argument, if needed, or if specifically requested, escaping characters accordingly.

--- a/src/System.Management.Automation/engine/lang/codegen.cs
+++ b/src/System.Management.Automation/engine/lang/codegen.cs
@@ -110,22 +110,26 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// Single-quote and escape a member name if it requires quoting, otherwise passing it unmodified.
         /// </summary>
-        /// <param name="value">The content to be used as a member name in a member access.</param>
+        /// <param name="name">The content to be used as a member name in a member access.</param>
         /// <returns>Content quoted and escaped if required for use as a member name.</returns>
-        public static string QuoteMemberName(string value)
+        public static string QuoteMemberName(string name)
         {
-            if (string.IsNullOrEmpty(value))
+            if (string.IsNullOrEmpty(name))
             {
                 return string.Empty;
             }
 
-            // determine if any character is not a standard indentifier character
-            bool requiresQuote = !value[0].IsIdentifierStart();
+            // Determine if first character is not an indentifier start character.
+            bool requiresQuote = !name[0].IsIdentifierStart();
             if (!requiresQuote)
             {
-                foreach (char c in value.Substring(1))
+                // Use an enumerator, skipping the first character which has already been
+                // evaluated with different rules, to determine if any remaining characters are 
+                // not an indentifier successive character.
+                CharEnumerator ce_name = name.GetEnumerator();
+                for (ce_name.MoveNext(); ce_name.MoveNext();)
                 {
-                    if (!c.IsIdentifierFollow())
+                    if (!ce_name.Current.IsIdentifierFollow())
                     {
                         requiresQuote = true;
                         break;
@@ -135,8 +139,8 @@ namespace System.Management.Automation.Language
 
             // quote the content if required.
             return requiresQuote ?
-                "'" + EscapeSingleQuotedStringContent(value) + "'" :
-                value;
+                "'" + EscapeSingleQuotedStringContent(name) + "'" :
+                name;
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/lang/codegen.cs
+++ b/src/System.Management.Automation/engine/lang/codegen.cs
@@ -148,10 +148,10 @@ namespace System.Management.Automation.Language
         /// handling escaping of wildcard patterns when argument is not already taken literally.
         /// </summary>
         /// <param name="value">The content to be used as an argument value taken literally.</param>
-        /// <param name="quoteInUse">The character to be quoted with.</param>
+        /// <param name="quoteInUse">The character to be quoted with, or an empty string for bareword.</param>
         /// <param name="isLiteralArgument">Treat the argument as taken literally, wildcard escaping not required.</param>
         /// <returns>Content quoted and escaped if required for use as an argument value.</returns>
-        public static string QuoteArgument(string value, char quoteInUse, bool isLiteralArgument) =>
+        public static string QuoteArgument(string value, string quoteInUse, bool isLiteralArgument) =>
             // WildcardPattern.Escape() fails to escape the escape character, so we use Replace() first
             // but not all CMDLets will process the fully escaped result correctly.
             string.IsNullOrEmpty(value) ?
@@ -162,17 +162,17 @@ namespace System.Management.Automation.Language
         /// Quote an argument, if needed, or if specifically requested, escaping characters accordingly.
         /// </summary>
         /// <param name="value">The content to be used as an argument value taken literally.</param>
-        /// <param name="quoteInUse">The character to be quoted with.</param>
+        /// <param name="quoteInUse">The character to be quoted with, or an empty string for bareword.</param>
         /// <returns>Content quoted and escaped if required for use as an argument value.</returns>
-        public static string QuoteArgument(string value, char quoteInUse)
+        public static string QuoteArgument(string value, string quoteInUse)
         {
             if (string.IsNullOrEmpty(value))
             {
                 return string.Empty;
             }
 
-            char quoteToUse = quoteInUse;
-            if (quoteToUse == 0)
+            char quoteToUse = string.IsNullOrWhiteSpace(quoteInUse) ? (char)0 : quoteInUse[0];
+            if (quoteToUse == (char)0)
             {
                 if (ShouldArgumentNotBeBareword(value))
                 {


### PR DESCRIPTION
# PR Summary

Correct completions (Tab/Intellisense) for quoting and escaping for the various kinds of completions available.

## PR Context

Completers of all types seem to have inconsistent quoting and escaping behaviors that often left the resulting completion still unusable, most specially when the completion contained:
 - potential wildcard patterns
 - escape sequence characters
 - curly quotes
 - variable interpolation patterns
 - specific file system conditions

This PR, through a series of commits, brings unity to the completers, implementing methods that were already available in the code and additional methods, where by each type of completer (variable name, member name, argument) utilizes a common quoting and escaping method.

Fix #10006 - Variable (`$` and `@`) name bracing and escaping and empty scope prefixing
Fix #10239 - Variable completion has no results with input `$:`
Fix #10198 - Member name completion quoting and escaping
Fix #9881 - General argument completion quoting and escaping
Fix #10218 - Argument completion of `ValidateSetAttribute` values quoting and escaping
Fix #7569 - `\\Server\Share With Space` quoting and escaping

This PR is still WIP, as it lacks any changes for testing, and it is unknown if it causes any tests to fail.

To quote @bergmeister, be gentle.  :)  This is my first work in C#.

@rkeithhill, from https://github.com/dahlbyk/posh-git/issues/683#issuecomment-501125585, this includes such a method, `[System.Management.Automation.Language.CodeGeneration]::QuoteArgument()`.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
