### PR TITLE
Fix global tool issues around exit code, command line parameters and path with spaces

### DIFF
--- a/src/Microsoft.PowerShell.GlobalTool.Shim/GlobalToolShim.cs
+++ b/src/Microsoft.PowerShell.GlobalTool.Shim/GlobalToolShim.cs
@@ -21,7 +21,8 @@ namespace Microsoft.PowerShell.GlobalTool.Shim
         /// <summary>
         /// Entry point for the global tool.
         /// </summary>
-        /// <param name="args">Arguments passed to the global tool.</param>
+        /// <param name="args">Arguments passed to the global tool.</param>'
+        /// <returns>Exit code returned by pwsh.</returns>
         public static int Main(string[] args)
         {
             var currentPath = new FileInfo(System.Reflection.Assembly.GetEntryAssembly().Location).Directory.FullName;

--- a/src/Microsoft.PowerShell.GlobalTool.Shim/GlobalToolShim.cs
+++ b/src/Microsoft.PowerShell.GlobalTool.Shim/GlobalToolShim.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerShell.GlobalTool.Shim
         /// Entry point for the global tool.
         /// </summary>
         /// <param name="args">Arguments passed to the global tool.</param>
-        public static void Main(string[] args)
+        public static int Main(string[] args)
         {
             var currentPath = new FileInfo(System.Reflection.Assembly.GetEntryAssembly().Location).Directory.FullName;
             var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
@@ -31,11 +31,13 @@ namespace Microsoft.PowerShell.GlobalTool.Shim
 
             string argsString = args.Length > 0 ? string.Join(" ", args) : null;
             var pwshPath = Path.Combine(currentPath, platformFolder, PwshDllName);
-            string processArgs = string.IsNullOrEmpty(argsString) ? $"{pwshPath}" : $"{pwshPath} {argsString}";
+            string processArgs = string.IsNullOrEmpty(argsString) ? $"\"{pwshPath}\"" : $"\"{pwshPath}\" {argsString}";
 
             if (File.Exists(pwshPath))
             {
-                System.Diagnostics.Process.Start("dotnet", processArgs).WaitForExit();
+                var process = System.Diagnostics.Process.Start("dotnet", processArgs);
+                process.WaitForExit();
+                return process.ExitCode;
             }
             else
             {

--- a/src/Microsoft.PowerShell.GlobalTool.Shim/GlobalToolShim.cs
+++ b/src/Microsoft.PowerShell.GlobalTool.Shim/GlobalToolShim.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PowerShell.GlobalTool.Shim
 
             string argsString = args.Length > 0 ? string.Join(" ", args) : null;
             var pwshPath = Path.Combine(currentPath, platformFolder, PwshDllName);
-            string processArgs = string.IsNullOrEmpty(argsString) ? $"{pwshPath}" : $"{pwshPath} -c {argsString}";
+            string processArgs = string.IsNullOrEmpty(argsString) ? $"{pwshPath}" : $"{pwshPath} {argsString}";
 
             if (File.Exists(pwshPath))
             {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes #10301 #10362 #10184 

1. Fix issue where `pwsh` command line options were not passed.
1. Fix issue where the location where the global tool was installed could not have spaces in them
1. Fix issue where the return code was not returned.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
