### PR TITLE
Add limit check in Get-WinEvent

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Diagnostics/GetEventCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/GetEventCommand.cs
@@ -963,6 +963,14 @@ namespace Microsoft.PowerShell.Commands
 
                 case "GetLogSet":
                     {
+                        const int WindowsEventLogAPILimit = 256;
+                        if (_logNamesMatchingWildcard.Count > WindowsEventLogAPILimit)
+                        {
+                            string msg = _resourceMgr.GetString("LogCountLimitExceeded");
+                            Exception exc = new Exception(string.Format(CultureInfo.InvariantCulture, msg, _logNamesMatchingWildcard.Count, WindowsEventLogAPILimit));
+                            ThrowTerminatingError(new ErrorRecord(exc, "LogCountLimitExceeded", ErrorCategory.LimitsExceeded, null));
+                        }
+
                         result.Append(queryListOpen);
                         uint queryId = 0;
                         foreach (string log in _logNamesMatchingWildcard)

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/resources/GetEventResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/resources/GetEventResources.resx
@@ -282,5 +282,7 @@ The defined template is following:
   <data name="Counter1FileLimit" xml:space="preserve">
     <value>You cannot import more than one comma-separated (.csv) or tab-separated (.tsv) performance counter file in each command.</value>
   </data>
-
+  <data name="LogCountLimitExceeded" xml:space="preserve">
+    <value>Log count ({0}) is exceeded Windows Event Log API limit ({1}). Adjust filter to return less log names.</value>
+  </data>
 </root>

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-WinEvent.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-WinEvent.Tests.ps1
@@ -51,6 +51,9 @@ Describe 'Get-WinEvent' -Tags "CI" {
             $results = get-winevent -logname $providerForTests.LogLinks.LogName -MaxEvents 10
             $results | Should -Not -BeNullOrEmpty
         }
+        It 'Throw if count of lognames exceeds Windows API limit' -Skip:([System.Environment]::OSVersion.Version.Major -lt 10) {
+            { get-winevent -logname * } | Should -Throw -ErrorId "LogCountLimitExceeded,Microsoft.PowerShell.Commands.GetWinEventCommand"
+        }
         It 'Get-WinEvent can use the simplest of filters' {
             $filter = @{ ProviderName = $providerForTests.Name }
             $testEvents = Get-WinEvent -filterhashtable $filter

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-WinEvent.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-WinEvent.Tests.ps1
@@ -51,8 +51,10 @@ Describe 'Get-WinEvent' -Tags "CI" {
             $results = get-winevent -logname $providerForTests.LogLinks.LogName -MaxEvents 10
             $results | Should -Not -BeNullOrEmpty
         }
-        It 'Throw if count of lognames exceeds Windows API limit' -Skip:([System.Environment]::OSVersion.Version.Major -lt 10) {
-            { get-winevent -logname * } | Should -Throw -ErrorId "LogCountLimitExceeded,Microsoft.PowerShell.Commands.GetWinEventCommand"
+        It 'Throw if count of lognames exceeds Windows API limit' {
+            if ([System.Environment]::OSVersion.Version.Major -ge 10) {
+                { get-winevent -logname * } | Should -Throw -ErrorId "LogCountLimitExceeded,Microsoft.PowerShell.Commands.GetWinEventCommand"
+            }
         }
         It 'Get-WinEvent can use the simplest of filters' {
             $filter = @{ ProviderName = $providerForTests.Name }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #10637

Add check and terminating throw if filter returns logs more 256.

Error message after the change:
```powershell
Get-WinEvent : Log count (441) is exceeded Windows Event Log API limit (256). Adjust filter to return less log names.
At line:1 char:1
+ Get-WinEvent
+ ~~~~~~~~~~~~
+ CategoryInfo          : LimitsExceeded: (:) [Get-WinEvent], Exception
+ FullyQualifiedErrorId : LogCountLimitExceeded,Microsoft.PowerShell.Commands.GetWinEventCommand
```


## PR Context

ReadEvent() returns the error if our query contains number of logs more then 256.
I did not find that 256 limit is documented. Nevertheless, we can verify that the filter returns more 256 log names and issue an appropriate message.
The design was ok for Windows XP with 3 logs, it worked on Windows 7 with 183 logs but now Windows 10 has over 400 logs and the query is no longer even executed (with exception "Invalid data").

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
