### PR TITLE
Select-String: Add OnlyMatching parameter to return only the actual matching value

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -1390,6 +1390,7 @@ namespace Microsoft.PowerShell.Commands
         /// If not (default) return MatchInfo (or bool objects, when Quiet is passed).
         /// </summary>
         [Parameter]
+        [Alias("o")]
         public SwitchParameter OnlyMatching { get; set; }
 
         private int[] _context;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -1693,7 +1693,17 @@ namespace Microsoft.PowerShell.Commands
             {
                 foreach (MatchInfo match in contextTracker.EmitQueue)
                 {
-                    WriteObject(match.Matches[0].Value);
+                    if (AllMatches)
+                    {
+                        foreach (Match individual in match.Matches)
+                        {
+                            WriteObject(individual.Value);
+                        }
+                    }
+                    else
+                    {
+                        WriteObject(match.Matches[0].Value);
+                    }
                 }
             }
             else if (Quiet && !List)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -1385,15 +1385,22 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating if only string values containing just the matched text should be returned.
+        /// If not (default) return MatchInfo (or bool objects, when Quiet is passed).
+        /// </summary>
+        [Parameter]
+        public SwitchParameter OnlyMatching { get; set; }
+
         private int[] _context;
 
         private int _preContext = 0;
 
         private int _postContext = 0;
 
-        // When we are in Raw mode or pre- and postcontext are zero, use the _noContextTracker, since we will not be needing trackedLines.
-        private IContextTracker GetContextTracker() => (Raw || (_preContext == 0 && _postContext == 0))
-            ? _noContextTracker
+        // When we are in Raw mode or OnlyMatching mode or pre- and postcontext are zero, use the _noContextTracker, since we will not be needing trackedLines.
+        private IContextTracker GetContextTracker() => (OnlyMatching || Raw || (_preContext == 0 && _postContext == 0)) 
+            ? _noContextTracker 
             : new ContextTracker(_preContext, _postContext);
 
         // This context tracker is only used for strings which are piped
@@ -1679,6 +1686,13 @@ namespace Microsoft.PowerShell.Commands
                 foreach (MatchInfo match in contextTracker.EmitQueue)
                 {
                     WriteObject(match.Line);
+                }
+            }
+            else if (OnlyMatching)
+            {
+                foreach (MatchInfo match in contextTracker.EmitQueue)
+                {
+                    WriteObject(match.Matches[0].Value);
                 }
             }
             else if (Quiet && !List)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/string.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/string.tests.ps1
@@ -75,5 +75,12 @@ Describe "String cmdlets" -Tags "CI" {
             $match.RelativePath($pshome.ToLower()) | Should -Be $file
             $match.RelativePath($pshome.ToUpper()) | Should -Be $file
         }
+
+        It "only matching string and not full MatchInfo object" {
+            $Match = "abc123","def456" | Select-String "abc" -OnlyMatching
+
+            $Match | Should -BeOfType [String]
+            $Match | Should -Be "abc"
+        }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/string.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/string.tests.ps1
@@ -76,7 +76,7 @@ Describe "String cmdlets" -Tags "CI" {
             $match.RelativePath($pshome.ToUpper()) | Should -Be $file
         }
 
-        It "only matching string and not full MatchInfo object" {
+        It "-OnlyMatching outputs strings instead of full MatchInfo objects" {
             $Match = "abc123","def456" | Select-String "abc" -OnlyMatching
 
             $Match | Should -BeOfType [String]

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/string.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/string.tests.ps1
@@ -82,5 +82,12 @@ Describe "String cmdlets" -Tags "CI" {
             $Match | Should -BeOfType [String]
             $Match | Should -Be "abc"
         }
+
+        It "-OnlyMatching and -AllMatches returns all strings in a matching line" {
+            $Match = "abc123abc" | Select-String "abc" -OnlyMatching -AllMatches
+
+            $Match | Should -HaveCount 2
+            $Match | Should -Be "abc","abc"
+        }
     }
 }


### PR DESCRIPTION
# PR Summary

## PR Context

Issue #7712 wanted a `-OnlyMatching` switch to allow Select-String to only return the text that matched rather than either the full MatchInfo object (default behaviour) or the Line (`-Raw` behaviour). This is the initial implementation of that. 

The issue does suggest allowing this switch to avoid the primary code path that creates the MatchInfo objects in the first place to improve performance since they aren't actually used in the output at all, I'd like to add that functionality but it's a bit beyond my abilities right now but I'll look into it and see if I can add that in either before this PR is merged or in a future PR if the team feels it's a needed improvement.

I had thought to add a parameter set for this new parameter since it doesn't make sense to be able to use both `-Raw` and `-OnlyMatching` but that broke parameter binding in a way I didn't expect and wasn't able to see why it would. I can add that back in as part of this PR and try to resolve it should it be required.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
