### PR TITLE
Rework Send-MailMessage cmdlet with MailKit

### DIFF
--- a/assets/files.wxs
+++ b/assets/files.wxs
@@ -3042,6 +3042,15 @@
       <Component Id="cmpD8D8DB4A941A4A5299849526DADC6356" Guid="{44d517a4-307a-4fe8-b27c-f0bc8a7631d6}">
         <File Id="filC7D414D25AFB4CA9A3243F5A8C0279C1" KeyPath="yes" Source="$(env.ProductSourcePath)\System.Resources.Extensions.dll" />
       </Component>
+      <Component Id="cmpE5C1153A7BA345DB8E6FA30B9D569367" Guid="{50dfdcbb-e3be-4a4f-acb9-041b16cc8234}">
+        <File Id="fil79B2049332604DAE9D33216D05BDACFA" KeyPath="yes" Source="$(env.ProductSourcePath)\BouncyCastle.Crypto.dll" />
+      </Component>
+      <Component Id="cmp6FCFC0BB6C7A467F9F3524181DD1AE2C" Guid="{231dbea7-c434-4850-bdf9-4c5e4625dbc1}">
+        <File Id="filA248708B4DBE4F5AA99CF7043851720D" KeyPath="yes" Source="$(env.ProductSourcePath)\MimeKit.dll" />
+      </Component>
+      <Component Id="cmp1A42A34AAF034E048D71F87C85412439" Guid="{f0741346-393b-46d0-9a65-51cc10d3d84d}">
+        <File Id="filFE4BB4E742884249987902AD7AA80A93" KeyPath="yes" Source="$(env.ProductSourcePath)\MailKit.dll" />
+      </Component>
     </DirectoryRef>
   </Fragment>
   <Fragment>
@@ -3874,6 +3883,9 @@
       <ComponentRef Id="cmpFAF0214999C3458FA8D3E78240FEF8E6" />
       <ComponentRef Id="cmp569CAE80DA274314823D3CB0680E519A" />
       <ComponentRef Id="cmpA6C3F8BAB7AF49D6A4A777B89BE95113" />
+      <ComponentRef Id="cmpE5C1153A7BA345DB8E6FA30B9D569367" />
+      <ComponentRef Id="cmp6FCFC0BB6C7A467F9F3524181DD1AE2C" />
+      <ComponentRef Id="cmp1A42A34AAF034E048D71F87C85412439" />
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
+++ b/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
@@ -58,6 +58,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.1.0" />
     <PackageReference Include="System.Threading.AccessControl" Version="4.6.0-preview6.19303.8" />
     <PackageReference Include="NJsonSchema" Version="10.0.21" />
+    <PackageReference Include="MailKit" Version="2.2.0" />
   </ItemGroup>
 
 </Project>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Send-MailMessage.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Send-MailMessage.Tests.ps1
@@ -272,8 +272,8 @@ Describe "Send-MailMessage Feature Tests" -Tags Feature, RequireSudoOnUnix {
         }
 
         It "Can send mail with attachments" {
-            $attachment1 = "$TestDrive\attachment1.txt"
-            $attachment2 = "$TestDrive\attachment2.png"
+            $attachment1 = "$TestDrive/attachment1.txt"
+            $attachment2 = "$TestDrive/attachment2.png"
 
             $pngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAAnElEQVR42u3RAQ0AAAgDoL9/aK3hHFSgyUw4o0KEIEQIQoQgRAhChAgRghAhCBGCECEIEYIQhAhBiBCECEGIEIQgRAhChCBECEKEIAQhQhAiBCFCECIEIQgRghAhCBGCECEIQYgQhAhBiBCECEEIQoQgRAhChCBECEIQIgQhQhAiBCFCEIIQIQgRghAhCBGCECFChCBECEKEIOS7BU5Hx50BmcQaAAAAAElFTkSuQmCC"
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Send-MailMessage.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Send-MailMessage.Tests.ps1
@@ -109,21 +109,6 @@ Describe "Send-MailMessage DRT Unit Tests" -Tags CI, RequireSudoOnUnix {
         }
     )
 
-    It "Shows obsolete message for cmdlet" {
-        $server | Should -Not -Be $null
-
-        $powershell = [PowerShell]::Create()
-
-        $null = $powershell.AddCommand("Send-MailMessage").AddParameters($testCases[0].InputObject).AddParameter("ErrorAction","SilentlyContinue")
-
-        $powershell.Invoke()
-
-        $warnings = $powershell.Streams.Warning
-
-        $warnings.count | Should -BeGreaterThan 0
-        $warnings[0].ToString() | Should -BeLike "The command 'Send-MailMessage' is obsolete. *"
-    }
-
     It "Can send mail message using named parameters <Name>" -TestCases $testCases {
         param($InputObject)
 
@@ -287,8 +272,8 @@ Describe "Send-MailMessage Feature Tests" -Tags Feature, RequireSudoOnUnix {
         }
 
         It "Can send mail with attachments" {
-            $attachment1 = "TestDrive:\attachment1.txt"
-            $attachment2 = "TestDrive:\attachment2.txt"
+            $attachment1 = "$TestDrive\attachment1.txt"
+            $attachment2 = "$TestDrive\attachment2.png"
 
             $pngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAAnElEQVR42u3RAQ0AAAgDoL9/aK3hHFSgyUw4o0KEIEQIQoQgRAhChAgRghAhCBGCECEIEYIQhAhBiBCECEGIEIQgRAhChCBECEKEIAQhQhAiBCFCECIEIQgRghAhCBGCECEIQYgQhAhBiBCECEEIQoQgRAhChCBECEIQIgQhQhAiBCFCEIIQIQgRghAhCBGCECFChCBECEKEIOS7BU5Hx50BmcQaAAAAAElFTkSuQmCC"
 
@@ -302,9 +287,7 @@ Describe "Send-MailMessage Feature Tests" -Tags Feature, RequireSudoOnUnix {
             $mail = Read-Mail
             $mail.MessageParts.Count | Should -BeExactly 3
 
-            $txt = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($mail.MessageParts[1].BodyData)) -replace "`n|`r"
-            $txt | Should -BeExactly "First attachment"
-
+            ($mail.MessageParts[1].BodyData) | Should -BeExactly "First attachment"
             ($mail.MessageParts[2].BodyData -replace "`n|`r") | Should -BeExactly $pngBase64
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Send-MailMessage.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Send-MailMessage.Tests.ps1
@@ -141,10 +141,8 @@ Describe "Send-MailMessage DRT Unit Tests" -Tags CI, RequireSudoOnUnix {
         $mail.MessageParts[0].BodyData | Should -BeExactly $InputObject.Body
     }
 
-    It "Can send mail message using pipline named parameters <Name>" -TestCases $testCases -Pending {
+    It "Can send mail message using pipline named parameters <Name>" -TestCases $testCases {
         param($InputObject)
-
-        Set-TestInconclusive "As of right now the Send-MailMessage cmdlet does not support piping named parameters (see issue 7591)"
 
         $server | Should -Not -Be $null
 


### PR DESCRIPTION
# PR Summary

This PR will fix the underlying architecture of the Send-MailMessage cmdlet using the actively maintained `MailKit` SMTP client.
Note: `System.Net.Mail.SmtpClient` receives no further development and only supports STARTTLS secure connections.

**Enhancements**
- Fix #7591: Pipelining into the cmdlet is now supported
- SMTPS is now supported

**Benefits of MailKit**
- Modern actively maintained dependency (would fix #10015)
- Secure connection upgrades from insecure connections using STARTTLS is supported implicitly (no parameter has to be specified)
- Secure connections over SSL/TLS is supported (Gmail, Yahoo, ... see #8987)
- MailKit and MimeKit allow easier implementation of missing functionality (see #9191)

**Backward compatibility and breaking changes**
All parameters are left as they are, BUT
- `Credential` parameter is the only way to provide credentials right now. `System.Net.Mail.SmtpClient` has the ability to get the default credentials from Windows. 
-> Requires change in documentation; X-plat credential provider solution for PowerShell 7 might be the solution to that.

- `DeliverNotificationOption` is implemented, but the functionality should be reviewed as all tested platforms either don't support Delivery Status Notfication (DSN) (e.g. Gmail, GMX, Yahoo) or ignore the setting (Outlook.com - btw the only SMTP server I've came accross which reports DSN capability).
-> Subject to discuss in RFC to deprecate this parameter.

- `Encoding` parameter no longer has any influence on subject/body encoding as this is handled by MimeKit
-> Requires further research, but may be subject to deprecate.

- `UseSsl` is no longer mandatory to allow STARTTLS upgrade from an insecure connection. The parameter is now used to explicitly state the the entire connection should be wrapped in a SSL/TLS connections, also known as SMTPS. -> Using Port 0 (default - automatic port selection will use Port 465 for `UseSsl` but can of course be overridden with any other port number; If `UseSsl` is not specified the default port 25 for SMTP is used, although most STARTTLS endpoints use port 587).
-> Critical breaking change for automated scripts; Subject to discuss
Possible workaround: Use another parameter for SMTPS functionality and keep `UseSsl` parameter for STARTTLS (though it wouldn't have any relevance in the code and would be a non-functional parameter like `Encoding`, though not breaking any scripts)

**Test infrastructure**
The Pester tests use netDumbster which only supports insecure connections.
STARTTLS and SMTPS functionality have been tested interactively against:
- Outlook.com (STARTTLS 587)
- Gmail.com (SMTPS 465)
- Yahoo.com (SMTPS 465 and STARTTLS 587)

## PR Context

As of #9178 is marked as obsolete and an RFC PR PowerShell/PowerShell-RFC#160 was opened to discuess the future of the cmdlet.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
