### PR TITLE
Add ConciseView for $ErrorView

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -732,6 +732,17 @@ namespace Microsoft.PowerShell
                 _ui = ui;
             }
 
+            public ConsoleColor ErrorAccentColor
+            {
+                [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+                get
+                { return _ui.ErrorAccentColor; }
+
+                [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+                set
+                { _ui.ErrorAccentColor = value; }
+            }
+
             public ConsoleColor ErrorForegroundColor
             {
                 [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -1356,6 +1356,7 @@ namespace Microsoft.PowerShell
         }
 
         // Error colors
+        public ConsoleColor ErrorAccentColor { get; set; } = ConsoleColor.Cyan;
         public ConsoleColor ErrorForegroundColor { get; set; } = ConsoleColor.Red;
         public ConsoleColor ErrorBackgroundColor { get; set; } = Console.BackgroundColor;
 

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -803,6 +803,10 @@ namespace System.Management.Automation.Runspaces
                                         }
 
                                         function Get-VT100Color([ConsoleColor] $color) {
+                                            if (! $Host.UI.SupportsVirtualTerminal) {
+                                                return ''
+                                            }
+
                                             switch ($color) {
                                                 'Black' { ""`e[2;30m"" }
                                                 'DarkRed' { ""`e[2;31m"" }
@@ -826,7 +830,7 @@ namespace System.Management.Automation.Runspaces
 
                                         $errorColor = ''
                                         $accentColor = ''
-                                        if ($Host.PrivateData -and $Host.UI.SupportsVirtualTerminal) {
+                                        if ($Host.PrivateData) {
                                             $errorColor = Get-VT100Color -color $Host.PrivateData.ErrorForegroundColor
                                             $accentColor = Get-VT100Color -color $Host.PrivateData.ErrorAccentColor
                                         }

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -843,7 +843,7 @@ namespace System.Management.Automation.Runspaces
                                         }
 
                                         # returns a string cut to last whitespace
-                                        function Get-TruncatedString($string, $length) {
+                                        function Get-TruncatedString($string, [int]$length) {
                                             if ($string.Length -le $length) {
                                                 return $string
                                             }
@@ -929,7 +929,7 @@ namespace System.Management.Automation.Runspaces
                                                 $null = $sb.Append([Environment]::Newline)
                                                 while (($remainingMessage.Length + $prefixLength) -gt [Console]::WindowWidth) {
                                                     $subMessage = $prefix + $remainingMessage.Substring(0, [Console]::WindowWidth - $prefixLength)
-                                                    $substring = Get-TruncatedString -string $subMessage -length [Console]::WindowWidth
+                                                    $substring = Get-TruncatedString -string $subMessage -length ([Console]::WindowWidth)
                                                     $null = $sb.Append($substring)
                                                     $null = $sb.Append([Environment]::Newline)
                                                     $remainingMessage = $remainingMessage.Substring($remainingMessage.Length - $substring.Length)

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -900,7 +900,7 @@ namespace System.Management.Automation.Runspaces
                                             $line = $line.Insert($myinv.OffsetInLine - 1 + $offsetLength, $resetColor)
                                             $line = $line.Insert($myinv.OffsetInLine - 1, $errorColor)
                                             $posmsg += ""${accentColor}${lineWhitespace}$($myinv.ScriptLineNumber) ${verticalBar} ${resetcolor}${line}`n""
-                                            $offsetWhitespace = ' ' * $myinv.OffsetInLine
+                                            $offsetWhitespace = ' ' * ($myinv.OffsetInLine - 1)
                                             $prefix = ""${accentColor}${headerWhitespace}     ${verticalBar} ${errorColor}""
                                             $message = ""${prefix}${offsetWhitespace}^ ""
                                         }
@@ -929,7 +929,7 @@ namespace System.Management.Automation.Runspaces
                                                 $sb = [Text.StringBuilder]::new()
                                                 $substring = Get-TruncatedString -string $message -length ([Console]::WindowWidth + $prefixVTLength)
                                                 $null = $sb.Append($substring)
-                                                $remainingMessage = $message.Substring($substring.Length)
+                                                $remainingMessage = $message.Substring($substring.Length).Trim()
                                                 $null = $sb.Append([Environment]::Newline)
                                                 while (($remainingMessage.Length + $prefixLength) -gt [Console]::WindowWidth) {
                                                     $subMessage = $prefix + $remainingMessage.Substring(0, [Console]::WindowWidth - $prefixLength)

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -921,6 +921,10 @@ namespace System.Management.Automation.Runspaces
                                         if ($myinv -and $myinv.ScriptName -or $_.CategoryInfo.Category -eq 'ParserError') {
                                             $prefixLength = Get-RawStringLength -string $prefix
                                             $prefixVtLength = $prefix.Length - $prefixLength
+
+                                            # replace newlines in message so it lines up correct
+                                            $message = $message.Replace([Environment]::Newline, ' ')
+
                                             if ([Console]::WindowWidth -gt 0 -and ($message.Length - $prefixVTLength) -gt [Console]::WindowWidth) {
                                                 $sb = [Text.StringBuilder]::new()
                                                 $substring = Get-TruncatedString -string $message -length ([Console]::WindowWidth + $prefixVTLength)

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -795,34 +795,35 @@ namespace System.Management.Automation.Runspaces
                                 ")
                         .AddScriptBlockExpressionBinding(@"
 
-                                    $resetColor = ''
-                                    if ($Host.UI.SupportsVirtualTerminal) {
-                                       $resetColor = ""`e[0m""
-                                    }
-
-                                    function Get-VT100Color([ConsoleColor] $color) {
-                                       switch ($color) {
-                                           'Black' { ""`e[2;30m"" }
-                                           'DarkRed' { ""`e[2;31m"" }
-                                           'DarkGreen' { ""`e[2;32m"" }
-                                           'DarkYellow' { ""`e[2;33m"" }
-                                           'DarkBlue' { ""`e[2;34m"" }
-                                           'DarkMagenta' { ""`e[2;35m"" }
-                                           'DarkCyan' { ""`e[2;36m"" }
-                                           'Gray' { ""`e[2;37m"" }
-                                           'DarkGray' { ""`e[1;30m"" }
-                                           'Red' { ""`e[1;31m"" }
-                                           'Green' { ""`e[1;32m"" }
-                                           'Yellow' { ""`e[1;33m"" }
-                                           'Blue' { ""`e[1;34m"" }
-                                           'Magenta' { ""`e[1;35m"" }
-                                           'Cyan' { ""`e[1;36m"" }
-                                           'White' { ""`e[1;37m"" }
-                                           default { ""`e[1;31m"" }
-                                       }
-                                    }
-
                                     function Get-ConciseViewPositionMessage {
+
+                                        $resetColor = ''
+                                        if ($Host.UI.SupportsVirtualTerminal) {
+                                            $resetColor = ""`e[0m""
+                                        }
+
+                                        function Get-VT100Color([ConsoleColor] $color) {
+                                            switch ($color) {
+                                                'Black' { ""`e[2;30m"" }
+                                                'DarkRed' { ""`e[2;31m"" }
+                                                'DarkGreen' { ""`e[2;32m"" }
+                                                'DarkYellow' { ""`e[2;33m"" }
+                                                'DarkBlue' { ""`e[2;34m"" }
+                                                'DarkMagenta' { ""`e[2;35m"" }
+                                                'DarkCyan' { ""`e[2;36m"" }
+                                                'Gray' { ""`e[2;37m"" }
+                                                'DarkGray' { ""`e[1;30m"" }
+                                                'Red' { ""`e[1;31m"" }
+                                                'Green' { ""`e[1;32m"" }
+                                                'Yellow' { ""`e[1;33m"" }
+                                                'Blue' { ""`e[1;34m"" }
+                                                'Magenta' { ""`e[1;35m"" }
+                                                'Cyan' { ""`e[1;36m"" }
+                                                'White' { ""`e[1;37m"" }
+                                                default { ""`e[1;31m"" }
+                                            }
+                                        }
+
                                         $errorColor = ''
                                         $accentColor = ''
                                         if ($Host.PrivateData -and $Host.UI.SupportsVirtualTerminal) {
@@ -832,7 +833,7 @@ namespace System.Management.Automation.Runspaces
 
                                         $posmsg = ''
 
-                                        if ($myinv.ScriptName -or $_.CategoryInfo.Category -eq 'ParserError') {
+                                        if ($myinv -and $myinv.ScriptName -or $_.CategoryInfo.Category -eq 'ParserError') {
                                             if ($myinv.ScriptName) {
                                                 $posmsg = ""${resetColor}At $($myinv.ScriptName)`n""
                                             }
@@ -899,7 +900,7 @@ namespace System.Management.Automation.Runspaces
                                     else
                                     {
                                         $myinv = $_.InvocationInfo
-                                        if ($myinv -and $ErrorView -eq 'ConciseView') {
+                                        if ($ErrorView -eq 'ConciseView') {
                                             $posmsg = Get-ConciseViewPositionMessage
                                         }
                                         elseif ($myinv -and ($myinv.MyCommand -or ($_.CategoryInfo.Category -ne 'ParserError'))) {
@@ -917,47 +918,43 @@ namespace System.Management.Automation.Runspaces
                                             $posmsg = ' : ' +  $_.PSMessageDetails + $posmsg
                                         }
 
-                                        switch($ErrorView) {
-                                            'NormalView' {
-                                                $indent = 4
+                                        if ($ErrorView -eq 'ConciseView') {
+                                            return $posmsg
+                                        }
 
-                                                $errorCategoryMsg = & { Set-StrictMode -Version 1; $_.ErrorCategory_Message }
+                                        $indent = 4
 
-                                                if ($null -ne $errorCategoryMsg)
-                                                {
-                                                    $indentString = '+ CategoryInfo          : ' + $_.ErrorCategory_Message
-                                                }
-                                                else
-                                                {
-                                                    $indentString = '+ CategoryInfo          : ' + $_.CategoryInfo
-                                                }
+                                        $errorCategoryMsg = & { Set-StrictMode -Version 1; $_.ErrorCategory_Message }
 
-                                                $posmsg += ""`n"" + $indentString
+                                        if ($null -ne $errorCategoryMsg)
+                                        {
+                                            $indentString = '+ CategoryInfo          : ' + $_.ErrorCategory_Message
+                                        }
+                                        else
+                                        {
+                                            $indentString = '+ CategoryInfo          : ' + $_.CategoryInfo
+                                        }
 
-                                                $indentString = '+ FullyQualifiedErrorId : ' + $_.FullyQualifiedErrorId
-                                                $posmsg += ""`n"" + $indentString
+                                        $posmsg += ""`n"" + $indentString
 
-                                                $originInfo = & { Set-StrictMode -Version 1; $_.OriginInfo }
+                                        $indentString = ""+ FullyQualifiedErrorId : "" + $_.FullyQualifiedErrorId
+                                        $posmsg += ""`n"" + $indentString
 
-                                                if (($null -ne $originInfo) -and ($null -ne $originInfo.PSComputerName))
-                                                {
-                                                    $indentString = '+ PSComputerName        : ' + $originInfo.PSComputerName
-                                                    $posmsg += ""`n"" + $indentString
-                                                }
+                                        $originInfo = & { Set-StrictMode -Version 1; $_.OriginInfo }
 
-                                                if ($ErrorView -eq 'CategoryView') {
-                                                    $_.CategoryInfo.GetMessage()
-                                                }
-                                                elseif (! $_.ErrorDetails -or ! $_.ErrorDetails.Message) {
-                                                    $_.Exception.Message + $posmsg + '`n '
-                                                } else {
-                                                    $_.ErrorDetails.Message + $posmsg
-                                                }
-                                            }
+                                        if (($null -ne $originInfo) -and ($null -ne $originInfo.PSComputerName))
+                                        {
+                                            $indentString = ""+ PSComputerName        : "" + $originInfo.PSComputerName
+                                            $posmsg += ""`n"" + $indentString
+                                        }
 
-                                            'ConciseView' {
-                                                $posmsg
-                                            }
+                                        if ($ErrorView -eq 'CategoryView') {
+                                            $_.CategoryInfo.GetMessage()
+                                        }
+                                        elseif (! $_.ErrorDetails -or ! $_.ErrorDetails.Message) {
+                                            $_.Exception.Message + $posmsg + ""`n""
+                                        } else {
+                                            $_.ErrorDetails.Message + $posmsg
                                         }
                                     }
                                 ")

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -841,7 +841,7 @@ namespace System.Management.Automation.Runspaces
 
                                         if ($myinv -and $myinv.ScriptName -or $_.CategoryInfo.Category -eq 'ParserError') {
                                             if ($myinv.ScriptName) {
-                                                $posmsg = ""${resetColor}In $($myinv.ScriptName)`n""
+                                                $posmsg = ""${resetColor}in $($myinv.ScriptName)`n""
                                             }
                                             else {
                                                 $posmsg = ""`n""

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -875,6 +875,12 @@ namespace System.Management.Automation.Runspaces
                                         if ($_.Exception -and $_.Exception.WasThrownFromThrowStatement) {
                                             $reason = 'Exception'
                                         }
+                                        elseif ($myinv.MyCommand) {
+                                            $reason = $myinv.MyCommand
+                                        }
+                                        elseif ($myinv.InvocationName) {
+                                            $reason = $myinv.InvocationName
+                                        }
                                         elseif ($_.CategoryInfo.Category) {
                                             $reason = $_.CategoryInfo.Category
                                         }

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -743,7 +743,7 @@ namespace System.Management.Automation.Runspaces
                 CustomControl.Create(outOfBand: true)
                     .StartEntry()
                         .AddScriptBlockExpressionBinding(@"
-                                    if (($_.FullyQualifiedErrorId -ne 'NativeCommandErrorMessage' -and $_.FullyQualifiedErrorId -ne 'NativeCommandError') -and $ErrorView -ne 'Category' -and $ErrorView -ne 'Concise')
+                                    if (($_.FullyQualifiedErrorId -ne 'NativeCommandErrorMessage' -and $_.FullyQualifiedErrorId -ne 'NativeCommandError') -and $ErrorView -ne 'CategoryView' -and $ErrorView -ne 'ConciseView')
                                     {
                                         $myinv = $_.InvocationInfo
                                         if ($myinv -and $myinv.MyCommand)
@@ -822,7 +822,7 @@ namespace System.Management.Automation.Runspaces
                                        }
                                     }
 
-                                    function Get-ConcisePositionMessage {
+                                    function Get-ConciseViewPositionMessage {
                                         $errorColor = ''
                                         $accentColor = ''
                                         if ($Host.PrivateData -and $Host.UI.SupportsVirtualTerminal) {
@@ -893,14 +893,14 @@ namespace System.Management.Automation.Runspaces
                                         ""${errorColor}${reason}:${resetColor} ${posmsg}${resetcolor}""
                                     }
 
-                                    if ($_.FullyQualifiedErrorId -eq ""NativeCommandErrorMessage"" -or $_.FullyQualifiedErrorId -eq ""NativeCommandError"" -or $ErrorView -eq ""Message"") {
+                                    if ($_.FullyQualifiedErrorId -eq 'NativeCommandErrorMessage' -or $_.FullyQualifiedErrorId -eq 'NativeCommandError') {
                                         $_.Exception.Message
                                     }
                                     else
                                     {
                                         $myinv = $_.InvocationInfo
-                                        if ($myinv -and $ErrorView -eq 'Concise') {
-                                            $posmsg = Get-ConcisePositionMessage
+                                        if ($myinv -and $ErrorView -eq 'ConciseView') {
+                                            $posmsg = Get-ConciseViewPositionMessage
                                         }
                                         elseif ($myinv -and ($myinv.MyCommand -or ($_.CategoryInfo.Category -ne 'ParserError'))) {
                                             $posmsg = $myinv.PositionMessage
@@ -918,7 +918,7 @@ namespace System.Management.Automation.Runspaces
                                         }
 
                                         switch($ErrorView) {
-                                            'Normal' {
+                                            'NormalView' {
                                                 $indent = 4
 
                                                 $errorCategoryMsg = & { Set-StrictMode -Version 1; $_.ErrorCategory_Message }
@@ -955,7 +955,7 @@ namespace System.Management.Automation.Runspaces
                                                 }
                                             }
 
-                                            'Concise' {
+                                            'ConciseView' {
                                                 $posmsg
                                             }
                                         }

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -798,8 +798,10 @@ namespace System.Management.Automation.Runspaces
                                     function Get-ConciseViewPositionMessage {
 
                                         $resetColor = ''
+                                        $inverseMode = ''
                                         if ($Host.UI.SupportsVirtualTerminal) {
                                             $resetColor = ""`e[0m""
+                                            $inverseMode = ""`e[7m""
                                         }
 
                                         function Get-VT100Color([ConsoleColor] $color) {
@@ -839,7 +841,7 @@ namespace System.Management.Automation.Runspaces
 
                                         if ($myinv -and $myinv.ScriptName -or $_.CategoryInfo.Category -eq 'ParserError') {
                                             if ($myinv.ScriptName) {
-                                                $posmsg = ""${resetColor}At $($myinv.ScriptName)`n""
+                                                $posmsg = ""${resetColor}In $($myinv.ScriptName)`n""
                                             }
                                             else {
                                                 $posmsg = ""`n""
@@ -856,12 +858,16 @@ namespace System.Management.Automation.Runspaces
                                                 $lineWhitespace = ' ' * (4 - $scriptLineNumberLength)
                                             }
 
-                                            $posmsg += ""${accentColor}${headerWhitespace}Line |`n""
-                                            $posmsg += ""${accentColor}${lineWhitespace}$($myinv.ScriptLineNumber) | ${resetcolor}$($myinv.Line)`n""
-
+                                            $verticalBar = '|'
+                                            $posmsg += ""${accentColor}${headerWhitespace}Line ${verticalBar}`n""
+                                            $line = $myinv.Line
+                                            $highlightLine = $myinv.PositionMessage.Split('+').Count - 1
+                                            $offsetLength = $myinv.PositionMessage.split('+')[$highlightLine].Trim().Length
+                                            $line = $line.Insert($myinv.OffsetInLine - 1 + $offsetLength, $resetColor)
+                                            $line = $line.Insert($myinv.OffsetInLine - 1, $errorColor)
+                                            $posmsg += ""${accentColor}${lineWhitespace}$($myinv.ScriptLineNumber) ${verticalBar} ${resetcolor}${line}`n""
                                             $offsetWhitespace = ' ' * $myinv.OffsetInLine
-
-                                            $posmsg += ""${accentColor}${headerWhitespace}     |${offsetWhitespace}${errorColor}^ ""
+                                            $posmsg += ""${accentColor}${headerWhitespace}     ${verticalBar}${offsetWhitespace}${errorColor}^ ""
                                         }
 
                                         if (! $_.ErrorDetails -or ! $_.ErrorDetails.Message) {

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -939,7 +939,7 @@ namespace System.Management.Automation.Runspaces
                                             }
                                         }
 
-                                        $posmsg += $message
+                                        $posmsg += ""${errorColor}"" + $message
 
                                         $reason = 'Error'
                                         if ($_.Exception -and $_.Exception.WasThrownFromThrowStatement) {

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -877,7 +877,7 @@ namespace System.Management.Automation.Runspaces
 
                                         if ($myinv -and $myinv.ScriptName -or $_.CategoryInfo.Category -eq 'ParserError') {
                                             if ($myinv.ScriptName) {
-                                                $posmsg = ""${resetColor}error in $($myinv.ScriptName)${newline}""
+                                                $posmsg = ""error in${resetcolor} $($myinv.ScriptName)${newline}""
                                             }
                                             else {
                                                 $posmsg = ""${newline}""
@@ -934,11 +934,11 @@ namespace System.Management.Automation.Runspaces
                                                 $remainingMessage = $message.Substring($substring.Length).Trim()
                                                 $null = $sb.Append($newline)
                                                 while (($remainingMessage.Length + $prefixLength) -gt [Console]::WindowWidth) {
-                                                    $subMessage = $prefix + $remainingMessage.Substring(0, [Console]::WindowWidth - $prefixLength)
-                                                    $substring = Get-TruncatedString -string $subMessage -length ([Console]::WindowWidth)
+                                                    $subMessage = $prefix + $remainingMessage
+                                                    $substring = Get-TruncatedString -string $subMessage -length ([Console]::WindowWidth + $prefixVtLength)
                                                     $null = $sb.Append($substring)
                                                     $null = $sb.Append($newline)
-                                                    $remainingMessage = $remainingMessage.Substring($substring.Length - $prefix.Length)
+                                                    $remainingMessage = $remainingMessage.Substring($substring.Length - $prefix.Length).Trim()
                                                 }
                                                 $null = $sb.Append($prefix + $remainingMessage.Trim())
                                                 $message = $sb.ToString()
@@ -966,7 +966,7 @@ namespace System.Management.Automation.Runspaces
 
                                         $errorMsg = 'Error'
 
-                                        ""${errorColor}${reason}:${resetColor} ${posmsg}${resetcolor}""
+                                        ""${errorColor}${reason}: ${posmsg}${resetcolor}""
                                     }
 
                                     if ($_.FullyQualifiedErrorId -eq 'NativeCommandErrorMessage' -or $_.FullyQualifiedErrorId -eq 'NativeCommandError') {

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -743,7 +743,7 @@ namespace System.Management.Automation.Runspaces
                 CustomControl.Create(outOfBand: true)
                     .StartEntry()
                         .AddScriptBlockExpressionBinding(@"
-                                    if (($_.FullyQualifiedErrorId -ne ""NativeCommandErrorMessage"" -and $_.FullyQualifiedErrorId -ne ""NativeCommandError"") -and $ErrorView -ne ""Category"")
+                                    if (($_.FullyQualifiedErrorId -ne 'NativeCommandErrorMessage' -and $_.FullyQualifiedErrorId -ne 'NativeCommandError') -and $ErrorView -ne 'Category' -and $ErrorView -ne 'Concise')
                                     {
                                         $myinv = $_.InvocationInfo
                                         if ($myinv -and $myinv.MyCommand)
@@ -754,7 +754,7 @@ namespace System.Management.Automation.Runspaces
                                                 {
                                                     if ($myinv.MyCommand.Path)
                                                     {
-                                                        $myinv.MyCommand.Path + "" : ""
+                                                        $myinv.MyCommand.Path + ' : '
                                                     }
 
                                                     break
@@ -764,27 +764,23 @@ namespace System.Management.Automation.Runspaces
                                                 {
                                                     if ($myinv.MyCommand.ScriptBlock)
                                                     {
-                                                        $myinv.MyCommand.ScriptBlock.ToString() + "" : ""
+                                                        $myinv.MyCommand.ScriptBlock.ToString() + ' : '
                                                     }
 
                                                     break
                                                 }
                                                 default
                                                 {
-                                                    if ($ErrorView -eq 'Analytic') {
-                                                        break
-                                                    }
-
                                                     if ($myinv.InvocationName -match '^[&\.]?$')
                                                     {
                                                         if ($myinv.MyCommand.Name)
                                                         {
-                                                            $myinv.MyCommand.Name + "" : ""
+                                                            $myinv.MyCommand.Name + ' : '
                                                         }
                                                     }
                                                     else
                                                     {
-                                                        $myinv.InvocationName + "" : ""
+                                                        $myinv.InvocationName + ' : '
                                                     }
 
                                                     break
@@ -793,7 +789,7 @@ namespace System.Management.Automation.Runspaces
                                         }
                                         elseif ($myinv -and $myinv.InvocationName)
                                         {
-                                            $myinv.InvocationName + "" : ""
+                                            $myinv.InvocationName + ' : '
                                         }
                                     }
                                 ")
@@ -826,7 +822,7 @@ namespace System.Management.Automation.Runspaces
                                        }
                                     }
 
-                                    function Get-AnalyticPositionMessage {
+                                    function Get-ConcisePositionMessage {
                                         $errorColor = ''
                                         $accentColor = ''
                                         if ($Host.PrivateData -and $Host.UI.SupportsVirtualTerminal) {
@@ -897,8 +893,8 @@ namespace System.Management.Automation.Runspaces
                                     else
                                     {
                                         $myinv = $_.InvocationInfo
-                                        if ($myinv -and $ErrorView -eq 'Analytic') {
-                                            $posmsg = Get-AnalyticPositionMessage
+                                        if ($myinv -and $ErrorView -eq 'Concise') {
+                                            $posmsg = Get-ConcisePositionMessage
                                         }
                                         elseif ($myinv -and ($myinv.MyCommand -or ($_.CategoryInfo.Category -ne 'ParserError'))) {
                                             $posmsg = $myinv.PositionMessage
@@ -953,7 +949,7 @@ namespace System.Management.Automation.Runspaces
                                                 }
                                             }
 
-                                            'Analytic' {
+                                            'Concise' {
                                                 $posmsg
                                             }
                                         }

--- a/src/System.Management.Automation/engine/CommandBase.cs
+++ b/src/System.Management.Automation/engine/CommandBase.cs
@@ -273,13 +273,13 @@ namespace System.Management.Automation
     public enum ErrorView
     {
         /// <summary>Existing all red multi-line output.</summary>
-        Normal = 0,
+        NormalView = 0,
 
         /// <summary>Only show category information.</summary>
-        Category = 1,
+        CategoryView = 1,
 
         /// <summary>Concise shows more information on the context of the error or just the message if not a script or parser error.</summary>
-        Concise = 2,
+        ConciseView = 2,
     }
     #endregion ErrorView
 

--- a/src/System.Management.Automation/engine/CommandBase.cs
+++ b/src/System.Management.Automation/engine/CommandBase.cs
@@ -278,8 +278,8 @@ namespace System.Management.Automation
         /// <summary>Only show category information.</summary>
         Category = 1,
 
-        /// <summary>Analytic shows more information on the context of the error or just the message if not a script</summary>
-        Analytic = 2,
+        /// <summary>Concise shows more information on the context of the error or just the message if not a script or parser error.</summary>
+        Concise = 2,
     }
     #endregion ErrorView
 

--- a/src/System.Management.Automation/engine/CommandBase.cs
+++ b/src/System.Management.Automation/engine/CommandBase.cs
@@ -266,6 +266,23 @@ namespace System.Management.Automation.Internal
 
 namespace System.Management.Automation
 {
+    #region ErrorView
+    /// <summary>
+    /// Defines the potential ErrorView options.
+    /// </summary>
+    public enum ErrorView
+    {
+        /// <summary>Existing all red multi-line output.</summary>
+        Normal = 0,
+
+        /// <summary>Only show category information.</summary>
+        Category = 1,
+
+        /// <summary>Analytic shows more information on the context of the error or just the message if not a script</summary>
+        Analytic = 2,
+    }
+    #endregion ErrorView
+
     #region ActionPreference
     /// <summary>
     /// Defines the Action Preference options.  These options determine

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -114,7 +114,10 @@ namespace System.Management.Automation
                     description: "New parameter set for ForEach-Object to run script blocks in parallel"),
                 new ExperimentalFeature(
                     name: "PSTernaryOperator",
-                    description: "Support the ternary operator in PowerShell language")
+                    description: "Support the ternary operator in PowerShell language"),
+                new ExperimentalFeature(
+                    name: "PSErrorView",
+                    description: "New formatting for ErrorRecord")
             };
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);
 

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4326,6 +4326,8 @@ end {
         internal const ActionPreference defaultVerbosePreference = ActionPreference.SilentlyContinue;
         internal const ActionPreference defaultWarningPreference = ActionPreference.Continue;
         internal const ActionPreference defaultInformationPreference = ActionPreference.SilentlyContinue;
+
+        internal const ErrorView defaultErrorView = ErrorView.Normal;
         internal const bool defaultWhatIfPreference = false;
         internal const ConfirmImpact defaultConfirmPreference = ConfirmImpact.High;
 
@@ -4408,8 +4410,10 @@ end {
                  ),
             new SessionStateVariableEntry(
                 SpecialVariables.ErrorView,
-                "NormalView",
-                RunspaceInit.ErrorViewDescription
+                ExperimentalFeature.IsEnabled("PSErrorView") ? ErrorView.Analytic : defaultErrorView,
+                RunspaceInit.ErrorViewDescription,
+                ScopedItemOptions.None,
+                new ArgumentTypeConverterAttribute(typeof(ErrorView))
                 ),
             new SessionStateVariableEntry(
                 SpecialVariables.NestedPromptLevel,

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4327,7 +4327,7 @@ end {
         internal const ActionPreference defaultWarningPreference = ActionPreference.Continue;
         internal const ActionPreference defaultInformationPreference = ActionPreference.SilentlyContinue;
 
-        internal const ErrorView defaultErrorView = ErrorView.Normal;
+        internal const ErrorView defaultErrorView = ErrorView.NormalView;
         internal const bool defaultWhatIfPreference = false;
         internal const ConfirmImpact defaultConfirmPreference = ConfirmImpact.High;
 
@@ -4410,7 +4410,7 @@ end {
                  ),
             new SessionStateVariableEntry(
                 SpecialVariables.ErrorView,
-                ExperimentalFeature.IsEnabled("PSErrorView") ? ErrorView.Concise : defaultErrorView,
+                ExperimentalFeature.IsEnabled("PSErrorView") ? ErrorView.ConciseView : defaultErrorView,
                 RunspaceInit.ErrorViewDescription,
                 ScopedItemOptions.None,
                 new ArgumentTypeConverterAttribute(typeof(ErrorView))

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4410,7 +4410,7 @@ end {
                  ),
             new SessionStateVariableEntry(
                 SpecialVariables.ErrorView,
-                ExperimentalFeature.IsEnabled("PSErrorView") ? ErrorView.Analytic : defaultErrorView,
+                ExperimentalFeature.IsEnabled("PSErrorView") ? ErrorView.Concise : defaultErrorView,
                 RunspaceInit.ErrorViewDescription,
                 ScopedItemOptions.None,
                 new ArgumentTypeConverterAttribute(typeof(ErrorView))

--- a/src/System.Management.Automation/engine/parser/Position.cs
+++ b/src/System.Management.Automation/engine/parser/Position.cs
@@ -243,49 +243,20 @@ namespace System.Management.Automation.Language
                 }
 
                 sb.Append(Environment.NewLine);
-                if (ExperimentalFeature.IsEnabled("PSErrorView"))
-                {
-                    whitespaceFill = "      ".Substring(0, position.StartLineNumber.ToString().Length);
-                    sb.Append(whitespaceFill);
-                    sb.Append("\x1b[1;36m | ");
-                    sb.Append(' ', spacesBeforeError + (needsPrefixDots ? 2 : 0));
-                    // errorLength of 0 happens at EOF - always write out 1.
-                    sb.Append("\x1b[1;31m");
-                    sb.Append('^', errorLength > 0 ? errorLength : 1);
-                    sb.Append("\x1b[0m");
-                }
-                else
-                {
-                    sb.Append("+ ");
-                    sb.Append(' ', spacesBeforeError + (needsPrefixDots ? 2 : 0));
-                    // errorLength of 0 happens at EOF - always write out 1.
-                    sb.Append('~', errorLength > 0 ? errorLength : 1);
-                }
+                sb.Append("+ ");
+                sb.Append(' ', spacesBeforeError + (needsPrefixDots ? 2 : 0));
+                // errorLength of 0 happens at EOF - always write out 1.
+                sb.Append('~', errorLength > 0 ? errorLength : 1);
 
                 message = sb.ToString();
             }
 
-            if (ExperimentalFeature.IsEnabled("PSErrorView"))
-            {
-                return StringUtil.Format(
-                    ParserStrings.TextForPositionMessageNew,
-                    fileName,
-                    position.StartLineNumber,
-                    position.StartColumnNumber,
-                    message,
-                    whitespaceFill).Replace('#','\x1b');
-
-            }
-            else
-            {
-                return StringUtil.Format(
-                    ParserStrings.TextForPositionMessage,
-                    fileName,
-                    position.StartLineNumber,
-                    position.StartColumnNumber,
-                    message);
-
-            }
+            return StringUtil.Format(
+                ParserStrings.TextForPositionMessage,
+                fileName,
+                position.StartLineNumber,
+                position.StartColumnNumber,
+                message);
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/parser/Position.cs
+++ b/src/System.Management.Automation/engine/parser/Position.cs
@@ -141,7 +141,6 @@ namespace System.Management.Automation.Language
 
             string sourceLine = position.StartScriptPosition.Line.TrimEnd();
 
-            string whitespaceFill = string.Empty;
             string message = string.Empty;
             if (!string.IsNullOrEmpty(sourceLine))
             {

--- a/src/System.Management.Automation/engine/parser/Position.cs
+++ b/src/System.Management.Automation/engine/parser/Position.cs
@@ -231,14 +231,14 @@ namespace System.Management.Automation.Language
 
                 if (needsPrefixDots)
                 {
-                    sb.Append("\u2026 ");
+                    sb.Append("\u2026 "); // Unicode ellipsis character
                 }
 
                 sb.Append(sourceLine);
 
                 if (needsSuffixDots)
                 {
-                    sb.Append(" \u2026");
+                    sb.Append(" \u2026"); // Unicode ellipsis character
                 }
 
                 sb.Append(Environment.NewLine);

--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -611,6 +611,11 @@ The correct form is: foreach ($a in $b) {...}</value>
     <value>At {0}:{1} char:{2}
 + {3}</value>
   </data>
+  <data name="TextForPositionMessageNew" xml:space="preserve">
+    <value>#[0mAt {0}:{1} char:{2}
+#[1;36m{4} |
+#[1;36m{1} | #[0m{3} </value>
+  </data>
   <data name="TextForCharPositionMessage" xml:space="preserve">
     <value>At char:{0}</value>
   </data>

--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -611,11 +611,6 @@ The correct form is: foreach ($a in $b) {...}</value>
     <value>At {0}:{1} char:{2}
 + {3}</value>
   </data>
-  <data name="TextForPositionMessageNew" xml:space="preserve">
-    <value>#[0mAt {0}:{1} char:{2}
-#[1;36m{4} |
-#[1;36m{1} | #[0m{3} </value>
-  </data>
   <data name="TextForCharPositionMessage" xml:space="preserve">
     <value>At char:{0}</value>
   </data>

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -393,7 +393,7 @@ export $envVarName='$guid'
         It "errors are in text if error is redirected, encoded command, non-interactive, and outputformat specified" {
             $p = [Diagnostics.Process]::new()
             $p.StartInfo.FileName = "pwsh"
-            $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes("`$ErrorView='NormalView';throw 'boom'"))
+            $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes('$ErrorView="NormalView";throw "boom"'))
             $p.StartInfo.Arguments = "-EncodedCommand $encoded -ExecutionPolicy Bypass -NoLogo -NonInteractive -NoProfile -OutputFormat text"
             $p.StartInfo.UseShellExecute = $false
             $p.StartInfo.RedirectStandardError = $true

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -393,7 +393,7 @@ export $envVarName='$guid'
         It "errors are in text if error is redirected, encoded command, non-interactive, and outputformat specified" {
             $p = [Diagnostics.Process]::new()
             $p.StartInfo.FileName = "pwsh"
-            $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes("throw 'boom'"))
+            $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes("`$ErrorView='NormalView';throw 'boom'"))
             $p.StartInfo.Arguments = "-EncodedCommand $encoded -ExecutionPolicy Bypass -NoLogo -NonInteractive -NoProfile -OutputFormat text"
             $p.StartInfo.UseShellExecute = $false
             $p.StartInfo.RedirectStandardError = $true

--- a/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
+++ b/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
@@ -96,6 +96,15 @@ Describe "File redirection mixed with Out-Null" -Tags CI {
 }
 
 Describe "File redirection should have 'DoComplete' called on the underlying pipeline processor" -Tags CI {
+    BeforeAll {
+        $originalErrorView = $ErrorView
+        $ErrorView = "NormalView"
+    }
+
+    AfterAll {
+        $ErrorView = $originalErrorView
+    }
+
     It "File redirection should result in the same file as Out-File" {
         $object = [pscustomobject] @{ one = 1 }
         $redirectFile = Join-Path $TestDrive fileRedirect.txt

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Implicit.Remoting.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Implicit.Remoting.Tests.ps1
@@ -193,11 +193,14 @@ try
             BeforeAll {
                 if ($skipTest) { return }
                 $module = Import-PSSession -Session $session -Name Get-Variable -Prefix My -AllowClobber
+                $oldErrorView = $ErrorView
+                $ErrorView = "NormalView"
             }
 
             AfterAll {
                 if ($skipTest) { return }
                 if ($null -ne $module) { Remove-Module $module -Force -ErrorAction SilentlyContinue }
+                $ErrorView = $oldErrorView
             }
 
             It "Test non-terminating error" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
@@ -101,8 +101,7 @@ Describe "Write-Error Tests" -Tags "CI" {
         while ($longtext.Length -lt [console]::WindowWidth) {
             $longtext += $longtext
         }
-        $pwsh = $pshome + "/pwsh"
-        $result = & $pwsh -c "`$ErrorView = 'Normal'; Write-Error -Message $longtext 2>&1"
+        $result = pwsh -noprofile -command "`$ErrorView = 'NormalView'; Write-Error -Message '$longtext' 2>&1"
         $result.Count | Should -BeExactly 3
         $result[0] | Should -Match $longtext
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
@@ -102,8 +102,8 @@ Describe "Write-Error Tests" -Tags "CI" {
             $longtext += $longtext
         }
         $pwsh = $pshome + "/pwsh"
-        $result = & $pwsh -c Write-Error -Message $longtext 2>&1
-        $result.Count | Should -BeExactly 4
+        $result = & $pwsh -c "`$ErrorView = 'Normal'; Write-Error -Message $longtext 2>&1"
+        $result.Count | Should -BeExactly 3
         $result[0] | Should -Match $longtext
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
@@ -101,7 +101,7 @@ Describe "Write-Error Tests" -Tags "CI" {
         while ($longtext.Length -lt [console]::WindowWidth) {
             $longtext += $longtext
         }
-        $result = pwsh -noprofile -command "`$ErrorView = 'NormalView'; Write-Error -Message '$longtext' 2>&1"
+        $result = pwsh -noprofile -command "`$ErrorView = 'NormalView'; Write-Error -Message '$longtext'" 2>&1
         $result.Count | Should -BeExactly 3
         $result[0] | Should -Match $longtext
     }

--- a/test/powershell/engine/Formatting/ErrorView.Tests.ps1
+++ b/test/powershell/engine/Formatting/ErrorView.Tests.ps1
@@ -1,30 +1,30 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-Describe "Tests for `$ErrorView" -Tag CI {
+Describe 'Tests for $ErrorView' -Tag CI {
 
-    It "`$ErrorView is an enum" {
+    It '$ErrorView is an enum' {
         $ErrorView | Should -BeOfType [System.Management.Automation.ErrorView]
     }
 
-    It "`$ErrorView should have correct default value" {
-        $expectedDefault = "NormalView"
+    It '$ErrorView should have correct default value' {
+        $expectedDefault = 'NormalView'
 
         if ((Get-ExperimentalFeature -Name PSErrorView).Enabled) {
-            $expectedDefault = "ConciseView"
+            $expectedDefault = 'ConciseView'
         }
 
         $ErrorView | Should -BeExactly $expectedDefault
     }
 
-    Context "ConciseView tests" {
+    Context 'ConciseView tests' {
 
-        It "Cmdlet error should be one line of text" {
+        It 'Cmdlet error should be one line of text' {
             Get-Item (New-Guid) -ErrorVariable e -ErrorAction SilentlyContinue
             ($e | Out-String).Trim().Count | Should -Be 1
         }
 
-        It "Script error should contain path to script and line for error" {
+        It 'Script error should contain path to script and line for error' {
             $testScript = @'
                 [cmdletbinding()]
                 param()
@@ -33,12 +33,12 @@ Describe "Tests for `$ErrorView" -Tag CI {
                 $b = 2
 '@
 
-            $testScriptPath = Join-Path -Path $TestDrive -ChildPath "test.ps1"
+            $testScriptPath = Join-Path -Path $TestDrive -ChildPath 'test.ps1'
             Set-Content -Path $testScriptPath -Value $testScript
-            $e = { & $testScriptPath } | Should -Throw -ErrorId "UnexpectedToken" -PassThru
+            $e = { & $testScriptPath } | Should -Throw -ErrorId 'UnexpectedToken' -PassThru
             $e | Out-String | Should -BeLike "*$testScriptPath*"
             # validate line number is shown
-            $e | Out-String | Should -BeLike "* 4 *"
+            $e | Out-String | Should -BeLike '* 4 *'
         }
 
         It "Remote errors show up correctly" {

--- a/test/powershell/engine/Formatting/ErrorView.Tests.ps1
+++ b/test/powershell/engine/Formatting/ErrorView.Tests.ps1
@@ -37,6 +37,8 @@ Describe "Tests for `$ErrorView" -Tag CI {
             Set-Content -Path $testScriptPath -Value $testScript
             $e = { & $testScriptPath } | Should -Throw -ErrorId "UnexpectedToken" -PassThru
             $e | Out-String | Should -BeLike "*$testScriptPath*"
+            # validate line number is shown
+            $e | Out-String | Should -BeLike "* 4 *"
         }
 
         It "Remote errors show up correctly" {

--- a/test/powershell/engine/Formatting/ErrorView.Tests.ps1
+++ b/test/powershell/engine/Formatting/ErrorView.Tests.ps1
@@ -10,7 +10,7 @@ Describe "Tests for `$ErrorView" -Tag CI {
     It "`$ErrorView should have correct default value" {
         $expectedDefault = "NormalView"
 
-        if ((Get-ExperimentalFeature -Name PSErrorView).IsEnabled) {
+        if ((Get-ExperimentalFeature -Name PSErrorView).Enabled) {
             $expectedDefault = "ConciseView"
         }
 
@@ -20,20 +20,28 @@ Describe "Tests for `$ErrorView" -Tag CI {
     Context "ConciseView tests" {
 
         It "Cmdlet error should be one line of text" {
-            Get-Item (New-Guid) -ErrorVariable e
+            Get-Item (New-Guid) -ErrorVariable e -ErrorAction SilentlyContinue
             ($e | Out-String).Trim().Count | Should -Be 1
         }
 
         It "Script error should contain path to script and line for error" {
             $testScript = @'
+                [cmdletbinding()]
+                param()
                 $a = 1
                 123)
                 $b = 2
 '@
 
             $testScriptPath = Join-Path -Path $TestDrive -ChildPath "test.ps1"
-            Set-Content -Path $testScriptPath -Value $testScriptPath
-            & $testScriptPath | Out-String | Should -Contain $testScriptPath
+            Set-Content -Path $testScriptPath -Value $testScript
+            $e = { & $testScriptPath } | Should -Throw -ErrorId "UnexpectedToken" -PassThru
+            $e | Out-String | Should -Match $testScriptPath
+        }
+
+        It "Remote errors show up correctly" {
+            Start-Job -ScriptBlock { get-item (new-guid) } | Wait-Job | Receive-Job -ErrorVariable e -ErrorAction SilentlyContinue
+            ($e | Out-String).Trim().Count | Should -Be 1
         }
     }
 }

--- a/test/powershell/engine/Formatting/ErrorView.Tests.ps1
+++ b/test/powershell/engine/Formatting/ErrorView.Tests.ps1
@@ -1,0 +1,39 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+Describe "Tests for `$ErrorView" -Tag CI {
+
+    It "`$ErrorView is an enum" {
+        $ErrorView | Should -BeOfType [System.Management.Automation.ErrorView]
+    }
+
+    It "`$ErrorView should have correct default value" {
+        $expectedDefault = "NormalView"
+
+        if ((Get-ExperimentalFeature -Name PSErrorView).IsEnabled) {
+            $expectedDefault = "ConciseView"
+        }
+
+        $ErrorView | Should -BeExactly $expectedDefault
+    }
+
+    Context "ConciseView tests" {
+
+        It "Cmdlet error should be one line of text" {
+            Get-Item (New-Guid) -ErrorVariable e
+            ($e | Out-String).Trim().Count | Should -Be 1
+        }
+
+        It "Script error should contain path to script and line for error" {
+            $testScript = @'
+                $a = 1
+                123)
+                $b = 2
+'@
+
+            $testScriptPath = Join-Path -Path $TestDrive -ChildPath "test.ps1"
+            Set-Content -Path $testScriptPath -Value $testScriptPath
+            & $testScriptPath | Out-String | Should -Contain $testScriptPath
+        }
+    }
+}

--- a/test/powershell/engine/Formatting/ErrorView.Tests.ps1
+++ b/test/powershell/engine/Formatting/ErrorView.Tests.ps1
@@ -36,7 +36,7 @@ Describe "Tests for `$ErrorView" -Tag CI {
             $testScriptPath = Join-Path -Path $TestDrive -ChildPath "test.ps1"
             Set-Content -Path $testScriptPath -Value $testScript
             $e = { & $testScriptPath } | Should -Throw -ErrorId "UnexpectedToken" -PassThru
-            $e | Out-String | Should -Match $testScriptPath
+            $e | Out-String | Should -BeLike "*$testScriptPath*"
         }
 
         It "Remote errors show up correctly" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add new `ConciseView` as Experimental Feature.  When this ExperimentalFeature is enabled, it defaults to `ConciseView`, otherwise, it defaults to `NormalView`.  `CategoryView` is still supported.
With new `ConciseView`, if the error is not from a script or parser error, then it's a single line error message.  Otherwise, you get a multiline error message that isn't all red showing the script file (if available), line
that contains the error and a pointer and error message showing where the error is in that line.  If the terminal doesn't support Virtual Terminal, then vt100 color codes are not used.  The error message within the line display will wrap at whitespace making it easier to read.

A new `$Host.PrivateData.ErrorAccentColor` member is added so users can customize the color.  `$ErrorView` is now of type `[System.Management.Automation.ErrorView]` instead of a string.

Some cleanup to the formatting script with regards to double double quotes vs single quotes where appropriate.  Also changed the PositionMessage when truncating to use unicode ellipsis instead of 3 dots.

![Imgur](https://i.imgur.com/86gABZH.png)

## PR Context

Implement $ErrorView part of https://github.com/PowerShell/PowerShell-RFC/pull/228

Fix https://github.com/PowerShell/PowerShell/issues/3647

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [x] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [x] Experimental feature name(s): PSErrorView
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [X] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/4851
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
