### PR TITLE
Enable nullable reference types in some base classes

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostRawUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostRawUserInterface.cs
@@ -17,6 +17,8 @@ using ConsoleHandle = Microsoft.Win32.SafeHandles.SafeFileHandle;
 using WORD = System.UInt16;
 using DWORD = System.UInt32;
 
+#nullable enable
+
 namespace Microsoft.PowerShell
 {
     /// <summary>
@@ -370,7 +372,7 @@ namespace Microsoft.PowerShell
                 }
                 catch (HostException e)
                 {
-                    Win32Exception win32exception = e.InnerException as Win32Exception;
+                    Win32Exception? win32exception = e.InnerException as Win32Exception;
                     if (win32exception != null &&
                         win32exception.NativeErrorCode == 0x57)
                     {
@@ -1321,7 +1323,7 @@ namespace Microsoft.PowerShell
 
         private ConsoleColor defaultBackground = ConsoleColor.Black;
 
-        private ConsoleHostUserInterface parent = null;
+        private ConsoleHostUserInterface parent;
 
         private ConsoleControl.KEY_EVENT_RECORD cachedKeyEvent;
 

--- a/src/System.Management.Automation/engine/SessionStateScopeAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateScopeAPIs.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 
-using Dbg = System.Management.Automation;
+#nullable enable
 
 #pragma warning disable 1634, 1691 // Stops compiler from warning about unknown warnings
 #pragma warning disable 56500
@@ -126,9 +126,9 @@ namespace System.Management.Automation
         /// If <paramref name="scopeID"/> is less than zero or greater than the number of currently
         /// active scopes.
         /// </exception>
-        internal SessionStateScope GetScopeByID(int scopeID)
+        internal SessionStateScope? GetScopeByID(int scopeID)
         {
-            SessionStateScope processingScope = _currentScope;
+            SessionStateScope processingScope = CurrentScope;
             int originalID = scopeID;
 
             while (scopeID > 0 && processingScope != null)
@@ -175,15 +175,17 @@ namespace System.Management.Automation
 
             set
             {
-                Diagnostics.Assert(
-                    value != null,
-                    "A null scope should never be set");
+                if (value == null)
+                {
+                     throw PSTraceSource.NewArgumentException(nameof(CurrentScope));
+                }
+
 #if DEBUG
                 // This code is ifdef'd for DEBUG because it may pose a significant
                 // performance hit and is only really required to validate our internal
                 // code. There is no way anyone outside the Monad codebase can cause
                 // these error conditions to be hit.
-
+                //
                 // Need to make sure the new scope is in the global scope lineage
 
                 SessionStateScope scope = value;

--- a/src/System.Management.Automation/engine/hostifaces/InternalHostRawUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/InternalHostRawUserInterface.cs
@@ -1,10 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Management.Automation.Host;
 using System.Management.Automation.Runspaces;
 
 using Dbg = System.Management.Automation.Diagnostics;
+
+#nullable enable
 
 namespace System.Management.Automation.Internal.Host
 {
@@ -19,6 +22,7 @@ namespace System.Management.Automation.Internal.Host
             _parentHost = parentHost;
         }
 
+        [DoesNotReturn]
         internal
         void
         ThrowNotInteractive()

--- a/src/System.Management.Automation/engine/hostifaces/MshHostRawUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostRawUserInterface.cs
@@ -5,6 +5,8 @@ using System.Globalization;
 
 #pragma warning disable 1634, 1691 // Stops compiler from warning about unknown warnings
 
+#nullable enable
+
 namespace System.Management.Automation.Host
 {
     #region Ancillary types.
@@ -89,7 +91,7 @@ namespace System.Management.Automation.Host
 
         public override
         bool
-        Equals(object obj)
+        Equals(object? obj)
         {
             bool result = false;
 
@@ -281,7 +283,7 @@ namespace System.Management.Automation.Host
 
         public override
         bool
-        Equals(object obj)
+        Equals(object? obj)
         {
             bool result = false;
 
@@ -615,7 +617,7 @@ namespace System.Management.Automation.Host
 
         public override
         bool
-        Equals(object obj)
+        Equals(object? obj)
         {
             bool result = false;
 
@@ -858,7 +860,7 @@ namespace System.Management.Automation.Host
 
         public override
         bool
-        Equals(object obj)
+        Equals(object? obj)
         {
             bool result = false;
 
@@ -1097,7 +1099,7 @@ namespace System.Management.Automation.Host
 
         public override
         bool
-        Equals(object obj)
+        Equals(object? obj)
         {
             bool result = false;
 

--- a/src/System.Management.Automation/engine/remoting/server/ServerRemoteHostRawUserInterface.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRemoteHostRawUserInterface.cs
@@ -4,8 +4,11 @@
 using System.Management.Automation.Host;
 
 using Dbg = System.Management.Automation.Diagnostics;
+
 // Stops compiler from warning about unknown warnings
 #pragma warning disable 1634, 1691
+
+#nullable enable
 
 namespace System.Management.Automation.Remoting
 {
@@ -40,7 +43,11 @@ namespace System.Management.Automation.Remoting
         /// </summary>
         internal ServerRemoteHostRawUserInterface(ServerRemoteHostUserInterface remoteHostUserInterface)
         {
-            Dbg.Assert(remoteHostUserInterface != null, "Expected remoteHostUserInterface != null");
+            if (remoteHostUserInterface == null)
+            {
+                throw new ArgumentNullException(nameof(remoteHostUserInterface));
+            }
+
             _remoteHostUserInterface = remoteHostUserInterface;
             Dbg.Assert(!remoteHostUserInterface.ServerRemoteHost.HostInfo.IsHostRawUINull, "Expected !remoteHostUserInterface.ServerRemoteHost.HostInfo.IsHostRawUINull");
 

--- a/src/System.Management.Automation/namespaces/CoreCommandContext.cs
+++ b/src/System.Management.Automation/namespaces/CoreCommandContext.cs
@@ -5,6 +5,8 @@ using System.Collections.ObjectModel;
 
 using Dbg = System.Management.Automation;
 
+#nullable enable
+
 namespace System.Management.Automation
 {
     /// <summary>
@@ -270,7 +272,11 @@ namespace System.Management.Automation
 
             Drive = contextToCopyFrom.Drive;
             _force = contextToCopyFrom.Force;
-            this.CopyFilters(contextToCopyFrom);
+
+            Include = contextToCopyFrom.Include;
+            Exclude = contextToCopyFrom.Exclude;
+            Filter = contextToCopyFrom.Filter;
+
             SuppressWildcardExpansion = contextToCopyFrom.SuppressWildcardExpansion;
             DynamicParameters = contextToCopyFrom.DynamicParameters;
             Origin = contextToCopyFrom.Origin;
@@ -295,7 +301,7 @@ namespace System.Management.Automation
         /// If the constructor that takes a context to copy is
         /// called, this will be set to the context being copied.
         /// </summary>
-        private CmdletProviderContext _copiedContext;
+        private CmdletProviderContext? _copiedContext;
 
         /// <summary>
         /// The credentials under which the operation should run.
@@ -313,7 +319,7 @@ namespace System.Management.Automation
         /// made visible to anyone and should only be set through the
         /// constructor.
         /// </summary>
-        private Cmdlet _command;
+        private Cmdlet? _command;
 
         /// <summary>
         /// This makes the origin of the provider request visible to the internals.
@@ -345,7 +351,7 @@ namespace System.Management.Automation
         /// <summary>
         /// The instance of the provider that is currently executing in this context.
         /// </summary>
-        private System.Management.Automation.Provider.CmdletProvider _providerInstance;
+        private System.Management.Automation.Provider.CmdletProvider? _providerInstance;
 
         #endregion private properties
 
@@ -360,7 +366,7 @@ namespace System.Management.Automation
         /// Gets or sets the provider instance for the current
         /// execution context.
         /// </summary>
-        internal System.Management.Automation.Provider.CmdletProvider ProviderInstance
+        internal System.Management.Automation.Provider.CmdletProvider? ProviderInstance
         {
             get
             {
@@ -371,24 +377,6 @@ namespace System.Management.Automation
             {
                 _providerInstance = value;
             }
-        }
-
-        /// <summary>
-        /// Copies the include, exclude, and provider filters from
-        /// the specified context to this context.
-        /// </summary>
-        /// <param name="context">
-        /// The context to copy the filters from.
-        /// </param>
-        private void CopyFilters(CmdletProviderContext context)
-        {
-            Dbg.Diagnostics.Assert(
-                context != null,
-                "The caller should have verified the context");
-
-            Include = context.Include;
-            Exclude = context.Exclude;
-            Filter = context.Filter;
         }
 
         internal void RemoveStopReferral()
@@ -405,12 +393,12 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets or sets the dynamic parameters for the context.
         /// </summary>
-        internal object DynamicParameters { get; set; }
+        internal object? DynamicParameters { get; set; }
 
         /// <summary>
         /// Returns MyInvocation from the underlying cmdlet.
         /// </summary>
-        internal InvocationInfo MyInvocation
+        internal InvocationInfo? MyInvocation
         {
             get
             {
@@ -437,7 +425,7 @@ namespace System.Management.Automation
         /// <exception cref="ArgumentNullException">
         /// If <paramref name="value"/> is null on set.
         /// </exception>
-        internal PSDriveInfo Drive { get; set; }
+        internal PSDriveInfo? Drive { get; set; }
 
         /// <summary>
         /// Gets the user name under which the operation should run.
@@ -470,7 +458,7 @@ namespace System.Management.Automation
             {
                 if ((_command != null) && (_command.CommandRuntime != null))
                 {
-                    MshCommandRuntime mshRuntime = _command.CommandRuntime as MshCommandRuntime;
+                    MshCommandRuntime? mshRuntime = _command.CommandRuntime as MshCommandRuntime;
 
                     if (mshRuntime != null)
                     {
@@ -499,7 +487,7 @@ namespace System.Management.Automation
         /// Gets an object that surfaces the current PowerShell transaction.
         /// When this object is disposed, PowerShell resets the active transaction.
         /// </summary>
-        public PSTransactionContext CurrentPSTransaction
+        public PSTransactionContext? CurrentPSTransaction
         {
             get
             {
@@ -527,19 +515,18 @@ namespace System.Management.Automation
         /// The provider specific filter that should be used when determining
         /// which items an action should take place on.
         /// </summary>
-        internal string Filter { get; set; }
+        internal string? Filter { get; set; }
 
         /// <summary>
         /// A glob string that signifies which items should be included when determining
         /// which items the action should occur on.
         /// </summary>
-        internal Collection<string> Include { get; private set; }
-
+        internal Collection<string>? Include { get; private set; }
         /// <summary>
         /// A glob string that signifies which items should be excluded when determining
         /// which items the action should occur on.
         /// </summary>
-        internal Collection<string> Exclude { get; private set; }
+        internal Collection<string>? Exclude { get; private set; }
 
         /// <summary>
         /// Gets or sets the property that tells providers (that
@@ -855,7 +842,7 @@ namespace System.Management.Automation
         /// <param name="filter">
         /// The provider specific filter for the operation.
         /// </param>
-        internal void SetFilters(Collection<string> include, Collection<string> exclude, string filter)
+        internal void SetFilters(Collection<string> include, Collection<string> exclude, string? filter)
         {
             Include = include;
             Exclude = exclude;
@@ -943,7 +930,7 @@ namespace System.Management.Automation
 
                     if (wrapExceptionInProviderException)
                     {
-                        ProviderInfo providerInfo = null;
+                        ProviderInfo? providerInfo = null;
                         if (this.ProviderInstance != null)
                         {
                             providerInfo = this.ProviderInstance.ProviderInfo;
@@ -1127,7 +1114,7 @@ namespace System.Management.Automation
                     errorRecord.ErrorDetails.TextLookupError = null;
                     MshLog.LogProviderHealthEvent(
                         this.ExecutionContext,
-                        this.ProviderInstance.ProviderInfo.Name,
+                        this.ProviderInstance?.ProviderInfo.Name,
                         textLookupError,
                         Severity.Warning);
                 }

--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -4698,7 +4698,7 @@ namespace System.Management.Automation
                 // Trace the filter
                 s_pathResolutionTracer.WriteLine("Filter: {0}", context.Filter ?? string.Empty);
 
-                if (context.Include != null)
+                if (context.Include != null && context.Include.Count > 0)
                 {
                     // Trace the include filters
                     StringBuilder includeString = new StringBuilder();
@@ -4710,7 +4710,7 @@ namespace System.Management.Automation
                     s_pathResolutionTracer.WriteLine("Include: {0}", includeString.ToString());
                 }
 
-                if (context.Exclude != null)
+                if (context.Exclude != null && context.Exclude.Count > 0)
                 {
                     // Trace the exclude filters
                     StringBuilder excludeString = new StringBuilder();

--- a/src/System.Management.Automation/namespaces/NavigationProviderBase.cs
+++ b/src/System.Management.Automation/namespaces/NavigationProviderBase.cs
@@ -543,7 +543,7 @@ namespace System.Management.Automation.Provider
             // Active Directory team.
             //
             // WORKAROUND WORKAROUND WORKAROUND WORKAROUND WORKAROUND WORKAROUND WORKAROUND WORKAROUND WORKAROUND
-            if (!string.Equals(context.ProviderInstance.ProviderInfo.FullName,
+            if (!string.Equals(context.ProviderInstance?.ProviderInfo.FullName,
                 @"Microsoft.ActiveDirectory.Management\ActiveDirectory", StringComparison.OrdinalIgnoreCase))
             {
                 normalizedPath = NormalizePath(path);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Enable nullable reference types in some base classes in:
- ConsoleHostRawUserInterface.cs 
- InternalHostRawUserInterface.cs
- ServerRemoteHostRawUserInterface.cs
- MshHostRawUserInterface.cs
- regex.cs - Here Init() method refactored to return delegate and ensure that _isMatch always have a value.
- CommandProcessorBase.cs
- SessionStateScopeAPIs.cs

## PR Context

C# 8.0 introduces great feature nullable reference types.
https://devblogs.microsoft.com/dotnet/try-out-nullable-reference-types/

The feature makes code more readable, understandable and reliable, it forces us to write cleaner code.

I started with some base classes so that using classes can benefit from this. 
I hope we will continue to roll up the feature after the PR.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
