### PR TITLE
Add test for the even handler leaking fix

### DIFF
--- a/test/xUnit/csharp/test_Runspace.cs
+++ b/test/xUnit/csharp/test_Runspace.cs
@@ -113,13 +113,13 @@ namespace PSTests.Sequential
             using (var ps = PowerShell.Create())
             {
                 ps.AddScript("1").Invoke();
-                eventHandler = (EventHandler) field.GetValue(null);
+                eventHandler = (EventHandler)field.GetValue(null);
                 delegates = eventHandler.GetInvocationList();
                 Assert.Contains(delegates, d => d.Method.Name == "CurrentDomain_ProcessExit");
             }
 
             // Handler registered by PowerShell should be unregistered.
-            eventHandler = (EventHandler) field.GetValue(null);
+            eventHandler = (EventHandler)field.GetValue(null);
             delegates = eventHandler.GetInvocationList();
             Assert.DoesNotContain(delegates, d => d.Method.Name == "CurrentDomain_ProcessExit");
         }

--- a/test/xUnit/csharp/test_Runspace.cs
+++ b/test/xUnit/csharp/test_Runspace.cs
@@ -102,9 +102,11 @@ namespace PSTests.Sequential
             }
         }
 
-        [Fact]
+        [SkippableFact]
         public void TestAppDomainProcessExitEvenHandlerNotLeaking()
         {
+            Skip.IfNot(Platform.IsWindows);
+
             EventHandler eventHandler;
             Delegate[] delegates;
             FieldInfo field = typeof(AppContext).GetField("ProcessExit", BindingFlags.NonPublic | BindingFlags.Static);

--- a/test/xUnit/csharp/test_Runspace.cs
+++ b/test/xUnit/csharp/test_Runspace.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
+using System.Reflection;
 using Xunit;
 
 namespace PSTests.Sequential
@@ -100,6 +100,28 @@ namespace PSTests.Sequential
 
                 runspace.Close();
             }
+        }
+
+        [Fact]
+        public void TestAppDomainProcessExitEvenHandlerNotLeaking()
+        {
+            EventHandler eventHandler;
+            Delegate[] delegates;
+            FieldInfo field = typeof(AppContext).GetField("ProcessExit", BindingFlags.NonPublic | BindingFlags.Static);
+
+            // Open runspace and invoke script twice.
+            using (var ps = PowerShell.Create())
+            {
+                ps.AddScript("1").Invoke();
+                eventHandler = (EventHandler) field.GetValue(null);
+                delegates = eventHandler.GetInvocationList();
+                Assert.Contains(delegates, d => d.Method.Name == "CurrentDomain_ProcessExit");
+            }
+
+            // Handler registered by PowerShell should be unregistered.
+            eventHandler = (EventHandler) field.GetValue(null);
+            delegates = eventHandler.GetInvocationList();
+            Assert.DoesNotContain(delegates, d => d.Method.Name == "CurrentDomain_ProcessExit");
         }
     }
 }

--- a/test/xUnit/csharp/test_Runspace.cs
+++ b/test/xUnit/csharp/test_Runspace.cs
@@ -109,7 +109,7 @@ namespace PSTests.Sequential
             Delegate[] delegates;
             FieldInfo field = typeof(AppContext).GetField("ProcessExit", BindingFlags.NonPublic | BindingFlags.Static);
 
-            // Open runspace and invoke script twice.
+            // Open runspace and invoke script.
             using (var ps = PowerShell.Create())
             {
                 ps.AddScript("1").Invoke();


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add a test for the even handler leaking fix addressed in https://github.com/PowerShell/PowerShell/pull/10626
The test is added to verify that PowerShell unregister the 'AppDomain.ProcessExit' event handler when a Runspace closes.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
