### PR TITLE
WIP: Add password confirmation to Get-Credential

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -66,8 +66,9 @@ namespace Microsoft.PowerShell
         /// <param name="message"></param>
         /// <param name="userName"></param>
         /// <param name="targetName"></param>
+        /// <param name="confirmPassword"></param>
         /// <returns></returns>
-        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName)
+        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName, bool confirmPassword)
         {
             throw new PSNotImplementedException();
         }
@@ -79,10 +80,11 @@ namespace Microsoft.PowerShell
         /// <param name="message"></param>
         /// <param name="userName"></param>
         /// <param name="targetName"></param>
+        /// <param name="confirmPassword"></param>
         /// <param name="allowedCredentialTypes"></param>
         /// <param name="options"></param>
         /// <returns></returns>
-        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
+        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName, bool confirmPassword, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
         {
             throw new PSNotImplementedException();
         }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfacePrompt.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfacePrompt.cs
@@ -306,7 +306,8 @@ namespace Microsoft.PowerShell
                         null,   // caption already written
                         null,   // message already written
                         null,
-                        string.Empty);
+                        string.Empty,
+                        false);
                 convertedObj = credential;
                 cancelInput = (convertedObj == null);
                 if ((credential != null) && (credential.Password.Length == 0) && listInput)

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfacePrompt.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfacePrompt.cs
@@ -307,7 +307,7 @@ namespace Microsoft.PowerShell
                         null,   // message already written
                         null,
                         string.Empty,
-                        false);
+                        confirmPassword: false);
                 convertedObj = credential;
                 cancelInput = (convertedObj == null);
                 if ((credential != null) && (credential.Password.Length == 0) && listInput)

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
@@ -177,9 +177,14 @@ namespace Microsoft.PowerShell
             finally
             {
                 if (retypedPasswordBstr != IntPtr.Zero)
+                {
                     Marshal.ZeroFreeBSTR(retypedPasswordBstr);
+                }
+                    
                 if (passwordBstr != IntPtr.Zero)
+                {
                     Marshal.ZeroFreeBSTR(passwordBstr);
+                }                 
             }
 
             if (match == 0)

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
@@ -125,6 +125,11 @@ namespace Microsoft.PowerShell
                     retypedPassword = ReadLineAsSecureString();
 
                     passwordsMatch = ComparePasswords(password, retypedPassword);
+                    if (!passwordsMatch)
+                    {
+                        WriteToConsole(StringUtil.Format(ConsoleHostUserInterfaceSecurityResources.PasswordMismatch), true);
+                        WriteLineToConsole();
+                    }
                 } while (!passwordsMatch);
             }
             else
@@ -144,7 +149,7 @@ namespace Microsoft.PowerShell
             return cred;
         }
 
-        private bool ComparePasswords(SecureString password, SecureString retypedPassword)
+        private static bool ComparePasswords(SecureString password, SecureString retypedPassword)
         {
             IntPtr passwordBstr = IntPtr.Zero;
             IntPtr retypedPasswordBstr = IntPtr.Zero;
@@ -195,8 +200,6 @@ namespace Microsoft.PowerShell
             else
             {
                 // passwords don't match
-                WriteToConsole(StringUtil.Format(ConsoleHostUserInterfaceSecurityResources.PasswordMismatch), true);
-                WriteLineToConsole();
                 return false;
             }
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
@@ -28,18 +28,21 @@ namespace Microsoft.PowerShell
         /// <param name="targetName">Name of the target for which creds are being collected.</param>
         /// <param name="message">Message to be displayed.</param>
         /// <param name="caption">Caption for the message.</param>
+        /// <param name="confirmPassword">Prompt to confirm the password.</param>
         /// <returns>PSCredential object.</returns>
 
         public override PSCredential PromptForCredential(
             string caption,
             string message,
             string userName,
-            string targetName)
+            string targetName,
+            bool confirmPassword)
         {
             return PromptForCredential(caption,
                                          message,
                                          userName,
                                          targetName,
+                                         confirmPassword,
                                          PSCredentialTypes.Default,
                                          PSCredentialUIOptions.Default);
         }
@@ -53,6 +56,7 @@ namespace Microsoft.PowerShell
         /// <param name="caption">Caption for the message.</param>
         /// <param name="allowedCredentialTypes">What type of creds can be supplied by the user.</param>
         /// <param name="options">Options that control the cred gathering UI behavior.</param>
+        /// <param name="confirmPassword">Prompt to confirm the password.</param>
         /// <returns>PSCredential object, or null if input was cancelled (or if reading from stdin and stdin at EOF).</returns>
 
         public override PSCredential PromptForCredential(
@@ -60,13 +64,16 @@ namespace Microsoft.PowerShell
             string message,
             string userName,
             string targetName,
+            bool confirmPassword,
             PSCredentialTypes allowedCredentialTypes,
             PSCredentialUIOptions options)
         {
             PSCredential cred = null;
             SecureString password = null;
+            SecureString confirmedPassword = null;
             string userPrompt = null;
             string passwordPrompt = null;
+            string confirmPasswordPrompt = null;
 
             if (!string.IsNullOrEmpty(caption))
             {
@@ -103,14 +110,40 @@ namespace Microsoft.PowerShell
             passwordPrompt = StringUtil.Format(ConsoleHostUserInterfaceSecurityResources.PromptForCredential_Password, userName
             );
 
+            // now, prompt for the password
+            //
+            //WriteToConsole(passwordPrompt, true);
+            //password = ReadLineAsSecureString();
+            //if (password == null)
+            //{
+            //    return null;
+            //}
+
+            //WriteLineToConsole();
+
+
             //
             // now, prompt for the password
             //
-            WriteToConsole(passwordPrompt, true);
-            password = ReadLineAsSecureString();
-            if (password == null)
+            if (confirmPassword)
             {
-                return null;
+                confirmPasswordPrompt = StringUtil.Format(ConsoleHostUserInterfaceSecurityResources.PromptForCredential_ConfirmPassword, userName);
+                do
+                {
+                    WriteToConsole(passwordPrompt, true);
+                    password = ReadLineAsSecureString();
+                    WriteToConsole(confirmPasswordPrompt, true);
+                    confirmedPassword = ReadLineAsSecureString();
+                } while (password != confirmedPassword);
+            }
+            else
+            {
+                WriteToConsole(passwordPrompt, true);
+                password = ReadLineAsSecureString();
+                if (password == null)
+                {
+                    return null;
+                }
             }
 
             WriteLineToConsole();

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostUserInterfaceSecurityResources.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostUserInterfaceSecurityResources.resx
@@ -123,4 +123,7 @@
   <data name="PromptForCredential_Password" xml:space="preserve">
     <value>Password for user {0}: </value>
   </data>
+  <data name="PromptForCredential_ConfirmPassword" xml:space="preserve">
+    <value>Confirm password for user {0}: </value>
+  </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostUserInterfaceSecurityResources.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostUserInterfaceSecurityResources.resx
@@ -127,6 +127,6 @@
     <value>Confirm password for user {0}: </value>
   </data>
     <data name="PasswordMismatch" xml:space="preserve">
-    <value>Passwords do not match. Enter your credentials. </value>
+    <value>Passwords do not match. Enter your credentials.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostUserInterfaceSecurityResources.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostUserInterfaceSecurityResources.resx
@@ -126,4 +126,7 @@
   <data name="PromptForCredential_ConfirmPassword" xml:space="preserve">
     <value>Confirm password for user {0}: </value>
   </data>
+    <data name="PasswordMismatch" xml:space="preserve">
+    <value>Passwords do not match. Enter your credentials. </value>
+  </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
@@ -80,14 +80,14 @@ namespace Microsoft.PowerShell.Commands
         private string _title = UtilsStrings.PromptForCredential_DefaultCaption;
         
         /// <summary>
-        /// Sets whether to confirm the password.
+        /// Gets and sets whether to confirm the password.
         /// </summary>
-        [Parameter(Mandatory = false, ParameterSetName = credentialSet)]
+        [Parameter(Mandatory = false)]
         [ValidateNotNullOrEmpty]
-        public bool ConfirmPassword
+        public SwitchParameter ConfirmPassword
         {
-            set { _confirmPassword = value; }
             get { return _confirmPassword; }
+            set { _confirmPassword = value; }
         }
 
         private bool _confirmPassword;

--- a/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
@@ -78,6 +78,19 @@ namespace Microsoft.PowerShell.Commands
         }
 
         private string _title = UtilsStrings.PromptForCredential_DefaultCaption;
+        
+        /// <summary>
+        /// Sets whether to confirm the password.
+        /// </summary>
+        [Parameter(Mandatory = false, ParameterSetName = credentialSet)]
+        [ValidateNotNullOrEmpty]
+        public bool ConfirmPassword
+        {
+            set { _confirmPassword = value; }
+            get { return _confirmPassword; }
+        }
+
+        private bool _confirmPassword;
 
         /// <summary>
         /// Initializes a new instance of the GetCredentialCommand
@@ -100,7 +113,7 @@ namespace Microsoft.PowerShell.Commands
 
             try
             {
-                Credential = this.Host.UI.PromptForCredential(_title, _message, _userName, string.Empty);
+                Credential = this.Host.UI.PromptForCredential(_title, _message, _userName, string.Empty, _confirmPassword);
             }
             catch (ArgumentException exception)
             {

--- a/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
@@ -82,7 +82,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Gets and sets whether to confirm the password.
         /// </summary>
-        [Parameter(Mandatory = false)]
+        [Parameter]
         [ValidateNotNullOrEmpty]
         public SwitchParameter ConfirmPassword
         {

--- a/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
@@ -106,7 +106,7 @@ namespace Microsoft.PowerShell.Commands
 
             try
             {
-                Credential = this.Host.UI.PromptForCredential(_title, _message, _userName, string.Empty, _confirmPassword);
+                Credential = this.Host.UI.PromptForCredential(_title, _message, _userName, string.Empty, ConfirmPassword);
             }
             catch (ArgumentException exception)
             {

--- a/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
@@ -83,7 +83,6 @@ namespace Microsoft.PowerShell.Commands
         /// Gets and sets whether to confirm the password.
         /// </summary>
         [Parameter]
-        [ValidateNotNullOrEmpty]
         public SwitchParameter ConfirmPassword
         {
             get { return _confirmPassword; }

--- a/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
@@ -89,7 +89,7 @@ namespace Microsoft.PowerShell.Commands
             set { _confirmPassword = value; }
         }
 
-        private bool _confirmPassword;
+        public SwitchParameter ConfirmPassword { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the GetCredentialCommand

--- a/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
@@ -83,12 +83,6 @@ namespace Microsoft.PowerShell.Commands
         /// Gets and sets whether to confirm the password.
         /// </summary>
         [Parameter]
-        public SwitchParameter ConfirmPassword
-        {
-            get { return _confirmPassword; }
-            set { _confirmPassword = value; }
-        }
-
         public SwitchParameter ConfirmPassword { get; set; }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -54,8 +54,8 @@ namespace System.Management.Automation.Host
         /// The characters typed by the user.
         /// </returns>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLineAsSecureString"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string)"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, bool)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, bool, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForChoice"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/>
         public abstract string ReadLine();
@@ -68,12 +68,12 @@ namespace System.Management.Automation.Host
         /// </returns>
         /// <remarks>
         /// Note that credentials (a user name and password) should be gathered with
-        /// <see cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string)"/>
-        /// <see cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
+        /// <see cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, bool)"/>
+        /// <see cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, bool, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
         /// </remarks>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLine"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string)"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, bool)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, bool, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForChoice"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/>
         public abstract SecureString ReadLineAsSecureString();
@@ -797,8 +797,8 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLine"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLineAsSecureString"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForChoice"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string)"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, bool)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, bool, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
         public abstract Dictionary<string, PSObject> Prompt(string caption, string message, Collection<FieldDescription> descriptions);
 
         /// <summary>
@@ -823,6 +823,7 @@ namespace System.Management.Automation.Host
         /// <param name="targetName">
         /// Name of the target for which the credential is being collected.
         /// </param>
+        /// <param name="confirmPassword"></param>
         /// <returns>
         /// User input credential.
         /// </returns>
@@ -830,9 +831,9 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLineAsSecureString"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForChoice"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, bool, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
         public abstract PSCredential PromptForCredential(string caption, string message,
-            string userName, string targetName
+            string userName, string targetName, bool confirmPassword
         );
 
         /// <summary>
@@ -851,6 +852,9 @@ namespace System.Management.Automation.Host
         /// <param name="targetName">
         /// Name of the target for which the credential is being collected.
         /// </param>
+        /// <param name="confirmPassword">
+        /// Confirm the password.
+        /// </param>
         /// <param name="allowedCredentialTypes">
         /// Types of credential can be supplied by the user.
         /// </param>
@@ -864,9 +868,9 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLineAsSecureString"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForChoice"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, bool)"/>
         public abstract PSCredential PromptForCredential(string caption, string message,
-            string userName, string targetName, PSCredentialTypes allowedCredentialTypes,
+            string userName, string targetName, bool confirmPassword, PSCredentialTypes allowedCredentialTypes,
             PSCredentialUIOptions options
         );
 
@@ -892,8 +896,8 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLine"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLineAsSecureString"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string)"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, bool)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, bool, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
         public abstract int PromptForChoice(string caption, string message, Collection<ChoiceDescription> choices, int defaultChoice);
 
         #endregion Dialog-oriented interaction

--- a/src/System.Management.Automation/engine/hostifaces/internalHostuserInterfacesecurity.cs
+++ b/src/System.Management.Automation/engine/hostifaces/internalHostuserInterfacesecurity.cs
@@ -22,11 +22,12 @@ namespace System.Management.Automation.Internal.Host
             string caption,
             string message,
             string userName,
-            string targetName
+            string targetName,
+            bool confirmPassword
         )
         {
             return PromptForCredential(caption, message, userName,
-                                         targetName,
+                                         targetName, confirmPassword,
                                          PSCredentialTypes.Default,
                                          PSCredentialUIOptions.Default);
         }
@@ -43,6 +44,7 @@ namespace System.Management.Automation.Internal.Host
             string message,
             string userName,
             string targetName,
+            bool confirmPassword,
             PSCredentialTypes allowedCredentialTypes,
             PSCredentialUIOptions options
         )
@@ -55,7 +57,7 @@ namespace System.Management.Automation.Internal.Host
             PSCredential result = null;
             try
             {
-                result = _externalUI.PromptForCredential(caption, message, userName, targetName, allowedCredentialTypes, options);
+                result = _externalUI.PromptForCredential(caption, message, userName, targetName, confirmPassword, allowedCredentialTypes, options);
             }
             catch (PipelineStoppedException)
             {

--- a/src/System.Management.Automation/engine/remoting/server/ServerRemoteHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRemoteHostUserInterface.cs
@@ -208,19 +208,19 @@ namespace System.Management.Automation.Remoting
         /// <summary>
         /// Prompt for credential.
         /// </summary>
-        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName)
+        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName, bool confirmPassword)
         {
             return _serverMethodExecutor.ExecuteMethod<PSCredential>(RemoteHostMethodId.PromptForCredential1,
-                    new object[] { caption, message, userName, targetName });
+                    new object[] { caption, message, userName, targetName, confirmPassword });
         }
 
         /// <summary>
         /// Prompt for credential.
         /// </summary>
-        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
+        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName, bool confirmPassword, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
         {
             return _serverMethodExecutor.ExecuteMethod<PSCredential>(RemoteHostMethodId.PromptForCredential2,
-                    new object[] { caption, message, userName, targetName, allowedCredentialTypes, options });
+                    new object[] { caption, message, userName, targetName, confirmPassword, allowedCredentialTypes, options });
         }
     }
 }

--- a/src/System.Management.Automation/security/CredentialParameter.cs
+++ b/src/System.Management.Automation/security/CredentialParameter.cs
@@ -32,6 +32,7 @@ namespace System.Management.Automation
             PSCredential cred = null;
             string userName = null;
             bool shouldPrompt = false;
+            bool confirmPassword = false;
 
             if ((engineIntrinsics == null) ||
                (engineIntrinsics.Host == null) ||
@@ -77,7 +78,8 @@ namespace System.Management.Automation
                            caption,
                            prompt,
                            userName,
-                           string.Empty);
+                           string.Empty,
+                           confirmPassword);
             }
 
             return cred;


### PR DESCRIPTION
# PR Summary

This PR adds a `-ConfirmPassword` parameter to `Get-Credential`. This helps to ensure that when entering a password, you really typed what you intended to (especially helpful with complex passwords). This only validates the text entered, and does not actually validate that the password meets any complexity requirements, nor does it actually validate it with any providers.

## PR Context

Originally logged as an enhancement request in #10625.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
