### PR TITLE
Cleanup TestConnectionCommand

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -17,11 +17,11 @@ namespace Microsoft.PowerShell.Commands
     /// The implementation of the "Test-Connection" cmdlet.
     /// </summary>
     [Cmdlet(VerbsDiagnostic.Test, "Connection", DefaultParameterSetName = DefaultPingSet, HelpUri = "https://go.microsoft.com/fwlink/?LinkID=135266")]
-    [OutputType(typeof(PingReport), ParameterSetName = new string[] { DefaultPingSet })]
-    [OutputType(typeof(PingReply), ParameterSetName = new string[] { RepeatPingSet, MtuSizeDetectSet })]
-    [OutputType(typeof(bool), ParameterSetName = new string[] { DefaultPingSet, RepeatPingSet, TcpPortSet })]
-    [OutputType(typeof(Int32), ParameterSetName = new string[] { MtuSizeDetectSet })]
-    [OutputType(typeof(TraceRouteReply), ParameterSetName = new string[] { TraceRouteSet })]
+    [OutputType(typeof(PingReport), ParameterSetName = new[] { DefaultPingSet })]
+    [OutputType(typeof(PingReply), ParameterSetName = new[] { RepeatPingSet, MtuSizeDetectSet })]
+    [OutputType(typeof(bool), ParameterSetName = new[] { DefaultPingSet, RepeatPingSet, TcpPortSet })]
+    [OutputType(typeof(int), ParameterSetName = new[] { MtuSizeDetectSet })]
+    [OutputType(typeof(TraceRouteReply), ParameterSetName = new[] { TraceRouteSet })]
     public class TestConnectionCommand : PSCmdlet
     {
         private const string DefaultPingSet = "DefaultPing";

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -16,7 +16,8 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// The implementation of the "Test-Connection" cmdlet.
     /// </summary>
-    [Cmdlet(VerbsDiagnostic.Test, "Connection", DefaultParameterSetName = DefaultPingSet, HelpUri = "https://go.microsoft.com/fwlink/?LinkID=135266")]
+    [Cmdlet(VerbsDiagnostic.Test, "Connection", DefaultParameterSetName = DefaultPingSet,
+        HelpUri = "https://go.microsoft.com/fwlink/?LinkID=135266")]
     [OutputType(typeof(PingReport), ParameterSetName = new[] { DefaultPingSet })]
     [OutputType(typeof(PingReply), ParameterSetName = new[] { RepeatPingSet, MtuSizeDetectSet })]
     [OutputType(typeof(bool), ParameterSetName = new[] { DefaultPingSet, RepeatPingSet, TcpPortSet })]
@@ -219,7 +220,7 @@ namespace Microsoft.PowerShell.Commands
 
         #region ConnectionTest
 
-        private void ProcessConnectionByTCPPort(String targetNameOrAddress)
+        private void ProcessConnectionByTCPPort(string targetNameOrAddress)
         {
             string resolvedTargetName;
             IPAddress targetAddress;
@@ -301,7 +302,7 @@ namespace Microsoft.PowerShell.Commands
         #endregion ConnectionTest
 
         #region TracerouteTest
-        private void ProcessTraceroute(String targetNameOrAddress)
+        private void ProcessTraceroute(string targetNameOrAddress)
         {
             byte[] buffer = GetSendBuffer(BufferSize);
 
@@ -316,11 +317,11 @@ namespace Microsoft.PowerShell.Commands
 
             TraceRouteResult traceRouteResult = new TraceRouteResult(Source, targetAddress, resolvedTargetName);
 
-            Int32 currentHop = 1;
+            int currentHop = 1;
             Ping sender = new Ping();
             PingOptions pingOptions = new PingOptions(currentHop, DontFragment.IsPresent);
             PingReply reply = null;
-            Int32 timeout = TimeoutSeconds * 1000;
+            int timeout = TimeoutSeconds * 1000;
 
             do
             {
@@ -345,7 +346,7 @@ namespace Microsoft.PowerShell.Commands
                             TestConnectionResources.NoPingResult,
                             resolvedTargetName,
                             ex.Message);
-                        Exception pingException = new System.Net.NetworkInformation.PingException(message, ex.InnerException);
+                        Exception pingException = new PingException(message, ex.InnerException);
                         ErrorRecord errorRecord = new ErrorRecord(
                             pingException,
                             TestConnectionExceptionId,
@@ -519,7 +520,7 @@ namespace Microsoft.PowerShell.Commands
         #endregion TracerouteTest
 
         #region MTUSizeTest
-        private void ProcessMTUSize(String targetNameOrAddress)
+        private void ProcessMTUSize(string targetNameOrAddress)
         {
             PingReply reply, replyResult = null;
             string resolvedTargetName;
@@ -535,7 +536,7 @@ namespace Microsoft.PowerShell.Commands
             int HighMTUSize = 10000;
             int CurrentMTUSize = 1473;
             int LowMTUSize = targetAddress.AddressFamily == AddressFamily.InterNetworkV6 ? 1280 : 68;
-            Int32 timeout = TimeoutSeconds * 1000;
+            int timeout = TimeoutSeconds * 1000;
 
             try
             {
@@ -578,7 +579,7 @@ namespace Microsoft.PowerShell.Commands
                                 TestConnectionResources.NoPingResult,
                                 targetAddress,
                                 reply.Status.ToString());
-                            Exception pingException = new System.Net.NetworkInformation.PingException(message);
+                            Exception pingException = new PingException(message);
                             ErrorRecord errorRecord = new ErrorRecord(
                                 pingException,
                                 TestConnectionExceptionId,
@@ -603,7 +604,7 @@ namespace Microsoft.PowerShell.Commands
             catch (PingException ex)
             {
                 string message = StringUtil.Format(TestConnectionResources.NoPingResult, targetAddress, ex.Message);
-                Exception pingException = new System.Net.NetworkInformation.PingException(message, ex.InnerException);
+                Exception pingException = new PingException(message, ex.InnerException);
                 ErrorRecord errorRecord = new ErrorRecord(
                     pingException,
                     TestConnectionExceptionId,
@@ -668,7 +669,7 @@ namespace Microsoft.PowerShell.Commands
 
         #region PingTest
 
-        private void ProcessPing(String targetNameOrAddress)
+        private void ProcessPing(string targetNameOrAddress)
         {
             string resolvedTargetName;
             IPAddress targetAddress;
@@ -689,8 +690,8 @@ namespace Microsoft.PowerShell.Commands
             PingReply reply;
             PingOptions pingOptions = new PingOptions(MaxHops, DontFragment.IsPresent);
             PingReport pingReport = new PingReport(Source, resolvedTargetName);
-            Int32 timeout = TimeoutSeconds * 1000;
-            Int32 delay = Delay * 1000;
+            int timeout = TimeoutSeconds * 1000;
+            int delay = Delay * 1000;
 
             for (int i = 1; i <= Count; i++)
             {
@@ -701,7 +702,7 @@ namespace Microsoft.PowerShell.Commands
                 catch (PingException ex)
                 {
                     string message = StringUtil.Format(TestConnectionResources.NoPingResult, resolvedTargetName, ex.Message);
-                    Exception pingException = new System.Net.NetworkInformation.PingException(message, ex.InnerException);
+                    Exception pingException = new PingException(message, ex.InnerException);
                     ErrorRecord errorRecord = new ErrorRecord(
                         pingException,
                         TestConnectionExceptionId,
@@ -835,7 +836,7 @@ namespace Microsoft.PowerShell.Commands
 
         #endregion PingTest
 
-        private bool InitProcessPing(String targetNameOrAddress, out string resolvedTargetName, out IPAddress targetAddress)
+        private bool InitProcessPing(string targetNameOrAddress, out string resolvedTargetName, out IPAddress targetAddress)
         {
             resolvedTargetName = targetNameOrAddress;
 
@@ -866,7 +867,7 @@ namespace Microsoft.PowerShell.Commands
                         TestConnectionResources.NoPingResult,
                         resolvedTargetName,
                         TestConnectionResources.CannotResolveTargetName);
-                    Exception pingException = new System.Net.NetworkInformation.PingException(message, ex);
+                    Exception pingException = new PingException(message, ex);
                     ErrorRecord errorRecord = new ErrorRecord(
                         pingException,
                         TestConnectionExceptionId,
@@ -895,7 +896,7 @@ namespace Microsoft.PowerShell.Commands
                             TestConnectionResources.NoPingResult,
                             resolvedTargetName,
                             TestConnectionResources.TargetAddressAbsent);
-                        Exception pingException = new System.Net.NetworkInformation.PingException(message, null);
+                        Exception pingException = new PingException(message, null);
                         ErrorRecord errorRecord = new ErrorRecord(
                             pingException,
                             TestConnectionExceptionId,

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -42,31 +42,19 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Force using IPv4 protocol.
         /// </summary>
-        [Parameter(ParameterSetName = DefaultPingSet)]
-        [Parameter(ParameterSetName = RepeatPingSet)]
-        [Parameter(ParameterSetName = TraceRouteSet)]
-        [Parameter(ParameterSetName = MtuSizeDetectSet)]
-        [Parameter(ParameterSetName = TcpPortSet)]
+        [Parameter()]
         public SwitchParameter IPv4 { get; set; }
 
         /// <summary>
         /// Force using IPv6 protocol.
         /// </summary>
-        [Parameter(ParameterSetName = DefaultPingSet)]
-        [Parameter(ParameterSetName = RepeatPingSet)]
-        [Parameter(ParameterSetName = TraceRouteSet)]
-        [Parameter(ParameterSetName = MtuSizeDetectSet)]
-        [Parameter(ParameterSetName = TcpPortSet)]
+        [Parameter()]
         public SwitchParameter IPv6 { get; set; }
 
         /// <summary>
         /// Do reverse DNS lookup to get names for IP addresses.
         /// </summary>
-        [Parameter(ParameterSetName = DefaultPingSet)]
-        [Parameter(ParameterSetName = RepeatPingSet)]
-        [Parameter(ParameterSetName = TraceRouteSet)]
-        [Parameter(ParameterSetName = MtuSizeDetectSet)]
-        [Parameter(ParameterSetName = TcpPortSet)]
+        [Parameter()]
         public SwitchParameter ResolveDestination { get; set; }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -43,19 +43,31 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Force using IPv4 protocol.
         /// </summary>
-        [Parameter]
+        [Parameter(ParameterSetName = DefaultPingParameterSet)]
+        [Parameter(ParameterSetName = RepeatPingParameterSet)]
+        [Parameter(ParameterSetName = TraceRouteParameterSet)]
+        [Parameter(ParameterSetName = MtuSizeDetectParameterSet)]
+        [Parameter(ParameterSetName = TcpPortParameterSet)]
         public SwitchParameter IPv4 { get; set; }
 
         /// <summary>
         /// Force using IPv6 protocol.
         /// </summary>
-        [Parameter]
+        [Parameter(ParameterSetName = DefaultPingParameterSet)]
+        [Parameter(ParameterSetName = RepeatPingParameterSet)]
+        [Parameter(ParameterSetName = TraceRouteParameterSet)]
+        [Parameter(ParameterSetName = MtuSizeDetectParameterSet)]
+        [Parameter(ParameterSetName = TcpPortParameterSet)]
         public SwitchParameter IPv6 { get; set; }
 
         /// <summary>
         /// Do reverse DNS lookup to get names for IP addresses.
         /// </summary>
-        [Parameter]
+        [Parameter(ParameterSetName = DefaultPingParameterSet)]
+        [Parameter(ParameterSetName = RepeatPingParameterSet)]
+        [Parameter(ParameterSetName = TraceRouteParameterSet)]
+        [Parameter(ParameterSetName = MtuSizeDetectParameterSet)]
+        [Parameter(ParameterSetName = TcpPortParameterSet)]
         public SwitchParameter ResolveDestination { get; set; }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -16,28 +16,28 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// The implementation of the "Test-Connection" cmdlet.
     /// </summary>
-    [Cmdlet(VerbsDiagnostic.Test, "Connection", DefaultParameterSetName = DefaultPingSet,
+    [Cmdlet(VerbsDiagnostic.Test, "Connection", DefaultParameterSetName = DefaultPingParameterSet,
         HelpUri = "https://go.microsoft.com/fwlink/?LinkID=135266")]
-    [OutputType(typeof(PingReport), ParameterSetName = new string[] { DefaultPingSet })]
-    [OutputType(typeof(PingReply), ParameterSetName = new string[] { RepeatPingSet, MtuSizeDetectSet })]
-    [OutputType(typeof(bool), ParameterSetName = new string[] { DefaultPingSet, RepeatPingSet, TcpPortSet })]
-    [OutputType(typeof(int), ParameterSetName = new string[] { MtuSizeDetectSet })]
-    [OutputType(typeof(TraceRouteReply), ParameterSetName = new string[] { TraceRouteSet })]
+    [OutputType(typeof(PingReport), ParameterSetName = new string[] { DefaultPingParameterSet })]
+    [OutputType(typeof(PingReply), ParameterSetName = new string[] { RepeatPingParameterSet, MtuSizeDetectParameterSet })]
+    [OutputType(typeof(bool), ParameterSetName = new string[] { DefaultPingParameterSet, RepeatPingParameterSet, TcpPortParameterSet })]
+    [OutputType(typeof(int), ParameterSetName = new string[] { MtuSizeDetectParameterSet })]
+    [OutputType(typeof(TraceRouteReply), ParameterSetName = new string[] { TraceRouteParameterSet })]
     public class TestConnectionCommand : PSCmdlet
     {
-        private const string DefaultPingSet = "DefaultPing";
-        private const string RepeatPingSet = "RepeatPing";
-        private const string TraceRouteSet = "TraceRoute";
-        private const string TcpPortSet = "TcpPort";
-        private const string MtuSizeDetectSet = "MtuSizeDetect";
+        private const string DefaultPingParameterSet = "DefaultPing";
+        private const string RepeatPingParameterSet = "RepeatPing";
+        private const string TraceRouteParameterSet = "TraceRoute";
+        private const string TcpPortParameterSet = "TcpPort";
+        private const string MtuSizeDetectParameterSet = "MtuSizeDetect";
 
         #region Parameters
 
         /// <summary>
         /// Do ping test.
         /// </summary>
-        [Parameter(ParameterSetName = DefaultPingSet)]
-        [Parameter(ParameterSetName = RepeatPingSet)]
+        [Parameter(ParameterSetName = DefaultPingParameterSet)]
+        [Parameter(ParameterSetName = RepeatPingParameterSet)]
         public SwitchParameter Ping { get; set; } = true;
 
         /// <summary>
@@ -63,10 +63,10 @@ namespace Microsoft.PowerShell.Commands
         /// The default is Local Host.
         /// Remoting is not yet implemented internally in the cmdlet.
         /// </summary>
-        [Parameter(ParameterSetName = DefaultPingSet)]
-        [Parameter(ParameterSetName = RepeatPingSet)]
-        [Parameter(ParameterSetName = TraceRouteSet)]
-        [Parameter(ParameterSetName = TcpPortSet)]
+        [Parameter(ParameterSetName = DefaultPingParameterSet)]
+        [Parameter(ParameterSetName = RepeatPingParameterSet)]
+        [Parameter(ParameterSetName = TraceRouteParameterSet)]
+        [Parameter(ParameterSetName = TcpPortParameterSet)]
         public string Source { get; } = Dns.GetHostName();
 
         /// <summary>
@@ -75,9 +75,9 @@ namespace Microsoft.PowerShell.Commands
         /// they decrement the Time-to-Live (TTL) value found in the packet header.
         /// The default (from Windows) is 128 hops.
         /// </summary>
-        [Parameter(ParameterSetName = DefaultPingSet)]
-        [Parameter(ParameterSetName = RepeatPingSet)]
-        [Parameter(ParameterSetName = TraceRouteSet)]
+        [Parameter(ParameterSetName = DefaultPingParameterSet)]
+        [Parameter(ParameterSetName = RepeatPingParameterSet)]
+        [Parameter(ParameterSetName = TraceRouteParameterSet)]
         [ValidateRange(0, sMaxHops)]
         [Alias("Ttl", "TimeToLive", "Hops")]
         public int MaxHops { get; set; } = sMaxHops;
@@ -88,7 +88,7 @@ namespace Microsoft.PowerShell.Commands
         /// Count of attempts.
         /// The default (from Windows) is 4 times.
         /// </summary>
-        [Parameter(ParameterSetName = DefaultPingSet)]
+        [Parameter(ParameterSetName = DefaultPingParameterSet)]
         [ValidateRange(ValidateRangeKind.Positive)]
         public int Count { get; set; } = 4;
 
@@ -96,8 +96,8 @@ namespace Microsoft.PowerShell.Commands
         /// Delay between attempts.
         /// The default (from Windows) is 1 second.
         /// </summary>
-        [Parameter(ParameterSetName = DefaultPingSet)]
-        [Parameter(ParameterSetName = RepeatPingSet)]
+        [Parameter(ParameterSetName = DefaultPingParameterSet)]
+        [Parameter(ParameterSetName = RepeatPingParameterSet)]
         [ValidateRange(ValidateRangeKind.Positive)]
         public int Delay { get; set; } = 1;
 
@@ -106,8 +106,8 @@ namespace Microsoft.PowerShell.Commands
         /// The default (from Windows) is 32 bites.
         /// Max value is 65500 (limit from Windows API).
         /// </summary>
-        [Parameter(ParameterSetName = DefaultPingSet)]
-        [Parameter(ParameterSetName = RepeatPingSet)]
+        [Parameter(ParameterSetName = DefaultPingParameterSet)]
+        [Parameter(ParameterSetName = RepeatPingParameterSet)]
         [Alias("Size", "Bytes", "BS")]
         [ValidateRange(0, 65500)]
         public int BufferSize { get; set; } = DefaultSendBufferSize;
@@ -116,15 +116,15 @@ namespace Microsoft.PowerShell.Commands
         /// Don't fragment ICMP packages.
         /// Currently CoreFX not supports this on Unix.
         /// </summary>
-        [Parameter(ParameterSetName = DefaultPingSet)]
-        [Parameter(ParameterSetName = RepeatPingSet)]
+        [Parameter(ParameterSetName = DefaultPingParameterSet)]
+        [Parameter(ParameterSetName = RepeatPingParameterSet)]
         public SwitchParameter DontFragment { get; set; }
 
         /// <summary>
         /// Continue ping until user press Ctrl-C
         /// or Int.MaxValue threshold reached.
         /// </summary>
-        [Parameter(ParameterSetName = RepeatPingSet)]
+        [Parameter(ParameterSetName = RepeatPingParameterSet)]
         public SwitchParameter Continues { get; set; }
 
         /// <summary>
@@ -159,20 +159,20 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Detect MTU size.
         /// </summary>
-        [Parameter(Mandatory = true, ParameterSetName = MtuSizeDetectSet)]
+        [Parameter(Mandatory = true, ParameterSetName = MtuSizeDetectParameterSet)]
         public SwitchParameter MTUSizeDetect { get; set; }
 
         /// <summary>
         /// Do traceroute test.
         /// </summary>
-        [Parameter(Mandatory = true, ParameterSetName = TraceRouteSet)]
+        [Parameter(Mandatory = true, ParameterSetName = TraceRouteParameterSet)]
         public SwitchParameter Traceroute { get; set; }
 
         /// <summary>
         /// Do tcp connection test.
         /// </summary>
         [ValidateRange(0, 65535)]
-        [Parameter(Mandatory = true, ParameterSetName = TcpPortSet)]
+        [Parameter(Mandatory = true, ParameterSetName = TcpPortParameterSet)]
         public int TCPPort { get; set; }
 
         #endregion Parameters
@@ -186,7 +186,7 @@ namespace Microsoft.PowerShell.Commands
 
             switch (ParameterSetName)
             {
-                case RepeatPingSet:
+                case RepeatPingParameterSet:
                     Count = int.MaxValue;
                     break;
             }
@@ -201,17 +201,17 @@ namespace Microsoft.PowerShell.Commands
             {
                 switch (ParameterSetName)
                 {
-                    case DefaultPingSet:
-                    case RepeatPingSet:
+                    case DefaultPingParameterSet:
+                    case RepeatPingParameterSet:
                         ProcessPing(targetName);
                         break;
-                    case MtuSizeDetectSet:
+                    case MtuSizeDetectParameterSet:
                         ProcessMTUSize(targetName);
                         break;
-                    case TraceRouteSet:
+                    case TraceRouteParameterSet:
                         ProcessTraceroute(targetName);
                         break;
-                    case TcpPortSet:
+                    case TcpPortParameterSet:
                         ProcessConnectionByTCPPort(targetName);
                         break;
                 }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -16,57 +16,57 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// The implementation of the "Test-Connection" cmdlet.
     /// </summary>
-    [Cmdlet(VerbsDiagnostic.Test, "Connection", DefaultParameterSetName = ParameterSetPingCount, HelpUri = "https://go.microsoft.com/fwlink/?LinkID=135266")]
-    [OutputType(typeof(PingReport), ParameterSetName = new string[] { ParameterSetPingCount })]
-    [OutputType(typeof(PingReply), ParameterSetName = new string[] { ParameterSetPingContinues, ParameterSetDetectionOfMTUSize })]
-    [OutputType(typeof(bool), ParameterSetName = new string[] { ParameterSetPingCount, ParameterSetPingContinues, ParameterSetConnectionByTCPPort })]
-    [OutputType(typeof(Int32), ParameterSetName = new string[] { ParameterSetDetectionOfMTUSize })]
-    [OutputType(typeof(TraceRouteReply), ParameterSetName = new string[] { ParameterSetTraceRoute })]
+    [Cmdlet(VerbsDiagnostic.Test, "Connection", DefaultParameterSetName = DefaultPingSet, HelpUri = "https://go.microsoft.com/fwlink/?LinkID=135266")]
+    [OutputType(typeof(PingReport), ParameterSetName = new string[] { DefaultPingSet })]
+    [OutputType(typeof(PingReply), ParameterSetName = new string[] { RepeatPingSet, MtuSizeDetectSet })]
+    [OutputType(typeof(bool), ParameterSetName = new string[] { DefaultPingSet, RepeatPingSet, TcpPortSet })]
+    [OutputType(typeof(Int32), ParameterSetName = new string[] { MtuSizeDetectSet })]
+    [OutputType(typeof(TraceRouteReply), ParameterSetName = new string[] { TraceRouteSet })]
     public class TestConnectionCommand : PSCmdlet
     {
-        private const string ParameterSetPingCount = "PingCount";
-        private const string ParameterSetPingContinues = "PingContinues";
-        private const string ParameterSetTraceRoute = "TraceRoute";
-        private const string ParameterSetConnectionByTCPPort = "ConnectionByTCPPort";
-        private const string ParameterSetDetectionOfMTUSize = "DetectionOfMTUSize";
+        private const string DefaultPingSet = "PingCount";
+        private const string RepeatPingSet = "PingContinues";
+        private const string TraceRouteSet = "TraceRoute";
+        private const string TcpPortSet = "ConnectionByTCPPort";
+        private const string MtuSizeDetectSet = "DetectionOfMTUSize";
 
         #region Parameters
 
         /// <summary>
         /// Do ping test.
         /// </summary>
-        [Parameter(ParameterSetName = ParameterSetPingCount)]
-        [Parameter(ParameterSetName = ParameterSetPingContinues)]
+        [Parameter(ParameterSetName = DefaultPingSet)]
+        [Parameter(ParameterSetName = RepeatPingSet)]
         public SwitchParameter Ping { get; set; } = true;
 
         /// <summary>
         /// Force using IPv4 protocol.
         /// </summary>
-        [Parameter(ParameterSetName = ParameterSetPingCount)]
-        [Parameter(ParameterSetName = ParameterSetPingContinues)]
-        [Parameter(ParameterSetName = ParameterSetTraceRoute)]
-        [Parameter(ParameterSetName = ParameterSetDetectionOfMTUSize)]
-        [Parameter(ParameterSetName = ParameterSetConnectionByTCPPort)]
+        [Parameter(ParameterSetName = DefaultPingSet)]
+        [Parameter(ParameterSetName = RepeatPingSet)]
+        [Parameter(ParameterSetName = TraceRouteSet)]
+        [Parameter(ParameterSetName = MtuSizeDetectSet)]
+        [Parameter(ParameterSetName = TcpPortSet)]
         public SwitchParameter IPv4 { get; set; }
 
         /// <summary>
         /// Force using IPv6 protocol.
         /// </summary>
-        [Parameter(ParameterSetName = ParameterSetPingCount)]
-        [Parameter(ParameterSetName = ParameterSetPingContinues)]
-        [Parameter(ParameterSetName = ParameterSetTraceRoute)]
-        [Parameter(ParameterSetName = ParameterSetDetectionOfMTUSize)]
-        [Parameter(ParameterSetName = ParameterSetConnectionByTCPPort)]
+        [Parameter(ParameterSetName = DefaultPingSet)]
+        [Parameter(ParameterSetName = RepeatPingSet)]
+        [Parameter(ParameterSetName = TraceRouteSet)]
+        [Parameter(ParameterSetName = MtuSizeDetectSet)]
+        [Parameter(ParameterSetName = TcpPortSet)]
         public SwitchParameter IPv6 { get; set; }
 
         /// <summary>
         /// Do reverse DNS lookup to get names for IP addresses.
         /// </summary>
-        [Parameter(ParameterSetName = ParameterSetPingCount)]
-        [Parameter(ParameterSetName = ParameterSetPingContinues)]
-        [Parameter(ParameterSetName = ParameterSetTraceRoute)]
-        [Parameter(ParameterSetName = ParameterSetDetectionOfMTUSize)]
-        [Parameter(ParameterSetName = ParameterSetConnectionByTCPPort)]
+        [Parameter(ParameterSetName = DefaultPingSet)]
+        [Parameter(ParameterSetName = RepeatPingSet)]
+        [Parameter(ParameterSetName = TraceRouteSet)]
+        [Parameter(ParameterSetName = MtuSizeDetectSet)]
+        [Parameter(ParameterSetName = TcpPortSet)]
         public SwitchParameter ResolveDestination { get; set; }
 
         /// <summary>
@@ -74,10 +74,10 @@ namespace Microsoft.PowerShell.Commands
         /// The default is Local Host.
         /// Remoting is not yet implemented internally in the cmdlet.
         /// </summary>
-        [Parameter(ParameterSetName = ParameterSetPingCount)]
-        [Parameter(ParameterSetName = ParameterSetPingContinues)]
-        [Parameter(ParameterSetName = ParameterSetTraceRoute)]
-        [Parameter(ParameterSetName = ParameterSetConnectionByTCPPort)]
+        [Parameter(ParameterSetName = DefaultPingSet)]
+        [Parameter(ParameterSetName = RepeatPingSet)]
+        [Parameter(ParameterSetName = TraceRouteSet)]
+        [Parameter(ParameterSetName = TcpPortSet)]
         public string Source { get; } = Dns.GetHostName();
 
         /// <summary>
@@ -86,9 +86,9 @@ namespace Microsoft.PowerShell.Commands
         /// they decrement the Time-to-Live (TTL) value found in the packet header.
         /// The default (from Windows) is 128 hops.
         /// </summary>
-        [Parameter(ParameterSetName = ParameterSetPingCount)]
-        [Parameter(ParameterSetName = ParameterSetPingContinues)]
-        [Parameter(ParameterSetName = ParameterSetTraceRoute)]
+        [Parameter(ParameterSetName = DefaultPingSet)]
+        [Parameter(ParameterSetName = RepeatPingSet)]
+        [Parameter(ParameterSetName = TraceRouteSet)]
         [ValidateRange(0, sMaxHops)]
         [Alias("Ttl", "TimeToLive", "Hops")]
         public int MaxHops { get; set; } = sMaxHops;
@@ -99,7 +99,7 @@ namespace Microsoft.PowerShell.Commands
         /// Count of attempts.
         /// The default (from Windows) is 4 times.
         /// </summary>
-        [Parameter(ParameterSetName = ParameterSetPingCount)]
+        [Parameter(ParameterSetName = DefaultPingSet)]
         [ValidateRange(ValidateRangeKind.Positive)]
         public int Count { get; set; } = 4;
 
@@ -107,8 +107,8 @@ namespace Microsoft.PowerShell.Commands
         /// Delay between attempts.
         /// The default (from Windows) is 1 second.
         /// </summary>
-        [Parameter(ParameterSetName = ParameterSetPingCount)]
-        [Parameter(ParameterSetName = ParameterSetPingContinues)]
+        [Parameter(ParameterSetName = DefaultPingSet)]
+        [Parameter(ParameterSetName = RepeatPingSet)]
         [ValidateRange(ValidateRangeKind.Positive)]
         public int Delay { get; set; } = 1;
 
@@ -117,8 +117,8 @@ namespace Microsoft.PowerShell.Commands
         /// The default (from Windows) is 32 bites.
         /// Max value is 65500 (limit from Windows API).
         /// </summary>
-        [Parameter(ParameterSetName = ParameterSetPingCount)]
-        [Parameter(ParameterSetName = ParameterSetPingContinues)]
+        [Parameter(ParameterSetName = DefaultPingSet)]
+        [Parameter(ParameterSetName = RepeatPingSet)]
         [Alias("Size", "Bytes", "BS")]
         [ValidateRange(0, 65500)]
         public int BufferSize { get; set; } = DefaultSendBufferSize;
@@ -127,15 +127,15 @@ namespace Microsoft.PowerShell.Commands
         /// Don't fragment ICMP packages.
         /// Currently CoreFX not supports this on Unix.
         /// </summary>
-        [Parameter(ParameterSetName = ParameterSetPingCount)]
-        [Parameter(ParameterSetName = ParameterSetPingContinues)]
+        [Parameter(ParameterSetName = DefaultPingSet)]
+        [Parameter(ParameterSetName = RepeatPingSet)]
         public SwitchParameter DontFragment { get; set; }
 
         /// <summary>
         /// Continue ping until user press Ctrl-C
         /// or Int.MaxValue threshold reached.
         /// </summary>
-        [Parameter(ParameterSetName = ParameterSetPingContinues)]
+        [Parameter(ParameterSetName = RepeatPingSet)]
         public SwitchParameter Continues { get; set; }
 
         /// <summary>
@@ -169,20 +169,20 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Detect MTU size.
         /// </summary>
-        [Parameter(Mandatory = true, ParameterSetName = ParameterSetDetectionOfMTUSize)]
+        [Parameter(Mandatory = true, ParameterSetName = MtuSizeDetectSet)]
         public SwitchParameter MTUSizeDetect { get; set; }
 
         /// <summary>
         /// Do traceroute test.
         /// </summary>
-        [Parameter(Mandatory = true, ParameterSetName = ParameterSetTraceRoute)]
+        [Parameter(Mandatory = true, ParameterSetName = TraceRouteSet)]
         public SwitchParameter Traceroute { get; set; }
 
         /// <summary>
         /// Do tcp connection test.
         /// </summary>
         [ValidateRange(0, 65535)]
-        [Parameter(Mandatory = true, ParameterSetName = ParameterSetConnectionByTCPPort)]
+        [Parameter(Mandatory = true, ParameterSetName = TcpPortSet)]
         public int TCPPort { get; set; }
 
         #endregion Parameters
@@ -196,7 +196,7 @@ namespace Microsoft.PowerShell.Commands
 
             switch (ParameterSetName)
             {
-                case ParameterSetPingContinues:
+                case RepeatPingSet:
                     Count = int.MaxValue;
                     break;
             }
@@ -211,17 +211,17 @@ namespace Microsoft.PowerShell.Commands
             {
                 switch (ParameterSetName)
                 {
-                    case ParameterSetPingCount:
-                    case ParameterSetPingContinues:
+                    case DefaultPingSet:
+                    case RepeatPingSet:
                         ProcessPing(targetName);
                         break;
-                    case ParameterSetDetectionOfMTUSize:
+                    case MtuSizeDetectSet:
                         ProcessMTUSize(targetName);
                         break;
-                    case ParameterSetTraceRoute:
+                    case TraceRouteSet:
                         ProcessTraceroute(targetName);
                         break;
-                    case ParameterSetConnectionByTCPPort:
+                    case TcpPortSet:
                         ProcessConnectionByTCPPort(targetName);
                         break;
                 }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -233,9 +233,8 @@ namespace Microsoft.PowerShell.Commands
 
         private void ProcessConnectionByTCPPort(String targetNameOrAddress)
         {
-            string resolvedTargetName = null;
-            IPAddress targetAddress = null;
-
+            string resolvedTargetName;
+            IPAddress targetAddress;
             if (!InitProcessPing(targetNameOrAddress, out resolvedTargetName, out targetAddress))
             {
                 return;
@@ -304,8 +303,10 @@ namespace Microsoft.PowerShell.Commands
 
         private void WriteConnectionTestFooter()
         {
-            ProgressRecord record = new ProgressRecord(s_ProgressId, _testConnectionProgressBarActivity, ProgressRecordSpace);
-            record.RecordType = ProgressRecordType.Completed;
+            var record = new ProgressRecord(s_ProgressId, _testConnectionProgressBarActivity, ProgressRecordSpace)
+            {
+                RecordType = ProgressRecordType.Completed
+            };
             WriteProgress(record);
         }
 
@@ -314,10 +315,10 @@ namespace Microsoft.PowerShell.Commands
         #region TracerouteTest
         private void ProcessTraceroute(String targetNameOrAddress)
         {
-            string resolvedTargetName = null;
-            IPAddress targetAddress = null;
             byte[] buffer = GetSendBuffer(BufferSize);
 
+            string resolvedTargetName;
+            IPAddress targetAddress;
             if (!InitProcessPing(targetNameOrAddress, out resolvedTargetName, out targetAddress))
             {
                 return;
@@ -420,8 +421,7 @@ namespace Microsoft.PowerShell.Commands
 
         private void WriteTraceRouteProgress(TraceRouteReply traceRouteReply)
         {
-            string msg = string.Empty;
-
+            string msg;
             if (traceRouteReply.PingReplies[2].Status == IPStatus.TtlExpired
                 || traceRouteReply.PingReplies[2].Status == IPStatus.Success)
             {
@@ -457,8 +457,10 @@ namespace Microsoft.PowerShell.Commands
         {
             WriteInformation(TestConnectionResources.TraceRouteComplete, s_PSHostTag);
 
-            ProgressRecord record = new ProgressRecord(s_ProgressId, _testConnectionProgressBarActivity, ProgressRecordSpace);
-            record.RecordType = ProgressRecordType.Completed;
+            var record = new ProgressRecord(s_ProgressId, _testConnectionProgressBarActivity, ProgressRecordSpace)
+            {
+                RecordType = ProgressRecordType.Completed
+            };
             WriteProgress(record);
         }
 
@@ -532,10 +534,8 @@ namespace Microsoft.PowerShell.Commands
         private void ProcessMTUSize(String targetNameOrAddress)
         {
             PingReply reply, replyResult = null;
-
-            string resolvedTargetName = null;
-            IPAddress targetAddress = null;
-
+            string resolvedTargetName;
+            IPAddress targetAddress;
             if (!InitProcessPing(targetNameOrAddress, out resolvedTargetName, out targetAddress))
             {
                 return;
@@ -669,8 +669,10 @@ namespace Microsoft.PowerShell.Commands
 
         private void WriteMTUSizeFooter()
         {
-            ProgressRecord record = new ProgressRecord(s_ProgressId, _testConnectionProgressBarActivity, ProgressRecordSpace);
-            record.RecordType = ProgressRecordType.Completed;
+            var record = new ProgressRecord(s_ProgressId, _testConnectionProgressBarActivity, ProgressRecordSpace)
+            {
+                RecordType = ProgressRecordType.Completed
+            };
             WriteProgress(record);
         }
 
@@ -680,9 +682,8 @@ namespace Microsoft.PowerShell.Commands
 
         private void ProcessPing(String targetNameOrAddress)
         {
-            string resolvedTargetName = null;
-            IPAddress targetAddress = null;
-
+            string resolvedTargetName;
+            IPAddress targetAddress;
             if (!InitProcessPing(targetNameOrAddress, out resolvedTargetName, out targetAddress))
             {
                 return;
@@ -697,8 +698,8 @@ namespace Microsoft.PowerShell.Commands
             byte[] buffer = GetSendBuffer(BufferSize);
 
             Ping sender = new Ping();
+            PingReply reply;
             PingOptions pingOptions = new PingOptions(MaxHops, DontFragment.IsPresent);
-            PingReply reply = null;
             PingReport pingReport = new PingReport(Source, resolvedTargetName);
             Int32 timeout = TimeoutSeconds * 1000;
             Int32 delay = Delay * 1000;
@@ -784,7 +785,7 @@ namespace Microsoft.PowerShell.Commands
 
         private void WritePingProgress(PingReply reply)
         {
-            string msg = string.Empty;
+            string msg;
             if (reply.Status != IPStatus.Success)
             {
                 msg = TestConnectionResources.PingTimeOut;
@@ -809,8 +810,10 @@ namespace Microsoft.PowerShell.Commands
         {
             WriteInformation(TestConnectionResources.PingComplete, s_PSHostTag);
 
-            ProgressRecord record = new ProgressRecord(s_ProgressId, _testConnectionProgressBarActivity, ProgressRecordSpace);
-            record.RecordType = ProgressRecordType.Completed;
+            var record = new ProgressRecord(s_ProgressId, _testConnectionProgressBarActivity, ProgressRecordSpace)
+            {
+                RecordType = ProgressRecordType.Completed
+            };
             WriteProgress(record);
         }
 
@@ -846,10 +849,9 @@ namespace Microsoft.PowerShell.Commands
 
         private bool InitProcessPing(String targetNameOrAddress, out string resolvedTargetName, out IPAddress targetAddress)
         {
-            IPHostEntry hostEntry = null;
-
             resolvedTargetName = targetNameOrAddress;
 
+            IPHostEntry hostEntry;
             if (IPAddress.TryParse(targetNameOrAddress, out targetAddress))
             {
                 if (ResolveDestination)

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -158,10 +158,11 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Destination - computer name or IP address.
         /// </summary>
-        [Parameter(Mandatory = true,
-                   Position = 0,
-                   ValueFromPipeline = true,
-                   ValueFromPipelineByPropertyName = true)]
+        [Parameter(
+            Mandatory = true,
+            Position = 0,
+            ValueFromPipeline = true,
+            ValueFromPipelineByPropertyName = true)]
         [ValidateNotNullOrEmpty]
         [Alias("ComputerName")]
         public string[] TargetName { get; set; }
@@ -292,10 +293,11 @@ namespace Microsoft.PowerShell.Commands
 
         private void WriteConnectionTestProgress(string targetNameOrAddress, string targetAddress, int timeout)
         {
-            var msg = StringUtil.Format(TestConnectionResources.ConnectionTestDescription,
-                                        targetNameOrAddress,
-                                        targetAddress,
-                                        timeout);
+            var msg = StringUtil.Format(
+                TestConnectionResources.ConnectionTestDescription,
+                targetNameOrAddress,
+                targetAddress,
+                timeout);
             ProgressRecord record = new ProgressRecord(s_ProgressId, _testConnectionProgressBarActivity, msg);
             WriteProgress(record);
         }
@@ -350,14 +352,16 @@ namespace Microsoft.PowerShell.Commands
                     }
                     catch (PingException ex)
                     {
-                        string message = StringUtil.Format(TestConnectionResources.NoPingResult,
-                                                           resolvedTargetName,
-                                                           ex.Message);
+                        string message = StringUtil.Format(
+                            TestConnectionResources.NoPingResult,
+                            resolvedTargetName,
+                            ex.Message);
                         Exception pingException = new System.Net.NetworkInformation.PingException(message, ex.InnerException);
-                        ErrorRecord errorRecord = new ErrorRecord(pingException,
-                                                                  TestConnectionExceptionId,
-                                                                  ErrorCategory.ResourceUnavailable,
-                                                                  resolvedTargetName);
+                        ErrorRecord errorRecord = new ErrorRecord(
+                            pingException,
+                            TestConnectionExceptionId,
+                            ErrorCategory.ResourceUnavailable,
+                            resolvedTargetName);
                         WriteError(errorRecord);
 
                         continue;
@@ -381,7 +385,9 @@ namespace Microsoft.PowerShell.Commands
                 WriteTraceRouteProgress(traceRouteReply);
 
                 traceRouteResult.Replies.Add(traceRouteReply);
-            } while (reply != null && currentHop <= sMaxHops && (reply.Status == IPStatus.TtlExpired || reply.Status == IPStatus.TimedOut));
+            } while (reply != null
+                && currentHop <= sMaxHops
+                && (reply.Status == IPStatus.TtlExpired || reply.Status == IPStatus.TimedOut));
 
             WriteTraceRouteFooter();
 
@@ -397,7 +403,11 @@ namespace Microsoft.PowerShell.Commands
 
         private void WriteConsoleTraceRouteHeader(string resolvedTargetName, string targetAddress)
         {
-            _testConnectionProgressBarActivity = StringUtil.Format(TestConnectionResources.TraceRouteStart, resolvedTargetName, targetAddress, MaxHops);
+            _testConnectionProgressBarActivity = StringUtil.Format(
+                TestConnectionResources.TraceRouteStart,
+                resolvedTargetName,
+                targetAddress,
+                MaxHops);
 
             WriteInformation(_testConnectionProgressBarActivity, s_PSHostTag);
 
@@ -412,15 +422,25 @@ namespace Microsoft.PowerShell.Commands
         {
             string msg = string.Empty;
 
-            if (traceRouteReply.PingReplies[2].Status == IPStatus.TtlExpired || traceRouteReply.PingReplies[2].Status == IPStatus.Success)
+            if (traceRouteReply.PingReplies[2].Status == IPStatus.TtlExpired
+                || traceRouteReply.PingReplies[2].Status == IPStatus.Success)
             {
                 var routerAddress = traceRouteReply.ReplyRouterAddress.ToString();
                 var routerName = traceRouteReply.ReplyRouterName ?? routerAddress;
-                var roundtripTime0 = traceRouteReply.PingReplies[0].Status == IPStatus.TimedOut ? "*" : traceRouteReply.PingReplies[0].RoundtripTime.ToString();
-                var roundtripTime1 = traceRouteReply.PingReplies[1].Status == IPStatus.TimedOut ? "*" : traceRouteReply.PingReplies[1].RoundtripTime.ToString();
-                msg = StringUtil.Format(TestConnectionResources.TraceRouteReply,
-                                        traceRouteReply.Hop, roundtripTime0, roundtripTime1, traceRouteReply.PingReplies[2].RoundtripTime.ToString(),
-                                        routerName, routerAddress);
+                var roundtripTime0 = traceRouteReply.PingReplies[0].Status == IPStatus.TimedOut
+                    ? "*"
+                    : traceRouteReply.PingReplies[0].RoundtripTime.ToString();
+                var roundtripTime1 = traceRouteReply.PingReplies[1].Status == IPStatus.TimedOut
+                    ? "*"
+                    : traceRouteReply.PingReplies[1].RoundtripTime.ToString();
+                msg = StringUtil.Format(
+                    TestConnectionResources.TraceRouteReply,
+                    traceRouteReply.Hop,
+                    roundtripTime0,
+                    roundtripTime1,
+                    traceRouteReply.PingReplies[2].RoundtripTime.ToString(),
+                    routerName,
+                    routerAddress);
             }
             else
             {
@@ -541,7 +561,11 @@ namespace Microsoft.PowerShell.Commands
 
                     WriteMTUSizeProgress(CurrentMTUSize, retry);
 
-                    WriteDebug(StringUtil.Format("LowMTUSize: {0}, CurrentMTUSize: {1}, HighMTUSize: {2}", LowMTUSize, CurrentMTUSize, HighMTUSize));
+                    WriteDebug(StringUtil.Format(
+                        "LowMTUSize: {0}, CurrentMTUSize: {1}, HighMTUSize: {2}",
+                        LowMTUSize,
+                        CurrentMTUSize,
+                        HighMTUSize));
 
                     reply = sender.Send(targetAddress, timeout, buffer, pingOptions);
 
@@ -562,14 +586,16 @@ namespace Microsoft.PowerShell.Commands
                         // Target host don't reply - try again up to 'Count'.
                         if (retry >= Count)
                         {
-                            string message = StringUtil.Format(TestConnectionResources.NoPingResult,
-                                                               targetAddress,
-                                                               reply.Status.ToString());
+                            string message = StringUtil.Format(
+                                TestConnectionResources.NoPingResult,
+                                targetAddress,
+                                reply.Status.ToString());
                             Exception pingException = new System.Net.NetworkInformation.PingException(message);
-                            ErrorRecord errorRecord = new ErrorRecord(pingException,
-                                                                      TestConnectionExceptionId,
-                                                                      ErrorCategory.ResourceUnavailable,
-                                                                      targetAddress);
+                            ErrorRecord errorRecord = new ErrorRecord(
+                                pingException,
+                                TestConnectionExceptionId,
+                                ErrorCategory.ResourceUnavailable,
+                                targetAddress);
                             WriteError(errorRecord);
                             return;
                         }
@@ -590,10 +616,11 @@ namespace Microsoft.PowerShell.Commands
             {
                 string message = StringUtil.Format(TestConnectionResources.NoPingResult, targetAddress, ex.Message);
                 Exception pingException = new System.Net.NetworkInformation.PingException(message, ex.InnerException);
-                ErrorRecord errorRecord = new ErrorRecord(pingException,
-                                                          TestConnectionExceptionId,
-                                                          ErrorCategory.ResourceUnavailable,
-                                                          targetAddress);
+                ErrorRecord errorRecord = new ErrorRecord(
+                    pingException,
+                    TestConnectionExceptionId,
+                    ErrorCategory.ResourceUnavailable,
+                    targetAddress);
                 WriteError(errorRecord);
                 return;
             }
@@ -622,10 +649,11 @@ namespace Microsoft.PowerShell.Commands
 
         private void WriteMTUSizeHeader(string resolvedTargetName, string targetAddress)
         {
-            _testConnectionProgressBarActivity = StringUtil.Format(TestConnectionResources.MTUSizeDetectStart,
-                                                                  resolvedTargetName,
-                                                                  targetAddress,
-                                                                  BufferSize);
+            _testConnectionProgressBarActivity = StringUtil.Format(
+                TestConnectionResources.MTUSizeDetectStart,
+                resolvedTargetName,
+                targetAddress,
+                BufferSize);
 
             ProgressRecord record = new ProgressRecord(s_ProgressId, _testConnectionProgressBarActivity, ProgressRecordSpace);
             WriteProgress(record);
@@ -685,10 +713,11 @@ namespace Microsoft.PowerShell.Commands
                 {
                     string message = StringUtil.Format(TestConnectionResources.NoPingResult, resolvedTargetName, ex.Message);
                     Exception pingException = new System.Net.NetworkInformation.PingException(message, ex.InnerException);
-                    ErrorRecord errorRecord = new ErrorRecord(pingException,
-                                                              TestConnectionExceptionId,
-                                                              ErrorCategory.ResourceUnavailable,
-                                                              resolvedTargetName);
+                    ErrorRecord errorRecord = new ErrorRecord(
+                        pingException,
+                        TestConnectionExceptionId,
+                        ErrorCategory.ResourceUnavailable,
+                        resolvedTargetName);
                     WriteError(errorRecord);
 
                     quietResult = false;
@@ -738,16 +767,18 @@ namespace Microsoft.PowerShell.Commands
 
         private void WritePingHeader(string resolvedTargetName, string targetAddress)
         {
-            _testConnectionProgressBarActivity = StringUtil.Format(TestConnectionResources.MTUSizeDetectStart,
-                                                                  resolvedTargetName,
-                                                                  targetAddress,
-                                                                  BufferSize);
+            _testConnectionProgressBarActivity = StringUtil.Format(
+                TestConnectionResources.MTUSizeDetectStart,
+                resolvedTargetName,
+                targetAddress,
+                BufferSize);
 
             WriteInformation(_testConnectionProgressBarActivity, s_PSHostTag);
 
-            ProgressRecord record = new ProgressRecord(s_ProgressId,
-                                                       _testConnectionProgressBarActivity,
-                                                       ProgressRecordSpace);
+            ProgressRecord record = new ProgressRecord(
+                s_ProgressId,
+                _testConnectionProgressBarActivity,
+                ProgressRecordSpace);
             WriteProgress(record);
         }
 
@@ -760,11 +791,12 @@ namespace Microsoft.PowerShell.Commands
             }
             else
             {
-                msg = StringUtil.Format(TestConnectionResources.PingReply,
-                                        reply.Address.ToString(),
-                                        reply.Buffer.Length,
-                                        reply.RoundtripTime,
-                                        reply.Options?.Ttl);
+                msg = StringUtil.Format(
+                    TestConnectionResources.PingReply,
+                    reply.Address.ToString(),
+                    reply.Buffer.Length,
+                    reply.RoundtripTime,
+                    reply.Options?.Ttl);
             }
 
             WriteInformation(msg, s_PSHostTag);
@@ -840,14 +872,16 @@ namespace Microsoft.PowerShell.Commands
                 }
                 catch (Exception ex)
                 {
-                    string message = StringUtil.Format(TestConnectionResources.NoPingResult,
-                                                       resolvedTargetName,
-                                                       TestConnectionResources.CannotResolveTargetName);
+                    string message = StringUtil.Format(
+                        TestConnectionResources.NoPingResult,
+                        resolvedTargetName,
+                        TestConnectionResources.CannotResolveTargetName);
                     Exception pingException = new System.Net.NetworkInformation.PingException(message, ex);
-                    ErrorRecord errorRecord = new ErrorRecord(pingException,
-                                                              TestConnectionExceptionId,
-                                                              ErrorCategory.ResourceUnavailable,
-                                                              resolvedTargetName);
+                    ErrorRecord errorRecord = new ErrorRecord(
+                        pingException,
+                        TestConnectionExceptionId,
+                        ErrorCategory.ResourceUnavailable,
+                        resolvedTargetName);
                     WriteError(errorRecord);
                     return false;
                 }
@@ -867,14 +901,16 @@ namespace Microsoft.PowerShell.Commands
 
                     if (targetAddress == null)
                     {
-                        string message = StringUtil.Format(TestConnectionResources.NoPingResult,
-                                                           resolvedTargetName,
-                                                           TestConnectionResources.TargetAddressAbsent);
+                        string message = StringUtil.Format(
+                            TestConnectionResources.NoPingResult,
+                            resolvedTargetName,
+                            TestConnectionResources.TargetAddressAbsent);
                         Exception pingException = new System.Net.NetworkInformation.PingException(message, null);
-                        ErrorRecord errorRecord = new ErrorRecord(pingException,
-                                                                  TestConnectionExceptionId,
-                                                                  ErrorCategory.ResourceUnavailable,
-                                                                  resolvedTargetName);
+                        ErrorRecord errorRecord = new ErrorRecord(
+                            pingException,
+                            TestConnectionExceptionId,
+                            ErrorCategory.ResourceUnavailable,
+                            resolvedTargetName);
                         WriteError(errorRecord);
                         return false;
                     }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -24,11 +24,11 @@ namespace Microsoft.PowerShell.Commands
     [OutputType(typeof(TraceRouteReply), ParameterSetName = new string[] { TraceRouteSet })]
     public class TestConnectionCommand : PSCmdlet
     {
-        private const string DefaultPingSet = "PingCount";
-        private const string RepeatPingSet = "PingContinues";
+        private const string DefaultPingSet = "DefaultPing";
+        private const string RepeatPingSet = "RepeatPing";
         private const string TraceRouteSet = "TraceRoute";
-        private const string TcpPortSet = "ConnectionByTCPPort";
-        private const string MtuSizeDetectSet = "DetectionOfMTUSize";
+        private const string TcpPortSet = "TcpPort";
+        private const string MtuSizeDetectSet = "MtuSizeDetect";
 
         #region Parameters
 

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -42,19 +42,19 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Force using IPv4 protocol.
         /// </summary>
-        [Parameter()]
+        [Parameter]
         public SwitchParameter IPv4 { get; set; }
 
         /// <summary>
         /// Force using IPv6 protocol.
         /// </summary>
-        [Parameter()]
+        [Parameter]
         public SwitchParameter IPv6 { get; set; }
 
         /// <summary>
         /// Do reverse DNS lookup to get names for IP addresses.
         /// </summary>
-        [Parameter()]
+        [Parameter]
         public SwitchParameter ResolveDestination { get; set; }
 
         /// <summary>
@@ -130,7 +130,7 @@ namespace Microsoft.PowerShell.Commands
         /// Set short output kind ('bool' for Ping, 'int' for MTU size ...).
         /// Default is to return typed result object(s).
         /// </summary>
-        [Parameter()]
+        [Parameter]
         public SwitchParameter Quiet;
 
         /// <summary>
@@ -139,7 +139,7 @@ namespace Microsoft.PowerShell.Commands
         /// It is not the cmdlet timeout! It is a timeout for waiting one ping response.
         /// The default (from Windows) is 5 second.
         /// </summary>
-        [Parameter()]
+        [Parameter]
         [ValidateRange(ValidateRangeKind.Positive)]
         public int TimeoutSeconds { get; set; } = 5;
 

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -18,11 +18,11 @@ namespace Microsoft.PowerShell.Commands
     /// </summary>
     [Cmdlet(VerbsDiagnostic.Test, "Connection", DefaultParameterSetName = DefaultPingSet,
         HelpUri = "https://go.microsoft.com/fwlink/?LinkID=135266")]
-    [OutputType(typeof(PingReport), ParameterSetName = new[] { DefaultPingSet })]
-    [OutputType(typeof(PingReply), ParameterSetName = new[] { RepeatPingSet, MtuSizeDetectSet })]
-    [OutputType(typeof(bool), ParameterSetName = new[] { DefaultPingSet, RepeatPingSet, TcpPortSet })]
-    [OutputType(typeof(int), ParameterSetName = new[] { MtuSizeDetectSet })]
-    [OutputType(typeof(TraceRouteReply), ParameterSetName = new[] { TraceRouteSet })]
+    [OutputType(typeof(PingReport), ParameterSetName = new string[] { DefaultPingSet })]
+    [OutputType(typeof(PingReply), ParameterSetName = new string[] { RepeatPingSet, MtuSizeDetectSet })]
+    [OutputType(typeof(bool), ParameterSetName = new string[] { DefaultPingSet, RepeatPingSet, TcpPortSet })]
+    [OutputType(typeof(int), ParameterSetName = new string[] { MtuSizeDetectSet })]
+    [OutputType(typeof(TraceRouteReply), ParameterSetName = new string[] { TraceRouteSet })]
     public class TestConnectionCommand : PSCmdlet
     {
         private const string DefaultPingSet = "DefaultPing";


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Style pass only as part of #10044 

## PR Context

Rewriting the Test-Connection Command a good bit. @iSazonov suggested I split it up into stages to make reviewing the PR changes much easier.

This is part 1, only containing style fixes. There are no functional changes.

Feel free to review commit-by-commit for easier diffs. 🙂 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
