### PR TITLE
Add PSUserRoot environment variable to control where the current user PowerShell profile is stored and managed

### DIFF
--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -249,7 +249,7 @@ namespace System.Management.Automation
 
             string xdgConfigHomeDefault = Path.Combine(envHome, ".config", "powershell");
             string xdgDataHomeDefault = Path.Combine(envHome, ".local", "share", "powershell");
-            string xdgModuleDefault = Path.Combine(xdgDataHomeDefault, "Modules");
+            string xdgModuleDefault = Path.Combine(xdgDataHomeDefault, Utils.ModulesFolder);
             string xdgCacheDefault = Path.Combine(envHome, ".cache", "powershell");
 
             switch (dirpath)
@@ -314,7 +314,7 @@ namespace System.Management.Automation
                     }
                     else
                     {
-                        return Path.Combine(xdgdatahome, "powershell", "Modules");
+                        return Path.Combine(xdgdatahome, "powershell", Utils.ModulesFolder);
                     }
 
                 case Platform.XDG_Type.SHARED_MODULES:

--- a/src/System.Management.Automation/engine/PSConfiguration.cs
+++ b/src/System.Management.Automation/engine/PSConfiguration.cs
@@ -103,10 +103,10 @@ namespace System.Management.Automation.Configuration
         /// Note: There is no setter because this value is immutable.
         /// </summary>
         /// <param name="scope">Whether this is a system-wide or per-user setting.</param>
-        /// <returns>Value if found, null otherwise. The behavior matches ModuleIntrinsics.GetExpandedEnvironmentVariable().</returns>
+        /// <returns>Value if found, null otherwise. The behavior matches EnvVarHelper.GetExpandedEnvironmentVariable().</returns>
         internal string GetModulePath(ConfigScope scope)
         {
-            string modulePath = ReadValueFromFile<string>(scope, Constants.PSModulePathEnvVar);
+            string modulePath = ReadValueFromFile<string>(scope, EnvVarHelper.PSModulePathEnvVar);
             if (!string.IsNullOrEmpty(modulePath))
             {
                 modulePath = Environment.ExpandEnvironmentVariables(modulePath);

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -467,8 +467,7 @@ namespace System.Management.Automation
 #if UNIX
             return Platform.SelectProductNameForDirectory(Platform.XDG_Type.CONFIG);
 #else
-            string basePath = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
-            return IO.Path.Combine(basePath, Utils.ProductNameForDirectory);
+            return UserConfigurationDirectory;
 #endif
         }
 
@@ -705,15 +704,29 @@ namespace System.Management.Automation
         internal const string DefaultPowerShellShellID = "Microsoft.PowerShell";
 
         /// <summary>
+        /// This is used to construct the module directory.
+        /// </summary>
+        internal const string ModulesFolder = "Modules";
+
+#if !UNIX
+        /// <summary>
         /// This is used to construct the profile path.
         /// </summary>
         internal const string ProductNameForDirectory = "PowerShell";
 
         /// <summary>
-        /// The subdirectory of module paths
-        /// e.g. ~\Documents\WindowsPowerShell\Modules and %ProgramFiles%\WindowsPowerShell\Modules.
+        /// The directory under which to store Modules and Scripts folders for the current user.
+        /// By default this will be ~\Documents\PowerShell.
         /// </summary>
-        internal static string ModuleDirectory = Path.Combine(ProductNameForDirectory, "Modules");
+        internal static string UserConfigurationDirectory =
+            EnvVarHelper.GetExpandedEnvironmentVariable(EnvVarHelper.PSUserRootEnvVar, EnvironmentVariableTarget.User)
+            ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), ProductNameForDirectory);
+
+        /// <summary>
+        /// The current user's modules folder.
+        /// </summary>
+        internal static string UserModulesFolder = Path.Combine(UserConfigurationDirectory, ModulesFolder);
+#endif
 
         internal static readonly ConfigScope[] SystemWideOnlyConfig = new[] { ConfigScope.AllUsers };
         internal static readonly ConfigScope[] CurrentUserOnlyConfig = new[] { ConfigScope.CurrentUser };

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Environment-Variables.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Environment-Variables.Tests.ps1
@@ -3,44 +3,77 @@
 Describe "Environment-Variables" -Tags "CI" {
 
     It "Should have environment variables" {
-	Get-Item ENV: | Should -Not -BeNullOrEmpty
+        Get-Item ENV: | Should -Not -BeNullOrEmpty
     }
 
     It "Should have a nonempty PATH" {
-	$ENV:PATH | Should -Not -BeNullOrEmpty
+        $ENV:PATH | Should -Not -BeNullOrEmpty
     }
 
     It "Should contain /bin in the PATH" {
-	if ($IsWindows)
-	{
-	    $ENV:PATH | Should -Match "C:"
-	}
-	else
-	{
-	    $ENV:PATH | Should -Match "/bin"
-	}
+        if ($IsWindows)
+        {
+            $ENV:PATH | Should -Match "C:"
+        }
+        else
+        {
+            $ENV:PATH | Should -Match "/bin"
+        }
     }
 
     It "Should have the correct HOME" {
-	if ($IsWindows)
-	{
-	    # \Windows\System32 is found as $env:HOMEPATH for temporary profiles
-	    $expected = "\Users", "\Windows"
-	    Split-Path $ENV:HOMEPATH -Parent | Should -BeIn $expected
-	}
-	else
-	{
-	    $expected = /bin/bash -c "cd ~ && pwd"
-	    $ENV:HOME | Should -Be $expected
-	}
+        if ($IsWindows)
+        {
+            # \Windows\System32 is found as $env:HOMEPATH for temporary profiles
+            $expected = "\Users", "\Windows"
+            Split-Path $ENV:HOMEPATH -Parent | Should -BeIn $expected
+        }
+        else
+        {
+            $expected = /bin/bash -c "cd ~ && pwd"
+            $ENV:HOME | Should -Be $expected
+        }
     }
 
     It "Should be able to set the environment variables" {
-	$expected = "this is a test environment variable"
-	{ $ENV:TESTENVIRONMENTVARIABLE = $expected  } | Should -Not -Throw
+        $expected = "this is a test environment variable"
+        { $ENV:TESTENVIRONMENTVARIABLE = $expected  } | Should -Not -Throw
 
-	$ENV:TESTENVIRONMENTVARIABLE | Should -Not -BeNullOrEmpty
-	$ENV:TESTENVIRONMENTVARIABLE | Should -Be $expected
+        $ENV:TESTENVIRONMENTVARIABLE | Should -Not -BeNullOrEmpty
+        $ENV:TESTENVIRONMENTVARIABLE | Should -Be $expected
+    }
 
+    It 'Uses the PSUserRoot environment variable when available to set up env:PSModulePath' -Skip:(!$IsWindows) {
+        try {
+            [Environment]::SetEnvironmentVariable('PSUserRoot', '%USERPROFILE%\.powershell', [EnvironmentVariableTarget]::User)
+
+            $psUserRoot = Join-Path -Path $env:USERPROFILE -ChildPath '.powershell'
+
+            $currentPsModulePaths = $env:PSModulePath -split ';'
+            $newPsModulePaths = (pwsh -noprofile -noninteractive -nologo -command {$env:PSModulePath}) -split ';'
+
+            $currentPsModulePaths[0] | Should -Not -Be $newPsModulePaths[0]
+            $newPsModulePaths[0] | Should -BeExactly "${psUserRoot}\Modules"
+        } finally {
+            [Environment]::SetEnvironmentVariable('PSUserRoot', '', [EnvironmentVariableTarget]::User)
+        }
+    }
+
+    It 'Uses the PSUserRoot environment variable when available to set up $profile.currentUser* values' -Skip:(!$IsWindows) {
+        try {
+            [Environment]::SetEnvironmentVariable('PSUserRoot', '%USERPROFILE%\.powershell', [EnvironmentVariableTarget]::User)
+
+            $psUserRoot = Join-Path -Path $env:USERPROFILE -ChildPath '.powershell'
+
+            $currentUserCurrentHost = pwsh -noprofile -noninteractive -nologo -command {$profile.currentUserCurrentHost}
+            $currentUserAllHosts = pwsh -noprofile -noninteractive -nologo -command {$profile.currentUserAllHosts}
+
+            $currentUserCurrentHost | Should -Not -Be $profile.currentUserCurrentHost
+            $currentUserCurrentHost | Should -BeExactly "${psUserRoot}\Microsoft.PowerShell_profile.ps1"
+            $currentUserAllHosts | Should -Not -Be $profile.currentUserAllHosts
+            $currentUserAllHosts | Should -BeExactly "${psUserRoot}\profile.ps1"
+        } finally {
+            [Environment]::SetEnvironmentVariable('PSUserRoot', '', [EnvironmentVariableTarget]::User)
+        }
     }
 }


### PR DESCRIPTION
# PR Summary

This PR is Windows-only (for now -- if folks want it cross platform, I'm happy to update it).

It adds support for a PSUserRoot user environment variable. If the environment variable is set when PowerShell is launched, the path it defines will be used as the base path for the current user's PowerShell profile. This allows users to move their PowerShell content out of their OneDrive (see linked issue for details) and into some other location where they want that content stored/managed. The PR affects how `$env:PSModulePath` is initialized, how `$profile.CurrentUserCurrentHost` and `$profile.CurrentUserAllHosts` are initialized, and the location where the config file is read from.

A matching PR will need to be submitted against PowerShellGet so that it works with this environment variable when installing modules to the user profile. I'll do that work soon.

Any tooling that works directly with the current user's PowerShell folder will need to take this environment variable into account.

## PR Context

See issue #8069, and in particular, [this comment about the PowerShell Committee's decision on the matter](https://github.com/PowerShell/PowerShell/issues/8069#issuecomment-504124566).

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [X] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [X] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
