### PR TITLE
WIP: Refactor ErrorRecord formatting

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -739,9 +739,9 @@ namespace System.Management.Automation.Runspaces
 
         private static IEnumerable<FormatViewDefinition> ViewsOf_System_Management_Automation_ErrorRecord()
         {
-            var formatNativeCommandError = "$_.Exception.Message";
             var isNativeCommandError = "$_.FullyQualifiedErrorId -in @('NativeCommandErrorMessage', 'NativeCommandError')";
-            var isNotNativeCommandErrorScript = $"-not ({isNativeCommandError})";
+            var isNotNativeCommandError = "$_.FullyQualifiedErrorId -notin @('NativeCommandErrorMessage', 'NativeCommandError')";
+            var formatNativeCommandError = "$_.Exception.Message";
 
             var customControlNormalView = CustomControl.Create()
                     .StartEntry()
@@ -809,21 +809,20 @@ namespace System.Management.Automation.Runspaces
 
                                     if ($_.ErrorDetails -and $_.ErrorDetails.Message) {
                                         $posmsg = $posmsg.Insert(0, $_.ErrorDetails.Message)
-                                        $sb = $sb.Append($posmsg)
                                     } else {
                                         $posmsg = $posmsg.Insert(0, $_.Exception.Message)
-                                        $sb = $sb.Append($posmsg).AppendLine()
                                     }
+                                    $sb = $sb.Append($posmsg).AppendLine()
 
                                     $sb.ToString()
-                                ", selectedByScript: isNotNativeCommandErrorScript)
+                                ", selectedByScript: isNotNativeCommandError)
                     .EndEntry()
                 .EndControl();
 
             var customControlCategoryView = CustomControl.Create()
                     .StartEntry()
                         .AddScriptBlockExpressionBinding(formatNativeCommandError, selectedByScript: isNativeCommandError)
-                        .AddScriptBlockExpressionBinding("$_.CategoryInfo.GetMessage()", selectedByScript: isNotNativeCommandErrorScript)
+                        .AddScriptBlockExpressionBinding("$_.CategoryInfo.GetMessage()", selectedByScript: isNotNativeCommandError)
                     .EndEntry()
                 .EndControl();
 


### PR DESCRIPTION
# PR Summary

I'm opening this PR to capture the refactoring work I did last night for the `ErrorRecord` custom formatting. This work, combined with the work I'm doing in #10430, allows you to pull up different error views on demand using `Format-Custom -View $viewName`. Without #10430 in place, you currently have to use `-Force` to see the different view.

## PR Context

This PR dramatically cleans up the `ErrorRecord` formatting logic that is written using PowerShell, improving performance and simplifying the logic substantially while retaining all existing functionality.

It also sets things up so that `ErrorRecord` views can be referenced in `Format-Custom` by name.

One possible point of contention with these changes: they allow you to use or discard the `View` suffix that is applied to whatever value you assign to `$ErrorView`. For the view names that you can reference in `Format-Custom -View $viewName`, those names are not suffixed with `View`.

I'm sharing this logic because of the open RFC about error views, so that it can be leveraged as part of that work if desired.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [X] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
