### PR TITLE
Replace Ambiguous language for tests from switch to parameter for accuracy

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
@@ -12,13 +12,13 @@ Describe "Remove-Item" -Tags "CI" {
 
 	}
 
-	It "Should be able to be called on a regular file without error using the Path argument" {
+	It "Should be able to be called on a regular file without error using the Path parameter" {
 	    { Remove-Item -Path $testfilepath } | Should -Not -Throw
 
 	    Test-Path $testfilepath | Should -BeFalse
 	}
 
-	It "Should be able to be called on a file without the Path argument" {
+	It "Should be able to be called on a file without the Path parameter" {
 	    { Remove-Item $testfilepath } | Should -Not -Throw
 
 	    Test-Path $testfilepath | Should -BeFalse
@@ -65,7 +65,7 @@ Describe "Remove-Item" -Tags "CI" {
 	    Test-Path $testfilepath | Should -BeFalse
 	}
 
-	It "Should be able to remove all files matching a regular expression with the include argument" {
+	It "Should be able to remove all files matching a regular expression with the include parameter" {
 	    # Create multiple files with specific string
 	    New-Item -Name file1.txt -Path $testpath -ItemType "file" -Value "lorem ipsum"
 	    New-Item -Name file2.txt -Path $testpath -ItemType "file" -Value "lorem ipsum"
@@ -86,7 +86,7 @@ Describe "Remove-Item" -Tags "CI" {
 	    Test-Path $testfilepath  | Should -BeFalse
 	}
 
-	It "Should be able to not remove any files matching a regular expression with the exclude argument" {
+	It "Should be able to not remove any files matching a regular expression with the exclude parameter" {
 	    # Create multiple files with specific string
 	    New-Item -Name file1.wav -Path $testpath -ItemType "file" -Value "lorem ipsum"
 	    New-Item -Name file2.wav -Path $testpath -ItemType "file" -Value "lorem ipsum"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
@@ -12,13 +12,13 @@ Describe "Remove-Item" -Tags "CI" {
 
 	}
 
-	It "Should be able to be called on a regular file without error using the Path switch" {
+	It "Should be able to be called on a regular file without error using the Path argument" {
 	    { Remove-Item -Path $testfilepath } | Should -Not -Throw
 
 	    Test-Path $testfilepath | Should -BeFalse
 	}
 
-	It "Should be able to be called on a file without the Path switch" {
+	It "Should be able to be called on a file without the Path argument" {
 	    { Remove-Item $testfilepath } | Should -Not -Throw
 
 	    Test-Path $testfilepath | Should -BeFalse
@@ -65,7 +65,7 @@ Describe "Remove-Item" -Tags "CI" {
 	    Test-Path $testfilepath | Should -BeFalse
 	}
 
-	It "Should be able to remove all files matching a regular expression with the include switch" {
+	It "Should be able to remove all files matching a regular expression with the include argument" {
 	    # Create multiple files with specific string
 	    New-Item -Name file1.txt -Path $testpath -ItemType "file" -Value "lorem ipsum"
 	    New-Item -Name file2.txt -Path $testpath -ItemType "file" -Value "lorem ipsum"
@@ -86,7 +86,7 @@ Describe "Remove-Item" -Tags "CI" {
 	    Test-Path $testfilepath  | Should -BeFalse
 	}
 
-	It "Should be able to not remove any files matching a regular expression with the exclude switch" {
+	It "Should be able to not remove any files matching a regular expression with the exclude argument" {
 	    # Create multiple files with specific string
 	    New-Item -Name file1.wav -Path $testpath -ItemType "file" -Value "lorem ipsum"
 	    New-Item -Name file2.wav -Path $testpath -ItemType "file" -Value "lorem ipsum"


### PR DESCRIPTION
# PR Summary

Replace Ambiguous language for pester tests.
Pester tests for Remove-Item used incorrect terminology using switch analogous with Parameter

## PR Context

Modify incorrect terminology, to use `parameter` instead of `switch`.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [x] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
