### PR TITLE
Adding positional parameter for ScriptBlock when using Invoke-Command with SSH

### DIFF
--- a/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
@@ -531,9 +531,11 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Position = 1,
                    Mandatory = true,
                    ParameterSetName = InvokeCommandCommand.ContainerIdParameterSet)]
-        [Parameter(Mandatory = true,
+        [Parameter(Position = 1,
+                   Mandatory = true,
                    ParameterSetName = InvokeCommandCommand.SSHHostParameterSet)]
-        [Parameter(Mandatory = true,
+        [Parameter(Position = 1,
+                   Mandatory = true,
                    ParameterSetName = InvokeCommandCommand.SSHHostHashParameterSet)]
         [ValidateNotNull]
         [Alias("Command")]

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/RemotingCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/RemotingCmdlets.Tests.ps1
@@ -13,7 +13,17 @@ Describe "SSH Remoting Cmdlet Tests" -Tags "Feature" {
     }
 
     It "Invoke-Command HostName parameter set should throw error for invalid key path" {
-        { Invoke-Command -HostName localhost -UserName User -KeyFilePath NoKeyFile -ScriptBlock {1} } |
+        { Invoke-Command -HostName localhost -UserName User -KeyFilePath NoKeyFile -ScriptBlock { 1 } } |
             Should -Throw -ErrorId "PathNotFound,Microsoft.PowerShell.Commands.InvokeCommandCommand"
+    }
+
+    It "Invoke-Command should support positional parameter ScriptBlock when using HostName" {
+        { Invoke-Command -HostName localhost { "test" } } |
+            Should -Not -Throw -ErrorId "System.ArgumentException,Microsoft.PowerShell.Commands.InvokeCommandCommand"
+    }
+
+    It "Invoke-Command should support poisitonal parameter ScriptBlock when using SSHConnection" {
+        { Invoke-Command -SSHConnection @{ HostName = "localhost" } { "test" } } |
+            Should -Not -Throw -ErrorId "System.ArgumentException,Microsoft.PowerShell.Commands.InvokeCommandCommand"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/RemotingCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/RemotingCmdlets.Tests.ps1
@@ -22,7 +22,7 @@ Describe "SSH Remoting Cmdlet Tests" -Tags "Feature" {
             Should -Not -Throw -ErrorId "System.ArgumentException,Microsoft.PowerShell.Commands.InvokeCommandCommand"
     }
 
-    It "Invoke-Command should support poisitonal parameter ScriptBlock when using SSHConnection" {
+    It "Invoke-Command should support positional parameter ScriptBlock when using SSHConnection" {
         { Invoke-Command -SSHConnection @{ HostName = "localhost" } { "test" } } |
             Should -Not -Throw -ErrorId "System.ArgumentException,Microsoft.PowerShell.Commands.InvokeCommandCommand"
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/RemotingCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/RemotingCmdlets.Tests.ps1
@@ -17,13 +17,11 @@ Describe "SSH Remoting Cmdlet Tests" -Tags "Feature" {
             Should -Throw -ErrorId "PathNotFound,Microsoft.PowerShell.Commands.InvokeCommandCommand"
     }
 
-    It "Invoke-Command should support positional parameter ScriptBlock when using HostName" {
-        { Invoke-Command -HostName localhost { "test" } } |
-            Should -Not -Throw -ErrorId "System.ArgumentException,Microsoft.PowerShell.Commands.InvokeCommandCommand"
-    }
-
-    It "Invoke-Command should support positional parameter ScriptBlock when using SSHConnection" {
-        { Invoke-Command -SSHConnection @{ HostName = "localhost" } { "test" } } |
-            Should -Not -Throw -ErrorId "System.ArgumentException,Microsoft.PowerShell.Commands.InvokeCommandCommand"
+    It "Invoke-Command should support positional parameter ScriptBlock when using parameter set '<ParameterSetName>'" -TestCases @{ParameterSetName = 'SSHHost' }, @{ParameterSetName = 'SSHHostHashParam' } {
+        param ([string]$ParameterSetName)
+        $commandInfo = Get-Command -Name Invoke-Command
+        $sshParameterSet = $commandInfo.ParameterSets | Where-Object { $_.Name -eq $ParameterSetName }
+        $scriptBlockPosition = $sshParameterSet.Parameters | Where-Object { $_.Name -eq 'ScriptBlock' } | Select-Object -ExpandProperty Position
+        $scriptBlockPosition | Should -Be 1
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
This PR adds the PositionalParameter Scriptblock when using Invoke-Command with the new -Hostname or -SSHConnection parameters.
This allows to use the same usage as when using WinRM with -Computername

examples:
`{ Invoke-Command -HostName localhost { 'test' } }`
`{ Invoke-Command -SSHConnection @{ HostName = 'localhost' }  { 'test' } }`

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
fixes #10708 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
