### PR TITLE
WIP: Demo: Offer Tokenizing Improvements for Highlighting

### DIFF
--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -5282,11 +5282,11 @@ namespace System.Management.Automation.Language
             }
 
             // A function name that matches a keyword isn't really a keyword, so don't color it that way
-            functionNameToken.TokenFlags &= ~TokenFlags.Keyword;
+            functionNameToken.SetIsCommandArgument();
+            //functionNameToken.TokenFlags &= ~TokenFlags.Keyword;
 
             // A function name is not an expandable token, so remove any nested tokens
-            var expandableToken = functionNameToken as StringExpandableToken;
-            if (expandableToken != null)
+            if (functionNameToken is StringExpandableToken expandableToken)
             {
                 expandableToken.NestedTokens = null;
             }
@@ -5324,8 +5324,8 @@ namespace System.Management.Automation.Language
                 _tokenizer.InWorkflowContext = isWorkflow;
 
                 ScriptBlockAst scriptBlock = ScriptBlockRule(lCurly, isFilter);
-                var functionName = (functionNameToken.Kind == TokenKind.Generic)
-                                       ? ((StringToken)functionNameToken).Value
+                var functionName = (functionNameToken is StringToken stringFunctionNameToken)
+                                       ? stringFunctionNameToken.Value
                                        : functionNameToken.Text;
 
                 FunctionDefinitionAst result = new FunctionDefinitionAst(ExtentOf(functionToken, scriptBlock),
@@ -6056,7 +6056,7 @@ namespace System.Management.Automation.Language
                     case TokenKind.AndAnd:
                     case TokenKind.OrOr:
                     case TokenKind.Ampersand:
-                    case TokenKind.MinusMinus:
+               //     case TokenKind.MinusMinus when (context == CommandArgumentContext.CommandName):
                     case TokenKind.Comma:
                         UngetToken(token);
 
@@ -6119,7 +6119,7 @@ namespace System.Management.Automation.Language
                             exprAst = new StringConstantExpressionAst(genericToken.Extent, genericToken.Value, StringConstantType.BareWord);
 
                             // If this is a verbatim argument, then don't continue peeking
-                            if (string.Equals(genericToken.Value, VERBATIM_ARGUMENT, StringComparison.OrdinalIgnoreCase))
+                            if (context == CommandArgumentContext.CommandArgument && string.Equals(genericToken.Value, VERBATIM_ARGUMENT, StringComparison.OrdinalIgnoreCase))
                             {
                                 foundVerbatimArgument = true;
                             }
@@ -6131,7 +6131,8 @@ namespace System.Management.Automation.Language
                         exprAst = new StringConstantExpressionAst(token.Extent, token.Text, StringConstantType.BareWord);
 
                         // A command/argument that matches a keyword isn't really a keyword, so don't color it that way
-                        token.TokenFlags &= ~TokenFlags.Keyword;
+                        // token.TokenFlags &= ~TokenFlags.Keyword;
+                        token.SetIsCommandArgument();
 
                         switch (context)
                         {
@@ -6142,7 +6143,6 @@ namespace System.Management.Automation.Language
                             case CommandArgumentContext.FileName:
                             case CommandArgumentContext.CommandArgument:
                             case CommandArgumentContext.SwitchCondition:
-                                token.SetIsCommandArgument();
                                 break;
                         }
 
@@ -6273,13 +6273,11 @@ namespace System.Management.Automation.Language
                             scanning = false;
                             continue;
 
-                        case TokenKind.MinusMinus:
+                        case TokenKind.MinusMinus when !sawDashDash && context != CommandArgumentContext.CommandNameAfterInvocationOperator:
                             endExtent = token.Extent;
                             // Add the first -- as a parameter, which is then ignored when constructing the command processor unless it's a native
                             // command.  All subsequent -- are added as arguments.
-                            elements.Add(sawDashDash
-                                ? (CommandElementAst)new StringConstantExpressionAst(token.Extent, token.Text, StringConstantType.BareWord)
-                                : new CommandParameterAst(token.Extent, "-", null, token.Extent));
+                            elements.Add(new CommandParameterAst(token.Extent, "-", null, token.Extent));
                             sawDashDash = true;
                             break;
 
@@ -6291,8 +6289,8 @@ namespace System.Management.Automation.Language
                             SkipNewlines();
                             break;
 
-                        case TokenKind.Parameter:
-                            if ((context & CommandArgumentContext.CommandName) != 0 || sawDashDash)
+                        case TokenKind.Parameter when !sawDashDash && (context & CommandArgumentContext.CommandName) == 0:
+                            if ((context & CommandArgumentContext.CommandName) != 0)
                             {
                                 endExtent = token.Extent;
                                 token.TokenFlags |= TokenFlags.CommandName;
@@ -6370,24 +6368,27 @@ namespace System.Management.Automation.Language
                             {
                                 var ast = GetCommandArgument(context, token);
 
-                                // If this is the special verbatim argument syntax, look for the next element
-                                StringToken argumentToken = token as StringToken;
-                                if ((argumentToken != null) && string.Equals(argumentToken.Value, VERBATIM_ARGUMENT, StringComparison.OrdinalIgnoreCase))
+                                if (context == CommandArgumentContext.CommandArgument)
                                 {
-                                    elements.Add(ast);
-                                    endExtent = ast.Extent;
-
-                                    var verbatimToken = GetVerbatimCommandArgumentToken();
-                                    if (verbatimToken != null)
+                                    // If this is the special verbatim argument syntax, look for the next element
+                                    StringToken argumentToken = token as StringToken;
+                                    if ((argumentToken != null) && string.Equals(argumentToken.Value, VERBATIM_ARGUMENT, StringComparison.OrdinalIgnoreCase))
                                     {
-                                        foundVerbatimArgument = true;
-                                        scanning = false;
-                                        ast = new StringConstantExpressionAst(verbatimToken.Extent, verbatimToken.Value, StringConstantType.BareWord);
                                         elements.Add(ast);
                                         endExtent = ast.Extent;
-                                    }
 
-                                    break;
+                                        var verbatimToken = GetVerbatimCommandArgumentToken();
+                                        if (verbatimToken != null)
+                                        {
+                                            foundVerbatimArgument = true;
+                                            scanning = false;
+                                            ast = new StringConstantExpressionAst(verbatimToken.Extent, verbatimToken.Value, StringConstantType.BareWord);
+                                            elements.Add(ast);
+                                            endExtent = ast.Extent;
+                                        }
+
+                                        break;
+                                    }
                                 }
 
                                 endExtent = ast.Extent;

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -3618,7 +3618,7 @@ namespace System.Management.Automation.Language
             : this(extent,
                    isFilter,
                    isWorkflow,
-                   (functionNameToken.Kind == TokenKind.Generic) ? ((StringToken)functionNameToken).Value : functionNameToken.Text,
+                   (functionNameToken is StringToken stringFunctionNameToken) ? stringFunctionNameToken.Value : functionNameToken.Text,
                    parameters,
                    body)
         {

--- a/src/System.Management.Automation/engine/parser/token.cs
+++ b/src/System.Management.Automation/engine/parser/token.cs
@@ -1203,6 +1203,7 @@ namespace System.Management.Automation.Language
             // considered a command argument.  This prevent arbitrary changes to the kind which should be safer.
             if (_kind != TokenKind.Identifier)
             {
+                _tokenFlags = _tokenFlags & ~_kind.GetTraits() | TokenKind.Generic.GetTraits();
                 _kind = TokenKind.Generic;
             }
         }


### PR DESCRIPTION
In function name and command name parsing, insure that an expandable string
does not exist as these are not to be expanded.
In command name parsing, insure that redirect tokens that will be accepted as
commands are flagged as such.
In command argument processing, arguments that originate as 'Operator' tokens have their TokenFlags reverted when switched from an 'operator' TokenKind to a 'Generic' TokenKind.
In command name processing, treat `DashDash` token as a command name and do not set in motion the 'no more parameters' mode.
In command argument processing, correct the 'no more parameters' mode so additional 'parameter' tokens are not marked as command names.
In command name processing, treat `--%` (verbatim argument operator) as a command and do not treat next argument verbatim.
In function definitions, correct function name token of `--` to be generic, and fix assumptions that generic tokens are string tokens.

Reference #10275, #10347, #10348

to do
- [ ] Find tests for `--`, add tests to make sure `--` after a command of `--` still works.
- [ ] Find tests for `--%`, add tests to make sure `--%` after a command of `--%` still works.
- [ ] Find tests for redirection operators, add tests to make sure redirection operators as commands do not interfere with redirection operators later in the command statement.

# PR Summary

Adjust token polishing to benefit token based highlighting.

## PR Context

The syntax highlighting offered by PSReadLine has always led me through some confusion and I am sure every once in a while it confuses some others as well as to what is really accepted as syntax.  However the issue is not really with PSReadLine but with the tokens that PSReadLine uses for highlighting, rather than using the AST.

It would appear that some house keeping tasks are not performed on the token collection after the AST is produced from them.  Some places clean up (set indicator flags) and some places do not.  The most notable item is that tokens that ultimately become `StringExpandableToken` but when processed in to AST are treated as just `StringToken` remain in that form, which then incorrectly informs any downstream applications.

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
