### PR TITLE
Make `ForEach-Object` faster for its commonly used scenarios

### DIFF
--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -341,6 +341,12 @@ namespace System.Management.Automation
         {
             const string ForEachObject_ProcessParam = "Process";
 
+            // Skip optimization if the debugger is enabled, so a breakpoint set on the command 'ForEach-Object' works properly.
+            if (context._debuggingMode > 0)
+            {
+                return false;
+            }
+
             if (commandProcessor.CommandInfo is CmdletInfo cmdlet && cmdlet.ImplementingType == typeof(ForEachObjectCommand))
             {
                 int indexAdvanceOffset = 0;

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -327,6 +327,7 @@ namespace System.Management.Automation
                     endBlock: null,
                     dynamicParamBlock: null);
                 newScriptBlockAst.PostParseChecksPerformed = sbAst.PostParseChecksPerformed;
+                sbAst.Parent.SetParent(newScriptBlockAst);
 
                 return new ScriptBlock(newScriptBlockAst, isFilter: false);
             };

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -355,9 +355,12 @@ namespace System.Management.Automation
 
                 if (commandIndex == cmdElementsLength - 1)
                 {
+                    // Target ForEach-Object syntax:
+                    //  * `... | ForEach-Object { ... } | ...`
+                    //  * `... | ForEach-Object -process:{ ... } | ...`
                     var currentElement = commandElements[commandIndex];
                     if (currentElement.ArgumentSpecified && !currentElement.ArgumentSplatted &&
-                        (!currentElement.ParameterAndArgumentSpecified || string.Equals(currentElement.ParameterName, "Process", StringComparison.OrdinalIgnoreCase)))
+                        (!currentElement.ParameterAndArgumentSpecified || ForEachObject_ProcessParam.Equals(currentElement.ParameterName, StringComparison.OrdinalIgnoreCase)))
                     {
                         processScriptBlock = currentElement.ArgumentValue as ScriptBlock;
                         indexAdvanceOffset = 1;
@@ -365,11 +368,13 @@ namespace System.Management.Automation
                 }
                 else if (commandIndex == cmdElementsLength - 2)
                 {
+                    // Target ForEach-Object syntax:
+                    //  * `... | ForEach-Object -Process { ... } | ...`
                     var currentElement = commandElements[commandIndex];
                     var nextElement = commandElements[commandIndex + 1];
 
                     if (currentElement.ParameterNameSpecified && !currentElement.ArgumentSpecified &&
-                        string.Equals(currentElement.ParameterName, ForEachObject_ProcessParam, StringComparison.OrdinalIgnoreCase) &&
+                        ForEachObject_ProcessParam.Equals(currentElement.ParameterName, StringComparison.OrdinalIgnoreCase) &&
                         nextElement.ArgumentSpecified && !nextElement.ArgumentSplatted && !nextElement.ParameterNameSpecified)
                     {
                         processScriptBlock = nextElement.ArgumentValue as ScriptBlock;

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -68,7 +68,7 @@ namespace System.Management.Automation
 
             object command;
             IScriptExtent commandExtent;
-            var cpiCommand = commandElements[commandIndex];
+            var cpiCommand = commandElements[commandIndex++];
             if (cpiCommand.ParameterNameSpecified)
             {
                 command = cpiCommand.ParameterText;
@@ -156,12 +156,16 @@ namespace System.Management.Automation
                 }
             }
 
-            InternalCommand cmd = commandProcessor.Command;
-            commandProcessor.UseLocalScope = !dotSource &&
-                                             (cmd is ScriptCommand || cmd is PSScriptCmdlet);
+            // If possible, rewrite the 'ForEach-Object' command into a filter-like script block in the pipeline.
+            //   e.g. 1..2 | ForEach-Object { $_ + 1 }  =>  1..2 | . { process { $_ + 1 } }
+            if (!TryRewriteForEachObjectCommand(context, commandSessionState, commandElements, ref commandProcessor, ref commandIndex))
+            {
+                InternalCommand cmd = commandProcessor.Command;
+                commandProcessor.UseLocalScope = !dotSource && (cmd is ScriptCommand || cmd is PSScriptCmdlet);
+            }
 
             bool isNativeCommand = commandProcessor is NativeCommandProcessor;
-            for (int i = commandIndex + 1; i < commandElements.Length; ++i)
+            for (int i = commandIndex; i < commandElements.Length; ++i)
             {
                 var cpi = commandElements[i];
 
@@ -309,6 +313,88 @@ namespace System.Management.Automation
             }
 
             return commandProcessor;
+        }
+
+        private static ConditionalWeakTable<ScriptBlockAst, ScriptBlock> s_astRewriteCache = new ConditionalWeakTable<ScriptBlockAst, ScriptBlock>();
+        private static ConditionalWeakTable<ScriptBlockAst, ScriptBlock>.CreateValueCallback s_astRewriteCallback =
+            sbAst =>
+            {
+                ScriptBlockAst newScriptBlockAst = new ScriptBlockAst(
+                    sbAst.Extent,
+                    paramBlock: null,
+                    beginBlock: null,
+                    processBlock: (NamedBlockAst)sbAst.EndBlock.Copy(),
+                    endBlock: null,
+                    dynamicParamBlock: null);
+                newScriptBlockAst.PostParseChecksPerformed = sbAst.PostParseChecksPerformed;
+
+                return new ScriptBlock(newScriptBlockAst, isFilter: false);
+            };
+
+        private static bool TryRewriteForEachObjectCommand(
+            ExecutionContext context,
+            SessionStateInternal commandSessionState,
+            CommandParameterInternal[] commandElements,
+            ref CommandProcessorBase commandProcessor,
+            ref int commandIndex)
+        {
+            const string ForEachObject_ProcessParam = "Process";
+
+            if (commandProcessor.CommandInfo is CmdletInfo cmdlet && cmdlet.ImplementingType == typeof(ForEachObjectCommand))
+            {
+                int indexAdvanceOffset = 0;
+                int cmdElementsLength = commandElements.Length;
+                ScriptBlock processScriptBlock = null;
+
+                if (commandIndex == cmdElementsLength - 1)
+                {
+                    var currentElement = commandElements[commandIndex];
+                    if (currentElement.ArgumentSpecified && !currentElement.ArgumentSplatted &&
+                        (!currentElement.ParameterAndArgumentSpecified || string.Equals(currentElement.ParameterName, "Process", StringComparison.OrdinalIgnoreCase)))
+                    {
+                        processScriptBlock = currentElement.ArgumentValue as ScriptBlock;
+                        indexAdvanceOffset = 1;
+                    }
+                }
+                else if (commandIndex == cmdElementsLength - 2)
+                {
+                    var currentElement = commandElements[commandIndex];
+                    var nextElement = commandElements[commandIndex + 1];
+
+                    if (currentElement.ParameterNameSpecified && !currentElement.ArgumentSpecified &&
+                        string.Equals(currentElement.ParameterName, ForEachObject_ProcessParam, StringComparison.OrdinalIgnoreCase) &&
+                        nextElement.ArgumentSpecified && !nextElement.ArgumentSplatted && !nextElement.ParameterNameSpecified)
+                    {
+                        processScriptBlock = nextElement.ArgumentValue as ScriptBlock;
+                        indexAdvanceOffset = 2;
+                    }
+                }
+
+                if (processScriptBlock != null && processScriptBlock.Ast is ScriptBlockAst sbAst)
+                {
+                    if (!sbAst.IsConfiguration && sbAst.ParamBlock == null && sbAst.BeginBlock == null &&
+                        sbAst.ProcessBlock == null && sbAst.DynamicParamBlock == null && sbAst.EndBlock != null &&
+                        sbAst.EndBlock.Unnamed)
+                    {
+                        ScriptBlock sbRewritten = s_astRewriteCache.GetValue(sbAst, s_astRewriteCallback);
+                        ScriptBlock sbToUse = sbRewritten.Clone();
+                        sbToUse.SessionStateInternal = processScriptBlock.SessionStateInternal;
+
+                        // We always clone the script block, so that the cached value doesn't hold on to any session state.
+                        // Foreach-Object invokes the script block in the caller's scope, so do not use new scope.
+                        commandProcessor = CommandDiscovery.CreateCommandProcessorForScript(
+                            sbToUse,
+                            context,
+                            useNewScope: false,
+                            commandSessionState);
+
+                        commandIndex += indexAdvanceOffset;
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         internal static IEnumerable<CommandParameterInternal> Splat(object splattedValue, Ast splatAst)

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/ForEach-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/ForEach-Object.Tests.ps1
@@ -1,0 +1,44 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+Describe "ForEach-Object" -Tags "CI" {
+    BeforeAll {
+        $testModulePsd1 = Join-Path $TestDrive "ForEachObjectTest.psd1"
+        $testModulePsm1 = Join-Path $TestDrive "ForEachObjectTest.psm1"
+        Set-Content -Path $testModulePsm1 -Value @'
+    function Zoo { "ForEachObjectTest-Zoo" }
+    function GetScriptBlock { return { Zoo } }
+'@
+        New-ModuleManifest -Path $testModulePsd1 -RootModule $testModulePsm1 -FunctionsToExport "GetScriptBlock"
+        Import-Module $testModulePsd1
+    }
+
+    AfterAll {
+        Remove-Module -Name ForEachObjectTest
+    }
+
+    It "Foreach-Object should execute script block in caller scope" {
+        $null = 1..2 | ForEach-Object { $bar = 100 }
+        Get-Variable -Name bar -Scope 0 -ValueOnly | Should -BeExactly 100
+    }
+
+    It "Foreach-Object should execute script block in caller scope regardless of the invocation operator in use" {
+        $null = 1..2 | . ForEach-Object { $bar = "bar" }
+        $null = 1..2 | & ForEach-Object { $foo = "foo" }
+
+        Get-Variable -Name bar -Scope 0 -ValueOnly | Should -BeExactly "bar"
+        Get-Variable -Name foo -Scope 0 -ValueOnly | Should -BeExactly "foo"
+    }
+
+    It "Foreach-Object should execute script block in the module scope if specified" {
+        { 1 | ForEach-Object { Zoo } } | Should -Throw -ErrorId "CommandNotFoundException"
+
+        $m = Get-Module ForEachObjectTest
+        1 | & $m ForEach-Object { Zoo } | Should -BeExactly "ForEachObjectTest-Zoo"
+    }
+
+    It "ForEach-Object should execute script block in the session state that the script block is associated with" {
+        $sbToUse = GetScriptBlock
+        1 | ForEach-Object $sbToUse | Should -BeExactly "ForEachObjectTest-Zoo"
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

**NOTE:** mark the PR as WIP because the rewriting causes some issues to stepping during debugging. Looking into that.

A follow-up PR for #10047
Make `ForEach-Object` faster for its commonly used scenarios by rewriting the command into a filter-like script block execution in the pipeline.
For the follow `ForEach-Object` usages, they will be rewritten to `... | . { process { ... } } | ...` when constructing the pipeline.

```powershell
... | % { ... } | ...
... | % -process { ... } | ...
... | % -process:{ ... } | ...
```

By doing this rewriting, we are able to eliminate all unnecessary overheads from:
1. parameter binding
2. invoking a script block with `ScriptBlock.InvokeUsingCmdlet` for every incoming object, which has to do the setting-up/tearing-down every time executing the script block.

This PR targets to improve the performance of `ForEach-Object` for the most common usages. It's not a goal to cover all possible scenarios, such as `% -pro:{...}` or `% { ... } { ... } { ... }`

| Script | Before | After |
|-|-|-|
| `1..100kb \| % { }` | 290ms | 37ms |
|`1..100kb \| . { process {} }`| 37ms | 37ms |
| `foreach ($i in 1..100kb) { }` | 28ms | 28ms |

This optimization will be turned off automatically in the following cases:
1. when debugger is enabled, namely when any breakpoint is set in the session. This is to make the debugger works as expected in case a breakpoint is set on `ForEach-Object`, e.g `Set-PSBreakpoint -Command ForEach-Object`.
2. when 'ConstrainedLanguageMode' has been used for the current Runspace. The language mode transition is tricky. It's better to stick with the same old code path for safety.

## PR Context

https://github.com/PowerShell/PowerShell/issues/9731#issuecomment-496721086
Draft PR: #10153 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [x] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
