### PR TITLE
Remove [ValidateNotNullOrEmpty] from -InputObject on Get-Random to allow empty string

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommand.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerShell.Commands
 
         private const string RandomNumberParameterSet = "RandomNumberParameterSet";
         private const string RandomListItemParameterSet = "RandomListItemParameterSet";
-        private readonly static object[] _nullInArray = new object[] { null };
+        private static readonly object[] _nullInArray = new object[] { null };
 
         private enum MyParameterSet
         {
@@ -492,9 +492,11 @@ namespace Microsoft.PowerShell.Commands
         {
             if (EffectiveParameterSet == MyParameterSet.RandomListItem)
             {
-                foreach (object item in InputObject ?? _nullInArray) // this allows for $null to be in an array passed to InputObject
+                // this allows for $null to be in an array passed to InputObject
+                foreach (object item in InputObject ?? _nullInArray)
                 {
-                    if (_numberOfProcessedListItems < Count) // (3)
+                    // (3)
+                    if (_numberOfProcessedListItems < Count)
                     {
                         Debug.Assert(_chosenListItems.Count == _numberOfProcessedListItems, "Initial K elements should all be included in chosenListItems");
                         _chosenListItems.Add(item);
@@ -502,9 +504,12 @@ namespace Microsoft.PowerShell.Commands
                     else
                     {
                         Debug.Assert(_chosenListItems.Count == Count, "After processing K initial elements, the length of chosenItems should stay equal to K");
-                        if (Generator.Next(_numberOfProcessedListItems + 1) < Count) // (1)
+
+                        // (1)
+                        if (Generator.Next(_numberOfProcessedListItems + 1) < Count)
                         {
-                            int indexToReplace = Generator.Next(_chosenListItems.Count); // (2)
+                            // (2)
+                            int indexToReplace = Generator.Next(_chosenListItems.Count);
                             _chosenListItems[indexToReplace] = item;
                         }
                     }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommand.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerShell.Commands
 
         private const string RandomNumberParameterSet = "RandomNumberParameterSet";
         private const string RandomListItemParameterSet = "RandomListItemParameterSet";
-        private static object[] _nullInArray = new object[] { null };
+        private readonly static object[] _nullInArray = new object[] { null };
 
         private enum MyParameterSet
         {
@@ -492,7 +492,7 @@ namespace Microsoft.PowerShell.Commands
         {
             if (EffectiveParameterSet == MyParameterSet.RandomListItem)
             {
-                foreach (object item in InputObject ?? _nullInArray)
+                foreach (object item in InputObject ?? _nullInArray) // this allows for $null to be in an array passed to InputObject
                 {
                     if (_numberOfProcessedListItems < Count) // (3)
                     {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommand.cs
@@ -28,6 +28,7 @@ namespace Microsoft.PowerShell.Commands
 
         private const string RandomNumberParameterSet = "RandomNumberParameterSet";
         private const string RandomListItemParameterSet = "RandomListItemParameterSet";
+        private static object[] _nullInArray = new object[] { null };
 
         private enum MyParameterSet
         {
@@ -275,6 +276,7 @@ namespace Microsoft.PowerShell.Commands
         /// List from which random elements are chosen.
         /// </summary>
         [Parameter(ParameterSetName = RandomListItemParameterSet, ValueFromPipeline = true, Position = 0, Mandatory = true)]
+        [System.Management.Automation.AllowNull]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public object[] InputObject { get; set; }
 
@@ -490,7 +492,7 @@ namespace Microsoft.PowerShell.Commands
         {
             if (EffectiveParameterSet == MyParameterSet.RandomListItem)
             {
-                foreach (object item in InputObject)
+                foreach (object item in InputObject ?? _nullInArray)
                 {
                     if (_numberOfProcessedListItems < Count) // (3)
                     {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommand.cs
@@ -275,7 +275,6 @@ namespace Microsoft.PowerShell.Commands
         /// List from which random elements are chosen.
         /// </summary>
         [Parameter(ParameterSetName = RandomListItemParameterSet, ValueFromPipeline = true, Position = 0, Mandatory = true)]
-        [ValidateNotNullOrEmpty]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public object[] InputObject { get; set; }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Random.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Random.Tests.ps1
@@ -182,4 +182,10 @@ Describe "Get-Random" -Tags "CI" {
     It "Should throw an error because the hexadecimal number is to large " {
         { Get-Random 0x07FFFFFFFFFFFFFFFF } | Should -Throw "Value was either too large or too small for a UInt32"
     }
+
+    It "Should accept collection containing empty string for -InputObject" {
+        1..10 | ForEach-Object {
+            Get-Random -InputObject @('a','b','') | Should -BeIn 'a','b',''
+        }
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Random.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Random.Tests.ps1
@@ -188,4 +188,10 @@ Describe "Get-Random" -Tags "CI" {
             Get-Random -InputObject @('a','b','') | Should -BeIn 'a','b',''
         }
     }
+
+    It "Should accept `$null in collection for -InputObject" {
+        1..10 | ForEach-Object {
+            Get-Random -InputObject @('a','b',$null) | Should -BeIn 'a','b',$null
+        }
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

`Get-Random` has `[ValidateNotNullOrEmpty]` attribute on `InputObject` parameter which limits a collection from having an empty string.  However, if you use the default positional parameter `Maximum` it doesn't have this restriction.  This creates confusion to users as they expect these two to be equivalent:

```powershell
Get-Random @('a','') # this already worked
Get-Random -InputObject @('a','')
```

Although it's not obvious that this is two different parameter sets.  However, there's no reason to restrict `InputObject` parameter here.  Since it's mandatory, you can't give it `$null` only. 

This change also allows `$null` in the collection:

```powershell
Get-Random @('a',$null) # this already worked
Get-Random -InputObject @(`a`,$null)
```

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/3682

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/4859
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
