### PR TITLE
Do not wrap return result to `PSObject` when converting ScriptBlock to delegate

### DIFF
--- a/src/System.Management.Automation/engine/lang/scriptblock.cs
+++ b/src/System.Management.Automation/engine/lang/scriptblock.cs
@@ -647,16 +647,17 @@ namespace System.Management.Automation
         /// <remarks>
         /// This does normal array reduction in the case of a one-element array.
         /// </remarks>
-        internal static object GetRawResult(List<object> result)
+        internal static object GetRawResult(List<object> result, bool wrapToPSObject)
         {
             switch (result.Count)
             {
                 case 0:
                     return AutomationNull.Value;
                 case 1:
-                    return LanguagePrimitives.AsPSObjectOrNull(result[0]);
+                    return wrapToPSObject ? LanguagePrimitives.AsPSObjectOrNull(result[0]) : result[0];
                 default:
-                    return LanguagePrimitives.AsPSObjectOrNull(result.ToArray());
+                    object resultArray = result.ToArray();
+                    return wrapToPSObject ? LanguagePrimitives.AsPSObjectOrNull(resultArray) : resultArray;
             }
         }
 
@@ -807,7 +808,7 @@ namespace System.Management.Automation
                 outputPipe: outputPipe,
                 invocationInfo: null,
                 args: args);
-            return GetRawResult(rawResult);
+            return GetRawResult(rawResult, wrapToPSObject: false);
         }
 
         #endregion
@@ -934,7 +935,7 @@ namespace System.Management.Automation
                 outputPipe: outputPipe,
                 invocationInfo: null,
                 args: args);
-            return GetRawResult(result);
+            return GetRawResult(result, wrapToPSObject: true);
         }
 
         internal void InvokeWithPipe(

--- a/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
+++ b/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
@@ -102,4 +102,54 @@ Describe "Language Primitive Tests" -Tags "CI" {
         $val | Should -BeTrue
         $result | Should -BeExactly $compareResult
     }
+
+    It "Convert ScriptBlock to delegate type" {
+        $code = @'
+        using System;
+        namespace Test.API
+        {
+            public enum TestEnum
+            {
+                Music,
+                Video
+            }
+            public class LanguagePrimitivesTest
+            {
+                Func<string, object> _handlerReturnObject;
+                Func<string, TestEnum> _handlerReturnEnum;
+                public LanguagePrimitivesTest(Func<string, object> handlerReturnObject, Func<string, TestEnum> handlerReturnEnum)
+                {
+                    _handlerReturnObject = handlerReturnObject;
+                    _handlerReturnEnum = handlerReturnEnum;
+                }
+
+                public bool TestHandlerReturnEnum()
+                {
+                    var value = _handlerReturnEnum("bar");
+                    return value == TestEnum.Music;
+                }
+
+                public bool TestHandlerReturnObject()
+                {
+                    object value = _handlerReturnObject("bar");
+                    return value is TestEnum;
+                }
+            }
+        }
+'@
+
+        if (-not ("Test.API.TestEnum" -as [type]))
+        {
+            Add-Type -TypeDefinition $code
+        }
+
+        # The script actually returns a enum value, and the converted delegate should return the boxed enum value.
+        $handlerReturnObject = [System.Func[string, object]] { param([string]$str) [Test.API.TestEnum]::Music }
+        # The script actually returns a string, and the converted delegate should return the corresponding enum value.
+        $handlerReturnEnum = [System.Func[string, TestEnum]] { param([string]$str) "Music" }
+        $test = [Test.API.LanguagePrimitivesTest]::new($handlerReturnObject, $handlerReturnEnum)
+
+        $test.TestHandlerReturnEnum() | Should -BeTrue
+        $test.TestHandlerReturnObject() | Should -BeTrue
+    }
 }

--- a/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
+++ b/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
@@ -146,7 +146,7 @@ Describe "Language Primitive Tests" -Tags "CI" {
         # The script actually returns a enum value, and the converted delegate should return the boxed enum value.
         $handlerReturnObject = [System.Func[string, object]] { param([string]$str) [Test.API.TestEnum]::Music }
         # The script actually returns a string, and the converted delegate should return the corresponding enum value.
-        $handlerReturnEnum = [System.Func[string, TestEnum]] { param([string]$str) "Music" }
+        $handlerReturnEnum = [System.Func[string, Test.API.TestEnum]] { param([string]$str) "Music" }
         $test = [Test.API.LanguagePrimitivesTest]::new($handlerReturnObject, $handlerReturnEnum)
 
         $test.TestHandlerReturnEnum() | Should -BeTrue


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Avoid wrapping return result to `PSObject` when converting ScriptBlock to delegate.
When a `ScriptBlock` is converted to a delegate type, it's supposed to be used in C# context, and wrapping the result to `PSObject` brings unneeded troubles:
- When the value can be converted to the delegate return type, the `PSObject` essentially gets unwrapped, so we basically creates `PSObject` in vain.
- When the delegate return type is `object`, the `PSObject` is returned, making it hard to work with the true return value in C# code.

This is a breaking change for the delegate types with the `object` return type:
- Before this change, the returned object will always be an `PSObject` instance.
- After this change, the returned object is the underlying object, which could still be an `PSObject` if that's what the script actually returns.

But I think this would fall in the `Bucket 3 Grey Area`.
With this change, when setting `AddToHistoryHandler` to `{ param($line) $line -notmatch '^\s+|ToSecureString|AsPlainText' }`, the time to load history entries from the history file reduces about `100` ms on my dev machine (from `~1750` to `~1650` ) for `213226` history records in the file.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
