### PR TITLE
Reduce minor allocations at runspace creation time

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddMember.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddMember.cs
@@ -311,7 +311,7 @@ namespace Microsoft.PowerShell.Commands
             EnsureValue1IsNotNull();
             Collection<string> value1Collection =
                 (Collection<string>)GetParameterType(_value1, typeof(Collection<string>));
-            return new PSPropertySet(_memberName, value1Collection);
+            return new PSPropertySet(_memberName, (IEnumerable<string>)value1Collection);
         }
 
         private PSMemberInfo GetScriptMethod()

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -3455,6 +3455,24 @@ namespace System.Management.Automation
             }
         }
 
+        // We mean that 'referencedPropertyNames' does not contain null and empty values,
+        // otherwise we should use public constructor with the check.
+        internal PSPropertySet(string name, IList<string> referencedPropertyNames)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw PSTraceSource.NewArgumentException(nameof(name));
+            }
+
+            this.name = name;
+            if (referencedPropertyNames == null)
+            {
+                throw PSTraceSource.NewArgumentNullException(nameof(referencedPropertyNames));
+            }
+
+            ReferencedPropertyNames = new Collection<string>(referencedPropertyNames);
+        }
+
         /// <summary>
         /// Gets the property names in this property set.
         /// </summary>

--- a/src/System.Management.Automation/engine/TypeTable.cs
+++ b/src/System.Management.Automation/engine/TypeTable.cs
@@ -3135,7 +3135,8 @@ namespace System.Management.Automation.Runspaces
             }
 
             // the node cardinality is OneToMany
-            Collection<string> referencedProperties = new Collection<string>();
+            var propList = new List<string>(propertySetData.ReferencedProperties.Count);
+            Collection<string> referencedProperties = new Collection<string>(propList);
             foreach (string name in propertySetData.ReferencedProperties)
             {
                 if (string.IsNullOrEmpty(name))


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- Use internal  PSPropertySet() constructor without checks for null and empty property names
- Initialize Collection with List which is created with explicit size (reduce re-allocations when add new items).

## PR Context

Test script:
```powershell
measure-Command {
for ($i=0; $i -lt 500; $i++) {
    [runspace] $rs = [runspacefactory]::CreateRunspace()
    $rs.Open()
    $rs.Close()
    if ($null -ne $rs) { $rs.Dispose() }
}
}
```

Allocations before:
![image](https://user-images.githubusercontent.com/22290914/66927706-b4510c00-f049-11e9-9b28-cdab1f218ff2.png)

Allocations after:
![image](https://user-images.githubusercontent.com/22290914/66927737-c632af00-f049-11e9-906a-be1b4fcda861.png)


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
