### PR TITLE
Improve cache for match, split, replace operators and WildcardPattern

### DIFF
--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -1354,7 +1354,6 @@ namespace System.Management.Automation
         /// <returns>New cached Regex.</returns>
         internal static Regex NewRegex(string patternString, RegexOptions options)
         {
-
             var cache = options.HasFlag(RegexOptions.IgnoreCase) ? s_regexIgnoreCaseCache : s_regexCache;
 
             return GetOrAddRegexCache(cache, patternString, options);
@@ -1384,10 +1383,10 @@ namespace System.Management.Automation
         }
 
         // The 's_regexIgnoreCaseCache' cache will work poorly with 'StringComparer.Ordinal' for a scenario with IgnoreCase
-        /// if there are many equal patterns in different cases but it is very edge case:
-        /// 'abc','abC','aBc','Abc' | ? { $text -match $_ }
-        private readonly static Dictionary<string, Regex> s_regexIgnoreCaseCache = new Dictionary<string, Regex>(StringComparer.Ordinal);
-        private readonly static Dictionary<string, Regex> s_regexCache = new Dictionary<string, Regex>(StringComparer.Ordinal);
+        // if there are many equal patterns in different cases but it is very edge case:
+        // 'abc','abC','aBc','Abc' | ? { $text -match $_ }
+        private static readonly Dictionary<string, Regex> s_regexIgnoreCaseCache = new Dictionary<string, Regex>(StringComparer.Ordinal);
+        private static readonly Dictionary<string, Regex> s_regexCache = new Dictionary<string, Regex>(StringComparer.Ordinal);
         private const int MaxRegexCache = 1000;
 
         /// <summary>

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -1368,8 +1368,7 @@ namespace System.Management.Automation
                             subordinateRegexCache.Clear();
                         }
 
-                        Regex re = new Regex(patternString, options);
-                        return re;
+                        return new Regex(patternString, options);
                 });
             }
         }

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -1360,16 +1360,14 @@ namespace System.Management.Automation
             }
             else
             {
-                return subordinateRegexCache.GetOrAdd(patternString, key =>
+                if (subordinateRegexCache.Count > MaxRegexCache)
                 {
-                        if (subordinateRegexCache.Count > MaxRegexCache)
-                        {
-                            // TODO: it would be useful to get a notice (in telemetry?) if the cache is full.
-                            subordinateRegexCache.Clear();
-                        }
+                    // TODO: it would be useful to get a notice (in telemetry?) if the cache is full.
+                    subordinateRegexCache.Clear();
+                }
 
-                        return new Regex(patternString, options);
-                });
+                var regex = new Regex(patternString, options);
+                return subordinateRegexCache.GetOrAdd(patternString, regex);
             }
         }
 

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -1376,8 +1376,10 @@ namespace System.Management.Automation
 
         private static readonly ConcurrentDictionary<RegexOptions, ConcurrentDictionary<string, Regex>> s_regexCache =
             new ConcurrentDictionary<RegexOptions, ConcurrentDictionary<string, Regex>>();
+
         private static readonly Func<RegexOptions, ConcurrentDictionary<string, Regex>> s_subordinateRegexCacheCreationDelegate =
             key => new ConcurrentDictionary<string, Regex>(StringComparer.Ordinal);
+
         private const int MaxRegexCache = 1000;
 
         /// <summary>

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -1364,7 +1364,7 @@ namespace System.Management.Automation
                 {
                         if (subordinateRegexCache.Count > MaxRegexCache)
                         {
-                            // TODO: it would be usefull to get a notice (in telemetry?) if the cache is full.
+                            // TODO: it would be useful to get a notice (in telemetry?) if the cache is full.
                             subordinateRegexCache.Clear();
                         }
 

--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -909,7 +909,7 @@ namespace System.Management.Automation
             WildcardPatternParser.Parse(wildcardPattern, parser);
             try
             {
-                return new Regex(parser._regexPattern.ToString(), parser._regexOptions);
+                return ParserOps.NewRegex(parser._regexPattern.ToString(), parser._regexOptions);
             }
             catch (ArgumentException)
             {
@@ -1258,7 +1258,7 @@ namespace System.Management.Automation
             protected override void EndBracketExpression()
             {
                 _bracketExpressionBuilder.Append(']');
-                Regex regex = new Regex(_bracketExpressionBuilder.ToString(), _regexOptions);
+                Regex regex = ParserOps.NewRegex(_bracketExpressionBuilder.ToString(), _regexOptions);
                 _patternElements.Add(new BracketExpressionElement(regex));
             }
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #8941

- Add new cache for case-sensitive Regex-s
- Use StringComparer.Ordinal in the cache (that will slightly speed up and reduce allocations)
- Use the cache in regex.cs (that will slightly speed up cmdlets)
- Make the cache two-level to take in account all regex option combinations.

## PR Context

Before the change we cached only case-insensitive Regex-s (with RegexOptions.IgnoreCase).

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
