### PR TITLE
Fix debugger disable performance regression

### DIFF
--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -1692,7 +1692,7 @@ namespace System.Management.Automation
         private volatile int _processingRunspaceDebugQueue;
         private ManualResetEventSlim _runspaceDebugCompleteEvent;
 
-        // Debugger disabling
+        // System is locked down when true. Used to disable debugger on lock down.
         private bool? _isSystemLockedDown;
 
         private static readonly string s_processDebugPromptMatch;

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -1692,6 +1692,9 @@ namespace System.Management.Automation
         private volatile int _processingRunspaceDebugQueue;
         private ManualResetEventSlim _runspaceDebugCompleteEvent;
 
+        // Debugger disabling
+        private bool? _isSystemLockedDown;
+
         private static readonly string s_processDebugPromptMatch;
 
         #endregion private members
@@ -2109,16 +2112,27 @@ namespace System.Management.Automation
             }
         }
 
-        private static bool IsSystemLockedDown
+        private bool IsSystemLockedDown
         {
             get
             {
-                return (System.Management.Automation.Security.SystemPolicy.GetSystemLockdownPolicy() ==
-                        System.Management.Automation.Security.SystemEnforcementMode.Enforce);
+                if (_isSystemLockedDown == null)
+                {
+                    lock (_syncObject)
+                    {
+                        if (_isSystemLockedDown == null)
+                        {
+                            _isSystemLockedDown = (System.Management.Automation.Security.SystemPolicy.GetSystemLockdownPolicy() ==
+                                System.Management.Automation.Security.SystemEnforcementMode.Enforce);
+                        }
+                    }
+                }
+
+                return _isSystemLockedDown.Value;
             }
         }
 
-        private static void CheckForBreakpointSupport()
+        private void CheckForBreakpointSupport()
         {
             if (IsSystemLockedDown)
             {

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageDebugger.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageDebugger.Tests.ps1
@@ -22,85 +22,6 @@ try
 
         BeforeAll {
 
-            # Invoke-LanguageModeTestingSupportCmdlet definition
-            $languageModeCmdletDef = @'
-            using System;
-            using System.Globalization;
-            using System.Reflection;
-            using System.Collections;
-            using System.Collections.Generic;
-            using System.IO;
-            using System.Security;
-            using System.Runtime.InteropServices;
-            using System.Threading;
-            using System.Management.Automation;
-
-            /// <summary>Adds a new type to the Application Domain</summary>
-            [Cmdlet("Invoke", "LanguageModeTestingSupportCmdlet")]
-            public sealed class InvokeLanguageModeTestingSupportCmdlet : PSCmdlet
-            {
-                [Parameter()]
-                public SwitchParameter EnableFullLanguageMode
-                {
-                    get { return enableFullLanguageMode; }
-                    set { enableFullLanguageMode = value; }
-                }
-                private SwitchParameter enableFullLanguageMode;
-
-                [Parameter()]
-                public SwitchParameter SetLockdownMode
-                {
-                    get { return setLockdownMode; }
-                    set { setLockdownMode = value; }
-                }
-                private SwitchParameter setLockdownMode;
-
-                [Parameter()]
-                public SwitchParameter RevertLockdownMode
-                {
-                    get { return revertLockdownMode; }
-                    set { revertLockdownMode = value; }
-                }
-                private SwitchParameter revertLockdownMode;
-
-                protected override void BeginProcessing()
-                {
-                    if(enableFullLanguageMode)
-                    {
-                        SessionState.LanguageMode = PSLanguageMode.FullLanguage;
-                    }
-
-                    if(setLockdownMode)
-                    {
-                        Environment.SetEnvironmentVariable("__PSLockdownPolicy", "0x80000007", EnvironmentVariableTarget.Machine);
-                    }
-
-                    if(revertLockdownMode)
-                    {
-                        Environment.SetEnvironmentVariable("__PSLockdownPolicy", null, EnvironmentVariableTarget.Machine);
-                    }
-                }
-            }
-'@
-
-            if (-not (Get-Command Invoke-LanguageModeTestingSupportCmdlet -ea Ignore))
-            {
-                $languageModeModuleName = "LanguageModeModule"
-                $modulePath = [System.IO.Path]::GetFileNameWithoutExtension([IO.Path]::GetRandomFileName())
-                $script:moduleDirectory = join-path "$PSScriptRoot\$modulePath" $languageModeModuleName
-                if (-not (Test-Path $moduleDirectory))
-                {
-                    $null = New-Item -ItemType Directory $moduleDirectory -Force
-                }
-
-                try
-                {
-                    Add-Type -TypeDefinition $languageModeCmdletDef -OutputAssembly $moduleDirectory\TestCmdletForConstrainedLanguage.dll -ErrorAction Ignore
-                } catch {}
-
-                Import-Module -Name $moduleDirectory\TestCmdletForConstrainedLanguage.dll
-            }
-
             # Debugger test type definition
             $debuggerTestTypeDef = @'
             using System;
@@ -146,6 +67,26 @@ try
 
             # Define debugger test type
             Add-Type -TypeDefinition $debuggerTestTypeDef
+
+            # Test cases
+            $TestCasesDisableDebugger = @(
+                @{
+                    testName = 'Verifies that Set-PSBreakpoint Line is disabled on locked down system'
+                    scriptText = 'Set-PSBreakpoint -Script {0} -Line 1' -f $scriptFilePath
+                },
+                @{
+                    testName = 'Verifies that Set-PSBreakpoint Statement is disabled on locked down system'
+                    scriptText = 'Set-PSBreakpoint -Script {0} -Line 1 -Column 1' -f $scriptFilePath
+                },
+                @{
+                    testName = 'Verifies that Set-PSBreakpoint Command is disabled on locked down system'
+                    scriptText = 'Set-PSBreakpoint -Command {0}' -f $scriptFilePath
+                },
+                @{
+                    testName = 'Verifies that Set-PSBreakpoint Variable is disabled on locked down system'
+                    scriptText = 'Set-PSBreakpoint -Variable HelloVar'
+                }
+            )
         }
 
         AfterAll {
@@ -156,93 +97,23 @@ try
             }
         }
 
-        It "Verifies that Set-PSBreakpoint Line is disabled on locked down system" {
+        It "<testName>" -TestCases $TestCasesDisableDebugger {
 
-            try
+            param ($scriptText)
+
+            try 
             {
                 Invoke-LanguageModeTestingSupportCmdlet -SetLockdownMode
-                $ExecutionContext.SessionState.LanguageMode = "ConstrainedLanguage"
 
-                Set-PSBreakpoint -Script $scriptFilePath -Line 1
-                throw "No Exception!"
-            }
-            catch
-            {
-                $expectedError = $_
+                # Run script in new runspace created within lock down mode.
+                [powershell] $ps = [powershell]::Create([System.Management.Automation.RunspaceMode]::NewRunspace);
+                $ps.AddScript($scriptText).Invoke()
+                $expectedError = $ps.Streams.Error[0]
             }
             finally
             {
-                Invoke-LanguageModeTestingSupportCmdlet -RevertLockdownMode
-                Invoke-LanguageModeTestingSupportCmdlet -EnableFullLanguageMode
-            }
-
-            $expectedError.FullyQualifiedErrorId | Should Be 'NotSupported,Microsoft.PowerShell.Commands.SetPSBreakpointCommand'
-        }
-
-        It "Verifies that Set-PSBreakpoint Statement is disabled on locked down system" {
-
-            try
-            {
-                Invoke-LanguageModeTestingSupportCmdlet -SetLockdownMode
-                $ExecutionContext.SessionState.LanguageMode = "ConstrainedLanguage"
-
-                Set-PSBreakpoint -Script $scriptFilePath -Line 1 -Column 1
-                throw "No Exception!"
-            }
-            catch
-            {
-                $expectedError = $_
-            }
-            finally
-            {
-                Invoke-LanguageModeTestingSupportCmdlet -RevertLockdownMode
-                Invoke-LanguageModeTestingSupportCmdlet -EnableFullLanguageMode
-            }
-
-            $expectedError.FullyQualifiedErrorId | Should Be 'NotSupported,Microsoft.PowerShell.Commands.SetPSBreakpointCommand'
-        }
-
-        It "Verifies that Set-PSBreakpoint Command is disabled on locked down system" {
-
-            try
-            {
-                Invoke-LanguageModeTestingSupportCmdlet -SetLockdownMode
-                $ExecutionContext.SessionState.LanguageMode = "ConstrainedLanguage"
-
-                Set-PSBreakpoint -Command $scriptFilePath
-                throw "No Exception!"
-            }
-            catch
-            {
-                $expectedError = $_
-            }
-            finally
-            {
-                Invoke-LanguageModeTestingSupportCmdlet -RevertLockdownMode
-                Invoke-LanguageModeTestingSupportCmdlet -EnableFullLanguageMode
-            }
-
-            $expectedError.FullyQualifiedErrorId | Should Be 'NotSupported,Microsoft.PowerShell.Commands.SetPSBreakpointCommand'
-        }
-
-        It "Verifies that Set-PSBreakpoint Variable is disabled on locked down system" {
-
-            try
-            {
-                Invoke-LanguageModeTestingSupportCmdlet -SetLockdownMode
-                $ExecutionContext.SessionState.LanguageMode = "ConstrainedLanguage"
-
-                Set-PSBreakpoint -Variable HelloVar
-                throw "No Exception!"
-            }
-            catch
-            {
-                $expectedError = $_
-            }
-            finally
-            {
-                Invoke-LanguageModeTestingSupportCmdlet -RevertLockdownMode
-                Invoke-LanguageModeTestingSupportCmdlet -EnableFullLanguageMode
+                Invoke-LanguageModeTestingSupportCmdlet -RevertLockdownMode -EnableFullLanguageMode
+                if ($ps -ne $null) { $ps.Dispose() }
             }
 
             $expectedError.FullyQualifiedErrorId | Should Be 'NotSupported,Microsoft.PowerShell.Commands.SetPSBreakpointCommand'


### PR DESCRIPTION
# PR Summary

This is a fix for the performance regression found in issue #9884

## PR Context

Even though the issue title indicate .net classes are slow to load, the repro steps make it clear that a general slow down can occur when a debug break point is set.

Repro:
```powershell
$measure1 = measure-command{
  foreach($i in 1..10000){
    [System.Environment]
  }
} |select -ExpandProperty TotalSeconds

Set-PSBreakpoint -Variable "test" -Action {$null}

$measure2 = measure-command{
  foreach($i in 1..10000){
    [System.Environment]
  }
} |select -ExpandProperty TotalSeconds

Write-Host "First measurement took $measure1 seconds, Second measurement took $measure2"

>>First measurement took 0.0482474 seconds, Second measurement took 0.8722697
```
It turns out that this problem (based on the above repro) is due to a recent change to disable the script debugger when the system is in lock down mode.  System lock down mode is checked each time the debugger state is changed, which occurs many times in a tight loop for variable processing, and the system check results in a significant slow down.

The fix is to cache the system lock down mode for each script debugger instance.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
