### PR TITLE
Replace CR and new line with a 0x23CE character

### DIFF
--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -1555,47 +1555,47 @@ namespace System.Management.Automation
 
         private static string FormatLogString(string textToLog)
         {
-            // characters we ar translating from
-            const char nullControlChar = '\u0000';
-            // new line / line feed control character
-            const char lfControlChar = '\u000A';
-            // carriage return control character
-            const char crControlChar = '\u000D';
+            // characters we are translating from
+
+            const char NullControlChar = '\u0000';
 
             // The null symbol - `␀`
-            const char nullSymbolChar = '\u2400';
-
-            // We chose the return symbol because we believe it is more associated with these concepts
-            // than the carriage return (␍), line feed (␊), or new line (␤) symbols.
-            // The return symbol - `⏎`
-            const char returnSymbolChar = '\u23CE';
+            const char NullSymbolChar = '\u2400';
 
             // No logging mechanism(s) cannot handle null and rendering may not be able to handle
             // null as we have the string defined as a null terminated string in the manifest.
             // So, replace null characters with the Unicode `SYMBOL FOR NULL`
             // We don't just remove the characters to preserve the fact that a null character was there.
 #if UNIX
+            const char LinefeedControlChar = '\u000A';
+            const char CarriageReturnControlChar = '\u000D';
+
+            // We chose the return symbol because we believe it is more associated with these concepts
+            // than the carriage return (␍), line feed (␊), or new line (␤) symbols.
+            // The return symbol - `⏎`
+            const char ReturnSymbolChar = '\u23CE';
+
             if (Platform.IsLinux)
             {
                 // Because the creation of the string builder is expensive
                 // We only do this on Linux where we are doing multiple replace operations
                 StringBuilder logBuilder = new StringBuilder(textToLog);
 
-                logBuilder.Replace(nullControlChar, nullSymbolChar);
+                logBuilder.Replace(NullControlChar, NullSymbolChar);
 
                 // Syslog (only used on Linux) encodes CR and NL to their octal values.
                 // We will replace them with a unicode charater for easier viewing
-                logBuilder.Replace(lfControlChar, returnSymbolChar);
-                logBuilder.Replace(crControlChar, returnSymbolChar);
+                logBuilder.Replace(LinefeedControlChar, ReturnSymbolChar);
+                logBuilder.Replace(CarriageReturnControlChar, ReturnSymbolChar);
 
                 return logBuilder.ToString();
             }
             else
             {
-                return textToLog.Replace(nullControlChar, nullSymbolChar);
+                return textToLog.Replace(NullControlChar, NullSymbolChar);
             }
 #else
-                return textToLog.Replace(nullControlChar, nullSymbolChar);
+                return textToLog.Replace(NullControlChar, NullSymbolChar);
 #endif
         }
 

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -1525,6 +1525,14 @@ namespace System.Management.Automation
                 // So, replace null characters with the Unicode `SYMBOL FOR NULL`
                 // We don't just remove the characters to preserve the fact that a null character was there.
                 textToLog = textToLog.Replace('\u0000', '\u2400');
+#if UNIX
+                if (Platform.IsLinux)
+                {
+                    // Syslog encodes CR and NL to their octal values.
+                    // We will replace them with a unicode charater for easier viewing
+                    textToLog = textToLog.Replace('\u000A', '\u23CE').Replace('\u000D', '\u23CE');
+                }
+#endif
             }
 
             if (scriptBlock._scriptBlockData.HasSuspiciousContent)

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -1555,8 +1555,6 @@ namespace System.Management.Automation
 
         private static string FormatLogString(string textToLog)
         {
-            // characters we are translating from
-
             const char NullControlChar = '\u0000';
 
             // The null symbol - `␀`
@@ -1584,7 +1582,7 @@ namespace System.Management.Automation
                 logBuilder.Replace(NullControlChar, NullSymbolChar);
 
                 // Syslog (only used on Linux) encodes CR and NL to their octal values.
-                // We will replace them with a unicode charater for easier viewing
+                // We will replace them with a unicode  'RETURN SYMBOL' (U+23CE) charater for easier viewing
                 logBuilder.Replace(LinefeedControlChar, ReturnSymbolChar);
                 logBuilder.Replace(CarriageReturnControlChar, ReturnSymbolChar);
 
@@ -1595,7 +1593,7 @@ namespace System.Management.Automation
                 return textToLog.Replace(NullControlChar, NullSymbolChar);
             }
 #else
-                return textToLog.Replace(NullControlChar, NullSymbolChar);
+            return textToLog.Replace(NullControlChar, NullSymbolChar);
 #endif
         }
 

--- a/test/powershell/Host/Logging.Tests.ps1
+++ b/test/powershell/Host/Logging.Tests.ps1
@@ -211,7 +211,7 @@ $pid
         $createdEvents[0].Message | Should -Match ($scriptBlockCreatedRegExTemplate -f ".*/$testFileName")
 
         # Verify we log that we are the script to create the scriptblock
-        $createdEvents[1].Message | Should -Match ($scriptBlockCreatedRegExTemplate -f (Get-RegEx -SimpleMatch $Script.Replace([System.Environment]::NewLine,'#012')))
+        $createdEvents[1].Message | Should -Match ($scriptBlockCreatedRegExTemplate -f (Get-RegEx -SimpleMatch $Script.Replace([System.Environment]::NewLine,"`u{23CE}")))
 
         # Verify we log that we are excuting the created scriptblock
         $createdEvents[2].Message | Should -Match ($scriptBlockCreatedRegExTemplate -f "Write\-Verbose 'testheader123' ;Write\-verbose 'after'")
@@ -240,7 +240,7 @@ $pid
         $createdEvents[0].Message | Should -Match ($scriptBlockCreatedRegExTemplate -f ".*/$testFileName")
 
         # Verify we log that we are the script to create the scriptblock
-        $createdEvents[1].Message | Should -Match ($scriptBlockCreatedRegExTemplate -f (Get-RegEx -SimpleMatch $Script.Replace([System.Environment]::NewLine,'#012')))
+        $createdEvents[1].Message | Should -Match ($scriptBlockCreatedRegExTemplate -f (Get-RegEx -SimpleMatch $Script.Replace([System.Environment]::NewLine,"`u{23CE}")))
 
         # Verify we log that we are excuting the created scriptblock
         $createdEvents[2].Message | Should -Match ($scriptBlockCreatedRegExTemplate -f "Write\-Verbose 'testheader123␀' ;Write\-verbose 'after'")

--- a/test/powershell/Host/Logging.Tests.ps1
+++ b/test/powershell/Host/Logging.Tests.ps1
@@ -157,9 +157,9 @@ Describe 'Basic SysLog tests on Linux' -Tag @('CI','RequireSudoOnUnix') {
                 $IsSupportedEnvironment = $false
             }
             [string] $powershell = Join-Path -Path $PSHome -ChildPath 'pwsh'
-            $scriptBlockCreatedRegExTemplate = @'
-Creating Scriptblock text \(1 of 1\):#012{0}(#012)*ScriptBlock ID: [0-9a-z\-]*#012Path:.*
-'@
+            $scriptBlockCreatedRegExTemplate = @"
+Creating Scriptblock text \(1 of 1\):#012{0}(`u{23CE}|\?|#012)*ScriptBlock ID: [0-9a-z\-]*#012Path:.*
+"@
 
         }
     }

--- a/test/powershell/Host/Logging.Tests.ps1
+++ b/test/powershell/Host/Logging.Tests.ps1
@@ -130,6 +130,7 @@ function Get-RegEx
     $regex = $regex -replace '\-', '\-'
     $regex = $regex -replace '\$', '\$'
     $regex = $regex -replace '\^', '\^'
+    $regex = $regex -replace "\`u{23CE}", "[`u{23CE}\?]"
     return $regex
 }
 

--- a/test/powershell/Host/Logging.Tests.ps1
+++ b/test/powershell/Host/Logging.Tests.ps1
@@ -130,7 +130,6 @@ function Get-RegEx
     $regex = $regex -replace '\-', '\-'
     $regex = $regex -replace '\$', '\$'
     $regex = $regex -replace '\^', '\^'
-    #$regex = $regex -replace "\`u{23CE}", "[`u{23CE}\?]"
     return $regex
 }
 

--- a/test/powershell/Host/Logging.Tests.ps1
+++ b/test/powershell/Host/Logging.Tests.ps1
@@ -130,7 +130,7 @@ function Get-RegEx
     $regex = $regex -replace '\-', '\-'
     $regex = $regex -replace '\$', '\$'
     $regex = $regex -replace '\^', '\^'
-    $regex = $regex -replace "\`u{23CE}", "[`u{23CE}\?]"
+    #$regex = $regex -replace "\`u{23CE}", "[`u{23CE}\?]"
     return $regex
 }
 
@@ -158,7 +158,7 @@ Describe 'Basic SysLog tests on Linux' -Tag @('CI','RequireSudoOnUnix') {
             }
             [string] $powershell = Join-Path -Path $PSHome -ChildPath 'pwsh'
             $scriptBlockCreatedRegExTemplate = @"
-Creating Scriptblock text \(1 of 1\):#012{0}(`u{23CE}|\?|#012)*ScriptBlock ID: [0-9a-z\-]*#012Path:.*
+Creating Scriptblock text \(1 of 1\):#012{0}(⏎|#012)*ScriptBlock ID: [0-9a-z\-]*#012Path:.*
 "@
 
         }
@@ -212,7 +212,7 @@ $pid
         $createdEvents[0].Message | Should -Match ($scriptBlockCreatedRegExTemplate -f ".*/$testFileName")
 
         # Verify we log that we are the script to create the scriptblock
-        $createdEvents[1].Message | Should -Match ($scriptBlockCreatedRegExTemplate -f (Get-RegEx -SimpleMatch $Script.Replace([System.Environment]::NewLine,"`u{23CE}")))
+        $createdEvents[1].Message | Should -Match ($scriptBlockCreatedRegExTemplate -f (Get-RegEx -SimpleMatch $Script.Replace([System.Environment]::NewLine,"⏎")))
 
         # Verify we log that we are excuting the created scriptblock
         $createdEvents[2].Message | Should -Match ($scriptBlockCreatedRegExTemplate -f "Write\-Verbose 'testheader123' ;Write\-verbose 'after'")
@@ -241,7 +241,7 @@ $pid
         $createdEvents[0].Message | Should -Match ($scriptBlockCreatedRegExTemplate -f ".*/$testFileName")
 
         # Verify we log that we are the script to create the scriptblock
-        $createdEvents[1].Message | Should -Match ($scriptBlockCreatedRegExTemplate -f (Get-RegEx -SimpleMatch $Script.Replace([System.Environment]::NewLine,"`u{23CE}")))
+        $createdEvents[1].Message | Should -Match ($scriptBlockCreatedRegExTemplate -f (Get-RegEx -SimpleMatch $Script.Replace([System.Environment]::NewLine,"⏎")))
 
         # Verify we log that we are excuting the created scriptblock
         $createdEvents[2].Message | Should -Match ($scriptBlockCreatedRegExTemplate -f "Write\-Verbose 'testheader123␀' ;Write\-verbose 'after'")


### PR DESCRIPTION
# PR Summary

Replace CR and new line with a 0x23CE character

## PR Context

Trying to document how to use logging with Azure Log Analytics and RSyslog converting these to `#012` and `#013`

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
