### PR TITLE
Get-Command: Specifying an alias and -Syntax returns the aliased commands syntax

### DIFF
--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -1306,7 +1306,14 @@ namespace Microsoft.PowerShell.Commands
                     {
                         // If the matching command was an alias, then use the resolved command
                         // instead of the alias...
-                        current = ai.ResolvedCommand;
+                        current = ai.ResolvedCommand ?? CommandDiscovery.LookupCommandInfo(
+                            ai.UnresolvedCommandName,
+                            this.MyInvocation.CommandOrigin,
+                            this.Context);
+
+                        // there are situations where both ResolvedCommand and UnresolvedCommandName
+                        // are both null (often due to multiple versions of modules with aliases)
+                        // therefore we need to exit early.
                         if (current == null)
                         {
                             return false;

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -1229,31 +1229,28 @@ namespace Microsoft.PowerShell.Commands
 
                 if (isCommandMatch)
                 {
-                    if (ArgumentList != null)
+                    if (Syntax.IsPresent && current is AliasInfo ai)
                     {
-                        AliasInfo ai = current as AliasInfo;
-                        if (ai != null)
+                        // If the matching command was an alias, then use the resolved command
+                        // instead of the alias...
+                        current = ai.ResolvedCommand;
+                        if (current == null)
                         {
-                            // If the matching command was an alias, then use the resolved command
-                            // instead of the alias...
-                            current = ai.ResolvedCommand;
-                            if (current == null)
-                            {
-                                return false;
-                            }
+                            return false;
                         }
-                        else if (!(current is CmdletInfo || current is IScriptCommandInfo))
-                        {
-                            // If current is not a cmdlet or script, we need to throw a terminating error.
-                            ThrowTerminatingError(
-                                new ErrorRecord(
-                                    PSTraceSource.NewArgumentException(
-                                        "ArgumentList",
-                                        DiscoveryExceptions.CommandArgsOnlyForSingleCmdlet),
-                                    "CommandArgsOnlyForSingleCmdlet",
-                                    ErrorCategory.InvalidArgument,
-                                    current));
-                        }
+                    }
+
+                    if (ArgumentList != null && !(current is CmdletInfo || current is IScriptCommandInfo))
+                    {
+                        // If current is not a cmdlet or script, we need to throw a terminating error.
+                        ThrowTerminatingError(
+                            new ErrorRecord(
+                                PSTraceSource.NewArgumentException(
+                                    "ArgumentList",
+                                    DiscoveryExceptions.CommandArgsOnlyForSingleCmdlet),
+                                "CommandArgsOnlyForSingleCmdlet",
+                                ErrorCategory.InvalidArgument,
+                                current));
                     }
 
                     // If the command implements dynamic parameters

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -533,6 +533,17 @@ namespace Microsoft.PowerShell.Commands
                         {
                             PSObject syntax = PSObject.AsPSObject(result.Syntax);
 
+                            if (!_nameContainsWildcard && !this.Name[0].Equals(result.Name))
+                            {
+                                string replacedSyntax = string.Format(
+                                    "{0} -> {1}{2}{3}",
+                                    this.Name[0],
+                                    result is ExternalScriptInfo extScript ? string.Format("{0}{1}", extScript.Path, Environment.NewLine) : result.Name,
+                                    Environment.NewLine,
+                                    result.Syntax.Replace(result.Name, this.Name[0]));
+                                syntax = PSObject.AsPSObject(replacedSyntax);
+                            }
+
                             syntax.IsHelpObject = true;
 
                             WriteObject(syntax);

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
@@ -113,7 +113,30 @@ Describe "Get-Command" -Tag CI {
             $Result = Get-Command -Name del -Syntax
 
             $Result | Should -BeOfType [String]
-            $Result | Should -Match 'Remove-Item \[-Path\]'
+            $Result | Should -Match 'del \[-Path\]'
+        }
+
+        It "Should return the path to an aliased script when -Syntax is specified" {
+            # First, create a script file
+            @'
+            [CmdletBinding()]
+            param(
+                [Parameter(Position=0, Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+                [ValidateNotNullOrEmpty()]
+                [string[]]
+                $Name
+            )
+            process {
+                "Processing ${Name}"
+            }
+'@ | out-File TestDrive:\Test-GcmSyntax.ps1
+
+            # Now set up an alias for that file
+            new-alias tgs TestDrive:\Test-GcmSyntax.ps1
+
+            $Result = Get-Command -Name tgs -Syntax
+
+            $Result | Should -Match "tgs -> $([Regex]::Escape((Get-Item TestDrive:\\Test-GcmSyntax.ps1).FullName))"
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
@@ -103,3 +103,32 @@ Describe "Get-Command Feature tests" -Tag Feature {
         }
     }
 }
+
+Describe "Get-Command" -Tag CI {
+    BeforeAll {
+        Import-Module Microsoft.PowerShell.Management
+    }
+    Context "-Syntax tests" {
+        It "Should return a string object when -Name is an alias and -Syntax is specified" {
+            $Result = Get-Command -Name del -Syntax
+
+            $Result | Should -BeOfType [String]
+            $Result | Should -Match 'Remove-Item \[-Path\]'
+        }
+    }
+
+    Context "-Name tests" {
+        It "Should return a AliasInfo object when -Name is an alias" {
+            $Result = Get-Command -Name del
+
+            $Result | Should -BeOfType [System.Management.Automation.AliasInfo]
+            $Result.DisplayName | Should -Be 'del -> Remove-Item'
+        }
+
+        It "Should return a CommandInfo object when -Name is a command" {
+            $Result = Get-Command -Name Remove-Item
+
+            $Result | Should -BeOfType [System.Management.Automation.CommandInfo]
+        }
+    }
+}


### PR DESCRIPTION
# PR Summary

Add an additional check into the `IsCommandMatch` method to return the syntax of an aliased command rather than just the name of the aliased command.

Previous behaviour:
![image](https://user-images.githubusercontent.com/16837142/66720667-d7847d00-edf7-11e9-944a-cae5e83f0d55.png)

New behaviour:
![image](https://user-images.githubusercontent.com/16837142/66720653-b4f26400-edf7-11e9-889a-c2624305f4df.png)


## PR Context

#5963 asked for this functionality as currently `Get-Command del -syntax` doesn't give you anything useful, especially not beyond what `Get-Command del` does. The Issue does suggest that instead of the original command it shows the alias in the syntax but the `Syntax` property is read-only and I didn't want to mess around with the base CommandInfo or AliasInfo object for something like this, not doing that also somewhat enables @KirkMunro's request that it shows the `alias -> real command` as part of the output since it'll now show the resolved command name in the syntax'

I don't think this is a breaking change because the likelihood of anyone actually using `Get-Command -Name <alias> -Syntax` for anything outside the command line is very minimal. I'm also not sure if there needs to be a docs change for it but it might be useful just so users are aware that it'll do this now.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [X] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
