### PR TITLE
Skip auto-loading PSReadLine on Windows if the NVDA screen reader is active

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -23,8 +23,8 @@ using System.Runtime;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.PowerShell.Telemetry;
+using Microsoft.PowerShell.Commands;
 
 using ConsoleHandle = Microsoft.Win32.SafeHandles.SafeFileHandle;
 using Dbg = System.Management.Automation.Diagnostics;
@@ -55,6 +55,11 @@ namespace Microsoft.PowerShell
         internal const int ExitCodeCtrlBreak = 128 + 21; // SIGBREAK
         internal const int ExitCodeInitFailure = 70; // Internal Software Error
         internal const int ExitCodeBadCommandLineParameter = 64; // Command Line Usage Error
+        private const uint SPI_GETSCREENREADER = 0x0046;
+
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool SystemParametersInfo(uint uiAction, uint uiParam, ref bool pvParam, uint fWinIni);
 
         // NTRAID#Windows Out Of Band Releases-915506-2005/09/09
         // Removed HandleUnexpectedExceptions infrastructure
@@ -582,7 +587,7 @@ namespace Microsoft.PowerShell
             }
 
             // Connect a disconnected command.
-            this.runningCmd = Microsoft.PowerShell.Commands.EnterPSSessionCommand.ConnectRunningPipeline(remoteRunspace);
+            this.runningCmd = EnterPSSessionCommand.ConnectRunningPipeline(remoteRunspace);
 
             // Push runspace.
             _runspaceRef.Override(remoteRunspace, hostGlobalLock, out _isRunspacePushed);
@@ -590,7 +595,7 @@ namespace Microsoft.PowerShell
 
             if (this.runningCmd != null)
             {
-                Microsoft.PowerShell.Commands.EnterPSSessionCommand.ContinueCommand(
+                EnterPSSessionCommand.ContinueCommand(
                     remoteRunspace,
                     this.runningCmd,
                     this,
@@ -858,7 +863,6 @@ namespace Microsoft.PowerShell
         /// </summary>
         /// <value></value>
         /// <exception/>
-
         public override System.Globalization.CultureInfo CurrentCulture
         {
             get
@@ -875,7 +879,6 @@ namespace Microsoft.PowerShell
         /// </summary>
         /// <value></value>
         /// <exception/>
-
         public override System.Globalization.CultureInfo CurrentUICulture
         {
             get
@@ -890,7 +893,6 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// </summary>
         /// <exception/>
-
         public override void SetShouldExit(int exitCode)
         {
             lock (hostGlobalLock)
@@ -1504,12 +1506,28 @@ namespace Microsoft.PowerShell
         }
 
         /// <summary>
-        /// This method is here only to make V1 tests compatible with V2. DO NOT USE THIS FUNCTION! Use DoCreateRunspace instead.
+        /// Check if a screen reviewer utility is running.
+        /// When a screen reader is running, we don't auto-load the PSReadLine module at startup,
+        /// as PSReadLine is not accessibility-firendly enough as of today.
         /// </summary>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        private void InitializeRunspace(string initialCommand, bool skipProfiles, Collection<CommandParameter> initialCommandArgs)
+        private bool IsScreenReaderActive()
         {
-            DoCreateRunspace(initialCommand, skipProfiles, staMode: false, configurationName: null, initialCommandArgs: initialCommandArgs);
+            if (_screenReaderActive.HasValue)
+            {
+                return _screenReaderActive.Value;
+            }
+
+            _screenReaderActive = false;
+            if (Platform.IsWindowsDesktop)
+            {
+                bool enabled = false;
+                if (SystemParametersInfo(SPI_GETSCREENREADER, 0, ref enabled, 0))
+                {
+                    _screenReaderActive = enabled;
+                }
+            }
+
+            return _screenReaderActive.Value;
         }
 
         private bool LoadPSReadline()
@@ -1542,6 +1560,7 @@ namespace Microsoft.PowerShell
                 bool psReadlineFailed = false;
 
                 // Load PSReadline by default unless there is no use:
+                //    - screen reader is active, such as NVDA, indicating non-visual access
                 //    - we're running a command/file and just exiting
                 //    - stdin is redirected by a parent process
                 //    - we're not interactive
@@ -1549,8 +1568,8 @@ namespace Microsoft.PowerShell
                 // It's also important to have a scenario where PSReadline is not loaded so it can be updated, e.g.
                 //    powershell -command "Update-Module PSReadline"
                 // This should work just fine as long as no other instances of PowerShell are running.
-                ReadOnlyCollection<Microsoft.PowerShell.Commands.ModuleSpecification> defaultImportModulesList = null;
-                if (LoadPSReadline())
+                ReadOnlyCollection<ModuleSpecification> defaultImportModulesList = null;
+                if (LoadPSReadline() && !IsScreenReaderActive())
                 {
                     // Create and open Runspace with PSReadline.
                     defaultImportModulesList = DefaultInitialSessionState.Modules;
@@ -2834,6 +2853,7 @@ namespace Microsoft.PowerShell
         private bool _setShouldExitCalled;
         private bool _isRunningPromptLoop;
         private bool _wasInitialCommandEncoded;
+        private bool? _screenReaderActive;
 
         // hostGlobalLock is used to sync public method calls (in case multiple threads call into the host) and access to
         // state that persists across method calls, like progress data. It's internal because the ui object also

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -1508,7 +1508,7 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// Check if a screen reviewer utility is running.
         /// When a screen reader is running, we don't auto-load the PSReadLine module at startup,
-        /// as PSReadLine is not accessibility-firendly enough as of today.
+        /// since PSReadLine is not accessibility-firendly enough as of today.
         /// </summary>
         private bool IsScreenReaderActive()
         {
@@ -1520,6 +1520,10 @@ namespace Microsoft.PowerShell
             _screenReaderActive = false;
             if (Platform.IsWindowsDesktop)
             {
+                // Note: this API can detect if a third-party screen reader is active, such as NVDA, but not the in-box Windows Narrator.
+                // Quoted from https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-systemparametersinfoa about the
+                // accessibility parameter 'SPI_GETSCREENREADER':
+                // "Narrator, the screen reader that is included with Windows, does not set the SPI_SETSCREENREADER or SPI_GETSCREENREADER flags."
                 bool enabled = false;
                 if (SystemParametersInfo(SPI_GETSCREENREADER, 0, ref enabled, 0))
                 {

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -124,6 +124,9 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 https://aka.ms/powershell
 Type 'help' to get help.</value>
   </data>
+  <data name="PSReadLineDisabledWhenScreenReaderIsActive" xml:space="preserve">
+    <value>Warning: PowerShell detected that you might be using a screen reader and has disabled PSReadLine for compatibility purposes. If you want to re-enable it, run 'Import-Module PSReadLine'.</value>
+  </data>
   <data name="UsageHelp" xml:space="preserve">
     <value>Usage: pwsh[.exe] [-Login] [[-File] &lt;filePath&gt; [args]]
                   [-Command { - | &lt;script-block&gt; [-args &lt;arg-array&gt;]

--- a/test/powershell/Host/ScreenReader.Tests.ps1
+++ b/test/powershell/Host/ScreenReader.Tests.ps1
@@ -43,6 +43,6 @@ Describe "Validate start of console host" -Tag CI {
 
         ## The warning message about screen reader should be returned, but the PSReadLine module should not be loaded.
         $output[0] | Should -BeLike "Warning:*'Import-Module PSReadLine'."
-        $output[1] | Should -BeExactly [string]::Empty
+        $output[1] | Should -BeExactly ([string]::Empty)
     }
 }

--- a/test/powershell/Host/ScreenReader.Tests.ps1
+++ b/test/powershell/Host/ScreenReader.Tests.ps1
@@ -1,0 +1,48 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+Describe "Validate start of console host" -Tag CI {
+    BeforeAll {
+        $csharp_source = @'
+            using System;
+            using System.Runtime.InteropServices;
+
+            public class ScreenReaderTestUtility {
+                private const uint SPI_SETSCREENREADER = 0x0047;
+
+                [DllImport("user32.dll", SetLastError = true)]
+                [return: MarshalAs(UnmanagedType.Bool)]
+                private static extern bool SystemParametersInfo(uint uiAction, uint uiParam, IntPtr pvParam, uint fWinIni);
+
+                public static bool ActivateScreenReader() {
+                    return SystemParametersInfo(SPI_SETSCREENREADER, 1u, IntPtr.Zero, 0);
+                }
+
+                public static bool DeactivateScreenReader() {
+                    return SystemParametersInfo(SPI_SETSCREENREADER, 0u, IntPtr.Zero, 0);
+                }
+            }
+'@
+        $utilType = "ScreenReaderTestUtility" -as [type]
+        if (-not $utilType) {
+            $utilType = Add-Type -TypeDefinition $csharp_source -PassThru
+        }
+
+        ## Make the screen reader status active.
+        $utilType::ActivateScreenReader()
+    }
+
+    AfterAll {
+        ## Make the screen reader status in-active.
+        $utilType::DeactivateScreenReader()
+    }
+
+    It "PSReadLine should not be auto-loaded when screen reader status is active" -Skip:(-not $IsWindows) {
+        $output = pwsh -noprofile -noexit -c "Get-Module PSReadLine; exit"
+        $output.Length | Should -BeExactly 2
+
+        ## The warning message about screen reader should be returned, but the PSReadLine module should not be loaded.
+        $output[0] | Should -BeLike "Warning:*'Import-Module PSReadLine'."
+        $output[1] | Should -BeExactly [string]::Empty
+    }
+}

--- a/test/powershell/Host/ScreenReader.Tests.ps1
+++ b/test/powershell/Host/ScreenReader.Tests.ps1
@@ -3,6 +3,10 @@
 
 Describe "Validate start of console host" -Tag CI {
     BeforeAll {
+        if (-not $IsWindows) {
+            return
+        }
+
         $csharp_source = @'
             using System;
             using System.Runtime.InteropServices;
@@ -33,8 +37,10 @@ Describe "Validate start of console host" -Tag CI {
     }
 
     AfterAll {
-        ## Make the screen reader status in-active.
-        $utilType::DeactivateScreenReader()
+        if ($IsWindows) {
+            ## Make the screen reader status in-active.
+            $utilType::DeactivateScreenReader()
+        }
     }
 
     It "PSReadLine should not be auto-loaded when screen reader status is active" -Skip:(-not $IsWindows) {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Skip auto-loading PSReadLine on Windows if the [NVDA screen reader](https://www.nvaccess.org/download/) is active.
The default rendering and formatting on Windows works with NVDA properly.

## PR Context

There is an accessibility issue with PowerShell Core:
> NVDA does not read the text (except first alphabet) whatever we type in the editor but when we delete it by using backspace, it reads all the characters.

PSReadLine moves the cursor a lot when rendering the text, and when a user is editing a multi-line text on screen, it has to re-render all text below the editing position because the rest of the text may need to move forward or backward depending on the editing. So as of today, the PSReadLine is not very friendly to the accessibility aspect of the user experience.
When it comes to `PSReadLine 3.0`, we will design with the accessibility aspect in mind from the very beginning.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/4659
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
