### PR TITLE
Remove the event handler that was causing breakpoint changes to be erroneously replicated to the host runspace debugger

### DIFF
--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -3013,7 +3013,6 @@ namespace System.Management.Automation
 
                     _runningJobs.Add(jobArgs.Job.InstanceId, jobArgs);
                     jobArgs.Debugger.DebuggerStop += HandleMonitorRunningJobsDebuggerStop;
-                    jobArgs.Debugger.BreakpointUpdated += HandleBreakpointUpdated;
 
                     newJob = true;
                 }
@@ -3090,7 +3089,6 @@ namespace System.Management.Automation
                 if (_runningJobs.TryGetValue(job.InstanceId, out jobArgs))
                 {
                     jobArgs.Debugger.DebuggerStop -= HandleMonitorRunningJobsDebuggerStop;
-                    jobArgs.Debugger.BreakpointUpdated -= HandleBreakpointUpdated;
                     _runningJobs.Remove(job.InstanceId);
                 }
             }
@@ -3308,28 +3306,6 @@ namespace System.Management.Automation
                     (((DebugMode & DebugModes.RemoteScript) == DebugModes.RemoteScript) && !IsLocalSession));
         }
 
-        private void HandleBreakpointUpdated(object sender, BreakpointUpdatedEventArgs e)
-        {
-            switch (e.UpdateType)
-            {
-                case BreakpointUpdateType.Set:
-                    AddNewBreakpoint(e.Breakpoint);
-                    break;
-
-                case BreakpointUpdateType.Removed:
-                    RemoveBreakpoint(e.Breakpoint);
-                    break;
-
-                case BreakpointUpdateType.Enabled:
-                    EnableBreakpoint(e.Breakpoint);
-                    break;
-
-                case BreakpointUpdateType.Disabled:
-                    DisableBreakpoint(e.Breakpoint);
-                    break;
-            }
-        }
-
         private bool IsRunningWFJobsDebugger(Debugger debugger)
         {
             lock (_syncObject)
@@ -3528,7 +3504,6 @@ namespace System.Management.Automation
             if (nestedDebugger != null)
             {
                 nestedDebugger.DebuggerStop -= HandleMonitorRunningRSDebuggerStop;
-                nestedDebugger.BreakpointUpdated -= HandleBreakpointUpdated;
                 nestedDebugger.Dispose();
 
                 // If current active debugger, then pop.
@@ -3698,7 +3673,6 @@ namespace System.Management.Automation
                     runspaceInfo.NestedDebugger = nestedDebugger;
 
                     nestedDebugger.DebuggerStop += HandleMonitorRunningRSDebuggerStop;
-                    nestedDebugger.BreakpointUpdated += HandleBreakpointUpdated;
 
                     if (((_lastActiveDebuggerAction == DebuggerResumeAction.StepInto) || (_currentDebuggerAction == DebuggerResumeAction.StepInto)) &&
                         !nestedDebugger.IsActive)

--- a/test/powershell/SDK/Breakpoint.Tests.ps1
+++ b/test/powershell/SDK/Breakpoint.Tests.ps1
@@ -77,13 +77,6 @@ Describe 'Breakpoint SDK Unit Tests' -Tags 'CI' {
 
     Context 'Managing breakpoints in a remote runspace via the SDK' {
 
-        AfterAll {
-            # Get rid of any breakpoints that were created in the default runspace.
-            # This is necessary due to a known bug that causes breakpoints with the
-            # same id to be created or updated in the default runspace.
-            Get-PSBreakpoint | Remove-PSBreakpoint
-        }
-
         It 'Can set command breakpoints' {
             $jobRunspace.Debugger.SetCommandBreakpoint('Write-Verbose', { break }) | Should -BeOfType [System.Management.Automation.CommandBreakpoint]
         }
@@ -113,6 +106,14 @@ Describe 'Breakpoint SDK Unit Tests' -Tags 'CI' {
                 $bp = $jobRunspace.Debugger.EnableBreakpoint($bp)                
                 $bp.Enabled | Should -BeTrue
             }
+        }
+
+        It 'Doesn''t manipulate any breakpoints in the default runspace' {
+            # Issue 10167 fix:
+            # Ensure that breakpoints were not created in the default runspace.
+            # Prior to this issue being fixed, breakpoints with the same id
+            # would be created or updated in the default runspace.
+            $host.Runspace.Debugger.GetBreakpoints() | Should -BeNullOrEmpty
         }
 
         It 'Can remove breakpoints' {

--- a/test/powershell/SDK/Breakpoint.Tests.ps1
+++ b/test/powershell/SDK/Breakpoint.Tests.ps1
@@ -109,7 +109,7 @@ Describe 'Breakpoint SDK Unit Tests' -Tags 'CI' {
         }
 
         It 'Doesn''t manipulate any breakpoints in the default runspace' {
-            # Issue 10167 fix:
+            # Issue https://github.com/PowerShell/PowerShell/issues/10167 fix:
             # Ensure that breakpoints were not created in the default runspace.
             # Prior to this issue being fixed, breakpoints with the same id
             # would be created or updated in the default runspace.


### PR DESCRIPTION
# PR Summary

Fixes #10167.

Prior to this fix, if you created, modified, or removed a breakpoint in a nested debugger or inside of a job debugger, whatever change you made would be applied to the breakpoint with the corresponding breakpoint ID in the host runspace debugger. This fix removes the event handler that was causing breakpoint changes to be erroneously replicated to the host runspace debugger.

## PR Context

See discussion with @PaulHigin in #10167.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
