### PR TITLE
Mark -parallel as reserved for foreach and switch, and -throttlelimit as reserved for foreach

### DIFF
--- a/src/System.Management.Automation/engine/parser/SemanticChecks.cs
+++ b/src/System.Management.Automation/engine/parser/SemanticChecks.cs
@@ -458,7 +458,8 @@ namespace System.Management.Automation.Language
             // Parallel flag not allowed
             if ((switchStatementAst.Flags & SwitchFlags.Parallel) == SwitchFlags.Parallel)
             {
-                _parser.ReportError(switchStatementAst.Extent,
+                _parser.ReportError(
+                    switchStatementAst.Extent,
                     nameof(ParserStrings.KeywordParameterReservedForFutureUse),
                     ParserStrings.KeywordParameterReservedForFutureUse,
                     "switch",
@@ -492,7 +493,8 @@ namespace System.Management.Automation.Language
             // Parallel flag not allowed
             if ((forEachStatementAst.Flags & ForEachFlags.Parallel) == ForEachFlags.Parallel)
             {
-                _parser.ReportError(forEachStatementAst.Extent,
+                _parser.ReportError(
+                    forEachStatementAst.Extent,
                     nameof(ParserStrings.KeywordParameterReservedForFutureUse),
                     ParserStrings.KeywordParameterReservedForFutureUse,
                     "foreach",
@@ -501,7 +503,8 @@ namespace System.Management.Automation.Language
 
             if (forEachStatementAst.ThrottleLimit != null)
             {
-                _parser.ReportError(forEachStatementAst.Extent,
+                _parser.ReportError(
+                    forEachStatementAst.Extent,
                     nameof(ParserStrings.KeywordParameterReservedForFutureUse),
                     ParserStrings.KeywordParameterReservedForFutureUse,
                     "foreach",
@@ -512,7 +515,8 @@ namespace System.Management.Automation.Language
             if ((forEachStatementAst.ThrottleLimit != null) &&
                 ((forEachStatementAst.Flags & ForEachFlags.Parallel) != ForEachFlags.Parallel))
             {
-                _parser.ReportError(forEachStatementAst.Extent,
+                _parser.ReportError(
+                    forEachStatementAst.Extent,
                     nameof(ParserStrings.ThrottleLimitRequiresParallelFlag),
                     ParserStrings.ThrottleLimitRequiresParallelFlag);
             }

--- a/src/System.Management.Automation/engine/parser/SemanticChecks.cs
+++ b/src/System.Management.Automation/engine/parser/SemanticChecks.cs
@@ -458,13 +458,11 @@ namespace System.Management.Automation.Language
             // Parallel flag not allowed
             if ((switchStatementAst.Flags & SwitchFlags.Parallel) == SwitchFlags.Parallel)
             {
-                bool reportError = !switchStatementAst.IsInWorkflow();
-                if (reportError)
-                {
-                    _parser.ReportError(switchStatementAst.Extent,
-                        nameof(ParserStrings.ParallelNotSupported),
-                        ParserStrings.ParallelNotSupported);
-                }
+                _parser.ReportError(switchStatementAst.Extent,
+                    nameof(ParserStrings.KeywordParameterReservedForFutureUse),
+                    ParserStrings.KeywordParameterReservedForFutureUse,
+                    "switch",
+                    "parallel");
             }
 
             return AstVisitAction.Continue;
@@ -494,13 +492,20 @@ namespace System.Management.Automation.Language
             // Parallel flag not allowed
             if ((forEachStatementAst.Flags & ForEachFlags.Parallel) == ForEachFlags.Parallel)
             {
-                bool reportError = !forEachStatementAst.IsInWorkflow();
-                if (reportError)
-                {
-                    _parser.ReportError(forEachStatementAst.Extent,
-                        nameof(ParserStrings.ParallelNotSupported),
-                        ParserStrings.ParallelNotSupported);
-                }
+                _parser.ReportError(forEachStatementAst.Extent,
+                    nameof(ParserStrings.KeywordParameterReservedForFutureUse),
+                    ParserStrings.KeywordParameterReservedForFutureUse,
+                    "foreach",
+                    "parallel");
+            }
+
+            if (forEachStatementAst.ThrottleLimit != null)
+            {
+                _parser.ReportError(forEachStatementAst.Extent,
+                    nameof(ParserStrings.KeywordParameterReservedForFutureUse),
+                    ParserStrings.KeywordParameterReservedForFutureUse,
+                    "foreach",
+                    "throttlelimit");
             }
 
             // Throttle limit must be combined with Parallel flag

--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -392,8 +392,8 @@ Possible matches are</value>
   <data name="IncompleteSwitchStatement" xml:space="preserve">
     <value>The switch statement was incomplete.</value>
   </data>
-  <data name="ParallelNotSupported" xml:space="preserve">
-    <value>The '-parallel' parameter can be used only within a workflow.</value>
+  <data name="KeywordParameterReservedForFutureUse" xml:space="preserve">
+    <value>The {0} '-{1}' parameter is reserved for future use.</value>
   </data>
   <data name="MissingFilenameOption" xml:space="preserve">
     <value>Cannot process the 'switch' statement because of a missing file name argument to the -file option.</value>

--- a/test/powershell/Language/Scripting/ForeachParallel.Tests.ps1
+++ b/test/powershell/Language/Scripting/ForeachParallel.Tests.ps1
@@ -1,44 +1,84 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-Describe "Parallel foreach syntax" -Tags "CI" {
+
+Describe 'Parallel foreach syntax' -Tags 'CI' {
 
     Context 'Should be able to retrieve AST of parallel foreach' {
-        $ast = [System.Management.Automation.Language.Parser]::ParseInput(
-            'foreach -parallel ($foo in $bar) {}', [ref] $null, [ref] $null)
-        It '$ast.EndBlock.Statements[0].Flags' { $ast.EndBlock.Statements[0].Flags | Should -BeExactly 'Parallel' }
+        BeforeAll {
+            $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+                'foreach -parallel ($foo in $bar) {}', [ref]$null, [ref]$null)
+        }
+
+        It '$ast.EndBlock.Statements[0].Flags' {
+            $ast.EndBlock.Statements[0].Flags | Should -BeExactly 'Parallel'
+        }
     }
 
     Context 'Supports newlines before and after' {
-        $errors = @()
-        $ast = [System.Management.Automation.Language.Parser]::ParseInput(
-            "foreach `n-parallel `n(`$foo in `$bar) {}", [ref] $null, [ref] $null)
-        It '$errors.Count' { $errors.Count | Should -Be 0 }
-        It '$ast.EndBlock.Statements[0].Flags' { $ast.EndBlock.Statements[0].Flags | Should -BeExactly 'Parallel' }
+        BeforeAll {
+            $errors = @()
+            $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+                "foreach `n-parallel `n(`$foo in `$bar) {}", [ref] $null, [ref] $null)
+        }
+
+        It '$errors.Count'
+            $errors.Count | Should -Be 0
+        }
+
+        It '$ast.EndBlock.Statements[0].Flags' {
+            $ast.EndBlock.Statements[0].Flags | Should -BeExactly 'Parallel'
+        }
     }
 
     Context 'Generates an error on invalid parameter' {
-        $errors = @()
-        $ast = [System.Management.Automation.Language.Parser]::ParseInput(
-            'foreach -bogus ($input in $bar) { }', [ref]$null, [ref]$errors)
-        It '$errors.Count' { $errors.Count | Should -Be 1 }
-        It '$errors[0].ErrorId' { $errors[0].ErrorId | Should -BeExactly 'InvalidForeachFlag' }
+        BeforeAll {
+            $errors = @()
+            $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+                'foreach -bogus ($input in $bar) { }', [ref]$null, [ref]$errors)
+        }
+
+        It '$errors.Count' {
+            $errors.Count | Should -Be 1
+        }
+
+        It '$errors[0].ErrorId' {
+            $errors[0].ErrorId | Should -BeExactly 'InvalidForeachFlag'
+        }
     }
 
     Context 'Generate an error on -parallel' {
-        $errors = @()
-        $ast = [System.Management.Automation.Language.Parser]::ParseInput(
-            'foreach -parallel ($input in $bar) { }', [ref]$null, [ref]$errors)
-        It '$errors.Count' { $errors.Count | Should -Be 1 }
-        It '$errors[0].ErrorId' { $errors[0].ErrorId | Should -Be 'KeywordParameterReservedForFutureUse' }
+        BeforeAll {
+            $errors = @()
+            $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+                'foreach -parallel ($input in $bar) { }', [ref]$null, [ref]$errors)
+        }
+
+        It '$errors.Count' {
+            $errors.Count | Should -Be 1
+        }
+
+        It '$errors[0].ErrorId' {
+            $errors[0].ErrorId | Should -Be 'KeywordParameterReservedForFutureUse'
+        }
     }
 
     Context 'Generate an error on -throttlelimit' {
-        $errors = @()
-        $ast = [System.Management.Automation.Language.Parser]::ParseInput(
-            'foreach -throttlelimit 2 ($input in $bar) { }', [ref]$null, [ref]$errors)
-        It '$errors.Count' { $errors.Count | Should -Be 2 }
-        It '$errors[0].ErrorId' { $errors[0].ErrorId | Should -Be 'KeywordParameterReservedForFutureUse' }
-        It '$errors[1].ErrorId' { $errors[1].ErrorId | Should -Be 'ThrottleLimitRequiresParallelFlag' }
-    }
+        BeforeAll {
+            $errors = @()
+            $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+                'foreach -throttlelimit 2 ($input in $bar) { }', [ref]$null, [ref]$errors)
+        }
 
+        It '$errors.Count' {
+            $errors.Count | Should -Be 2
+        }
+
+        It '$errors[0].ErrorId' {
+            $errors[0].ErrorId | Should -Be 'KeywordParameterReservedForFutureUse'
+        }
+
+        It '$errors[1].ErrorId' {
+            $errors[1].ErrorId | Should -Be 'ThrottleLimitRequiresParallelFlag'
+        }
+    }
 }

--- a/test/powershell/Language/Scripting/ForeachParallel.Tests.ps1
+++ b/test/powershell/Language/Scripting/ForeachParallel.Tests.ps1
@@ -21,7 +21,7 @@ Describe 'Parallel foreach syntax' -Tags 'CI' {
                 "foreach `n-parallel `n(`$foo in `$bar) {}", [ref] $null, [ref] $null)
         }
 
-        It '$errors.Count'
+        It '$errors.Count' {
             $errors.Count | Should -Be 0
         }
 

--- a/test/powershell/Language/Scripting/ForeachParallel.Tests.ps1
+++ b/test/powershell/Language/Scripting/ForeachParallel.Tests.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 Describe "Parallel foreach syntax" -Tags "CI" {
 
-   Context 'Should be able to retrieve AST of parallel foreach' {
+    Context 'Should be able to retrieve AST of parallel foreach' {
         $ast = [System.Management.Automation.Language.Parser]::ParseInput(
             'foreach -parallel ($foo in $bar) {}', [ref] $null, [ref] $null)
         It '$ast.EndBlock.Statements[0].Flags' { $ast.EndBlock.Statements[0].Flags | Should -BeExactly 'Parallel' }

--- a/test/powershell/Language/Scripting/SwitchParallel.Tests.ps1
+++ b/test/powershell/Language/Scripting/SwitchParallel.Tests.ps1
@@ -1,27 +1,48 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-Describe "Parallel switch syntax" -Tags "CI" {
+
+Describe 'Parallel switch syntax' -Tags 'CI' {
 
     Context 'Should be able to retrieve AST of parallel switch' {
-        $ast = [System.Management.Automation.Language.Parser]::ParseInput(
-            'switch -parallel ($foo) {1 {break}}', [ref] $null, [ref] $null)
-        It '$ast.EndBlock.Statements[0].Flags' { $ast.EndBlock.Statements[0].Flags | Should -BeExactly 'Parallel' }
+        BeforeAll {
+            $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+                'switch -parallel ($foo) {1 {break}}', [ref] $null, [ref] $null)
+        }
+
+        It '$ast.EndBlock.Statements[0].Flags' {
+            $ast.EndBlock.Statements[0].Flags | Should -BeExactly 'Parallel'
+        }
     }
 
     Context 'Generates an error on invalid parameter' {
-        $errors = @()
-        $ast = [System.Management.Automation.Language.Parser]::ParseInput(
-            'switch -bogus ($foo) {1 {break}}', [ref]$null, [ref]$errors)
-        It '$errors.Count' { $errors.Count | Should -Be 1 }
-        It '$errors[0].ErrorId' { $errors[0].ErrorId | Should -BeExactly 'InvalidSwitchFlag' }
+        BeforeAll {
+            $errors = @()
+            $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+                'switch -bogus ($foo) {1 {break}}', [ref]$null, [ref]$errors)
+        }
+
+        It '$errors.Count' {
+            $errors.Count | Should -Be 1
+        }
+
+        It '$errors[0].ErrorId' {
+            $errors[0].ErrorId | Should -BeExactly 'InvalidSwitchFlag'
+        }
     }
 
     Context 'Generate an error on -parallel' {
-        $errors = @()
-        $ast = [System.Management.Automation.Language.Parser]::ParseInput(
-            'switch -parallel ($foo) {1 {break}}', [ref]$null, [ref]$errors)
-        It '$errors.Count' { $errors.Count | Should -Be 1 }
-        It '$errors[0].ErrorId' { $errors[0].ErrorId | Should -Be 'KeywordParameterReservedForFutureUse' }
-    }
+        BeforeAll {
+            $errors = @()
+            $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+                'switch -parallel ($foo) {1 {break}}', [ref]$null, [ref]$errors)
+        }
 
+        It '$errors.Count' {
+            $errors.Count | Should -Be 1
+        }
+
+        It '$errors[0].ErrorId' {
+            $errors[0].ErrorId | Should -Be 'KeywordParameterReservedForFutureUse'
+        }
+    }
 }

--- a/test/powershell/Language/Scripting/SwitchParallel.Tests.ps1
+++ b/test/powershell/Language/Scripting/SwitchParallel.Tests.ps1
@@ -1,0 +1,27 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+Describe "Parallel switch syntax" -Tags "CI" {
+
+   Context 'Should be able to retrieve AST of parallel switch' {
+        $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+            'switch -parallel ($foo) {1 {break}}', [ref] $null, [ref] $null)
+        It '$ast.EndBlock.Statements[0].Flags' { $ast.EndBlock.Statements[0].Flags | Should -BeExactly 'Parallel' }
+    }
+
+    Context 'Generates an error on invalid parameter' {
+        $errors = @()
+        $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+            'switch -bogus ($foo) {1 {break}}', [ref]$null, [ref]$errors)
+        It '$errors.Count' { $errors.Count | Should -Be 1 }
+        It '$errors[0].ErrorId' { $errors[0].ErrorId | Should -BeExactly 'InvalidSwitchFlag' }
+    }
+
+    Context 'Generate an error on -parallel' {
+        $errors = @()
+        $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+            'switch -parallel ($foo) {1 {break}}', [ref]$null, [ref]$errors)
+        It '$errors.Count' { $errors.Count | Should -Be 1 }
+        It '$errors[0].ErrorId' { $errors[0].ErrorId | Should -Be 'KeywordParameterReservedForFutureUse' }
+    }
+
+}

--- a/test/powershell/Language/Scripting/SwitchParallel.Tests.ps1
+++ b/test/powershell/Language/Scripting/SwitchParallel.Tests.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 Describe "Parallel switch syntax" -Tags "CI" {
 
-   Context 'Should be able to retrieve AST of parallel switch' {
+    Context 'Should be able to retrieve AST of parallel switch' {
         $ast = [System.Management.Automation.Language.Parser]::ParseInput(
             'switch -parallel ($foo) {1 {break}}', [ref] $null, [ref] $null)
         It '$ast.EndBlock.Statements[0].Flags' { $ast.EndBlock.Statements[0].Flags | Should -BeExactly 'Parallel' }


### PR DESCRIPTION
# PR Summary

As part of the workflow cleanup, this PR:
- marks `-parallel` and `-throttlelimit` as reserved parameters for the `foreach` keyword.
- marks `-parallel` as reserved parameters for the `switch` keyword.
- updates `foreach -parallel` tests.
- adds `foreach -switch` tests.

## PR Context

See issue #9570.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
