### PR TITLE
UseNewEnvironment restores environment variables for child process

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -1911,10 +1911,8 @@ namespace Microsoft.PowerShell.Commands
                     // Use environment variables from saved at startup dictionary
                     var envVariables = startInfo.EnvironmentVariables;
                     envVariables.Clear();
-                    IDictionaryEnumerator e = System.Management.Automation.Runspaces.EarlyStartup.InitialEnvironmentVariables.GetEnumerator();
-                    while (e.MoveNext())
+                    foreach (DictionaryEntry entry in System.Management.Automation.Runspaces.EarlyStartup.InitialEnvironmentVariables)
                     {
-                        DictionaryEntry entry = e.Entry;
                         envVariables.Add((string)entry.Key, (string)entry.Value);
                     }
                 }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -1908,9 +1908,15 @@ namespace Microsoft.PowerShell.Commands
 
                 if (_UseNewEnvironment)
                 {
-                    startInfo.EnvironmentVariables.Clear();
-                    LoadEnvironmentVariable(startInfo, Environment.GetEnvironmentVariables(EnvironmentVariableTarget.Machine));
-                    LoadEnvironmentVariable(startInfo, Environment.GetEnvironmentVariables(EnvironmentVariableTarget.User));
+                    // Use environment variables from saved at startup dictionary
+                    var envVariables = startInfo.EnvironmentVariables;
+                    envVariables.Clear();
+                    IDictionaryEnumerator e = System.Management.Automation.Runspaces.EarlyStartup.InitialEnvironmentVariables.GetEnumerator();
+                    while (e.MoveNext())
+                    {
+                        DictionaryEntry entry = e.Entry;
+                        envVariables.Add((string)entry.Key, (string)entry.Value);
+                    }
                 }
 
                 startInfo.WindowStyle = _windowstyle;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ManagedEntrance.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ManagedEntrance.cs
@@ -32,6 +32,9 @@ namespace Microsoft.PowerShell
         /// </param>
         public static int Start(string consoleFilePath, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 2)]string[] args, int argc)
         {
+            // Save environment variables before we change them.
+            EarlyStartup.SaveEnvironmentVariables();
+
             // Warm up some components concurrently on background threads.
             EarlyStartup.Init();
 

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -65,6 +65,18 @@ namespace System.Management.Automation.Runspaces
                 LanguagePrimitives.GetEnumerator(null);
             });
         }
+
+        internal static IDictionary InitialEnvironmentVariables
+        {
+            get => _environmentVariables;
+        }
+
+        private static IDictionary _environmentVariables;
+
+        internal static void SaveEnvironmentVariables()
+        {
+            _environmentVariables = Environment.GetEnvironmentVariables();
+        }
     }
 
     /// <summary>

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -28,6 +28,8 @@ namespace System.Management.Automation.Runspaces
 {
     internal class EarlyStartup
     {
+        private static IDictionary _environmentVariables;
+
         internal static void Init()
         {
             // Code added here should:
@@ -70,8 +72,6 @@ namespace System.Management.Automation.Runspaces
         {
             get => _environmentVariables;
         }
-
-        private static IDictionary _environmentVariables;
 
         internal static void SaveEnvironmentVariables()
         {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- Save environment variables at startup
- Restore these saved environment variables for child process is UseNewEnvironment parameter is used in Start-Process cmdlet

Formally it is a breaking change in grey area.

I hope we do not load any additional dlls with the change at startup and slowdown the startup scenario will be minimal.

## PR Context

Fix #4671
Fix #3545

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
