### PR TITLE
Flag `default` switch statement condition clause as keyword

### DIFF
--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -2745,14 +2745,14 @@ namespace System.Management.Automation.Language
                 while (true)
                 {
                     Token token = PeekToken();
-                    var isDefaultClause = token.Kind == TokenKind.Default;
+                    bool isDefaultClause = token.Kind == TokenKind.Default;
                     ExpressionAst clauseCondition = null;
 
                     if (isDefaultClause)
                     {
                         // Consume the 'default' token.
                         SkipToken();
-                        endErrorStatement = token.Extent;
+                        clauseCondition = new StringConstantExpressionAst(token.Extent, token.Text, StringConstantType.BareWord);
                     }
                     else
                     {
@@ -2775,10 +2775,10 @@ namespace System.Management.Automation.Language
 
                             break;
                         }
-
-                        errorAsts.Add(clauseCondition);
-                        endErrorStatement = clauseCondition.Extent;
                     }
+
+                    errorAsts.Add(clauseCondition);
+                    endErrorStatement = clauseCondition.Extent;
 
                     StatementBlockAst clauseBody = StatementBlockRule();
                     if (clauseBody == null)
@@ -2802,7 +2802,7 @@ namespace System.Management.Automation.Language
                                 // ErrorRecovery: just report the error and continue, forget the previous default clause.
 
                                 isError = true;
-                                ReportError(token.Extent,
+                                ReportError(clauseCondition.Extent,
                                     nameof(ParserStrings.MultipleSwitchDefaultClauses),
                                     ParserStrings.MultipleSwitchDefaultClauses);
                             }

--- a/src/System.Management.Automation/engine/parser/token.cs
+++ b/src/System.Management.Automation/engine/parser/token.cs
@@ -573,6 +573,9 @@ namespace System.Management.Automation.Language
         /// <summary>The 'base' keyword</summary>
         Base = 168,
 
+        /// <summary>The 'default' keyword</summary>
+        Default = 169,
+
         #endregion Keywords
     }
 
@@ -927,6 +930,7 @@ namespace System.Management.Automation.Language
             /*              Command */ TokenFlags.Keyword,
             /*               Hidden */ TokenFlags.Keyword,
             /*                 Base */ TokenFlags.Keyword,
+            /*              Default */ TokenFlags.Keyword,
 
             #endregion Flags for keywords
         };
@@ -1125,6 +1129,7 @@ namespace System.Management.Automation.Language
             /*              Command */ "command",
             /*               Hidden */ "hidden",
             /*                 Base */ "base",
+            /*              Default */ "default",
 
             #endregion Text for keywords
         };
@@ -1132,9 +1137,9 @@ namespace System.Management.Automation.Language
 #if DEBUG
         static TokenTraits()
         {
-            Diagnostics.Assert(s_staticTokenFlags.Length == ((int)TokenKind.Base + 1),
+            Diagnostics.Assert(s_staticTokenFlags.Length == ((int)TokenKind.Default + 1),
                                "Table size out of sync with enum - _staticTokenFlags");
-            Diagnostics.Assert(s_tokenText.Length == ((int)TokenKind.Base + 1),
+            Diagnostics.Assert(s_tokenText.Length == ((int)TokenKind.Default + 1),
                                "Table size out of sync with enum - _tokenText");
             // Some random assertions to make sure the enum and the traits are in sync
             Diagnostics.Assert(GetTraits(TokenKind.Begin) == (TokenFlags.Keyword | TokenFlags.ScriptBlockBlockName),

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -628,7 +628,7 @@ namespace System.Management.Automation.Language
         /*A*/    "configuration",           "public",           "private",          "static",                     /*A*/
         /*B*/    "interface",               "enum",             "namespace",        "module",                     /*B*/
         /*C*/    "type",                    "assembly",         "command",          "hidden",                     /*C*/
-        /*D*/    "base",                                                                                          /*D*/
+        /*D*/    "base",                    "default",                                                            /*D*/
         };
 
         private static readonly TokenKind[] s_keywordTokenKind = new TokenKind[] {
@@ -644,7 +644,7 @@ namespace System.Management.Automation.Language
         /*A*/    TokenKind.Configuration,   TokenKind.Public,   TokenKind.Private,  TokenKind.Static,             /*A*/
         /*B*/    TokenKind.Interface,       TokenKind.Enum,     TokenKind.Namespace,TokenKind.Module,             /*B*/
         /*C*/    TokenKind.Type,            TokenKind.Assembly, TokenKind.Command,  TokenKind.Hidden,             /*C*/
-        /*D*/    TokenKind.Base,                                                                                  /*D*/
+        /*D*/    TokenKind.Base,            TokenKind.Default,                                                    /*D*/
         };
 
         internal static readonly string[] _operatorText = new string[] {

--- a/test/powershell/Language/Parser/Parsing.Tests.ps1
+++ b/test/powershell/Language/Parser/Parsing.Tests.ps1
@@ -237,7 +237,7 @@ Describe 'switch statement parsing' -Tags "CI" {
     Test-ErrorStmt 'switch (1) {foo'       'switch (1) {foo' 'foo' '1' '1' '1'
     Test-ErrorStmt 'switch (1) {foo}'      'switch (1) {foo' 'foo' '1' '1' '1'
     Test-ErrorStmt 'switch (1) {foo {bar}' 'switch (1) {foo {bar}' 'foo' '{bar}' 'bar' 'bar' 'bar' '1' '1' '1'
-    Test-ErrorStmt 'switch (1) {default {9} default{2}' 'switch (1) {default {9} default{2}' '{9}' '9' '9' '9' '{2}' '2' '2' '2' '1' '1' '1'
+    Test-ErrorStmt 'switch (1) {default {9} default{2}' 'switch (1) {default {9} default{2}' 'default' '{9}' '9' '9' '9' 'default' '{2}' '2' '2' '2' '1' '1' '1'
 }
 
 Describe 'function statement parsing' -Tags "CI" {

--- a/test/powershell/Language/Parser/Parsing.Tests.ps1
+++ b/test/powershell/Language/Parser/Parsing.Tests.ps1
@@ -423,3 +423,165 @@ Describe "Ternary Operator parsing" -Tags CI {
         $expr.IfFalse | Should -BeOfType 'System.Management.Automation.Language.ConstantExpressionAst'
     }
 }
+
+Describe "Keywords 'default', 'hidden', 'in', 'static' Token parsing" -Tags CI {
+    BeforeAll {
+        $testCases_basic = @(
+            @{
+                Script = 'switch (1) {default {0} 1 {1}}'
+                TokensToCheck = @{
+                    5 = @{
+                        TokenKind = [System.Management.Automation.Language.TokenKind]::Default
+                        TokenFlags_Mask = [System.Management.Automation.Language.TokenFlags]::Keyword
+                        TokenFlags_Value = [System.Management.Automation.Language.TokenFlags]::Keyword
+                    }
+                }
+            }
+            @{
+                Script = 'switch (1) {"default" {0} 1 {1}}'
+                TokensToCheck = @{
+                    5 = @{
+                        TokenKind = [System.Management.Automation.Language.TokenKind]::StringExpandable
+                        TokenFlags_Mask = [System.Management.Automation.Language.TokenFlags]::Keyword
+                        TokenFlags_Value = [System.Management.Automation.Language.TokenFlags]::None
+                    }
+                }
+            }
+            @{
+                Script = 'switch (1) {adefault {0} 1 {1}}'
+                TokensToCheck = @{
+                    5 = @{
+                        TokenKind = [System.Management.Automation.Language.TokenKind]::Identifier
+                        TokenFlags_Mask = [System.Management.Automation.Language.TokenFlags]::Keyword
+                        TokenFlags_Value = [System.Management.Automation.Language.TokenFlags]::None
+                    }
+                }
+            }
+            @{
+                Script = 'foreach ($i in 1..2) {$i}'
+                TokensToCheck = @{
+                    3 = @{
+                        TokenKind = [System.Management.Automation.Language.TokenKind]::In
+                        TokenFlags_Mask = [System.Management.Automation.Language.TokenFlags]::Keyword
+                        TokenFlags_Value = [System.Management.Automation.Language.TokenFlags]::Keyword
+                    }
+                }
+            }
+            @{
+                Script = 'class test {hidden $a; static aMethod () {return $this.a} }'
+                TokensToCheck = @{
+                    3 = @{
+                        TokenKind = [System.Management.Automation.Language.TokenKind]::Hidden
+                        TokenFlags_Mask = [System.Management.Automation.Language.TokenFlags]::Keyword
+                        TokenFlags_Value = [System.Management.Automation.Language.TokenFlags]::Keyword
+                    }
+                    6 = @{
+                        TokenKind = [System.Management.Automation.Language.TokenKind]::Static
+                        TokenFlags_Mask = [System.Management.Automation.Language.TokenFlags]::Keyword
+                        TokenFlags_Value = [System.Management.Automation.Language.TokenFlags]::Keyword
+                    }
+                }
+            }
+            @{
+                Script = 'echo default hidden in static'
+                TokensToCheck = @{
+                    1 = @{
+                        TokenKind = [System.Management.Automation.Language.TokenKind]::Generic
+                        TokenFlags_Mask = [System.Management.Automation.Language.TokenFlags]::Keyword
+                        TokenFlags_Value = [System.Management.Automation.Language.TokenFlags]::None
+                    }
+                    2 = @{
+                        TokenKind = [System.Management.Automation.Language.TokenKind]::Generic
+                        TokenFlags_Mask = [System.Management.Automation.Language.TokenFlags]::Keyword
+                        TokenFlags_Value = [System.Management.Automation.Language.TokenFlags]::None
+                    }
+                    3 = @{
+                        TokenKind = [System.Management.Automation.Language.TokenKind]::Generic
+                        TokenFlags_Mask = [System.Management.Automation.Language.TokenFlags]::Keyword
+                        TokenFlags_Value = [System.Management.Automation.Language.TokenFlags]::None
+                    }
+                    4 = @{
+                        TokenKind = [System.Management.Automation.Language.TokenKind]::Generic
+                        TokenFlags_Mask = [System.Management.Automation.Language.TokenFlags]::Keyword
+                        TokenFlags_Value = [System.Management.Automation.Language.TokenFlags]::None
+                    }
+                }
+            }
+            @{
+                Script = 'default'
+                TokensToCheck = @{
+                    0 = @{
+                        TokenKind = [System.Management.Automation.Language.TokenKind]::Default
+                        TokenFlags_Mask = [System.Management.Automation.Language.TokenFlags]::Keyword -bor [System.Management.Automation.Language.TokenFlags]::CommandName
+                        TokenFlags_Value = [System.Management.Automation.Language.TokenFlags]::CommandName
+                    }
+                }
+            }
+            @{
+                Script = 'hidden'
+                TokensToCheck = @{
+                    0 = @{
+                        TokenKind = [System.Management.Automation.Language.TokenKind]::Hidden
+                        TokenFlags_Mask = [System.Management.Automation.Language.TokenFlags]::Keyword -bor [System.Management.Automation.Language.TokenFlags]::CommandName
+                        TokenFlags_Value = [System.Management.Automation.Language.TokenFlags]::CommandName
+                    }
+                }
+            }
+            @{
+                Script = 'in'
+                TokensToCheck = @{
+                    0 = @{
+                        TokenKind = [System.Management.Automation.Language.TokenKind]::In
+                        TokenFlags_Mask = [System.Management.Automation.Language.TokenFlags]::Keyword -bor [System.Management.Automation.Language.TokenFlags]::CommandName
+                        TokenFlags_Value = [System.Management.Automation.Language.TokenFlags]::CommandName
+                    }
+                }
+            }
+            @{
+                Script = 'static'
+                TokensToCheck = @{
+                    0 = @{
+                        TokenKind = [System.Management.Automation.Language.TokenKind]::Static
+                        TokenFlags_Mask = [System.Management.Automation.Language.TokenFlags]::Keyword -bor [System.Management.Automation.Language.TokenFlags]::CommandName
+                        TokenFlags_Value = [System.Management.Automation.Language.TokenFlags]::CommandName
+                    }
+                }
+            }
+        )
+    }
+
+    AfterAll {
+    }
+
+    It "Keywords 'default', 'hidden', 'in', 'static' in {<Script>} correctly tokenized." -TestCases $testCases_basic {
+        param($Script, $TokensToCheck)
+
+        $tks = $null
+        $ers = $null
+        $result = [System.Management.Automation.Language.Parser]::ParseInput($Script, [ref]$tks, [ref]$ers)
+
+        foreach ($token in $TokensToCheck.Keys ) {
+            if ($TokensToCheck[$Token].ContainsKey('TokenKind')) {
+                $tks[$token].Kind | Should -Be $TokensToCheck[$token].TokenKind -Because 'because TokenKind must be as expected'
+            }
+            if ($TokensToCheck[$Token].ContainsKey('TokenFlags_Value')) {
+                $tks[$token].TokenFlags -band $TokensToCheck[$token].TokenFlags_Mask | Should -Be $TokensToCheck[$token].TokenFlags_Value -Because 'because TokenFlags must be as expected after masking'
+            }
+        }
+    }
+
+    $testKeywordsAsCmds = @(
+        @{ Keyword = 'default' }
+        @{ Keyword = 'hidden' }
+        @{ Keyword = 'in' }         # Note: this overwrites Pester's `In` function.
+        @{ Keyword = 'static' }
+    )
+
+    It "<Keyword> can be used as command name" -TestCases $testKeywordsAsCmds {
+        param($Keyword)
+
+        Invoke-Expression "function $Keyword { '$Keyword' }"
+
+        . $Keyword | Should -BeExactly $Keyword
+    }
+}

--- a/test/powershell/Language/Parser/Parsing.Tests.ps1
+++ b/test/powershell/Language/Parser/Parsing.Tests.ps1
@@ -237,7 +237,7 @@ Describe 'switch statement parsing' -Tags "CI" {
     Test-ErrorStmt 'switch (1) {foo'       'switch (1) {foo' 'foo' '1' '1' '1'
     Test-ErrorStmt 'switch (1) {foo}'      'switch (1) {foo' 'foo' '1' '1' '1'
     Test-ErrorStmt 'switch (1) {foo {bar}' 'switch (1) {foo {bar}' 'foo' '{bar}' 'bar' 'bar' 'bar' '1' '1' '1'
-    Test-ErrorStmt 'switch (1) {default {9} default{2}' 'switch (1) {default {9} default{2}' 'default' '{9}' '9' '9' '9' 'default' '{2}' '2' '2' '2' '1' '1' '1'
+    Test-ErrorStmt 'switch (1) {default {9} default{2}' 'switch (1) {default {9} default{2}' '{9}' '9' '9' '9' '{2}' '2' '2' '2' '1' '1' '1'
 }
 
 Describe 'function statement parsing' -Tags "CI" {


### PR DESCRIPTION
# PR Summary

Flag the `switch` statement condition clause `default` token as a keyword
token to facilitate (PSReadLine) highlighting it as a keyword.  Closes #10470.

This change is to treat the `default` clause keyword as a full keyword token, and as such token based highlighters will see it as a keyword.

## PR Context

Flagging the `default` condition clause token of the `switch` statement as a keyword will facilitate highlighting of the keyword to better contrast against other bareword string literal conditions.

A simple (partial) example:
```PowerShell
# return simple element value (need to check for Boolean datatype, and process value accordingly)
switch ($node.Name) {
    true { $true; continue } # return a Boolean TRUE value
    false { $false; continue } # return a Boolean FALSE value
    default { $node.Value } # return the element value
}
```
Highlighting of the `default` keyword in the above example makes it easier to distinguish the special condition clause from the other bareword conditions.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
