### PR TITLE
Fix for ForEach-Object -Parallel perf problem with many runspaces

### DIFF
--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -448,10 +448,10 @@ namespace Microsoft.PowerShell.Commands
             if (TimeoutSeconds != 0)
             {
                 _taskTimer = new Timer(
-                    (_) => { _taskCollection.Complete(); _taskPool.StopAll(); },
-                    null,
-                    TimeoutSeconds * 1000,
-                    Timeout.Infinite);
+                    callback: (_) => { _taskCollection.Complete(); _taskPool.StopAll(); },
+                    state: null,
+                    dueTime: TimeoutSeconds * 1000,
+                    period: Timeout.Infinite);
             }
 
             // Task collection handler.

--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -689,7 +689,7 @@ namespace System.Management.Automation.PSTasks
                 return false;
             }
 
-            // Block until either room is available, or a stop is commanded
+            // Block until either space is available, or a stop is commanded
             var index = WaitHandle.WaitAny(_waitHandles);
 
             switch (index)

--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -602,11 +602,15 @@ namespace System.Management.Automation.PSTasks
         #region Members
 
         private readonly ManualResetEvent _addAvailable;
-        private readonly ManualResetEvent _stopAll;
-        private readonly Dictionary<int, PSTaskBase> _taskPool;
         private readonly int _sizeLimit;
+        private readonly ManualResetEvent _stopAll;
         private readonly object _syncObject;
+        private readonly Dictionary<int, PSTaskBase> _taskPool;
+        private readonly WaitHandle[] _waitHandles;
         private bool _isOpen;
+
+        private const int AddAvailable = 0;
+        private const int Stop = 1;
 
         #endregion
 
@@ -625,6 +629,11 @@ namespace System.Management.Automation.PSTasks
             _syncObject = new object();
             _addAvailable = new ManualResetEvent(true);
             _stopAll = new ManualResetEvent(false);
+            _waitHandles = new WaitHandle[]
+            {
+                _addAvailable,      // index 0
+                _stopAll,           // index 1
+            };
             _taskPool = new Dictionary<int, PSTaskBase>(size);
         }
 
@@ -672,46 +681,21 @@ namespace System.Management.Automation.PSTasks
         /// This method is not multi-thread safe and assumes only one thread waits and adds tasks.
         /// </summary>
         /// <param name="task">Task to be added to pool.</param>
-        /// <param name="dataStreamWriter">Optional cmdlet data stream writer.</param>
         /// <returns>True when task is successfully added.</returns>
-        public bool Add(
-            PSTaskBase task, 
-            PSTaskDataStreamWriter dataStreamWriter = null)
+        public bool Add(PSTaskBase task)
         {
             if (!_isOpen)
             {
                 return false;
             }
 
-            WaitHandle[] waitHandles;
-            if (dataStreamWriter != null)
-            {
-                waitHandles = new WaitHandle[]
-                {
-                    _addAvailable,                          // index 0
-                    _stopAll,                               // index 1
-                    dataStreamWriter.DataAddedWaitHandle    // index 2
-                };
-            }
-            else
-            {
-                waitHandles = new WaitHandle[]
-                {
-                    _addAvailable,                          // index 0
-                    _stopAll,                               // index 1
-                };
-            }
+            // Block until either room is available, or a stop is commanded
+            var index = WaitHandle.WaitAny(_waitHandles);
 
-            // Block until either room is available, data is ready for writing, or a stop command
-            while (true)
+            switch (index)
             {
-                var index = WaitHandle.WaitAny(waitHandles);
-
-                // Add new task
-                if (index == 0)
-                {
+                case AddAvailable:
                     task.StateChanged += HandleTaskStateChangedDelegate;
-
                     lock (_syncObject)
                     {
                         if (!_isOpen)
@@ -727,21 +711,13 @@ namespace System.Management.Automation.PSTasks
 
                         task.Start();
                     }
-
                     return true;
-                }
 
-                // Stop all
-                if (index == 1)
-                {
+                case Stop:
                     return false;
-                }
-                
-                // Data ready for writing
-                if (index == 2)
-                {
-                    dataStreamWriter.WriteImmediate();
-                }
+
+                default:
+                    return false;
             }
         }
 
@@ -977,7 +953,7 @@ namespace System.Management.Automation.PSTasks
             // This thread will end once all jobs reach a finished state by either running
             // to completion, terminating with error, or stopped.
             System.Threading.ThreadPool.QueueUserWorkItem(
-                (state) => 
+                (_) => 
                 {
                     foreach (var childJob in ChildJobs)
                     {

--- a/src/System.Management.Automation/resources/InternalCommandStrings.resx
+++ b/src/System.Management.Automation/resources/InternalCommandStrings.resx
@@ -181,4 +181,7 @@
     <value>The following common parameters are not currently supported in the Parallel parameter set:
 ErrorAction, WarningAction, InformationAction, PipelineVariable</value>
   </data>
+  <data name="ParallelPipedInputProcessingError" xml:space="preserve">
+    <value>An unexpected error has occurred while processing ForEach-Object -Parallel input. This may mean that some of the piped input did not get processed. Error: {0}.</value>
+  </data>
 </root>


### PR DESCRIPTION
# PR Summary

This is a fix for the ForEach-Object perf Issue: #10450.  

```powershell
measure-command { 1..254 | foreach -Parallel {ping "192.168.0.$_" -n 1 | where {$_ -match "ttl="}} -ThrottleLimit 300 }

# Time for ThreadJob and ForEach -Parallel -AsJob is around 8 seconds
# Time for ForEach -Parallel is around 60 seconds
```

## PR Context

The problem was that the number of concurrent runspaces was being limited to around 40-50, even though the ThrottleLimit was set to 300.  It turns out it was the Cmdlet input processing thread that was causing the bottleneck.  I don't know what the conflict is while spinning up runspaces, but the fix is to now do this on a dedicated thread similar to how it currently works for -AsJob.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
