### PR TITLE
Allow Web Cmdlets to Ignore HTTP Error Statuses

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -75,6 +75,12 @@ namespace Microsoft.PowerShell.Commands
         [Alias("RHV")]
         public string ResponseHeadersVariable { get; set; }
 
+        /// <summary>
+        /// Gets or sets the variable name to use for storing the status code from the response.
+        /// </summary>
+        [Parameter]
+        public string StatusCodeVariable { get; set; }
+
         #endregion Parameters
 
         #region Helper Methods
@@ -452,6 +458,12 @@ namespace Microsoft.PowerShell.Commands
                 if (ShouldSaveToOutFile)
                 {
                     StreamHelper.SaveStreamToFile(responseStream, QualifiedOutFile, this);
+                }
+
+                if (!string.IsNullOrEmpty(StatusCodeVariable))
+                {
+                    PSVariableIntrinsics vi = SessionState.PSVariable;
+                    vi.Set(StatusCodeVariable, (int)response.StatusCode);
                 }
 
                 if (!string.IsNullOrEmpty(ResponseHeadersVariable))

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -381,6 +381,12 @@ namespace Microsoft.PowerShell.Commands
         [Parameter]
         public virtual SwitchParameter Resume { get; set; }
 
+        /// <summary>
+        /// Ignores the HTTP status code in the response, and acts as if error statuses are successes.
+        /// </summary>
+        [Parameter]
+        public virtual SwitchParameter SkipHttpErrorCheck { get; set; }
+
         #endregion
 
         #endregion Virtual Properties
@@ -688,6 +694,11 @@ namespace Microsoft.PowerShell.Commands
         internal bool ShouldWriteToPipeline
         {
             get { return (!ShouldSaveToOutFile || PassThru); }
+        }
+
+        internal bool ShouldCheckHttpStatus
+        {
+            get { return !SkipHttpErrorCheck; }
         }
 
         /// <summary>
@@ -1513,7 +1524,7 @@ namespace Microsoft.PowerShell.Commands
                                     OutFile = null;
                                 }
 
-                                if (!_isSuccess)
+                                if (ShouldCheckHttpStatus && !_isSuccess)
                                 {
                                     string message = string.Format(CultureInfo.CurrentCulture, WebCmdletStrings.ResponseStatusCodeFailure,
                                         (int)response.StatusCode, response.ReasonPhrase);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -382,7 +382,7 @@ namespace Microsoft.PowerShell.Commands
         public virtual SwitchParameter Resume { get; set; }
 
         /// <summary>
-        /// Ignores the HTTP status code in the response, and acts as if error statuses are successes.
+        /// Gets or sets whether to skip checking HTTP status for error codes.
         /// </summary>
         [Parameter]
         public virtual SwitchParameter SkipHttpErrorCheck { get; set; }
@@ -1253,7 +1253,7 @@ namespace Microsoft.PowerShell.Commands
 
             // Add the content headers
             if (request.Content == null)
-            {   
+            {
                 request.Content = new StringContent(string.Empty);
                 request.Content.Headers.Clear();
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -2340,7 +2340,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
             statuscode = 500
             responsephrase = 'Internal Server Error'
             contenttype = 'application/json'
-            body = '{"message": "works"}'
+            body = '{"message": "oops"}'
             headers = "{}"
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -370,6 +370,13 @@ $redirectTests = @(
 Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
     BeforeAll {
         $WebListener = Start-WebListener
+        $NotFoundQuery = @{
+            statuscode = 404
+            responsephrase = 'Not Found'
+            contenttype = 'text/plain'
+            body = 'oops'
+            headers = "{}"
+        }
     }
 
     # Validate the output of Invoke-WebRequest
@@ -781,36 +788,20 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
     }
 
     It "Verify Invoke-WebRequest supresses terminating errors with -SkipHttpErrorCheck" {
-        $query = @{
-            statuscode = 404
-            responsephrase = 'Not found'
-            contenttype = 'text/plain'
-            body = 'oops'
-            headers = "{}"
-        }
-
-        $uri =  Get-WebListenerUrl -Test 'Response' -Query $query
+        $uri =  Get-WebListenerUrl -Test 'Response' -Query $NotFoundQuery
         $command = "Invoke-WebRequest -SkipHttpErrorCheck -Uri '$uri'"
         $result = ExecuteWebCommand -Command $command
         $result.output.StatusCode | Should -Be 404
-        $result.output.Content | Should -Match "oops"
-        $result.error | Should -Be $null
+        $result.output.Content | Should -BeExactly "oops"
+        $result.error | Should -BeNullOrEmpty
     }
 
     It "Verify Invoke-WebRequest terminates without -SkipHttpErrorCheck" {
-        $query = @{
-            statuscode = 404
-            responsephrase = 'Not found'
-            contenttype = 'text/plain'
-            body = 'oops'
-            headers = "{}"
-        }
-
-        $uri =  Get-WebListenerUrl -Test 'Response' -Query $query
+        $uri =  Get-WebListenerUrl -Test 'Response' -Query $NotFoundQuery
         $command = "Invoke-WebRequest -Uri '$uri'"
         $result = ExecuteWebCommand -Command $command
-        $result.output | Should -Be $null
-        $result.error | Should -Not -Be $null
+        $result.output | Should -BeNullOrEmpty
+        $result.error | Should -Not -BeNullOrEmpty
     }
 
     Context "Redirect" {
@@ -1963,6 +1954,14 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
 Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
     BeforeAll {
         $WebListener = Start-WebListener
+
+        $NotFoundQuery = @{
+            statuscode = 404
+            responsephrase = 'Not Found'
+            contenttype = 'application/json'
+            body = '{"message": "oops"}'
+            headers = "{}"
+        }
     }
 
     #User-Agent changes on different platforms, so tests should only be run if on the correct platform
@@ -2293,35 +2292,19 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
     }
 
     It "Verify Invoke-RestMethod supresses terminating errors with -SkipHttpErrorCheck" {
-        $query = @{
-            statuscode = 404
-            responsephrase = 'Not found'
-            contenttype = 'application/json'
-            body = '{"message": "oops"}'
-            headers = "{}"
-        }
-
-        $uri =  Get-WebListenerUrl -Test 'Response' -Query $query
+        $uri =  Get-WebListenerUrl -Test 'Response' -Query $NotFoundQuery
         $command = "Invoke-RestMethod -SkipHttpErrorCheck -Uri '$uri'"
         $result = ExecuteWebCommand -Command $command
-        $result.output.message | Should -Match "oops"
-        $result.output.error | Should -Be $null
+        $result.output.message | Should -BeExactly "oops"
+        $result.output.error | Should -BeNullOrEmpty
     }
 
     It "Verify Invoke-RestMethod terminates without -SkipHttpErrorCheck" {
-        $query = @{
-            statuscode = 404
-            responsephrase = 'Not found'
-            contenttype = 'application/json'
-            body = '{"message": "oops"}'
-            headers = "{}"
-        }
-
-        $uri =  Get-WebListenerUrl -Test 'Response' -Query $query
+        $uri =  Get-WebListenerUrl -Test 'Response' -Query $NotFoundQuery
         $command = "Invoke-RestMethod -Uri '$uri'"
         $result = ExecuteWebCommand -Command $command
-        $result.output | Should -Be $null
-        $result.error | Should -Not -Be $null
+        $result.output | Should -BeNullOrEmpty
+        $result.error | Should -Not -BeNullOrEmpty
     }
 
     It "Verify Invoke-RestMethod assigns status code with -StatusCodeVariable" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -797,6 +797,22 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
         $result.error | Should -Be $null
     }
 
+    It "Verify Invoke-WebRequest terminates without -SkipHttpErrorCheck" {
+        $query = @{
+            statuscode = 404
+            responsephrase = 'Not found'
+            contenttype = 'text/plain'
+            body = 'oops'
+            headers = "{}"
+        }
+
+        $uri =  Get-WebListenerUrl -Test 'Response' -Query $query
+        $command = "Invoke-WebRequest -Uri '$uri'"
+        $result = ExecuteWebCommand -Command $command
+        $result.output | Should -Be $null
+        $result.error | Should -Not -Be $null
+    }
+
     Context "Redirect" {
         It "Validates Invoke-WebRequest with -PreserveAuthorizationOnRedirect preserves the authorization header on redirect: <redirectType> <redirectedMethod>" -TestCases $redirectTests {
             param($redirectType, $redirectedMethod)
@@ -2290,6 +2306,22 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
         $result = ExecuteWebCommand -Command $command
         $result.output.message | Should -Match "oops"
         $result.output.error | Should -Be $null
+    }
+
+    It "Verify Invoke-RestMethod terminates without -SkipHttpErrorCheck" {
+        $query = @{
+            statuscode = 404
+            responsephrase = 'Not found'
+            contenttype = 'application/json'
+            body = '{"message": "oops"}'
+            headers = "{}"
+        }
+
+        $uri =  Get-WebListenerUrl -Test 'Response' -Query $query
+        $command = "Invoke-RestMethod -Uri '$uri'"
+        $result = ExecuteWebCommand -Command $command
+        $result.output | Should -Be $null
+        $result.error | Should -Not -Be $null
     }
 
     It "Verify Invoke-RestMethod assigns status code with -StatusCodeVariable" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -781,7 +781,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
     }
 
     It "Verify Invoke-WebRequest supresses terminating errors with -SkipHttpErrorCheck" {
-        $Query = @{
+        $query = @{
             statuscode = 404
             responsephrase = 'Not found'
             contenttype = 'text/plain'
@@ -789,12 +789,12 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
             headers = "{}"
         }
 
-        $Uri =  Get-WebListenerUrl -Test 'Response' -Query $Query
+        $uri =  Get-WebListenerUrl -Test 'Response' -Query $query
         $command = "Invoke-WebRequest -SkipHttpErrorCheck -Uri '$uri'"
-        $result = ExecuteWebCommand -command $command
-        $result.output.StatusCode | Should -be 404
-        $result.output.Content | Should -match "oops"
-        $result.error | Should -be $null
+        $result = ExecuteWebCommand -Command $command
+        $result.output.StatusCode | Should -Be 404
+        $result.output.Content | Should -Match "oops"
+        $result.error | Should -Be $null
     }
 
     Context "Redirect" {
@@ -2277,7 +2277,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
     }
 
     It "Verify Invoke-RestMethod supresses terminating errors with -SkipHttpErrorCheck" {
-        $Query = @{
+        $query = @{
             statuscode = 404
             responsephrase = 'Not found'
             contenttype = 'application/json'
@@ -2285,11 +2285,11 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
             headers = "{}"
         }
 
-        $Uri =  Get-WebListenerUrl -Test 'Response' -Query $Query
+        $uri =  Get-WebListenerUrl -Test 'Response' -Query $query
         $command = "Invoke-RestMethod -SkipHttpErrorCheck -Uri '$uri'"
-        $result = ExecuteWebCommand -command $command
-        $result.output.message | Should -match "oops"
-        $result.output.error | Should -be $null
+        $result = ExecuteWebCommand -Command $command
+        $result.output.message | Should -Match "oops"
+        $result.output.error | Should -Be $null
     }
 
     It "Verify Invoke-RestMethod assigns status code with -StatusCodeVariable" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -2293,7 +2293,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
     }
 
     It "Verify Invoke-RestMethod assigns status code with -StatusCodeVariable" {
-        $Query = @{
+        $query = @{
             statuscode = 200
             responsephrase = 'OK'
             contenttype = 'application/json'
@@ -2301,9 +2301,9 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
             headers = "{}"
         }
 
-        $Uri =  Get-WebListenerUrl -Test 'Response' -Query $Query
+        $uri =  Get-WebListenerUrl -Test 'Response' -Query $query
         Invoke-RestMethod -SkipHttpErrorCheck -StatusCodeVariable code -Uri "$uri"
-        $code | Should -be 200
+        $code | Should -Be 200
     }
 
     #region Redirect tests

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -780,6 +780,23 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
         $result.Output.RelationLink["next"] | Should -BeExactly "${baseUri}?maxlinks=3&linknumber=2&type=${type}"
     }
 
+    It "Verify Invoke-WebRequest supresses terminating errors with -SkipHttpErrorCheck" {
+        $Query = @{
+            statuscode = 404
+            responsephrase = 'Not found'
+            contenttype = 'text/plain'
+            body = 'oops'
+            headers = "{}"
+        }
+
+        $Uri =  Get-WebListenerUrl -Test 'Response' -Query $Query
+        $command = "Invoke-WebRequest -SkipHttpErrorCheck -Uri '$uri'"
+        $result = ExecuteWebCommand -command $command
+        $result.output.StatusCode | Should -be 404
+        $result.output.Content | Should -match "oops"
+        $result.error | Should -be $null
+    }
+
     Context "Redirect" {
         It "Validates Invoke-WebRequest with -PreserveAuthorizationOnRedirect preserves the authorization header on redirect: <redirectType> <redirectedMethod>" -TestCases $redirectTests {
             param($redirectType, $redirectedMethod)
@@ -2259,6 +2276,22 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
         1..3 | ForEach-Object { $result.Output[$_ - 1].linknumber | Should -BeExactly $_ }
     }
 
+    It "Verify Invoke-RestMethod supresses terminating errors with -SkipHttpErrorCheck" {
+        $Query = @{
+            statuscode = 404
+            responsephrase = 'Not found'
+            contenttype = 'application/json'
+            body = '{"message": "oops"}'
+            headers = "{}"
+        }
+
+        $Uri =  Get-WebListenerUrl -Test 'Response' -Query $Query
+        $command = "Invoke-RestMethod -SkipHttpErrorCheck -Uri '$uri'"
+        $result = ExecuteWebCommand -command $command
+        $result.output.message | Should -match "oops"
+        $result.output.error | Should -be $null
+    }
+
     #region Redirect tests
 
     It "Validates Invoke-RestMethod with -PreserveAuthorizationOnRedirect preserves the authorization header on redirect: <redirectType> <redirectedMethod>" -TestCases $redirectTests {
@@ -3387,4 +3420,3 @@ Describe "Web cmdlets tests using the cmdlet's aliases" -Tags "CI", "RequireAdmi
         $result.Hello | Should -Be "world"
     }
 }
-

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -2307,7 +2307,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
         $result.error | Should -Not -BeNullOrEmpty
     }
 
-    It "Verify Invoke-RestMethod assigns status code with -StatusCodeVariable" {
+    It "Verify Invoke-RestMethod assigns 200 status code with -StatusCodeVariable" {
         $query = @{
             statuscode = 200
             responsephrase = 'OK'
@@ -2317,8 +2317,36 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
         }
 
         $uri =  Get-WebListenerUrl -Test 'Response' -Query $query
-        Invoke-RestMethod -SkipHttpErrorCheck -StatusCodeVariable code -Uri "$uri"
+        Invoke-RestMethod -StatusCodeVariable code -Uri "$uri"
         $code | Should -Be 200
+    }
+
+    It "Verify Invoke-RestMethod assigns 404 status code with -StatusCodeVariable" {
+        $query = @{
+            statuscode = 404
+            responsephrase = 'Not Found'
+            contenttype = 'application/json'
+            body = '{"message": "oops"}'
+            headers = "{}"
+        }
+
+        $uri =  Get-WebListenerUrl -Test 'Response' -Query $query
+        Invoke-RestMethod -SkipHttpErrorCheck -StatusCodeVariable code -Uri "$uri"
+        $code | Should -Be 404
+    }
+
+    It "Verify Invoke-RestMethod assigns 500 status code with -StatusCodeVariable" {
+        $query = @{
+            statuscode = 500
+            responsephrase = 'Internal Server Error'
+            contenttype = 'application/json'
+            body = '{"message": "works"}'
+            headers = "{}"
+        }
+
+        $uri =  Get-WebListenerUrl -Test 'Response' -Query $query
+        Invoke-RestMethod -SkipHttpErrorCheck -StatusCodeVariable code -Uri "$uri"
+        $code | Should -Be 500
     }
 
     #region Redirect tests

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -2292,6 +2292,20 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
         $result.output.error | Should -be $null
     }
 
+    It "Verify Invoke-RestMethod assigns status code with -StatusCodeVariable" {
+        $Query = @{
+            statuscode = 200
+            responsephrase = 'OK'
+            contenttype = 'application/json'
+            body = '{"message": "works"}'
+            headers = "{}"
+        }
+
+        $Uri =  Get-WebListenerUrl -Test 'Response' -Query $Query
+        Invoke-RestMethod -SkipHttpErrorCheck -StatusCodeVariable code -Uri "$uri"
+        $code | Should -be 200
+    }
+
     #region Redirect tests
 
     It "Validates Invoke-RestMethod with -PreserveAuthorizationOnRedirect preserves the authorization header on redirect: <redirectType> <redirectedMethod>" -TestCases $redirectTests {


### PR DESCRIPTION
# PR Summary
Fix #5555
Fix #9769

This PR adds a  -SkipHttpErrorCheck flag to Invoke-WebRequest and Invoke-RestMethod, and adds a -ResponseStatusVariable option to Invoke-RestMethod. The -SkipHttpErrorCheck flag causes the cmdlets to ignore HTTP error statuses and continue to process the responses and write to the pipeline as if these had been successful. The -ResponseStatusVariable assigns the integer value of the status code to the variable named. It can be used with or without -SkipHttpErrorCheck.

## PR Context

These cmdlets as they are currently written will throw an exception when the HTTP status is not considered a success. The error handling code will extract the body of the response and modify its contents to assign to the exception, but will leave the original body contents inaccessible. This isn't feasible with web APIs and other sites that return useful diagnostic messages in the body that would be modified by the error handling code.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [X] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [X] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/4724
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
