### PR TITLE
Fix for `Get-Content -ReadCount 0` behavior when `-TotalCount` is set

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetContentCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetContentCommand.cs
@@ -206,7 +206,7 @@ namespace Microsoft.PowerShell.Commands
                             // I am using TotalCount - countToRead so that I don't
                             // have to worry about overflow
 
-                            if ((TotalCount > 0) && (TotalCount - countToRead < countRead))
+                            if ((TotalCount > 0) && (countToRead == 0 || (TotalCount - countToRead < countRead)))
                             {
                                 countToRead = TotalCount - countRead;
                             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -342,7 +342,7 @@ baz
             $expected[1] = $thirdLine
             Compare-Object -ReferenceObject $expected -DifferenceObject $result | Should -BeNullOrEmpty
         }
-        It "Should return first three lines at a time for -TotalCount 3 and -ReadCount 0" {
+        It "Should return the same number of first lines as set in -TotalCount at one time for -ReadCount 0" {
             $result = Get-Content -Path $testPath -TotalCount 3 -ReadCount 0
             $result.Length | Should -Be 3
             $expected = $firstLine,$secondLine,$thirdLine

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -342,6 +342,12 @@ baz
             $expected[1] = $thirdLine
             Compare-Object -ReferenceObject $expected -DifferenceObject $result | Should -BeNullOrEmpty
         }
+        It "Should return first three lines at a time for -TotalCount 3 and -ReadCount 0" {
+            $result = Get-Content -Path $testPath -TotalCount 3 -ReadCount 0
+            $result.Length | Should -Be 3
+            $expected = $firstLine,$secondLine,$thirdLine
+            Compare-Object -ReferenceObject $expected -DifferenceObject $result | Should -BeNullOrEmpty
+        }
         It "A warning should be emitted if both -AsByteStream and -Encoding are used together" {
             [byte[]][char[]]"test" | Set-Content -Encoding Unicode -AsByteStream "${TESTDRIVE}\bfile.txt" -WarningVariable contentWarning *> $null
             $contentWarning.Message | Should -Match "-AsByteStream"


### PR DESCRIPTION
# PR Summary

`-ReadCount 0` parameter of `Get-Count` command is now respect `-TotalCount <n>` parameter

## PR Context

Fix #10707 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
