### PR TITLE
Use fast set location at startup

### DIFF
--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -3269,7 +3269,7 @@ namespace System.Management.Automation.Runspaces
                             // default drive to $pshome
                             System.Diagnostics.Process currentProcess = System.Diagnostics.Process.GetCurrentProcess();
                             string defaultPath = System.IO.Path.GetDirectoryName(PsUtils.GetMainModule(currentProcess).FileName);
-                            context.EngineSessionState.SetLocationFast(defaultPath);
+                            context.EngineSessionState.SetLocationFileSystemFast(defaultPath);
                         }
                     }
                 }

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -3259,12 +3259,9 @@ namespace System.Management.Automation.Runspaces
 
                     if (proceedWithSetLocation && setLocation)
                     {
-                        CmdletProviderContext providerContext = new CmdletProviderContext(context);
-
                         try
                         {
-                            providerContext.SuppressWildcardExpansion = true;
-                            context.EngineSessionState.SetLocation(Directory.GetCurrentDirectory(), providerContext);
+                            context.EngineSessionState.SetLocationFileSystemFast(Directory.GetCurrentDirectory());
                         }
                         catch (ItemNotFoundException)
                         {
@@ -3272,7 +3269,7 @@ namespace System.Management.Automation.Runspaces
                             // default drive to $pshome
                             System.Diagnostics.Process currentProcess = System.Diagnostics.Process.GetCurrentProcess();
                             string defaultPath = System.IO.Path.GetDirectoryName(PsUtils.GetMainModule(currentProcess).FileName);
-                            context.EngineSessionState.SetLocation(defaultPath, providerContext);
+                            context.EngineSessionState.SetLocationFast(defaultPath);
                         }
                     }
                 }

--- a/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
@@ -596,6 +596,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="path">
         /// The file system path of the new current working directory.
+        /// The path must be an absolute file system path like 'c:\folder' or direct path like '/folder'.
         /// </param>
         /// <exception cref="ArgumentNullException">
         /// If <paramref name="path"/> is null.
@@ -617,8 +618,6 @@ namespace System.Management.Automation
                 current = CurrentLocation;
             }
 
-            PSDriveInfo previousWorkingDrive = CurrentDrive;
-
             if (LocationGlobber.IsProviderDirectPath(path))
             {
                 // The path is a provider-direct (drive is implicitly in the provider path) path so use the current
@@ -629,18 +628,7 @@ namespace System.Management.Automation
             }
             else
             {
-                // See if the path is a relative or absolute
-                // path.
-                if (Globber.IsAbsolutePath(path, out string driveName))
-                {
-                    // Since the path is an absolute path
-                    // we need to change the current working
-                    // drive
-                    CurrentDrive = GetDrive(driveName);
-
-                    // Now that the current working drive is set,
-                    // process the rest of the path as a relative path.
-                }
+                Dbg.Diagnostics.Assert(Globber.IsAbsolutePath(path, out string driveName), "Path must be an absolute file system path");
             }
 
             string currentPath = path.Substring(CurrentDrive.Root.Length);

--- a/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
@@ -621,7 +621,7 @@ namespace System.Management.Automation
 
             if (LocationGlobber.IsProviderDirectPath(path))
             {
-                // The path is a provider-direct path so use the current
+                // The path is a provider-direct (drive is implicitly in the provider path) path so use the current
                 // provider and its hidden drive but don't modify the path
                 // at all.
                 ProviderInfo provider = CurrentLocation.Provider;

--- a/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
@@ -596,7 +596,6 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="path">
         /// The file system path of the new current working directory.
-        /// The path must be an absolute file system path like 'c:\folder' or direct path like '/folder'.
         /// </param>
         /// <exception cref="ArgumentNullException">
         /// If <paramref name="path"/> is null.
@@ -618,6 +617,8 @@ namespace System.Management.Automation
                 current = CurrentLocation;
             }
 
+            PSDriveInfo previousWorkingDrive = CurrentDrive;
+
             if (LocationGlobber.IsProviderDirectPath(path))
             {
                 // The path is a provider-direct (drive is implicitly in the provider path) path so use the current
@@ -628,7 +629,18 @@ namespace System.Management.Automation
             }
             else
             {
-                Dbg.Diagnostics.Assert(Globber.IsAbsolutePath(path, out string driveName), "Path must be an absolute file system path");
+                // See if the path is a relative or absolute
+                // path.
+                if (Globber.IsAbsolutePath(path, out string driveName))
+                {
+                    // Since the path is an absolute path
+                    // we need to change the current working
+                    // drive
+                    CurrentDrive = GetDrive(driveName);
+
+                    // Now that the current working drive is set,
+                    // process the rest of the path as a relative path.
+                }
             }
 
             string currentPath = path.Substring(CurrentDrive.Root.Length);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

At startup we create initial runspace and set default location to current file system location (path).
For that we use _generic_ SetLocation() which designed to work with all providers and do many extra checks/operations.
In the startup scenario we know that the path is _valid_ file system path so we can use more simple and more fast set location.

On my system I get win ~10ms or ~1.62% and ~8Mb or ~3%.
The win comes from removing some extra file operations:
![image](https://user-images.githubusercontent.com/22290914/63431597-a19acc00-c438-11e9-9367-31d51a6e354c.png)

## PR Context

Related #6443

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
