### PR TITLE
Update PSDesiredStateConfiguration to 2.0.3 and bring new tests.

### DIFF
--- a/assets/files.wxs
+++ b/assets/files.wxs
@@ -1699,6 +1699,14 @@
               <File Id="fil98D6A2CAE08A408BB0215CD1DD6C7A0F" KeyPath="yes" Source="$(env.ProductSourcePath)\Modules\PSDesiredStateConfiguration\helpers\DscResourceInfo.psm1" />
             </Component>
           </Directory>
+          <Directory Name="en-US" Id="dir28499A54B1694A25BB7EFA06CAE3272E">
+            <Component Id="cmpAC685A1C6E354E228EB6A1DD95FF03D5" Guid="{c377f473-c4e3-4005-9424-a1711f60fdfc}">
+              <File Id="filD2DD9066D1A148EBB7AD542DAC529862" KeyPath="yes" Source="$(env.ProductSourcePath)\Modules\PSDesiredStateConfiguration\en-US\about_PSDesiredStateConfiguration.md" />
+            </Component>
+          </Directory>
+          <Component Id="cmp67C4A6FC5E48487BB31DE411CF38B0B2" Guid="{321941e8-214c-470e-9002-ee21ef600145}">
+            <File Id="fil747B2801746E4FFCB93000BBA1089F15" KeyPath="yes" Source="$(env.ProductSourcePath)\Modules\PSDesiredStateConfiguration\PSDesiredStateConfiguration.cat" />
+          </Component>
         </Directory>
         <Directory Id="dirECE37E3EC3637A365744D075BD8132E9" Name="Microsoft.PowerShell.Management">
           <Component Id="cmp6DAFD01CAA3A4C67185922F445EDE495" Guid="{D4374EC0-26FC-4607-AF6B-35721698E8A5}">
@@ -3888,6 +3896,8 @@
       <ComponentRef Id="cmpD7A187ADE66347E5A7550B96BA10D493" />
       <ComponentRef Id="cmp827B25EEC28D4699BB29042B273C8CBF" />
       <ComponentRef Id="cmp712842BFA391403DA3F21B2A4C729ED3" />
+      <ComponentRef Id="cmpAC685A1C6E354E228EB6A1DD95FF03D5" />
+      <ComponentRef Id="cmp67C4A6FC5E48487BB31DE411CF38B0B2" />
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/build.psm1
+++ b/build.psm1
@@ -493,16 +493,7 @@ Fix steps:
     if ((Test-IsPreview $psVersion) -and -not $Runtime.Contains("arm")) {
         $json = & $publishPath\pwsh -noprofile -command {
             $expFeatures = [System.Collections.Generic.List[string]]::new()
-
             Get-ExperimentalFeature | ForEach-Object { $expFeatures.Add($_.Name) }
-
-            # Make sure we add the experimental features from the modules
-            Get-Module -ListAvailable | Where-Object {$_.Path -like "${pshome}*" -and $_.ExperimentalFeatures} | Select-Object -ExpandProperty ExperimentalFeatures | ForEach-Object {
-                if (!$expFeatures.Contains($_.Name)) {
-                    $expFeatures.Add($_.Name)
-                }
-            }
-
             ConvertTo-Json $expFeatures.ToArray()
         }
 

--- a/build.psm1
+++ b/build.psm1
@@ -497,7 +497,8 @@ Fix steps:
             ConvertTo-Json $expFeatures.ToArray()
         }
 
-        $config += @{ ExperimentalFeatures = ($json | ConvertFrom-Json) }
+
+        $config += @{ ExperimentalFeatures = ([string[]] ($json | ConvertFrom-Json)) }
     }
 
     if ($config.Count -gt 0) {

--- a/build.psm1
+++ b/build.psm1
@@ -446,12 +446,6 @@ Fix steps:
         Pop-Location
     }
 
-    # publish powershell.config.json
-    $config = @{}
-    if ($Environment.IsWindows) {
-        $config = @{ "Microsoft.PowerShell:ExecutionPolicy" = "RemoteSigned" }
-    }
-
     if ($ReleaseTag) {
         $psVersion = $ReleaseTag
     }
@@ -489,6 +483,12 @@ Fix steps:
         Restore-PSModuleToBuild -PublishPath $publishPath
     }
 
+    # publish powershell.config.json
+    $config = @{}
+    if ($Environment.IsWindows) {
+        $config = @{ "Microsoft.PowerShell:ExecutionPolicy" = "RemoteSigned" }
+    }
+
     # ARM is cross compiled, so we can't run pwsh to enumerate Experimental Features
     if ((Test-IsPreview $psVersion) -and -not $Runtime.Contains("arm")) {
         $json = & $publishPath\pwsh -noprofile -command {
@@ -496,7 +496,6 @@ Fix steps:
             Get-ExperimentalFeature | ForEach-Object { $expFeatures.Add($_.Name) }
             ConvertTo-Json $expFeatures.ToArray()
         }
-
 
         $config += @{ ExperimentalFeatures = ([string[]] ($json | ConvertFrom-Json)) }
     }

--- a/build.psm1
+++ b/build.psm1
@@ -462,7 +462,10 @@ Fix steps:
     # ARM is cross compiled, so we can't run pwsh to enumerate Experimental Features
     if ((Test-IsPreview $psVersion) -and -not $Runtime.Contains("arm")) {
         $expFeatures = [System.Collections.Generic.List[string]]::new()
-        & $publishPath\pwsh -noprofile -out XML -command Get-ExperimentalFeature | ForEach-Object { $expFeatures.Add($_.Name) }
+        & $publishPath\pwsh -noprofile -out XML -command {
+            Get-Module -ListAvailable
+            Get-ExperimentalFeature | ForEach-Object { $expFeatures.Add($_.Name) }
+        }
         $config += @{ ExperimentalFeatures = $expFeatures.ToArray() }
     }
 

--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.3.0" />
     <PackageReference Include="PSReadLine" Version="2.0.0-beta4" />
     <PackageReference Include="ThreadJob" Version="2.0.1" />
+    <PackageReference Include="PSDesiredStateConfiguration" Version="2.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/powershell-unix/powershell-unix.csproj
+++ b/src/powershell-unix/powershell-unix.csproj
@@ -38,7 +38,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="PSDesiredStateConfiguration" Version="2.0" />
     <PackageReference Include="PowerShellHelpFiles" Version="1.0.0-*" />
   </ItemGroup>
 

--- a/src/powershell-win-core/powershell-win-core.csproj
+++ b/src/powershell-win-core/powershell-win-core.csproj
@@ -53,7 +53,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="PSDesiredStateConfiguration" Version="2.0" />
     <PackageReference Include="PowerShellHelpFiles" Version="1.0.0-*" />
   </ItemGroup>
 

--- a/test/powershell/Modules/PSDesiredStateConfiguration/PSDesiredStateConfiguration.Tests.ps1
+++ b/test/powershell/Modules/PSDesiredStateConfiguration/PSDesiredStateConfiguration.Tests.ps1
@@ -1,0 +1,501 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+Function Install-ModuleIfMissing
+{
+    param(
+        [parameter(Mandatory)]
+        [String]
+        $Name,
+        [version]
+        $MinimumVersion,
+        [switch]
+        $SkipPublisherCheck,
+        [switch]
+        $Force
+    )
+
+    $module = Get-Module -Name $Name -ListAvailable -ErrorAction Ignore | Sort-Object -Property Version -Descending | Select-Object -First 1
+
+    if(!$module -or $module.Version -lt $MinimumVersion)
+    {
+        Write-Verbose "Installing module '$Name' ..." -Verbose
+        Install-Module -Name $Name -Force -SkipPublisherCheck:$SkipPublisherCheck.IsPresent
+    }
+}
+
+Function Test-IsInvokeDscResourceEnable
+{
+    return [ExperimentalFeature]::IsEnabled("PSDesiredStateConfiguration.InvokeDscResource")
+}
+
+Describe "Test PSDesiredStateConfiguration" -tags CI {
+    Context "Module loading" {
+        BeforeAll {
+            $commands = Get-Command -Module PSDesiredStateConfiguration
+            $expectedCommandCount = 3
+            if (Test-IsInvokeDscResourceEnable)
+            {
+                $expectedCommandCount ++
+            }
+        }
+        BeforeEach {
+        }
+        AfterEach {
+        }
+        AfterAll {
+        }
+
+        It "The module should have $expectedCommandCount commands" {
+            if($commands.Count -ne $expectedCommandCount)
+            {
+                $modulePath = (Get-Module PSDesiredStateConfiguration).Path
+                Write-Verbose -Verbose -Message "PSDesiredStateConfiguration Path: $modulePath"
+                $commands | Out-String | Write-Verbose -Verbose
+            }
+            $commands.Count | Should -Be $expectedCommandCount
+        }
+        It "The module should have the Configuration Command" {
+            $commands | Where-Object {$_.Name -eq 'Configuration'} | Should -Not -BeNullOrEmpty
+        }
+        It "The module should have the Get-DscResource Command" {
+            $commands | Where-Object {$_.Name -eq 'Get-DscResource'} | Should -Not -BeNullOrEmpty
+        }
+    }
+    Context "Get-DscResource - Composite Resources" {
+        BeforeAll {
+            $origProgress = $global:ProgressPreference
+            $global:ProgressPreference = 'SilentlyContinue'
+            Install-ModuleIfMissing -Name PSDscResources
+            $testCases = @(
+                @{
+                    TestCaseName = 'case mismatch in resource name'
+                    Name = 'groupset'
+                    ModuleName = 'PSDscResources'
+                }
+                @{
+                    TestCaseName = 'Both names have matching case'
+                    Name = 'GroupSet'
+                    ModuleName = 'PSDscResources'
+                }
+                @{
+                    TestCaseName = 'case mismatch in module name'
+                    Name = 'GroupSet'
+                    ModuleName = 'psdscResources'
+                }
+            )
+        }
+        AfterAll {
+            $Global:ProgressPreference = $origProgress
+        }
+        it "should be able to get <Name> - <TestCaseName>" -TestCases $testCases {
+            param($Name)
+
+            if($IsWindows)
+            {
+                Set-ItResult -Pending -Because "Will only find script from PSDesiredStateConfiguration without modulename"
+            }
+
+            if($IsLinux)
+            {
+                Set-ItResult -Pending -Because "https://github.com/PowerShell/PSDesiredStateConfiguration/issues/26"
+            }
+
+            $resource = Get-DscResource -Name $name
+            $resource | Should -Not -BeNullOrEmpty
+            $resource.Name | Should -Be $Name
+            if (Test-IsInvokeDscResourceEnable)
+            {
+                $resource.ImplementationDetail | Should -BeNullOrEmpty
+            }            else
+            {
+                $resource.ImplementationDetail | Should -BeNullOrEmpty
+            }
+
+        }
+
+        it "should be able to get <Name> from <ModuleName> - <TestCaseName>" -TestCases $testCases {
+            param($Name,$ModuleName, $PendingBecause)
+
+            if($IsLinux)
+            {
+                Set-ItResult -Pending -Because "https://github.com/PowerShell/PSDesiredStateConfiguration/issues/26"
+            }
+
+            if($PendingBecause)
+            {
+                Set-ItResult -Pending -Because $PendingBecause
+            }
+            $resource = Get-DscResource -Name $Name -Module $ModuleName
+            $resource | Should -Not -BeNullOrEmpty
+            $resource.Name | Should -Be $Name
+            if (Test-IsInvokeDscResourceEnable)
+            {
+                $resource.ImplementationDetail | Should -BeNullOrEmpty
+            }
+            else
+            {
+                $resource.ImplementationDetail | Should -BeNullOrEmpty
+            }
+        }
+    }
+    Context "Get-DscResource - ScriptResources" {
+        BeforeAll {
+            $origProgress = $global:ProgressPreference
+            $global:ProgressPreference = 'SilentlyContinue'
+
+            Install-ModuleIfMissing -Name PSDscResources -Force
+
+            Install-ModuleIfMissing -Name PowerShellGet -MinimumVersion '2.2.1'
+            $module = Get-Module PowerShellGet -ListAvailable | Sort-Object -Property Version -Descending | Select-Object -First 1
+
+            $psGetModuleSpecification = @{ModuleName=$module.Name;ModuleVersion=$module.Version.ToString()}
+            $psGetModuleCount = @(Get-Module PowerShellGet -ListAvailable).Count
+            $testCases = @(
+                @{
+                    TestCaseName = 'case mismatch in resource name'
+                    Name = 'script'
+                    ModuleName = 'PSDscResources'
+                }
+                @{
+                    TestCaseName = 'Both names have matching case'
+                    Name = 'Script'
+                    ModuleName = 'PSDscResources'
+                }
+                @{
+                    TestCaseName = 'case mismatch in module name'
+                    Name = 'Script'
+                    ModuleName = 'psdscResources'
+                }
+                <#
+                Add these back when PowerShellGet is fixed https://github.com/PowerShell/PowerShellGet/pull/529
+                @{
+                    TestCaseName = 'case mismatch in resource name'
+                    Name = 'PsModule'
+                    ModuleName = 'PowerShellGet'
+                }
+                @{
+                    TestCaseName = 'Both names have matching case'
+                    Name = 'PSModule'
+                    ModuleName = 'PowerShellGet'
+                }
+                @{
+                    TestCaseName = 'case mismatch in module name'
+                    Name = 'PSModule'
+                    ModuleName = 'powershellget'
+                }
+                #>
+            )
+        }
+        AfterAll {
+            $Global:ProgressPreference = $origProgress
+        }
+
+        it "should be able to get <Name> - <TestCaseName>" -TestCases $testCases {
+            param($Name)
+
+            if($IsWindows)
+            {
+                Set-ItResult -Pending -Because "Will only find script from PSDesiredStateConfiguration without modulename"
+            }
+
+            if($PendingBecause)
+            {
+                Set-ItResult -Pending -Because $PendingBecause
+            }
+
+            $resources = @(Get-DscResource -Name $name)
+            $resources | Should -Not -BeNullOrEmpty
+            foreach($resource in $resource)
+            {
+                $resource.Name | Should -Be $Name
+                if (Test-IsInvokeDscResourceEnable)
+                {
+                    $resource.ImplementationDetail | Should -Be 'ScriptBased'
+                }
+                else
+                {
+                    $resource.ImplementationDetail | Should -BeNullOrEmpty
+                }
+
+            }
+        }
+
+        it "should be able to get <Name> from <ModuleName> - <TestCaseName>" -TestCases $testCases {
+            param($Name,$ModuleName, $PendingBecause)
+
+            if($IsLinux)
+            {
+                Set-ItResult -Pending -Because "https://github.com/PowerShell/PSDesiredStateConfiguration/issues/12 and https://github.com/PowerShell/PowerShellGet/pull/529"
+            }
+
+            if($PendingBecause)
+            {
+                Set-ItResult -Pending -Because $PendingBecause
+            }
+
+            $resources = @(Get-DscResource -Name $name -Module $ModuleName)
+            $resources | Should -Not -BeNullOrEmpty
+            foreach($resource in $resource)
+            {
+                $resource.Name | Should -Be $Name
+                if (Test-IsInvokeDscResourceEnable)
+                {
+                    $resource.ImplementationDetail | Should -Be 'ScriptBased'
+                }
+                else
+                {
+                    $resource.ImplementationDetail | Should -BeNullOrEmpty
+                }
+            }
+        }
+
+        it "should throw when resource is not found" {
+            Set-ItResult -Pending -Because "https://github.com/PowerShell/PSDesiredStateConfiguration/issues/17"
+            {
+                Get-DscResource -Name antoehusatnoheusntahoesnuthao -Module tanshoeusnthaosnetuhasntoheusnathoseun
+            } |
+                Should -Throw -ErrorId 'Microsoft.PowerShell.Commands.WriteErrorException,CheckResourceFound'
+        }
+    }
+    Context "Get-DscResource - Class base Resources" {
+
+        BeforeAll {
+            $origProgress = $global:ProgressPreference
+            $global:ProgressPreference = 'SilentlyContinue'
+            Install-ModuleIfMissing -Name XmlContentDsc -Force
+            $classTestCases = @(
+                @{
+                    TestCaseName = 'Good case'
+                    Name = 'XmlFileContentResource'
+                    ModuleName = 'XmlContentDsc'
+                }
+                @{
+                    TestCaseName = 'Module Name case mismatch'
+                    Name = 'XmlFileContentResource'
+                    ModuleName = 'xmlcontentdsc'
+                }
+                @{
+                    TestCaseName = 'Resource name case mismatch'
+                    Name = 'xmlfilecontentresource'
+                    ModuleName = 'XmlContentDsc'
+                }
+            )
+        }
+        AfterAll {
+            $Global:ProgressPreference = $origProgress
+        }
+
+        it "should be able to get class resource - <Name> from <ModuleName> - <TestCaseName>" -TestCases $classTestCases {
+            param($Name,$ModuleName, $PendingBecause)
+
+            if($PendingBecause)
+            {
+                Set-ItResult -Pending -Because $PendingBecause
+            }
+
+            $resource = Get-DscResource -Name $Name -Module $ModuleName
+            $resource | Should -Not -BeNullOrEmpty
+            $resource.Name | Should -Be $Name
+            if (Test-IsInvokeDscResourceEnable)
+            {
+                $resource.ImplementationDetail | Should -Be 'ClassBased'
+            }
+            else
+            {
+                $resource.ImplementationDetail | Should -BeNullOrEmpty
+            }
+        }
+
+        it "should be able to get class resource - <Name> - <TestCaseName>" -TestCases $classTestCases {
+            param($Name,$ModuleName, $PendingBecause)
+            if($IsWindows)
+            {
+                Set-ItResult -Pending -Because "https://github.com/PowerShell/PSDesiredStateConfiguration/issues/19"
+            }
+            if($PendingBecause)
+            {
+                Set-ItResult -Pending -Because $PendingBecause
+            }
+            $resource = Get-DscResource -Name $Name
+            $resource | Should -Not -BeNullOrEmpty
+            $resource.Name | Should -Be $Name
+            if (Test-IsInvokeDscResourceEnable)
+            {
+                $resource.ImplementationDetail | Should -Be 'ClassBased'
+            }
+            else
+            {
+                $resource.ImplementationDetail | Should -BeNullOrEmpty
+            }
+        }
+    }
+    Context "Invoke-DscResource" {
+        BeforeAll {
+            $origProgress = $global:ProgressPreference
+            $global:ProgressPreference = 'SilentlyContinue'
+            $module = Get-InstalledModule -Name PsDscResources -ErrorAction Ignore
+            if($module)
+            {
+                Write-Verbose "removing PSDscResources, tests will re-install..." -Verbose
+                Uninstall-Module -Name PsDscResources -AllVersions -Force
+            }
+        }
+        AfterAll {
+            $Global:ProgressPreference = $origProgress
+        }
+        Context "mof resources"  {
+            BeforeAll {
+                $dscMachineStatusCases = @(
+                    @{
+                        value = '1'
+                        expectedResult = $true
+                    }
+                    @{
+                        value = '$true'
+                        expectedResult = $true
+                    }
+                    @{
+                        value = '0'
+                        expectedResult = $false
+                    }
+                    @{
+                        value = '$false'
+                        expectedResult = $false
+                    }
+                )
+
+                Install-ModuleIfMissing -Name PowerShellGet -Force -SkipPublisherCheck -MinimumVersion '2.2.1'
+                $module = Get-Module PowerShellGet -ListAvailable | Sort-Object -Property Version -Descending | Select-Object -First 1
+
+                $psGetModuleSpecification = @{ModuleName=$module.Name;ModuleVersion=$module.Version.ToString()}
+            }
+            it "Set method should work" -Skip:(!(Test-IsInvokeDscResourceEnable)) {
+                if(!$IsLinux)
+                {
+                        $result  = Invoke-DscResource -Name PSModule -ModuleName $psGetModuleSpecification -Method set -Property @{
+                        Name = 'PsDscResources'
+                        InstallationPolicy = 'Trusted'
+                    }
+                }
+                else
+                {
+                    # workraound because of https://github.com/PowerShell/PowerShellGet/pull/529
+                    Install-ModuleIfMissing -Name PsDscResources -Force
+                }
+
+                $result.RebootRequired | Should -BeFalse
+                $module = Get-module PsDscResources -ListAvailable
+                $module | Should -Not -BeNullOrEmpty -Because "Resource should have installed module"
+            }
+            it 'Set method should return RebootRequired=<expectedResult> when $global:DSCMachineStatus = <value>'  -Skip:(!(Test-IsInvokeDscResourceEnable))  -TestCases $dscMachineStatusCases {
+                param(
+                    $value,
+                    $ExpectedResult
+                )
+
+                # using create scriptBlock because $using:<variable> doesn't work with existing Invoke-DscResource
+                # Verified in Windows PowerShell on 20190814
+                $result  = Invoke-DscResource -Name Script -ModuleName PSDscResources -Method Set -Property @{TestScript = {Write-Output 'test';return $false};GetScript = {return @{}}; SetScript = [scriptblock]::Create("`$global:DSCMachineStatus = $value;return")}
+                $result | Should -Not -BeNullOrEmpty
+                $result.RebootRequired | Should -BeExactly $expectedResult
+            }
+            it "Test method should return false"  -Skip:(!(Test-IsInvokeDscResourceEnable))  {
+                $result  = Invoke-DscResource -Name Script -ModuleName PSDscResources -Method Test -Property @{TestScript = {Write-Output 'test';return $false};GetScript = {return @{}}; SetScript = {return}}
+                $result | Should -Not -BeNullOrEmpty
+                $result.InDesiredState | Should -BeFalse -Because "Test method return false"
+            }
+            it "Test method should return true"  -Skip:(!(Test-IsInvokeDscResourceEnable))  {
+                $result  = Invoke-DscResource -Name Script -ModuleName PSDscResources -Method Test -Property @{TestScript = {Write-Verbose 'test';return $true};GetScript = {return @{}}; SetScript = {return}}
+                $result | Should -BeTrue -Because "Test method return true"
+            }
+            it "Test method should return true with moduleSpecification"  -Skip:(!(Test-IsInvokeDscResourceEnable))  {
+                $module = get-module PsDscResources -ListAvailable
+                $moduleSpecification = @{ModuleName=$module.Name;ModuleVersion=$module.Version.ToString()}
+                $result  = Invoke-DscResource -Name Script -ModuleName $moduleSpecification -Method Test -Property @{TestScript = {Write-Verbose 'test';return $true};GetScript = {return @{}}; SetScript = {return}}
+                $result | Should -BeTrue -Because "Test method return true"
+            }
+
+            it "Invalid moduleSpecification"  -Skip:(!(Test-IsInvokeDscResourceEnable))  {
+                Set-ItResult -Pending -Because "https://github.com/PowerShell/PSDesiredStateConfiguration/issues/17"
+                $moduleSpecification = @{ModuleName='PsDscResources';ModuleVersion='99.99.99.993'}
+                {
+                    Invoke-DscResource -Name Script -ModuleName $moduleSpecification -Method Test -Property @{TestScript = {Write-Host 'test';return $true};GetScript = {return @{}}; SetScript = {return}} -ErrorAction Stop
+                } |
+                    Should -Throw -ErrorId 'InvalidResourceSpecification,Invoke-DscResource' -ExpectedMessage 'Invalid Resource Name ''Script'' or module specification.'
+            }
+
+            # waiting on Get-DscResource to be fixed
+            it "Invalid module name" -Skip:(!(Test-IsInvokeDscResourceEnable))  {
+                Set-ItResult -Pending -Because "https://github.com/PowerShell/PSDesiredStateConfiguration/issues/17"
+                {
+                    Invoke-DscResource -Name Script -ModuleName santoheusnaasonteuhsantoheu -Method Test -Property @{TestScript = {Write-Host 'test';return $true};GetScript = {return @{}}; SetScript = {return}} -ErrorAction Stop
+                } |
+                    Should -Throw -ErrorId 'Microsoft.PowerShell.Commands.WriteErrorException,CheckResourceFound'
+            }
+
+            it "Invalid resource name" -Skip:(!(Test-IsInvokeDscResourceEnable))  {
+                if ($IsWindows) {
+                    Set-ItResult -Pending -Because "https://github.com/PowerShell/PSDesiredStateConfiguration/issues/17"
+                }
+
+                {
+                    Invoke-DscResource -Name santoheusnaasonteuhsantoheu -Method Test -Property @{TestScript = {Write-Host 'test';return $true};GetScript = {return @{}}; SetScript = {return}} -ErrorAction Stop
+                } |
+                    Should -Throw -ErrorId 'Microsoft.PowerShell.Commands.WriteErrorException,CheckResourceFound'
+            }
+
+            it "Get method should work"  -Skip:(!(Test-IsInvokeDscResourceEnable))  {
+                if($IsLinux)
+                {
+                    Set-ItResult -Pending -Because "https://github.com/PowerShell/PSDesiredStateConfiguration/issues/12 and https://github.com/PowerShell/PowerShellGet/pull/529"
+                }
+
+                $result  = Invoke-DscResource -Name PSModule -ModuleName $psGetModuleSpecification -Method Get -Property @{ Name = 'PsDscResources'}
+                $result | Should -Not -BeNullOrEmpty
+                $result.Author | Should -BeLike 'Microsoft*'
+                $result.InstallationPolicy | Should -BeOfType [string]
+                $result.Guid | Should -BeOfType [Guid]
+                $result.Ensure | Should -Be 'Present'
+                $result.Name | Should -be 'PsDscResources'
+                $result.Description | Should -BeLike 'This*DSC*'
+                $result.InstalledVersion | should -BeOfType [Version]
+                $result.ModuleBase | Should -BeLike '*PSDscResources*'
+                $result.Repository | should -BeOfType [string]
+                $result.ModuleType | Should -Be 'Manifest'
+            }
+        }
+        Context "Class Based Resources" {
+            BeforeAll {
+                Install-ModuleIfMissing -Name XmlContentDsc -Force
+            }
+            AfterAll {
+                $Global:ProgressPreference = $origProgress
+            }
+            BeforeEach {
+                $testXmlPath = 'TestDrive:\test.xml'
+                @'
+<configuration>
+<appSetting>
+    <Test1/>
+</appSetting>
+</configuration>
+'@ | Out-File -FilePath $testXmlPath -Encoding utf8NoBOM
+                $resolvedXmlPath = (Resolve-Path -Path $testXmlPath).ProviderPath
+            }
+            it 'Set method should work'  -Skip:(!(Test-IsInvokeDscResourceEnable))  {
+                param(
+                    $value,
+                    $ExpectedResult
+                )
+
+                $testString = '890574209347509120348'
+                $result  = Invoke-DscResource -Name XmlFileContentResource -ModuleName XmlContentDsc -Property @{Path=$resolvedXmlPath; XPath = '/configuration/appSetting/Test1';Ensure='Present'; Attributes=@{ TestValue2 = $testString; Name = $testString } } -Method Set
+                $result | Should -Not -BeNullOrEmpty
+                $result.RebootRequired | Should -BeFalse
+                $testXmlPath | Should -FileContentMatch $testString
+            }
+        }
+    }
+}
+

--- a/test/powershell/Modules/PSDesiredStateConfiguration/PSDesiredStateConfiguration.Tests.ps1
+++ b/test/powershell/Modules/PSDesiredStateConfiguration/PSDesiredStateConfiguration.Tests.ps1
@@ -47,7 +47,7 @@ Describe "Test PSDesiredStateConfiguration" -tags CI {
         }
 
         It "The module should have $expectedCommandCount commands" {
-            if($commands.Count -ne $expectedCommandCount)
+            if ($commands.Count -ne $expectedCommandCount)
             {
                 $modulePath = (Get-Module PSDesiredStateConfiguration).Path
                 Write-Verbose -Verbose -Message "PSDesiredStateConfiguration Path: $modulePath"

--- a/test/powershell/Modules/PSDesiredStateConfiguration/PSDesiredStateConfiguration.Tests.ps1
+++ b/test/powershell/Modules/PSDesiredStateConfiguration/PSDesiredStateConfiguration.Tests.ps1
@@ -55,6 +55,7 @@ Describe "Test PSDesiredStateConfiguration" -tags CI {
             }
             $commands.Count | Should -Be $expectedCommandCount
         }
+
         It "The module should have the Configuration Command" {
             $commands | Where-Object {$_.Name -eq 'Configuration'} | Should -Not -BeNullOrEmpty
         }

--- a/test/powershell/Modules/PSDesiredStateConfiguration/configuration.Tests.ps1
+++ b/test/powershell/Modules/PSDesiredStateConfiguration/configuration.Tests.ps1
@@ -1,0 +1,36 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+Describe "DSC MOF Compilation" -tags "CI" {
+    BeforeAll {
+        Import-module PSDesiredStateConfiguration
+        $module = Get-Module PowerShellGet -ListAvailable | Sort-Object -Property Version -Descending | Select-Object -First 1
+
+        $psGetModuleVersion = $module.Version.ToString()
+    }
+
+    It "Should be able to compile a MOF using PSModule resource"  {
+        if ($IsLinux) {
+            Set-ItResult -Pending -Because "https://github.com/PowerShell/PowerShellGet/pull/529"
+        }
+
+        Write-Verbose "DSC_HOME: ${env:DSC_HOME}" -verbose
+        [Scriptblock]::Create(@"
+        configuration DSCTestConfig
+        {
+            Import-DscResource -ModuleName PowerShellGet -ModuleVersion $psGetModuleVersion
+            Node "localhost" {
+                PSModule f1
+                {
+                    Name = 'PsDscResources'
+                    InstallationPolicy = 'Trusted'
+                }
+            }
+        }
+
+        DSCTestConfig -OutputPath TestDrive:\DscTestConfig2
+"@) | Should -Not -Throw
+
+        "TestDrive:\DscTestConfig2\localhost.mof" | Should -Exist
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Update PSDesiredStateConfiguration to 2.0.3 and bring new tests.

## PR Context

Adds Invoke-DscResource as an experimental feature and fixes to Get-DscResource

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/4780
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
