### PR TITLE
Update `ConciseView` to remove unnecessary text and not color entire line in red

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -905,8 +905,7 @@ namespace System.Management.Automation.Runspaces
 
                                             # don't color the whole line red
                                             if ($offsetLength -lt $line.Length - 1) {
-                                                $line = $line.Insert($myinv.OffsetInLine - 1 + $offsetLength, $resetColor)
-                                                $line = $line.Insert($myinv.OffsetInLine - 1, $accentColor)
+                                                $line = $line.Insert($myinv.OffsetInLine - 1 + $offsetLength, $resetColor).Insert($myinv.OffsetInLine - 1, $accentColor)
                                             }
 
                                             $posmsg += ""${accentColor}${lineWhitespace}$($myinv.ScriptLineNumber) ${verticalBar} ${resetcolor}${line}`n""

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -905,7 +905,7 @@ namespace System.Management.Automation.Runspaces
                                             # don't color the whole line red
                                             if ($offsetLength -lt $line.Length - 1) {
                                                 $line = $line.Insert($myinv.OffsetInLine - 1 + $offsetLength, $resetColor)
-                                                $line = $line.Insert($myinv.OffsetInLine - 1, $errorColor)
+                                                $line = $line.Insert($myinv.OffsetInLine - 1, $accentColor)
                                             }
 
                                             $posmsg += ""${accentColor}${lineWhitespace}$($myinv.ScriptLineNumber) ${verticalBar} ${resetcolor}${line}`n""

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -880,7 +880,7 @@ namespace System.Management.Automation.Runspaces
 
                                         if ($myinv -and $myinv.ScriptName -or $_.CategoryInfo.Category -eq 'ParserError') {
                                             if ($myinv.ScriptName) {
-                                                $posmsg = ""error in${resetcolor} $($myinv.ScriptName)${newline}""
+                                                $posmsg = ""${resetcolor}$($myinv.ScriptName)${newline}""
                                             }
                                             else {
                                                 $posmsg = ""${newline}""
@@ -901,8 +901,13 @@ namespace System.Management.Automation.Runspaces
                                             $line = $myinv.Line
                                             $highlightLine = $myinv.PositionMessage.Split('+').Count - 1
                                             $offsetLength = $myinv.PositionMessage.split('+')[$highlightLine].Trim().Length
-                                            $line = $line.Insert($myinv.OffsetInLine - 1 + $offsetLength, $resetColor)
-                                            $line = $line.Insert($myinv.OffsetInLine - 1, $errorColor)
+
+                                            # don't color the whole line red
+                                            if ($offsetLength -lt $line.Length - 1) {
+                                                $line = $line.Insert($myinv.OffsetInLine - 1 + $offsetLength, $resetColor)
+                                                $line = $line.Insert($myinv.OffsetInLine - 1, $errorColor)
+                                            }
+
                                             $posmsg += ""${accentColor}${lineWhitespace}$($myinv.ScriptLineNumber) ${verticalBar} ${resetcolor}${line}`n""
                                             $offsetWhitespace = ' ' * ($myinv.OffsetInLine - 1)
                                             $prefix = ""${accentColor}${headerWhitespace}     ${verticalBar} ${errorColor}""

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -742,7 +742,7 @@ namespace System.Management.Automation.Runspaces
                 CustomControl.Create(outOfBand: true)
                     .StartEntry()
                         .AddScriptBlockExpressionBinding(@"
-                                    if (@('NativeCommandErrorMessage'.'NativeCommandError') -notcontains $_.FullyQualifiedErrorId -and @('CategoryView','ConciseView') -notcontains $ErrorView)
+                                    if (@('NativeCommandErrorMessage','NativeCommandError') -notcontains $_.FullyQualifiedErrorId -and @('CategoryView','ConciseView') -notcontains $ErrorView)
                                     {
                                         $myinv = $_.InvocationInfo
                                         if ($myinv -and $myinv.MyCommand)
@@ -795,6 +795,7 @@ namespace System.Management.Automation.Runspaces
                         .AddScriptBlockExpressionBinding(@"
 
                                     function Get-ConciseViewPositionMessage {
+                                        Set-StrictMode -Off
 
                                         $resetColor = ''
                                         if ($Host.UI.SupportsVirtualTerminal) {
@@ -970,7 +971,7 @@ namespace System.Management.Automation.Runspaces
                                         elseif ($_.CategoryInfo.Category) {
                                             $reason = $_.CategoryInfo.Category
                                         }
-                                        elseif ($_CategoryInfo.Reason) {
+                                        elseif ($_.CategoryInfo.Reason) {
                                             $reason = $_.CategoryInfo.Reason
                                         }
 


### PR DESCRIPTION
# PR Summary

Remove unnecessary text before script path, detect if whole line is emphasized, then don't do any emphasis.  Change emphasis color to accent color instead of error color to make it easier to read.  Also fixed some typos and disabled strict mode in helper that works with different dynamic objects that puts errors in $error if strict mode is enabled.

Before:

![img](https://i.imgur.com/cwOOKSA.png)

After:

![img](https://i.imgur.com/RJTbiHA.png)

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/10716

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
