### PR TITLE
Deprecate workflow debugging code

### DIFF
--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -304,12 +304,12 @@ namespace System.Management.Automation
         Default = 0x1,
 
         /// <summary>
-        /// PowerShell script debugging including workflow script.
+        /// PowerShell script debugging.
         /// </summary>
         LocalScript = 0x2,
 
         /// <summary>
-        /// PowerShell remote script and workflow debugging.
+        /// PowerShell remote script debugging.
         /// </summary>
         RemoteScript = 0x4
     };
@@ -3333,18 +3333,6 @@ namespace System.Management.Automation
                         _lastActiveDebuggerAction = dbgCommand.ResumeAction.Value;
                         return new DebuggerCommandResults(dbgCommand.ResumeAction, true);
                     }
-
-                    // If active debugger is Workflow debugger then process command here (for "list" and "help").
-                    if (activeDebugger.GetType().FullName.Equals("Microsoft.PowerShell.Workflow.PSWorkflowDebugger", StringComparison.OrdinalIgnoreCase))
-                    {
-                        DebuggerCommand results = _commandProcessor.ProcessCommand(null, commandText, stopArgs.InvocationInfo, output);
-
-                        if ((results != null) &&
-                             results.ExecutedByDebugger)
-                        {
-                            return new DebuggerCommandResults(results.ResumeAction, true);
-                        }
-                    }
                 }
 
                 return activeDebugger.ProcessCommand(command, output);
@@ -3544,39 +3532,6 @@ namespace System.Management.Automation
                 if (nestedDebugger == null) { return; }
 
                 PSMonitorRunspaceType runspaceType = nestedDebugger.RunspaceType;
-
-                // If this is a workflow debugger then ensure that there is a current active
-                // debugger that is the associated job debugger for this inline script WF runspace.
-                if (runspaceType == PSMonitorRunspaceType.WorkflowInlineScript)
-                {
-                    bool needToPushAssociatedWFDebugger = true;
-                    if (_activeDebuggers.TryPeek(out activeDebugger))
-                    {
-                        needToPushAssociatedWFDebugger = (activeDebugger.InstanceId != nestedDebugger.ParentDebuggerId);
-                        if (needToPushAssociatedWFDebugger)
-                        {
-                            // Pop incorrect active debugger.
-                            PopActiveDebugger();
-                        }
-                    }
-
-                    if (needToPushAssociatedWFDebugger)
-                    {
-                        PSJobStartEventArgs wfJobArgs = null;
-                        lock (_syncObject)
-                        {
-                            _runningJobs.TryGetValue(nestedDebugger.ParentDebuggerId, out wfJobArgs);
-                        }
-
-                        if (wfJobArgs == null)
-                        {
-                            Diagnostics.Assert(false, "We should never get a WF job InlineScript debugger without an associated WF parent job.");
-                            return;
-                        }
-
-                        PushActiveDebugger(wfJobArgs.Debugger, _jobCallStackOffset);
-                    }
-                }
 
                 // Fix up invocation info script extents for embedded nested debuggers where the script source is
                 // from the parent.
@@ -4239,7 +4194,7 @@ namespace System.Management.Automation
         /// Attempts to fix up the debugger stop invocation information so that
         /// the correct stack and source can be displayed in the debugger, for
         /// cases where the debugged runspace is called inside a parent sccript,
-        /// such as with Workflow InlineScripts and script Invoke-Command cases.
+        /// such as with script Invoke-Command cases.
         /// </summary>
         /// <param name="debugStopInvocationInfo"></param>
         /// <returns>InvocationInfo.</returns>
@@ -4405,8 +4360,7 @@ namespace System.Management.Automation
 
     /// <summary>
     /// Wrapper class for runspace debugger where the runspace is being used in an
-    /// embedded scenario such as Workflow InlineScript or Invoke-Command command
-    /// inside script.
+    /// embedded scenario such as Invoke-Command command inside script.
     /// </summary>
     internal sealed class EmbeddedRunspaceDebugger : NestedRunspaceDebugger
     {
@@ -4515,7 +4469,7 @@ namespace System.Management.Automation
         /// Attempts to fix up the debugger stop invocation information so that
         /// the correct stack and source can be displayed in the debugger, for
         /// cases where the debugged runspace is called inside a parent sccript,
-        /// such as with Workflow InlineScripts and script Invoke-Command cases.
+        /// such as with script Invoke-Command cases.
         /// </summary>
         /// <param name="debugStopInvocationInfo">Invocation information from debugger stop.</param>
         /// <returns>InvocationInfo.</returns>
@@ -5360,65 +5314,6 @@ namespace System.Management.Automation.Internal
     [SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes", Justification = "Needed Internal use only")]
     public static class DebuggerUtils
     {
-        /// <summary>
-        /// Set-DebuggerVariable function.
-        /// </summary>
-        public const string SetVariableFunction = @"function Set-DebuggerVariable
-        {
-            [CmdletBinding()]
-            param(
-                [Parameter(Position=0)]
-                [HashTable]
-                $Variables
-            )
-
-            foreach($key in $Variables.Keys)
-            {
-                microsoft.powershell.utility\set-variable -Name $key -Value $Variables[$key] -Scope global
-            }
-
-            Set-StrictMode -Off
-        }";
-
-        /// <summary>
-        /// Remove-DebuggerVariable function.
-        /// </summary>
-        public const string RemoveVariableFunction = @"function Remove-DebuggerVariable
-        {
-            [CmdletBinding()]
-            param(
-                [Parameter(Position=0)]
-                [string[]]
-                $Name
-            )
-
-            foreach ($item in $Name)
-            {
-                microsoft.powershell.utility\remove-variable -name $item -scope global
-            }
-
-            Set-StrictMode -Off
-        }";
-
-        /// <summary>
-        /// Get-PSCallStack override function.
-        /// </summary>
-        public const string GetPSCallStackOverrideFunction = @"function Get-PSCallStack
-        {
-            [CmdletBinding()]
-            param()
-
-            if ($null -ne $PSWorkflowDebugger)
-            {
-                foreach ($frame in $PSWorkflowDebugger.GetCallStack())
-                {
-                    Write-Output $frame
-                }
-            }
-
-            Set-StrictMode -Off
-        }";
-
         internal const string SetDebugModeFunctionName = "__Set-PSDebugMode";
         internal const string SetDebuggerActionFunctionName = "__Set-PSDebuggerAction";
         internal const string GetDebuggerStopArgsFunctionName = "__Get-PSDebuggerStopArgs";
@@ -5451,21 +5346,6 @@ namespace System.Management.Automation.Internal
             {
                 return !(s_noHistoryCommandNames.Contains(command, StringComparer.OrdinalIgnoreCase));
             }
-        }
-
-        /// <summary>
-        /// Helper method to return an enumeration of workflow debugger
-        /// functions.
-        /// </summary>
-        /// <returns></returns>
-        public static IEnumerable<string> GetWorkflowDebuggerFunctions()
-        {
-            return new Collection<string>()
-            {
-                SetVariableFunction,
-                RemoveVariableFunction,
-                GetPSCallStackOverrideFunction
-            };
         }
 
         /// <summary>
@@ -5526,11 +5406,6 @@ namespace System.Management.Automation.Internal
         /// Runspace from remote Invoke-Command script.
         /// </summary>
         InvokeCommand,
-
-        /// <summary>
-        /// Runspace from Workflow activity inline script.
-        /// </summary>
-        WorkflowInlineScript
     }
 
     /// <summary>

--- a/test/powershell/SDK/PSDebugging.Tests.ps1
+++ b/test/powershell/SDK/PSDebugging.Tests.ps1
@@ -187,7 +187,7 @@ Describe "Runspace Debugging API tests" -tag CI {
     Context "PSStandaloneMonitorRunspaceInfo tests" {
         BeforeAll {
             $runspace = [runspacefactory]::CreateRunspace()
-            $runspaceType = [PSMonitorRunspaceType]::WorkflowInlineScript
+            $runspaceType = [PSMonitorRunspaceType]::InvokeCommand
             $monitorInfo = [PSStandaloneMonitorRunspaceInfo]::new($runspace)
             $instanceId = $runspace.InstanceId
             $parentDebuggerId = [guid]::newguid()


### PR DESCRIPTION
# PR Summary

This PR removes deprecated workflow debugging logic from PowerShell.

## PR Context

See issue #9570.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [X] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
