### PR TITLE
Fix minor breakpoint rehydration bug

### DIFF
--- a/src/System.Management.Automation/engine/debugger/Breakpoint.cs
+++ b/src/System.Management.Automation/engine/debugger/Breakpoint.cs
@@ -72,7 +72,7 @@ namespace System.Management.Automation
         protected Breakpoint(string script, ScriptBlock action)
         {
             Enabled = true;
-            Script = script;
+            Script = string.IsNullOrEmpty(script) ? null : script;
             Id = Interlocked.Increment(ref s_lastID);
             Action = action;
             HitCount = 0;
@@ -91,7 +91,7 @@ namespace System.Management.Automation
         protected Breakpoint(string script, ScriptBlock action, int id)
         {
             Enabled = true;
-            Script = script;
+            Script = string.IsNullOrEmpty(script) ? null : script;
             Id = id;
             Action = action;
             HitCount = 0;

--- a/src/System.Management.Automation/engine/serialization.cs
+++ b/src/System.Management.Automation/engine/serialization.cs
@@ -7096,7 +7096,7 @@ namespace Microsoft.PowerShell
 
         internal static CommandBreakpoint RehydrateCommandBreakpoint(PSObject pso)
         {
-            string script = GetPropertyValue<string>(pso, "Script", RehydrationFlags.MissingPropertyOk);
+            string script = GetPropertyValue<string>(pso, "Script", RehydrationFlags.MissingPropertyOk | RehydrationFlags.NullValueOk);
             string command = GetPropertyValue<string>(pso, "Command");
             int id = GetPropertyValue<int>(pso, "Id");
             bool enabled = GetPropertyValue<bool>(pso, "Enabled");
@@ -7111,7 +7111,7 @@ namespace Microsoft.PowerShell
 
         internal static VariableBreakpoint RehydrateVariableBreakpoint(PSObject pso)
         {
-            string script = GetPropertyValue<string>(pso, "Script", RehydrationFlags.MissingPropertyOk);
+            string script = GetPropertyValue<string>(pso, "Script", RehydrationFlags.MissingPropertyOk | RehydrationFlags.NullValueOk);
             string variableName = GetPropertyValue<string>(pso, "Variable");
             int id = GetPropertyValue<int>(pso, "Id");
             bool enabled = GetPropertyValue<bool>(pso, "Enabled");

--- a/test/powershell/Language/Scripting/PSSerializer.Tests.ps1
+++ b/test/powershell/Language/Scripting/PSSerializer.Tests.ps1
@@ -1,0 +1,52 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+Describe 'Tests for lossless rehydration of serialized types.' -Tags 'CI' {
+    BeforeAll {
+        $cmdBp = Set-PSBreakpoint -Command Get-Process
+        $varBp = Set-PSBreakpoint -Variable ?
+        $lineBp = Set-PSBreakpoint -Script $PSScriptRoot/PSSerializer.Tests.ps1 -Line 1
+
+        function ShouldRehydrateLosslessly {
+            [CmdletBinding()]
+            param(
+                [Parameter(Mandatory, ValueFromPipeline)]
+                [ValidateNotNull()]
+                [System.Management.Automation.Breakpoint]
+                $Breakpoint
+            )
+            $dehydratedBp = [System.Management.Automation.PSSerializer]::Serialize($Breakpoint)
+            $rehydratedBp = [System.Management.Automation.PSSerializer]::Deserialize($dehydratedBp)
+            foreach ($property in $Breakpoint.PSObject.Properties) {
+                $bpValue = $Breakpoint.$($property.Name)
+                $rehydratedBpValue = $rehydratedBp.$($property.Name)
+                $propertyType = $property.TypeNameOfValue -as [System.Type]
+                if ($bpValue -eq $null) {
+                    $rehydratedBpValue | Should -Be $null
+                } elseif ($propertyType.IsValueType) {
+                    $bpValue | Should -Be $rehydratedBpValue
+                } elseif ($propertyType -eq [string]) {
+                    $bpValue | Should -BeExactly $bpValue
+                } else {
+                    $bpValue.ToString() | Should -BeExactly $rehydratedBpValue.ToString()
+                }
+            }
+        }
+    }
+
+    AfterAll {
+        Remove-PSBreakpoint -Breakpoint $cmdBp,$varBp,$lineBp
+    }
+
+    It 'Losslessly rehydrates command breakpoints' {
+        $cmdBp | ShouldRehydrateLosslessly
+    }
+
+    It 'Losslessly rehydrates variable breakpoints' {
+        $varBp | ShouldRehydrateLosslessly
+    }
+
+    It 'Losslessly rehydrates line breakpoints' {
+        $lineBp | ShouldRehydrateLosslessly
+    }
+}

--- a/test/powershell/Language/Scripting/PSSerializer.Tests.ps1
+++ b/test/powershell/Language/Scripting/PSSerializer.Tests.ps1
@@ -26,7 +26,7 @@ Describe 'Tests for lossless rehydration of serialized types.' -Tags 'CI' {
                 } elseif ($propertyType.IsValueType) {
                     $bpValue | Should -Be $rehydratedBpValue
                 } elseif ($propertyType -eq [string]) {
-                    $bpValue | Should -BeExactly $bpValue
+                    $bpValue | Should -BeExactly $rehydratedBpValue
                 } else {
                     $bpValue.ToString() | Should -BeExactly $rehydratedBpValue.ToString()
                 }

--- a/test/powershell/Language/Scripting/PSSerializer.Tests.ps1
+++ b/test/powershell/Language/Scripting/PSSerializer.Tests.ps1
@@ -21,7 +21,7 @@ Describe 'Tests for lossless rehydration of serialized types.' -Tags 'CI' {
                 $bpValue = $Breakpoint.$($property.Name)
                 $rehydratedBpValue = $rehydratedBp.$($property.Name)
                 $propertyType = $property.TypeNameOfValue -as [System.Type]
-                if ($bpValue -eq $null) {
+                if ($null -eq $bpValue) {
                     $rehydratedBpValue | Should -Be $null
                 } elseif ($propertyType.IsValueType) {
                     $bpValue | Should -Be $rehydratedBpValue


### PR DESCRIPTION
# PR Summary

This PR fixes a minor rehydration bug with breakpoints.

## PR Context

When debugging a remote job or runspace, when you hit a breakpoint the PS debugger would show you a string representation of that breakpoint. There was a bug that would make a breakpoint that was hit in a remote runspace render with a leading colon, which should only appear if the breakpoint is specific to a file. This bug was due to how the breakpoint object script property was dehydrated and then rehydrated when it passes through the MS-PSRDP protocol.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
