### PR TITLE
Add back newline for grouping with `Format-Table` and `-Property`

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/Certificate_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/Certificate_format_ps1xml.cs
@@ -11,10 +11,9 @@ namespace System.Management.Automation.Runspaces
         {
             var SignatureTypes_GroupingFormat = CustomControl.Create()
                     .StartEntry()
-                        .StartFrame(leftIndent: 4)
+                        .StartFrame()
                             .AddText(FileSystemProviderStrings.DirectoryDisplayGrouping)
                             .AddScriptBlockExpressionBinding(@"split-path $_.Path")
-                            .AddNewline()
                         .EndFrame()
                     .EndEntry()
                 .EndControl();

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/FileSystem_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/FileSystem_format_ps1xml.cs
@@ -11,12 +11,11 @@ namespace System.Management.Automation.Runspaces
         {
             var FileSystemTypes_GroupingFormat = CustomControl.Create()
                     .StartEntry()
-                        .StartFrame(leftIndent: 4)
+                        .StartFrame()
                             .AddText(FileSystemProviderStrings.DirectoryDisplayGrouping)
                             .AddScriptBlockExpressionBinding(@"
                                                   $_.PSParentPath.Replace(""Microsoft.PowerShell.Core\FileSystem::"", """")
                                               ")
-                            .AddNewline()
                         .EndFrame()
                     .EndEntry()
                 .EndControl();

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -11,10 +11,9 @@ namespace System.Management.Automation.Runspaces
         {
             var AvailableModules_GroupingFormat = CustomControl.Create()
                     .StartEntry()
-                        .StartFrame(leftIndent: 4)
+                        .StartFrame()
                             .AddText(FileSystemProviderStrings.DirectoryDisplayGrouping)
                             .AddScriptBlockExpressionBinding(@"Split-Path -Parent $_.Path | ForEach-Object { if([Version]::TryParse((Split-Path $_ -Leaf), [ref]$null)) { Split-Path -Parent $_} else {$_} } | Split-Path -Parent")
-                            .AddNewline()
                         .EndFrame()
                     .EndEntry()
                 .EndControl();

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/Registry_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/Registry_format_ps1xml.cs
@@ -11,10 +11,9 @@ namespace System.Management.Automation.Runspaces
         {
             var Registry_GroupingFormat = CustomControl.Create()
                     .StartEntry()
-                        .StartFrame(leftIndent: 4)
-                            .AddText("Hive: ")
+                        .StartFrame()
+                            .AddText("    Hive: ")
                             .AddScriptBlockExpressionBinding(@"$_.PSParentPath.Replace(""Microsoft.PowerShell.Core\Registry::"", """")")
-                            .AddNewline()
                         .EndFrame()
                     .EndEntry()
                 .EndControl();

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -481,6 +481,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 ComplexWriter writer = new ComplexWriter();
                 writer.Initialize(_lo, _lo.ColumnNumber);
                 writer.WriteObject(goc.Data.groupingEntry.formatValueList);
+                _lo.WriteLine(string.Empty);
             }
 
             goc.GroupStart();

--- a/src/System.Management.Automation/resources/FileSystemProviderStrings.resx
+++ b/src/System.Management.Automation/resources/FileSystemProviderStrings.resx
@@ -253,7 +253,7 @@
     <value>Cannot process the file because the file {0} was not found.</value>
   </data>
   <data name="DirectoryDisplayGrouping" xml:space="preserve">
-    <value>Directory: </value>
+    <value>    Directory: </value>
   </data>
   <data name="ReadBackward_Encoding_NotSupport" xml:space="preserve">
     <value>Cannot detect the encoding of the file. The specified encoding {0} is not supported when the content is read in reverse.</value>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Custom.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Custom.Tests.ps1
@@ -399,6 +399,7 @@ Describe "Format-Custom with expression based EntrySelectedBy in a CustomControl
 
 
 Entry selected by property
+
 Name
 ----
 testing
@@ -425,6 +426,7 @@ testing
 
 
 Entry selected by ScriptBlock
+
 Name
 ----
 SelectScriptBlock


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

When using `Format-Table` explicitly with `-Property` and `-Grouping`, it was missing a newline between the group and the content.  Fix is to add back a newline after writing the grouping information.  Also changed the default formatting of cert, registry, and files so that when there is grouping, it doesn't insert an extra newline (resulting in two).  Because of the way formatting works, needed to remove use of the indent param and simply insert the indention into the resx string.

Before this change:
![img](https://i.imgur.com/Ocari1H.png)

After this change:
![img](https://i.imgur.com/kgjfy9p.png)

`dir` with default table formatting is the same, but the changes were needed to keep them the same.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/9299

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
