### PR TITLE
Test-Connection - Remove informational output, consolidate Ping usage

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -325,7 +325,7 @@ namespace Microsoft.PowerShell.Commands
                 return;
             }
 
-            WriteConsoleTraceRouteHeader(resolvedTargetName, targetAddress.ToString());
+            WriteTraceRouteHeader(resolvedTargetName, targetAddress.ToString());
 
             TraceRouteResult traceRouteResult = new TraceRouteResult(Source, targetAddress, resolvedTargetName);
 
@@ -402,7 +402,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        private void WriteConsoleTraceRouteHeader(string resolvedTargetName, string targetAddress)
+        private void WriteTraceRouteHeader(string resolvedTargetName, string targetAddress)
         {
             _testConnectionProgressBarActivity = StringUtil.Format(
                 TestConnectionResources.TraceRouteStart,

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -782,7 +782,7 @@ namespace Microsoft.PowerShell.Commands
         private const int DefaultSendBufferSize = 32;
         private static byte[] s_DefaultSendBuffer = null;
 
-        private bool disposed = false;
+        private bool disposed;
 
         private readonly Ping _sender = new Ping();
 

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -330,7 +330,6 @@ namespace Microsoft.PowerShell.Commands
             TraceRouteResult traceRouteResult = new TraceRouteResult(Source, targetAddress, resolvedTargetName);
 
             int currentHop = 1;
-            Ping sender = new Ping();
             PingOptions pingOptions = new PingOptions(currentHop, DontFragment.IsPresent);
             PingReply reply = null;
             int timeout = TimeoutSeconds * 1000;
@@ -348,7 +347,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     try
                     {
-                        reply = sender.Send(targetAddress, timeout, buffer, pingOptions);
+                        reply = _sender.Send(targetAddress, timeout, buffer, pingOptions);
 
                         traceRouteReply.PingReplies.Add(reply);
                     }
@@ -552,7 +551,6 @@ namespace Microsoft.PowerShell.Commands
 
             try
             {
-                Ping sender = new Ping();
                 PingOptions pingOptions = new PingOptions(MaxHops, true);
                 int retry = 1;
 
@@ -568,7 +566,7 @@ namespace Microsoft.PowerShell.Commands
                         CurrentMTUSize,
                         HighMTUSize));
 
-                    reply = sender.Send(targetAddress, timeout, buffer, pingOptions);
+                    reply = _sender.Send(targetAddress, timeout, buffer, pingOptions);
 
                     // Cautious! Algorithm is sensitive to changing boundary values.
                     if (reply.Status == IPStatus.PacketTooBig)
@@ -698,7 +696,6 @@ namespace Microsoft.PowerShell.Commands
             bool quietResult = true;
             byte[] buffer = GetSendBuffer(BufferSize);
 
-            Ping sender = new Ping();
             PingReply reply;
             PingOptions pingOptions = new PingOptions(MaxHops, DontFragment.IsPresent);
             PingReport pingReport = new PingReport(Source, resolvedTargetName);
@@ -709,7 +706,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 try
                 {
-                    reply = sender.Send(targetAddress, timeout, buffer, pingOptions);
+                    reply = _sender.Send(targetAddress, timeout, buffer, pingOptions);
                 }
                 catch (PingException ex)
                 {
@@ -959,6 +956,8 @@ namespace Microsoft.PowerShell.Commands
         /// Create the default send buffer once and cache it.
         private const int DefaultSendBufferSize = 32;
         private static byte[] s_DefaultSendBuffer = null;
+
+        private readonly Ping _sender = new Ping();
 
         // Random value for WriteProgress Activity Id.
         private static readonly int s_ProgressId = 174593053;

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -997,7 +997,7 @@ namespace Microsoft.PowerShell.Commands
         private const string TestConnectionExceptionId = "TestConnectionException";
 
         /// <summary>
-        /// Finalizer for IDisposable class.
+        /// Finalizes an instance of the <see cref="TestConnectionCommand"/> class.
         /// </summary>
         ~TestConnectionCommand()
         {

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -410,14 +410,13 @@ namespace Microsoft.PowerShell.Commands
                 targetAddress,
                 MaxHops);
 
-            WriteInformation(_testConnectionProgressBarActivity, s_PSHostTag);
+            WriteVerbose(_testConnectionProgressBarActivity);
 
             ProgressRecord record = new ProgressRecord(s_ProgressId, _testConnectionProgressBarActivity, ProgressRecordSpace);
             WriteProgress(record);
         }
 
         private string _testConnectionProgressBarActivity;
-        private static string[] s_PSHostTag = new string[] { "PSHOST" };
 
         private void WriteTraceRouteProgress(TraceRouteReply traceRouteReply)
         {
@@ -447,7 +446,7 @@ namespace Microsoft.PowerShell.Commands
                 msg = StringUtil.Format(TestConnectionResources.TraceRouteTimeOut, traceRouteReply.Hop);
             }
 
-            WriteInformation(msg, s_PSHostTag);
+            WriteVerbose(msg);
 
             ProgressRecord record = new ProgressRecord(s_ProgressId, _testConnectionProgressBarActivity, msg);
             WriteProgress(record);
@@ -455,7 +454,7 @@ namespace Microsoft.PowerShell.Commands
 
         private void WriteTraceRouteFooter()
         {
-            WriteInformation(TestConnectionResources.TraceRouteComplete, s_PSHostTag);
+            WriteVerbose(TestConnectionResources.TraceRouteComplete);
 
             var record = new ProgressRecord(s_ProgressId, _testConnectionProgressBarActivity, ProgressRecordSpace)
             {
@@ -772,7 +771,7 @@ namespace Microsoft.PowerShell.Commands
                 targetAddress,
                 BufferSize);
 
-            WriteInformation(_testConnectionProgressBarActivity, s_PSHostTag);
+            WriteVerbose(_testConnectionProgressBarActivity);
 
             ProgressRecord record = new ProgressRecord(
                 s_ProgressId,
@@ -798,7 +797,7 @@ namespace Microsoft.PowerShell.Commands
                     reply.Options?.Ttl);
             }
 
-            WriteInformation(msg, s_PSHostTag);
+            WriteVerbose(msg);
 
             ProgressRecord record = new ProgressRecord(s_ProgressId, _testConnectionProgressBarActivity, msg);
             WriteProgress(record);
@@ -806,7 +805,7 @@ namespace Microsoft.PowerShell.Commands
 
         private void WritePingFooter()
         {
-            WriteInformation(TestConnectionResources.PingComplete, s_PSHostTag);
+            WriteVerbose(TestConnectionResources.PingComplete);
 
             var record = new ProgressRecord(s_ProgressId, _testConnectionProgressBarActivity, ProgressRecordSpace)
             {

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -762,14 +762,14 @@ namespace Microsoft.PowerShell.Commands
         /// </param>
         protected virtual void Dispose(bool disposing)
         {
-            if (!this.disposed)
+            if (!this._disposed)
             {
                 if (disposing)
                 {
                     _sender.Dispose();
                 }
 
-                disposed = true;
+                _disposed = true;
             }
         }
 
@@ -782,7 +782,7 @@ namespace Microsoft.PowerShell.Commands
         private const int DefaultSendBufferSize = 32;
         private static byte[] s_DefaultSendBuffer = null;
 
-        private bool disposed;
+        private bool _disposed;
 
         private readonly Ping _sender = new Ping();
 

--- a/src/Microsoft.PowerShell.Commands.Management/resources/TestConnectionResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/TestConnectionResources.resx
@@ -117,30 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="TraceRouteStart" xml:space="preserve">
-    <value>Tracing route to {0} [{1}] over a maximum of {2} hops:</value>
-  </data>
-  <data name="TraceRouteReply" xml:space="preserve">
-    <value>{0,3}   {1} ms   {2} ms   {3} ms   {4} [{5}]</value>
-  </data>
-  <data name="TraceRouteTimeOut" xml:space="preserve">
-    <value>{0,3}   * ms   * ms   * ms   Request timed out.</value>
-  </data>
-  <data name="TraceRouteComplete" xml:space="preserve">
-    <value>Trace complete.</value>
-  </data>
-  <data name="ConnectionTestStart" xml:space="preserve">
-    <value>Trying to connect to {0} [{1}]:</value>
-  </data>
-  <data name="ConnectionTestDescription" xml:space="preserve">
-    <value>Target: {0} [{1}]. Seconds: {2}</value>
-  </data>
-  <data name="MTUSizeDetectStart" xml:space="preserve">
-    <value>Pinging {0} [{1}] with {2} bytes of data:</value>
-  </data>
-  <data name="MTUSizeDetectDescription" xml:space="preserve">
-    <value>MTU size: {0}. Attempt: {1}</value>
-  </data>
   <data name="NoPingResult" xml:space="preserve">
     <value>Testing connection to computer '{0}' failed: {1}</value>
   </data>
@@ -149,17 +125,5 @@
   </data>
   <data name="TargetAddressAbsent" xml:space="preserve">
     <value>Target IPv4/IPv6 address absent.</value>
-  </data>
-  <data name="PingStart" xml:space="preserve">
-    <value>Pinging {0} [{1}] with {2} bytes of data:</value>
-  </data>
-  <data name="PingTimeOut" xml:space="preserve">
-    <value>Request timed out.</value>
-  </data>
-  <data name="PingReply" xml:space="preserve">
-    <value>Reply from {0}: bytes={1} time={2}ms TTL={3}</value>
-  </data>
-  <data name="PingComplete" xml:space="preserve">
-    <value>Ping complete.</value>
   </data>
 </root>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

1. ~~Replaces all `WriteInformation()` calls with `WriteVerbose()`~~ **Removes** all verbose and progress output. We will revisit verbose output in a later PR.
2. Refactors ping implementation to create only a single `Ping` object which is reused for all `Send()` calls.
3. Implements `IDisposable` for `Test-Connection` so that it can dispose of the `Ping` object when it is no longer needed.

## PR Context

Part 2 of #10044, refactor of `Test-Connection` cmdlet.
Fixes #6768

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
