### PR TITLE
Fix pure expressions setting $? in pipeline chains

### DIFF
--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -3200,7 +3200,7 @@ namespace System.Management.Automation.Language
                     ExpressionCache.Constant(0)));
             tryBodyExprs.Add(Expression.Label(label0));
             tryBodyExprs.Add(Expression.Assign(dispatchIndex, ExpressionCache.Constant(1)));
-            tryBodyExprs.Add(Compile(currentChain.LhsPipelineChain));
+            tryBodyExprs.Add(CompilePipelineChainElement((PipelineAst)currentChain.LhsPipelineChain));
 
             // Remainder of try statement body
             // L1: dispatchIndex = 2; if ($?) pipeline2;
@@ -3234,7 +3234,7 @@ namespace System.Management.Automation.Language
                     ? s_getDollarQuestion
                     : s_notDollarQuestion;
 
-                tryBodyExprs.Add(Expression.IfThen(dollarQuestionCheck, Compile(currentChain.RhsPipeline)));
+                tryBodyExprs.Add(Expression.IfThen(dollarQuestionCheck, CompilePipelineChainElement(currentChain.RhsPipeline)));
 
                 currentChain = currentChain.Parent as PipelineChainAst;
             }
@@ -3275,6 +3275,24 @@ namespace System.Management.Automation.Language
             BlockExpression fullyExpandedBlock = Expression.Block(typeof(void), temps, exprs);
 
             return fullyExpandedBlock;
+        }
+
+        /// <summary>
+        /// Compile a pipeline as an element in a pipeline chain.
+        /// Needed since pure expressions won't set $? after them.
+        /// <seealso cref="CompileTrappableExpression"/> which does something similar.
+        /// </summary>
+        /// <param name="pipelineAst">The pipeline in the pipeline chain to compile to an expression.</param>
+        /// <returns>The compiled expression to execute the pipeline.</returns>
+        private Expression CompilePipelineChainElement(PipelineAst pipelineAst)
+        {
+            if (pipelineAst.PipelineElements.Count == 1 && pipelineAst.PipelineElements[0] is CommandExpressionAst)
+            {
+                // A single expression - must set $? after the expression.
+                return Expression.Block(Compile(pipelineAst), s_setDollarQuestionToTrue);
+            }
+
+            return Compile(pipelineAst);
         }
 
         public object VisitPipeline(PipelineAst pipelineAst)

--- a/src/System.Management.Automation/engine/parser/token.cs
+++ b/src/System.Management.Automation/engine/parser/token.cs
@@ -790,8 +790,8 @@ namespace System.Management.Automation.Language
 
             #region Flags for operators
 
-            /*               AndAnd */ TokenFlags.BinaryOperator | TokenFlags.ParseModeInvariant,
-            /*                 OrOr */ TokenFlags.BinaryOperator | TokenFlags.ParseModeInvariant,
+            /*               AndAnd */ TokenFlags.ParseModeInvariant,
+            /*                 OrOr */ TokenFlags.ParseModeInvariant,
             /*            Ampersand */ TokenFlags.SpecialOperator | TokenFlags.ParseModeInvariant,
             /*                 Pipe */ TokenFlags.SpecialOperator | TokenFlags.ParseModeInvariant,
             /*                Comma */ TokenFlags.UnaryOperator | TokenFlags.ParseModeInvariant,

--- a/test/powershell/Language/Operators/PipelineChainOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/PipelineChainOperator.Tests.ps1
@@ -77,6 +77,7 @@ Describe "Experimental Feature: && and || operators - Feature-Enabled" -Tag CI {
             @{ Statement = 'testexe -returncode 1 && "Hi"'; Output = @('1') }
             @{ Statement = 'testexe -returncode 1 || "hi"'; Output = @('1', 'hi') }
             @{ Statement = '"hello" && get-item macarena_doesnotexist || "there"; "hello" || "there"'; Output = @('hello', 'there', 'hello') }
+            @{ Statement = '1 + 1 && "Hi"'; Output = @(2, 'Hi') }
 
             # Pipeline and native command
             @{ Statement = '1,2,3 | % { $_ + 1 } && testexe -returncode 0'; Output = @('2','3','4','0') }

--- a/test/powershell/Language/Operators/PipelineChainOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/PipelineChainOperator.Tests.ps1
@@ -76,6 +76,7 @@ Describe "Experimental Feature: && and || operators - Feature-Enabled" -Tag CI {
             @{ Statement = '"hi" && testexe -returncode 1'; Output = @('hi', '1') }
             @{ Statement = 'testexe -returncode 1 && "Hi"'; Output = @('1') }
             @{ Statement = 'testexe -returncode 1 || "hi"'; Output = @('1', 'hi') }
+            @{ Statement = '"hello" && get-item macarena_doesnotexist || "there"; "hello" || "there"'; Output = @('hello', 'there', 'hello') }
 
             # Pipeline and native command
             @{ Statement = '1,2,3 | % { $_ + 1 } && testexe -returncode 0'; Output = @('2','3','4','0') }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

Fixes https://github.com/PowerShell/PowerShell/issues/10835.

Pure expressions now set `$?` properly in pipeline chains.

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
