### PR TITLE
Cleanups in command discovery

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerShell.Commands
     /// Cmdlet to stop computer.
     /// </summary>
     [Cmdlet(VerbsLifecycle.Stop, "Computer", SupportsShouldProcess = true,
-        HelpUri = "https://go.microsoft.com/fwlink/?LinkID=135263", RemotingCapability = RemotingCapability.SupportedByCommand)]
+        HelpUri = "https://go.microsoft.com/fwlink/?LinkID=2097151", RemotingCapability = RemotingCapability.SupportedByCommand)]
     public sealed class StopComputerCommand : PSCmdlet, IDisposable
     {
         #region Private Members

--- a/src/System.Management.Automation/engine/CommandDiscovery.cs
+++ b/src/System.Management.Automation/engine/CommandDiscovery.cs
@@ -1287,27 +1287,6 @@ namespace System.Management.Automation
         private HashSet<string> _activePostCommand = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
-        /// Gets a CommandPathSearch constructed with the specified patterns and
-        /// using the PATH as the lookup directories.
-        /// </summary>
-        /// <param name="patterns">
-        /// The patterns to search for. These patterns must be in the form taken
-        /// by DirectoryInfo.GetFiles().
-        /// </param>
-        /// <returns>
-        /// An instance of CommandPathSearch that is initialized with the specified
-        /// patterns and using the PATH as the lookup directories.
-        /// </returns>
-        internal IEnumerable<string> GetCommandPathSearcher(IEnumerable<string> patterns)
-        {
-            // Get the PATH environment variable
-            IEnumerable<string> lookupPathArray = GetLookupDirectoryPaths();
-
-            // Construct the CommandPathSearch object and return it.
-            return new CommandPathSearch(patterns, lookupPathArray, Context);
-        }
-
-        /// <summary>
         /// Gets the resolved paths contained in the PATH environment
         /// variable.
         /// </summary>
@@ -1317,7 +1296,7 @@ namespace System.Management.Automation
         /// <remarks>
         /// The result is an ordered list of paths with paths starting with "." unresolved until lookup time.
         /// </remarks>
-        internal IEnumerable<string> GetLookupDirectoryPaths()
+        internal LookupPathCollection GetLookupDirectoryPaths()
         {
             LookupPathCollection result = new LookupPathCollection();
 

--- a/src/System.Management.Automation/engine/CommandPathSearch.cs
+++ b/src/System.Management.Automation/engine/CommandPathSearch.cs
@@ -7,7 +7,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 
-using Dbg = System.Management.Automation.Diagnostics;
+#nullable enable
 
 namespace System.Management.Automation
 {
@@ -24,29 +24,28 @@ namespace System.Management.Automation
         /// Constructs a command searching enumerator that resolves the location
         /// of a command using the PATH environment variable.
         /// </summary>
-        /// <param name="patterns">
-        /// The patterns to search for in the path.
+        /// <param name="commandName">
+        /// The command name to search for in the path.
         /// </param>
         /// <param name="lookupPaths">
         /// The paths to directories in which to lookup the command.
+        /// Ex.null: paths from PATH environment variable.
         /// </param>
         /// <param name="context">
         /// The execution context for the current engine instance.
         /// </param>
-        internal CommandPathSearch(
-            IEnumerable<string> patterns,
-            IEnumerable<string> lookupPaths,
-            ExecutionContext context)
-        {
-            Init(patterns, lookupPaths, context);
-        }
-
+        /// <param name="acceptableCommandNames">
+        /// The patterns to search for in the paths.
+        /// </param>
+        /// <param name="useFuzzyMatch">
+        /// Use likely relevant search.
+        /// </param>
         internal CommandPathSearch(
             string commandName,
-            IEnumerable<string> lookupPaths,
+            LookupPathCollection lookupPaths,
             ExecutionContext context,
             Collection<string> acceptableCommandNames,
-            bool useFuzzyMatch = false)
+            bool useFuzzyMatch)
         {
             _useFuzzyMatch = useFuzzyMatch;
             string[] commandPatterns;
@@ -76,21 +75,20 @@ namespace System.Management.Automation
                 _postProcessEnumeratedFiles = JustCheckExtensions;
             }
 
-            Init(commandPatterns, lookupPaths, context);
-            _orderedPathExt = CommandDiscovery.PathExtensionsWithPs1Prepended;
-        }
-
-        private void Init(IEnumerable<string> commandPatterns, IEnumerable<string> searchPath, ExecutionContext context)
-        {
             // Note, discovery must be set before resolving the current directory
-
             _context = context;
             _patterns = commandPatterns;
-
-            _lookupPaths = new LookupPathCollection(searchPath);
+            _lookupPaths = lookupPaths;
             ResolveCurrentDirectoryInLookupPaths();
 
-            this.Reset();
+            _orderedPathExt = CommandDiscovery.PathExtensionsWithPs1Prepended;
+
+            // The same as in this.Reset()
+            _lookupPathsEnumerator = _lookupPaths.GetEnumerator();
+            _patternEnumerator = _patterns.GetEnumerator();
+            _currentDirectoryResults = Array.Empty<string>();
+            _currentDirectoryResultsEnumerator = _currentDirectoryResults.GetEnumerator();
+            _justReset = true;
         }
 
         /// <summary>
@@ -120,8 +118,8 @@ namespace System.Management.Automation
 
             foreach (int index in _lookupPaths.IndexOfRelativePath())
             {
-                string resolvedDirectory = null;
-                string resolvedPath = null;
+                string? resolvedDirectory = null;
+                string? resolvedPath = null;
 
                 CommandDiscovery.discoveryTracer.WriteLine(
                     "Lookup directory \"{0}\" appears to be a relative path. Attempting resolution...",
@@ -407,7 +405,7 @@ namespace System.Management.Automation
         /// </param>
         private void GetNewDirectoryResults(string pattern, string directory)
         {
-            IEnumerable<string> result = null;
+            IEnumerable<string>? result = null;
             try
             {
                 CommandDiscovery.discoveryTracer.WriteLine("Looking for {0} in {1}", pattern, directory);
@@ -473,7 +471,7 @@ namespace System.Management.Automation
             _currentDirectoryResultsEnumerator = _currentDirectoryResults.GetEnumerator();
         }
 
-        private IEnumerable<string> CheckAgainstAcceptableCommandNames(string[] fileNames)
+        private IEnumerable<string>? CheckAgainstAcceptableCommandNames(string[] fileNames)
         {
             var baseNames = fileNames.Select(Path.GetFileName).ToArray();
 
@@ -482,8 +480,8 @@ namespace System.Management.Automation
 
             // Porting note: allow files with executable bit on non-Windows platforms
 
-            Collection<string> result = null;
-            if (baseNames.Length > 0)
+            Collection<string>? result = null;
+            if (baseNames.Length > 0 && _acceptableCommandNames != null)
             {
                 foreach (var name in _acceptableCommandNames)
                 {
@@ -504,14 +502,14 @@ namespace System.Management.Automation
             return result;
         }
 
-        private IEnumerable<string> JustCheckExtensions(string[] fileNames)
+        private IEnumerable<string>? JustCheckExtensions(string[] fileNames)
         {
             // Warning: pretty duplicated code
             // Result must be ordered by PATHEXT order of precedence.
 
             // Porting note: allow files with executable bit on non-Windows platforms
 
-            Collection<string> result = null;
+            Collection<string>? result = null;
             foreach (var allowedExt in _orderedPathExt)
             {
                 foreach (var fileName in fileNames)
@@ -575,10 +573,10 @@ namespace System.Management.Automation
         /// <summary>
         /// If not null, called with the enumerated files for further processing.
         /// </summary>
-        private Func<string[], IEnumerable<string>> _postProcessEnumeratedFiles;
+        private Func<string[], IEnumerable<string>?> _postProcessEnumeratedFiles;
 
         private string[] _orderedPathExt;
-        private Collection<string> _acceptableCommandNames;
+        private Collection<string>? _acceptableCommandNames;
 
         private bool _useFuzzyMatch = false;
 

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -1360,7 +1360,7 @@ namespace System.Management.Automation
                     result.Add(name + StringLiterals.PowerShellDataFileExtension);
                 }
             }
-#if !Unix
+#if !UNIX
             if (_commandTypes.HasFlag(CommandTypes.Application))
             {
                 // Now add each extension from the PATHEXT environment variable

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -1360,7 +1360,7 @@ namespace System.Management.Automation
                     result.Add(name + StringLiterals.PowerShellDataFileExtension);
                 }
             }
-
+#if !Unix
             if (_commandTypes.HasFlag(CommandTypes.Application))
             {
                 // Now add each extension from the PATHEXT environment variable
@@ -1369,7 +1369,7 @@ namespace System.Management.Automation
                     result.Add(name + extension);
                 }
             }
-
+#endif
             // Now add the commandName by itself if it wasn't added as the first pattern
             if (!commandNameAddedFirst)
             {

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -1332,27 +1332,25 @@ namespace System.Management.Automation
         /// If <paramref name="name"/> contains one or more of the
         /// invalid characters defined in InvalidPathChars.
         /// </exception>
-        internal Collection<string> ConstructSearchPatternsFromName(string name, bool commandDiscovery = false)
+        internal LookupPathCollection ConstructSearchPatternsFromName(string name, bool commandDiscovery = false)
         {
             Dbg.Assert(
                 !string.IsNullOrEmpty(name),
                 "Caller should verify name");
 
-            Collection<string> result = new Collection<string>();
+            var result = new LookupPathCollection();
 
             // First check to see if the commandName has an extension, if so
             // look for that first
+            bool commandNameAddedFirst = Path.HasExtension(name);
 
-            bool commandNameAddedFirst = false;
-
-            if (!string.IsNullOrEmpty(Path.GetExtension(name)))
+            if (commandNameAddedFirst)
             {
                 result.Add(name);
-                commandNameAddedFirst = true;
             }
 
             // Add the extensions for script, module and data files in that order...
-            if ((_commandTypes & CommandTypes.ExternalScript) != 0)
+            if (_commandTypes.HasFlag(CommandTypes.ExternalScript))
             {
                 result.Add(name + StringLiterals.PowerShellScriptFileExtension);
                 if (!commandDiscovery)
@@ -1363,19 +1361,16 @@ namespace System.Management.Automation
                 }
             }
 
-            if ((_commandTypes & CommandTypes.Application) != 0)
+            if (_commandTypes.HasFlag(CommandTypes.Application))
             {
                 // Now add each extension from the PATHEXT environment variable
-
                 foreach (string extension in CommandDiscovery.PathExtensions)
                 {
                     result.Add(name + extension);
                 }
             }
 
-            // Now add the commandName by itself if it wasn't added as the first
-            // pattern
-
+            // Now add the commandName by itself if it wasn't added as the first pattern
             if (!commandNameAddedFirst)
             {
                 result.Add(name);
@@ -1553,14 +1548,15 @@ namespace System.Management.Automation
                             _commandName,
                             _context.CommandDiscovery.GetLookupDirectoryPaths(),
                             _context,
-                            ConstructSearchPatternsFromName(_commandName, commandDiscovery: true));
+                            ConstructSearchPatternsFromName(_commandName, commandDiscovery: true),
+                            useFuzzyMatch : false);
                 }
                 else if (_canDoPathLookupResult == CanDoPathLookupResult.PathIsRooted)
                 {
                     _canDoPathLookup = true;
 
                     string directory = Path.GetDirectoryName(_commandName);
-                    var directoryCollection = new[] { directory };
+                    var directoryCollection = new LookupPathCollection { directory };
 
                     CommandDiscovery.discoveryTracer.WriteLine(
                         "The path is rooted, so only doing the lookup in the specified directory: {0}",
@@ -1576,7 +1572,8 @@ namespace System.Management.Automation
                                 fileName,
                                 directoryCollection,
                                 _context,
-                                ConstructSearchPatternsFromName(fileName, commandDiscovery: true));
+                                ConstructSearchPatternsFromName(fileName, commandDiscovery: true),
+                                useFuzzyMatch : false);
                     }
                     else
                     {
@@ -1603,7 +1600,7 @@ namespace System.Management.Automation
                     }
                     else
                     {
-                        var directoryCollection = new[] { directory };
+                        var directoryCollection = new LookupPathCollection { directory };
 
                         string fileName = Path.GetFileName(_commandName);
 
@@ -1615,7 +1612,8 @@ namespace System.Management.Automation
                                     fileName,
                                     directoryCollection,
                                     _context,
-                                    ConstructSearchPatternsFromName(fileName, commandDiscovery: true));
+                                    ConstructSearchPatternsFromName(fileName, commandDiscovery: true),
+                                    useFuzzyMatch : false);
                         }
                         else
                         {

--- a/src/System.Management.Automation/engine/SessionStateAliasAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateAliasAPIs.cs
@@ -42,8 +42,10 @@ namespace System.Management.Automation
         /// </summary>
         internal IDictionary<string, AliasInfo> GetAliasTable()
         {
+            // On 7.0 version we have 132 aliases so we set a larger number to reduce re-allocations.
+            const int InitialAliasCount = 150;
             Dictionary<string, AliasInfo> result =
-                new Dictionary<string, AliasInfo>(StringComparer.OrdinalIgnoreCase);
+                new Dictionary<string, AliasInfo>(InitialAliasCount, StringComparer.OrdinalIgnoreCase);
 
             SessionStateScopeEnumerator scopeEnumerator =
                 new SessionStateScopeEnumerator(_currentScope);

--- a/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
+++ b/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
@@ -224,7 +224,7 @@ Describe "Command Discovery tests" -Tags "CI" {
         }
 
         It 'Can discover a native command with extension on Windows' -skip:(-not $IsWindows) {
-            (Get-Command -Name "pingG.exe" -CommandType Application).Name | Should -Match "ping.exe"
+            (Get-Command -Name "ping.exe" -CommandType Application).Name | Should -Match "ping.exe"
         }
     }
 }

--- a/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
+++ b/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+
 Describe "Command Discovery tests" -Tags "CI" {
 
     BeforeAll {
@@ -213,6 +214,17 @@ Describe "Command Discovery tests" -Tags "CI" {
 
         It "Should return command not found for commands in the global scope" {
             {Get-Command -Name 'global:help' -ErrorAction Stop} | Should -Throw -ErrorId 'CommandNotFoundException'
+        }
+    }
+
+    Context "Native command discovery" {
+        It 'Can discover a native command without extension' {
+            $expectedName = if ($IsWindows) { "ping.exe" } else { "ping" }
+            (Get-Command -Name "ping" -CommandType Application).Name | Should -Match $expectedName
+        }
+
+        It 'Can discover a native command with extension on Windows' -skip:(-not $IsWindows) {
+            (Get-Command -Name "pingG.exe" -CommandType Application).Name | Should -Match "ping.exe"
         }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Some cleanups in the command discovery code after investigating a performance:
- Remove unused code.
- Enable nullable reference types in CommandPathSearch.cs.
- Add tests for discovery native commands.
- Reduce allocations in GetAliasTable().
- Remove searching by extensions (ignore PATHEXT environment variable) on Unix

## PR Context

Related to #6577.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
