### PR TITLE
Add working directory parameter to `Start-Job`

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -201,7 +201,7 @@ namespace Microsoft.PowerShell
                 if (s_cpp.ServerMode)
                 {
                     ProfileOptimization.StartProfile("StartupProfileData-ServerMode");
-                    System.Management.Automation.Remoting.Server.OutOfProcessMediator.Run(s_cpp.InitialCommand);
+                    System.Management.Automation.Remoting.Server.OutOfProcessMediator.Run(s_cpp.InitialCommand, s_cpp.WorkingDirectory);
                     exitCode = 0;
                 }
                 else if (s_cpp.NamedPipeServerMode)

--- a/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
@@ -47,7 +47,7 @@ namespace System.Management.Automation.Runspaces
         /// <param name="initializationScript"></param>
         /// <param name="useWow64"></param>
         /// <param name="workingDirectory"></param>
-        public PowerShellProcessInstance(Version powerShellVersion, PSCredential credential, ScriptBlock initializationScript, bool useWow64, string workingDirectory)
+        public PowerShellProcessInstance(Version powerShellVersion, PSCredential credential, ScriptBlock initializationScript, bool useWow64, string workingDirectory = null)
         {
             string processArguments = " -s -NoLogo -NoProfile";
 

--- a/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
@@ -46,9 +46,16 @@ namespace System.Management.Automation.Runspaces
         /// <param name="credential"></param>
         /// <param name="initializationScript"></param>
         /// <param name="useWow64"></param>
-        public PowerShellProcessInstance(Version powerShellVersion, PSCredential credential, ScriptBlock initializationScript, bool useWow64)
+        /// <param name="workingDirectory"></param>
+        public PowerShellProcessInstance(Version powerShellVersion, PSCredential credential, ScriptBlock initializationScript, bool useWow64, string workingDirectory)
         {
             string processArguments = " -s -NoLogo -NoProfile";
+
+            if (workingDirectory != null)
+            {
+                processArguments = string.Format(CultureInfo.InvariantCulture,
+                    "{0} -wd {1}", processArguments, workingDirectory);
+            }
 
             if (initializationScript != null)
             {
@@ -92,7 +99,7 @@ namespace System.Management.Automation.Runspaces
 
         /// <summary>
         /// </summary>
-        public PowerShellProcessInstance() : this(null, null, null, false)
+        public PowerShellProcessInstance() : this(null, null, null, false, null)
         {
         }
 

--- a/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
@@ -41,6 +41,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="PowerShellProcessInstance"/> class. Initializes the underlying dotnet process class. 
         /// </summary>
         /// <param name="powerShellVersion"></param>
         /// <param name="credential"></param>
@@ -51,7 +52,7 @@ namespace System.Management.Automation.Runspaces
         {
             string processArguments = " -s -NoLogo -NoProfile";
 
-            if (workingDirectory != null)
+            if (!string.IsNullOrWhiteSpace(workingDirectory))
             {
                 processArguments = string.Format(CultureInfo.InvariantCulture,
                     "{0} -wd {1}", processArguments, workingDirectory);

--- a/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
@@ -99,6 +99,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="PowerShellProcessInstance"/> class. Initializes the underlying dotnet process class. 
         /// </summary>
         /// <param name="powerShellVersion"></param>
         /// <param name="credential"></param>
@@ -109,6 +110,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="PowerShellProcessInstance"/> class. Deafault initializes the underlying dotnet process class
         /// </summary>
         public PowerShellProcessInstance() : this(null, null, null, false, null)
         {

--- a/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
@@ -47,7 +47,7 @@ namespace System.Management.Automation.Runspaces
         /// <param name="initializationScript"></param>
         /// <param name="useWow64"></param>
         /// <param name="workingDirectory"></param>
-        public PowerShellProcessInstance(Version powerShellVersion, PSCredential credential, ScriptBlock initializationScript, bool useWow64, string workingDirectory = null)
+        public PowerShellProcessInstance(Version powerShellVersion, PSCredential credential, ScriptBlock initializationScript, bool useWow64, string workingDirectory)
         {
             string processArguments = " -s -NoLogo -NoProfile";
 
@@ -95,6 +95,16 @@ namespace System.Management.Automation.Runspaces
             }
 
             Process = new Process { StartInfo = _startInfo, EnableRaisingEvents = true };
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="powerShellVersion"></param>
+        /// <param name="credential"></param>
+        /// <param name="initializationScript"></param>
+        /// <param name="useWow64"></param>
+        public PowerShellProcessInstance(Version powerShellVersion, PSCredential credential, ScriptBlock initializationScript, bool useWow64) : this(powerShellVersion, credential, initializationScript, useWow64, null)
+        {
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
@@ -105,14 +105,14 @@ namespace System.Management.Automation.Runspaces
         /// <param name="credential"></param>
         /// <param name="initializationScript"></param>
         /// <param name="useWow64"></param>
-        public PowerShellProcessInstance(Version powerShellVersion, PSCredential credential, ScriptBlock initializationScript, bool useWow64) : this(powerShellVersion, credential, initializationScript, useWow64, null)
+        public PowerShellProcessInstance(Version powerShellVersion, PSCredential credential, ScriptBlock initializationScript, bool useWow64) : this(powerShellVersion, credential, initializationScript, useWow64, workingDirectory: null)
         {
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PowerShellProcessInstance"/> class. Default initializes the underlying dotnet process class
         /// </summary>
-        public PowerShellProcessInstance() : this(null, null, null, false, null)
+        public PowerShellProcessInstance() : this(powerShellVersion: null, credential: null, initializationScript: null, useWow64: false, workingDirectory: null)
         {
         }
 

--- a/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
@@ -110,7 +110,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PowerShellProcessInstance"/> class. Deafault initializes the underlying dotnet process class
+        /// Initializes a new instance of the <see cref="PowerShellProcessInstance"/> class. Default initializes the underlying dotnet process class
         /// </summary>
         public PowerShellProcessInstance() : this(null, null, null, false, null)
         {

--- a/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
@@ -43,19 +43,22 @@ namespace System.Management.Automation.Runspaces
         /// <summary>
         /// Initializes a new instance of the <see cref="PowerShellProcessInstance"/> class. Initializes the underlying dotnet process class. 
         /// </summary>
-        /// <param name="powerShellVersion"></param>
-        /// <param name="credential"></param>
-        /// <param name="initializationScript"></param>
-        /// <param name="useWow64"></param>
-        /// <param name="workingDirectory"></param>
+        /// <param name="powerShellVersion">Specifies the version of powershell.</param>
+        /// <param name="credential">Specifies a user account credentials.</param>
+        /// <param name="initializationScript">Specifies a script that will be executed when the powershell process is initialized.</param>
+        /// <param name="useWow64">Specifies if the powershell process will be 32-bit.</param>
+        /// <param name="workingDirectory">Specifies the initial working directory for the new powershell process.</param>
         public PowerShellProcessInstance(Version powerShellVersion, PSCredential credential, ScriptBlock initializationScript, bool useWow64, string workingDirectory)
         {
             string processArguments = " -s -NoLogo -NoProfile";
 
             if (!string.IsNullOrWhiteSpace(workingDirectory))
             {
-                processArguments = string.Format(CultureInfo.InvariantCulture,
-                    "{0} -wd {1}", processArguments, workingDirectory);
+                processArguments = string.Format(
+                    CultureInfo.InvariantCulture,
+                    "{0} -wd {1}",
+                    processArguments,
+                    workingDirectory);
             }
 
             if (initializationScript != null)
@@ -65,8 +68,11 @@ namespace System.Management.Automation.Runspaces
                 {
                     string encodedCommand =
                         Convert.ToBase64String(Encoding.Unicode.GetBytes(scripBlockAsString));
-                    processArguments = string.Format(CultureInfo.InvariantCulture,
-                        "{0} -EncodedCommand {1}", processArguments, encodedCommand);
+                    processArguments = string.Format(
+                        CultureInfo.InvariantCulture,
+                        "{0} -EncodedCommand {1}",
+                        processArguments,
+                        encodedCommand);
                 }
             }
 
@@ -110,7 +116,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PowerShellProcessInstance"/> class. Default initializes the underlying dotnet process class
+        /// Initializes a new instance of the <see cref="PowerShellProcessInstance"/> class. Default initializes the underlying dotnet process class.
         /// </summary>
         public PowerShellProcessInstance() : this(powerShellVersion: null, credential: null, initializationScript: null, useWow64: false, workingDirectory: null)
         {

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -1515,6 +1515,11 @@ namespace System.Management.Automation.Runspaces
         public bool RunAs32 { get; set; }
 
         /// <summary>
+        /// Gets or sets an initial working directory for the powershell background process.
+        /// </summary>
+        public string WorkingDirectory { get; set; }
+
+        /// <summary>
         /// Powershell version to execute the job in.
         /// </summary>
         public Version PSVersion { get; set; }
@@ -1590,6 +1595,7 @@ namespace System.Management.Automation.Runspaces
             NewProcessConnectionInfo result = new NewProcessConnectionInfo(_credential);
             result.AuthenticationMechanism = this.AuthenticationMechanism;
             result.InitializationScript = this.InitializationScript;
+            result.WorkingDirectory = this.WorkingDirectory;
             result.RunAs32 = this.RunAs32;
             result.PSVersion = this.PSVersion;
             result.Process = Process;

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -1003,7 +1003,8 @@ namespace System.Management.Automation.Remoting.Client
                 _processInstance = _connectionInfo.Process ?? new PowerShellProcessInstance(_connectionInfo.PSVersion,
                                                                                            _connectionInfo.Credential,
                                                                                            _connectionInfo.InitializationScript,
-                                                                                           _connectionInfo.RunAs32);
+                                                                                           _connectionInfo.RunAs32,
+                                                                                           _connectionInfo.WorkingDirectory);
                 if (_connectionInfo.Process != null)
                 {
                     _processCreated = false;

--- a/src/System.Management.Automation/engine/remoting/server/OutOfProcServerMediator.cs
+++ b/src/System.Management.Automation/engine/remoting/server/OutOfProcServerMediator.cs
@@ -301,7 +301,7 @@ namespace System.Management.Automation.Remoting.Server
 
         #region Methods
 
-        protected OutOfProcessServerSessionTransportManager CreateSessionTransportManager(string configurationName, PSRemotingCryptoHelperServer cryptoHelper, string initialLocation)
+        protected OutOfProcessServerSessionTransportManager CreateSessionTransportManager(string configurationName, PSRemotingCryptoHelperServer cryptoHelper, string workingDirectory)
         {
             PSSenderInfo senderInfo;
 #if !UNIX
@@ -318,16 +318,16 @@ namespace System.Management.Automation.Remoting.Server
             OutOfProcessServerSessionTransportManager tm = new OutOfProcessServerSessionTransportManager(originalStdOut, originalStdErr, cryptoHelper);
 
             ServerRemoteSession srvrRemoteSession = ServerRemoteSession.CreateServerRemoteSession(senderInfo,
-                _initialCommand, tm, configurationName, initialLocation);
+                _initialCommand, tm, configurationName, workingDirectory);
 
             return tm;
         }
 
-        protected void Start(string initialCommand, PSRemotingCryptoHelperServer cryptoHelper, string initialLocation = null, string configurationName = null)
+        protected void Start(string initialCommand, PSRemotingCryptoHelperServer cryptoHelper, string workingDirectory = null, string configurationName = null)
         {
             _initialCommand = initialCommand;
 
-            sessionTM = CreateSessionTransportManager(configurationName, cryptoHelper, initialLocation);
+            sessionTM = CreateSessionTransportManager(configurationName, cryptoHelper, workingDirectory);
 
             try
             {
@@ -338,7 +338,7 @@ namespace System.Management.Automation.Remoting.Server
                     {
                         if (sessionTM == null)
                         {
-                            sessionTM = CreateSessionTransportManager(configurationName, cryptoHelper, initialLocation);
+                            sessionTM = CreateSessionTransportManager(configurationName, cryptoHelper, workingDirectory);
                         }
                     }
 

--- a/src/System.Management.Automation/engine/remoting/server/OutOfProcServerMediator.cs
+++ b/src/System.Management.Automation/engine/remoting/server/OutOfProcServerMediator.cs
@@ -301,7 +301,7 @@ namespace System.Management.Automation.Remoting.Server
 
         #region Methods
 
-        protected OutOfProcessServerSessionTransportManager CreateSessionTransportManager(string configurationName, PSRemotingCryptoHelperServer cryptoHelper)
+        protected OutOfProcessServerSessionTransportManager CreateSessionTransportManager(string configurationName, PSRemotingCryptoHelperServer cryptoHelper, string initialLocation)
         {
             PSSenderInfo senderInfo;
 #if !UNIX
@@ -318,16 +318,16 @@ namespace System.Management.Automation.Remoting.Server
             OutOfProcessServerSessionTransportManager tm = new OutOfProcessServerSessionTransportManager(originalStdOut, originalStdErr, cryptoHelper);
 
             ServerRemoteSession srvrRemoteSession = ServerRemoteSession.CreateServerRemoteSession(senderInfo,
-                _initialCommand, tm, configurationName);
+                _initialCommand, tm, configurationName, initialLocation);
 
             return tm;
         }
 
-        protected void Start(string initialCommand, PSRemotingCryptoHelperServer cryptoHelper, string configurationName = null)
+        protected void Start(string initialCommand, PSRemotingCryptoHelperServer cryptoHelper, string initialLocation = null, string configurationName = null)
         {
             _initialCommand = initialCommand;
 
-            sessionTM = CreateSessionTransportManager(configurationName, cryptoHelper);
+            sessionTM = CreateSessionTransportManager(configurationName, cryptoHelper, initialLocation);
 
             try
             {
@@ -338,7 +338,7 @@ namespace System.Management.Automation.Remoting.Server
                     {
                         if (sessionTM == null)
                         {
-                            sessionTM = CreateSessionTransportManager(configurationName, cryptoHelper);
+                            sessionTM = CreateSessionTransportManager(configurationName, cryptoHelper, initialLocation);
                         }
                     }
 
@@ -469,7 +469,7 @@ namespace System.Management.Automation.Remoting.Server
 
         /// <summary>
         /// </summary>
-        internal static void Run(string initialCommand)
+        internal static void Run(string initialCommand, string workingDirectory)
         {
             lock (SyncObject)
             {
@@ -486,7 +486,7 @@ namespace System.Management.Automation.Remoting.Server
             // Setup unhandled exception to log events
             AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(AppDomainUnhandledException);
 #endif
-            s_singletonInstance.Start(initialCommand, new PSRemotingCryptoHelperServer());
+            s_singletonInstance.Start(initialCommand, new PSRemotingCryptoHelperServer(), workingDirectory);
         }
 
         #endregion

--- a/src/System.Management.Automation/engine/remoting/server/OutOfProcServerMediator.cs
+++ b/src/System.Management.Automation/engine/remoting/server/OutOfProcServerMediator.cs
@@ -325,7 +325,7 @@ namespace System.Management.Automation.Remoting.Server
 
             OutOfProcessServerSessionTransportManager tm = new OutOfProcessServerSessionTransportManager(originalStdOut, originalStdErr, cryptoHelper);
 
-            ServerRemoteSession srvrRemoteSession = ServerRemoteSession.CreateServerRemoteSession(
+            ServerRemoteSession _ = ServerRemoteSession.CreateServerRemoteSession(
                 senderInfo,
                 _initialCommand,
                 tm,

--- a/src/System.Management.Automation/engine/remoting/server/OutOfProcServerMediator.cs
+++ b/src/System.Management.Automation/engine/remoting/server/OutOfProcServerMediator.cs
@@ -87,7 +87,9 @@ namespace System.Management.Automation.Remoting.Server
             catch (Exception e)
             {
                 PSEtwLog.LogOperationalError(
-                    PSEventId.TransportError, PSOpcode.Open, PSTask.None,
+                    PSEventId.TransportError,
+                    PSOpcode.Open,
+                    PSTask.None,
                     PSKeyword.UseAlwaysOperational,
                     Guid.Empty.ToString(),
                     Guid.Empty.ToString(),
@@ -96,7 +98,9 @@ namespace System.Management.Automation.Remoting.Server
                     e.StackTrace);
 
                 PSEtwLog.LogAnalyticError(
-                    PSEventId.TransportError_Analytic, PSOpcode.Open, PSTask.None,
+                    PSEventId.TransportError_Analytic,
+                    PSOpcode.Open,
+                    PSTask.None,
                     PSKeyword.Transport | PSKeyword.UseAlwaysAnalytic,
                     Guid.Empty.ToString(),
                     Guid.Empty.ToString(),
@@ -158,7 +162,9 @@ namespace System.Management.Automation.Remoting.Server
 
         protected void OnDataAckPacketReceived(Guid psGuid)
         {
-            throw new PSRemotingTransportException(PSRemotingErrorId.IPCUnknownElementReceived, RemotingErrorIdStrings.IPCUnknownElementReceived,
+            throw new PSRemotingTransportException(
+                PSRemotingErrorId.IPCUnknownElementReceived,
+                RemotingErrorIdStrings.IPCUnknownElementReceived,
                 OutOfProcessUtils.PS_OUT_OF_PROC_DATA_ACK_TAG);
         }
 
@@ -306,19 +312,25 @@ namespace System.Management.Automation.Remoting.Server
             PSSenderInfo senderInfo;
 #if !UNIX
             WindowsIdentity currentIdentity = WindowsIdentity.GetCurrent();
-            PSPrincipal userPrincipal = new PSPrincipal(new PSIdentity(string.Empty, true, currentIdentity.Name, null),
+            PSPrincipal userPrincipal = new PSPrincipal(
+                new PSIdentity(string.Empty, true, currentIdentity.Name, null),
                 currentIdentity);
             senderInfo = new PSSenderInfo(userPrincipal, "http://localhost");
 #else
-            PSPrincipal userPrincipal = new PSPrincipal(new PSIdentity(string.Empty, true, string.Empty, null),
+            PSPrincipal userPrincipal = new PSPrincipal(
+                new PSIdentity(string.Empty, true, string.Empty, null),
                 null);
             senderInfo = new PSSenderInfo(userPrincipal, "http://localhost");
 #endif
 
             OutOfProcessServerSessionTransportManager tm = new OutOfProcessServerSessionTransportManager(originalStdOut, originalStdErr, cryptoHelper);
 
-            ServerRemoteSession srvrRemoteSession = ServerRemoteSession.CreateServerRemoteSession(senderInfo,
-                _initialCommand, tm, configurationName, workingDirectory);
+            ServerRemoteSession srvrRemoteSession = ServerRemoteSession.CreateServerRemoteSession(
+                senderInfo,
+                _initialCommand,
+                tm,
+                configurationName,
+                workingDirectory);
 
             return tm;
         }
@@ -352,8 +364,10 @@ namespace System.Management.Automation.Remoting.Server
                             sessionTM = null;
                         }
 
-                        throw new PSRemotingTransportException(PSRemotingErrorId.IPCUnknownElementReceived,
-                            RemotingErrorIdStrings.IPCUnknownElementReceived, string.Empty);
+                        throw new PSRemotingTransportException(
+                            PSRemotingErrorId.IPCUnknownElementReceived,
+                            RemotingErrorIdStrings.IPCUnknownElementReceived,
+                            string.Empty);
                     }
 
                     // process data in a thread pool thread..this way Runspace, Command
@@ -366,7 +380,8 @@ namespace System.Management.Automation.Remoting.Server
 #else
                     ThreadPool.QueueUserWorkItem(new WaitCallback(ProcessingThreadStart), data);
 #endif
-                } while (true);
+                }
+                while (true);
             }
             catch (Exception e)
             {
@@ -468,7 +483,10 @@ namespace System.Management.Automation.Remoting.Server
         #region Static Methods
 
         /// <summary>
+        /// Starts the out-of-process powershell server instance.  
         /// </summary>
+        /// <param name="initialCommand">Specifies the initialization script.</param>
+        /// <param name="workingDirectory">Specifies the initial working directory. The working directory is set before the initial command.</param>
         internal static void Run(string initialCommand, string workingDirectory)
         {
             lock (SyncObject)

--- a/src/System.Management.Automation/engine/remoting/server/OutOfProcServerMediator.cs
+++ b/src/System.Management.Automation/engine/remoting/server/OutOfProcServerMediator.cs
@@ -325,7 +325,7 @@ namespace System.Management.Automation.Remoting.Server
 
             OutOfProcessServerSessionTransportManager tm = new OutOfProcessServerSessionTransportManager(originalStdOut, originalStdErr, cryptoHelper);
 
-            ServerRemoteSession _ = ServerRemoteSession.CreateServerRemoteSession(
+            ServerRemoteSession.CreateServerRemoteSession(
                 senderInfo,
                 _initialCommand,
                 tm,

--- a/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Management.Automation.Host;
 using System.Management.Automation.Internal;
@@ -656,14 +657,21 @@ namespace System.Management.Automation
             // on Remoting in PowerShell engine
             try
             {
-                string initialLocation = string.IsNullOrWhiteSpace(_initialLocation) ? Platform.GetFolderPath(Environment.SpecialFolder.MyDocuments) : _initialLocation;
-                args.Runspace.ExecutionContext.EngineSessionState.SetLocation(initialLocation);
+                string personalfolder = Platform.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+                args.Runspace.ExecutionContext.EngineSessionState.SetLocation(personalfolder);
             }
             catch (Exception)
             {
                 // SetLocation API can call 3rd party code and so there is no telling what exception may be thrown.
                 // Setting location is not critical and is expected not to work with some account types, so we want
                 // to ignore all but critical errors.
+            }
+            
+            if (!string.IsNullOrWhiteSpace(_initialLocation))
+            {
+                var setLocationCommand = new Command("Set-Location");
+                setLocationCommand.Parameters.Add(new CommandParameter("LiteralPath", _initialLocation));
+                InvokeScript(setLocationCommand, args);
             }
     
             // Run startup scripts

--- a/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
@@ -99,51 +99,6 @@ namespace System.Management.Automation
 
         #region Constructors
 
-<<<<<<< HEAD
-=======
-#if CORECLR // No ApartmentState In CoreCLR
-        /// <summary>
-        /// Creates the runspace pool driver.
-        /// </summary>
-        /// <param name="clientRunspacePoolId">Client runspace pool id to associate.</param>
-        /// <param name="transportManager">transport manager associated with this
-        /// runspace pool driver</param>
-        /// <param name="maxRunspaces">Maximum runspaces to open.</param>
-        /// <param name="minRunspaces">Minimum runspaces to open.</param>
-        /// <param name="threadOptions">Threading options for the runspaces in the pool.</param>
-        /// <param name="hostInfo">Host information about client side host.</param>
-        /// <param name="configData">
-        /// Contains:
-        /// 1. Script to run after a RunspacePool/Runspace is created in this session.
-        /// For RunspacePool case, every newly created Runspace (in the pool) will run
-        /// this script.
-        /// 2. ThreadOptions for RunspacePool/Runspace
-        /// 3. ThreadApartment for RunspacePool/Runspace
-        /// </param>
-        /// <param name="initialSessionState">Configuration of the runspace.</param>
-        /// <param name="applicationPrivateData">Application private data.</param>
-        /// <param name="isAdministrator">True if the driver is being created by an administrator.</param>
-        /// <param name="serverCapability">Server capability reported to the client during negotiation (not the actual capability).</param>
-        /// <param name="psClientVersion">Client PowerShell version.</param>
-        /// <param name="configurationName">Optional endpoint configuration name to create a pushed configured runspace.</param>
-        /// <param name="initialLocation">Optional initial location of the powershell.</param>
-        internal ServerRunspacePoolDriver(
-            Guid clientRunspacePoolId,
-            int minRunspaces,
-            int maxRunspaces,
-            PSThreadOptions threadOptions,
-            HostInfo hostInfo,
-            InitialSessionState initialSessionState,
-            PSPrimitiveDictionary applicationPrivateData,
-            ConfigurationDataFromXML configData,
-            AbstractServerSessionTransportManager transportManager,
-            bool isAdministrator,
-            RemoteSessionCapability serverCapability,
-            Version psClientVersion,
-            string configurationName,
-            string initialLocation)
-#else
->>>>>>> starting working directory for powershell running in server mode
         /// <summary>
         /// Creates the runspace pool driver.
         /// </summary>

--- a/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
@@ -86,6 +86,9 @@ namespace System.Management.Automation
         // Results in a configured remote runspace pushed onto driver host.
         private string _configurationName;
 
+        // Optional initial location of the PowerShell session
+        private string _initialLocation;
+
         /// <summary>
         /// Event that get raised when the RunspacePool is closed.
         /// </summary>
@@ -95,6 +98,51 @@ namespace System.Management.Automation
 
         #region Constructors
 
+<<<<<<< HEAD
+=======
+#if CORECLR // No ApartmentState In CoreCLR
+        /// <summary>
+        /// Creates the runspace pool driver.
+        /// </summary>
+        /// <param name="clientRunspacePoolId">Client runspace pool id to associate.</param>
+        /// <param name="transportManager">transport manager associated with this
+        /// runspace pool driver</param>
+        /// <param name="maxRunspaces">Maximum runspaces to open.</param>
+        /// <param name="minRunspaces">Minimum runspaces to open.</param>
+        /// <param name="threadOptions">Threading options for the runspaces in the pool.</param>
+        /// <param name="hostInfo">Host information about client side host.</param>
+        /// <param name="configData">
+        /// Contains:
+        /// 1. Script to run after a RunspacePool/Runspace is created in this session.
+        /// For RunspacePool case, every newly created Runspace (in the pool) will run
+        /// this script.
+        /// 2. ThreadOptions for RunspacePool/Runspace
+        /// 3. ThreadApartment for RunspacePool/Runspace
+        /// </param>
+        /// <param name="initialSessionState">Configuration of the runspace.</param>
+        /// <param name="applicationPrivateData">Application private data.</param>
+        /// <param name="isAdministrator">True if the driver is being created by an administrator.</param>
+        /// <param name="serverCapability">Server capability reported to the client during negotiation (not the actual capability).</param>
+        /// <param name="psClientVersion">Client PowerShell version.</param>
+        /// <param name="configurationName">Optional endpoint configuration name to create a pushed configured runspace.</param>
+        /// <param name="initialLocation">Optional initial location of the powershell.</param>
+        internal ServerRunspacePoolDriver(
+            Guid clientRunspacePoolId,
+            int minRunspaces,
+            int maxRunspaces,
+            PSThreadOptions threadOptions,
+            HostInfo hostInfo,
+            InitialSessionState initialSessionState,
+            PSPrimitiveDictionary applicationPrivateData,
+            ConfigurationDataFromXML configData,
+            AbstractServerSessionTransportManager transportManager,
+            bool isAdministrator,
+            RemoteSessionCapability serverCapability,
+            Version psClientVersion,
+            string configurationName,
+            string initialLocation)
+#else
+>>>>>>> starting working directory for powershell running in server mode
         /// <summary>
         /// Creates the runspace pool driver.
         /// </summary>
@@ -120,6 +168,7 @@ namespace System.Management.Automation
         /// <param name="serverCapability">Server capability reported to the client during negotiation (not the actual capability).</param>
         /// <param name="psClientVersion">Client PowerShell version.</param>
         /// <param name="configurationName">Optional endpoint configuration name to create a pushed configured runspace.</param>
+        /// <param name="initialLocation">Optional initial location of the powershell.</param>
         internal ServerRunspacePoolDriver(
             Guid clientRunspacePoolId,
             int minRunspaces,
@@ -134,7 +183,8 @@ namespace System.Management.Automation
             bool isAdministrator,
             RemoteSessionCapability serverCapability,
             Version psClientVersion,
-            string configurationName)
+            string configurationName,
+            string initialLocation)
         {
             Dbg.Assert(configData != null, "ConfigurationData cannot be null");
 
@@ -142,6 +192,7 @@ namespace System.Management.Automation
             _clientPSVersion = psClientVersion;
 
             _configurationName = configurationName;
+            _initialLocation = initialLocation;
 
             // Create a new server host and associate for host call
             // integration
@@ -605,8 +656,8 @@ namespace System.Management.Automation
             // on Remoting in PowerShell engine
             try
             {
-                string personalfolder = Platform.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-                args.Runspace.ExecutionContext.EngineSessionState.SetLocation(personalfolder);
+                string initialLocation = string.IsNullOrWhiteSpace(_initialLocation) ? Platform.GetFolderPath(Environment.SpecialFolder.MyDocuments) : _initialLocation;
+                args.Runspace.ExecutionContext.EngineSessionState.SetLocation(initialLocation);
             }
             catch (Exception)
             {
@@ -614,7 +665,7 @@ namespace System.Management.Automation
                 // Setting location is not critical and is expected not to work with some account types, so we want
                 // to ignore all but critical errors.
             }
-
+    
             // Run startup scripts
             InvokeStartupScripts(args);
 

--- a/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
@@ -152,8 +152,8 @@ namespace System.Management.Automation
 
             // Create a new server host and associate for host call
             // integration
-            _remoteHost = new ServerDriverRemoteHost(clientRunspacePoolId,
-                Guid.Empty, hostInfo, transportManager, null);
+            _remoteHost = new ServerDriverRemoteHost(
+                clientRunspacePoolId, Guid.Empty, hostInfo, transportManager, null);
 
             _configData = configData;
             _applicationPrivateData = applicationPrivateData;

--- a/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
@@ -88,7 +88,7 @@ namespace System.Management.Automation
         private string _configurationName;
 
         // Optional initial location of the PowerShell session
-        private string _initialLocation;
+        private readonly string _initialLocation;
 
         /// <summary>
         /// Event that get raised when the RunspacePool is closed.
@@ -621,14 +621,14 @@ namespace System.Management.Automation
                 // Setting location is not critical and is expected not to work with some account types, so we want
                 // to ignore all but critical errors.
             }
-            
+
             if (!string.IsNullOrWhiteSpace(_initialLocation))
             {
                 var setLocationCommand = new Command("Set-Location");
                 setLocationCommand.Parameters.Add(new CommandParameter("LiteralPath", _initialLocation));
                 InvokeScript(setLocationCommand, args);
             }
-    
+
             // Run startup scripts
             InvokeStartupScripts(args);
 

--- a/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
+++ b/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
@@ -88,6 +88,9 @@ namespace System.Management.Automation.Remoting
         // Specifies an optional endpoint configuration for out-of-proc session use.
         // Creates a pushed remote runspace session created with this configuration name.
         private string _configurationName;
+        
+        // Specifies an initial location of the powershell session.
+        private string _initialLocation;
 
         #region Events
         /// <summary>
@@ -176,6 +179,7 @@ namespace System.Management.Automation.Remoting
         /// </param>
         /// <param name="transportManager"></param>
         /// <param name="configurationName">Optional configuration endpoint name for OutOfProc sessions.</param>
+        /// <param name="initialLocation">Optional configuration initial location of the powershell session.</param>
         /// <returns></returns>
         /// <exception cref="InvalidOperationException">
         /// InitialSessionState provider with <paramref name="configurationProviderId"/> does
@@ -192,7 +196,8 @@ namespace System.Management.Automation.Remoting
             string configurationProviderId,
             string initializationParameters,
             AbstractServerSessionTransportManager transportManager,
-            string configurationName = null)
+            string configurationName = null,
+            string initialLocation = null)
         {
             Dbg.Assert((senderInfo != null) & (senderInfo.UserInfo != null),
                 "senderInfo and userInfo cannot be null.");
@@ -212,7 +217,8 @@ namespace System.Management.Automation.Remoting
                 initializationParameters,
                 transportManager)
             {
-                _configurationName = configurationName
+                _configurationName = configurationName,
+                _initialLocation = initialLocation
             };
 
             // start state machine.
@@ -229,14 +235,15 @@ namespace System.Management.Automation.Remoting
         /// <param name="initializationScriptForOutOfProcessRunspace"></param>
         /// <param name="transportManager"></param>
         /// <param name="configurationName"></param>
+        /// <param name="initialLocation"></param>
         /// <returns></returns>
         internal static ServerRemoteSession CreateServerRemoteSession(PSSenderInfo senderInfo,
             string initializationScriptForOutOfProcessRunspace,
             AbstractServerSessionTransportManager transportManager,
-            string configurationName)
+            string configurationName, string initialLocation)
         {
             ServerRemoteSession result = CreateServerRemoteSession(senderInfo,
-                "Microsoft.PowerShell", string.Empty, transportManager, configurationName);
+                "Microsoft.PowerShell", string.Empty, transportManager, configurationName, initialLocation);
             result._initScriptForOutOfProcRS = initializationScriptForOutOfProcessRunspace;
             return result;
         }
@@ -885,7 +892,8 @@ namespace System.Management.Automation.Remoting
                 isAdministrator,
                 Context.ServerCapability,
                 psClientVersion,
-                _configurationName);
+                _configurationName,
+                _initialLocation);
 
             // attach the necessary event handlers and start the driver.
             Interlocked.Exchange(ref _runspacePoolDriver, tmpDriver);

--- a/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
+++ b/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
@@ -199,7 +199,8 @@ namespace System.Management.Automation.Remoting
             string configurationName = null,
             string initialLocation = null)
         {
-            Dbg.Assert((senderInfo != null) & (senderInfo.UserInfo != null),
+            Dbg.Assert(
+                (senderInfo != null) & (senderInfo.UserInfo != null),
                 "senderInfo and userInfo cannot be null.");
 
             s_trace.WriteLine("Finding InitialSessionState provider for id : {0}", configurationProviderId);
@@ -212,7 +213,8 @@ namespace System.Management.Automation.Remoting
             string shellPrefix = System.Management.Automation.Remoting.Client.WSManNativeApi.ResourceURIPrefix;
             int index = configurationProviderId.IndexOf(shellPrefix, StringComparison.OrdinalIgnoreCase);
             senderInfo.ConfigurationName = (index == 0) ? configurationProviderId.Substring(shellPrefix.Length) : string.Empty;
-            ServerRemoteSession result = new ServerRemoteSession(senderInfo,
+            ServerRemoteSession result = new ServerRemoteSession(
+                senderInfo,
                 configurationProviderId,
                 initializationParameters,
                 transportManager)
@@ -237,13 +239,20 @@ namespace System.Management.Automation.Remoting
         /// <param name="configurationName"></param>
         /// <param name="initialLocation"></param>
         /// <returns></returns>
-        internal static ServerRemoteSession CreateServerRemoteSession(PSSenderInfo senderInfo,
+        internal static ServerRemoteSession CreateServerRemoteSession(
+            PSSenderInfo senderInfo,
             string initializationScriptForOutOfProcessRunspace,
             AbstractServerSessionTransportManager transportManager,
-            string configurationName, string initialLocation)
+            string configurationName,
+            string initialLocation)
         {
-            ServerRemoteSession result = CreateServerRemoteSession(senderInfo,
-                "Microsoft.PowerShell", string.Empty, transportManager, configurationName, initialLocation);
+            ServerRemoteSession result = CreateServerRemoteSession(
+                senderInfo,
+                "Microsoft.PowerShell",
+                string.Empty,
+                transportManager,
+                configurationName: configurationName,
+                initialLocation: initialLocation);
             result._initScriptForOutOfProcRS = initializationScriptForOutOfProcessRunspace;
             return result;
         }

--- a/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
+++ b/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
@@ -88,7 +88,7 @@ namespace System.Management.Automation.Remoting
         // Specifies an optional endpoint configuration for out-of-proc session use.
         // Creates a pushed remote runspace session created with this configuration name.
         private string _configurationName;
-        
+
         // Specifies an initial location of the powershell session.
         private string _initialLocation;
 
@@ -200,7 +200,7 @@ namespace System.Management.Automation.Remoting
             string initialLocation = null)
         {
             Dbg.Assert(
-                (senderInfo != null) & (senderInfo.UserInfo != null),
+                (senderInfo != null) && (senderInfo.UserInfo != null),
                 "senderInfo and userInfo cannot be null.");
 
             s_trace.WriteLine("Finding InitialSessionState provider for id : {0}", configurationProviderId);

--- a/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
+++ b/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
@@ -1301,6 +1301,9 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
     <value>Cannot find a scheduled job with type {0} and name {1}.</value>
     <comment>{0} is the job definition type and {1} is the job definition name.</comment>
   </data>
+  <data name="StartJobWorkingDirectoryNotFound" xml:space="preserve">
+    <value>Cannot find the directory {0}.</value>
+  </data>
   <data name="CannotFindSessionForConnect" xml:space="preserve">
     <value>Cannot connect to session {0}.  The session no longer exists on computer {1}.</value>
     <comment>{0} is the session name that cannot be found.

--- a/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
+++ b/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
@@ -1302,7 +1302,7 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
     <comment>{0} is the job definition type and {1} is the job definition name.</comment>
   </data>
   <data name="StartJobWorkingDirectoryNotFound" xml:space="preserve">
-    <value>Cannot find the directory {0}.</value>
+    <value>Cannot find the WorkingDirectory path {0}.</value>
   </data>
   <data name="CannotFindSessionForConnect" xml:space="preserve">
     <value>Cannot connect to session {0}.  The session no longer exists on computer {1}.</value>

--- a/test/powershell/engine/Job/Jobs.Tests.ps1
+++ b/test/powershell/engine/Job/Jobs.Tests.ps1
@@ -79,7 +79,6 @@ Describe 'Basic Job Tests' -Tags 'CI' {
 
         It 'Throws an error message if the working directory parameter points to an invalid path' {
             $invalidPaths = @(""," ", "this is an invalid path")
-
             foreach ($tempPath in $invalidPaths)
             {
                 {Start-Job -ScriptBlock { 1 + 1 } -WorkingDirectory $tempPath} | Should -Throw

--- a/test/powershell/engine/Job/Jobs.Tests.ps1
+++ b/test/powershell/engine/Job/Jobs.Tests.ps1
@@ -69,6 +69,14 @@ Describe 'Basic Job Tests' -Tags 'CI' {
             $ProgressMsg[0].StatusDescription | Should -BeExactly 2
         }
 
+        It 'Can use the user specified working directory parameter' {
+            $tempPath = [System.IO.Path]::GetTempPath()
+            # In the script block we use join path to normalize the path string
+            $job = Start-Job -ScriptBlock { Join-Path $pwd "" } -WorkingDirectory $tempPath | Wait-Job
+            $jobOutput = Receive-Job $job
+            $jobOutput | Should -BeExactly $tempPath
+        }
+
         It "Create job with native command" {
             try {
                 $nativeJob = Start-job { pwsh -c 1+1 }

--- a/test/powershell/engine/Job/Jobs.Tests.ps1
+++ b/test/powershell/engine/Job/Jobs.Tests.ps1
@@ -77,6 +77,15 @@ Describe 'Basic Job Tests' -Tags 'CI' {
             $jobOutput | Should -BeExactly $tempPath
         }
 
+        It 'Throws an error message if the working directory parameter points to an invalid path' {
+            $invalidPaths = @(""," ", "this is an invalid path")
+
+            foreach ($tempPath in $invalidPaths)
+            {
+                {Start-Job -ScriptBlock { 1 + 1 } -WorkingDirectory $tempPath} | Should -Throw
+            }
+        }
+
         It "Create job with native command" {
             try {
                 $nativeJob = Start-job { pwsh -c 1+1 }

--- a/test/powershell/engine/Job/Jobs.Tests.ps1
+++ b/test/powershell/engine/Job/Jobs.Tests.ps1
@@ -84,10 +84,9 @@ Describe 'Basic Job Tests' -Tags 'CI' {
         }
 
         It 'Throws an error when the working directory parameter is <case>' -TestCases $invalidPathTestCases {
-            foreach ($tempPath in $invalidPaths)
-            {
-                {Start-Job -ScriptBlock { 1 + 1 } -WorkingDirectory $path} | Should -Throw
-            }
+            param($path,$case)
+
+            {Start-Job -ScriptBlock { 1 + 1 } -WorkingDirectory $path} | Should -Throw
         }
 
         It "Create job with native command" {

--- a/test/powershell/engine/Job/Jobs.Tests.ps1
+++ b/test/powershell/engine/Job/Jobs.Tests.ps1
@@ -28,9 +28,9 @@ Describe 'Basic Job Tests' -Tags 'CI' {
 
         BeforeAll {
             $invalidPathTestCases = @(
-                @{ path = "This is an invalid path"; case = "invalid path"}
-                @{ path = ""; case = "empty string"}
-                @{ path = " "; case = "whitespace string (single space)"}
+                @{ path = "This is an invalid path"; case = "invalid path"; errorId = "DirectoryNotFoundException,Microsoft.PowerShell.Commands.StartJobCommand"}
+                @{ path = ""; case = "empty string"; errorId = "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.StartJobCommand"}
+                @{ path = " "; case = "whitespace string (single space)"; errorId = "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.StartJobCommand"}
             )
         }
 
@@ -84,9 +84,9 @@ Describe 'Basic Job Tests' -Tags 'CI' {
         }
 
         It 'Throws an error when the working directory parameter is <case>' -TestCases $invalidPathTestCases {
-            param($path,$case)
+            param($path, $case, $expectedErrorId)
 
-            {Start-Job -ScriptBlock { 1 + 1 } -WorkingDirectory $path} | Should -Throw
+            {Start-Job -ScriptBlock { 1 + 1 } -WorkingDirectory $path} | Should -Throw -ErrorId $expectedErrorId
         }
 
         It "Create job with native command" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary and Changes

Solves the same problem as #10274 (for future reference you can read the discussion) with a different implementation

1. Enables the workingDirectory parameter when PowerShell runs in Server mode
2. Uses the workingDirectory PowerShell  parameter to implement `start-job` workingDirectory 

Awaiting your feedback and comments!

## PR Context

Fix #4287 
## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/4626
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
