### PR TITLE
Enable tab completion for variable assignment that is enum

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -1139,6 +1139,7 @@ namespace System.Management.Automation
             out List<CompletionResult> completions)
         {
             completions = null;
+
             // Try to get the variable from the assignment, plus any type constraint on it
             Type typeConstraint = null;
             ValidateSetAttribute setConstraint = null;
@@ -1198,11 +1199,11 @@ namespace System.Management.Automation
 
         private List<CompletionResult> GetResultForSet(
             Type type,
-            IList<string> ValidValues,
+            IList<string> validValues,
             CompletionContext completionContext)
         {
             var allValues = new List<string>();
-            foreach (string value in ValidValues)
+            foreach (string value in validValues)
             {
                 if (type == typeof(string) || type.IsEnum)
                 {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -1111,7 +1111,7 @@ namespace System.Management.Automation
 
             PSVariable variable = completionContext.ExecutionContext.EngineSessionState.GetVariable(variableName);
 
-            if (variable?.Attributes == null || variable.Attributes.Count == 0)
+            if (variable.Attributes.Count == 0)
             {
                 return false;
             }
@@ -1256,18 +1256,8 @@ namespace System.Management.Automation
                 stringToComplete = completionContext.TokenAtCursor.Text;
             }
 
-            var quote = "'";
-            if (stringToComplete.StartsWith('"'))
-            {
-                quote = "\"";
-            }
-
-            if (quote != string.Empty)
-            {
-                return quote + value + quote;
-            }
-
-            return value;
+            var quote = stringToComplete.StartsWith('"') ? "\"" : "'";
+            return quote + value + quote;
         }
 
         private List<CompletionResult> GetResultForEnum(

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -1062,7 +1062,7 @@ namespace System.Management.Automation
             Type type,
             CompletionContext completionContext)
         {
-            var stringToComplete = "";
+            var stringToComplete = string.Empty;
             if (completionContext.TokenAtCursor != null)
             {
                 stringToComplete = completionContext.TokenAtCursor.Text;
@@ -1080,18 +1080,6 @@ namespace System.Management.Automation
                 allValues.Add(quote + value.ToString() + quote);
             }
 
-//            replacementLength = completionContext.ReplacementLength = stringToComplete.Length;
-
-//            if (completionContext.TokenAtCursor is StringToken)
-//            {
-//                replacementIndex = completionContext.TokenAtCursor.Extent.StartOffset + 1;
-//            }
-//            else
-//            {
-//                replacementIndex = completionContext.CursorPosition.Offset - replacementLength;
-//            }
-
- //           completionContext.ReplacementIndex = replacementIndex;
             string matchString = stringToComplete + "*";
             var wildcardPattern = WildcardPattern.Get(matchString, WildcardOptions.IgnoreCase | WildcardOptions.CultureInvariant);
 

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -1133,7 +1133,7 @@ namespace System.Management.Automation
             return typeConstraint != null || setConstraint != null;
         }
 
-        private bool TryGetCompletionsForVariableAssignment(
+        private static bool TryGetCompletionsForVariableAssignment(
             CompletionContext completionContext,
             AssignmentStatementAst assignmentAst,
             out List<CompletionResult> completions)
@@ -1197,7 +1197,7 @@ namespace System.Management.Automation
             }
         }
 
-        private List<CompletionResult> GetResultForSet(
+        private static List<CompletionResult> GetResultForSet(
             Type type,
             IList<string> validValues,
             CompletionContext completionContext)
@@ -1260,7 +1260,7 @@ namespace System.Management.Automation
             return quote + value + quote;
         }
 
-        private List<CompletionResult> GetResultForEnum(
+        private static List<CompletionResult> GetResultForEnum(
             Type type,
             CompletionContext completionContext)
         {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -1100,7 +1100,7 @@ namespace System.Management.Automation
         }
 
         // Gets any type constraints or validateset constraints on a given variable
-        private bool TryGetTypeConstraintOnVariable(
+        private static bool TryGetTypeConstraintOnVariable(
             CompletionContext completionContext,
             string variableName,
             out Type typeConstraint,
@@ -1218,7 +1218,7 @@ namespace System.Management.Automation
             return GetMatchedResults(allValues, completionContext);
         }
 
-        private List<CompletionResult> GetMatchedResults(
+        private static List<CompletionResult> GetMatchedResults(
             List<string> allValues,
             CompletionContext completionContext)
         {
@@ -1246,7 +1246,7 @@ namespace System.Management.Automation
             return result;
         }
 
-        private string GetQuotedString(
+        private static string GetQuotedString(
             string value,
             CompletionContext completionContext)
         {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -1080,6 +1080,7 @@ namespace System.Management.Automation
                 allValues.Add(quote + value.ToString() + quote);
             }
 
+            allValues.Sort();
             string matchString = stringToComplete + "*";
             var wildcardPattern = WildcardPattern.Get(matchString, WildcardOptions.IgnoreCase | WildcardOptions.CultureInvariant);
 

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -424,6 +424,7 @@ namespace System.Management.Automation
                         if (lastAst.Parent is CommandExpressionAst
                             && lastAst.Parent.Parent is AssignmentStatementAst assignmentAst)
                         {
+                            // Handle scenarios like '$ErrorActionPreference = '<tab>'
                             if (TryGetCompletionsForVariableAssignment(completionContext, assignmentAst, out List<CompletionResult> completions))
                             {
                                 return completions;
@@ -518,6 +519,7 @@ namespace System.Management.Automation
                         else if (lastAst.Parent is CommandExpressionAst
                             && lastAst.Parent.Parent is AssignmentStatementAst assignmentAst2)
                         {
+                            // Handle scenarios like '[ValidateSet(1,2)][int]$i = 2; $i = <tab>'
                             if (TryGetCompletionsForVariableAssignment(completionContext, assignmentAst2, out List<CompletionResult> completions))
                             {
                                 result = completions;
@@ -586,6 +588,8 @@ namespace System.Management.Automation
                             {
                                 completionContext.ReplacementIndex = replacementIndex += tokenAtCursor.Text.Length;
                                 completionContext.ReplacementLength = replacementLength = 0;
+
+                                // Handle scenarios like '$ErrorActionPreference =<tab>'
                                 if (TryGetCompletionsForVariableAssignment(completionContext, assignmentAst2, out List<CompletionResult> completions))
                                 {
                                     return completions;
@@ -761,6 +765,7 @@ namespace System.Management.Automation
                                     {
                                         if (lastAst is AssignmentStatementAst assignmentAst && assignmentAst.Left is VariableExpressionAst variableAst)
                                         {
+                                            // Handle scenarios like '$ErrorActionPreference = <tab>'
                                             if (TryGetCompletionsForVariableAssignment(completionContext, assignmentAst, out result))
                                             {
                                                 break;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add code to CompletionAnalysis class to detect if completion is for variable assignment and the variable is an enum.  Then use helper GetResultForEnum() to return appropriate results matching string to complete.  Enum strings are always quoted and will match initial single or double quote.  Needed to have similar code in 3 places to handle:

```powershell
$ErrorActionPreference = <tab>
$ErrorActionPreference = '<tab> # in this case, it's a string completion
$ErrorActionPreference=<tab>
```

Although it's not in this gif, the results are sorted by enum name alphabetically.

![img](https://i.imgur.com/XeyOtK6.gif)

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/10631

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
