### PR TITLE
Add missing experimental feature check for ForEach-Object -Parallel tests

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
@@ -126,50 +126,50 @@ Describe 'ForEach-Object -Parallel common parameters' -Tags 'CI' {
             Write-Verbose "Test Suite Skipped. The test suite requires the experimental feature 'PSForEachObjectParallel' to be enabled." -Verbose
             $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
             $PSDefaultParameterValues["it:skip"] = $true
-        } else {
-            # Test cases
-            $TestCasesNotSupportedCommonParameters = @(
-                @{
-                    testName    = 'Verifies that ErrorAction common parameter is not supported'
-                    scriptBlock = { 1..1 | ForEach-Object -Parallel { "Hello" } -ErrorAction Stop }
-                },
-                @{
-                    testName    = 'Verifies that WarningAction common parameter is not supported'
-                    scriptBlock = { 1..1 | ForEach-Object -Parallel { "Hello" } -WarningAction SilentlyContinue }
-                },
-                @{
-                    testName    = 'Verifies that InformationAction common parameter is not supported'
-                    scriptBlock = { 1..1 | ForEach-Object -Parallel { "Hello" } -InformationAction SilentlyContinue }
-                },
-                @{
-                    testName    = 'Verifies that PipelineVariable common parameter is not supported'
-                    scriptBlock = { 1..1 | ForEach-Object -Parallel { "Hello" } -PipelineVariable pipeVar }
-                }
-            )
-
-            $TestCasesForSupportedCommonParameters = @(
-                @{
-                    testName       = 'Verifies ErrorVariable common parameter'
-                    scriptBlock    = { 1..1 | ForEach-Object -Parallel { Write-Error "Error:$_" } -ErrorVariable global:actualVariable }
-                    expectedResult = 'Error:1'
-                },
-                @{
-                    testName       = 'Verifies WarningVarible common parameter'
-                    scriptBlock    = { 1..1 | ForEach-Object -Parallel { Write-Warning "Warning:$_" } -WarningVariable global:actualVariable }
-                    expectedResult = 'Warning:1'
-                },
-                @{
-                    testName       = 'Verifies InformationVariable common parameter'
-                    scriptBlock    = { 1..1 | ForEach-Object -Parallel { Write-Information "Information:$_" } -InformationVariable global:actualVariable }
-                    expectedResult = 'Information:1'
-                },
-                @{
-                    testName       = 'Verifies OutVariable common parameter'
-                    scriptBlock    = { 1..1 | ForEach-Object -Parallel { Write-Output "Output:$_" } -OutVariable global:actualVariable }
-                    expectedResult = 'Output:1'
-                }
-            )
         }
+
+        # Test cases
+        $TestCasesNotSupportedCommonParameters = @(
+            @{
+                testName    = 'Verifies that ErrorAction common parameter is not supported'
+                scriptBlock = { 1..1 | ForEach-Object -Parallel { "Hello" } -ErrorAction Stop }
+            },
+            @{
+                testName    = 'Verifies that WarningAction common parameter is not supported'
+                scriptBlock = { 1..1 | ForEach-Object -Parallel { "Hello" } -WarningAction SilentlyContinue }
+            },
+            @{
+                testName    = 'Verifies that InformationAction common parameter is not supported'
+                scriptBlock = { 1..1 | ForEach-Object -Parallel { "Hello" } -InformationAction SilentlyContinue }
+            },
+            @{
+                testName    = 'Verifies that PipelineVariable common parameter is not supported'
+                scriptBlock = { 1..1 | ForEach-Object -Parallel { "Hello" } -PipelineVariable pipeVar }
+            }
+        )
+
+        $TestCasesForSupportedCommonParameters = @(
+            @{
+                testName       = 'Verifies ErrorVariable common parameter'
+                scriptBlock    = { 1..1 | ForEach-Object -Parallel { Write-Error "Error:$_" } -ErrorVariable global:actualVariable }
+                expectedResult = 'Error:1'
+            },
+            @{
+                testName       = 'Verifies WarningVarible common parameter'
+                scriptBlock    = { 1..1 | ForEach-Object -Parallel { Write-Warning "Warning:$_" } -WarningVariable global:actualVariable }
+                expectedResult = 'Warning:1'
+            },
+            @{
+                testName       = 'Verifies InformationVariable common parameter'
+                scriptBlock    = { 1..1 | ForEach-Object -Parallel { Write-Information "Information:$_" } -InformationVariable global:actualVariable }
+                expectedResult = 'Information:1'
+            },
+            @{
+                testName       = 'Verifies OutVariable common parameter'
+                scriptBlock    = { 1..1 | ForEach-Object -Parallel { Write-Output "Output:$_" } -OutVariable global:actualVariable }
+                expectedResult = 'Output:1'
+            }
+        )
     }
 
     BeforeEach {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
@@ -121,56 +121,65 @@ Describe 'ForEach-Object -Parallel common parameters' -Tags 'CI' {
 
     BeforeAll {
 
-        # Test cases
-        $TestCasesNotSupportedCommonParameters = @(
-            @{
-                testName = 'Verifies that ErrorAction common parameter is not supported'
-                scriptBlock = { 1..1 | ForEach-Object -Parallel { "Hello" } -ErrorAction Stop }
-            },
-            @{
-                testName = 'Verifies that WarningAction common parameter is not supported'
-                scriptBlock = { 1..1 | ForEach-Object -Parallel { "Hello" } -WarningAction SilentlyContinue }
-            },
-            @{
-                testName = 'Verifies that InformationAction common parameter is not supported'
-                scriptBlock = { 1..1 | ForEach-Object -Parallel { "Hello" } -InformationAction SilentlyContinue }
-            },
-            @{
-                testName = 'Verifies that PipelineVariable common parameter is not supported'
-                scriptBlock = { 1..1 | ForEach-Object -Parallel { "Hello" } -PipelineVariable pipeVar }
-            }
-        )
+        $skipTest = -not $EnabledExperimentalFeatures.Contains('PSForEachObjectParallel')
+        if ($skipTest) {
+            Write-Verbose "Test Suite Skipped. The test suite requires the experimental feature 'PSForEachObjectParallel' to be enabled." -Verbose
+            $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
+            $PSDefaultParameterValues["it:skip"] = $true
+        } else {
+            # Test cases
+            $TestCasesNotSupportedCommonParameters = @(
+                @{
+                    testName    = 'Verifies that ErrorAction common parameter is not supported'
+                    scriptBlock = { 1..1 | ForEach-Object -Parallel { "Hello" } -ErrorAction Stop }
+                },
+                @{
+                    testName    = 'Verifies that WarningAction common parameter is not supported'
+                    scriptBlock = { 1..1 | ForEach-Object -Parallel { "Hello" } -WarningAction SilentlyContinue }
+                },
+                @{
+                    testName    = 'Verifies that InformationAction common parameter is not supported'
+                    scriptBlock = { 1..1 | ForEach-Object -Parallel { "Hello" } -InformationAction SilentlyContinue }
+                },
+                @{
+                    testName    = 'Verifies that PipelineVariable common parameter is not supported'
+                    scriptBlock = { 1..1 | ForEach-Object -Parallel { "Hello" } -PipelineVariable pipeVar }
+                }
+            )
 
-        $TestCasesForSupportedCommonParameters = @(
-            @{
-                testName = 'Verifies ErrorVariable common parameter'
-                scriptBlock = { 1..1 | ForEach-Object -Parallel { Write-Error "Error:$_" } -ErrorVariable global:actualVariable }
-                expectedResult = 'Error:1'
-            },
-            @{
-                testName = 'Verifies WarningVarible common parameter'
-                scriptBlock = { 1..1 | ForEach-Object -Parallel { Write-Warning "Warning:$_" } -WarningVariable global:actualVariable }
-                expectedResult = 'Warning:1'
-            },
-            @{
-                testName = 'Verifies InformationVariable common parameter'
-                scriptBlock = { 1..1 | ForEach-Object -Parallel { Write-Information "Information:$_"} -InformationVariable global:actualVariable }
-                expectedResult = 'Information:1'
-            },
-            @{
-                testName = 'Verifies OutVariable common parameter'
-                scriptBlock = { 1..1 | ForEach-Object -Parallel {Write-Output "Output:$_"} -OutVariable global:actualVariable }
-                expectedResult = 'Output:1'
-            }
-        )
+            $TestCasesForSupportedCommonParameters = @(
+                @{
+                    testName       = 'Verifies ErrorVariable common parameter'
+                    scriptBlock    = { 1..1 | ForEach-Object -Parallel { Write-Error "Error:$_" } -ErrorVariable global:actualVariable }
+                    expectedResult = 'Error:1'
+                },
+                @{
+                    testName       = 'Verifies WarningVarible common parameter'
+                    scriptBlock    = { 1..1 | ForEach-Object -Parallel { Write-Warning "Warning:$_" } -WarningVariable global:actualVariable }
+                    expectedResult = 'Warning:1'
+                },
+                @{
+                    testName       = 'Verifies InformationVariable common parameter'
+                    scriptBlock    = { 1..1 | ForEach-Object -Parallel { Write-Information "Information:$_" } -InformationVariable global:actualVariable }
+                    expectedResult = 'Information:1'
+                },
+                @{
+                    testName       = 'Verifies OutVariable common parameter'
+                    scriptBlock    = { 1..1 | ForEach-Object -Parallel { Write-Output "Output:$_" } -OutVariable global:actualVariable }
+                    expectedResult = 'Output:1'
+                }
+            )
+        }
     }
 
     BeforeEach {
-
         $global:actualVariable = $null
     }
 
     AfterAll {
+        if ($skipTest) {
+            $global:PSDefaultParameterValues = $originalDefaultParameterValues
+        }
 
         $global:actualVariable = $null
     }


### PR DESCRIPTION
# PR Summary

PR #10229 was merged, but one set of the new Pester tests it added was missing a check for the associated experimental feature flag. This PR adds that check so that the tests don't generate false failures if the feature is disabled.

cc: @PaulHigin 

## PR Context

See Summary and PR #10229.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [X] Experimental feature name(s): `PSForEachObjectParallel`
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
