### PR TITLE
Add -Delimiter to ConvertFrom-StringData

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertFrom-StringData.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertFrom-StringData.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Management.Automation;
 using System.Collections;
+using System.Management.Automation;
 using System.Text.RegularExpressions;
 
 namespace Microsoft.PowerShell.Commands
@@ -30,10 +30,25 @@ namespace Microsoft.PowerShell.Commands
             {
                 return _stringData;
             }
+
             set
             {
                 _stringData = value;
             }
+        }
+
+        private string _Delimiter;
+
+        /// <summary>
+        /// The delimiter to index from to create the object
+        /// </summary>
+        /// <value></value>
+        [Parameter(Position = 1)]
+        public string Delimiter
+        {
+
+            get{}
+            set{}
         }
 
         /// <summary>
@@ -42,7 +57,7 @@ namespace Microsoft.PowerShell.Commands
         {
             Hashtable result = new Hashtable(StringComparer.OrdinalIgnoreCase);
 
-            if (String.IsNullOrEmpty(_stringData))
+            if (string.IsNullOrEmpty(_stringData))
             {
                 WriteObject(result);
                 return;
@@ -54,10 +69,10 @@ namespace Microsoft.PowerShell.Commands
             {
                 string s = line.Trim();
 
-                if (String.IsNullOrEmpty(s) || s[0] == '#')
+                if (string.IsNullOrEmpty(s) || s[0] == '#')
                     continue;
 
-                int index = s.IndexOf('=');
+                int index = s.IndexOf(Delimiter);
                 if (index <= 0)
                 {
                     throw PSTraceSource.NewInvalidOperationException(

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertFrom-StringData.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertFrom-StringData.cs
@@ -37,19 +37,12 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        private string _Delimiter;
 
         /// <summary>
-        /// The delimiter to index from to create the object
+        /// Gets or sets the delimiter.
         /// </summary>
-        /// <value></value>
         [Parameter(Position = 1)]
-        public string Delimiter
-        {
-
-            get{}
-            set{}
-        }
+        public char Delimiter { get; set; } = '=';
 
         /// <summary>
         /// </summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertFrom-StringData.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertFrom-StringData.cs
@@ -37,7 +37,6 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-
         /// <summary>
         /// Gets or sets the delimiter.
         /// </summary>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-StringData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-StringData.Tests.ps1
@@ -66,7 +66,7 @@ bazz = 2
     }
 }
 
-Describe "Delimiter parameter tests" {
+Describe "Delimiter parameter tests" -Tags "CI" {
 
     $sampleData = @"
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-StringData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-StringData.Tests.ps1
@@ -91,11 +91,19 @@ a:b
     {$sampleData | ConvertFrom-StringData -Delimiter ':' }| Should -Not -Throw
     }
 
-    It "Should handle multiple delimiter types"{
-        {"A:B" | ConvertFrom-StringData -Delimiter ':' } | Should -Not -Throw
-        {"A-B" | ConvertFrom-StringData -Delimiter "-" } | Should -Not -Throw
-        {"A,B" | ConvertFrom-StringData -Delimiter "," } | Should -Not -Throw
+
+    $TestCases = @( @{ Delimiter = ':'; StringData = 'value:10'; ExpectedResult = @{ Values = 10 } },
+                    @{ Delimiter = '-'; StringData = 'a-b' ; ExpectedResult = @{ Values = 'b' } },
+                    @{ Delimiter = ','; StringData = 'c,d' ; ExpectedResult = @{ Values = 'd' } }
+    )
+
+    It 'is able to parse <StringData> with delimiter "<Delimiter>"' -TestCases $TestCases {
+        param($Delimiter, $StringData, $ExpectedResult)
+
+        $(ConvertFrom-StringData -StringData $StringData -Delimiter $Delimiter).Values | Should -Be $ExpectedResult.Values
+
     }
+
 
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-StringData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-StringData.Tests.ps1
@@ -74,6 +74,7 @@ Describe "Delimiter parameter tests" -Tags "CI" {
             @{ Delimiter = ','; StringData = 'c,d' ; ExpectedResult = @{ Values = 'd' } }
         )
     }
+
     It "Default delimiter '=' works" {
         $actualValue = ConvertFrom-StringData -StringData 'a=b'
 
@@ -85,17 +86,18 @@ Describe "Delimiter parameter tests" -Tags "CI" {
         $sampleData = @"
 a:b
 "@
-    { $sampleData | ConvertFrom-StringData -Delimiter ':' }| Should -Not -Throw
+    { $sampleData | ConvertFrom-StringData -Delimiter ':' } | Should -Not -Throw
     }
 
     It 'is able to parse <StringData> with delimiter "<Delimiter>"' -TestCases $TestCases {
         param($Delimiter, $StringData, $ExpectedResult)
 
         $Result = ConvertFrom-StringData -StringData $StringData -Delimiter $Delimiter
-        foreach ($Name in $ExpectedResult.Keys) {
-            $Result.$Name | Should -Be $ExpectedResult.$Name
-        }
 
+        foreach ($Key in $ExpectedResult.Keys) {
+            $Key | Should -BeIn $ExpectedResult.Keys
+            $Result.$Key | Should -Be $ExpectedResult.$Key
+        }
     }
 
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-StringData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-StringData.Tests.ps1
@@ -86,7 +86,7 @@ Describe "Delimiter parameter tests" -Tags "CI" {
         $sampleData = @"
 a:b
 "@
-    { $sampleData | ConvertFrom-StringData -Delimiter ':' } | Should -Not -Throw
+        { $sampleData | ConvertFrom-StringData -Delimiter ':' } | Should -Not -Throw
     }
 
     It 'is able to parse <StringData> with delimiter "<Delimiter>"' -TestCases $TestCases {
@@ -99,5 +99,4 @@ a:b
             $Result.$Key | Should -Be $ExpectedResult.$Key
         }
     }
-
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-StringData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-StringData.Tests.ps1
@@ -65,3 +65,38 @@ bazz = 2
 	$(ConvertFrom-StringData -StringData $sampleData).Values | Should -BeIn @("0","1","2")
     }
 }
+
+Describe "Delimiter parameter tests" {
+
+    $sampleData = @"
+
+a:b
+
+"@
+
+
+    It "Should return the data on the left side in the key" {
+        $actualValue = ConvertFrom-StringData -StringData 'a:b' -Delimiter ':'
+
+        $actualValue.Keys | Should -BeExactly "a"
+    }
+
+    It "Should return the data on the right side in the value" {
+        $actualValue = ConvertFrom-StringData -StringData 'a=b'
+
+        $actualValue.Values | Should -BeExactly "b"
+    }
+
+    It "Should not throw on given delimiter" {
+    {$sampleData | ConvertFrom-StringData -Delimiter ':' }| Should -Not -Throw
+    }
+
+    It "Should handle multiple delimiter types"{
+        {"A:B" | ConvertFrom-StringData -Delimiter ':' } | Should -Not -Throw
+        {"A-B" | ConvertFrom-StringData -Delimiter "-" } | Should -Not -Throw
+        {"A,B" | ConvertFrom-StringData -Delimiter "," } | Should -Not -Throw
+    }
+
+}
+
+

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-StringData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-StringData.Tests.ps1
@@ -92,15 +92,19 @@ a:b
     }
 
 
-    $TestCases = @( @{ Delimiter = ':'; StringData = 'value:10'; ExpectedResult = @{ Values = 10 } },
-                    @{ Delimiter = '-'; StringData = 'a-b' ; ExpectedResult = @{ Values = 'b' } },
-                    @{ Delimiter = ','; StringData = 'c,d' ; ExpectedResult = @{ Values = 'd' } }
+    $TestCases = @(
+        @{ Delimiter = ':'; StringData = 'value:10'; ExpectedResult = @{ Values = 10 } }
+        @{ Delimiter = '-'; StringData = 'a-b' ; ExpectedResult = @{ Values = 'b' } }
+        @{ Delimiter = ','; StringData = 'c,d' ; ExpectedResult = @{ Values = 'd' } }
     )
 
     It 'is able to parse <StringData> with delimiter "<Delimiter>"' -TestCases $TestCases {
         param($Delimiter, $StringData, $ExpectedResult)
 
-        $(ConvertFrom-StringData -StringData $StringData -Delimiter $Delimiter).Values | Should -Be $ExpectedResult.Values
+        $Result = ConvertFrom-StringData -StringData $StringData -Delimiter $Delimiter
+        foreach ($Name in $ExpectedResult.Keys) {
+            $Result.$Name | Should -Be $ExpectedResult.$Name
+        }
 
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-StringData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-StringData.Tests.ps1
@@ -67,36 +67,26 @@ bazz = 2
 }
 
 Describe "Delimiter parameter tests" -Tags "CI" {
-
-    $sampleData = @"
-
-a:b
-
-"@
-
-
-    It "Should return the data on the left side in the key" {
-        $actualValue = ConvertFrom-StringData -StringData 'a:b' -Delimiter ':'
-
-        $actualValue.Keys | Should -BeExactly "a"
+    BeforeAll  {
+        $TestCases = @(
+            @{ Delimiter = ':'; StringData = 'value:10'; ExpectedResult = @{ Values = 10 } }
+            @{ Delimiter = '-'; StringData = 'a-b' ; ExpectedResult = @{ Values = 'b' } }
+            @{ Delimiter = ','; StringData = 'c,d' ; ExpectedResult = @{ Values = 'd' } }
+        )
     }
-
-    It "Should return the data on the right side in the value" {
+    It "Default delimiter '=' works" {
         $actualValue = ConvertFrom-StringData -StringData 'a=b'
 
         $actualValue.Values | Should -BeExactly "b"
+        $actualValue.Keys | Should -BeExactly "a"
     }
 
     It "Should not throw on given delimiter" {
-    {$sampleData | ConvertFrom-StringData -Delimiter ':' }| Should -Not -Throw
+        $sampleData = @"
+a:b
+"@
+    { $sampleData | ConvertFrom-StringData -Delimiter ':' }| Should -Not -Throw
     }
-
-
-    $TestCases = @(
-        @{ Delimiter = ':'; StringData = 'value:10'; ExpectedResult = @{ Values = 10 } }
-        @{ Delimiter = '-'; StringData = 'a-b' ; ExpectedResult = @{ Values = 'b' } }
-        @{ Delimiter = ','; StringData = 'c,d' ; ExpectedResult = @{ Values = 'd' } }
-    )
 
     It 'is able to parse <StringData> with delimiter "<Delimiter>"' -TestCases $TestCases {
         param($Delimiter, $StringData, $ExpectedResult)
@@ -108,7 +98,4 @@ a:b
 
     }
 
-
 }
-
-


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR adds the ability to specify a delimiter to the ConvertFrom-StringData cmdlet

## PR Context

ConvertFrom-StringData is powerful, but not very discoverable. This addition eases usability of the cmdlet to work with many string formats easily.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/4864
- **Testing - New and feature**
    - [] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
