### PR TITLE
Support ternary operator in PowerShell language

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -6994,8 +6994,8 @@ namespace System.Management.Automation
         public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
         {
             return (bool)ternaryExpressionAst.Condition.Accept(this) &&
-                   (bool)ternaryExpressionAst.IfOperand.Accept(this) &&
-                   (bool)ternaryExpressionAst.ElseOperand.Accept(this);
+                   (bool)ternaryExpressionAst.IfTrue.Accept(this) &&
+                   (bool)ternaryExpressionAst.IfFalse.Accept(this);
         }
 
         public object VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -6991,6 +6991,13 @@ namespace System.Management.Automation
             return expr != null && (bool)expr.Accept(this);
         }
 
+        public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
+        {
+            return (bool)ternaryExpressionAst.Condition.Accept(this) &&
+                   (bool)ternaryExpressionAst.IfOperand.Accept(this) &&
+                   (bool)ternaryExpressionAst.ElseOperand.Accept(this);
+        }
+
         public object VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)
         {
             return (bool)binaryExpressionAst.Left.Accept(this) && (bool)binaryExpressionAst.Right.Accept(this);

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -111,7 +111,10 @@ namespace System.Management.Automation
                     description: "Recommend potential commands based on fuzzy search on a CommandNotFoundException"),
                 new ExperimentalFeature(
                     name: "PSForEachObjectParallel",
-                    description: "New parameter set for ForEach-Object to run script blocks in parallel")
+                    description: "New parameter set for ForEach-Object to run script blocks in parallel"),
+                new ExperimentalFeature(
+                    name: "PSTernaryOperator",
+                    description: "Support the ternary operator in PowerShell langauge.")
             };
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);
 

--- a/src/System.Management.Automation/engine/Modules/ScriptAnalysis.cs
+++ b/src/System.Management.Automation/engine/Modules/ScriptAnalysis.cs
@@ -258,6 +258,8 @@ namespace System.Management.Automation
 
         public override AstVisitAction VisitSwitchStatement(SwitchStatementAst switchStatementAst) { return AstVisitAction.SkipChildren; }
 
+        public override AstVisitAction VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst) { return AstVisitAction.SkipChildren; }
+
         // Visit one the other variations:
         //  - Dotting scripts
         //  - Setting aliases

--- a/src/System.Management.Automation/engine/parser/AstVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/AstVisitor.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Reflection;
 using System.Reflection.Emit;
 
 namespace System.Management.Automation.Language
@@ -171,6 +170,9 @@ namespace System.Management.Automation.Language
 
         /// <summary/>
         object VisitDynamicKeywordStatement(DynamicKeywordStatementAst dynamicKeywordAst);
+
+        /// <summary/>
+        object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst) => null;
     }
 
 #if DEBUG
@@ -312,6 +314,8 @@ namespace System.Management.Automation.Language
         public override AstVisitAction VisitConfigurationDefinition(ConfigurationDefinitionAst ast) { return CheckParent(ast); }
 
         public override AstVisitAction VisitDynamicKeywordStatement(DynamicKeywordStatementAst ast) { return CheckParent(ast); }
+
+        public override AstVisitAction VisitTernaryExpression(TernaryExpressionAst ast) => CheckParent(ast);
     }
 
     /// <summary>
@@ -544,6 +548,8 @@ namespace System.Management.Automation.Language
         public override AstVisitAction VisitConfigurationDefinition(ConfigurationDefinitionAst ast) { return Check(ast); }
 
         public override AstVisitAction VisitDynamicKeywordStatement(DynamicKeywordStatementAst ast) { return Check(ast); }
+
+        public override AstVisitAction VisitTernaryExpression(TernaryExpressionAst ast) { return Check(ast); }
     }
 
     /// <summary>
@@ -680,5 +686,7 @@ namespace System.Management.Automation.Language
         public virtual object VisitTypeDefinition(TypeDefinitionAst typeDefinitionAst) { return null; }
         /// <summary/>
         public virtual object VisitFunctionMember(FunctionMemberAst functionMemberAst) { return null; }
+        /// <summary/>
+        public virtual object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst) { return null; }
     }
 }

--- a/src/System.Management.Automation/engine/parser/AstVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/AstVisitor.cs
@@ -150,6 +150,8 @@ namespace System.Management.Automation.Language
     /// <summary/>
     public interface ICustomAstVisitor2 : ICustomAstVisitor
     {
+        private object DefaultVisit(Ast ast) => null;
+
         /// <summary/>
         object VisitTypeDefinition(TypeDefinitionAst typeDefinitionAst);
 
@@ -172,7 +174,7 @@ namespace System.Management.Automation.Language
         object VisitDynamicKeywordStatement(DynamicKeywordStatementAst dynamicKeywordAst);
 
         /// <summary/>
-        object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst) => null;
+        object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst) => DefaultVisit(ternaryExpressionAst);
     }
 
 #if DEBUG

--- a/src/System.Management.Automation/engine/parser/CharTraits.cs
+++ b/src/System.Management.Automation/engine/parser/CharTraits.cs
@@ -376,11 +376,16 @@ namespace System.Management.Automation.Language
 
         // Return true if the character ends the current number token.  This allows the tokenizer
         // to scan '7z' as a single token, but '7+' as 2 tokens.
-        internal static bool ForceStartNewTokenAfterNumber(this char c)
+        internal static bool ForceStartNewTokenAfterNumber(this char c, bool forceEndNumberOnTernaryOperatorChars)
         {
             if (c < 128)
             {
-                return (s_traits[c] & CharTraits.ForceStartNewTokenAfterNumber) != 0;
+                if ((s_traits[c] & CharTraits.ForceStartNewTokenAfterNumber) != 0)
+                {
+                    return true;
+                }
+
+                return forceEndNumberOnTernaryOperatorChars && (c == '?' || c == ':');
             }
 
             return c.IsDash();

--- a/src/System.Management.Automation/engine/parser/CharTraits.cs
+++ b/src/System.Management.Automation/engine/parser/CharTraits.cs
@@ -374,8 +374,16 @@ namespace System.Management.Automation.Language
             return c.IsWhitespace();
         }
 
-        // Return true if the character ends the current number token.  This allows the tokenizer
-        // to scan '7z' as a single token, but '7+' as 2 tokens.
+        /// <summary>
+        /// Check if the current character forces to end scanning a number token.
+        /// This allows the tokenizer to scan '7z' as a single token, but '7+' as 2 tokens.
+        /// </summary>
+        /// <param name="c">The character to check.</param>
+        /// <param name="forceEndNumberOnTernaryOperatorChars">
+        /// In some cases, we want '?' and ':' to end a number token too, so they can be
+        /// treated as the ternary operator tokens.
+        /// </param>
+        /// <returns>Return true if the character ends the current number token.</returns>
         internal static bool ForceStartNewTokenAfterNumber(this char c, bool forceEndNumberOnTernaryOperatorChars)
         {
             if (c < 128)

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -4984,18 +4984,16 @@ namespace System.Management.Automation.Language
 
         public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
         {
-            var tmp = NewTemp(typeof(object), "result");
-
-            var expr = Expression.IfThenElse(
+            var expr = Expression.Condition(
                 CaptureAstResults(
                     CallAddPipe(
                         Compile(ternaryExpressionAst.Condition),
                         s_getCurrentPipe),
                     CaptureAstContext.Condition).Convert(typeof(bool)),
-                Expression.Assign(tmp, Compile(ternaryExpressionAst.IfTrue).Convert(typeof(object))),
-                Expression.Assign(tmp, Compile(ternaryExpressionAst.IfFalse).Convert(typeof(object))));
+                Compile(ternaryExpressionAst.IfTrue).Convert(typeof(object)),
+                Compile(ternaryExpressionAst.IfFalse).Convert(typeof(object)));
 
-            return Expression.Block(new[] { tmp }, expr, tmp);
+            return expr;
         }
 
         public object VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -4986,10 +4986,8 @@ namespace System.Management.Automation.Language
         {
             var expr = Expression.Condition(
                 CaptureAstResults(
-                    CallAddPipe(
-                        Compile(ternaryExpressionAst.Condition),
-                        s_getCurrentPipe),
-                    CaptureAstContext.Condition).Convert(typeof(bool)),
+                    CallAddPipe(Compile(ternaryExpressionAst.Condition), s_getCurrentPipe),
+                    CaptureAstContext.Condition),
                 Compile(ternaryExpressionAst.IfTrue).Convert(typeof(object)),
                 Compile(ternaryExpressionAst.IfFalse).Convert(typeof(object)));
 

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -4992,8 +4992,8 @@ namespace System.Management.Automation.Language
                         Compile(ternaryExpressionAst.Condition),
                         s_getCurrentPipe),
                     CaptureAstContext.Condition).Convert(typeof(bool)),
-                Expression.Assign(tmp, Compile(ternaryExpressionAst.IfOperand).Convert(typeof(object))),
-                Expression.Assign(tmp, Compile(ternaryExpressionAst.ElseOperand).Convert(typeof(object))));
+                Expression.Assign(tmp, Compile(ternaryExpressionAst.IfTrue).Convert(typeof(object))),
+                Expression.Assign(tmp, Compile(ternaryExpressionAst.IfFalse).Convert(typeof(object))));
 
             return Expression.Block(new[] { tmp }, expr, tmp);
         }

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -1932,14 +1932,6 @@ namespace System.Management.Automation.Language
             CaptureAstContext context,
             MergeRedirectExprs generateRedirectExprs = null)
         {
-            return CaptureAstResults(Compile(ast), context, generateRedirectExprs);
-        }
-
-        private Expression CaptureAstResults(
-            Expression genCode,
-            CaptureAstContext context,
-            MergeRedirectExprs generateRedirectExprs = null)
-        {
             Expression result;
 
             // We'll generate code like:
@@ -1974,7 +1966,7 @@ namespace System.Management.Automation.Language
                 generateRedirectExprs(exprs, finallyExprs);
             }
 
-            exprs.Add(genCode);
+            exprs.Add(Compile(ast));
 
             switch (context)
             {
@@ -4985,9 +4977,7 @@ namespace System.Management.Automation.Language
         public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
         {
             var expr = Expression.Condition(
-                CaptureAstResults(
-                    CallAddPipe(Compile(ternaryExpressionAst.Condition), s_getCurrentPipe),
-                    CaptureAstContext.Condition),
+                Compile(ternaryExpressionAst.Condition).Convert(typeof(bool)),
                 Compile(ternaryExpressionAst.IfTrue).Convert(typeof(object)),
                 Compile(ternaryExpressionAst.IfFalse).Convert(typeof(object)));
 

--- a/src/System.Management.Automation/engine/parser/ConstantValues.cs
+++ b/src/System.Management.Automation/engine/parser/ConstantValues.cs
@@ -15,7 +15,7 @@ namespace System.Management.Automation.Language
      * There is a number of similarities between these two classes, and changes (fixes) in this code
      * may need to be reflected in that class and vice versa
      */
-    internal class IsConstantValueVisitor : ICustomAstVisitor
+    internal class IsConstantValueVisitor : ICustomAstVisitor2
     {
         public static bool IsConstant(Ast ast, out object constantValue, bool forAttribute = false, bool forRequires = false)
         {
@@ -130,6 +130,20 @@ namespace System.Management.Automation.Language
 
         public object VisitInvokeMemberExpression(InvokeMemberExpressionAst invokeMemberExpressionAst) { return false; }
 
+        public object VisitTypeDefinition(TypeDefinitionAst typeDefinitionAst) { return false; }
+
+        public object VisitPropertyMember(PropertyMemberAst propertyMemberAst) { return false; }
+
+        public object VisitFunctionMember(FunctionMemberAst functionMemberAst) { return false; }
+
+        public object VisitBaseCtorInvokeMemberExpression(BaseCtorInvokeMemberExpressionAst baseCtorInvokeMemberExpressionAst) { return false; }
+
+        public object VisitUsingStatement(UsingStatementAst usingStatement) { return false; }
+
+        public object VisitConfigurationDefinition(ConfigurationDefinitionAst configurationDefinitionAst) { return false; }
+
+        public object VisitDynamicKeywordStatement(DynamicKeywordStatementAst dynamicKeywordAst) { return false; }
+
         public object VisitStatementBlock(StatementBlockAst statementBlockAst)
         {
             if (statementBlockAst.Traps != null) return false;
@@ -170,6 +184,13 @@ namespace System.Management.Automation.Language
             }
 
             return false;
+        }
+
+        public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
+        {
+            return (bool)ternaryExpressionAst.Condition.Accept(this) &&
+                   (bool)ternaryExpressionAst.IfOperand.Accept(this) &&
+                   (bool)ternaryExpressionAst.ElseOperand.Accept(this);
         }
 
         public object VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)
@@ -300,7 +321,7 @@ namespace System.Management.Automation.Language
         }
     }
 
-    internal class ConstantValueVisitor : ICustomAstVisitor
+    internal class ConstantValueVisitor : ICustomAstVisitor2
     {
         internal bool AttributeArgument { get; set; }
         internal bool RequiresArgument { get; set; }
@@ -400,6 +421,21 @@ namespace System.Management.Automation.Language
 
         public object VisitInvokeMemberExpression(InvokeMemberExpressionAst invokeMemberExpressionAst) { return AutomationNull.Value; }
 
+        public object VisitTypeDefinition(TypeDefinitionAst typeDefinitionAst) { return AutomationNull.Value; }
+
+        public object VisitPropertyMember(PropertyMemberAst propertyMemberAst) { return AutomationNull.Value; }
+
+        public object VisitFunctionMember(FunctionMemberAst functionMemberAst) { return AutomationNull.Value; }
+
+        public object VisitBaseCtorInvokeMemberExpression(BaseCtorInvokeMemberExpressionAst baseCtorInvokeMemberExpressionAst) { return AutomationNull.Value; }
+
+        public object VisitUsingStatement(UsingStatementAst usingStatement) { return AutomationNull.Value; }
+
+        public object VisitConfigurationDefinition(ConfigurationDefinitionAst configurationDefinitionAst) { return AutomationNull.Value; }
+
+        public object VisitDynamicKeywordStatement(DynamicKeywordStatementAst dynamicKeywordAst) { return AutomationNull.Value; }
+
+
         public object VisitStatementBlock(StatementBlockAst statementBlockAst)
         {
             CheckIsConstant(statementBlockAst, "Caller to verify ast is constant");
@@ -410,6 +446,12 @@ namespace System.Management.Automation.Language
         {
             CheckIsConstant(pipelineAst, "Caller to verify ast is constant");
             return pipelineAst.GetPureExpression().Accept(this);
+        }
+
+        public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
+        {
+            CheckIsConstant(ternaryExpressionAst, "Caller to verify ast is constant");
+            return CompileAndInvoke(ternaryExpressionAst);
         }
 
         public object VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)

--- a/src/System.Management.Automation/engine/parser/ConstantValues.cs
+++ b/src/System.Management.Automation/engine/parser/ConstantValues.cs
@@ -189,8 +189,8 @@ namespace System.Management.Automation.Language
         public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
         {
             return (bool)ternaryExpressionAst.Condition.Accept(this) &&
-                   (bool)ternaryExpressionAst.IfOperand.Accept(this) &&
-                   (bool)ternaryExpressionAst.ElseOperand.Accept(this);
+                   (bool)ternaryExpressionAst.IfTrue.Accept(this) &&
+                   (bool)ternaryExpressionAst.IfFalse.Accept(this);
         }
 
         public object VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)

--- a/src/System.Management.Automation/engine/parser/ConstantValues.cs
+++ b/src/System.Management.Automation/engine/parser/ConstantValues.cs
@@ -451,7 +451,11 @@ namespace System.Management.Automation.Language
         public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
         {
             CheckIsConstant(ternaryExpressionAst, "Caller to verify ast is constant");
-            return CompileAndInvoke(ternaryExpressionAst);
+
+            object condition = ternaryExpressionAst.Condition.Accept(this);
+            return LanguagePrimitives.IsTrue(condition)
+                ? ternaryExpressionAst.IfTrue.Accept(this)
+                : ternaryExpressionAst.IfFalse.Accept(this);
         }
 
         public object VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -6449,12 +6449,22 @@ namespace System.Management.Automation.Language
 
                 componentAsts.Add(condition);
                 Token token = PeekToken();
+
+                // Skip newlines before question mark token to support (ternary operator)line continuance when
+                // the quetion-mark tokens start the next line of script
+                if (token.Kind == TokenKind.NewLine && _tokenizer.IsTernaryContinuance(token.Extent))
+                {
+                    SkipNewlines();
+                    token = PeekToken();
+                }
+
                 if (token.Kind != TokenKind.QuestionMark)
                 {
                     return condition;
                 }
 
                 SkipToken();
+                SkipNewlines();
 
                 ExpressionAst ifOperand = ExpressionRule();
                 if (ifOperand == null)
@@ -6493,6 +6503,8 @@ namespace System.Management.Automation.Language
 
                     return new ErrorExpressionAst(ExtentOf(condition, Before(token)), componentAsts);
                 }
+
+                SkipNewlines();
 
                 ExpressionAst elseOperand = ExpressionRule();
                 if (elseOperand == null)

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -6800,9 +6800,12 @@ namespace System.Management.Automation.Language
 
                 if (_ungotToken != null)
                 {
+                    // Possibly a signed number. Need to resync.
                     bool needResync = _ungotToken.Kind == TokenKind.Minus;
+
                     if (!needResync)
                     {
+                        // A generic token possibly composed of numbers and ternary operator chars. Need to resync.
                         needResync = endNumberOnTernaryOpChars && _ungotToken.Kind == TokenKind.Generic;
                     }
 

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -6442,7 +6442,7 @@ namespace System.Management.Automation.Language
             // G      ternary-expression
             // G
             // G  ternary-expression:
-            // G      binary-expression  new-lines:opt   '?'   new-lines:opt   ternary-expression   new-lines:opt   ':'   new-lines:opt   ternary-expression
+            // G      binary-expression   '?'   new-lines:opt   ternary-expression   new-lines:opt   ':'   new-lines:opt   ternary-expression
 
             // TODO: remove this if-block when making 'ternary operator' an official feature.
             if (!ExperimentalFeature.IsEnabled("PSTernaryOperator"))

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -6444,14 +6444,12 @@ namespace System.Management.Automation.Language
             {
                 SetTokenizerMode(TokenizerMode.Expression);
 
-                List<Ast> componentAsts = new List<Ast>();
                 ExpressionAst condition = BinaryExpressionRule(endNumberOnTernaryOpChars);
                 if (condition == null)
                 {
                     return null;
                 }
 
-                componentAsts.Add(condition);
                 Token token = PeekToken();
 
                 // Skip newlines before question mark token to support (ternary operator)line continuance when the
@@ -6490,22 +6488,21 @@ namespace System.Management.Automation.Language
                         token.Text);
                     ifTrue = new ErrorExpressionAst(extent);
                 }
-                else
-                {
-                    componentAsts.Add(ifTrue);
-                }
 
                 SkipNewlines();
 
                 token = NextToken();
                 if (token.Kind != TokenKind.Colon)
                 {
+                    var componentAsts = new List<Ast>() { condition };
+
                     // ErrorRecovery: we have done the expression parsing and should try parsing something else.
                     UngetToken(token);
 
                     // Don't bother reporting this error if we already reported an empty 'IfTrue' operand error.
                     if (!(ifTrue is ErrorExpressionAst))
                     {
+                        componentAsts.Add(ifTrue);
                         ReportIncompleteInput(
                             token.Extent,
                             nameof(ParserStrings.MissingColonInTernaryExpression),

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -6426,6 +6426,12 @@ namespace System.Management.Automation.Language
 
         #region Expressions
 
+        /// <summary>Parse an expression.</summary>
+        /// <param name="endNumberOnTernaryOpChars">
+        /// When it's known for sure that we are expecting an expression, allowing a generic token like '12?' or '12:' is
+        /// not useful. In those cases, we force to start a new token upon seeing '?' and ':' when scanning for a number
+        /// by setting this parameter to true, hoping to find a ternary expression.
+        /// </param>
         private ExpressionAst ExpressionRule(bool endNumberOnTernaryOpChars = false)
         {
             // G  expression:
@@ -6472,9 +6478,6 @@ namespace System.Management.Automation.Language
                 SkipNewlines();
 
                 // We have seen the ternary operator '?' and now expecting the 'IfFalse' expression.
-                // Allowing a generic token like '12?' or '12:' is not useful in the current situation,
-                // so we force to start a new token upon seeing '?' and ':' when scanning for a number,
-                // hoping to find a ternary expression.
                 ExpressionAst ifTrue = ExpressionRule(endNumberOnTernaryOpChars: true);
                 if (ifTrue == null)
                 {
@@ -6536,6 +6539,12 @@ namespace System.Management.Automation.Language
             }
         }
 
+        /// <summary>Parse a binary expression.</summary>
+        /// <param name="endNumberOnTernaryOpChars">
+        /// When it's known for sure that we are expecting an expression, allowing a generic token like '12?' or '12:' is
+        /// not useful. In those cases, we force to start a new token upon seeing '?' and ':' when scanning for a number
+        /// by setting this parameter to true, hoping to find a ternary expression.
+        /// </param>
         private ExpressionAst BinaryExpressionRule(bool endNumberOnTernaryOpChars = false)
         {
             // G  binary-expression:
@@ -6613,9 +6622,6 @@ namespace System.Management.Automation.Language
                     SkipNewlines();
 
                     // We have seen a binary operator token and now expecting the right-hand-side expression.
-                    // Allowing a generic token like '12?' or '12:' is not useful in the current situation,
-                    // so we force to start a new token upon seeing '?' and ':' when scanning for a number,
-                    // hoping to find a ternary expression.
                     expr = ArrayLiteralRule(endNumberOnTernaryOpChars: true);
                     if (expr == null)
                     {
@@ -6698,6 +6704,12 @@ namespace System.Management.Automation.Language
                     new CommandParameterAst(paramToken.Extent, paramToken.ParameterName, null, paramToken.Extent)});
         }
 
+        /// <summary>Parse an array literal expression.</summary>
+        /// <param name="endNumberOnTernaryOpChars">
+        /// When it's known for sure that we are expecting an expression, allowing a generic token like '12?' or '12:' is
+        /// not useful. In those cases, we force to start a new token upon seeing '?' and ':' when scanning for a number
+        /// by setting this parameter to true, hoping to find a ternary expression.
+        /// </param>
         private ExpressionAst ArrayLiteralRule(bool endNumberOnTernaryOpChars = false)
         {
             // G  array-literal-expression:
@@ -6726,9 +6738,6 @@ namespace System.Management.Automation.Language
                 SkipNewlines();
 
                 // We have seen a comma token and now expecting an expression as an array element.
-                // Allowing a generic token like '12?' or '12:' is not useful in the current situation,
-                // so we force to start a new token upon seeing '?' and ':' when scanning for a number,
-                // hoping to find a ternary expression.
                 lastExpr = UnaryExpressionRule(endNumberOnTernaryOpChars: true);
                 if (lastExpr == null)
                 {
@@ -6751,6 +6760,12 @@ namespace System.Management.Automation.Language
             return new ArrayLiteralAst(ExtentOf(firstExpr, lastExpr), arrayValues);
         }
 
+        /// <summary>Parse an unary expression.</summary>
+        /// <param name="endNumberOnTernaryOpChars">
+        /// When it's known for sure that we are expecting an expression, allowing a generic token like '12?' or '12:' is
+        /// not useful. In those cases, we force to start a new token upon seeing '?' and ':' when scanning for a number
+        /// by setting this parameter to true, hoping to find a ternary expression.
+        /// </param>
         private ExpressionAst UnaryExpressionRule(bool endNumberOnTernaryOpChars = false)
         {
             // G  unary-expression:
@@ -6822,9 +6837,6 @@ namespace System.Management.Automation.Language
                 SkipNewlines();
 
                 // We have seen a unary operator token and now expecting an expression.
-                // Allowing a generic token like '12?' or '12:' is not useful in the current situation,
-                // so we force to start a new token upon seeing '?' and ':' when scanning for a number,
-                // hoping to find a ternary expression.
                 child = UnaryExpressionRule(endNumberOnTernaryOpChars: true);
                 if (child != null)
                 {
@@ -6865,8 +6877,7 @@ namespace System.Management.Automation.Language
                 {
                     SkipNewlines();
 
-                    // We are now expecting a child expression. Allowing a generic token like '12?' or '12:' is not useful in the current situation,
-                    // so we force to start a new token upon seeing '?' and ':' when scanning for a number, hoping to find a ternary expression.
+                    // We are now expecting a child expression.
                     child = UnaryExpressionRule(endNumberOnTernaryOpChars: true);
                     if (child == null)
                     {
@@ -6900,8 +6911,7 @@ namespace System.Management.Automation.Language
                         token = PeekToken();
                         if (token.Kind != TokenKind.NewLine && token.Kind != TokenKind.Comma)
                         {
-                            // We are now expecting a child expression. Allowing a generic token like '12?' or '12:' is not useful in the current situation,
-                            // so we force to start a new token upon seeing '?' and ':' when scanning for a number, hoping to find a ternary expression.
+                            // We are now expecting a child expression.
                             child = UnaryExpressionRule(endNumberOnTernaryOpChars: true);
                             if (child != null)
                             {

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -6426,7 +6426,7 @@ namespace System.Management.Automation.Language
 
         #region Expressions
 
-        private ExpressionAst ExpressionRule(bool endNumbeOnTernaryOpChars = false)
+        private ExpressionAst ExpressionRule(bool endNumberOnTernaryOpChars = false)
         {
             // G  expression:
             // G      logical-expression
@@ -6445,7 +6445,7 @@ namespace System.Management.Automation.Language
                 SetTokenizerMode(TokenizerMode.Expression);
 
                 List<Ast> componentAsts = new List<Ast>();
-                ExpressionAst condition = BinaryExpressionRule(endNumbeOnTernaryOpChars);
+                ExpressionAst condition = BinaryExpressionRule(endNumberOnTernaryOpChars);
                 if (condition == null)
                 {
                     return null;
@@ -6477,7 +6477,7 @@ namespace System.Management.Automation.Language
                 // Allowing a generic token like '12?' or '12:' is not useful in the current situation,
                 // so we force to start a new token upon seeing '?' and ':' when scanning for a number,
                 // hoping to find a ternary expression.
-                ExpressionAst ifTrue = ExpressionRule(endNumbeOnTernaryOpChars: true);
+                ExpressionAst ifTrue = ExpressionRule(endNumberOnTernaryOpChars: true);
                 if (ifTrue == null)
                 {
                     // ErrorRecovery: create an error expression to fill out the ast and keep parsing.
@@ -6517,7 +6517,7 @@ namespace System.Management.Automation.Language
 
                 SkipNewlines();
 
-                ExpressionAst ifFalse = ExpressionRule(endNumbeOnTernaryOpChars: true);
+                ExpressionAst ifFalse = ExpressionRule(endNumberOnTernaryOpChars: true);
                 if (ifFalse == null)
                 {
                     // ErrorRecovery: create an error expression to fill out the ast and keep parsing.
@@ -6539,7 +6539,7 @@ namespace System.Management.Automation.Language
             }
         }
 
-        private ExpressionAst BinaryExpressionRule(bool endNumbeOnTernaryOpChars = false)
+        private ExpressionAst BinaryExpressionRule(bool endNumberOnTernaryOpChars = false)
         {
             // G  binary-expression:
             // G      bitwise-expression
@@ -6582,7 +6582,7 @@ namespace System.Management.Automation.Language
                 SetTokenizerMode(TokenizerMode.Expression);
 
                 ExpressionAst lhs, rhs;
-                ExpressionAst expr = ArrayLiteralRule(endNumbeOnTernaryOpChars);
+                ExpressionAst expr = ArrayLiteralRule(endNumberOnTernaryOpChars);
 
                 if (expr == null)
                 {
@@ -6619,7 +6619,7 @@ namespace System.Management.Automation.Language
                     // Allowing a generic token like '12?' or '12:' is not useful in the current situation,
                     // so we force to start a new token upon seeing '?' and ':' when scanning for a number,
                     // hoping to find a ternary expression.
-                    expr = ArrayLiteralRule(endNumbeOnTernaryOpChars: true);
+                    expr = ArrayLiteralRule(endNumberOnTernaryOpChars: true);
                     if (expr == null)
                     {
                         // ErrorRecovery: create an error expression to fill out the ast and keep parsing.
@@ -6701,13 +6701,13 @@ namespace System.Management.Automation.Language
                     new CommandParameterAst(paramToken.Extent, paramToken.ParameterName, null, paramToken.Extent)});
         }
 
-        private ExpressionAst ArrayLiteralRule(bool endNumbeOnTernaryOpChars = false)
+        private ExpressionAst ArrayLiteralRule(bool endNumberOnTernaryOpChars = false)
         {
             // G  array-literal-expression:
             // G      unary-expression
             // G      unary-expression   ','    new-lines:opt   array-literal-expression
 
-            ExpressionAst lastExpr = UnaryExpressionRule(endNumbeOnTernaryOpChars);
+            ExpressionAst lastExpr = UnaryExpressionRule(endNumberOnTernaryOpChars);
             if (lastExpr == null)
             {
                 return null;
@@ -6732,7 +6732,7 @@ namespace System.Management.Automation.Language
                 // Allowing a generic token like '12?' or '12:' is not useful in the current situation,
                 // so we force to start a new token upon seeing '?' and ':' when scanning for a number,
                 // hoping to find a ternary expression.
-                lastExpr = UnaryExpressionRule(endNumbeOnTernaryOpChars: true);
+                lastExpr = UnaryExpressionRule(endNumberOnTernaryOpChars: true);
                 if (lastExpr == null)
                 {
                     // ErrorRecovery: create an error expression for the ast and break.
@@ -6754,7 +6754,7 @@ namespace System.Management.Automation.Language
             return new ArrayLiteralAst(ExtentOf(firstExpr, lastExpr), arrayValues);
         }
 
-        private ExpressionAst UnaryExpressionRule(bool endNumbeOnTernaryOpChars = false)
+        private ExpressionAst UnaryExpressionRule(bool endNumberOnTernaryOpChars = false)
         {
             // G  unary-expression:
             // G      primary-expression
@@ -6785,18 +6785,18 @@ namespace System.Management.Automation.Language
             ExpressionAst expr = null;
             Token token;
             bool oldAllowSignedNumbers = _tokenizer.AllowSignedNumbers;
-            bool oldForceEndNumberOnTernaryOperators = _tokenizer.ForceEndNumbeOnTernaryOpChars;
+            bool oldForceEndNumberOnTernaryOperators = _tokenizer.ForceEndNumberOnTernaryOpChars;
             try
             {
                 _tokenizer.AllowSignedNumbers = true;
-                _tokenizer.ForceEndNumbeOnTernaryOpChars = endNumbeOnTernaryOpChars;
+                _tokenizer.ForceEndNumberOnTernaryOpChars = endNumberOnTernaryOpChars;
 
                 if (_ungotToken != null)
                 {
                     bool needResync = _ungotToken.Kind == TokenKind.Minus;
                     if (!needResync)
                     {
-                        needResync = endNumbeOnTernaryOpChars && _ungotToken.Kind == TokenKind.Generic;
+                        needResync = endNumberOnTernaryOpChars && _ungotToken.Kind == TokenKind.Generic;
                     }
 
                     if (needResync)
@@ -6810,7 +6810,7 @@ namespace System.Management.Automation.Language
             finally
             {
                 _tokenizer.AllowSignedNumbers = oldAllowSignedNumbers;
-                _tokenizer.ForceEndNumbeOnTernaryOpChars = oldForceEndNumberOnTernaryOperators;
+                _tokenizer.ForceEndNumberOnTernaryOpChars = oldForceEndNumberOnTernaryOperators;
             }
 
             ExpressionAst child;
@@ -6828,7 +6828,7 @@ namespace System.Management.Automation.Language
                 // Allowing a generic token like '12?' or '12:' is not useful in the current situation,
                 // so we force to start a new token upon seeing '?' and ':' when scanning for a number,
                 // hoping to find a ternary expression.
-                child = UnaryExpressionRule(endNumbeOnTernaryOpChars: true);
+                child = UnaryExpressionRule(endNumberOnTernaryOpChars: true);
                 if (child != null)
                 {
                     if (token.Kind == TokenKind.Comma)
@@ -6870,7 +6870,7 @@ namespace System.Management.Automation.Language
 
                     // We are now expecting a child expression. Allowing a generic token like '12?' or '12:' is not useful in the current situation,
                     // so we force to start a new token upon seeing '?' and ':' when scanning for a number, hoping to find a ternary expression.
-                    child = UnaryExpressionRule(endNumbeOnTernaryOpChars: true);
+                    child = UnaryExpressionRule(endNumberOnTernaryOpChars: true);
                     if (child == null)
                     {
                         // ErrorRecovery: We have a list of attributes, and we know it's not before a param statement,
@@ -6905,7 +6905,7 @@ namespace System.Management.Automation.Language
                         {
                             // We are now expecting a child expression. Allowing a generic token like '12?' or '12:' is not useful in the current situation,
                             // so we force to start a new token upon seeing '?' and ':' when scanning for a number, hoping to find a ternary expression.
-                            child = UnaryExpressionRule(endNumbeOnTernaryOpChars: true);
+                            child = UnaryExpressionRule(endNumberOnTernaryOpChars: true);
                             if (child != null)
                             {
                                 expr = new ConvertExpressionAst(ExtentOf(lastAttribute, child),

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -6444,6 +6444,12 @@ namespace System.Management.Automation.Language
             // G  ternary-expression:
             // G      binary-expression  new-lines:opt   '?'   new-lines:opt   ternary-expression   new-lines:opt   ':'   new-lines:opt   ternary-expression
 
+            // TODO: remove this if-block when making 'ternary operator' an official feature.
+            if (!ExperimentalFeature.IsEnabled("PSTernaryOperator"))
+            {
+                return BinaryExpressionRule();
+            }
+
             RuntimeHelpers.EnsureSufficientExecutionStack();
             var oldTokenizerMode = _tokenizer.Mode;
             try
@@ -6457,17 +6463,6 @@ namespace System.Management.Automation.Language
                 }
 
                 Token token = PeekToken();
-
-                // Skip newlines before question mark token to support (ternary operator)line continuance when the
-                // quetion-mark token starts on the next line of script. This is to support the common usage like:
-                //     $varName1 -eq $varName2
-                //         ? <do-something-if-true>
-                //         : <do-something-if-false>
-                if (token.Kind == TokenKind.NewLine && _tokenizer.IsTernaryContinuation(token.Extent))
-                {
-                    SkipNewlines();
-                    token = PeekToken();
-                }
 
                 if (token.Kind != TokenKind.QuestionMark)
                 {

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -5824,7 +5824,7 @@ namespace System.Management.Automation.Language
 
                 // Skip newlines before pipe tokens to support (pipe)line continuance when pipe
                 // tokens start the next line of script
-                if (nextToken.Kind == TokenKind.NewLine && _tokenizer.IsPipeContinuance(nextToken.Extent))
+                if (nextToken.Kind == TokenKind.NewLine && _tokenizer.IsPipeContinuation(nextToken.Extent))
                 {
                     SkipNewlines();
                     nextToken = PeekToken();
@@ -6459,7 +6459,7 @@ namespace System.Management.Automation.Language
                 //     $varName1 -eq $varName2
                 //         ? <do-something-if-true>
                 //         : <do-something-if-false>
-                if (token.Kind == TokenKind.NewLine && _tokenizer.IsTernaryContinuance(token.Extent))
+                if (token.Kind == TokenKind.NewLine && _tokenizer.IsTernaryContinuation(token.Extent))
                 {
                     SkipNewlines();
                     token = PeekToken();
@@ -6500,7 +6500,7 @@ namespace System.Management.Automation.Language
                 token = NextToken();
                 if (token.Kind != TokenKind.Colon)
                 {
-                    // ErrorRecovery: we have done the expression parsing and should tr parsing something else.
+                    // ErrorRecovery: we have done the expression parsing and should try parsing something else.
                     UngetToken(token);
 
                     // Don't bother reporting this error if we already reported an empty 'IfTrue' operand error.

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -6477,8 +6477,8 @@ namespace System.Management.Automation.Language
                 // Allowing a generic token like '12?' or '12:' is not useful in the current situation,
                 // so we force to start a new token upon seeing '?' and ':' when scanning for a number,
                 // hoping to find a ternary expression.
-                ExpressionAst ifOperand = ExpressionRule(endNumbeOnTernaryOpChars: true);
-                if (ifOperand == null)
+                ExpressionAst ifTrue = ExpressionRule(endNumbeOnTernaryOpChars: true);
+                if (ifTrue == null)
                 {
                     // ErrorRecovery: create an error expression to fill out the ast and keep parsing.
                     IScriptExtent extent = After(token);
@@ -6488,11 +6488,11 @@ namespace System.Management.Automation.Language
                         nameof(ParserStrings.ExpectedValueExpression),
                         ParserStrings.ExpectedValueExpression,
                         token.Text);
-                    ifOperand = new ErrorExpressionAst(extent);
+                    ifTrue = new ErrorExpressionAst(extent);
                 }
                 else
                 {
-                    componentAsts.Add(ifOperand);
+                    componentAsts.Add(ifTrue);
                 }
 
                 SkipNewlines();
@@ -6503,8 +6503,8 @@ namespace System.Management.Automation.Language
                     // ErrorRecovery: we have done the expression parsing and should tr parsing something else.
                     UngetToken(token);
 
-                    // Don't bother reporting this error if we already reported an empty if-operand error.
-                    if (!(ifOperand is ErrorExpressionAst))
+                    // Don't bother reporting this error if we already reported an empty 'IfTrue' operand error.
+                    if (!(ifTrue is ErrorExpressionAst))
                     {
                         ReportIncompleteInput(
                             token.Extent,
@@ -6517,8 +6517,8 @@ namespace System.Management.Automation.Language
 
                 SkipNewlines();
 
-                ExpressionAst elseOperand = ExpressionRule(endNumbeOnTernaryOpChars: true);
-                if (elseOperand == null)
+                ExpressionAst ifFalse = ExpressionRule(endNumbeOnTernaryOpChars: true);
+                if (ifFalse == null)
                 {
                     // ErrorRecovery: create an error expression to fill out the ast and keep parsing.
                     IScriptExtent extent = After(token);
@@ -6528,10 +6528,10 @@ namespace System.Management.Automation.Language
                         nameof(ParserStrings.ExpectedValueExpression),
                         ParserStrings.ExpectedValueExpression,
                         token.Text);
-                    elseOperand = new ErrorExpressionAst(extent);
+                    ifFalse = new ErrorExpressionAst(extent);
                 }
 
-                return new TernaryExpressionAst(ExtentOf(condition, elseOperand), condition, ifOperand, elseOperand);
+                return new TernaryExpressionAst(ExtentOf(condition, ifFalse), condition, ifTrue, ifFalse);
             }
             finally
             {

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -6459,7 +6459,7 @@ namespace System.Management.Automation.Language
                 Token token = PeekToken();
 
                 // Skip newlines before question mark token to support (ternary operator)line continuance when the
-                // quetion -mark tokens start the next line of script. This is to support the common usage like:
+                // quetion-mark token starts on the next line of script. This is to support the common usage like:
                 //     $varName1 -eq $varName2
                 //         ? <do-something-if-true>
                 //         : <do-something-if-false>

--- a/src/System.Management.Automation/engine/parser/PreOrderVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/PreOrderVisitor.cs
@@ -186,6 +186,9 @@ namespace System.Management.Automation.Language
 
         /// <summary/>
         public virtual AstVisitAction VisitDynamicKeywordStatement(DynamicKeywordStatementAst dynamicKeywordStatementAst) { return AstVisitAction.Continue; }
+
+        /// <summary/>
+        public virtual AstVisitAction VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst) { return AstVisitAction.Continue; }
     }
 
     /// <summary>

--- a/src/System.Management.Automation/engine/parser/SafeValues.cs
+++ b/src/System.Management.Automation/engine/parser/SafeValues.cs
@@ -208,8 +208,8 @@ namespace System.Management.Automation.Language
         public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
         {
             return (bool)ternaryExpressionAst.Condition.Accept(this) &&
-                   (bool)ternaryExpressionAst.IfOperand.Accept(this) &&
-                   (bool)ternaryExpressionAst.ElseOperand.Accept(this);
+                   (bool)ternaryExpressionAst.IfTrue.Accept(this) &&
+                   (bool)ternaryExpressionAst.IfFalse.Accept(this);
         }
 
         public object VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)

--- a/src/System.Management.Automation/engine/parser/SafeValues.cs
+++ b/src/System.Management.Automation/engine/parser/SafeValues.cs
@@ -380,7 +380,7 @@ namespace System.Management.Automation.Language
                 return null;
             }
 
-            throw PSTraceSource.NewArgumentException("ast");
+            throw PSTraceSource.NewArgumentException(nameof(ast));
         }
 
         /// <summary>
@@ -389,89 +389,89 @@ namespace System.Management.Automation.Language
         [ThreadStatic]
         private static ExecutionContext t_context;
 
-        public object VisitErrorStatement(ErrorStatementAst errorStatementAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitErrorStatement(ErrorStatementAst errorStatementAst) { throw PSTraceSource.NewArgumentException(nameof(errorStatementAst)); }
 
-        public object VisitErrorExpression(ErrorExpressionAst errorExpressionAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitErrorExpression(ErrorExpressionAst errorExpressionAst) { throw PSTraceSource.NewArgumentException(nameof(errorExpressionAst)); }
 
-        public object VisitScriptBlock(ScriptBlockAst scriptBlockAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitScriptBlock(ScriptBlockAst scriptBlockAst) { throw PSTraceSource.NewArgumentException(nameof(scriptBlockAst)); }
 
-        public object VisitParamBlock(ParamBlockAst paramBlockAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitParamBlock(ParamBlockAst paramBlockAst) { throw PSTraceSource.NewArgumentException(nameof(paramBlockAst)); }
 
-        public object VisitNamedBlock(NamedBlockAst namedBlockAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitNamedBlock(NamedBlockAst namedBlockAst) { throw PSTraceSource.NewArgumentException(nameof(namedBlockAst)); }
 
-        public object VisitTypeConstraint(TypeConstraintAst typeConstraintAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitTypeConstraint(TypeConstraintAst typeConstraintAst) { throw PSTraceSource.NewArgumentException(nameof(typeConstraintAst)); }
 
-        public object VisitAttribute(AttributeAst attributeAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitAttribute(AttributeAst attributeAst) { throw PSTraceSource.NewArgumentException(nameof(attributeAst)); }
 
-        public object VisitNamedAttributeArgument(NamedAttributeArgumentAst namedAttributeArgumentAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitNamedAttributeArgument(NamedAttributeArgumentAst namedAttributeArgumentAst) { throw PSTraceSource.NewArgumentException(nameof(namedAttributeArgumentAst)); }
 
-        public object VisitParameter(ParameterAst parameterAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitParameter(ParameterAst parameterAst) { throw PSTraceSource.NewArgumentException(nameof(parameterAst)); }
 
-        public object VisitFunctionDefinition(FunctionDefinitionAst functionDefinitionAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitFunctionDefinition(FunctionDefinitionAst functionDefinitionAst) { throw PSTraceSource.NewArgumentException(nameof(functionDefinitionAst)); }
 
-        public object VisitIfStatement(IfStatementAst ifStmtAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitIfStatement(IfStatementAst ifStmtAst) { throw PSTraceSource.NewArgumentException(nameof(ifStmtAst)); }
 
-        public object VisitTrap(TrapStatementAst trapStatementAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitTrap(TrapStatementAst trapStatementAst) { throw PSTraceSource.NewArgumentException(nameof(trapStatementAst)); }
 
-        public object VisitSwitchStatement(SwitchStatementAst switchStatementAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitSwitchStatement(SwitchStatementAst switchStatementAst) { throw PSTraceSource.NewArgumentException(nameof(switchStatementAst)); }
 
-        public object VisitDataStatement(DataStatementAst dataStatementAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitDataStatement(DataStatementAst dataStatementAst) { throw PSTraceSource.NewArgumentException(nameof(dataStatementAst)); }
 
-        public object VisitForEachStatement(ForEachStatementAst forEachStatementAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitForEachStatement(ForEachStatementAst forEachStatementAst) { throw PSTraceSource.NewArgumentException(nameof(forEachStatementAst)); }
 
-        public object VisitDoWhileStatement(DoWhileStatementAst doWhileStatementAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitDoWhileStatement(DoWhileStatementAst doWhileStatementAst) { throw PSTraceSource.NewArgumentException(nameof(doWhileStatementAst)); }
 
-        public object VisitForStatement(ForStatementAst forStatementAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitForStatement(ForStatementAst forStatementAst) { throw PSTraceSource.NewArgumentException(nameof(forStatementAst)); }
 
-        public object VisitWhileStatement(WhileStatementAst whileStatementAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitWhileStatement(WhileStatementAst whileStatementAst) { throw PSTraceSource.NewArgumentException(nameof(whileStatementAst)); }
 
-        public object VisitCatchClause(CatchClauseAst catchClauseAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitCatchClause(CatchClauseAst catchClauseAst) { throw PSTraceSource.NewArgumentException(nameof(catchClauseAst)); }
 
-        public object VisitTryStatement(TryStatementAst tryStatementAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitTryStatement(TryStatementAst tryStatementAst) { throw PSTraceSource.NewArgumentException(nameof(tryStatementAst)); }
 
-        public object VisitBreakStatement(BreakStatementAst breakStatementAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitBreakStatement(BreakStatementAst breakStatementAst) { throw PSTraceSource.NewArgumentException(nameof(breakStatementAst)); }
 
-        public object VisitContinueStatement(ContinueStatementAst continueStatementAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitContinueStatement(ContinueStatementAst continueStatementAst) { throw PSTraceSource.NewArgumentException(nameof(continueStatementAst)); }
 
-        public object VisitReturnStatement(ReturnStatementAst returnStatementAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitReturnStatement(ReturnStatementAst returnStatementAst) { throw PSTraceSource.NewArgumentException(nameof(returnStatementAst)); }
 
-        public object VisitExitStatement(ExitStatementAst exitStatementAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitExitStatement(ExitStatementAst exitStatementAst) { throw PSTraceSource.NewArgumentException(nameof(exitStatementAst)); }
 
-        public object VisitThrowStatement(ThrowStatementAst throwStatementAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitThrowStatement(ThrowStatementAst throwStatementAst) { throw PSTraceSource.NewArgumentException(nameof(throwStatementAst)); }
 
-        public object VisitDoUntilStatement(DoUntilStatementAst doUntilStatementAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitDoUntilStatement(DoUntilStatementAst doUntilStatementAst) { throw PSTraceSource.NewArgumentException(nameof(doUntilStatementAst)); }
 
-        public object VisitAssignmentStatement(AssignmentStatementAst assignmentStatementAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitAssignmentStatement(AssignmentStatementAst assignmentStatementAst) { throw PSTraceSource.NewArgumentException(nameof(assignmentStatementAst)); }
 
-        public object VisitCommand(CommandAst commandAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitCommand(CommandAst commandAst) { throw PSTraceSource.NewArgumentException(nameof(commandAst)); }
 
-        public object VisitCommandExpression(CommandExpressionAst commandExpressionAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitCommandExpression(CommandExpressionAst commandExpressionAst) { throw PSTraceSource.NewArgumentException(nameof(commandExpressionAst)); }
 
-        public object VisitCommandParameter(CommandParameterAst commandParameterAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitCommandParameter(CommandParameterAst commandParameterAst) { throw PSTraceSource.NewArgumentException(nameof(commandParameterAst)); }
 
-        public object VisitFileRedirection(FileRedirectionAst fileRedirectionAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitFileRedirection(FileRedirectionAst fileRedirectionAst) { throw PSTraceSource.NewArgumentException(nameof(fileRedirectionAst)); }
 
-        public object VisitMergingRedirection(MergingRedirectionAst mergingRedirectionAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitMergingRedirection(MergingRedirectionAst mergingRedirectionAst) { throw PSTraceSource.NewArgumentException(nameof(mergingRedirectionAst)); }
 
-        public object VisitAttributedExpression(AttributedExpressionAst attributedExpressionAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitAttributedExpression(AttributedExpressionAst attributedExpressionAst) { throw PSTraceSource.NewArgumentException(nameof(attributedExpressionAst)); }
 
-        public object VisitBlockStatement(BlockStatementAst blockStatementAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitBlockStatement(BlockStatementAst blockStatementAst) { throw PSTraceSource.NewArgumentException(nameof(blockStatementAst)); }
 
-        public object VisitInvokeMemberExpression(InvokeMemberExpressionAst invokeMemberExpressionAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitInvokeMemberExpression(InvokeMemberExpressionAst invokeMemberExpressionAst) { throw PSTraceSource.NewArgumentException(nameof(invokeMemberExpressionAst)); }
 
-        public object VisitTypeDefinition(TypeDefinitionAst typeDefinitionAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitTypeDefinition(TypeDefinitionAst typeDefinitionAst) { throw PSTraceSource.NewArgumentException(nameof(typeDefinitionAst)); }
 
-        public object VisitPropertyMember(PropertyMemberAst propertyMemberAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitPropertyMember(PropertyMemberAst propertyMemberAst) { throw PSTraceSource.NewArgumentException(nameof(propertyMemberAst)); }
 
-        public object VisitFunctionMember(FunctionMemberAst functionMemberAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitFunctionMember(FunctionMemberAst functionMemberAst) { throw PSTraceSource.NewArgumentException(nameof(functionMemberAst)); }
 
-        public object VisitBaseCtorInvokeMemberExpression(BaseCtorInvokeMemberExpressionAst baseCtorInvokeMemberExpressionAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitBaseCtorInvokeMemberExpression(BaseCtorInvokeMemberExpressionAst baseCtorInvokeMemberExpressionAst) { throw PSTraceSource.NewArgumentException(nameof(baseCtorInvokeMemberExpressionAst)); }
 
-        public object VisitUsingStatement(UsingStatementAst usingStatement) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitUsingStatement(UsingStatementAst usingStatement) { throw PSTraceSource.NewArgumentException(nameof(usingStatement)); }
 
-        public object VisitConfigurationDefinition(ConfigurationDefinitionAst configurationDefinitionAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitConfigurationDefinition(ConfigurationDefinitionAst configurationDefinitionAst) { throw PSTraceSource.NewArgumentException(nameof(configurationDefinitionAst)); }
 
-        public object VisitDynamicKeywordStatement(DynamicKeywordStatementAst dynamicKeywordAst) { throw PSTraceSource.NewArgumentException("ast"); }
+        public object VisitDynamicKeywordStatement(DynamicKeywordStatementAst dynamicKeywordAst) { throw PSTraceSource.NewArgumentException(nameof(dynamicKeywordAst)); }
 
         //
         // This is similar to logic used deep in the engine for slicing something that can be sliced
@@ -630,7 +630,7 @@ namespace System.Management.Automation.Language
                 }
                 else
                 {
-                    throw PSTraceSource.NewArgumentException("ast");
+                    throw PSTraceSource.NewArgumentException(nameof(statementBlockAst));
                 }
             }
 
@@ -645,14 +645,14 @@ namespace System.Management.Automation.Language
                 return expr.Accept(this);
             }
 
-            throw PSTraceSource.NewArgumentException("ast");
+            throw PSTraceSource.NewArgumentException(nameof(pipelineAst));
         }
 
         public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
         {
             if (t_context == null)
             {
-                throw PSTraceSource.NewArgumentException("ast");
+                throw PSTraceSource.NewArgumentException(nameof(ternaryExpressionAst));
             }
 
             return Compiler.GetExpressionValue(ternaryExpressionAst, isTrustedInput: true, t_context, usingValues: null);
@@ -663,14 +663,14 @@ namespace System.Management.Automation.Language
             // This can be used for a denial of service
             // Write-Output (((((("AAAAAAAAAAAAAAAAAAAAAA"*2)*2)*2)*2)*2)*2)
             // Keep on going with that pattern, and we're generating gigabytes of strings.
-            throw PSTraceSource.NewArgumentException("ast");
+            throw PSTraceSource.NewArgumentException(nameof(binaryExpressionAst));
         }
 
         public object VisitUnaryExpression(UnaryExpressionAst unaryExpressionAst)
         {
             if (t_context == null)
             {
-                throw PSTraceSource.NewArgumentException("ast");
+                throw PSTraceSource.NewArgumentException(nameof(unaryExpressionAst));
             }
 
             return Compiler.GetExpressionValue(unaryExpressionAst, isTrustedInput: true, t_context, usingValues: null);
@@ -682,7 +682,7 @@ namespace System.Management.Automation.Language
             // so now we can just call the compiler and indicate that it's trusted (at this point)
             if (t_context == null)
             {
-                throw PSTraceSource.NewArgumentException("ast");
+                throw PSTraceSource.NewArgumentException(nameof(convertExpressionAst));
             }
 
             return Compiler.GetExpressionValue(convertExpressionAst, isTrustedInput: true, t_context, usingValues: null);
@@ -741,7 +741,7 @@ namespace System.Management.Automation.Language
                 return VariableOps.GetVariableValue(variableExpressionAst.VariablePath, t_context, variableExpressionAst);
             }
 
-            throw PSTraceSource.NewArgumentException("ast");
+            throw PSTraceSource.NewArgumentException(nameof(variableExpressionAst));
         }
 
         public object VisitTypeExpression(TypeExpressionAst typeExpressionAst)
@@ -749,12 +749,12 @@ namespace System.Management.Automation.Language
             // Type expressions are not safe as they allow fingerprinting by providing
             // a set of types, you can inspect the types in the AppDomain implying which assemblies are in use
             // and their version
-            throw PSTraceSource.NewArgumentException("ast");
+            throw PSTraceSource.NewArgumentException(nameof(typeExpressionAst));
         }
 
         public object VisitMemberExpression(MemberExpressionAst memberExpressionAst)
         {
-            throw PSTraceSource.NewArgumentException("ast");
+            throw PSTraceSource.NewArgumentException(nameof(memberExpressionAst));
         }
 
         public object VisitArrayExpression(ArrayExpressionAst arrayExpressionAst)

--- a/src/System.Management.Automation/engine/parser/SafeValues.cs
+++ b/src/System.Management.Automation/engine/parser/SafeValues.cs
@@ -646,14 +646,9 @@ namespace System.Management.Automation.Language
 
         public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
         {
-            if (s_context != null)
-            {
-                return Compiler.GetExpressionValue(ternaryExpressionAst, true, s_context, null);
-            }
-            else
-            {
-                throw PSTraceSource.NewArgumentException("ast");
-            }
+            return s_context != null
+                ? Compiler.GetExpressionValue(ternaryExpressionAst, true, s_context, null)
+                : throw PSTraceSource.NewArgumentException("ast");
         }
 
         public object VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)
@@ -666,28 +661,18 @@ namespace System.Management.Automation.Language
 
         public object VisitUnaryExpression(UnaryExpressionAst unaryExpressionAst)
         {
-            if (s_context != null)
-            {
-                return Compiler.GetExpressionValue(unaryExpressionAst, true, s_context, null);
-            }
-            else
-            {
-                throw PSTraceSource.NewArgumentException("ast");
-            }
+            return s_context != null
+                ? Compiler.GetExpressionValue(unaryExpressionAst, true, s_context, null)
+                : throw PSTraceSource.NewArgumentException("ast");
         }
 
         public object VisitConvertExpression(ConvertExpressionAst convertExpressionAst)
         {
             // at this point, we know we're safe because we checked both the type and the child,
             // so now we can just call the compiler and indicate that it's trusted (at this point)
-            if (s_context != null)
-            {
-                return Compiler.GetExpressionValue(convertExpressionAst, true, s_context, null);
-            }
-            else
-            {
-                throw PSTraceSource.NewArgumentException("ast");
-            }
+            return s_context != null
+                ? Compiler.GetExpressionValue(convertExpressionAst, true, s_context, null)
+                : throw PSTraceSource.NewArgumentException("ast");
         }
 
         public object VisitConstantExpression(ConstantExpressionAst constantExpressionAst)

--- a/src/System.Management.Automation/engine/parser/SafeValues.cs
+++ b/src/System.Management.Automation/engine/parser/SafeValues.cs
@@ -647,9 +647,12 @@ namespace System.Management.Automation.Language
 
         public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
         {
-            return s_context != null
-                ? Compiler.GetExpressionValue(ternaryExpressionAst, true, s_context, null)
-                : throw PSTraceSource.NewArgumentException("ast");
+            if (s_context == null)
+            {
+                throw PSTraceSource.NewArgumentException("ast");
+            }
+
+            return Compiler.GetExpressionValue(ternaryExpressionAst, true, s_context, null);
         }
 
         public object VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)
@@ -662,18 +665,24 @@ namespace System.Management.Automation.Language
 
         public object VisitUnaryExpression(UnaryExpressionAst unaryExpressionAst)
         {
-            return s_context != null
-                ? Compiler.GetExpressionValue(unaryExpressionAst, true, s_context, null)
-                : throw PSTraceSource.NewArgumentException("ast");
+            if (s_context == null)
+            {
+                throw PSTraceSource.NewArgumentException("ast");
+            }
+
+            return Compiler.GetExpressionValue(unaryExpressionAst, true, s_context, null);
         }
 
         public object VisitConvertExpression(ConvertExpressionAst convertExpressionAst)
         {
             // at this point, we know we're safe because we checked both the type and the child,
             // so now we can just call the compiler and indicate that it's trusted (at this point)
-            return s_context != null
-                ? Compiler.GetExpressionValue(convertExpressionAst, true, s_context, null)
-                : throw PSTraceSource.NewArgumentException("ast");
+            if (s_context == null)
+            {
+                throw PSTraceSource.NewArgumentException("ast");
+            }
+
+            return Compiler.GetExpressionValue(convertExpressionAst, true, s_context, null);
         }
 
         public object VisitConstantExpression(ConstantExpressionAst constantExpressionAst)

--- a/src/System.Management.Automation/engine/parser/SafeValues.cs
+++ b/src/System.Management.Automation/engine/parser/SafeValues.cs
@@ -36,7 +36,7 @@ using System.Management.Automation.Internal;
 
 namespace System.Management.Automation.Language
 {
-    internal class IsSafeValueVisitor : ICustomAstVisitor
+    internal class IsSafeValueVisitor : ICustomAstVisitor2
     {
         public static bool IsAstSafe(Ast ast, GetSafeValueVisitor.SafeValueContext safeValueContext)
         {
@@ -142,6 +142,20 @@ namespace System.Management.Automation.Language
 
         public object VisitInvokeMemberExpression(InvokeMemberExpressionAst invokeMemberExpressionAst) { return false; }
 
+        public object VisitTypeDefinition(TypeDefinitionAst typeDefinitionAst) { return false; }
+
+        public object VisitPropertyMember(PropertyMemberAst propertyMemberAst) { return false; }
+
+        public object VisitFunctionMember(FunctionMemberAst functionMemberAst) { return false; }
+
+        public object VisitBaseCtorInvokeMemberExpression(BaseCtorInvokeMemberExpressionAst baseCtorInvokeMemberExpressionAst) { return false; }
+
+        public object VisitUsingStatement(UsingStatementAst usingStatement) { return false; }
+
+        public object VisitConfigurationDefinition(ConfigurationDefinitionAst configurationDefinitionAst) { return false; }
+
+        public object VisitDynamicKeywordStatement(DynamicKeywordStatementAst dynamicKeywordAst) { return false; }
+
         public object VisitIndexExpression(IndexExpressionAst indexExpressionAst)
         {
             return (bool)indexExpressionAst.Index.Accept(this) && (bool)indexExpressionAst.Target.Accept(this);
@@ -189,6 +203,13 @@ namespace System.Management.Automation.Language
         {
             var expr = pipelineAst.GetPureExpression();
             return expr != null && (bool)expr.Accept(this);
+        }
+
+        public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
+        {
+            return (bool)ternaryExpressionAst.Condition.Accept(this) &&
+                   (bool)ternaryExpressionAst.IfOperand.Accept(this) &&
+                   (bool)ternaryExpressionAst.ElseOperand.Accept(this);
         }
 
         public object VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)
@@ -334,7 +355,7 @@ namespace System.Management.Automation.Language
      * except in the case of handling the unary operator
      * ExecutionContext is provided to ensure we can resolve variables
      */
-    internal class GetSafeValueVisitor : ICustomAstVisitor
+    internal class GetSafeValueVisitor : ICustomAstVisitor2
     {
         internal enum SafeValueContext
         {
@@ -433,6 +454,20 @@ namespace System.Management.Automation.Language
         public object VisitBlockStatement(BlockStatementAst blockStatementAst) { throw PSTraceSource.NewArgumentException("ast"); }
 
         public object VisitInvokeMemberExpression(InvokeMemberExpressionAst invokeMemberExpressionAst) { throw PSTraceSource.NewArgumentException("ast"); }
+
+        public object VisitTypeDefinition(TypeDefinitionAst typeDefinitionAst) { throw PSTraceSource.NewArgumentException("ast"); }
+
+        public object VisitPropertyMember(PropertyMemberAst propertyMemberAst) { throw PSTraceSource.NewArgumentException("ast"); }
+
+        public object VisitFunctionMember(FunctionMemberAst functionMemberAst) { throw PSTraceSource.NewArgumentException("ast"); }
+
+        public object VisitBaseCtorInvokeMemberExpression(BaseCtorInvokeMemberExpressionAst baseCtorInvokeMemberExpressionAst) { throw PSTraceSource.NewArgumentException("ast"); }
+
+        public object VisitUsingStatement(UsingStatementAst usingStatement) { throw PSTraceSource.NewArgumentException("ast"); }
+
+        public object VisitConfigurationDefinition(ConfigurationDefinitionAst configurationDefinitionAst) { throw PSTraceSource.NewArgumentException("ast"); }
+
+        public object VisitDynamicKeywordStatement(DynamicKeywordStatementAst dynamicKeywordAst) { throw PSTraceSource.NewArgumentException("ast"); }
 
         //
         // This is similar to logic used deep in the engine for slicing something that can be sliced
@@ -607,6 +642,18 @@ namespace System.Management.Automation.Language
             }
 
             throw PSTraceSource.NewArgumentException("ast");
+        }
+
+        public object VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
+        {
+            if (s_context != null)
+            {
+                return Compiler.GetExpressionValue(ternaryExpressionAst, true, s_context, null);
+            }
+            else
+            {
+                throw PSTraceSource.NewArgumentException("ast");
+            }
         }
 
         public object VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)

--- a/src/System.Management.Automation/engine/parser/SafeValues.cs
+++ b/src/System.Management.Automation/engine/parser/SafeValues.cs
@@ -383,6 +383,7 @@ namespace System.Management.Automation.Language
             throw PSTraceSource.NewArgumentException("ast");
         }
 
+        [ThreadStatic]
         private static ExecutionContext s_context;
 
         public object VisitErrorStatement(ErrorStatementAst errorStatementAst) { throw PSTraceSource.NewArgumentException("ast"); }

--- a/src/System.Management.Automation/engine/parser/SafeValues.cs
+++ b/src/System.Management.Automation/engine/parser/SafeValues.cs
@@ -655,7 +655,7 @@ namespace System.Management.Automation.Language
                 throw PSTraceSource.NewArgumentException("ast");
             }
 
-            return Compiler.GetExpressionValue(ternaryExpressionAst, true, t_context, null);
+            return Compiler.GetExpressionValue(ternaryExpressionAst, isTrustedInput: true, t_context, usingValues: null);
         }
 
         public object VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)
@@ -673,7 +673,7 @@ namespace System.Management.Automation.Language
                 throw PSTraceSource.NewArgumentException("ast");
             }
 
-            return Compiler.GetExpressionValue(unaryExpressionAst, true, t_context, null);
+            return Compiler.GetExpressionValue(unaryExpressionAst, isTrustedInput: true, t_context, usingValues: null);
         }
 
         public object VisitConvertExpression(ConvertExpressionAst convertExpressionAst)
@@ -685,7 +685,7 @@ namespace System.Management.Automation.Language
                 throw PSTraceSource.NewArgumentException("ast");
             }
 
-            return Compiler.GetExpressionValue(convertExpressionAst, true, t_context, null);
+            return Compiler.GetExpressionValue(convertExpressionAst, isTrustedInput: true, t_context, usingValues: null);
         }
 
         public object VisitConstantExpression(ConstantExpressionAst constantExpressionAst)

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -2326,6 +2326,11 @@ namespace System.Management.Automation
             return dynamicKeywordAst.CommandElements[0].Accept(this);
         }
 
+        object ICustomAstVisitor2.VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
+        {
+            return InferTypes(ternaryExpressionAst.IfOperand).Concat(InferTypes(ternaryExpressionAst.ElseOperand));
+        }
+
         private static CommandBaseAst GetPreviousPipelineCommand(CommandAst commandAst)
         {
             var pipe = (PipelineAst)commandAst.Parent;

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -2328,7 +2328,7 @@ namespace System.Management.Automation
 
         object ICustomAstVisitor2.VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
         {
-            return InferTypes(ternaryExpressionAst.IfOperand).Concat(InferTypes(ternaryExpressionAst.ElseOperand));
+            return InferTypes(ternaryExpressionAst.IfTrue).Concat(InferTypes(ternaryExpressionAst.IfFalse));
         }
 
         private static CommandBaseAst GetPreviousPipelineCommand(CommandAst commandAst)

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -7148,10 +7148,10 @@ namespace System.Management.Automation.Language
         /// </summary>
         public override Ast Copy()
         {
-            var newCondition = CopyElement(Condition);
-            var newIfClause = CopyElement(IfTrue);
-            var newElseClause = CopyElement(IfFalse);
-            return new TernaryExpressionAst(this.Extent, newCondition, newIfClause, newElseClause);
+            var newCondition = CopyElement(this.Condition);
+            var newIfTrue = CopyElement(this.IfTrue);
+            var newIfFalse = CopyElement(this.IfFalse);
+            return new TernaryExpressionAst(this.Extent, newCondition, newIfTrue, newIfFalse);
         }
 
         #region Visitors

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -7170,21 +7170,21 @@ namespace System.Management.Automation.Language
                 {
                     return visitor.CheckForPostAction(this, AstVisitAction.Continue);
                 }
+            }
 
-                if (action == AstVisitAction.Continue)
-                {
-                    action = Condition.InternalVisit(visitor2);
-                }
+            if (action == AstVisitAction.Continue)
+            {
+                action = Condition.InternalVisit(visitor);
+            }
 
-                if (action == AstVisitAction.Continue)
-                {
-                    action = IfTrue.InternalVisit(visitor2);
-                }
+            if (action == AstVisitAction.Continue)
+            {
+                action = IfTrue.InternalVisit(visitor);
+            }
 
-                if (action == AstVisitAction.Continue)
-                {
-                    action = IfFalse.InternalVisit(visitor2);
-                }
+            if (action == AstVisitAction.Continue)
+            {
+                action = IfFalse.InternalVisit(visitor);
             }
 
             return visitor.CheckForPostAction(this, action);

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -7108,24 +7108,24 @@ namespace System.Management.Automation.Language
         /// </summary>
         /// <param name="extent">The extent of the expression.</param>
         /// <param name="condition">The condition operand.</param>
-        /// <param name="ifClause">The if clause.</param>
-        /// <param name="elseClause">The else clause.</param>
-        public TernaryExpressionAst(IScriptExtent extent, ExpressionAst condition, ExpressionAst ifClause, ExpressionAst elseClause)
+        /// <param name="ifTrue">The if clause.</param>
+        /// <param name="ifFalse">The else clause.</param>
+        public TernaryExpressionAst(IScriptExtent extent, ExpressionAst condition, ExpressionAst ifTrue, ExpressionAst ifFalse)
             : base(extent)
         {
-            if (condition == null || ifClause == null || elseClause == null)
+            if (condition == null || ifTrue == null || ifFalse == null)
             {
-                throw PSTraceSource.NewArgumentNullException(condition == null ? nameof(condition) : ifClause == null ? nameof(ifClause) : nameof(elseClause));
+                throw PSTraceSource.NewArgumentNullException(condition == null ? nameof(condition) : ifTrue == null ? nameof(ifTrue) : nameof(ifFalse));
             }
 
             Condition = condition;
             SetParent(condition);
 
-            IfOperand = ifClause;
-            SetParent(ifClause);
+            IfTrue = ifTrue;
+            SetParent(ifTrue);
 
-            ElseOperand = elseClause;
-            SetParent(elseClause);
+            IfFalse = ifFalse;
+            SetParent(ifFalse);
         }
 
         /// <summary>
@@ -7136,12 +7136,12 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The ast for the if-operand of the ternary expression. The property is never null.
         /// </summary>
-        public ExpressionAst IfOperand { get; }
+        public ExpressionAst IfTrue { get; }
 
         /// <summary>
         /// The ast for the else-operand of the ternary expression. The property is never null.
         /// </summary>
-        public ExpressionAst ElseOperand { get; }
+        public ExpressionAst IfFalse { get; }
 
         /// <summary>
         /// Copy the TernaryExpressionAst instance.
@@ -7149,8 +7149,8 @@ namespace System.Management.Automation.Language
         public override Ast Copy()
         {
             var newCondition = CopyElement(Condition);
-            var newIfClause = CopyElement(IfOperand);
-            var newElseClause = CopyElement(ElseOperand);
+            var newIfClause = CopyElement(IfTrue);
+            var newElseClause = CopyElement(IfFalse);
             return new TernaryExpressionAst(this.Extent, newCondition, newIfClause, newElseClause);
         }
 
@@ -7173,9 +7173,9 @@ namespace System.Management.Automation.Language
                 if (action == AstVisitAction.Continue)
                     action = Condition.InternalVisit(visitor2);
                 if (action == AstVisitAction.Continue)
-                    action = IfOperand.InternalVisit(visitor2);
+                    action = IfTrue.InternalVisit(visitor2);
                 if (action == AstVisitAction.Continue)
-                    action = ElseOperand.InternalVisit(visitor2);
+                    action = IfFalse.InternalVisit(visitor2);
             }
 
             return visitor.CheckForPostAction(this, action);

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -7142,9 +7142,9 @@ namespace System.Management.Automation.Language
         /// </summary>
         public override Ast Copy()
         {
-            var newCondition = CopyElement(this.Condition);
-            var newIfTrue = CopyElement(this.IfTrue);
-            var newIfFalse = CopyElement(this.IfFalse);
+            ExpressionAst newCondition = CopyElement(this.Condition);
+            ExpressionAst newIfTrue = CopyElement(this.IfTrue);
+            ExpressionAst newIfFalse = CopyElement(this.IfFalse);
             return new TernaryExpressionAst(this.Extent, newCondition, newIfTrue, newIfFalse);
         }
 

--- a/src/System.Management.Automation/engine/parser/token.cs
+++ b/src/System.Management.Automation/engine/parser/token.cs
@@ -413,6 +413,9 @@ namespace System.Management.Automation.Language
         /// <summary>The PS class base class and implemented interfaces operator ':'. Also used in base class ctor calls.</summary>
         Colon = 99,
 
+        /// <summary>The ternary operator '?'.</summary>
+        QuestionMark = 100,
+
         #endregion Operators
 
         #region Keywords
@@ -655,7 +658,10 @@ namespace System.Management.Automation.Language
         /// </summary>
         CaseSensitiveOperator = 0x00000400,
 
-        // Unused = 0x00000800,
+        /// <summary>
+        /// The token is a ternary operator '?'.
+        /// </summary>
+        TernaryOperator = 0x00000800,
 
         /// <summary>
         /// The operators '&amp;', '|', and the member access operators ':' and '::'.
@@ -847,7 +853,7 @@ namespace System.Management.Automation.Language
             /*                  Shl */ TokenFlags.BinaryOperator | TokenFlags.BinaryPrecedenceComparison | TokenFlags.CanConstantFold,
             /*                  Shr */ TokenFlags.BinaryOperator | TokenFlags.BinaryPrecedenceComparison | TokenFlags.CanConstantFold,
             /*                Colon */ TokenFlags.SpecialOperator | TokenFlags.DisallowedInRestrictedMode,
-            /*     Reserved slot 2  */ TokenFlags.None,
+            /*         QuestionMark */ TokenFlags.TernaryOperator | TokenFlags.DisallowedInRestrictedMode,
             /*     Reserved slot 3  */ TokenFlags.None,
             /*     Reserved slot 4  */ TokenFlags.None,
             /*     Reserved slot 5  */ TokenFlags.None,

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -721,7 +721,15 @@ namespace System.Management.Automation.Language
 
         internal TokenizerMode Mode { get; set; }
         internal bool AllowSignedNumbers { get; set; }
-        internal bool ForceEndNumberOnTernaryOpChars { get; set; }
+
+        // TODO: use auto-properties when making 'ternary operator' an official feature.
+        private bool _forceEndNumberOnTernaryOpChars;
+        internal bool ForceEndNumberOnTernaryOpChars
+        {
+            get { return _forceEndNumberOnTernaryOpChars; }
+            set { _forceEndNumberOnTernaryOpChars = value && ExperimentalFeature.IsEnabled("PSTernaryOperator"); }
+        }
+
         internal bool WantSimpleName { get; set; }
         internal bool InWorkflowContext { get; set; }
         internal List<Token> TokenList { get; set; }
@@ -1348,13 +1356,6 @@ namespace System.Management.Automation.Language
             // If the first non-whitespace & non-comment (regular or block) character following a newline is a pipe, we have
             // pipe continuation.
             return extent.EndOffset < _script.Length && ContinuationAfterExtent(extent, continuationChar: '|');
-        }
-
-        internal bool IsTernaryContinuation(IScriptExtent extent)
-        {
-            // If the first non-whitespace character following a newline is a question mark, we have
-            // ternary continuation.
-            return extent.EndOffset < _script.Length && ContinuationAfterExtent(extent, continuationChar: '?');
         }
 
         private bool ContinuationAfterExtent(IScriptExtent extent, char continuationChar)

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -721,7 +721,7 @@ namespace System.Management.Automation.Language
 
         internal TokenizerMode Mode { get; set; }
         internal bool AllowSignedNumbers { get; set; }
-        internal bool ForceEndNumbeOnTernaryOpChars { get; set; }
+        internal bool ForceEndNumberOnTernaryOpChars { get; set; }
         internal bool WantSimpleName { get; set; }
         internal bool InWorkflowContext { get; set; }
         internal List<Token> TokenList { get; set; }
@@ -4119,7 +4119,7 @@ namespace System.Management.Automation.Language
 
             if (!c.ForceStartNewToken())
             {
-                if (!InExpressionMode() || !c.ForceStartNewTokenAfterNumber(ForceEndNumbeOnTernaryOpChars))
+                if (!InExpressionMode() || !c.ForceStartNewTokenAfterNumber(ForceEndNumberOnTernaryOpChars))
                 {
                     notNumber = true;
                 }

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -1343,23 +1343,21 @@ namespace System.Management.Automation.Language
             return true;
         }
 
-        internal bool IsPipeContinuance(IScriptExtent extent)
+        internal bool IsPipeContinuation(IScriptExtent extent)
         {
             // If the first non-whitespace & non-comment (regular or block) character following a newline is a pipe, we have
-            // pipe continuance.
-            return extent.EndOffset < _script.Length &&
-                   ContinuanceAfterExtent(extent, continuanceChar: '|', skipComment: true);
+            // pipe continuation.
+            return extent.EndOffset < _script.Length && ContinuationAfterExtent(extent, continuationChar: '|');
         }
 
-        internal bool IsTernaryContinuance(IScriptExtent extent)
+        internal bool IsTernaryContinuation(IScriptExtent extent)
         {
             // If the first non-whitespace character following a newline is a question mark, we have
-            // ternary continuance
-            return extent.EndOffset < _script.Length &&
-                   ContinuanceAfterExtent(extent, continuanceChar: '?', skipComment: false);
+            // ternary continuation.
+            return extent.EndOffset < _script.Length && ContinuationAfterExtent(extent, continuationChar: '?');
         }
 
-        private bool ContinuanceAfterExtent(IScriptExtent extent, char continuanceChar, bool skipComment)
+        private bool ContinuationAfterExtent(IScriptExtent extent, char continuationChar)
         {
             bool lastNonWhitespaceIsNewline = true;
             int i = extent.EndOffset;
@@ -1382,7 +1380,7 @@ namespace System.Management.Automation.Language
                 {
                     if (lastNonWhitespaceIsNewline)
                     {
-                        // blank or whitespace-only lines are not allowed in automatic line continuance
+                        // blank or whitespace-only lines are not allowed in automatic line continuation
                         return false;
                     }
 
@@ -1394,7 +1392,7 @@ namespace System.Management.Automation.Language
                 {
                     if (lastNonWhitespaceIsNewline)
                     {
-                        // blank or whitespace-only lines are not allowed in automatic line continuance
+                        // blank or whitespace-only lines are not allowed in automatic line continuation
                         return false;
                     }
 
@@ -1405,27 +1403,24 @@ namespace System.Management.Automation.Language
 
                 lastNonWhitespaceIsNewline = false;
 
-                if (skipComment)
+                if (c == '#')
                 {
-                    if (c == '#')
-                    {
-                        // SkipLineComment will return the position after the comment end
-                        // which is either at the end of the file, or a cr or lf.
-                        i = SkipLineComment(i + 1);
-                        continue;
-                    }
-
-                    if (c == '<' && _script[i + 1] == '#')
-                    {
-                        i = SkipBlockComment(i + 2);
-                        continue;
-                    }
+                    // SkipLineComment will return the position after the comment end
+                    // which is either at the end of the file, or a cr or lf.
+                    i = SkipLineComment(i + 1);
+                    continue;
                 }
 
-                return c == continuanceChar;
+                if (c == '<' && _script[i + 1] == '#')
+                {
+                    i = SkipBlockComment(i + 2);
+                    continue;
+                }
+
+                return c == continuationChar;
             }
 
-            return _script[_script.Length - 1] == continuanceChar;
+            return _script[_script.Length - 1] == continuationChar;
         }
 
         private int SkipLineComment(int i)

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -721,6 +721,7 @@ namespace System.Management.Automation.Language
 
         internal TokenizerMode Mode { get; set; }
         internal bool AllowSignedNumbers { get; set; }
+        internal bool ForceEndNumbeOnTernaryOpChars { get; set; }
         internal bool WantSimpleName { get; set; }
         internal bool InWorkflowContext { get; set; }
         internal List<Token> TokenList { get; set; }
@@ -4118,7 +4119,7 @@ namespace System.Management.Automation.Language
 
             if (!c.ForceStartNewToken())
             {
-                if (!InExpressionMode() || !c.ForceStartNewTokenAfterNumber())
+                if (!InExpressionMode() || !c.ForceStartNewTokenAfterNumber(ForceEndNumbeOnTernaryOpChars))
                 {
                     notNumber = true;
                 }

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -3858,7 +3858,7 @@ namespace System.Management.Automation.Language
                 firstChar == '.' || (firstChar >= '0' && firstChar <= '9')
                 || (AllowSignedNumbers && (firstChar == '+' || firstChar.IsDash())), "Number must start with '.', '-', or digit.");
 
-            ReadOnlySpan<char> strNum = ScanNumberHelper(firstChar, out NumberFormat format, out NumberSuffixFlags suffix, out bool real, out long multiplier);
+            string strNum = ScanNumberHelper(firstChar, out NumberFormat format, out NumberSuffixFlags suffix, out bool real, out long multiplier);
 
             // the token is not a number. i.e. 77z.exe
             if (strNum == null)
@@ -3900,7 +3900,7 @@ namespace System.Management.Automation.Language
         /// OR
         /// Return the string format of the number.
         /// </returns>
-        private ReadOnlySpan<char> ScanNumberHelper(char firstChar, out NumberFormat format, out NumberSuffixFlags suffix, out bool real, out long multiplier)
+        private string ScanNumberHelper(char firstChar, out NumberFormat format, out NumberSuffixFlags suffix, out bool real, out long multiplier)
         {
             format = NumberFormat.Decimal;
             suffix = NumberSuffixFlags.None;
@@ -4129,7 +4129,7 @@ namespace System.Management.Automation.Language
                 sb[0] = '-';
             }
 
-            return GetStringAndRelease(sb).AsSpan();
+            return GetStringAndRelease(sb);
         }
 
         #endregion Numbers
@@ -4953,7 +4953,7 @@ namespace System.Management.Automation.Language
                     if (InExpressionMode() && (char.IsDigit(c1) || c1 == '.'))
                     {
                         // check if the next token is actually a number
-                        ReadOnlySpan<char> strNum = ScanNumberHelper(c, out NumberFormat format, out NumberSuffixFlags suffix, out bool real, out long multiplier);
+                        string strNum = ScanNumberHelper(c, out _, out _, out _, out _);
                         // rescan characters after the check
                         _currentIndex = _tokenStart;
                         c = GetChar();
@@ -4983,6 +4983,9 @@ namespace System.Management.Automation.Language
                     }
 
                     return this.NewToken(TokenKind.Colon);
+
+                case '?' when InExpressionMode():
+                    return this.NewToken(TokenKind.QuestionMark);
 
                 case '\0':
                     if (AtEof())

--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -1500,4 +1500,7 @@ ModuleVersion : Version of module to import. If used, ModuleName must represent 
   <data name="ClassesNotAllowedInConstrainedLanguage" xml:space="preserve">
     <value>Class keyword is not allowed in ConstrainedLanguage mode.</value>
   </data>
+  <data name="MissingColonInTernaryExpression" xml:space="preserve">
+    <value>Missing ':' in the ternary expression.</value>
+  </data>
 </root>

--- a/test/powershell/Language/Operators/TernaryOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/TernaryOperator.Tests.ps1
@@ -7,7 +7,7 @@ using namespace System.Management.Automation.Language
 Describe "Ternary Operator" -Tags CI {
     Context "Parsing of ternary operator" {
         BeforeAll {
-            $testCases_1 = @(
+            $testCases_basic = @(
                 @{ Script = '$true?2:3'; TokenKind = [TokenKind]::Variable; }
                 @{ Script = '$false?';   TokenKind = [TokenKind]::Variable; }
                 @{ Script = '$:abc';     TokenKind = [TokenKind]::Variable; }
@@ -21,14 +21,14 @@ Describe "Ternary Operator" -Tags CI {
                 @{ Script = '?2:3';      TokenKind = [TokenKind]::Generic;  }
             )
 
-            $testCases_2 = @(
+            $testCases_incomplete = @(
                 @{ Script = '$true ?';     ErrorId = "ExpectedValueExpression";         AstType = [ErrorExpressionAst] }
                 @{ Script = '$true ? 3';   ErrorId = "MissingColonInTernaryExpression"; AstType = [ErrorExpressionAst] }
                 @{ Script = '$true ? 3 :'; ErrorId = "ExpectedValueExpression";         AstType = [TernaryExpressionAst] }
             )
         }
 
-        It "Question-mark and colon parsed correctly in '<Script>' when not in ternary expression context" -TestCases $testCases_1 {
+        It "Question-mark and colon parsed correctly in '<Script>' when not in ternary expression context" -TestCases $testCases_basic {
             param($Script, $TokenKind)
 
             $tks = $null
@@ -55,7 +55,7 @@ Describe "Ternary Operator" -Tags CI {
             2?3:4 | Should -BeExactly '2?3:4'
         }
 
-        It "Generate incomplete parsing error properly for '<Script>'" -TestCases $testCases_2 {
+        It "Generate incomplete parsing error properly for '<Script>'" -TestCases $testCases_incomplete {
             param($Script, $ErrorId, $AstType)
 
             $ers = $null
@@ -98,7 +98,7 @@ Describe "Ternary Operator" -Tags CI {
 
     Context "Using of ternary operator" {
         BeforeAll {
-            $testCases_1 = @(
+            $testCases = @(
                 ## Condition: variable and constant expressions
                 @{ Script = { $true ? 1 : 2 };  ExpectedValue = 1 }
                 @{ Script = { $true? ?1 :2 };   ExpectedValue = 2 }
@@ -136,7 +136,7 @@ Describe "Ternary Operator" -Tags CI {
             )
         }
 
-        It "Basic uses of ternary operator - '<Script>'" -TestCases $testCases_1 {
+        It "Basic uses of ternary operator - '<Script>'" -TestCases $testCases {
             param($Script, $ExpectedValue)
             & $Script | Should -BeExactly $ExpectedValue
         }

--- a/test/powershell/Language/Operators/TernaryOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/TernaryOperator.Tests.ps1
@@ -1,9 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-using namespace System.Management.Automation
-using namespace System.Management.Automation.Language
-
 Describe "Using of ternary operator" -Tags CI {
     BeforeAll {
         $skipTest = -not $EnabledExperimentalFeatures.Contains('PSTernaryOperator')
@@ -35,8 +32,8 @@ Describe "Using of ternary operator" -Tags CI {
                 @{ Script = { $($p = Get-Process -Id $PID; $p.Name -eq 'pwsh') ? 'Core' : 'Desktop' }; ExpectedValue = 'Core' }
                 @{ Script = { ($a = 1) ? 2 : 3 };  ExpectedValue = 2 }
                 @{ Script = { $($a = 1) ? 2 : 3 }; ExpectedValue = 3 }
-                @{ Script = { (Write-Warning -Message warning) ? 1 : 2 }; ExpectedValue = 2 }
-                @{ Script = { (Write-Error -Message error) ? 1 : 2 };     ExpectedValue = 2 }
+                @{ Script = { (Write-Warning -Message warning -WarningAction SilentlyContinue) ? 1 : 2 }; ExpectedValue = 2 }
+                @{ Script = { (Write-Error -Message error -ErrorAction SilentlyContinue) ? 1 : 2 };     ExpectedValue = 2 }
 
                 ## Condition: unary and binary expression expressions
                 @{ Script = { -not $IsCoreCLR ? 'Desktop' : 'Core' };             ExpectedValue = 'Core' }
@@ -68,7 +65,7 @@ Describe "Using of ternary operator" -Tags CI {
     }
 
     It "Ternary expression which generates a terminating error should halt appropriately" {
-        (write-error -Message error -ErrorAction Stop) ? 1 : 2 } | Should -Throw -ErrorId Microsoft.PowerShell.Commands.WriteErrorException
+        { (write-error -Message error -ErrorAction Stop) ? 1 : 2 } | Should -Throw -ErrorId Microsoft.PowerShell.Commands.WriteErrorException
     }
 
     It "Use ternary operator in parameter default values" {

--- a/test/powershell/Language/Operators/TernaryOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/TernaryOperator.Tests.ps1
@@ -1,0 +1,185 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+using namespace System.Management.Automation
+using namespace System.Management.Automation.Language
+
+Describe "Ternary Operator" -Tags CI {
+    Context "Parsing of ternary operator" {
+        BeforeAll {
+            $testCases_1 = @(
+                @{ Script = '$true?2:3'; TokenKind = [TokenKind]::Variable; }
+                @{ Script = '$false?';   TokenKind = [TokenKind]::Variable; }
+                @{ Script = '$:abc';     TokenKind = [TokenKind]::Variable; }
+                @{ Script = '$env:abc';  TokenKind = [TokenKind]::Variable; }
+                @{ Script = '$env:123';  TokenKind = [TokenKind]::Variable; }
+                @{ Script = 'a?2:2';     TokenKind = [TokenKind]::Generic;  }
+                @{ Script = '1?2:3';     TokenKind = [TokenKind]::Generic;  }
+                @{ Script = 'a?';        TokenKind = [TokenKind]::Generic;  }
+                @{ Script = 'a?b';       TokenKind = [TokenKind]::Generic;  }
+                @{ Script = '1?';        TokenKind = [TokenKind]::Generic;  }
+                @{ Script = '?2:3';      TokenKind = [TokenKind]::Generic;  }
+            )
+
+            $testCases_2 = @(
+                @{ Script = '$true ?';     ErrorId = "ExpectedValueExpression";         AstType = [ErrorExpressionAst] }
+                @{ Script = '$true ? 3';   ErrorId = "MissingColonInTernaryExpression"; AstType = [ErrorExpressionAst] }
+                @{ Script = '$true ? 3 :'; ErrorId = "ExpectedValueExpression";         AstType = [TernaryExpressionAst] }
+            )
+        }
+
+        It "Question-mark and colon parsed correctly in '<Script>' when not in ternary expression context" -TestCases $testCases_1 {
+            param($Script, $TokenKind)
+
+            $tks = $null
+            $ers = $null
+            $result = [Parser]::ParseInput($Script, [ref]$tks, [ref]$ers)
+
+            $tks[0].Kind | Should -BeExactly $TokenKind
+            $tks[0].Text | Should -BeExactly $Script
+
+            if ($TokenKind -eq "Variable") {
+                $result.EndBlock.Statements[0].PipelineElements[0].Expression | Should -BeOfType 'System.Management.Automation.Language.VariableExpressionAst'
+                $result.EndBlock.Statements[0].PipelineElements[0].Expression.Extent.Text | Should -BeExactly $Script
+            } else {
+                $result.EndBlock.Statements[0].PipelineElements[0].CommandElements[0] | Should -BeOfType 'System.Management.Automation.Language.StringConstantExpressionAst'
+                $result.EndBlock.Statements[0].PipelineElements[0].CommandElements[0].Extent.Text | Should -BeExactly $Script
+            }
+        }
+
+        It "Question-mark and colon can be used as command names" {
+            function a?b:c { 'a?b:c' }
+            function 2?3:4 { '2?3:4' }
+
+            a?b:c | Should -BeExactly 'a?b:c'
+            2?3:4 | Should -BeExactly '2?3:4'
+        }
+
+        It "Generate incomplete parsing error properly for '<Script>'" -TestCases $testCases_2 {
+            param($Script, $ErrorId, $AstType)
+
+            $ers = $null
+            $result = [Parser]::ParseInput($Script, [ref]$null, [ref]$ers)
+
+            $ers.Count | Should -Be 1
+            $ers.IncompleteInput | Should -BeTrue
+            $ers.ErrorId | Should -BeExactly $ErrorId
+
+            $result.EndBlock.Statements[0].PipelineElements[0].Expression | Should -BeOfType $AstType
+        }
+
+        It "Generate ternary ast when possible" {
+            $ers = $null
+            $result = [Parser]::ParseInput('$true ? :', [ref]$null, [ref]$ers)
+            $ers.Count | Should -Be 2
+
+            $ers[0].IncompleteInput | Should -BeFalse
+            $ers[0].ErrorId | Should -BeExactly 'ExpectedValueExpression'
+            $ers[1].IncompleteInput | Should -BeTrue
+            $ers[1].ErrorId | Should -BeExactly 'ExpectedValueExpression'
+
+            $expr = $result.EndBlock.Statements[0].PipelineElements[0].Expression
+            $expr | Should -BeOfType 'System.Management.Automation.Language.TernaryExpressionAst'
+            $expr.IfTrue | Should -BeOfType 'System.Management.Automation.Language.ErrorExpressionAst'
+            $expr.IfFalse | Should -BeOfType 'System.Management.Automation.Language.ErrorExpressionAst'
+
+            $ers = $null
+            $result = [Parser]::ParseInput('$true ? : 3', [ref]$null, [ref]$ers)
+            $ers.Count | Should -Be 1
+
+            $ers.IncompleteInput | Should -BeFalse
+            $ers.ErrorId | Should -BeExactly "ExpectedValueExpression"
+            $expr = $result.EndBlock.Statements[0].PipelineElements[0].Expression
+            $expr | Should -BeOfType 'System.Management.Automation.Language.TernaryExpressionAst'
+            $expr.IfTrue | Should -BeOfType 'System.Management.Automation.Language.ErrorExpressionAst'
+            $expr.IfFalse | Should -BeOfType 'System.Management.Automation.Language.ConstantExpressionAst'
+        }
+    }
+
+    Context "Using of ternary operator" {
+        BeforeAll {
+            $testCases_1 = @(
+                ## Condition: variable and constant expressions
+                @{ Script = { $true ? 1 : 2 };  ExpectedValue = 1 }
+                @{ Script = { $true? ?1 :2 };   ExpectedValue = 2 }
+                @{ Script = { ${true}?1:2 };    ExpectedValue = 1 }
+                @{ Script = { 1 ? 1kb : 0xf };  ExpectedValue = 1kb }
+                @{ Script = { 0 ?1kb:0xf };     ExpectedValue = 15 }
+                @{ Script = { 's' ?1kb:0xf };   ExpectedValue = 1kb }
+                @{ Script = { $null ?1kb:0xf }; ExpectedValue = 15 }
+                @{ Script = { '' ?1kb:0xf };    ExpectedValue = 15 }
+
+                ## Condition: other primary expressions
+                @{ Script = { 1,2,3,4 ? 'Core' : 'Desktop' };          ExpectedValue = 'Core' }
+                @{ Script = { @(1,2,3,4) ? 'Core' : 'Desktop' };       ExpectedValue = 'Core' }
+                @{ Script = { @{name = 'name'} ? 'Core' : 'Desktop' };  ExpectedValue = 'Core' }
+                @{ Script = { @{name = 'name'}.name ? 'Core' : 'Desktop' }; ExpectedValue = 'Core' }
+                @{ Script = { @{name = 'name'}.Contains('name') ? 'Core' : 'Desktop' }; ExpectedValue = 'Core' }
+                @{ Script = { (Test-Path Env:\NonExist) ? 'true' : 'false' };     ExpectedValue = 'false' }
+                @{ Script = { (Test-Path Env:\PSModulePath) ? 'true' : 'false' }; ExpectedValue = 'true' }
+                @{ Script = { $($p = Get-Process -Id $PID; $p.Name -eq 'pwsh') ? 'Core' : 'Desktop' }; ExpectedValue = 'Core' }
+
+                ## Condition: unary and binary expression expressions
+                @{ Script = { -not $IsCoreCLR ? 'Desktop' : 'Core' };             ExpectedValue = 'Core' }
+                @{ Script = { $PSEdition -eq 'Core' ? 'Core' : 'Desktop' };       ExpectedValue = 'Core' }
+                @{ Script = { $IsCoreCLR -and (Get-Process -Id $PID).Name -eq 'pwsh' ? 'Core' : 'Desktop' }; ExpectedValue = 'Core' }
+                @{ Script = { $IsCoreCLR -and 'pwsh' -match 'p.*h' ? 'Core' : 'Desktop' }; ExpectedValue = 'Core' }
+                @{ Script = { 1,2,3 -contains 2 ? 'Core' : 'Desktop' }; ExpectedValue = 'Core' }
+
+                ## Nested ternary expressions
+                @{ Script = { $IsCoreCLR ? $false ? 'nested-if-true' : 'nested-if-false' : 'if-false' }; ExpectedValue = 'nested-if-false' }
+                @{ Script = { $IsCoreCLR ? $false ? 'nested-if-true' : $true ? 'nested-nested-if-true' : 'nested-nested-if-false' : 'if-false' }; ExpectedValue = 'nested-nested-if-true' }
+
+                ## Binary operator has higher precedence order than ternary
+                @{ Script = { !$IsCoreCLR ? 'Core' : 'Desktop' -eq 'Core' };  ExpectedValue = !$IsCoreCLR ? 'Core' : ('Desktop' -eq 'Core') }
+                @{ Script = { ($IsCoreCLR ? 'Core' : 'Desktop') -eq 'Core' }; ExpectedValue = $true }
+            )
+        }
+
+        It "Basic uses of ternary operator - '<Script>'" -TestCases $testCases_1 {
+            param($Script, $ExpectedValue)
+            & $Script | Should -BeExactly $ExpectedValue
+        }
+
+        It "Use ternary operator in parameter default values" {
+            function testFunc {
+                param($psExec = $IsCoreCLR ? 'pwsh' : 'powershell.exe')
+                $psExec
+            }
+            testFunc | Should -BeExactly 'pwsh'
+        }
+
+        It "Use ternary operator with assignments" {
+            $IsCoreCLR ? ([string]$var = 'string') : 'blah' > $null
+            $var = [System.IO.FileInfo]::new('abc')
+            $var | Should -BeOfType [string]
+            $var | Should -BeExactly 'abc'
+        }
+
+        It "Use ternary operator in pipeline" {
+            $result = $IsCoreCLR ? 'Core' : 'Desktop' | ForEach-Object { $_ + '-Pipe' }
+            $result | Should -BeExactly 'Core-Pipe'
+        }
+
+        It "Return script block from ternary expression" {
+            $result = ${IsCoreCLR}?{'Core'}:{'Desktop'}
+            $result | Should -BeOfType [scriptblock]
+            & $result | Should -BeExactly 'Core'
+        }
+
+        It "Tab completion for variables assigned with ternary expression" {
+            ## Type inference for the ternary expression should aggregate the inferred values from both branches
+            $text1 = '$var1 = $IsCoreCLR ? (Get-Item $PSHome) : (Get-Process -Id $PID); $var1.Full'
+            $result = TabExpansion2 -inputScript $text1 -cursorColumn $text1.Length
+            $result.CompletionMatches[0].CompletionText | Should -BeExactly FullName
+
+            $text2 = '$var1 = $IsCoreCLR ? (Get-Item $PSHome) : (Get-Process -Id $PID); $var1.Proce'
+            $result = TabExpansion2 -inputScript $text2 -cursorColumn $text2.Length
+            $result.CompletionMatches[0].CompletionText | Should -BeExactly ProcessName
+
+            $text3 = '$IsCoreCLR ? ($var2 = Get-Item $PSHome) : "blah"; $var2.Full'
+            $result = TabExpansion2 -inputScript $text3 -cursorColumn $text3.Length
+            $result.CompletionMatches[0].CompletionText | Should -BeExactly FullName
+        }
+    }
+}

--- a/test/powershell/Language/Parser/Parsing.Tests.ps1
+++ b/test/powershell/Language/Parser/Parsing.Tests.ps1
@@ -313,3 +313,110 @@ Describe 'Unicode escape sequence parsing' -Tag "CI" {
     ShouldBeParseError '"`u{123456' MissingUnicodeEscapeSequenceTerminator,TerminatorExpectedAtEndOfString 10,0
     ShouldBeParseError '"`u{1234567' TooManyDigitsInUnicodeEscapeSequence,TerminatorExpectedAtEndOfString 10,0
 }
+
+Describe "Ternary Operator parsing" -Tags CI {
+    BeforeAll {
+        $skipTest = -not $EnabledExperimentalFeatures.Contains('PSTernaryOperator')
+        if ($skipTest) {
+            Write-Verbose "Test Suite Skipped. The test suite requires the experimental feature 'PSTernaryOperator' to be enabled." -Verbose
+            $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
+            $PSDefaultParameterValues["it:skip"] = $true
+        }
+        else {
+            $testCases_basic = @(
+                @{ Script = '$true?2:3'; TokenKind = [TokenKind]::Variable; }
+                @{ Script = '$false?';   TokenKind = [TokenKind]::Variable; }
+                @{ Script = '$:abc';     TokenKind = [TokenKind]::Variable; }
+                @{ Script = '$env:abc';  TokenKind = [TokenKind]::Variable; }
+                @{ Script = '$env:123';  TokenKind = [TokenKind]::Variable; }
+                @{ Script = 'a?2:2';     TokenKind = [TokenKind]::Generic;  }
+                @{ Script = '1?2:3';     TokenKind = [TokenKind]::Generic;  }
+                @{ Script = 'a?';        TokenKind = [TokenKind]::Generic;  }
+                @{ Script = 'a?b';       TokenKind = [TokenKind]::Generic;  }
+                @{ Script = '1?';        TokenKind = [TokenKind]::Generic;  }
+                @{ Script = '?2:3';      TokenKind = [TokenKind]::Generic;  }
+            )
+
+            $testCases_incomplete = @(
+                @{ Script = '$true ?';     ErrorId = "ExpectedValueExpression";         AstType = [ErrorExpressionAst] }
+                @{ Script = '$true ? 3';   ErrorId = "MissingColonInTernaryExpression"; AstType = [ErrorExpressionAst] }
+                @{ Script = '$true ? 3 :'; ErrorId = "ExpectedValueExpression";         AstType = [TernaryExpressionAst] }
+            )
+        }
+    }
+
+    AfterAll {
+        if ($skipTest) {
+            $global:PSDefaultParameterValues = $originalDefaultParameterValues
+        }
+    }
+
+    It "Question-mark and colon parsed correctly in '<Script>' when not in ternary expression context" -TestCases $testCases_basic {
+        param($Script, $TokenKind)
+
+        $tks = $null
+        $ers = $null
+        $result = [Parser]::ParseInput($Script, [ref]$tks, [ref]$ers)
+
+        $tks[0].Kind | Should -BeExactly $TokenKind
+        $tks[0].Text | Should -BeExactly $Script
+
+        if ($TokenKind -eq "Variable") {
+            $result.EndBlock.Statements[0].PipelineElements[0].Expression | Should -BeOfType 'System.Management.Automation.Language.VariableExpressionAst'
+            $result.EndBlock.Statements[0].PipelineElements[0].Expression.Extent.Text | Should -BeExactly $Script
+        } else {
+            $result.EndBlock.Statements[0].PipelineElements[0].CommandElements[0] | Should -BeOfType 'System.Management.Automation.Language.StringConstantExpressionAst'
+            $result.EndBlock.Statements[0].PipelineElements[0].CommandElements[0].Extent.Text | Should -BeExactly $Script
+        }
+    }
+
+    It "Question-mark and colon can be used as command names" {
+        function a?b:c { 'a?b:c' }
+        function 2?3:4 { '2?3:4' }
+
+        a?b:c | Should -BeExactly 'a?b:c'
+        2?3:4 | Should -BeExactly '2?3:4'
+    }
+
+    It "Incomplete ternary expression '<Script>' should generate correct error" -TestCases $testCases_incomplete {
+        param($Script, $ErrorId, $AstType)
+
+        $ers = $null
+        $result = [Parser]::ParseInput($Script, [ref]$null, [ref]$ers)
+
+        $ers.Count | Should -Be 1
+        $ers.IncompleteInput | Should -BeTrue
+        $ers.ErrorId | Should -BeExactly $ErrorId
+
+        $result.EndBlock.Statements[0].PipelineElements[0].Expression | Should -BeOfType $AstType
+    }
+
+    It "Generate ternary AST when operands are missing - '`$true ? :'" {
+        $ers = $null
+        $result = [Parser]::ParseInput('$true ? :', [ref]$null, [ref]$ers)
+        $ers.Count | Should -Be 2
+
+        $ers[0].IncompleteInput | Should -BeFalse
+        $ers[0].ErrorId | Should -BeExactly 'ExpectedValueExpression'
+        $ers[1].IncompleteInput | Should -BeTrue
+        $ers[1].ErrorId | Should -BeExactly 'ExpectedValueExpression'
+
+        $expr = $result.EndBlock.Statements[0].PipelineElements[0].Expression
+        $expr | Should -BeOfType 'System.Management.Automation.Language.TernaryExpressionAst'
+        $expr.IfTrue | Should -BeOfType 'System.Management.Automation.Language.ErrorExpressionAst'
+        $expr.IfFalse | Should -BeOfType 'System.Management.Automation.Language.ErrorExpressionAst'
+    }
+
+    It "Generate ternary AST when operands are missing - '`$true ? : 3'" {
+        $ers = $null
+        $result = [Parser]::ParseInput('$true ? : 3', [ref]$null, [ref]$ers)
+        $ers.Count | Should -Be 1
+
+        $ers.IncompleteInput | Should -BeFalse
+        $ers.ErrorId | Should -BeExactly "ExpectedValueExpression"
+        $expr = $result.EndBlock.Statements[0].PipelineElements[0].Expression
+        $expr | Should -BeOfType 'System.Management.Automation.Language.TernaryExpressionAst'
+        $expr.IfTrue | Should -BeOfType 'System.Management.Automation.Language.ErrorExpressionAst'
+        $expr.IfFalse | Should -BeOfType 'System.Management.Automation.Language.ConstantExpressionAst'
+    }
+}

--- a/test/powershell/Language/Parser/Parsing.Tests.ps1
+++ b/test/powershell/Language/Parser/Parsing.Tests.ps1
@@ -324,23 +324,26 @@ Describe "Ternary Operator parsing" -Tags CI {
         }
         else {
             $testCases_basic = @(
-                @{ Script = '$true?2:3'; TokenKind = [TokenKind]::Variable; }
-                @{ Script = '$false?';   TokenKind = [TokenKind]::Variable; }
-                @{ Script = '$:abc';     TokenKind = [TokenKind]::Variable; }
-                @{ Script = '$env:abc';  TokenKind = [TokenKind]::Variable; }
-                @{ Script = '$env:123';  TokenKind = [TokenKind]::Variable; }
-                @{ Script = 'a?2:2';     TokenKind = [TokenKind]::Generic;  }
-                @{ Script = '1?2:3';     TokenKind = [TokenKind]::Generic;  }
-                @{ Script = 'a?';        TokenKind = [TokenKind]::Generic;  }
-                @{ Script = 'a?b';       TokenKind = [TokenKind]::Generic;  }
-                @{ Script = '1?';        TokenKind = [TokenKind]::Generic;  }
-                @{ Script = '?2:3';      TokenKind = [TokenKind]::Generic;  }
+                @{ Script = '$true?2:3'; TokenKind = [System.Management.Automation.Language.TokenKind]::Variable; }
+                @{ Script = '$false?';   TokenKind = [System.Management.Automation.Language.TokenKind]::Variable; }
+                @{ Script = '$:abc';     TokenKind = [System.Management.Automation.Language.TokenKind]::Variable; }
+                @{ Script = '$env:abc';  TokenKind = [System.Management.Automation.Language.TokenKind]::Variable; }
+                @{ Script = '$env:123';  TokenKind = [System.Management.Automation.Language.TokenKind]::Variable; }
+                @{ Script = 'a?2:2';     TokenKind = [System.Management.Automation.Language.TokenKind]::Generic;  }
+                @{ Script = '1?2:3';     TokenKind = [System.Management.Automation.Language.TokenKind]::Generic;  }
+                @{ Script = 'a?';        TokenKind = [System.Management.Automation.Language.TokenKind]::Generic;  }
+                @{ Script = 'a?b';       TokenKind = [System.Management.Automation.Language.TokenKind]::Generic;  }
+                @{ Script = '1?';        TokenKind = [System.Management.Automation.Language.TokenKind]::Generic;  }
+                @{ Script = '?2:3';      TokenKind = [System.Management.Automation.Language.TokenKind]::Generic;  }
             )
 
             $testCases_incomplete = @(
-                @{ Script = '$true ?';     ErrorId = "ExpectedValueExpression";         AstType = [ErrorExpressionAst] }
-                @{ Script = '$true ? 3';   ErrorId = "MissingColonInTernaryExpression"; AstType = [ErrorExpressionAst] }
-                @{ Script = '$true ? 3 :'; ErrorId = "ExpectedValueExpression";         AstType = [TernaryExpressionAst] }
+                @{ Script = '$true ?';     ErrorId = "ExpectedValueExpression";         AstType = [System.Management.Automation.Language.ErrorExpressionAst] }
+                @{ Script = '$true ? 3';   ErrorId = "MissingColonInTernaryExpression"; AstType = [System.Management.Automation.Language.ErrorExpressionAst] }
+                @{ Script = '$true ? 3 :'; ErrorId = "ExpectedValueExpression";         AstType = [System.Management.Automation.Language.TernaryExpressionAst] }
+                @{ Script = "`$true`t?";     ErrorId = "ExpectedValueExpression";         AstType = [System.Management.Automation.Language.ErrorExpressionAst] }
+                @{ Script = "`$true`t?`t3";   ErrorId = "MissingColonInTernaryExpression"; AstType = [System.Management.Automation.Language.ErrorExpressionAst] }
+                @{ Script = "`$true`t?`t3`t:"; ErrorId = "ExpectedValueExpression";         AstType = [System.Management.Automation.Language.TernaryExpressionAst] }
             )
         }
     }
@@ -351,12 +354,12 @@ Describe "Ternary Operator parsing" -Tags CI {
         }
     }
 
-    It "Question-mark and colon parsed correctly in '<Script>' when not in ternary expression context" -TestCases $testCases_basic {
+    It "Question-mark and colon parsed correctly in <Script> when not in ternary expression context" -TestCases $testCases_basic {
         param($Script, $TokenKind)
 
         $tks = $null
         $ers = $null
-        $result = [Parser]::ParseInput($Script, [ref]$tks, [ref]$ers)
+        $result = [System.Management.Automation.Language.Parser]::ParseInput($Script, [ref]$tks, [ref]$ers)
 
         $tks[0].Kind | Should -BeExactly $TokenKind
         $tks[0].Text | Should -BeExactly $Script
@@ -378,11 +381,11 @@ Describe "Ternary Operator parsing" -Tags CI {
         2?3:4 | Should -BeExactly '2?3:4'
     }
 
-    It "Incomplete ternary expression '<Script>' should generate correct error" -TestCases $testCases_incomplete {
+    It "Incomplete ternary expression <Script> should generate correct error" -TestCases $testCases_incomplete {
         param($Script, $ErrorId, $AstType)
 
         $ers = $null
-        $result = [Parser]::ParseInput($Script, [ref]$null, [ref]$ers)
+        $result = [System.Management.Automation.Language.Parser]::ParseInput($Script, [ref]$null, [ref]$ers)
 
         $ers.Count | Should -Be 1
         $ers.IncompleteInput | Should -BeTrue
@@ -393,7 +396,7 @@ Describe "Ternary Operator parsing" -Tags CI {
 
     It "Generate ternary AST when operands are missing - '`$true ? :'" {
         $ers = $null
-        $result = [Parser]::ParseInput('$true ? :', [ref]$null, [ref]$ers)
+        $result = [System.Management.Automation.Language.Parser]::ParseInput('$true ? :', [ref]$null, [ref]$ers)
         $ers.Count | Should -Be 2
 
         $ers[0].IncompleteInput | Should -BeFalse
@@ -409,7 +412,7 @@ Describe "Ternary Operator parsing" -Tags CI {
 
     It "Generate ternary AST when operands are missing - '`$true ? : 3'" {
         $ers = $null
-        $result = [Parser]::ParseInput('$true ? : 3', [ref]$null, [ref]$ers)
+        $result = [System.Management.Automation.Language.Parser]::ParseInput('$true ? : 3', [ref]$null, [ref]$ers)
         $ers.Count | Should -Be 1
 
         $ers.IncompleteInput | Should -BeFalse


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add support to ternary operator `<condition> ? <if-true> : <if-false>`. It results in a `TernaryExpressionAst`.
Address #3239 
RFC: https://github.com/PowerShell/PowerShell-RFC/pull/218
The old draft PR where a lot of discussions happened: #10161

The ternary operator behaves like the simplified if-else statement. The `condition-expression` will always be evaluated, and its result will be converted to boolean to determine which branch will be evaluated next:
- `if-true-expression` will execute if the condition's result is evaluated as `true`
- `if-false-expression` will execute if the condition's result is evaluated as `false`

## PR Context

Ternary operator has lower precedence than binary operator, so you can write `$a -eq $b ? "Hello World" : [int]::MaxValue`.
In order to make the number constant expression work naturally with ternary operators, such as in `return ${succeed}?0:1`, characters `?` and `:` are made start-new-token chars conditionally when scanning for numbers.
When it's known for sure that we are expecting an expression, allowing a generic token like `123?` is not useful and bound to result in parsing errors.
In those cases, we will force to start a new token upon seeing characters `?` and `:` when scanning for a number, so that that number constant expressions can work with ternary operators more intuitively.

Note that, the implicit line continuance for `?` support was reverted in the latest code change based on the feedback I received within the team.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [x] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [x] Experimental feature name(s): `PSTernaryOperator`
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/4648
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [x] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
