### PR TITLE
Add `Get-ChildItem` test

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -188,15 +188,23 @@ Describe "Get-ChildItem" -Tags "CI" {
         }
 
         It "Wildcard matching behavior is the same between -Path and -Include parameters when using escape characters" {
-            try {
-                New-Item -Type File 'a`[b]' -ErrorAction SilentlyContinue > $null
-                $WithInclude = Get-ChildItem * -Include 'a```[b`]'
-                $WithPath = Get-ChildItem -Path 'a```[b`]'
-                $WithInclude.Name | Should -BeExactly 'a`[b]'
-                $WithPath.Name | Should -BeExactly 'a`[b]'
-            } finally {
-                Remove-Item -Path 'a`[b]' -ErrorAction SilentlyContinue
-            }
+            $expectedPath = Join-Path -Path $TestDrive -ChildPath 'a`[b]'
+            $escapedPath = 'a```[b`]'
+            $escapedPath = 'a```[b`]'
+            $escapedPathWithWildcard = 'a```[b*'
+            New-Item -Type File $expectedPath -ErrorAction SilentlyContinue > $null
+
+            $WithInclude = Get-ChildItem * -Include $escapedPath
+            $WithPath = Get-ChildItem -Path $escapedPath
+
+            $WithInclude.Name | Should -BeExactly $expectedPath
+            $WithPath.Name | Should -BeExactly $expectedPath
+
+            $WithInclude = Get-ChildItem * -Include $escapedPathWithWildcard
+            $WithPath = Get-ChildItem -Path $escapedPathWithWildcard
+
+            $WithInclude.Name | Should -BeExactly $expectedPath
+            $WithPath.Name | Should -BeExactly $expectedPath
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -186,6 +186,18 @@ Describe "Get-ChildItem" -Tags "CI" {
             $app.Target | Should -Not -Be $app.FullName
             $app.LinkType | Should -BeExactly 'AppExeCLink'
         }
+
+        It "Wildcard matching behavior is the same between -Path and -Include parameters when using escape characters" {
+            try {
+                New-Item -Type File 'a`[b]' -ErrorAction SilentlyContinue > $null
+                $WithInclude = Get-ChildItem * -Include 'a```[b`]'
+                $WithPath = Get-ChildItem -Path 'a```[b`]'
+                $WithInclude.Name | Should -BeExactly 'a`[b]'
+                $WithPath.Name | Should -BeExactly 'a`[b]'
+            } finally {
+                Remove-Item -Path 'a`[b]' -ErrorAction SilentlyContinue
+            }
+        }
     }
 
     Context 'Env: Provider' {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -188,23 +188,24 @@ Describe "Get-ChildItem" -Tags "CI" {
         }
 
         It "Wildcard matching behavior is the same between -Path and -Include parameters when using escape characters" {
-            $expectedPath = Join-Path -Path $TestDrive -ChildPath 'a`[b]'
-            $escapedPath = 'a```[b`]'
-            $escapedPath = 'a```[b`]'
-            $escapedPathWithWildcard = 'a```[b*'
-            New-Item -Type File $expectedPath -ErrorAction SilentlyContinue > $null
+            $oldLocation = Get-Location
 
-            $WithInclude = Get-ChildItem * -Include $escapedPath
-            $WithPath = Get-ChildItem -Path $escapedPath
+            try {
+                Set-Location $TestDrive
 
-            $WithInclude.Name | Should -BeExactly $expectedPath
-            $WithPath.Name | Should -BeExactly $expectedPath
+                $expectedPath = 'a`[b]'
+                $escapedPath = 'a```[b`]'
+                New-Item -Type File $expectedPath -ErrorAction SilentlyContinue > $null
 
-            $WithInclude = Get-ChildItem * -Include $escapedPathWithWildcard
-            $WithPath = Get-ChildItem -Path $escapedPathWithWildcard
+                $WithInclude = Get-ChildItem * -Include $escapedPath
+                $WithPath = Get-ChildItem -Path $escapedPath
 
-            $WithInclude.Name | Should -BeExactly $expectedPath
-            $WithPath.Name | Should -BeExactly $expectedPath
+                $WithInclude.Name | Should -BeExactly $expectedPath
+                $WithPath.Name | Should -BeExactly $expectedPath
+
+            } finally {
+                Set-Location $oldLocation
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add new test for #3724 to exclude a regression.

## PR Context

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
