### PR TITLE
Cleanup AutomationEngine and remove extra SetSessionStateDrive method call

### DIFF
--- a/src/System.Management.Automation/engine/AutomationEngine.cs
+++ b/src/System.Management.Automation/engine/AutomationEngine.cs
@@ -50,7 +50,7 @@ namespace System.Management.Automation
             {
                 // Fast skip if we already added the extention as ";.CPL".
                 // Fast skip if user already added the extention.
-                pathext = pathext + ";.CPL";
+                pathext += pathext[pathext.Length - 1] == ';' ? ".CPL" : ";.CPL";
                 Environment.SetEnvironmentVariable("PATHEXT", pathext);
             }
 #endif

--- a/src/System.Management.Automation/engine/AutomationEngine.cs
+++ b/src/System.Management.Automation/engine/AutomationEngine.cs
@@ -38,27 +38,19 @@ namespace System.Management.Automation
 #if !UNIX
             // Update the env variable PathEXT to contain .CPL
             var pathext = Environment.GetEnvironmentVariable("PathEXT");
-            pathext = pathext ?? string.Empty;
-            bool cplExist = false;
-            if (pathext != string.Empty)
-            {
-                string[] entries = pathext.Split(Utils.Separators.Semicolon);
-                foreach (string entry in entries)
-                {
-                    string ext = entry.Trim();
-                    if (ext.Equals(".CPL", StringComparison.OrdinalIgnoreCase))
-                    {
-                        cplExist = true;
-                        break;
-                    }
-                }
-            }
 
-            if (!cplExist)
+            if (string.IsNullOrEmpty(pathext))
             {
-                pathext = (pathext == string.Empty) ? ".CPL" :
-                    pathext.EndsWith(";", StringComparison.OrdinalIgnoreCase)
-                    ? (pathext + ".CPL") : (pathext + ";.CPL");
+                Environment.SetEnvironmentVariable("PathEXT", ".CPL");
+            }
+            else if (!(pathext.EndsWith(";.CPL", StringComparison.OrdinalIgnoreCase) ||
+                       pathext.StartsWith(".CPL;", StringComparison.OrdinalIgnoreCase) ||
+                       pathext.Contains(";.CPL;", StringComparison.OrdinalIgnoreCase) ||
+                       pathext.Equals(".CPL", StringComparison.OrdinalIgnoreCase)))
+            {
+                // Fast skip if we already added the extention as ";.CPL".
+                // Fast skip if user already added the extention.
+                pathext = pathext + ";.CPL";
                 Environment.SetEnvironmentVariable("PathEXT", pathext);
             }
 #endif

--- a/src/System.Management.Automation/engine/AutomationEngine.cs
+++ b/src/System.Management.Automation/engine/AutomationEngine.cs
@@ -61,9 +61,7 @@ namespace System.Management.Automation
             CommandDiscovery = new CommandDiscovery(Context);
 
             // Load the iss, resetting everything to it's defaults...
-            iss.Bind(Context, /*updateOnly*/ false);
-
-            InitialSessionState.SetSessionStateDrive(Context, true);
+            iss.Bind(Context, updateOnly: false, module: null, noClobber: false, local: false, setLocation: true);
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/AutomationEngine.cs
+++ b/src/System.Management.Automation/engine/AutomationEngine.cs
@@ -36,12 +36,12 @@ namespace System.Management.Automation
         internal AutomationEngine(PSHost hostInterface, InitialSessionState iss)
         {
 #if !UNIX
-            // Update the env variable PathEXT to contain .CPL
-            var pathext = Environment.GetEnvironmentVariable("PathEXT");
+            // Update the env variable PATHEXT to contain .CPL
+            var pathext = Environment.GetEnvironmentVariable("PATHEXT");
 
             if (string.IsNullOrEmpty(pathext))
             {
-                Environment.SetEnvironmentVariable("PathEXT", ".CPL");
+                Environment.SetEnvironmentVariable("PATHEXT", ".CPL");
             }
             else if (!(pathext.EndsWith(";.CPL", StringComparison.OrdinalIgnoreCase) ||
                        pathext.StartsWith(".CPL;", StringComparison.OrdinalIgnoreCase) ||
@@ -51,7 +51,7 @@ namespace System.Management.Automation
                 // Fast skip if we already added the extention as ";.CPL".
                 // Fast skip if user already added the extention.
                 pathext = pathext + ";.CPL";
-                Environment.SetEnvironmentVariable("PathEXT", pathext);
+                Environment.SetEnvironmentVariable("PATHEXT", pathext);
             }
 #endif
 

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -2097,12 +2097,7 @@ namespace System.Management.Automation.Runspaces
 
         private object _syncObject = new Object();
 
-        internal void Bind(ExecutionContext context, bool updateOnly)
-        {
-            Bind(context, updateOnly, null, /*noClobber*/false, /*local*/ false);
-        }
-
-        internal void Bind(ExecutionContext context, bool updateOnly, PSModuleInfo module, bool noClobber, bool local)
+        internal void Bind(ExecutionContext context, bool updateOnly, PSModuleInfo module, bool noClobber, bool local, bool setLocation)
         {
             Host = context.EngineHostInterface;
             lock (_syncObject)
@@ -2205,7 +2200,7 @@ namespace System.Management.Automation.Runspaces
                 }
             }
 
-            SetSessionStateDrive(context, setLocation: false);
+            SetSessionStateDrive(context, setLocation: setLocation);
         }
 
         private void Bind_SetVariables(SessionStateInternal ss)

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -2396,7 +2396,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     try
                     {
-                        iss.Bind(Context, /*updateOnly*/ true);
+                        iss.Bind(Context, updateOnly: true, module: null, noClobber: false, local: false, setLocation: false);
                     }
                     catch (Exception e)
                     {
@@ -6765,7 +6765,7 @@ namespace Microsoft.PowerShell.Commands
                         iss.DisableFormatUpdates = true;
 
                     // Load the cmdlets and providers, bound to the new module...
-                    iss.Bind(Context, /*updateOnly*/ true, module, options.NoClobber, options.Local);
+                    iss.Bind(Context, updateOnly: true, module, options.NoClobber, options.Local, setLocation: false);
 
                     // Scan all of the types in the assembly to register JobSourceAdapters.
                     IEnumerable<Type> allTypes = new Type[] { };


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- first commit is more cosmetic (only 0.3us (8%) perf win at startup time and 3us (80%) at opening follow runspaces). I measured the impact of the Steve's commit for .CPL and a result is this code, so I publish it. I measured with BenchmarkDotNet only the .CPL related code.
- second commit remove extra SetSessionStateDrive method call. I haven't reliable tests to show perf win. Script tests have too much deviation. Main perf win in the code path (I mean AutomationEngine() ) is fixed in #10401 - there we exclude some extra file operations that is ~10 ms perf win on my system. But there still is extra SetSessionStateDrive method call - we remove this in the PR that will be ~<1 ms perf win.

Based on the commit description I mark the PR as cleanup, not performance.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
