### PR TITLE
Fix stringdata test to correctly validate keys of hashtables

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-StringData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-StringData.Tests.ps1
@@ -69,9 +69,9 @@ bazz = 2
 Describe "Delimiter parameter tests" -Tags "CI" {
     BeforeAll  {
         $TestCases = @(
-            @{ Delimiter = ':'; StringData = 'value:10'; ExpectedResult = @{ Values = 10 } }
-            @{ Delimiter = '-'; StringData = 'a-b' ; ExpectedResult = @{ Values = 'b' } }
-            @{ Delimiter = ','; StringData = 'c,d' ; ExpectedResult = @{ Values = 'd' } }
+            @{ Delimiter = ':'; StringData = 'value:10'; ExpectedResult = @{ value = 10 } }
+            @{ Delimiter = '-'; StringData = 'a-b' ; ExpectedResult = @{ a = 'b' } }
+            @{ Delimiter = ','; StringData = 'c,d' ; ExpectedResult = @{ c = 'd' } }
         )
     }
 
@@ -89,14 +89,17 @@ a:b
         { $sampleData | ConvertFrom-StringData -Delimiter ':' } | Should -Not -Throw
     }
 
-    It 'is able to parse <StringData> with delimiter "<Delimiter>"' -TestCases $TestCases {
+    It 'is able to parse <StringData> with delimiter "<Delimiter> with <stringdata>"' -TestCases $TestCases {
         param($Delimiter, $StringData, $ExpectedResult)
 
         $Result = ConvertFrom-StringData -StringData $StringData -Delimiter $Delimiter
 
-        foreach ($Key in $ExpectedResult.Keys) {
-            $Key | Should -BeIn $ExpectedResult.Keys
-            $Result.$Key | Should -Be $ExpectedResult.$Key
-        }
+        $key = $ExpectedResult.Keys
+
+        # validate the key in expected and result hashtables match
+        $Result.Keys | Should -BeExactly $ExpectedResult.Keys
+
+        # validate the values in expected and result hashtables match
+        $Result[$key] | Should -BeExactly $ExpectedResult.Values
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The previous test wasn't correctly validating the keys in the hashtable match expected and actual.  Fix is to update the test cases so the expected hashtable has the right key names and remove the unnecessary `foreach` loop (since we know the hashtable only has one entry) and verify the key and the value.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
