### PR TITLE
Improve Null-Like behaviour in comparisons

### DIFF
--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -1071,7 +1071,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="obj">The object to test.</param>
         /// <returns>True if the object is null.</returns>
-        public static bool IsNullLike(object obj) => obj == DBNull.Value || obj == NullString.Value || IsNull(obj);
+        public static bool IsNullLike(object obj) => IsNull(obj) || obj == DBNull.Value || obj == NullString.Value;
 
         /// <summary>
         /// Auxiliary for the cases where we want a new PSObject or null.

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -3184,9 +3184,9 @@ namespace System.Management.Automation.Language
                     ? CompareWithZero(target, Expression.LessThan)
                     : arg.LimitType.IsNumeric()
                         ? CompareWithZero(arg, Expression.GreaterThanOrEqual)
-                        : !LanguagePrimitives.IsNullLike(arg.Value)
-                            ? ExpressionCache.BoxedTrue
-                            : ExpressionCache.BoxedFalse;
+                        : LanguagePrimitives.IsNullLike(arg.Value)
+                            ? ExpressionCache.BoxedFalse
+                            : ExpressionCache.BoxedTrue;
 
                 return new DynamicMetaObject(result, target.CombineRestrictions(arg));
             }
@@ -3209,9 +3209,9 @@ namespace System.Management.Automation.Language
                     ? CompareWithZero(target, Expression.LessThan)
                     : arg.LimitType.IsNumeric()
                         ? CompareWithZero(arg, Expression.GreaterThanOrEqual)
-                        : !LanguagePrimitives.IsNullLike(target.Value)
-                            ? ExpressionCache.BoxedFalse
-                            : ExpressionCache.BoxedTrue;
+                        : LanguagePrimitives.IsNullLike(target.Value)
+                            ? ExpressionCache.BoxedTrue
+                            : ExpressionCache.BoxedFalse;
 
                 return new DynamicMetaObject(result, target.CombineRestrictions(arg));
             }
@@ -3236,9 +3236,9 @@ namespace System.Management.Automation.Language
                     ? CompareWithZero(target, Expression.GreaterThanOrEqual)
                     : arg.LimitType.IsNumeric()
                         ? CompareWithZero(arg, Expression.LessThan)
-                        : !LanguagePrimitives.IsNullLike(target.Value)
-                            ? ExpressionCache.BoxedTrue
-                            : ExpressionCache.BoxedFalse;
+                        : LanguagePrimitives.IsNullLike(target.Value)
+                            ? ExpressionCache.BoxedFalse
+                            : ExpressionCache.BoxedTrue;
 
                 return new DynamicMetaObject(result, target.CombineRestrictions(arg));
             }
@@ -3263,9 +3263,9 @@ namespace System.Management.Automation.Language
                     ? CompareWithZero(target, Expression.GreaterThanOrEqual)
                     : arg.LimitType.IsNumeric()
                         ? CompareWithZero(arg, Expression.LessThan)
-                        : !LanguagePrimitives.IsNullLike(arg.Value)
-                            ? ExpressionCache.BoxedFalse
-                            : ExpressionCache.BoxedTrue;
+                        : LanguagePrimitives.IsNullLike(arg.Value)
+                            ? ExpressionCache.BoxedTrue
+                            : ExpressionCache.BoxedFalse;
 
                 return new DynamicMetaObject(result, target.CombineRestrictions(arg));
             }

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -3206,7 +3206,7 @@ namespace System.Management.Automation.Language
                     || LanguagePrimitives.IsNullLike(arg.Value)))
             {
                 Expression result = target.LimitType.IsNumeric()
-                    ? CompareWithZero(target, Expression.LessThan)
+                    ? CompareWithZero(target, Expression.LessThanOrEqual)
                     : arg.LimitType.IsNumeric()
                         ? CompareWithZero(arg, Expression.GreaterThanOrEqual)
                         : LanguagePrimitives.IsNullLike(target.Value)
@@ -3262,7 +3262,7 @@ namespace System.Management.Automation.Language
                 Expression result = target.LimitType.IsNumeric()
                     ? CompareWithZero(target, Expression.GreaterThanOrEqual)
                     : arg.LimitType.IsNumeric()
-                        ? CompareWithZero(arg, Expression.LessThan)
+                        ? CompareWithZero(arg, Expression.LessThanOrEqual)
                         : LanguagePrimitives.IsNullLike(arg.Value)
                             ? ExpressionCache.BoxedTrue
                             : ExpressionCache.BoxedFalse;

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -3170,18 +3170,23 @@ namespace System.Management.Automation.Language
             return comparer(target.Expression.Cast(target.LimitType), ExpressionCache.Constant(0).Cast(target.LimitType)).Cast(typeof(object));
         }
 
-        private DynamicMetaObject CompareLT(DynamicMetaObject target,
-                                            DynamicMetaObject arg,
-                                            DynamicMetaObject errorSuggestion)
+        private DynamicMetaObject CompareLT(
+            DynamicMetaObject target,
+            DynamicMetaObject arg,
+            DynamicMetaObject errorSuggestion)
         {
             var enumerable = PSEnumerableBinder.IsEnumerable(target);
-            if (enumerable == null && (target.Value == null || arg.Value == null))
+            if (enumerable == null
+                && (LanguagePrimitives.IsNullLike(target.Value)
+                    || LanguagePrimitives.IsNullLike(arg.Value)))
             {
-                Expression result =
-                      target.LimitType.IsNumeric() ? CompareWithZero(target, Expression.LessThan)
-                    : arg.LimitType.IsNumeric() ? CompareWithZero(arg, Expression.GreaterThanOrEqual)
-                    : arg.Value != null ? ExpressionCache.BoxedTrue
-                    : ExpressionCache.BoxedFalse;
+                Expression result = target.LimitType.IsNumeric()
+                    ? CompareWithZero(target, Expression.LessThan)
+                    : arg.LimitType.IsNumeric()
+                        ? CompareWithZero(arg, Expression.GreaterThanOrEqual)
+                        : !LanguagePrimitives.IsNullLike(arg.Value)
+                            ? ExpressionCache.BoxedTrue
+                            : ExpressionCache.BoxedFalse;
 
                 return new DynamicMetaObject(result, target.CombineRestrictions(arg));
             }
@@ -3190,18 +3195,23 @@ namespace System.Management.Automation.Language
                 ?? BinaryComparison(target, arg, e => Expression.LessThan(e, ExpressionCache.Constant(0)));
         }
 
-        private DynamicMetaObject CompareLE(DynamicMetaObject target,
-                                            DynamicMetaObject arg,
-                                            DynamicMetaObject errorSuggestion)
+        private DynamicMetaObject CompareLE(
+            DynamicMetaObject target,
+            DynamicMetaObject arg,
+            DynamicMetaObject errorSuggestion)
         {
             var enumerable = PSEnumerableBinder.IsEnumerable(target);
-            if (enumerable == null && (target.Value == null || arg.Value == null))
+            if (enumerable == null
+                && (LanguagePrimitives.IsNullLike(target.Value)
+                    || LanguagePrimitives.IsNullLike(arg.Value)))
             {
-                Expression result =
-                      target.LimitType.IsNumeric() ? CompareWithZero(target, Expression.LessThan)
-                    : arg.LimitType.IsNumeric() ? CompareWithZero(arg, Expression.GreaterThanOrEqual)
-                    : target.Value != null ? ExpressionCache.BoxedFalse
-                    : ExpressionCache.BoxedTrue;
+                Expression result = target.LimitType.IsNumeric()
+                    ? CompareWithZero(target, Expression.LessThan)
+                    : arg.LimitType.IsNumeric()
+                        ? CompareWithZero(arg, Expression.GreaterThanOrEqual)
+                        : !LanguagePrimitives.IsNullLike(target.Value)
+                            ? ExpressionCache.BoxedFalse
+                            : ExpressionCache.BoxedTrue;
 
                 return new DynamicMetaObject(result, target.CombineRestrictions(arg));
             }
@@ -3210,20 +3220,25 @@ namespace System.Management.Automation.Language
                 ?? BinaryComparison(target, arg, e => Expression.LessThanOrEqual(e, ExpressionCache.Constant(0)));
         }
 
-        private DynamicMetaObject CompareGT(DynamicMetaObject target,
-                                            DynamicMetaObject arg,
-                                            DynamicMetaObject errorSuggestion)
+        private DynamicMetaObject CompareGT(
+            DynamicMetaObject target,
+            DynamicMetaObject arg,
+            DynamicMetaObject errorSuggestion)
         {
             // Handle a null operand as a special case here unless the target is enumerable or if one of the operands is numeric,
             // in which case null is converted to 0 and regular numeric comparison is done.
             var enumerable = PSEnumerableBinder.IsEnumerable(target);
-            if (enumerable == null && (target.Value == null || arg.Value == null))
+            if (enumerable == null
+                && (LanguagePrimitives.IsNullLike(target.Value)
+                    || LanguagePrimitives.IsNullLike(arg.Value)))
             {
-                Expression result =
-                      target.LimitType.IsNumeric() ? CompareWithZero(target, Expression.GreaterThanOrEqual)
-                    : arg.LimitType.IsNumeric() ? CompareWithZero(arg, Expression.LessThan)
-                    : target.Value != null ? ExpressionCache.BoxedTrue
-                    : ExpressionCache.BoxedFalse;
+                Expression result = target.LimitType.IsNumeric()
+                    ? CompareWithZero(target, Expression.GreaterThanOrEqual)
+                    : arg.LimitType.IsNumeric()
+                        ? CompareWithZero(arg, Expression.LessThan)
+                        : !LanguagePrimitives.IsNullLike(target.Value)
+                            ? ExpressionCache.BoxedTrue
+                            : ExpressionCache.BoxedFalse;
 
                 return new DynamicMetaObject(result, target.CombineRestrictions(arg));
             }
@@ -3232,20 +3247,25 @@ namespace System.Management.Automation.Language
                 ?? BinaryComparison(target, arg, e => Expression.GreaterThan(e, ExpressionCache.Constant(0)));
         }
 
-        private DynamicMetaObject CompareGE(DynamicMetaObject target,
-                                            DynamicMetaObject arg,
-                                            DynamicMetaObject errorSuggestion)
+        private DynamicMetaObject CompareGE(
+            DynamicMetaObject target,
+            DynamicMetaObject arg,
+            DynamicMetaObject errorSuggestion)
         {
             // Handle a null operand as a special case here unless the target is enumerable or if one of the operands is numeric,
             // in which case null is converted to 0 and regular numeric comparison is done.
             var enumerable = PSEnumerableBinder.IsEnumerable(target);
-            if (enumerable == null && (target.Value == null || arg.Value == null))
+            if (enumerable == null
+                && (LanguagePrimitives.IsNullLike(target.Value)
+                    || LanguagePrimitives.IsNullLike(arg.Value)))
             {
-                Expression result =
-                      target.LimitType.IsNumeric() ? CompareWithZero(target, Expression.GreaterThanOrEqual)
-                    : arg.LimitType.IsNumeric() ? CompareWithZero(arg, Expression.LessThan)
-                    : arg.Value != null ? ExpressionCache.BoxedFalse
-                    : ExpressionCache.BoxedTrue;
+                Expression result = target.LimitType.IsNumeric()
+                    ? CompareWithZero(target, Expression.GreaterThanOrEqual)
+                    : arg.LimitType.IsNumeric()
+                        ? CompareWithZero(arg, Expression.LessThan)
+                        : !LanguagePrimitives.IsNullLike(arg.Value)
+                            ? ExpressionCache.BoxedFalse
+                            : ExpressionCache.BoxedTrue;
 
                 return new DynamicMetaObject(result, target.CombineRestrictions(arg));
             }

--- a/test/powershell/Language/Scripting/NullRepresentatives.Tests.ps1
+++ b/test/powershell/Language/Scripting/NullRepresentatives.Tests.ps1
@@ -100,25 +100,33 @@ Describe 'Null Representatives' -Tags 'CI' {
         It '<Value> should be considered greater than or equal to 0' -TestCases $TestValues {
             param($Value)
 
-            $Value.InvokeReturnAsIs() -ge 0 | Should -BeTrue
+            $TestValue = $Value.InvokeReturnAsIs()
+            $TestValue -ge 0 | Should -BeTrue
+            0 -le $TestValue | Should -BeTrue
         }
 
         It '<Value> should be considered less than or equal to 0' -TestCases $TestValues {
             param($Value)
 
-            $Value.InvokeReturnAsIs() -le 0 | Should -BeTrue
+            $TestValue = $Value.InvokeReturnAsIs()
+            $TestValue -le 0 | Should -BeTrue
+            0 -ge $TestValue | Should -BeTrue
         }
 
         It '<Value> should be less than 1' -TestCases $TestValues {
             param($Value)
 
-            $Value.InvokeReturnAsIs() -lt 1 | Should -BeTrue
+            $TestValue = $Value.InvokeReturnAsIs()
+            $TestValue -lt 1 | Should -BeTrue
+            1 -gt $TestValue | Should -BeTrue
         }
 
         It '<Value> should be greater than -1' -TestCases $TestValues {
             param($Value)
 
-            $Value.InvokeReturnAsIs() -gt -1 | Should -BeTrue
+            $TestValue = $Value.InvokeReturnAsIs()
+            $TestValue -gt -1 | Should -BeTrue
+            -1 -lt $TestValue | Should -BeTrue
         }
     }
 }

--- a/test/powershell/Language/Scripting/NullRepresentatives.Tests.ps1
+++ b/test/powershell/Language/Scripting/NullRepresentatives.Tests.ps1
@@ -100,7 +100,13 @@ Describe 'Null Representatives' -Tags 'CI' {
         It '<Value> should be considered greater than or equal to 0' -TestCases $TestValues {
             param($Value)
 
-            0 -ge $Value.InvokeReturnAsIs() | Should -BeTrue
+            $Value.InvokeReturnAsIs() -ge 0 | Should -BeTrue
+        }
+
+        It '<Value> should be considered less than or equal to 0' -TestCases $TestValues {
+            param($Value)
+
+            $Value.InvokeReturnAsIs() -le 0 | Should -BeTrue
         }
 
         It '<Value> should be less than 1' -TestCases $TestValues {

--- a/test/powershell/Language/Scripting/NullRepresentatives.Tests.ps1
+++ b/test/powershell/Language/Scripting/NullRepresentatives.Tests.ps1
@@ -86,4 +86,33 @@ Describe 'Null Representatives' -Tags 'CI' {
             @{ Value = [NullString]::Value; ExpectedCount = 5 }
         )
     }
+
+    Context 'Numeric Comparisons' {
+        BeforeAll {
+            $TestValues = @(
+                @{ Value = { $null } }
+                @{ Value = { [DBNull]::Value } }
+                @{ Value = { [NullString]::Value } }
+                @{ Value = { [AutomationNull]::Value } }
+            )
+        }
+
+        It '<Value> should be considered greater than or equal to 0' -TestCases $TestValues {
+            param($Value)
+
+            0 -ge $Value.InvokeReturnAsIs() | Should -BeTrue
+        }
+
+        It '<Value> should be less than 1' -TestCases $TestValues {
+            param($Value)
+
+            $Value.InvokeReturnAsIs() -lt 1 | Should -BeTrue
+        }
+
+        It '<Value> should be greater than -1' -TestCases $TestValues {
+            param($Value)
+
+            $Value.InvokeReturnAsIs() -gt -1 | Should -BeTrue
+        }
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This changes the operator binders for `-lt`/`-gt` (etc.) to recognise null-like values the same as it does for `null`, so that it treats them as a `0` value when comparing to a numeric value.

```powershell
[nullstring]::Value -gt 3 # False
[dbnull]::Value -gt 2 # False
```

## PR Context

Fixes #10404

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
