### PR TITLE
Support notification on `pwsh` startup when a new release is available

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -1019,10 +1019,13 @@ namespace Microsoft.PowerShell
             {
                 DisplayBanner();
 
+                var sw = Stopwatch.StartNew();
                 if (UpdatesNotification.CanNotifyUpdates)
                 {
                     UpdatesNotification.ShowUpdateNotification(_hostUI);
                 }
+                sw.Stop();
+                Console.WriteLine("Time-to-print: {0}", sw.ElapsedMilliseconds);
             }
 
             Dbg.Assert(

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -1019,13 +1019,10 @@ namespace Microsoft.PowerShell
             {
                 DisplayBanner();
 
-                var sw = Stopwatch.StartNew();
                 if (UpdatesNotification.CanNotifyUpdates)
                 {
                     UpdatesNotification.ShowUpdateNotification(_hostUI);
                 }
-                sw.Stop();
-                Console.WriteLine("Time-to-print: {0}", sw.ElapsedMilliseconds);
             }
 
             Dbg.Assert(

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -1018,6 +1018,11 @@ namespace Microsoft.PowerShell
             if (_showBanner && !_showHelp)
             {
                 DisplayBanner();
+
+                if (UpdatesNotification.CanNotifyUpdates)
+                {
+                    UpdatesNotification.ShowUpdateNotification(_hostUI);
+                }
             }
 
             Dbg.Assert(

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -234,9 +234,13 @@ namespace Microsoft.PowerShell
 
                     if (s_theConsoleHost.LoadPSReadline())
                     {
-                        // Start a task in the background to check for the update release.
-                        _ = UpdatesNotification.CheckForUpdates();
                         ProfileOptimization.StartProfile("StartupProfileData-Interactive");
+
+                        if (UpdatesNotification.CanNotifyUpdates)
+                        {
+                            // Start a task in the background to check for the update release.
+                            _ = UpdatesNotification.CheckForUpdates();
+                        }
                     }
                     else
                     {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -157,7 +157,7 @@ namespace Microsoft.PowerShell
                     hostException = e;
                 }
 
-                var hostUi = s_theConsoleHost?.UI ?? new NullHostUserInterface();
+                PSHostUserInterface hostUi = s_theConsoleHost?.UI ?? new NullHostUserInterface();
                 s_cpp = new CommandLineParameterParser(hostUi, bannerText, helpText);
                 s_cpp.Parse(args);
 
@@ -248,7 +248,7 @@ namespace Microsoft.PowerShell
                     }
 
                     s_theConsoleHost.BindBreakHandler();
-                    IsStdOutputRedirected = Console.IsOutputRedirected;
+                    PSHost.IsStdOutputRedirected = Console.IsOutputRedirected;
 
                     // Send startup telemetry for ConsoleHost startup
                     ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("Normal");

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -61,8 +61,6 @@ namespace Microsoft.PowerShell
         [return: MarshalAs(UnmanagedType.Bool)]
         private static extern bool SystemParametersInfo(uint uiAction, uint uiParam, ref bool pvParam, uint fWinIni);
 
-        // NTRAID#Windows Out Of Band Releases-915506-2005/09/09
-        // Removed HandleUnexpectedExceptions infrastructure
         /// <summary>
         /// Internal Entry point in msh console host implementation.
         /// </summary>
@@ -78,8 +76,8 @@ namespace Microsoft.PowerShell
         /// <returns>
         /// The exit code for the shell.
         ///
-        /// NTRAID#Windows OS Bugs-1036968-2005/01/20-sburns The behavior here is related to monitor work.  The low word of the
-        /// exit code is available for the user.  The high word is reserved for the shell and monitor.
+        /// The behavior here is related to monitor work.
+        /// The low word of the exit code is available for the user.  The high word is reserved for the shell and monitor.
         ///
         /// The shell process needs to return:
         ///
@@ -98,13 +96,10 @@ namespace Microsoft.PowerShell
         /// or 0xFFFE0000 (user hit ctrl-break), the monitor should restart the shell.exe. Otherwise, the monitor should exit
         /// with the same exit code as the shell.exe.
         ///
-        /// Anyone checking the exit code of the shell or monitor can mask off the hiword to determine the exit code passed
+        /// Anyone checking the exit code of the shell or monitor can mask off the high word to determine the exit code passed
         /// by the script that the shell last executed.
         /// </returns>
-        internal static int Start(
-            string bannerText,
-            string helpText,
-            string[] args)
+        internal static int Start(string bannerText, string helpText, string[] args)
         {
 #if DEBUG
             if (Environment.GetEnvironmentVariable("POWERSHELL_DEBUG_STARTUP") != null)
@@ -162,10 +157,8 @@ namespace Microsoft.PowerShell
                     hostException = e;
                 }
 
-                s_cpp = new CommandLineParameterParser(
-                    (s_theConsoleHost != null) ? s_theConsoleHost.UI : new NullHostUserInterface(),
-                    bannerText, helpText);
-
+                var hostUi = s_theConsoleHost?.UI ?? new NullHostUserInterface();
+                s_cpp = new CommandLineParameterParser(hostUi, bannerText, helpText);
                 s_cpp.Parse(args);
 
 #if UNIX
@@ -239,13 +232,19 @@ namespace Microsoft.PowerShell
                         throw hostException;
                     }
 
-                    ProfileOptimization.StartProfile(
-                        s_theConsoleHost.LoadPSReadline()
-                            ? "StartupProfileData-Interactive"
-                            : "StartupProfileData-NonInteractive");
+                    if (s_theConsoleHost.LoadPSReadline())
+                    {
+                        // Start a task in the background to check for the update release.
+                        _ = UpdatesNotification.CheckForUpdates();
+                        ProfileOptimization.StartProfile("StartupProfileData-Interactive");
+                    }
+                    else
+                    {
+                        ProfileOptimization.StartProfile("StartupProfileData-NonInteractive");
+                    }
 
                     s_theConsoleHost.BindBreakHandler();
-                    PSHost.IsStdOutputRedirected = Console.IsOutputRedirected;
+                    IsStdOutputRedirected = Console.IsOutputRedirected;
 
                     // Send startup telemetry for ConsoleHost startup
                     ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("Normal");
@@ -1532,7 +1531,7 @@ namespace Microsoft.PowerShell
             // Don't load PSReadline if:
             //   * we don't think the process will be interactive, e.g. -command or -file
             //     - exception: when -noexit is specified, we will be interactive after the command/file finishes
-            //   * -noninteractive: this should be obvious, they've asked that we don't every prompt
+            //   * -noninteractive: this should be obvious, they've asked that we don't ever prompt
             //
             // Note that PSReadline doesn't support redirected stdin/stdout, but we don't check that here because
             // a future version might, and we should automatically load it at that unknown point in the future.

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/UpdatesNotification.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/UpdatesNotification.cs
@@ -1,0 +1,376 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Management.Automation;
+using System.Management.Automation.Host;
+using System.Threading.Tasks;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
+
+namespace Microsoft.PowerShell
+{
+    /// <summary>
+    /// A Helper class for printing notification on PowerShell startup when there is a new update.
+    /// </summary>
+    internal static class UpdatesNotification
+    {
+        private const string UpdateCheckOptOutEnvVar = "POWERSHELL_UPDATECHECK_OPTOUT";
+        private const string Last4ReleasesUri = "https://api.github.com/repos/PowerShell/PowerShell/releases?per_page=3";
+        private const string LatestReleaseUri = "https://api.github.com/repos/PowerShell/PowerShell/releases/latest";
+        private const string ReleasePageUri = "https://github.com/PowerShell/PowerShell/releases/tag/v{0}";
+
+        private const string SentinelFileName = "_sentinel_";
+        private const string DoneFileNameTemplate = "sentinel-{0}-{1}-{2}.done";
+        private const string DoneFileNamePattern = "sentinel-*.done";
+        private const string UpdateFileNameTemplate = "update_{0}_{1}";
+        private const string UpdateFileNamePattern = "update_v*.*.*_????-??-??";
+
+        private readonly static EnumerationOptions s_enumOptions = new EnumerationOptions();
+        private readonly static string s_cacheDirectory = Path.Combine(Platform.CacheDirectory, PSVersionInfo.GitCommitId);
+
+        // A few things to think about:
+        //   - it might look better if we write out notification with yellow background color and black foreground color,
+        //     but padding is expensive and not reliable (console width may change)
+        //   - maybe we shouldn't do update check and show notification when it's from a mini-shell, meaning when
+        //     'ConsoleShell.Start' is not called by 'ManagedEntrance.Start'
+
+        internal static void ShowUpdateNotification(PSHostUserInterface hostUI)
+        {
+            if (!Directory.Exists(s_cacheDirectory))
+            {
+                return;
+            }
+
+            if (TryParseUpdateFile(
+                    out bool noFileFound,
+                    updateFilePath: out _,
+                    out SemanticVersion lastUpdateVersion,
+                    lastUpdateDate: out _) && !noFileFound)
+            {
+                string releaseTag = lastUpdateVersion.ToString();
+                string releaseUri = string.Format(CultureInfo.InvariantCulture, ReleasePageUri, releaseTag);
+
+                string notificationMsgTemplate = string.IsNullOrEmpty(lastUpdateVersion.PreReleaseLabel)
+                    ? ManagedEntranceStrings.OfficialUpdateNotificationMsg1
+                    : ManagedEntranceStrings.PreviewUpdateNotificationMsg1;
+                string notificationMsg1 = string.Format(CultureInfo.InvariantCulture, notificationMsgTemplate, releaseTag);
+                string notificationMsg2 = ManagedEntranceStrings.UpdateNotificationMsg2;
+
+                int maxLength = GetMaxLength(notificationMsg1, notificationMsg2, releaseUri);
+                notificationMsg1 = Padding(notificationMsg1, maxLength);
+                notificationMsg2 = Padding(notificationMsg2, maxLength);
+                releaseUri = Padding(releaseUri, maxLength);
+
+                hostUI.WriteLine(ConsoleColor.Black, ConsoleColor.Yellow, notificationMsg1);
+                hostUI.WriteLine(ConsoleColor.Black, ConsoleColor.Yellow, notificationMsg2);
+                hostUI.WriteLine(ConsoleColor.Black, ConsoleColor.Yellow, releaseUri);
+                hostUI.WriteLine();
+            }
+
+            int GetMaxLength(string a, string b, string c)
+            {
+                int maxLength = a.Length;
+
+                if (maxLength < b.Length)
+                {
+                    maxLength = b.Length;
+                }
+
+                if (maxLength < c.Length)
+                {
+                    maxLength = c.Length;
+                }
+
+                return maxLength;
+            }
+
+            string Padding(string str, int length)
+            {
+                if (str.Length == length)
+                {
+                    return str;
+                }
+
+                Span<char> buffer = stackalloc char[length];
+                buffer.Fill(' ');
+                str.AsSpan().CopyTo(buffer);
+                return buffer.ToString();
+            }
+        }
+
+        internal static async Task CheckForUpdates()
+        {
+            // Delay the update check for 3 seconds so that it has the minimal impact on startup.
+            await Task.Delay(3000);
+
+            // A self-built pwsh for development purpose has the SHA1 commit hash baked in 'GitCommitId',
+            // which is 40 characters long. So we can quickly check the length of 'GitCommitId' to tell
+            // if this is a self-built pwsh, and skip the update check if so.
+            if (PSVersionInfo.GitCommitId.Length > 40)
+            {
+                return;
+            }
+
+            // If the update check is opt out, then skip the rest of the check.
+            if (Utils.GetOptOutEnvVariableAsBool(UpdateCheckOptOutEnvVar, defaultValue: false))
+            {
+                return;
+            }
+
+            // Create the update cache directory if it hasn't exists
+            if (!Directory.Exists(s_cacheDirectory))
+            {
+                Directory.CreateDirectory(s_cacheDirectory);
+            }
+
+            DateTime today = DateTime.UtcNow;
+
+            if (TryParseUpdateFile(
+                    out bool noFileFound,
+                    updateFilePath: out _,
+                    lastUpdateVersion: out _,
+                    out DateTime lastUpdateDate))
+            {
+                if (!noFileFound && (today - lastUpdateDate).TotalDays < 7)
+                {
+                    // There is an existing update file, and the last update was release less than a week.
+                    // It's unlikely a new version is release within a week, so we can skip this check.
+                    return;
+                }
+            }
+
+            // Construct the sentinel file paths for today's check.
+            string todayDoneFileName = string.Format(
+                CultureInfo.InvariantCulture,
+                DoneFileNameTemplate,
+                today.Year.ToString(),
+                today.Month.ToString(),
+                today.Day.ToString());
+
+            string sentinelFilePath = Path.Combine(s_cacheDirectory, SentinelFileName);
+            string todayDoneFilePath = Path.Combine(s_cacheDirectory, todayDoneFileName);
+
+            if (File.Exists(todayDoneFilePath))
+            {
+                // A successful update check has been done today.
+                // We can skip this update check.
+                return;
+            }
+
+            try
+            {
+                // Use 'sentinelFilePath' as the file lock.
+                // The update check tasks started by every 'pwsh' process will compete on holding this file.
+                using (FileStream s = new FileStream(sentinelFilePath, FileMode.Create, FileAccess.Write, FileShare.None))
+                {
+                    if (File.Exists(todayDoneFilePath))
+                    {
+                        // After acquiring the file lock, it turns out a successful check has already been done for today.
+                        // Then let's skip this update check.
+                        return;
+                    }
+
+                    // Now it's guaranteed that I'm the only process that reaches here.
+                    // Clean up the old '.done' file, there should be only one of it.
+                    foreach (string oldFile in Directory.EnumerateFiles(s_cacheDirectory, DoneFileNamePattern, s_enumOptions))
+                    {
+                        File.Delete(oldFile);
+                    }
+
+                    if (!TryParseUpdateFile(
+                            noFileFound: out _,
+                            out string updateFilePath,
+                            out SemanticVersion lastUpdateVersion,
+                            lastUpdateDate: out _))
+                    {
+                        // The update file is corrupted, either because more than one update files were found unexpectedly,
+                        // or because the update file name is not in the valid format.
+                        // This is **very unlikely** to happen unless the file is altered manually accidentally.
+                        // We try to recover here by cleaning up all update files.
+                        foreach (string file in Directory.EnumerateFiles(s_cacheDirectory, UpdateFileNamePattern, s_enumOptions))
+                        {
+                            File.Delete(file);
+                        }
+                    }
+
+                    // Do the real update check:
+                    //  - Send HTTP request to query for the new release/pre-release;
+                    //  - If there is a valid new release that should be reported to the user,
+                    //    create the file `update_<tag>_<publish-date>` when no `update` file exists,
+                    //    or rename the existing file to `update_<new-version>_<new-publish-date>`.
+                    SemanticVersion baselineVersion = lastUpdateVersion ?? PSVersionInfo.PSV6Version;
+                    Release release = await QueryNewReleaseAsync(baselineVersion);
+
+                    if (release != null)
+                    {
+                        string newUpdateFileName = string.Format(
+                            CultureInfo.InvariantCulture,
+                            UpdateFileNameTemplate,
+                            release.TagName,
+                            release.PublishAt.Substring(0, 10));
+
+                        string newUpdateFilePath = Path.Combine(s_cacheDirectory, newUpdateFileName);
+
+                        if (updateFilePath == null)
+                        {
+                            new FileStream(newUpdateFilePath, FileMode.CreateNew, FileAccess.Write, FileShare.None).Close();
+                        }
+                        else
+                        {
+                            File.Move(updateFilePath, newUpdateFilePath);
+                        }
+                    }
+
+                    // Finally, create the `todayDoneFilePath` file as an indicator that a successful update check has finished today.
+                    new FileStream(todayDoneFilePath, FileMode.CreateNew, FileAccess.Write, FileShare.None).Close();
+                }
+            }
+            catch (Exception)
+            {
+                // An update check initiated from another `pwsh` process is in progress.
+                // It's OK to just return and let that update check to finish the work.
+            }
+        }
+
+        private static bool TryParseUpdateFile(
+            out bool noFileFound,
+            out string updateFilePath,
+            out SemanticVersion lastUpdateVersion,
+            out DateTime lastUpdateDate)
+        {
+            noFileFound = false;
+            updateFilePath = null;
+            lastUpdateVersion = null;
+            lastUpdateDate = DateTime.MinValue;
+
+            var files = Directory.EnumerateFiles(s_cacheDirectory, UpdateFileNamePattern, s_enumOptions);
+            var enumerator = files.GetEnumerator();
+
+            if (!enumerator.MoveNext())
+            {
+                // No file was found that matches the pattern, but it's OK that an update file doesn't exist.
+                // This could happen when there is no new updates yet.
+                noFileFound = true;
+                return true;
+            }
+
+            updateFilePath = enumerator.Current;
+            if (enumerator.MoveNext())
+            {
+                // More than 1 files were found that match the pattern. This is a corrupted state. 
+                // Theoretically, there should be only one update file at any point of time.
+                updateFilePath = null;
+                return false;
+            }
+
+            // OK, only found one update file, which is expected.
+            // Now let's parse the file name.
+            string updateFileName = Path.GetFileName(updateFilePath);
+            int dateStartIndex = updateFileName.LastIndexOf('_') + 1;
+
+            bool success = DateTime.TryParse(
+                updateFileName.AsSpan().Slice(dateStartIndex),
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out lastUpdateDate);
+
+            if (success)
+            {
+                int versionStartIndex = updateFileName.IndexOf('_') + 2;
+                int versionLength = dateStartIndex - versionStartIndex - 1;
+                string versionString = updateFileName.Substring(versionStartIndex, versionLength);
+                success = SemanticVersion.TryParse(versionString, out lastUpdateVersion);
+            }
+
+            if (!success)
+            {
+                updateFilePath = null;
+                lastUpdateVersion = null;
+                lastUpdateDate = DateTime.MinValue;
+            }
+
+            return success;
+        }
+
+        private static async Task<Release> QueryNewReleaseAsync(SemanticVersion baselineVersion)
+        {
+            bool noPreRelease = string.IsNullOrEmpty(PSVersionInfo.PSV6Version.PreReleaseLabel);
+            string queryUri = noPreRelease ? LatestReleaseUri : Last4ReleasesUri;
+
+            using (HttpClient client = new HttpClient())
+            {
+                string userAgent = string.Format(CultureInfo.InvariantCulture, "PowerShell {0}", PSVersionInfo.GitCommitId);
+                client.DefaultRequestHeaders.Add("User-Agent", userAgent);
+                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+                var response = await client.GetAsync(queryUri);
+                response.EnsureSuccessStatusCode();
+
+                using (var stream = await response.Content.ReadAsStreamAsync())
+                using (var reader = new StreamReader(stream))
+                using (JsonReader jsonReader = new JsonTextReader(reader))
+                {
+                    Release releaseToReturn = null;
+                    var settings = new JsonSerializerSettings() { DateParseHandling = DateParseHandling.None };
+                    var serializer = JsonSerializer.Create(settings);
+
+                    if (noPreRelease)
+                    {
+                        var release = serializer.Deserialize<JObject>(jsonReader);
+                        var tagName = release["tag_name"].ToString();
+                        var version = SemanticVersion.Parse(tagName.Substring(1));
+
+                        if (version > baselineVersion)
+                        {
+                            var publishAt = release["published_at"].ToString();
+                            releaseToReturn = new Release(publishAt, tagName);
+                        }
+                    }
+                    else
+                    {
+                        var last4Releases = serializer.Deserialize<JArray>(jsonReader);
+                        var highestVersion = baselineVersion;
+
+                        for (int i=0; i < last4Releases.Count; i++)
+                        {
+                            var release = last4Releases[i];
+                            var tagName = release["tag_name"].ToString();
+                            var version = SemanticVersion.Parse(tagName.Substring(1));
+
+                            if (version > highestVersion)
+                            {
+                                highestVersion = version;
+                                var publishAt = release["published_at"].ToString();
+                                releaseToReturn = new Release(publishAt, tagName);
+                            }
+                        }
+                    }
+
+                    return releaseToReturn;
+                }
+            }
+        }
+
+        private class Release
+        {
+            internal Release(string publishAt, string tagName)
+            {
+                PublishAt = publishAt;
+                TagName = tagName;
+            }
+
+            // The datetime stamp is in UTC: 2019-03-28T18:42:02Z
+            internal string PublishAt { get; }
+            internal string TagName { get; }
+        }
+    }
+}

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/UpdatesNotification.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/UpdatesNotification.cs
@@ -229,28 +229,28 @@ namespace Microsoft.PowerShell
             string updateFileName = Path.GetFileName(updateFilePath);
             int dateStartIndex = updateFileName.LastIndexOf('_') + 1;
 
-            bool success = DateTime.TryParse(
-                updateFileName.AsSpan().Slice(dateStartIndex),
-                CultureInfo.InvariantCulture,
-                DateTimeStyles.AssumeLocal,
-                out lastUpdateDate);
-
-            if (success)
-            {
-                int versionStartIndex = updateFileName.IndexOf('_') + 2;
-                int versionLength = dateStartIndex - versionStartIndex - 1;
-                string versionString = updateFileName.Substring(versionStartIndex, versionLength);
-                success = SemanticVersion.TryParse(versionString, out lastUpdateVersion);
-            }
-
-            if (!success)
+            if (!DateTime.TryParse(
+                    updateFileName.AsSpan().Slice(dateStartIndex),
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeLocal,
+                    out lastUpdateDate))
             {
                 updateFilePath = null;
-                lastUpdateVersion = null;
-                lastUpdateDate = default;
+                return false;
             }
 
-            return success;
+            int versionStartIndex = updateFileName.IndexOf('_') + 2;
+            int versionLength = dateStartIndex - versionStartIndex - 1;
+            string versionString = updateFileName.Substring(versionStartIndex, versionLength);
+
+            if (SemanticVersion.TryParse(versionString, out lastUpdateVersion))
+            {
+                return true;
+            }
+
+            updateFilePath = null;
+            lastUpdateDate = default;
+            return false;
         }
 
         private static async Task<Release> QueryNewReleaseAsync(SemanticVersion baselineVersion)

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/UpdatesNotification.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/UpdatesNotification.cs
@@ -36,7 +36,8 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// Gets a value indicating whether update notification should be done.
         /// </summary>
-        internal static readonly bool CanNotifyUpdates = !Utils.GetOptOutEnvVariableAsBool(UpdateCheckOptOutEnvVar, defaultValue: false);
+        internal static readonly bool CanNotifyUpdates = !Utils.GetOptOutEnvVariableAsBool(UpdateCheckOptOutEnvVar, defaultValue: false)
+            && ExperimentalFeature.IsEnabled("PSUpdatesNotification");
 
         // Maybe we shouldn't do update check and show notification when it's from a mini-shell, meaning when
         // 'ConsoleShell.Start' is not called by 'ManagedEntrance.Start'.

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -127,6 +127,15 @@ Type 'help' to get help.</value>
   <data name="PSReadLineDisabledWhenScreenReaderIsActive" xml:space="preserve">
     <value>Warning: PowerShell detected that you might be using a screen reader and has disabled PSReadLine for compatibility purposes. If you want to re-enable it, run 'Import-Module PSReadLine'.</value>
   </data>
+  <data name="PreviewUpdateNotificationMsg1" xml:space="preserve">
+    <value>A new PowerShell preview release is available: v{0}</value>
+  </data>
+  <data name="OfficialUpdateNotificationMsg1" xml:space="preserve">
+    <value>A new PowerShell release is available: v{0}</value>
+  </data>
+  <data name="UpdateNotificationMsg2" xml:space="preserve">
+    <value>Upgrade now, or check out the release page at:</value>
+  </data>
   <data name="UsageHelp" xml:space="preserve">
     <value>Usage: pwsh[.exe] [-Login] [[-File] &lt;filePath&gt; [args]]
                   [-Command { - | &lt;script-block&gt; [-args &lt;arg-array&gt;]

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -127,14 +127,17 @@ Type 'help' to get help.</value>
   <data name="PSReadLineDisabledWhenScreenReaderIsActive" xml:space="preserve">
     <value>Warning: PowerShell detected that you might be using a screen reader and has disabled PSReadLine for compatibility purposes. If you want to re-enable it, run 'Import-Module PSReadLine'.</value>
   </data>
-  <data name="PreviewUpdateNotificationMsg1" xml:space="preserve">
-    <value>A new PowerShell preview release is available: v{0}</value>
+  <data name="PreviewUpdateNotificationMessage" xml:space="preserve">
+    <value>!! A new PowerShell preview release is available: v{0} !!
+Upgrade now, or check out the release page at:
+https://github.com/PowerShell/PowerShell/releases/tag/v{0}
+</value>
   </data>
-  <data name="OfficialUpdateNotificationMsg1" xml:space="preserve">
-    <value>A new PowerShell release is available: v{0}</value>
-  </data>
-  <data name="UpdateNotificationMsg2" xml:space="preserve">
-    <value>Upgrade now, or check out the release page at:</value>
+  <data name="StableUpdateNotificationMessage" xml:space="preserve">
+    <value>!! A new PowerShell stable release is available: v{0} !!
+Upgrade now, or check out the release page at:
+https://github.com/PowerShell/PowerShell/releases/tag/v{0}
+</value>
   </data>
   <data name="UsageHelp" xml:space="preserve">
     <value>Usage: pwsh[.exe] [-Login] [[-File] &lt;filePath&gt; [args]]

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -117,7 +117,10 @@ namespace System.Management.Automation
                     description: "Support the ternary operator in PowerShell language"),
                 new ExperimentalFeature(
                     name: "PSErrorView",
-                    description: "New formatting for ErrorRecord")
+                    description: "New formatting for ErrorRecord"),
+                new ExperimentalFeature(
+                    name: "PSUpdatesNotification",
+                    description: "Print notification message when new releases are available")
             };
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);
 

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -304,6 +304,36 @@ namespace System.Management.Automation
         internal static string[] AllowedEditionValues = { "Desktop", "Core" };
 
         /// <summary>
+        /// Utility method to interpret the value of an opt-out environment variable.
+        /// e.g. POWERSHELL_TELEMETRY_OPTOUT and POWERSHELL_UPDATECHECK_OPTOUT
+        /// </summary>
+        /// <param name="name">The name of the environment variable.</param>
+        /// <param name="defaultValue">If the environment variable is not set, use this as the default value.</param>
+        /// <returns>A boolean representing the value of the environment variable.</returns>
+        internal static bool GetOptOutEnvVariableAsBool(string name, bool defaultValue)
+        {
+            string str = Environment.GetEnvironmentVariable(name);
+            if (string.IsNullOrEmpty(str))
+            {
+                return defaultValue;
+            }
+
+            switch (str.ToLowerInvariant())
+            {
+                case "true":
+                case "1":
+                case "yes":
+                    return true;
+                case "false":
+                case "0":
+                case "no":
+                    return false;
+                default:
+                    return defaultValue;
+            }
+        }
+
+        /// <summary>
         /// Helper fn to check byte[] arg for null.
         /// </summary>
         ///<param name="arg"> arg to check </param>

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -305,7 +305,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Utility method to interpret the value of an opt-out environment variable.
-        /// e.g. POWERSHELL_TELEMETRY_OPTOUT and POWERSHELL_UPDATECHECK_OPTOUT
+        /// e.g. POWERSHELL_TELEMETRY_OPTOUT and POWERSHELL_UPDATECHECK_OPTOUT.
         /// </summary>
         /// <param name="name">The name of the environment variable.</param>
         /// <param name="defaultValue">If the environment variable is not set, use this as the default value.</param>

--- a/src/System.Management.Automation/utils/Telemetry.cs
+++ b/src/System.Management.Automation/utils/Telemetry.cs
@@ -99,7 +99,7 @@ namespace Microsoft.PowerShell.Telemetry
         static ApplicationInsightsTelemetry()
         {
             // If we can't send telemetry, there's no reason to do any of this
-            CanSendTelemetry = !GetEnvironmentVariableAsBool(name: _telemetryOptoutEnvVar, defaultValue: false);
+            CanSendTelemetry = !Utils.GetOptOutEnvVariableAsBool(name: _telemetryOptoutEnvVar, defaultValue: false);
             if (CanSendTelemetry)
             {
                 s_telemetryClient = new TelemetryClient();
@@ -126,35 +126,6 @@ namespace Microsoft.PowerShell.Telemetry
                     };
 
                 s_uniqueUserIdentifier = GetUniqueIdentifier().ToString();
-            }
-        }
-
-        /// <summary>
-        /// Determine whether the environment variable is set and how.
-        /// </summary>
-        /// <param name="name">The name of the environment variable.</param>
-        /// <param name="defaultValue">If the environment variable is not set, use this as the default value.</param>
-        /// <returns>A boolean representing the value of the environment variable.</returns>
-        private static bool GetEnvironmentVariableAsBool(string name, bool defaultValue)
-        {
-            var str = Environment.GetEnvironmentVariable(name);
-            if (string.IsNullOrEmpty(str))
-            {
-                return defaultValue;
-            }
-
-            switch (str.ToLowerInvariant())
-            {
-                case "true":
-                case "1":
-                case "yes":
-                    return true;
-                case "false":
-                case "0":
-                case "no":
-                    return false;
-                default:
-                    return defaultValue;
             }
         }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

RFC: https://github.com/PowerShell/PowerShell-RFC/pull/162
Support notification on `pwsh` startup when a new release is available

- Preview `pwsh` will check both new preview and stable releases. It prints notification message at startup time as long as the latest preview version or stable version is higher than the current version.
- Stable `pwsh` will check new stable releases only. It prints notification message at startup time if the latest stable version is higher than the current version.
- Update check and notification will only happen for interactive sessions, and it can be suppressed by both the `-NoLogo` flag and an environment variable `POWERSHELL_UPDATECHECK_OPTOUT`.
- Update check is done by a task that is delayed for 3 seconds after `pwsh` starts, so it has minimum impact to the startup time.

For detailed implementation design, please look at the RFC.

## Notification Message

For stable version `pwsh`:
```none
C:\Users\user>e:\6.2.1\pwsh.exe -noprofile
PowerShell 6.2.1
Copyright (c) Microsoft Corporation. All rights reserved.

https://aka.ms/powershell
Type 'help' to get help.

!! A new PowerShell stable release is available: v6.2.3 !!
Upgrade now, or check out the release page at:
https://github.com/PowerShell/PowerShell/releases/tag/v6.2.3

PS C:\Users\user>
```

For preview version `pwsh`:
```none
C:\Users\user>e:\preview\pwsh.exe -noprofile
PowerShell 6.2.0-preview.3
Copyright (c) Microsoft Corporation. All rights reserved.

https://aka.ms/powershell
Type 'help' to get help.

!! A new PowerShell preview release is available: v7.0.0-preview.4 !!
Upgrade now, or check out the release page at:
https://github.com/PowerShell/PowerShell/releases/tag/v7.0.0-preview.4

PS C:\Users\user>
```

## Startup Perf Measurement on my dev machines

### Windows
When no new release is available, namely on the latest preview/stable `pwsh` where notification will not be printed, the update notification change adds about `4ms` to the startup time of an interactive session.
- `2ms` spent on starting the update-check task
- `2ms` spent on the notification printing logic

When a new release is available, namely on an old preview/stable `pwsh` where a notification message will be printed, the update notification change adds about `6ms` to the startup time of an interactive session.
- `2ms` spent on starting the update-check task
- `4ms` spent on the notification printing logic

As a reference, `Measure-Command { F:\pscore70.preview4\pwsh.exe -noprofile -c exit }` takes about `400ms` on average on my Windows dev machine.

### Linux (Ubuntu 16.04)
When no new release is available, namely on the latest preview/stable `pwsh` where notification will not be printed, the update notification change adds about `6ms` to the startup time of an interactive session.
- `3ms` spent on starting the update-check task
- `3ms` spent on the notification printing logic

When a new release is available, namely on an old preview/stable `pwsh` where a notification message will be printed, the update notification change adds about `9ms` to the startup time of an interactive session.
- `3ms` spent on starting the update-check task
- `6ms` spent on the notification printing logic

As a reference, `Measure-Command { pwsh-preview -noprofile -c exit }` takes about `445ms` on average on my Linux dev machine.

### macOS (10.14.6)
When no new release is available, namely on the latest preview/stable `pwsh` where notification will not be printed, the update notification change adds about `4ms` to the startup time of an interactive session.
- `2ms` spent on starting the update-check task
- `2ms` spent on the notification printing logic

When a new release is available, namely on an old preview/stable `pwsh` where a notification message will be printed, the update notification change adds about `5ms` to the startup time of an interactive session.
- `2ms` spent on starting the update-check task
- `3ms` spent on the notification printing logic

As a reference, `Measure-Command { pwsh-preview -noprofile -c exit }` takes about `316ms` on average on my macOS dev machine.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [x] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [x] Experimental feature name(s): `PSUpdatesNotification`
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/4881
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
