### PR TITLE
Make Get-DscResource work with class based resources

### DIFF
--- a/src/System.Management.Automation/DscSupport/CimDSCParser.cs
+++ b/src/System.Management.Automation/DscSupport/CimDSCParser.cs
@@ -391,10 +391,6 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration
 
         internal List<CimClass> ParseSchemaMofFileBuffer(string mof)
         {
-            if(string.IsNullOrEmpty(mof))
-            {
-                throw new Exception("mof is null");
-            }
             uint offset = 0;
             #if UNIX
             // OMI only supports UT8 without BOM
@@ -406,15 +402,6 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration
             #endif
 
             var buffer = encoding.GetBytes(mof);
-            if(buffer is null )
-            {
-                throw new Exception("buffer is null");
-            }
-
-            if(_onClassNeeded is null )
-            {
-                throw new Exception("buffer is null");
-            }
 
             var result = new List<CimClass>(_deserializer.DeserializeClasses(buffer, ref offset, null, null, null, _onClassNeeded, null));
             return result;

--- a/src/System.Management.Automation/DscSupport/CimDSCParser.cs
+++ b/src/System.Management.Automation/DscSupport/CimDSCParser.cs
@@ -391,8 +391,28 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration
 
         internal List<CimClass> ParseSchemaMofFileBuffer(string mof)
         {
+            if(string.IsNullOrEmpty(mof))
+            {
+                throw new Exception("mof is null");
+            }
             uint offset = 0;
-            var buffer = Encoding.Unicode.GetBytes(mof);
+            #if UNIX
+            var encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+            #else
+            var encoding = new UnicodeEncoding();
+            #endif
+
+            var buffer = encoding.GetBytes(mof);
+            if(buffer is null )
+            {
+                throw new Exception("buffer is null");
+            }
+
+            if(_onClassNeeded is null )
+            {
+                throw new Exception("buffer is null");
+            }
+
             var result = new List<CimClass>(_deserializer.DeserializeClasses(buffer, ref offset, null, null, null, _onClassNeeded, null));
             return result;
         }

--- a/src/System.Management.Automation/DscSupport/CimDSCParser.cs
+++ b/src/System.Management.Automation/DscSupport/CimDSCParser.cs
@@ -392,14 +392,14 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration
         internal List<CimClass> ParseSchemaMofFileBuffer(string mof)
         {
             uint offset = 0;
-            #if UNIX
+#if UNIX
             // OMI only supports UT8 without BOM
             var encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-            #else
+#else
             // This is what we traditionally use with Windows
             // DSC asked to keep it UTF-32 for Windows
             var encoding = new UnicodeEncoding();
-            #endif
+#endif
 
             var buffer = encoding.GetBytes(mof);
 

--- a/src/System.Management.Automation/DscSupport/CimDSCParser.cs
+++ b/src/System.Management.Automation/DscSupport/CimDSCParser.cs
@@ -397,8 +397,11 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration
             }
             uint offset = 0;
             #if UNIX
+            // OMI only supports UT8 without BOM
             var encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
             #else
+            // This is what we traditionally use with Windows
+            // DSC asked to keep it UTF-32 for Windows
             var encoding = new UnicodeEncoding();
             #endif
 

--- a/src/System.Management.Automation/DscSupport/CimDSCParser.cs
+++ b/src/System.Management.Automation/DscSupport/CimDSCParser.cs
@@ -2340,7 +2340,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
                 enumNames = propTypeName._typeDefinitionAst.Members.Select(m => m.Name).ToArray();
                 isArrayType = false;
                 embeddedInstanceType = null;
-                return "String";
+                return "string";
             }
 
             if (!embeddedInstanceTypes.Contains(propTypeName._typeDefinitionAst))
@@ -2351,7 +2351,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
             // The type is obviously not a string, but in the mof, we represent
             // it as string (really, embeddedinstance of the class type)
             embeddedInstanceType = propTypeName.Name.Replace('.', '_');
-            return "String";
+            return "string";
         }
 
         private static void GenerateMofForAst(TypeDefinitionAst typeAst, StringBuilder sb, List<object> embeddedInstanceTypes)
@@ -2718,9 +2718,9 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
             { typeof(float) , "real32"},
             { typeof(double) , "real64"},
             { typeof(bool) , "boolean"},
-            { typeof(string), "String" },
+            { typeof(string), "string" },
             { typeof(DateTime), "datetime" },
-            { typeof(PSCredential), "String" },
+            { typeof(PSCredential), "string" },
             { typeof(char), "char16" },
         };
 
@@ -2825,7 +2825,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
             if (type.IsEnum)
             {
                 embeddedInstanceType = null;
-                return "String";
+                return "string";
             }
 
             if (type == typeof(Hashtable))
@@ -2835,13 +2835,13 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
                 // we need an array to hold each entry in the hashtable.
                 isArrayType = true;
                 embeddedInstanceType = "MSFT_KeyValuePair";
-                return "String";
+                return "string";
             }
 
             if (type == typeof(PSCredential))
             {
                 embeddedInstanceType = "MSFT_Credential";
-                return "String";
+                return "string";
             }
 
             if (type.IsArray)
@@ -2896,7 +2896,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
                 // The type is obviously not a string, but in the mof, we represent
                 // it as string (really, embeddedinstance of the class type)
                 embeddedInstanceType = type.FullName.Replace('.', '_');
-                return "String";
+                return "string";
             }
 
             if (missingDefaultConstructor)
@@ -2930,19 +2930,19 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
                 {
                     if (dscProperty.Key)
                     {
-                        sb.AppendFormat(CultureInfo.InvariantCulture, "{0}Key", needComma ? ", " : string.Empty);
+                        sb.AppendFormat(CultureInfo.InvariantCulture, "{0}key", needComma ? ", " : string.Empty);
                         needComma = true;
                     }
 
                     if (dscProperty.Mandatory)
                     {
-                        sb.AppendFormat(CultureInfo.InvariantCulture, "{0}Required", needComma ? ", " : string.Empty);
+                        sb.AppendFormat(CultureInfo.InvariantCulture, "{0}required", needComma ? ", " : string.Empty);
                         needComma = true;
                     }
 
                     if (dscProperty.NotConfigurable)
                     {
-                        sb.AppendFormat(CultureInfo.InvariantCulture, "{0}Read", needComma ? ", " : string.Empty);
+                        sb.AppendFormat(CultureInfo.InvariantCulture, "{0}read", needComma ? ", " : string.Empty);
                         needComma = true;
                     }
 
@@ -2973,7 +2973,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
             // Default is write - skipped if we already have some attributes
             if (sb.Length == 1)
             {
-                sb.Append("Write");
+                sb.Append("write");
                 needComma = true;
             }
 
@@ -3002,7 +3002,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
                 sb.AppendFormat(CultureInfo.InvariantCulture, "{0}EmbeddedInstance(\"{1}\")", needComma ? ", " : string.Empty, embeddedInstanceType);
             }
 
-            sb.Append("] ");
+            sb.Append("]");
             return sb.ToString();
         }
 
@@ -3163,8 +3163,6 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
         private static void ProcessMofForDynamicKeywords(PSModuleInfo module, ICollection<string> resourcesFound,
             Dictionary<string, ScriptBlock> functionsToDefine, CimDSCParser parser, string mof, DSCResourceRunAsCredential runAsBehavior)
         {
-            Console.WriteLine(mof);
-            Console.ReadLine();
             foreach (var c in parser.ParseSchemaMofFileBuffer(mof))
             {
                 var className = c.CimSystemProperties.ClassName;

--- a/src/System.Management.Automation/DscSupport/CimDSCParser.cs
+++ b/src/System.Management.Automation/DscSupport/CimDSCParser.cs
@@ -2340,7 +2340,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
                 enumNames = propTypeName._typeDefinitionAst.Members.Select(m => m.Name).ToArray();
                 isArrayType = false;
                 embeddedInstanceType = null;
-                return "string";
+                return "String";
             }
 
             if (!embeddedInstanceTypes.Contains(propTypeName._typeDefinitionAst))
@@ -2351,7 +2351,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
             // The type is obviously not a string, but in the mof, we represent
             // it as string (really, embeddedinstance of the class type)
             embeddedInstanceType = propTypeName.Name.Replace('.', '_');
-            return "string";
+            return "String";
         }
 
         private static void GenerateMofForAst(TypeDefinitionAst typeAst, StringBuilder sb, List<object> embeddedInstanceTypes)
@@ -2718,9 +2718,9 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
             { typeof(float) , "real32"},
             { typeof(double) , "real64"},
             { typeof(bool) , "boolean"},
-            { typeof(string), "string" },
+            { typeof(string), "String" },
             { typeof(DateTime), "datetime" },
-            { typeof(PSCredential), "string" },
+            { typeof(PSCredential), "String" },
             { typeof(char), "char16" },
         };
 
@@ -2825,7 +2825,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
             if (type.IsEnum)
             {
                 embeddedInstanceType = null;
-                return "string";
+                return "String";
             }
 
             if (type == typeof(Hashtable))
@@ -2835,13 +2835,13 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
                 // we need an array to hold each entry in the hashtable.
                 isArrayType = true;
                 embeddedInstanceType = "MSFT_KeyValuePair";
-                return "string";
+                return "String";
             }
 
             if (type == typeof(PSCredential))
             {
                 embeddedInstanceType = "MSFT_Credential";
-                return "string";
+                return "String";
             }
 
             if (type.IsArray)
@@ -2896,7 +2896,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
                 // The type is obviously not a string, but in the mof, we represent
                 // it as string (really, embeddedinstance of the class type)
                 embeddedInstanceType = type.FullName.Replace('.', '_');
-                return "string";
+                return "String";
             }
 
             if (missingDefaultConstructor)
@@ -2930,19 +2930,19 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
                 {
                     if (dscProperty.Key)
                     {
-                        sb.AppendFormat(CultureInfo.InvariantCulture, "{0}key", needComma ? ", " : string.Empty);
+                        sb.AppendFormat(CultureInfo.InvariantCulture, "{0}Key", needComma ? ", " : string.Empty);
                         needComma = true;
                     }
 
                     if (dscProperty.Mandatory)
                     {
-                        sb.AppendFormat(CultureInfo.InvariantCulture, "{0}required", needComma ? ", " : string.Empty);
+                        sb.AppendFormat(CultureInfo.InvariantCulture, "{0}Required", needComma ? ", " : string.Empty);
                         needComma = true;
                     }
 
                     if (dscProperty.NotConfigurable)
                     {
-                        sb.AppendFormat(CultureInfo.InvariantCulture, "{0}read", needComma ? ", " : string.Empty);
+                        sb.AppendFormat(CultureInfo.InvariantCulture, "{0}Read", needComma ? ", " : string.Empty);
                         needComma = true;
                     }
 
@@ -2973,7 +2973,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
             // Default is write - skipped if we already have some attributes
             if (sb.Length == 1)
             {
-                sb.Append("write");
+                sb.Append("Write");
                 needComma = true;
             }
 
@@ -3002,7 +3002,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
                 sb.AppendFormat(CultureInfo.InvariantCulture, "{0}EmbeddedInstance(\"{1}\")", needComma ? ", " : string.Empty, embeddedInstanceType);
             }
 
-            sb.Append("]");
+            sb.Append("] ");
             return sb.ToString();
         }
 
@@ -3163,6 +3163,8 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
         private static void ProcessMofForDynamicKeywords(PSModuleInfo module, ICollection<string> resourcesFound,
             Dictionary<string, ScriptBlock> functionsToDefine, CimDSCParser parser, string mof, DSCResourceRunAsCredential runAsBehavior)
         {
+            Console.WriteLine(mof);
+            Console.ReadLine();
             foreach (var c in parser.ParseSchemaMofFileBuffer(mof))
             {
                 var className = c.CimSystemProperties.ClassName;

--- a/src/System.Management.Automation/DscSupport/CimDSCParser.cs
+++ b/src/System.Management.Automation/DscSupport/CimDSCParser.cs
@@ -393,7 +393,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration
         {
             uint offset = 0;
 #if UNIX
-            // OMI only supports UT8 without BOM
+            // OMI only supports UTF-8 without BOM
             var encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 #else
             // This is what we traditionally use with Windows


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Make Get-DscResource work with class based resources

I'll add tests in the PSDesiredStateConfiguration repo

## PR Context

OMI only support UTF-8 without BOM

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
