### PR TITLE
Add comment describing why -ia is not the alias for -InformationAction common parameter

### DIFF
--- a/src/System.Management.Automation/engine/CommonCommandParameters.cs
+++ b/src/System.Management.Automation/engine/CommonCommandParameters.cs
@@ -109,7 +109,11 @@ namespace System.Management.Automation.Internal
         /// This parameter tells the command what to do when an informational record occurs.
         /// </remarks>
         [Parameter]
-        [Alias("infa", "ia")]
+        [Alias("infa")]
+        // NOTE: The "infa" alias name does not follow the same alias naming convention used
+        // with other common parameter aliases that control stream functionality; however,
+        // "ia" was already taken as a parameter alias in other commands when this parameter
+        // was added to PowerShell, so "infa" was chosen instead.
         public ActionPreference InformationAction
         {
             get { return _commandRuntime.InformationPreference; }

--- a/src/System.Management.Automation/engine/CommonCommandParameters.cs
+++ b/src/System.Management.Automation/engine/CommonCommandParameters.cs
@@ -109,7 +109,7 @@ namespace System.Management.Automation.Internal
         /// This parameter tells the command what to do when an informational record occurs.
         /// </remarks>
         [Parameter]
-        [Alias("infa")]
+        [Alias("infa", "ia")]
         public ActionPreference InformationAction
         {
             get { return _commandRuntime.InformationPreference; }

--- a/src/System.Management.Automation/engine/CommonCommandParameters.cs
+++ b/src/System.Management.Automation/engine/CommonCommandParameters.cs
@@ -108,12 +108,14 @@ namespace System.Management.Automation.Internal
         /// <remarks>
         /// This parameter tells the command what to do when an informational record occurs.
         /// </remarks>
+        /// <!--
+        /// NOTE: The "infa" alias name does not follow the same alias naming convention used
+        /// with other common parameter aliases that control stream functionality; however,
+        /// "ia" was already taken as a parameter alias in other commands when this parameter
+        /// was added to PowerShell, so "infa" was chosen instead.
+        /// -->
         [Parameter]
         [Alias("infa")]
-        // NOTE: The "infa" alias name does not follow the same alias naming convention used
-        // with other common parameter aliases that control stream functionality; however,
-        // "ia" was already taken as a parameter alias in other commands when this parameter
-        // was added to PowerShell, so "infa" was chosen instead.
         public ActionPreference InformationAction
         {
             get { return _commandRuntime.InformationPreference; }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
@@ -122,11 +122,4 @@ Describe "Stream writer tests" -Tags "CI" {
             $i.MessageData | Should -Be $null
         }
     }
-
-    Context "Stream common parameter tests" {
-        It '-InformationAction accepts -ia alias' {
-            Write-Information -MessageData Test -ia Continue -iv i *> $null
-            $i.MessageData | Should -BeExactly 'Test'
-        }
-    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
@@ -122,4 +122,11 @@ Describe "Stream writer tests" -Tags "CI" {
             $i.MessageData | Should -Be $null
         }
     }
+
+    Context "Stream common parameter tests" {
+        It '-InformationAction accepts -ia alias' {
+            Write-Information -MessageData Test -ia Continue -iv i *> $null
+            $i.MessageData | Should -BeExactly 'Test'
+        }
+    }
 }


### PR DESCRIPTION
# PR Summary

This adds a comment highlighting why a common parameter alias name breaks the naming convention used for other common parameters.

## PR Context

This comment is being added so that others looking at this code in the future will know why the alias naming convention is different in this case.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [] Issue filed:
- **Testing - New and feature**
    - [X] N/A or can only be tested interactively
    - **OR**
    - [] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
