### PR TITLE
Allow CompleteInput to return results from ArgumentCompleter when AST or Script has matching function definition

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -1998,14 +1998,16 @@ namespace System.Management.Automation
             // Fall back to the commandAst command name if a command name is not found. This can be caused by a script block or AST with the matching function definition being passed to CompleteInput
             // This allows for editors and other tools using CompleteInput with Script/AST definations to get values from RegisteredArgumentCompleters to better match the console experience.
             // See issue https://github.com/PowerShell/PowerShell/issues/10567
-            if (string.IsNullOrEmpty(commandName) && string.IsNullOrEmpty(commandAst.GetCommandName()))
+            string actualCommandName = string.IsNullOrEmpty(commandName)
+                        ? commandAst.GetCommandName()
+                        : commandName;
+
+            if (string.IsNullOrEmpty(actualCommandName))
             {
                 return;
             }
 
-            string parameterFullName = string.IsNullOrEmpty(commandName)
-                        ? commandAst.GetCommandName() + ":" + parameterName
-                        : commandName + ":" + parameterName;
+            string parameterFullName = actualCommandName + ":" + parameterName;
 
             ScriptBlock customCompleter = GetCustomArgumentCompleter(
                 "CustomArgumentCompleters",

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -1995,20 +1995,19 @@ namespace System.Management.Automation
         {
             var parameterName = parameter.Name;
             ScriptBlock customCompleter;
-            if (string.IsNullOrEmpty(commandName))
-            {
-                customCompleter = GetCustomArgumentCompleter(
-                                    "CustomArgumentCompleters",
-                                    new[] { commandAst.GetCommandName() + ":" + parameterName, parameterName },
-                                    context);
-            }
-            else
-            {
-                customCompleter = GetCustomArgumentCompleter(
-                                    "CustomArgumentCompleters",
-                                    new[] { commandName + ":" + parameterName, parameterName },
-                                    context);
-            }
+
+            // Fall back to the commandAst command name if a command name is not found. This can be caused by a script block or AST with the matching function definition being passed to CompleteInput
+            // This allows for editors and other tools using CompleteInput with Script/AST definations to get values from RegisteredArgumentCompleters to better match the console experience.
+            // See issue https://github.com/PowerShell/PowerShell/issues/10567
+            var parameterFullName = string.IsNullOrEmpty(commandName)
+                        ? commandAst.GetCommandName() + ":" + parameterName
+                        : commandName + ":" + parameterName;
+
+            customCompleter = GetCustomArgumentCompleter(
+                "CustomArgumentCompleters",
+                new[] { parameterFullName, parameterName },
+                context
+            );
 
             if (customCompleter != null)
             {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -1994,16 +1994,20 @@ namespace System.Management.Automation
             Dictionary<string, AstParameterArgumentPair> boundArguments = null)
         {
             var parameterName = parameter.Name;
-            ScriptBlock customCompleter;
 
             // Fall back to the commandAst command name if a command name is not found. This can be caused by a script block or AST with the matching function definition being passed to CompleteInput
             // This allows for editors and other tools using CompleteInput with Script/AST definations to get values from RegisteredArgumentCompleters to better match the console experience.
             // See issue https://github.com/PowerShell/PowerShell/issues/10567
+            if(string.IsNullOrEmpty(commandName) && string.IsNullOrEmpty(commandAst.GetCommandName()))
+            {
+                return;
+            }
+
             var parameterFullName = string.IsNullOrEmpty(commandName)
                         ? commandAst.GetCommandName() + ":" + parameterName
                         : commandName + ":" + parameterName;
 
-            customCompleter = GetCustomArgumentCompleter(
+            ScriptBlock customCompleter = GetCustomArgumentCompleter(
                 "CustomArgumentCompleters",
                 new[] { parameterFullName, parameterName },
                 context);

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -1993,16 +1993,23 @@ namespace System.Management.Automation
             CompletionContext context,
             Dictionary<string, AstParameterArgumentPair> boundArguments = null)
         {
+            var parameterName = parameter.Name;
+            ScriptBlock customCompleter;
             if (string.IsNullOrEmpty(commandName))
             {
-                return;
+                customCompleter = GetCustomArgumentCompleter(
+                                    "CustomArgumentCompleters",
+                                    new[] { commandAst.GetCommandName() + ":" + parameterName, parameterName },
+                                    context);
+            }
+            else
+            {
+                customCompleter =  GetCustomArgumentCompleter(
+                                    "CustomArgumentCompleters",
+                                    new[] { commandName + ":" + parameterName, parameterName },
+                                    context);
             }
 
-            var parameterName = parameter.Name;
-            var customCompleter = GetCustomArgumentCompleter(
-                    "CustomArgumentCompleters",
-                    new[] { commandName + ":" + parameterName, parameterName },
-                    context);
             if (customCompleter != null)
             {
                 if (InvokeScriptArgumentCompleter(

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -1998,7 +1998,7 @@ namespace System.Management.Automation
             // Fall back to the commandAst command name if a command name is not found. This can be caused by a script block or AST with the matching function definition being passed to CompleteInput
             // This allows for editors and other tools using CompleteInput with Script/AST definations to get values from RegisteredArgumentCompleters to better match the console experience.
             // See issue https://github.com/PowerShell/PowerShell/issues/10567
-            if(string.IsNullOrEmpty(commandName) && string.IsNullOrEmpty(commandAst.GetCommandName()))
+            if (string.IsNullOrEmpty(commandName) && string.IsNullOrEmpty(commandAst.GetCommandName()))
             {
                 return;
             }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -2006,8 +2006,7 @@ namespace System.Management.Automation
             customCompleter = GetCustomArgumentCompleter(
                 "CustomArgumentCompleters",
                 new[] { parameterFullName, parameterName },
-                context
-            );
+                context);
 
             if (customCompleter != null)
             {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -1993,7 +1993,7 @@ namespace System.Management.Automation
             CompletionContext context,
             Dictionary<string, AstParameterArgumentPair> boundArguments = null)
         {
-            var parameterName = parameter.Name;
+            string parameterName = parameter.Name;
 
             // Fall back to the commandAst command name if a command name is not found. This can be caused by a script block or AST with the matching function definition being passed to CompleteInput
             // This allows for editors and other tools using CompleteInput with Script/AST definations to get values from RegisteredArgumentCompleters to better match the console experience.
@@ -2003,7 +2003,7 @@ namespace System.Management.Automation
                 return;
             }
 
-            var parameterFullName = string.IsNullOrEmpty(commandName)
+            string parameterFullName = string.IsNullOrEmpty(commandName)
                         ? commandAst.GetCommandName() + ":" + parameterName
                         : commandName + ":" + parameterName;
 

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -2007,7 +2007,7 @@ namespace System.Management.Automation
                 return;
             }
 
-            string parameterFullName = actualCommandName + ":" + parameterName;
+            string parameterFullName = $"{actualCommandName}:{parameterName}";
 
             ScriptBlock customCompleter = GetCustomArgumentCompleter(
                 "CustomArgumentCompleters",

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -2004,7 +2004,7 @@ namespace System.Management.Automation
             }
             else
             {
-                customCompleter =  GetCustomArgumentCompleter(
+                customCompleter = GetCustomArgumentCompleter(
                                     "CustomArgumentCompleters",
                                     new[] { commandName + ":" + parameterName, parameterName },
                                     context);

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -688,19 +688,6 @@ Describe "TabCompletion" -Tags CI {
         }
 
         It "Tab completion for ArgumentCompleter when AST is passed to CompleteInput" {
-            $script = @'
-function Test-Completion {
-    param (
-        [String]$TestVal
-    )
-}
-
-Register-ArgumentCompleter -CommandName Test-Completion -ParameterName TestVal -ScriptBlock $completer
-
-Test-Completion -TestVal
-'@
-            # Workaround to prevent editors from trimming required trailing space.
-            $script += " "
             $scriptBl = {
                 function Test-Completion {
                     param (
@@ -717,7 +704,10 @@ Test-Completion -TestVal
             $pwsh = [PowerShell]::Create()
             $pwsh.AddScript($scriptBl)
             $pwsh.Invoke()
-            $res = [System.Management.Automation.CommandCompletion]::CompleteInput($script, $script.Length, $null, $pwsh)
+
+            $completeInput_Input = $scriptBl.ToString()
+            $completeInput_Input += "`nTest-Completion -TestVal "
+            $res = [System.Management.Automation.CommandCompletion]::CompleteInput($completeInput_Input, $completeInput_Input.Length, $null, $pwsh)
             $res.CompletionMatches | Should -HaveCount 2
             $res.CompletionMatches[0].CompletionText | Should -BeExactly 'Val1'
             $res.CompletionMatches[1].CompletionText | Should -BeExactly 'Val2'


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Fix #10567 

This PR adds a check in NativeCommandArgumentCompletion to retrieve the commandName from the CommandAST if the commandName passed is null.
<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
When `[System.Management.Automation.CommandCompletion]::CompleteInput` is provided a `ScriptBlock` or `AST` that contains a definition of the function to be completed while there is a registered `ArgumentCompleter` for the function, the `ArgumentCompleter` is ignored.

This issue is visible when an editor leverages the CompleteInput to provide Intellisense(PowerShell/vscode-powershell#2162 ). 

The impact to editors is that completion will be returned in such a way that better matches the terminal experience.
## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [x] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
