### PR TITLE
Remove extra cast to PSObject in ToStringEnumerable() method

### DIFF
--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -1131,9 +1131,7 @@ namespace System.Management.Automation
                 return string.Empty;
             }
 
-            int separatorLength = separatorToUse.Length;
-            returnValue.Remove(returnValue.Length - separatorLength, separatorLength);
-            return returnValue.ToString();
+            return returnValue.ToString(0, returnValue.Length - separatorToUse.Length);
         }
 
         internal static string ToStringEnumerable(ExecutionContext context, IEnumerable enumerable, string separator, string format, IFormatProvider formatProvider)

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -1144,8 +1144,7 @@ namespace System.Management.Automation
             {
                 if (obj != null)
                 {
-                    PSObject mshObj = PSObject.AsPSObject(obj);
-                    returnValue.Append(PSObject.ToString(context, mshObj, separator, format, formatProvider, false, false));
+                    returnValue.Append(PSObject.ToString(context, obj, separator, format, formatProvider, false, false));
                 }
 
                 returnValue.Append(separatorToUse);
@@ -1156,9 +1155,7 @@ namespace System.Management.Automation
                 return string.Empty;
             }
 
-            int separatorLength = separatorToUse.Length;
-            returnValue.Remove(returnValue.Length - separatorLength, separatorLength);
-            return returnValue.ToString();
+            return returnValue.ToString(0, returnValue.Length - separatorToUse.Length);
         }
 
         private static string ToStringEmptyBaseObject(ExecutionContext context, PSObject mshObj, string separator, string format, IFormatProvider formatProvider)

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -1130,8 +1130,9 @@ namespace System.Management.Automation
                 {
                     PSObject mshObj = PSObject.AsPSObject(obj);
                     returnValue.Append(PSObject.ToString(context, mshObj, separator, format, formatProvider, false, false));
-                    returnValue.Append(separatorToUse);
                 }
+
+                returnValue.Append(separatorToUse);
             }
 
             if (returnValue.Length == 0)

--- a/test/powershell/Language/Scripting/Join.Tests.ps1
+++ b/test/powershell/Language/Scripting/Join.Tests.ps1
@@ -1,0 +1,32 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+Describe 'Tests for join operator' -Tags "CI" {
+    BeforeAll {
+    }
+
+    It 'Join operator can use the custom ToString method defined in ETS' {
+        Add-Type -TypeDefinition @"
+        namespace TestNS
+        {
+           public class TestClass
+           {
+               public override string ToString()
+               {
+                   return "1";
+               }
+           }
+        }
+"@
+
+        $a1=[TestNS.TestClass]::new()
+        $a2=[TestNS.TestClass]::new()
+        $a3=[TestNS.TestClass]::new()
+
+        $a1,$a2,$a3 -join ";" | Should -BeExactly "1;1;1"
+
+        Update-TypeData -TypeName "TestNS.TestClass" -MemberType ScriptMethod -MemberName "ToString" -Value { return "test"}
+
+        $a1,$a2,$a3 -join ";" | Should -BeExactly "test;test;test"
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- Remove extra cast to PSObject in ToStringEnumerable() method
- Remove extra Remove() call

PerfView screenshot: left - before the change, right - after the fix.
![image](https://user-images.githubusercontent.com/22290914/63333357-c0269780-c352-11e9-898f-2a8cf6a22d62.png)


## PR Context

Fix #10377

For the scenario:
```powershell
$w2=${C:\tmp\source2.csv}
for ($i=1; $i -le 100; $i++) { $tmp = $w2 -join "`r`n" }
```
in `$w2` we have an array of strings (_not PSObjects!_) and join the strings. Before the fix in ToStringEnumerable() we did extra cast every string from $w2 to PSObject which caused unnecessary memory allocations and slow down the scenario because of skipping fast code path for value types.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
