### PR TITLE
Prevent the installation of the same version we have.

### DIFF
--- a/tools/install-powershell.ps1
+++ b/tools/install-powershell.ps1
@@ -256,7 +256,7 @@ try {
 
         if($currentlyInstalledVersion -eq $release) {
             Write-Verbose "Latest PowerShell Daily already installed." -Verbose
-	    return
+            return
         }
 
         if ($IsWinEnv) {

--- a/tools/install-powershell.ps1
+++ b/tools/install-powershell.ps1
@@ -244,7 +244,7 @@ try {
     [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
 
     if ($Daily) {
-        $metadata = Invoke-RestMethod https://pscoretestdata.blob.core.windows.net/buildinfo/daily.json
+        $metadata = Invoke-RestMethod 'https://aka.ms/pwsh-buildinfo-daily'
         $release = $metadata.ReleaseTag -replace '^v'
         $blobName = $metadata.BlobName
 

--- a/tools/install-powershell.ps1
+++ b/tools/install-powershell.ps1
@@ -250,7 +250,7 @@ try {
 
         # Get version from currently installed PowerShell Daily if available.
         $pwshPath = Join-Path $Destination "pwsh"
-	$currentlyInstalledVersion = if(Test-Path $pwshPath) {
+        $currentlyInstalledVersion = if(Test-Path $pwshPath) {
             ((& $pwshPath -version) -split " ")[1]
         }
 

--- a/tools/install-powershell.ps1
+++ b/tools/install-powershell.ps1
@@ -248,6 +248,17 @@ try {
         $release = $metadata.ReleaseTag -replace '^v'
         $blobName = $metadata.BlobName
 
+        # Get version from currently installed PowerShell Daily if available.
+        $pwshPath = Join-Path $Destination "pwsh"
+	$currentlyInstalledVersion = if(Test-Path $pwshPath) {
+            ((& $pwshPath -version) -split " ")[1]
+        }
+
+        if($currentlyInstalledVersion -eq $release) {
+            Write-Verbose "Latest PowerShell Daily already installed." -Verbose
+	    return
+        }
+
         if ($IsWinEnv) {
             if ($UseMSI) {
                 $packageName = "PowerShell-${release}-win-${architecture}.msi"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This makes it so that you don't install the same Daily build that you already have.

## PR Context

I want to include a single line in my profile like:

```pwsh
iex "& {$(irm aka.ms/install-powershell.ps1)} -Daily"
```

Without having to check if I already have the latest Daily installed.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
