### PR TITLE
Preserve PSModulePath environment variable

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -1145,7 +1145,6 @@ namespace System.Management.Automation
                 }
             }
 
-
             int indexOfSharedModulePath = IndexOfPath(sharedModulePath);
             if (indexOfSharedModulePath == -1)
             {

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -1216,7 +1216,6 @@ namespace System.Management.Automation
 #endif
                 }
 
-                CheckModulePath();
                 s_modulePathCache = s_modulePath;
                 s_psModulePathEnvVar = currentModulePath;
 
@@ -1234,18 +1233,6 @@ namespace System.Management.Automation
                 }
 
                 return s_modulePath;
-            }
-        }
-
-        private static void CheckModulePath()
-        {
-            HashSet<string> processedPathSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var p in s_modulePath)
-            {
-                if (!processedPathSet.Add(p))
-                {
-                    PSTraceSource.NewInvalidOperationException();
-                }
             }
         }
 

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -727,7 +727,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// The subdirectory of module paths
-        /// e.g. ~\Documents\WindowsPowerShell\Modules and %ProgramFiles%\WindowsPowerShell\Modules.
+        /// e.g. ~\Documents\PowerShell\Modules and %ProgramFiles%\PowerShell\Modules.
         /// </summary>
         internal static string ModuleDirectory = Path.Combine(ProductNameForDirectory, "Modules");
 
@@ -2065,6 +2065,7 @@ namespace System.Management.Automation.Internal
         // A location to test PSEdition compatibility functionality for Windows PowerShell modules with
         // since we can't manipulate the System32 directory in a test
         internal static string TestWindowsPowerShellPSHomeLocation;
+        internal static object[] TestPowerShellPSModulePaths;
 
         internal static bool ShowMarkdownOutputBypass;
 

--- a/src/System.Management.Automation/engine/remoting/fanin/InitialSessionStateProvider.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/InitialSessionStateProvider.cs
@@ -1907,8 +1907,7 @@ namespace System.Management.Automation.Remoting
             }
 
             // Go through each directory in the module path
-            string[] modulePaths = ModuleIntrinsics.GetModulePath().Split(Utils.Separators.PathSeparator);
-            foreach (string path in modulePaths)
+            foreach (string path in ModuleIntrinsics.GetModulePath())
             {
                 try
                 {

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -19,7 +19,7 @@ Describe "TabCompletion" -Tags CI {
     It 'Should complete abbreviated function' {
         $res = (TabExpansion2 -inputScript 'pschrl' -cursorColumn 'pschr'.Length).CompletionMatches.CompletionText
         $res.Count | Should -BeGreaterOrEqual 1
-        $res | Should -BeExactly 'PSConsoleHostReadLine'
+        $res[0] | Should -BeExactly 'PSConsoleHostReadLine'
     }
 
     It 'Should complete native exe' -Skip:(!$IsWindows) {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -39,9 +39,9 @@ function New-EditionCompatibleModule
     $psm1Name = "$ModuleName.psm1"
     $psm1Path = Join-Path $modulePath $psm1Name
 
-    New-Item -Path $modulePath -ItemType Directory
+    New-Item -Path $modulePath -ItemType Directory > $null
 
-    New-Item -Path $psm1Path -Value "function Test-$ModuleName { `$true }"
+    New-Item -Path $psm1Path -Value "function Test-$ModuleName { `$true }" > $null
 
     if ($CompatiblePSEditions)
     {
@@ -86,7 +86,7 @@ function New-TestNestedModule
     $nestedModules = [System.Collections.ArrayList]::new()
 
     # Create script module
-    New-Item -Path (Join-Path $ModuleBase $ScriptModuleFileName) -Value $ScriptModuleContent
+    New-Item -Path (Join-Path $ModuleBase $ScriptModuleFileName) -Value $ScriptModuleContent > $null
     $nestedModules.Add($ScriptModuleFilename)
 
     if ($BinaryModuleFilename -and $BinaryModuleDllPath)
@@ -99,7 +99,7 @@ function New-TestNestedModule
     # Create the root module if there is one
     if ($UseRootModule)
     {
-        New-Item -Path (Join-Path $ModuleBase $RootModuleFilename) -Value $RootModuleContent
+        New-Item -Path (Join-Path $ModuleBase $RootModuleFilename) -Value $RootModuleContent > $null
     }
 
     # Create the manifest command
@@ -412,7 +412,7 @@ Describe "Get-Module nested module behaviour with Edition checking" -Tag "Featur
 
         foreach ($basePath in $compatiblePath,$incompatiblePath)
         {
-            New-Item -Path $basePath -ItemType Directory
+            New-Item -Path $basePath -ItemType Directory > $null
         }
     }
 
@@ -432,11 +432,13 @@ Describe "Get-Module nested module behaviour with Edition checking" -Tag "Featur
             $containingDir = Join-Path $TestDrive $compatibilityDir $guid
             $moduleName = "CpseTestModule"
             $moduleBase = Join-Path $containingDir $moduleName
-            New-Item -Path $moduleBase -ItemType Directory
+            New-Item -Path $moduleBase -ItemType Directory > $null
             Add-ModulePath $containingDir
         }
 
         AfterEach {
+            Get-Module $moduleName | Remove-Module -Force
+            Remove-Item -Recurse -Path $moduleBase -Force
             Restore-ModulePath
         }
 
@@ -494,7 +496,11 @@ Describe "Get-Module nested module behaviour with Edition checking" -Tag "Featur
                 return
             }
 
-            $modules.Count | Should -Be 1
+            # In $env:PSModulePath we have 2 paths to the module:
+            # - direct path to the module
+            # - "system" path to a directory on one level above
+            # so we will get the module path twice (2 instead of 1).
+            $modules.Count | Should -Be 2
             $modules[0].Name | Should -Be $moduleName
         }
 
@@ -538,13 +544,17 @@ Describe "Get-Module nested module behaviour with Edition checking" -Tag "Featur
                 Get-Module -ListAvailable -All | Where-Object { $_.Path.Contains($guid) }
             }
 
+            # In $env:PSModulePath we have 2 paths to the module:
+            # - direct path to the module
+            # - "system" path to a directory on one level above
+            # so we will get the module path twice (8 instead of 4, 6 instead of 3).
             if ($UseRootModule)
             {
-                $modules.Count | Should -Be 4
+                $modules.Count | Should -Be 8
             }
             else
             {
-                $modules.Count | Should -Be 3
+                $modules.Count | Should -Be 6
             }
 
             $names = $modules.Name
@@ -562,11 +572,13 @@ Describe "Get-Module nested module behaviour with Edition checking" -Tag "Featur
             $containingDir = Join-Path $TestDrive $compatibilityDir $guid
             $moduleName = "CpseTestModule"
             $moduleBase = Join-Path $containingDir $moduleName
-            New-Item -Path $moduleBase -ItemType Directory
+            New-Item -Path $moduleBase -ItemType Directory > $null
             Add-ModulePath $containingDir
         }
 
         AfterEach {
+            Get-Module $moduleName | Remove-Module -Force
+            Remove-Item -Recurse -Path $moduleBase -Force
             Restore-ModulePath
         }
 
@@ -708,7 +720,7 @@ Describe "Import-Module nested module behaviour with Edition checking" -Tag "Fea
 
         foreach ($basePath in $compatiblePath,$incompatiblePath)
         {
-            New-Item -Path $basePath -ItemType Directory
+            New-Item -Path $basePath -ItemType Directory > $null
         }
     }
 
@@ -728,12 +740,13 @@ Describe "Import-Module nested module behaviour with Edition checking" -Tag "Fea
             $containingDir = Join-Path $TestDrive $compatibilityDir $guid
             $moduleName = "CpseTestModule"
             $moduleBase = Join-Path $containingDir $moduleName
-            New-Item -Path $moduleBase -ItemType Directory
+            New-Item -Path $moduleBase -ItemType Directory > $null
             Add-ModulePath $containingDir
         }
 
         AfterEach {
             Get-Module $moduleName | Remove-Module -Force
+            Remove-Item -Recurse -Path $moduleBase -Force
             Restore-ModulePath
         }
 
@@ -818,12 +831,13 @@ Describe "Import-Module nested module behaviour with Edition checking" -Tag "Fea
             $containingDir = Join-Path $TestDrive $compatibilityDir $guid
             $moduleName = "CpseTestModule"
             $moduleBase = Join-Path $containingDir $moduleName
-            New-Item -Path $moduleBase -ItemType Directory
+            New-Item -Path $moduleBase -ItemType Directory > $null
             Add-ModulePath $containingDir
         }
 
         AfterEach {
             Get-Module $moduleName | Remove-Module -Force
+            Remove-Item -Recurse -Path $moduleBase -Force
             Restore-ModulePath
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -5,7 +5,7 @@ Describe "Import-Module" -Tags "CI" {
     BeforeAll {
         $originalPSModulePath = $env:PSModulePath
 
-        # Remove system paths
+        # Remove system paths because PS 6 modify $env:PSModulePath
         $env:PSModulePath = ""
         New-Item -ItemType Directory -Path "$testdrive\Modules\TestModule\1.1" -Force > $null
         New-Item -ItemType Directory -Path "$testdrive\Modules\TestModule\2.0" -Force > $null

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -4,6 +4,9 @@ Describe "Import-Module" -Tags "CI" {
     $moduleName = "Microsoft.PowerShell.Security"
     BeforeAll {
         $originalPSModulePath = $env:PSModulePath
+
+        # Remove system paths
+        $env:PSModulePath = ""
         New-Item -ItemType Directory -Path "$testdrive\Modules\TestModule\1.1" -Force > $null
         New-Item -ItemType Directory -Path "$testdrive\Modules\TestModule\2.0" -Force > $null
         $env:PSModulePath += [System.IO.Path]::PathSeparator + "$testdrive\Modules"

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
@@ -393,7 +393,17 @@ Describe "Remove-Module : module contains nested modules" -Tags "CI" {
 }
 
 Describe "Remove-Module core module on module path by name" -Tags "CI" {
-    $moduleName = "Microsoft.PowerShell.Security"
+    BeforeAll {
+        $originalPSModulePath = $env:PSModulePath
+
+        # Remove system paths because PS 6 modify $env:PSModulePath
+        $env:PSModulePath = ""
+        $moduleName = "Microsoft.PowerShell.Security"
+    }
+
+    AfterAll {
+        $env:PSModulePath = $originalPSModulePath
+    }
 
     BeforeEach {
         Import-Module -Name $moduleName -Force

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
@@ -399,6 +399,7 @@ Describe "Remove-Module core module on module path by name" -Tags "CI" {
         # Remove system paths because PS 6 modify $env:PSModulePath
         $env:PSModulePath = ""
         $moduleName = "Microsoft.PowerShell.Security"
+        Remove-Module -Name $moduleName -Force -ErrorAction SilentlyContinue
     }
 
     AfterAll {
@@ -422,10 +423,6 @@ Describe "Remove-Module core module on module path by name" -Tags "CI" {
         $a = Get-Module -Name $moduleName
         { Remove-Module -ModuleInfo $a } | Should -Not -Throw
         (Get-Module -Name $moduleName).Name | Should -BeNullOrEmpty
-    }
-
-	AfterEach {
-        Import-Module -Name $moduleName -Force
     }
 }
 

--- a/test/powershell/Modules/PSDesiredStateConfiguration/MOF-Compilation.Tests.ps1
+++ b/test/powershell/Modules/PSDesiredStateConfiguration/MOF-Compilation.Tests.ps1
@@ -8,6 +8,7 @@ Describe "DSC MOF Compilation" -tags "CI" {
 
     BeforeAll {
         $IsAlpine = (Get-PlatformInfo) -eq "alpine"
+        $env:PSModulePath = ""
         Import-Module PSDesiredStateConfiguration
         $dscModule = Get-Module PSDesiredStateConfiguration
         $baseSchemaPath = Join-Path $dscModule.ModuleBase 'Configuration'

--- a/test/powershell/engine/Module/ModulePath.Tests.ps1
+++ b/test/powershell/engine/Module/ModulePath.Tests.ps1
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+
 Describe "SxS Module Path Basic Tests" -tags "CI" {
 
     BeforeAll {
@@ -7,11 +8,7 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
         if ($IsWindows)
         {
             $powershell = "$PSHOME\pwsh.exe"
-            $ProductName = "WindowsPowerShell"
-            if ($IsCoreCLR -and ($PSHOME -notlike "*Windows\System32\WindowsPowerShell\v1.0"))
-            {
-                $ProductName =  "PowerShell"
-            }
+            $ProductName =  "PowerShell"
             $expectedUserPath = Join-Path -Path $HOME -ChildPath "Documents\$ProductName\Modules"
             $expectedSharedPath = Join-Path -Path $env:ProgramFiles -ChildPath "$ProductName\Modules"
         }
@@ -21,6 +18,7 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
             $expectedUserPath = [System.Management.Automation.Platform]::SelectProductNameForDirectory("USER_MODULES")
             $expectedSharedPath = [System.Management.Automation.Platform]::SelectProductNameForDirectory("SHARED_MODULES")
         }
+
         $expectedSystemPath = Join-Path -Path $PSHOME -ChildPath 'Modules'
 
         # Skip these tests in cases when there is no 'pwsh' executable (e.g. when framework dependent PS package is used)
@@ -34,11 +32,6 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
         ## Setup a fake PSHome
         $fakePSHome = Join-Path -Path $TestDrive -ChildPath 'FakePSHome'
         $fakePSHomeModuleDir = Join-Path -Path $fakePSHome -ChildPath 'Modules'
-        $fakePowerShell = Join-Path -Path $fakePSHome -ChildPath (Split-Path -Path $powershell -Leaf)
-        $fakePSDepsFile = Join-Path -Path $fakePSHome -ChildPath "pwsh.deps.json"
-
-        New-Item -Path $fakePSHome -ItemType Directory > $null
-        New-Item -Path $fakePSHomeModuleDir -ItemType Directory > $null
     }
 
     BeforeEach {
@@ -49,71 +42,26 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
         $env:PSModulePath = $originalModulePath
     }
 
-    It "validate sxs module path" -Skip:$skipNoPwsh {
+    It "All standard module paths present" -Skip:$skipNoPwsh {
 
         $env:PSModulePath = ""
-        $defaultModulePath = & $powershell -nopro -c '$env:PSModulePath'
 
-        $paths = $defaultModulePath -split [System.IO.Path]::PathSeparator
-
+        $expectedPaths = @($expectedUserPath, $expectedSharedPath, $expectedSystemPath)
         if ($IsWindows)
         {
-            $paths.Count | Should -Be 4
-        }
-        else
-        {
-            $paths.Count | Should -Be 3
+            $expectedPaths += $expectedWindowsPowerShellPSHomePath
         }
 
-        $paths[0].TrimEnd([System.IO.Path]::DirectorySeparatorChar) | Should -Be $expectedUserPath
-        $paths[1].TrimEnd([System.IO.Path]::DirectorySeparatorChar) | Should -Be $expectedSharedPath
-        $paths[2].TrimEnd([System.IO.Path]::DirectorySeparatorChar) | Should -Be $expectedSystemPath
-        if ($IsWindows)
-        {
-            $paths[3].TrimEnd([System.IO.Path]::DirectorySeparatorChar) | Should -Be $expectedWindowsPowerShellPSHomePath
-        }
-    }
-
-    It "ignore pshome module path derived from a different PowerShell instance" -Skip:(!$IsCoreCLR -or $skipNoPwsh) {
-
-        ## Create 'powershell' and 'pwsh.deps.json' in the fake PSHome folder,
-        ## so that the module path calculation logic would believe it's real.
-        New-Item -Path $fakePowerShell -ItemType File -Force > $null
-        New-Item -Path $fakePSDepsFile -ItemType File -Force > $null
-
+        [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("TestPowerShellPSModulePaths", $expectedPaths)
         try {
-
-            ## PSHome module path derived from another PowerShell instance should be ignored
-            $env:PSModulePath = $fakePSHomeModuleDir
-            $newModulePath = & $powershell -nopro -c '$env:PSModulePath'
-            $paths = $newModulePath -split [System.IO.Path]::PathSeparator
-
-            if ($IsWindows)
-            {
-                $paths.Count | Should -Be 4
-            }
-            else
-            {
-                $paths.Count | Should -Be 3
-            }
-
-            $paths[0] | Should -Be $expectedUserPath
-            $paths[1] | Should -Be $expectedSharedPath
-            $paths[2] | Should -Be $expectedSystemPath
-            if ($IsWindows)
-            {
-                $paths[3].TrimEnd([System.IO.Path]::DirectorySeparatorChar) | Should -Be $expectedWindowsPowerShellPSHomePath
-            }
-
+            { Get-Module -Listavailable -All }  | Should -Not -Throw
         } finally {
-
-            ## Remove 'powershell' and 'pwsh.deps.json' from the fake PSHome folder
-            Remove-Item -Path $fakePowerShell -Force -ErrorAction SilentlyContinue
-            Remove-Item -Path $fakePSDepsFile -Force -ErrorAction SilentlyContinue
+            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("TestPowerShellPSModulePaths", $null)
         }
+
     }
 
-    It "keep non-pshome module path derived from PowerShell instance parent" -Skip:(!$IsCoreCLR -or $skipNoPwsh) {
+    It "keep non-pshome module path derived from PowerShell instance parent" -Skip:$skipNoPwsh {
 
         ## non-pshome module path derived from another PowerShell instance should be preserved
         $customeModules = Join-Path -Path $TestDrive -ChildPath 'CustomModules'
@@ -121,45 +69,7 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
         $newModulePath = & $powershell -nopro -c '$env:PSModulePath'
         $paths = $newModulePath -split [System.IO.Path]::PathSeparator
 
-        if ($IsWindows)
-        {
-            $paths.Count | Should -Be 6
-        }
-        else
-        {
-            $paths.Count | Should -Be 5
-        }
         $paths -contains $fakePSHomeModuleDir | Should -BeTrue
         $paths -contains $customeModules | Should -BeTrue
-    }
-
-    It 'Ensures $PSHOME\Modules is inserted correctly when launched from a different version of PowerShell' -Skip:(!($IsCoreCLR -and $IsWindows) -or $skipNoPwsh) {
-        # When launched from a different version of PowerShell, PSModulePath contains the other version's PSHOME\Modules path
-        # and the Windows PowerShell module path. The other version's module path should be removed and this version's
-        # PSHOME\Modules path should be inserted before Windows PowerShell module path.
-        $winpwshModulePath = [System.IO.Path]::Combine([System.Environment]::SystemDirectory, "WindowsPowerShell", "v1.0", "Modules");
-        $pwshModulePath = Join-Path -Path $PSHOME -ChildPath 'Modules'
-
-        # create a fake 'other version' $PSHOME and $PSHOME\Modules
-        $fakeHome = Join-Path -Path $TestDrive -ChildPath 'fakepwsh'
-        $fakeModulePath = Join-Path -Path $fakeHome -ChildPath 'Modules'
-
-        $null = New-Item -Path $fakeHome -ItemType Directory
-        $null = New-Item -Path $fakeModulePath -ItemType Directory
-
-        # powershell looks for these to files to determine the directory is a pwsh directory.
-        Set-Content -Path "$fakeHome\pwsh.exe" -Value "fake pwsh.exe"
-        Set-Content -Path "$fakeHome\pwsh.deps.json" -Value 'fake pwsh.deps.json'
-
-        # replace the actual pwsh module path with the fake one.
-        $fakeModulePath = $env:PSModulePath.Replace($pwshModulePath, $fakeModulePath, [StringComparison]::OrdinalIgnoreCase)
-
-        $newModulePath = & $powershell -nopro -c '$env:PSModulePath'
-        $pwshIndex = $newModulePath.IndexOf($pwshModulePath, [StringComparison]::OrdinalIgnoreCase)
-        $wpshIndex = $newModulePath.IndexOf($winpwshModulePath, [StringComparison]::OrdinalIgnoreCase)
-        # ensure both module paths exist and the pwsh module path occurs before the Windows PowerShell module path
-        $pwshIndex | Should -Not -Be -1
-        $wpshIndex | Should -Not -Be -1
-        $pwshIndex | Should -BeLessThan $wpshIndex
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #9957
Fix #9921
Fix #7082
Fix #6850
Fix #10620

For reference #9845

The fix was approved by PowerShell Committee.
The fix is that now we do not change PSModulePath environment variable. Now we only read it and add to a module path cache. Also we add Powershell standard paths in the cache.

Because now we don't change PSModulePath environment variable we have no needs to manipulate strings and the module path cache is List\<string>.

There was discovered some bugs. I hope they is related only tests.
- We use `string.Contains()` but correct way is to use PathContainsSubstring()
https://github.com/PowerShell/PowerShell/blob/17fb524adb85566aa5cb6041db279905c2700e6d/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs#L1357-L1363
As result the system path was not added in tests because we added a module path like c:\tmp\root\modulename then we were tried to add c:\tmp\root (come from test hook) but string.Contains() returns true.

- We don't removed a root module in CompatiblePSEditions.Module.Tests.ps1 
https://github.com/PowerShell/PowerShell/blob/17fb524adb85566aa5cb6041db279905c2700e6d/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1#L735-L738
As result some tests below failed after the PR fix. I hope it is only test issue - please review in depth.

- Perhaps it is not bug but we need a conclusion. If we add a path to module in PSModulePath and then add a root path from the module path like c:\tmp\root\modulename and c:\tmp\root - Get-Module -Listavailable -All returns the module twice. (No regression - Windows PowerShell works the same way.)

The PR fix doesn't remove path to PSHome/Module if 7.0 starts from 6.0:
![image](https://user-images.githubusercontent.com/22290914/62530725-876ac680-b85a-11e9-8132-614542d8c9d7.png)
I think it makes no sense to remove the path because 6.0 will deprecated (EOL) soon.

## PR Context

See #9957

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
