### PR TITLE
Expose PreRelease label in PSModuleInfo formatter

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -355,7 +355,7 @@ namespace System.Management.Automation.Runspaces
                                 }
                                 elseif ($_.Duration.TotalMinutes -ge 1) {
                                     $formatString = ""m\:ss\.fff""
-                                } 
+                                }
                                 else {
                                     $formatString = ""s\.fff""
                                 }
@@ -1224,12 +1224,18 @@ namespace System.Management.Automation.Runspaces
                     .GroupByScriptBlock("Split-Path -Parent $_.Path | ForEach-Object { if([Version]::TryParse((Split-Path $_ -Leaf), [ref]$null)) { Split-Path -Parent $_} else {$_} } | Split-Path -Parent", customControl: sharedControls[0])
                     .AddHeader(Alignment.Left, width: 10)
                     .AddHeader(Alignment.Left, width: 10)
+                    .AddHeader(Alignment.Left, label: "PreRelease", width: 10)
                     .AddHeader(Alignment.Left, width: 35)
                     .AddHeader(Alignment.Left, width: 9, label: "PSEdition")
                     .AddHeader(Alignment.Left, label: "ExportedCommands")
                     .StartRowDefinition()
                         .AddPropertyColumn("ModuleType")
                         .AddPropertyColumn("Version")
+                        .AddScriptBlockColumn(@"
+                            if ($_.PrivateData -and $_.PrivateData.PSData)
+                            {
+                                    $_.PrivateData.PSData.PreRelease
+                            }")
                         .AddPropertyColumn("Name")
                         .AddScriptBlockColumn(@"
                             $result = [System.Collections.ArrayList]::new()
@@ -1256,11 +1262,17 @@ namespace System.Management.Automation.Runspaces
                 TableControl.Create()
                     .AddHeader(Alignment.Left, width: 10)
                     .AddHeader(Alignment.Left, width: 10)
+                    .AddHeader(Alignment.Left, label: "PreRelease", width: 10)
                     .AddHeader(Alignment.Left, width: 35)
                     .AddHeader(Alignment.Left, label: "ExportedCommands")
                     .StartRowDefinition()
                         .AddPropertyColumn("ModuleType")
                         .AddPropertyColumn("Version")
+                        .AddScriptBlockColumn(@"
+                            if ($_.PrivateData -and $_.PrivateData.PSData)
+                            {
+                                    $_.PrivateData.PSData.PreRelease
+                            }")
                         .AddPropertyColumn("Name")
                         .AddScriptBlockColumn("$_.ExportedCommands.Keys")
                     .EndRowDefinition()
@@ -1279,6 +1291,11 @@ namespace System.Management.Automation.Runspaces
                         .AddItemProperty(@"Description")
                         .AddItemProperty(@"ModuleType")
                         .AddItemProperty(@"Version")
+                        .AddItemScriptBlock(@"
+                            if ($_.PrivateData -and $_.PrivateData.PSData)
+                            {
+                                    $_.PrivateData.PSData.PreRelease
+                            }", label: "PreRelease")
                         .AddItemProperty(@"NestedModules")
                         .AddItemScriptBlock(@"$_.ExportedFunctions.Keys", label: "ExportedFunctions")
                         .AddItemScriptBlock(@"$_.ExportedCmdlets.Keys", label: "ExportedCmdlets")

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1291,11 +1291,13 @@ namespace System.Management.Automation.Runspaces
                         .AddItemProperty(@"Description")
                         .AddItemProperty(@"ModuleType")
                         .AddItemProperty(@"Version")
-                        .AddItemScriptBlock(@"
+                        .AddItemScriptBlock(
+                            @"
                             if ($_.PrivateData -and $_.PrivateData.PSData)
                             {
                                     $_.PrivateData.PSData.PreRelease
-                            }", label: "PreRelease")
+                            }",
+                            label: "PreRelease")
                         .AddItemProperty(@"NestedModules")
                         .AddItemScriptBlock(@"$_.ExportedFunctions.Keys", label: "ExportedFunctions")
                         .AddItemScriptBlock(@"$_.ExportedCmdlets.Keys", label: "ExportedCmdlets")


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add `PreRelease` script property to PSModuleInfo table and list formatters to easily get PreRelease info.  Also update ModuleInfoGrouping formatter so `-ListAvailable` also shows it.

```powershell
PS> gmo psreadline

ModuleType Version    PreRelease Name                                ExportedCommands
---------- -------    ---------- ----                                ----------------
Script     2.0.0      beta4      PSReadLine                          {Get-PSReadLineKeyHandler, Get-PSReadLineOption, Remove-PSReadLineKeyHandler, Set-PSReadLineKeyHandler…}

[67.67ms] /Users/steve/repos/PowerShell [origin/module-info-psdata]
PS> gmo psreadline | fl

Name              : PSReadLine
Path              : /Users/steve/.local/share/powershell/Modules/PSReadLine/2.0.0/PSReadLine.psm1
Description       : Great command line editing in the PowerShell console host
ModuleType        : Script
Version           : 2.0.0
PreRelease        : beta4
NestedModules     : {Microsoft.PowerShell.PSReadLine2}
ExportedFunctions : PSConsoleHostReadLine
ExportedCmdlets   : {Get-PSReadLineKeyHandler, Get-PSReadLineOption, Remove-PSReadLineKeyHandler, Set-PSReadLineKeyHandler…}
ExportedVariables :
ExportedAliases   :
```

## PR Context

Got tired of asking people to run `(gmo psreadline).privatedata.psdata` to find out which version of 2.0.0 they have, so exposing this as part of formatting in PSModuleInfo.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
