### PR TITLE
Fix command runtime so StopUpstreamCommandsException doesn't get populated in `-ErrorVariable`

### DIFF
--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -2381,7 +2381,8 @@ namespace System.Management.Automation
             // 913088-2005/06/06
             // PipelineStoppedException should not get added to $Error
             // 2008/06/25 - narrieta: ExistNestedPromptException should not be added to $error either
-            if (!(e is HaltCommandException) && !(e is PipelineStoppedException) && !(e is ExitNestedPromptException))
+            // 2019/10/18 - StopUpstreamCommandsException should not be added either
+            if (!(e is HaltCommandException) && !(e is PipelineStoppedException) && !(e is ExitNestedPromptException) && !(e is StopUpstreamCommandsException))
             {
                 try
                 {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
@@ -115,7 +115,7 @@ Describe "Select-Object" -Tags "CI" {
 	$dirObject[$TestLength].Size | Should -Be ($orig2 + 1)
 	}
 
-	It "Should not leak internal exception for stopping upstream" {
+	It "Should not leak 'StopUpstreamCommandsException' internal exception for stopping upstream" {
 		1,2 | Select-Object -First 1 -ErrorVariable err
 		$err | Should -BeNullOrEmpty
 	}

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
@@ -113,7 +113,12 @@ Describe "Select-Object" -Tags "CI" {
 	$result[0].Size              | Should -Be ($orig1 + 1)
 	$dirObject[0].Size           | Should -Be ($orig1 + 1)
 	$dirObject[$TestLength].Size | Should -Be ($orig2 + 1)
-    }
+	}
+
+	It "Should not leak internal exception for stopping upstream" {
+		1,2 | Select-Object -First 1 -ErrorVariable err
+		$err | Should -BeNullOrEmpty
+	}
 }
 
 Describe "Select-Object DRT basic functionality" -Tags "CI" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

`StopUpstreamCommandsException` is a special exception used by cmdlets to tell PowerShell to stop upstream commands as it doesn't need any additional input.  For example: "1,2,3 | select-object -first 1" should stop the first part of the pipeline after `select-object` received 1 object as the request has been fulfilled.  However, if you use `1,2,3 | select-object -first 1 -errorvariable err`, the internal exception (which is handled) is put into the `$err` variable (although `$error` it not populated).  This means that scripts may treat this as an error or special case this `System error` and throwing it away.

The fix is in the code where the engine populates `-ErrorVariable` to discard `StopUpstreamCommandsException`.

I don't believe this is a breaking change as anyone working around this by throwing away that specific error (because `select-object` actually succeeded) won't be impacted by this change.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/9185

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
