### PR TITLE
Add support for \\wsl$\ubuntu path

### DIFF
--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1267,7 +1267,7 @@ namespace System.Management.Automation
             }
 
             // handle special cases like \\wsl$\ubuntu which isn't a UNC path, but we can say it is so the filesystemprovider can use it
-            if (path.StartsWith(@"\\wsl$"))
+            if (path.StartsWith(@"\\wsl$", StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1260,7 +1260,7 @@ namespace System.Management.Automation
 #if UNIX
             return false;
 #else
-            if (!path.StartsWith('\\'))
+            if (string.IsNullOrEmpty(path) || !path.StartsWith('\\'))
             {
                 return false;
             }
@@ -1272,7 +1272,7 @@ namespace System.Management.Automation
             }
 
             Uri uri;
-            return !string.IsNullOrEmpty(path) && Uri.TryCreate(path, UriKind.Absolute, out uri) && uri.IsUnc;
+            return Uri.TryCreate(path, UriKind.Absolute, out uri) && uri.IsUnc;
 #endif
         }
 

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1256,8 +1256,6 @@ namespace System.Management.Automation
             return false;
         }
 
-        private static readonly Regex _specialDriveRegex = new Regex(@"^\\\\\w+\$");
-
         internal static bool PathIsUnc(string path)
         {
 #if UNIX
@@ -1269,7 +1267,7 @@ namespace System.Management.Automation
             }
 
             // handle special cases like \\wsl$\ubuntu which isn't a UNC path, but we can say it is so the filesystemprovider can use it
-            if (_specialDriveRegex.IsMatch(path))
+            if (path.StartsWith(@"\\wsl$"))
             {
                 return true;
             }

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -25,7 +25,6 @@ using System.Security;
 using System.Security.Principal;
 #endif
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 using Microsoft.PowerShell.Commands;
 using Microsoft.Win32;

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1258,7 +1258,6 @@ namespace System.Management.Automation
 
         private static readonly Regex _specialDriveRegex = new Regex(@"^\\\\\w+\$");
 
-
         internal static bool PathIsUnc(string path)
         {
 #if UNIX


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

WSL2 introduces a new filesystem path to access the Linux filesystem from Windows.  Depending on the distro name, it would look like `\\wsl$\ubuntu`.  The problem is that this is not a valid UNC path so it gets rejected outright.
Fix is to check for this type of path and pass it off as a UNC path so that the filesystemprovider accepts it as a valid filesystem path.  The .NET APIs handle this just fine once it makes it that far into the code.

Manually validated `dir \\wsl$\ubuntu` and `cd \\wsl$\ubuntu; dir`

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/10360

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
