### PR TITLE
Update UseNewEnvironment parameter behavior of Start-Process cmdlet on Windows

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -2348,22 +2348,8 @@ namespace Microsoft.PowerShell.Commands
             return bytes;
         }
 
-        /// <summary>
-        /// This method will be used on all windows platforms, both full desktop and headless SKUs.
-        /// </summary>
-        private Process StartWithCreateProcess(ProcessStartInfo startinfo)
+        private void SetStartupInfo(ProcessStartInfo startinfo, ref ProcessNativeMethods.STARTUPINFO lpStartupInfo, ref int creationFlags)
         {
-            ProcessNativeMethods.STARTUPINFO lpStartupInfo = new ProcessNativeMethods.STARTUPINFO();
-            SafeNativeMethods.PROCESS_INFORMATION lpProcessInformation = new SafeNativeMethods.PROCESS_INFORMATION();
-            int error = 0;
-            GCHandle pinnedEnvironmentBlock = new GCHandle();
-            string message = string.Empty;
-
-            // building the cmdline with the file name given and it's arguments
-            StringBuilder cmdLine = BuildCommandLine(startinfo.FileName, startinfo.Arguments);
-
-            try
-            {
                 // RedirectionStandardInput
                 if (_redirectstandardinput != null)
                 {
@@ -2375,6 +2361,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     lpStartupInfo.hStdInput = new SafeFileHandle(ProcessNativeMethods.GetStdHandle(-10), false);
                 }
+
                 // RedirectionStandardOutput
                 if (_redirectstandardoutput != null)
                 {
@@ -2386,6 +2373,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     lpStartupInfo.hStdOutput = new SafeFileHandle(ProcessNativeMethods.GetStdHandle(-11), false);
                 }
+
                 // RedirectionStandardError
                 if (_redirectstandarderror != null)
                 {
@@ -2397,10 +2385,9 @@ namespace Microsoft.PowerShell.Commands
                 {
                     lpStartupInfo.hStdError = new SafeFileHandle(ProcessNativeMethods.GetStdHandle(-12), false);
                 }
+
                 // STARTF_USESTDHANDLES
                 lpStartupInfo.dwFlags = 0x100;
-
-                int creationFlags = 0;
 
                 if (startinfo.CreateNoWindow)
                 {
@@ -2411,6 +2398,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     // CREATE_NEW_CONSOLE
                     creationFlags |= 0x00000010;
+
                     // STARTF_USESHOWWINDOW
                     lpStartupInfo.dwFlags |= 0x00000001;
 
@@ -2438,15 +2426,41 @@ namespace Microsoft.PowerShell.Commands
 
                 // Create the new process suspended so we have a chance to get a corresponding Process object in case it terminates quickly.
                 creationFlags |= 0x00000004;
+        }
 
-                IntPtr AddressOfEnvironmentBlock = IntPtr.Zero;
-                var environmentVars = startinfo.EnvironmentVariables;
-                if (environmentVars != null)
+        /// <summary>
+        /// This method will be used on all windows platforms, both full desktop and headless SKUs.
+        /// </summary>
+        private Process StartWithCreateProcess(ProcessStartInfo startinfo)
+        {
+            ProcessNativeMethods.STARTUPINFO lpStartupInfo = new ProcessNativeMethods.STARTUPINFO();
+            SafeNativeMethods.PROCESS_INFORMATION lpProcessInformation = new SafeNativeMethods.PROCESS_INFORMATION();
+            int error = 0;
+            GCHandle pinnedEnvironmentBlock = new GCHandle();
+            IntPtr AddressOfEnvironmentBlock = IntPtr.Zero;
+            string message = string.Empty;
+
+            // building the cmdline with the file name given and it's arguments
+            StringBuilder cmdLine = BuildCommandLine(startinfo.FileName, startinfo.Arguments);
+
+            try
+            {
+                int creationFlags = 0;
+
+                SetStartupInfo(startinfo, ref lpStartupInfo, ref creationFlags);
+
+                // We follow the logic:
+                //   - Ignore `UseNewEnvironment` when we run a process as another user.
+                //          Setting initial environment variables makes sense only for current user.
+                //   - Set environment variables if they present in ProcessStartupInfo.
+                if (!UseNewEnvironment)
                 {
-                    if (this.UseNewEnvironment)
+                    var environmentVars = startinfo.EnvironmentVariables;
+                    if (environmentVars != null)
                     {
                         // All Windows Operating Systems that we support are Windows NT systems, so we use Unicode for environment.
                         creationFlags |= 0x400;
+
                         pinnedEnvironmentBlock = GCHandle.Alloc(ConvertEnvVarsToByteArray(environmentVars), GCHandleType.Pinned);
                         AddressOfEnvironmentBlock = pinnedEnvironmentBlock.AddrOfPinnedObject();
                     }
@@ -2456,6 +2470,7 @@ namespace Microsoft.PowerShell.Commands
 
                 if (_credential != null)
                 {
+                    // Run process as another user.
                     ProcessNativeMethods.LogonFlags logonFlags = 0;
                     if (startinfo.LoadUserProfile)
                     {
@@ -2504,6 +2519,22 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
 
+                // Run process as current user.
+                if (UseNewEnvironment)
+                {
+                    // All Windows Operating Systems that we support are Windows NT systems, so we use Unicode for environment.
+                    creationFlags |= 0x400;
+
+                    IntPtr token = WindowsIdentity.GetCurrent().Token;
+                    if (!ProcessNativeMethods.CreateEnvironmentBlock(out AddressOfEnvironmentBlock, token, false))
+                    {
+                        Win32Exception win32ex = new Win32Exception(error);
+                        message = StringUtil.Format(ProcessResources.InvalidStartProcess, win32ex.Message);
+                        var errorRecord = new ErrorRecord(new InvalidOperationException(message), "InvalidOperationException", ErrorCategory.InvalidOperation, null);
+                        ThrowTerminatingError(errorRecord);
+                    }
+                }
+
                 ProcessNativeMethods.SECURITY_ATTRIBUTES lpProcessAttributes = new ProcessNativeMethods.SECURITY_ATTRIBUTES();
                 ProcessNativeMethods.SECURITY_ATTRIBUTES lpThreadAttributes = new ProcessNativeMethods.SECURITY_ATTRIBUTES();
                 flag = ProcessNativeMethods.CreateProcess(null, cmdLine, lpProcessAttributes, lpThreadAttributes, true, creationFlags, AddressOfEnvironmentBlock, startinfo.WorkingDirectory, lpStartupInfo, lpProcessInformation);
@@ -2530,6 +2561,10 @@ namespace Microsoft.PowerShell.Commands
                 if (pinnedEnvironmentBlock.IsAllocated)
                 {
                     pinnedEnvironmentBlock.Free();
+                }
+                else
+                {
+                    ProcessNativeMethods.DestroyEnvironmentBlock(AddressOfEnvironmentBlock);
                 }
 
                 lpStartupInfo.Dispose();
@@ -2719,6 +2754,14 @@ namespace Microsoft.PowerShell.Commands
             DWORD dwFlagsAndAttributes,
             System.IntPtr hTemplateFile
             );
+
+        [DllImport("userenv.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool CreateEnvironmentBlock(out IntPtr lpEnvironment, IntPtr hToken, bool bInherit);
+
+        [DllImport("userenv.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool DestroyEnvironmentBlock(IntPtr lpEnvironment);
 
         [Flags]
         internal enum LogonFlags

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+
 Describe "Start-Process" -Tag "Feature","RequireAdminOnWindows" {
 
     BeforeAll {
@@ -19,7 +20,7 @@ Describe "Start-Process" -Tag "Feature","RequireAdminOnWindows" {
             $pingParam = "-n 2 localhost"
         }
         elseif ($IsLinux -Or $IsMacOS) {
-	        $pingParam = "-c 2 localhost"
+            $pingParam = "-c 2 localhost"
         }
     }
 
@@ -27,7 +28,7 @@ Describe "Start-Process" -Tag "Feature","RequireAdminOnWindows" {
     # This has been fixed on Linux, but not on macOS
 
     It "Should process arguments without error" {
-	    $process = Start-Process ping -ArgumentList $pingParam -PassThru -RedirectStandardOutput "$TESTDRIVE/output" @extraArgs
+        $process = Start-Process ping -ArgumentList $pingParam -PassThru -RedirectStandardOutput "$TESTDRIVE/output" @extraArgs
 
 	    $process.Length      | Should -Be 1
 	    $process.Id          | Should -BeGreaterThan 1
@@ -35,7 +36,7 @@ Describe "Start-Process" -Tag "Feature","RequireAdminOnWindows" {
     }
 
     It "Should work correctly when used with full path name" {
-	    $process = Start-Process $pingCommand -ArgumentList $pingParam -PassThru -RedirectStandardOutput "$TESTDRIVE/output"  @extraArgs
+        $process = Start-Process $pingCommand -ArgumentList $pingParam -PassThru -RedirectStandardOutput "$TESTDRIVE/output"  @extraArgs
 
 	    $process.Length      | Should -Be 1
 	    $process.Id          | Should -BeGreaterThan 1
@@ -43,7 +44,7 @@ Describe "Start-Process" -Tag "Feature","RequireAdminOnWindows" {
     }
 
     It "Should invoke correct path when used with FilePath argument" {
-	    $process = Start-Process -FilePath $pingCommand -ArgumentList $pingParam -PassThru -RedirectStandardOutput "$TESTDRIVE/output" @extraArgs
+        $process = Start-Process -FilePath $pingCommand -ArgumentList $pingParam -PassThru -RedirectStandardOutput "$TESTDRIVE/output" @extraArgs
 
 	    $process.Length      | Should -Be 1
 	    $process.Id          | Should -BeGreaterThan 1
@@ -51,18 +52,18 @@ Describe "Start-Process" -Tag "Feature","RequireAdminOnWindows" {
     }
 
     It "Should invoke correct path when used with Path alias argument" {
-	    $process = Start-Process -Path $pingCommand -ArgumentList $pingParam -PassThru -RedirectStandardOutput "$TESTDRIVE/output" @extraArgs
+        $process = Start-Process -Path $pingCommand -ArgumentList $pingParam -PassThru -RedirectStandardOutput "$TESTDRIVE/output" @extraArgs
 
-	    $process.Length | Should -Be 1
-	    $process.Id     | Should -BeGreaterThan 1
+        $process.Length | Should -Be 1
+        $process.Id     | Should -BeGreaterThan 1
     }
 
     It "Should wait for command completion if used with Wait argument" {
-	    $process = Start-Process ping -ArgumentList $pingParam -Wait -PassThru -RedirectStandardOutput "$TESTDRIVE/output" @extraArgs
+        $process = Start-Process ping -ArgumentList $pingParam -Wait -PassThru -RedirectStandardOutput "$TESTDRIVE/output" @extraArgs
     }
 
     It "Should work correctly with WorkingDirectory argument" {
-	    $process = Start-Process ping -WorkingDirectory $pingDirectory -ArgumentList $pingParam -PassThru -RedirectStandardOutput "$TESTDRIVE/output" @extraArgs
+        $process = Start-Process ping -WorkingDirectory $pingDirectory -ArgumentList $pingParam -PassThru -RedirectStandardOutput "$TESTDRIVE/output" @extraArgs
 
 	    $process.Length      | Should -Be 1
 	    $process.Id          | Should -BeGreaterThan 1
@@ -70,7 +71,7 @@ Describe "Start-Process" -Tag "Feature","RequireAdminOnWindows" {
     }
 
     It "Should handle stderr redirection without error" {
-	    $process = Start-Process ping -ArgumentList $pingParam -PassThru -RedirectStandardError $tempFile -RedirectStandardOutput "$TESTDRIVE/output"  @extraArgs
+        $process = Start-Process ping -ArgumentList $pingParam -PassThru -RedirectStandardError $tempFile -RedirectStandardOutput "$TESTDRIVE/output"  @extraArgs
 
 	    $process.Length      | Should -Be 1
 	    $process.Id          | Should -BeGreaterThan 1
@@ -78,16 +79,16 @@ Describe "Start-Process" -Tag "Feature","RequireAdminOnWindows" {
     }
 
     It "Should handle stdout redirection without error" {
-	    $process = Start-Process ping -ArgumentList $pingParam -Wait -RedirectStandardOutput $tempFile  @extraArgs
-	    $dirEntry = get-childitem $tempFile
-	    $dirEntry.Length | Should -BeGreaterThan 0
+        $process = Start-Process ping -ArgumentList $pingParam -Wait -RedirectStandardOutput $tempFile  @extraArgs
+        $dirEntry = get-childitem $tempFile
+        $dirEntry.Length | Should -BeGreaterThan 0
     }
 
     # Marking this test 'pending' to unblock daily builds. Filed issue : https://github.com/PowerShell/PowerShell/issues/2396
     It "Should handle stdin redirection without error" -Pending {
-	    $process = Start-Process sort -Wait -RedirectStandardOutput $tempFile -RedirectStandardInput $assetsFile  @extraArgs
-	    $dirEntry = get-childitem $tempFile
-	    $dirEntry.Length | Should -BeGreaterThan 0
+        $process = Start-Process sort -Wait -RedirectStandardOutput $tempFile -RedirectStandardInput $assetsFile  @extraArgs
+        $dirEntry = get-childitem $tempFile
+        $dirEntry.Length | Should -BeGreaterThan 0
     }
 
     ## -Verb is supported in PowerShell on Windows full desktop.
@@ -167,5 +168,32 @@ Describe "Start-Process tests requiring admin" -Tags "Feature","RequireAdminOnWi
 
         Wait-FileToBePresent -File "$testdrive\foo.txt" -TimeoutInSeconds 10 -IntervalInMilliseconds 100 | Should -BeTrue
         Get-Content $testdrive\foo.txt | Should -BeExactly $fooFile
+    }
+}
+
+Describe "Start-Process" -Tags "Feature" {
+
+    It "UseNewEnvironment parameter should reset environment variables for child process" {
+
+        $PWSH = (Get-Process -Id $PID).MainModule.FileName
+        $outputFile = Join-Path -Path $TestDrive -ChildPath output.txt
+
+        $env:TestEnvVariable | Should -BeNullOrEmpty
+
+        $env:TestEnvVariable = 1
+        $userName = $env:USERNAME
+
+        try {
+            Start-Process $PWSH -ArgumentList '-NoProfile','-Command Write-Output \"$($env:TestEnvVariable);$($env:USERNAME)\"' -RedirectStandardOutput $outputFile -Wait
+            Get-Content -LiteralPath $outputFile | Should -BeExactly "1;$userName"
+
+            # Check that:
+            # 1. Environment variables is resetted (TestEnvVariable is removed)
+            # 2. Environment variables comes from current user profile
+            Start-Process $PWSH -ArgumentList '-NoProfile','-Command Write-Output \"$($env:TestEnvVariable);$($env:USERNAME)\"' -RedirectStandardOutput $outputFile -Wait -UseNewEnvironment
+            Get-Content -LiteralPath $outputFile | Should -BeExactly ";$userName"
+        } finally {
+            $env:TestEnvVariable = $null
+        }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The PR effects only Windows behavior.
- With UseNewEnvironment parameter Start-Process run a child process with environment variables without modifications in current session (state before the session start).
See #4671 and PowerShell Committee conclusion https://github.com/PowerShell/PowerShell/pull/10745#issuecomment-542923823
- Without UseNewEnvironment parameter Start-Process run a child process with current environment variables from current session. (This allow us easily to add `-Environment` parameter late)

## PR Context

Replace #10561 
Fix #3545
Fix partially #4671

PowerShell Committee conclusion https://github.com/PowerShell/PowerShell/pull/10745#issuecomment-542923823

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/5774
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
