### PR TITLE
Set current working directory of each ForEach-Object -Parallel running script to the same location as the calling script.

### DIFF
--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -375,6 +375,7 @@ namespace Microsoft.PowerShell.Commands
         private PSTaskJob _taskJob;
         private PSDataCollection<System.Management.Automation.PSTasks.PSTask> _taskCollection;
         private Exception _taskCollectionException;
+        private string _currentLocationPath;
 
         private void InitParallelParameterSet()
         {
@@ -392,6 +393,13 @@ namespace Microsoft.PowerShell.Commands
                             ErrorCategory.NotImplemented,
                             this));
             }
+
+            // Get the current working directory location, if available.
+            try
+            {
+                _currentLocationPath = SessionState.Internal.CurrentLocation.Path;
+            }
+            catch (PSInvalidOperationException) { }
 
             bool allowUsingExpression = this.Context.SessionState.LanguageMode != PSLanguageMode.NoLanguage;
             _usingValuesMap = ScriptBlockToPowerShellConverter.GetUsingValuesAsDictionary(
@@ -529,7 +537,7 @@ namespace Microsoft.PowerShell.Commands
                     Parallel,
                     _usingValuesMap,
                     InputObject,
-                    SessionState.Internal.CurrentLocation);
+                    _currentLocationPath);
 
                 _taskJob.AddJob(taskChildJob);
 
@@ -551,7 +559,7 @@ namespace Microsoft.PowerShell.Commands
                             Parallel,
                             _usingValuesMap,
                             InputObject,
-                            SessionState.Internal.CurrentLocation,
+                            _currentLocationPath,
                             _taskDataStreamWriter));
                 }
                 catch (InvalidOperationException)

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -415,7 +415,7 @@ namespace Microsoft.PowerShell.Commands
                             this));
                 }
             }
-
+            
             if (AsJob)
             {
                 // Set up for returning a job object.
@@ -486,10 +486,10 @@ namespace Microsoft.PowerShell.Commands
                         }
                         catch (Exception ex)
                         {
-                            // Close the _taskCollection on an unexpected exception so the pool closes and
-                            // lets any running tasks complete.
                             _taskCollection.Complete();
                             _taskCollectionException = ex;
+                            _taskDataStreamWriter.Close();
+                            
                             break;
                         }
 
@@ -528,7 +528,8 @@ namespace Microsoft.PowerShell.Commands
                 var taskChildJob = new PSTaskChildJob(
                     Parallel,
                     _usingValuesMap,
-                    InputObject);
+                    InputObject,
+                    SessionState.Internal.CurrentLocation);
 
                 _taskJob.AddJob(taskChildJob);
 
@@ -550,6 +551,7 @@ namespace Microsoft.PowerShell.Commands
                             Parallel,
                             _usingValuesMap,
                             InputObject,
+                            SessionState.Internal.CurrentLocation,
                             _taskDataStreamWriter));
                 }
                 catch (InvalidOperationException)

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -399,7 +399,9 @@ namespace Microsoft.PowerShell.Commands
             {
                 _currentLocationPath = SessionState.Internal.CurrentLocation.Path;
             }
-            catch (PSInvalidOperationException) { }
+            catch (PSInvalidOperationException) 
+            {
+            }
 
             bool allowUsingExpression = this.Context.SessionState.LanguageMode != PSLanguageMode.NoLanguage;
             _usingValuesMap = ScriptBlockToPowerShellConverter.GetUsingValuesAsDictionary(

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -415,7 +415,7 @@ namespace Microsoft.PowerShell.Commands
                             this));
                 }
             }
-            
+
             if (AsJob)
             {
                 // Set up for returning a job object.

--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -438,7 +438,7 @@ namespace System.Management.Automation.PSTasks
             _runspace.Name = string.Format(CultureInfo.InvariantCulture, "{0}:{1}", RunspaceName, s_taskId);
             _runspace.Open();
 
-            // Set current working directory on the runspace to be the same as the calling script.
+            // If available, set current working directory on the runspace.
             // Temporarily set the newly created runspace as the thread default runspace for any needed module loading.
             if (_currentLocationPath != null)
             {

--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -35,16 +35,19 @@ namespace System.Management.Automation.PSTasks
         /// <param name="scriptBlock">Script block to run in task.</param>
         /// <param name="usingValuesMap">Using values passed into script block.</param>
         /// <param name="dollarUnderbar">Dollar underbar variable value.</param>
+        /// <param name="currentLocation">Current working directory.</param>
         /// <param name="dataStreamWriter">Cmdlet data stream writer.</param>
         public PSTask(
             ScriptBlock scriptBlock,
             Dictionary<string, object> usingValuesMap,
             object dollarUnderbar,
+            PathInfo currentLocation,
             PSTaskDataStreamWriter dataStreamWriter)
             : base(
                 scriptBlock,
                 usingValuesMap,
-                dollarUnderbar)
+                dollarUnderbar,
+                currentLocation)
         {
             _dataStreamWriter = dataStreamWriter;
         }
@@ -176,15 +179,18 @@ namespace System.Management.Automation.PSTasks
         /// <param name="scriptBlock">Script block to run.</param>
         /// <param name="usingValuesMap">Using variable values passed to script block.</param>
         /// <param name="dollarUnderbar">Dollar underbar variable value for script block.</param>
+        /// <param name="currentLocation">Current working directory.</param>
         /// <param name="job">Job object associated with task.</param>
         public PSJobTask(
             ScriptBlock scriptBlock,
             Dictionary<string, object> usingValuesMap,
             object dollarUnderbar,
+            PathInfo currentLocation,
             Job job) : base(
                 scriptBlock,
                 usingValuesMap,
-                dollarUnderbar)
+                dollarUnderbar,
+                currentLocation)
         {
             _job = job;
         }
@@ -309,6 +315,7 @@ namespace System.Management.Automation.PSTasks
         private readonly Dictionary<string, object> _usingValuesMap;
         private readonly object _dollarUnderbar;
         private readonly int _id;
+        private readonly PathInfo _currentLocation;
         private Runspace _runspace;
         protected PowerShell _powershell;
         protected PSDataCollection<PSObject> _output;
@@ -372,14 +379,17 @@ namespace System.Management.Automation.PSTasks
         /// <param name="scriptBlock">Script block to run.</param>
         /// <param name="usingValuesMap">Using variable values passed to script block.</param>
         /// <param name="dollarUnderbar">Dollar underbar variable value.</param>
+        /// <param name="currentLocation">Current working directory.</param>
         protected PSTaskBase(
             ScriptBlock scriptBlock,
             Dictionary<string, object> usingValuesMap,
-            object dollarUnderbar) : this()
+            object dollarUnderbar,
+            PathInfo currentLocation) : this()
         {
             _scriptBlockToRun = scriptBlock;
             _usingValuesMap = usingValuesMap;
             _dollarUnderbar = dollarUnderbar;
+            _currentLocation = currentLocation;
         }
 
         #endregion
@@ -427,6 +437,20 @@ namespace System.Management.Automation.PSTasks
             _runspace = RunspaceFactory.CreateRunspace(iss);
             _runspace.Name = string.Format(CultureInfo.InvariantCulture, "{0}:{1}", RunspaceName, s_taskId);
             _runspace.Open();
+            Runspace.DefaultRunspace = _runspace;
+
+            // Set current working directory on the runspace to be the same as the calling script.
+            // Temporarily set the newly created runspace as the thread default runspace for any needed module loading.
+            var oldDefaultRunspace = Runspace.DefaultRunspace;
+            try
+            {
+                Runspace.DefaultRunspace = _runspace;
+                _runspace.ExecutionContext.SessionState.Internal.SetLocation(_currentLocation.Path);
+            }
+            finally
+            {
+                Runspace.DefaultRunspace = oldDefaultRunspace;
+            }
 
             // Create the PowerShell command pipeline for the provided script block
             // The script will run on the provided Runspace in a new thread by default
@@ -1216,15 +1240,17 @@ namespace System.Management.Automation.PSTasks
         /// <param name="scriptBlock">Script block to run.</param>
         /// <param name="usingValuesMap">Using variable values passed to script block.</param>
         /// <param name="dollarUnderbar">Dollar underbar variable value.</param>
+        /// <param name="currentLocation">Current working directory.</param>
         public PSTaskChildJob(
             ScriptBlock scriptBlock,
             Dictionary<string, object> usingValuesMap,
-            object dollarUnderbar)
+            object dollarUnderbar,
+            PathInfo currentLocation)
             : base(scriptBlock.ToString(), string.Empty)
 
         {
             PSJobTypeName = nameof(PSTaskChildJob);
-            _task = new PSJobTask(scriptBlock, usingValuesMap, dollarUnderbar, this);
+            _task = new PSJobTask(scriptBlock, usingValuesMap, dollarUnderbar, currentLocation, this);
             _task.StateChanged += (sender, args) => HandleTaskStateChange(sender, args);
         }
 

--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -437,7 +437,6 @@ namespace System.Management.Automation.PSTasks
             _runspace = RunspaceFactory.CreateRunspace(iss);
             _runspace.Name = string.Format(CultureInfo.InvariantCulture, "{0}:{1}", RunspaceName, s_taskId);
             _runspace.Open();
-            Runspace.DefaultRunspace = _runspace;
 
             // Set current working directory on the runspace to be the same as the calling script.
             // Temporarily set the newly created runspace as the thread default runspace for any needed module loading.

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
@@ -115,6 +115,11 @@ Describe 'ForEach-Object -Parallel Basic Tests' -Tags 'CI' {
         $results = 1..1 | ForEach-Object -Parallel { $ExecutionContext.SessionState.LanguageMode }
         $results | Should -BeExactly 'FullLanguage'
     }
+
+    It 'Verifies that the current working directory is preserved' {
+        $parallelScriptLocation = 1..1 | ForEach-Object -Parallel { $pwd }
+        $parallelScriptLocation.Path | Should -BeExactly $pwd.Path
+    }
 }
 
 Describe 'ForEach-Object -Parallel common parameters' -Tags 'CI' {
@@ -343,6 +348,13 @@ Describe 'ForEach-Object -Parallel -AsJob Basic Tests' -Tags 'CI' {
         $job.Command | Should -BeExactly '"Hello"'
         $job.ChildJobs[0].Command | Should -BeExactly '"Hello"'
         $job | Wait-Job | Remove-Job
+    }
+
+    It 'Verifies that the current working directory is preserved' {
+        $job = 1..1 | ForEach-Object -AsJob -Parallel { $pwd }
+        $parallelScriptLocation = $job | Wait-Job | Receive-Job
+        $job | Remove-Job
+        $parallelScriptLocation.Path | Should -BeExactly $pwd.Path
     }
 }
 


### PR DESCRIPTION
# PR Summary

This changes fixes issue, #10537.  It sets each parallel running script block context to have the same working directory location as the calling script.

## PR Context

Previously, parallel running script blocks would use the default PowerShell working directory, similar to remoting and job execution.  But ForEach-Object -Parallel should run all script in the same working directory as the calling script, to make it consistent with ForEach-Object while running in normal (non-parallel) mode.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
