### PR TITLE
Minor performance improvements for runspace initialization

### DIFF
--- a/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
+++ b/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
@@ -1039,11 +1039,6 @@ namespace System.Management.Automation
 
                 string moduleName = Path.Combine(applicationBase, defaultMshSnapinInfo.AssemblyName + ".dll");
 
-                if (!File.Exists(moduleName))
-                {
-                    moduleName = defaultMshSnapinInfo.AssemblyName;
-                }
-
                 PSSnapInInfo defaultMshSnapin = new PSSnapInInfo(
                     defaultMshSnapinInfo.PSSnapInName,
                     isDefault: true,

--- a/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
+++ b/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
@@ -880,12 +880,14 @@ namespace System.Management.Automation
         internal static void ReadRegistryInfo(out Version assemblyVersion, out string publicKeyToken, out string culture, out string architecture, out string applicationBase, out Version psVersion)
         {
             applicationBase = Utils.DefaultPowerShellAppBase;
-            Dbg.Assert(!string.IsNullOrEmpty(applicationBase),
+            Dbg.Assert(
+                !string.IsNullOrEmpty(applicationBase),
                 string.Format(CultureInfo.CurrentCulture, "{0} is empty or null", RegistryStrings.MonadEngine_ApplicationBase));
 
             // Get the PSVersion from Utils..this is hardcoded
             psVersion = PSVersionInfo.PSVersion;
-            Dbg.Assert(psVersion != null,
+            Dbg.Assert(
+                psVersion != null,
                 string.Format(CultureInfo.CurrentCulture, "{0} is null", RegistryStrings.MonadEngine_MonadVersion));
 
             // Get version number in x.x.x.x format
@@ -895,19 +897,21 @@ namespace System.Management.Automation
             // culture, publickeytoken...This will break the scenarios where only one of
             // the assemblies is patched. ie., all monad assemblies should have the
             // same version number.
-
             Assembly currentAssembly = typeof(PSSnapInReader).Assembly;
-            assemblyVersion = currentAssembly.GetName().Version;
-            byte[] publicTokens = currentAssembly.GetName().GetPublicKeyToken();
+            AssemblyName assemblyName = currentAssembly.GetName();
+            assemblyVersion = assemblyName.Version;
+            byte[] publicTokens = assemblyName.GetPublicKeyToken();
             if (publicTokens.Length == 0)
             {
                 throw PSTraceSource.NewArgumentException("PublicKeyToken", MshSnapinInfo.PublicKeyTokenAccessFailed);
             }
 
             publicKeyToken = ConvertByteArrayToString(publicTokens);
+
             // save some cpu cycles by hardcoding the culture to neutral
             // assembly should never be targeted to a particular culture
             culture = "neutral";
+
             // Hardcoding the architecture MSIL as PowerShell assemblies are architecture neutral, this should
             // be changed if the assumption is broken. Preferred hardcoded string to using (for perf reasons):
             // string architecture = currentAssembly.GetName().ProcessorArchitecture.ToString()
@@ -1010,13 +1014,20 @@ namespace System.Management.Automation
 
             // create default mshsnapininfo objects..
             Collection<PSSnapInInfo> engineMshSnapins = new Collection<PSSnapInInfo>();
+            string assemblyVersionString = assemblyVersion.ToString();
 
             for (int item = 0; item < DefaultMshSnapins.Count; item++)
             {
                 DefaultPSSnapInInformation defaultMshSnapinInfo = DefaultMshSnapins[item];
 
-                string strongName = string.Format(CultureInfo.InvariantCulture, "{0}, Version={1}, Culture={2}, PublicKeyToken={3}, ProcessorArchitecture={4}",
-                    defaultMshSnapinInfo.AssemblyName, assemblyVersion.ToString(), culture, publicKeyToken, architecture);
+                string strongName = string.Format(
+                    CultureInfo.InvariantCulture,
+                    "{0}, Version={1}, Culture={2}, PublicKeyToken={3}, ProcessorArchitecture={4}",
+                    defaultMshSnapinInfo.AssemblyName,
+                    assemblyVersionString,
+                    culture,
+                    publicKeyToken,
+                    architecture);
 
                 Collection<string> formats = null;
                 Collection<string> types = null;
@@ -1026,8 +1037,7 @@ namespace System.Management.Automation
                     formats = smaFormats;
                     types = smaTypes;
                 }
-                else if (defaultMshSnapinInfo.AssemblyName.Equals("Microsoft.PowerShell.Commands.Diagnostics",
-                    StringComparison.OrdinalIgnoreCase))
+                else if (defaultMshSnapinInfo.AssemblyName.Equals("Microsoft.PowerShell.Commands.Diagnostics", StringComparison.OrdinalIgnoreCase))
                 {
                     types = new Collection<string>(new string[] { "GetEvent.types.ps1xml" });
                     formats = new Collection<string>(new string[] { "Event.format.ps1xml", "Diagnostics.format.ps1xml" });


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Comments says that the code was optimized in Windows PowerShell but there is still room for improvements that is important for scenarios actively using runspaces and startup.

1. Remove check that file exist.
    The code came from Windows PowerShell but now all the standard dlls is placed in $PSHome and we have no need to search them in other paths by the dll name.
![image](https://user-images.githubusercontent.com/22290914/65128298-aa1ffb80-da12-11e9-901b-f7c6c1265d1e.png)

2. Remove some obvious allocations
- Assembly.GetName() allocates - put it in temp variable.
- Move Version.ToString() out of the cycle.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
