### PR TITLE
Deprecate internal HelpCategory.Workflow enumeration

### DIFF
--- a/src/System.Management.Automation/help/AliasHelpInfo.cs
+++ b/src/System.Management.Automation/help/AliasHelpInfo.cs
@@ -27,7 +27,7 @@ namespace System.Management.Automation
             this.ForwardTarget = name;
             // A Cmdlet/Function/Script etc can have alias.
             this.ForwardHelpCategory = HelpCategory.Cmdlet |
-                HelpCategory.Function | HelpCategory.ExternalScript | HelpCategory.ScriptCommand | HelpCategory.Filter | HelpCategory.Workflow;
+                HelpCategory.Function | HelpCategory.ExternalScript | HelpCategory.ScriptCommand | HelpCategory.Filter;
 
             if (!string.IsNullOrEmpty(aliasInfo.Name))
             {

--- a/src/System.Management.Automation/help/CommandHelpProvider.cs
+++ b/src/System.Management.Automation/help/CommandHelpProvider.cs
@@ -1253,7 +1253,7 @@ namespace System.Management.Automation
         internal override IEnumerable<HelpInfo> ProcessForwardedHelp(HelpInfo helpInfo, HelpRequest helpRequest)
         {
             HelpCategory categoriesHandled = (HelpCategory.Alias
-                | HelpCategory.ExternalScript | HelpCategory.Filter | HelpCategory.Function | HelpCategory.ScriptCommand | HelpCategory.Workflow);
+                | HelpCategory.ExternalScript | HelpCategory.Filter | HelpCategory.Function | HelpCategory.ScriptCommand);
 
             if ((helpInfo.HelpCategory & categoriesHandled) != 0)
             {

--- a/src/System.Management.Automation/help/HelpCommands.cs
+++ b/src/System.Management.Automation/help/HelpCommands.cs
@@ -499,7 +499,7 @@ namespace Microsoft.PowerShell.Commands
             // categories that support -Parameter, -Role, -Functionality, -Component parameters
             HelpCategory supportedCategories =
                 HelpCategory.Alias | HelpCategory.Cmdlet | HelpCategory.ExternalScript |
-                HelpCategory.Filter | HelpCategory.Function | HelpCategory.ScriptCommand | HelpCategory.Workflow;
+                HelpCategory.Filter | HelpCategory.Function | HelpCategory.ScriptCommand;
 
             if ((cat & supportedCategories) == 0)
             {

--- a/src/System.Management.Automation/help/HelpRequest.cs
+++ b/src/System.Management.Automation/help/HelpRequest.cs
@@ -155,7 +155,7 @@ namespace System.Management.Automation
             if ((!(Component == null && Role == null && Functionality == null)) &&
                 (HelpCategory == HelpCategory.None))
             {
-                HelpCategory = HelpCategory.Alias | HelpCategory.Cmdlet | HelpCategory.Function | HelpCategory.Filter | HelpCategory.ExternalScript | HelpCategory.ScriptCommand | HelpCategory.Workflow;
+                HelpCategory = HelpCategory.Alias | HelpCategory.Cmdlet | HelpCategory.Function | HelpCategory.Filter | HelpCategory.ExternalScript | HelpCategory.ScriptCommand;
 
                 return;
             }

--- a/src/System.Management.Automation/help/HelpSystem.cs
+++ b/src/System.Management.Automation/help/HelpSystem.cs
@@ -909,11 +909,6 @@ namespace System.Management.Automation
         DefaultHelp = 0x1000,
 
         ///<summary>
-        /// Help for a Workflow.
-        /// </summary>
-        Workflow = 0x2000,
-
-        ///<summary>
         /// Help for a Configuration.
         /// </summary>
         Configuration = 0x4000,

--- a/src/System.Management.Automation/help/ScriptCommandHelpProvider.cs
+++ b/src/System.Management.Automation/help/ScriptCommandHelpProvider.cs
@@ -37,8 +37,7 @@ namespace System.Management.Automation
                     HelpCategory.Filter |
                     HelpCategory.Function |
                     HelpCategory.Configuration |
-                    HelpCategory.ScriptCommand |
-                    HelpCategory.Workflow;
+                    HelpCategory.ScriptCommand;
             }
         }
 


### PR DESCRIPTION
# PR Summary

Deprecate the internal `HelpCategory.Workflow` enumerated value. This value was only used internally, and this PR removes all references to it, as well as the value itself.

## PR Context

See issue #9570.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [X] N/A
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
