### PR TITLE
Alpine validation changes

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -1006,7 +1006,13 @@ function Start-PSPester {
     Write-Verbose "Running pester tests at '$path' with tag '$($Tag -join ''', ''')' and ExcludeTag '$($ExcludeTag -join ''', ''')'" -Verbose
     if(!$SkipTestToolBuild.IsPresent)
     {
-        Publish-PSTestTools | ForEach-Object {Write-Host $_}
+        $publishArgs = @{ }
+        # if we are building for Alpine, we must include the runtime as linux-x64
+        # will not build runnable test tools
+        if ( $Environment.IsAlpine ) {
+            $publishArgs['runtime'] = 'alpine-x64'
+        }
+        Publish-PSTestTools @publishArgs | ForEach-Object {Write-Host $_}
     }
 
     # All concatenated commands/arguments are suffixed with the delimiter (space)

--- a/test/powershell/Host/Startup.Tests.ps1
+++ b/test/powershell/Host/Startup.Tests.ps1
@@ -103,6 +103,11 @@ Describe "Validate start of console host" -Tag CI {
     }
 
     It "No new assemblies are loaded" {
+        if ( (Get-PlatformInfo) -eq "alpine" ) {
+            Set-ItResult -Pending -Because "Missing MI library causes list to be different"
+            return
+        }
+
         $diffs = Compare-Object -ReferenceObject $allowedAssemblies -DifferenceObject $loadedAssemblies
 
         if ($null -ne $diffs) {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -108,7 +108,12 @@ Describe "Test-Connection" -tags "CI" {
             # After .Net Core fix we should have 'DontFragment | Should -Be $true' here.
             $result1.Replies[0].Options.Ttl          | Should -BeLessOrEqual 128
             if (!$isWindows) {
-                $result1.Replies[0].Options.DontFragment | Should -BeNullOrEmpty
+                if ( (Get-PlatformInfo) -eq "alpine" ) {
+                    $result1.Replies[0].Options.DontFragment | Should -Be $true
+                }
+                else {
+                    $result1.Replies[0].Options.DontFragment | Should -BeNullOrEmpty
+                }
                 # depending on the network configuration any of the following should be returned
                 $result2.Replies[0].Status               | Should -BeIn "TtlExpired","TimedOut","Success"
             } else {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
@@ -29,7 +29,12 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
 
         $seconds | Should -Be "1577836800"
         if ($isLinux) {
-            $seconds | Should -Be (date --date='01/01/2020 UTC' +%s)
+            $dateString = "01/01/2020 UTC"
+            if ( (Get-PlatformInfo) -eq "alpine" ) {
+                $dateString = "2020-01-01"
+            }
+            $expected = date --date=${dateString} +%s
+            $seconds | Should -Be $expected
         }
     }
 

--- a/test/powershell/Modules/PSDesiredStateConfiguration/MOF-Compilation.Tests.ps1
+++ b/test/powershell/Modules/PSDesiredStateConfiguration/MOF-Compilation.Tests.ps1
@@ -7,6 +7,7 @@ Describe "DSC MOF Compilation" -tags "CI" {
     }
 
     BeforeAll {
+        $IsAlpine = (Get-PlatformInfo) -eq "alpine"
         Import-Module PSDesiredStateConfiguration
         $dscModule = Get-Module PSDesiredStateConfiguration
         $baseSchemaPath = Join-Path $dscModule.ModuleBase 'Configuration'
@@ -20,7 +21,7 @@ Describe "DSC MOF Compilation" -tags "CI" {
         $env:PSModulePath = join-path ([io.path]::GetDirectoryName($powershellexe)) Modules
     }
 
-    It "Should be able to compile a MOF from a basic configuration" -Skip:($IsMacOS -or $IsWindows) {
+    It "Should be able to compile a MOF from a basic configuration" -Skip:($IsMacOS -or $IsWindows -or $IsAlpine) {
         [Scriptblock]::Create(@"
         configuration DSCTestConfig
         {
@@ -39,7 +40,7 @@ Describe "DSC MOF Compilation" -tags "CI" {
         "TestDrive:\DscTestConfig1\localhost.mof" | Should -Exist
     }
 
-    It "Should be able to compile a MOF from another basic configuration" -Skip:($IsMacOS -or $IsWindows) {
+    It "Should be able to compile a MOF from another basic configuration" -Skip:($IsMacOS -or $IsWindows -or $IsAlpine) {
         [Scriptblock]::Create(@"
         configuration DSCTestConfig
         {
@@ -61,7 +62,7 @@ Describe "DSC MOF Compilation" -tags "CI" {
         "TestDrive:\DscTestConfig2\localhost.mof" | Should -Exist
     }
 
-    It "Should be able to compile a MOF from a complex configuration" -Skip:($IsMacOS -or $IsWindows) {
+    It "Should be able to compile a MOF from a complex configuration" -Skip:($IsMacOS -or $IsWindows -or $IsAlpine) {
         [Scriptblock]::Create(@"
     Configuration WordPressServer{
 
@@ -170,7 +171,7 @@ Describe "DSC MOF Compilation" -tags "CI" {
         "TestDrive:\DscTestConfig3\CentOS.mof" | Should -Exist
     }
 
-    It "Should be able to compile a MOF from a basic configuration on Windows" -Skip:($IsMacOS -or $IsLinux) {
+    It "Should be able to compile a MOF from a basic configuration on Windows" -Skip:($IsMacOS -or $IsLinux -or $IsAlpine) {
         [Scriptblock]::Create(@"
         configuration DSCTestConfig
         {
@@ -190,7 +191,7 @@ Describe "DSC MOF Compilation" -tags "CI" {
         "TestDrive:\DscTestConfig4\localhost.mof" | Should -Exist
     }
 
-    It "Should be able to compile a MOF from a configuration with multiple resources on Windows" -Skip:($IsMacOS -or $IsLinux) {
+    It "Should be able to compile a MOF from a configuration with multiple resources on Windows" -Skip:($IsMacOS -or $IsLinux -or $IsAlpine) {
         [Scriptblock]::Create(@"
         configuration DSCTestConfig
         {

--- a/test/powershell/engine/Remoting/PSSession.Tests.ps1
+++ b/test/powershell/engine/Remoting/PSSession.Tests.ps1
@@ -73,6 +73,11 @@ Describe "SkipCACheck and SkipCNCheck PSSession options are required for New-PSS
     It "<Name>" -TestCases $testCases {
         param ($scriptBlock, $expectedErrorCode)
 
+        if ( (Get-PlatformInfo) -eq "alpine" ) {
+            Set-ItResult -Pending -Because "MI library not available for Alpine"
+            return
+        }
+
         $er = { & $scriptBlock } | Should -Throw -ErrorId 'System.Management.Automation.Remoting.PSRemotingDataStructureException,Microsoft.PowerShell.Commands.NewPSSessionCommand' -PassThru
         $er.Exception.ErrorCode | Should -Be $expectedErrorCode
     }

--- a/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
+++ b/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
@@ -5,6 +5,11 @@ Import-Module HelpersCommon
 
 Describe "New-PSSession basic test" -Tag @("CI") {
     It "New-PSSession should not crash powershell" {
+        if ( (Get-PlatformInfo) -eq "alpine" ) {
+            Set-ItResult -Pending -Because "MI library not available for Alpine"
+            return
+        }
+
         { New-PSSession -ComputerName nonexistcomputer -Authentication Basic } |
            Should -Throw -ErrorId "InvalidOperation,Microsoft.PowerShell.Commands.NewPSSessionCommand"
     }
@@ -12,6 +17,11 @@ Describe "New-PSSession basic test" -Tag @("CI") {
 
 Describe "Basic Auth over HTTP not allowed on Unix" -Tag @("CI") {
     It "New-PSSession should throw when specifying Basic Auth over HTTP on Unix" -skip:($IsWindows) {
+        if ( (Get-PlatformInfo) -eq "alpine" ) {
+            Set-ItResult -Pending -Because "MI library not available for Alpine"
+            return
+        }
+
         $password = ConvertTo-SecureString -String "password" -AsPlainText -Force
         $credential = [PSCredential]::new('username', $password)
 
@@ -23,6 +33,11 @@ Describe "Basic Auth over HTTP not allowed on Unix" -Tag @("CI") {
     }
 
     It "New-PSSession should NOT throw a ConnectFailed exception when specifying Basic Auth over HTTPS on Unix" -skip:($IsWindows) {
+        if ( (Get-PlatformInfo) -eq "alpine" ) {
+            Set-ItResult -Pending -Because "MI library not available for Alpine"
+            return
+        }
+
         $password = ConvertTo-SecureString -String "password" -AsPlainText -Force
         $credential = [PSCredential]::new('username', $password)
 

--- a/test/tools/Modules/HelpersCommon/HelpersCommon.psd1
+++ b/test/tools/Modules/HelpersCommon/HelpersCommon.psd1
@@ -34,6 +34,7 @@ FunctionsToExport = @(
         'Test-TesthookIsSet'
         'Wait-FileToBePresent'
         'Wait-UntilTrue'
+        'Get-PlatformInfo'
     )
 
 CmdletsToExport= @()

--- a/test/tools/Modules/HelpersCommon/HelpersCommon.psm1
+++ b/test/tools/Modules/HelpersCommon/HelpersCommon.psm1
@@ -363,3 +363,21 @@ function New-ComplexPassword
 
     $password
 }
+
+# return a specific string with regard to platform information
+function Get-PlatformInfo
+{
+    if ( $IsWindows ) {
+        return "windows"
+    }
+    if ( $IsMacOS ) {
+        return "macos"
+    }
+    if ( $IsLinux ) {
+        $osrelease = Get-Content /etc/os-release | ConvertFrom-StringData
+        if ( -not [string]::IsNullOrEmpty($osrelease.ID) ) {
+            return $osrelease.ID
+        }
+        return "unknown"
+    }
+}


### PR DESCRIPTION
# PR Summary

Test (and build) changes to run validation on alpine 8, 9, and 10

## PR Context

Alpine has different behavior for some native tools (ping and date) which causes validation to fail.
Also when building test executables for alpine, using `-runtime linux-x64` will not build executable binaries, you must use `-runtime alpine-x64`.
I've also created a new function in the common test helper to return platform information that is more granular than IsLinux/IsMacOS/IsWindows as we need to know when we're running on alpine as some tests are not going to work until libmi is delivered. so all of the session cmdlets aren't going to work.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
