### PR TITLE
Fix tab completion for parameters so that it shows common parameters as available

### DIFF
--- a/src/System.Management.Automation/engine/MergedCommandParameterMetadata.cs
+++ b/src/System.Management.Automation/engine/MergedCommandParameterMetadata.cs
@@ -500,47 +500,27 @@ namespace System.Management.Automation
 
             if (matchingParameters.Count > 1)
             {
-                // Prefer parameters in the cmdlet over common parameters
-                Collection<MergedCompiledCommandParameter> filteredParameters =
-                    new Collection<MergedCompiledCommandParameter>();
+                StringBuilder possibleMatches = new StringBuilder();
 
                 foreach (MergedCompiledCommandParameter matchingParameter in matchingParameters)
                 {
-                    if ((matchingParameter.BinderAssociation == ParameterBinderAssociation.DeclaredFormalParameters) ||
-                        (matchingParameter.BinderAssociation == ParameterBinderAssociation.DynamicParameters))
-                    {
-                        filteredParameters.Add(matchingParameter);
-                    }
+                    possibleMatches.Append(" -");
+                    possibleMatches.Append(matchingParameter.Parameter.Name);
                 }
 
-                if (filteredParameters.Count == 1)
-                {
-                    matchingParameters = filteredParameters;
-                }
-                else
-                {
-                    StringBuilder possibleMatches = new StringBuilder();
+                ParameterBindingException exception =
+                    new ParameterBindingException(
+                        ErrorCategory.InvalidArgument,
+                        invocationInfo,
+                        null,
+                        name,
+                        null,
+                        null,
+                        ParameterBinderStrings.AmbiguousParameter,
+                        "AmbiguousParameter",
+                        possibleMatches);
 
-                    foreach (MergedCompiledCommandParameter matchingParameter in matchingParameters)
-                    {
-                        possibleMatches.Append(" -");
-                        possibleMatches.Append(matchingParameter.Parameter.Name);
-                    }
-
-                    ParameterBindingException exception =
-                        new ParameterBindingException(
-                            ErrorCategory.InvalidArgument,
-                            invocationInfo,
-                            null,
-                            name,
-                            null,
-                            null,
-                            ParameterBinderStrings.AmbiguousParameter,
-                            "AmbiguousParameter",
-                            possibleMatches);
-
-                    throw exception;
-                }
+                throw exception;
             }
             else if (matchingParameters.Count == 0)
             {

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -906,7 +906,7 @@ dir -Recurse `
         It "Test completion with exact match" {
             $inputStr = 'get-content -wa'
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches | Should -HaveCount 3
+            $res.CompletionMatches | Should -HaveCount 4
             [string]::Join(',', ($res.CompletionMatches.completiontext | Sort-Object)) | Should -BeExactly "-wa,-Wait,-WarningAction,-WarningVariable"
         }
     }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -895,6 +895,20 @@ dir -Recurse `
             $res.CompletionMatches | Should -HaveCount 33
             $res.CompletionMatches[0].CompletionText | Should -BeExactly "Commands"
         }
+
+        It "Test completion with common parameters" {
+            $inputStr = 'invoke-webrequest -out'
+            $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
+            $res.CompletionMatches | Should -HaveCount 3
+            [string]::Join(',', ($res.CompletionMatches.completiontext | Sort-Object)) | Should -BeExactly "-OutBuffer,-OutFile,-OutVariable"
+        }
+
+        It "Test completion with exact match" {
+            $inputStr = 'get-content -wa'
+            $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
+            $res.CompletionMatches | Should -HaveCount 3
+            [string]::Join(',', ($res.CompletionMatches.completiontext | Sort-Object)) | Should -BeExactly "-wa,-Wait,-WarningAction,-WarningVariable"
+        }
     }
 
     Context "Module completion for 'using module'" {

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1336,7 +1336,7 @@ Describe "WSMan Config Provider tab complete tests" -Tags Feature,RequireAdminOn
     }
 
     It "Tab completion gets dynamic parameters for '<path>' using '<parameter>'" -TestCases @(
-        @{path = ""; parameter = "-co"; expected = "ConnectionURI"},
+        @{path = ""; parameter = "-conn"; expected = "ConnectionURI"},
         @{path = ""; parameter = "-op"; expected = "OptionSet"},
         @{path = ""; parameter = "-au"; expected = "Authentication"},
         @{path = ""; parameter = "-ce"; expected = "CertificateThumbprint"},

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Member.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Member.Tests.ps1
@@ -2,43 +2,43 @@
 # Licensed under the MIT License.
 Describe "Get-Member" -Tags "CI" {
     It "Should be able to be called on string objects, ints, arrays, etc" {
-	$a = 1 #test numbers
-	$b = 1.3
-	$c = $false #test bools
-	$d = @(1,3) # test arrays
-	$e = "anoeduntodeu" #test strings
-	$f = 'asntoheusth' #test strings
+        $a = 1 #test numbers
+        $b = 1.3
+        $c = $false #test bools
+        $d = @(1, 3) # test arrays
+        $e = "anoeduntodeu" #test strings
+        $f = 'asntoheusth' #test strings
 
-	Get-Member -InputObject $a | Should -Not -BeNullOrEmpty
-	Get-Member -InputObject $b | Should -Not -BeNullOrEmpty
-	Get-Member -InputObject $c | Should -Not -BeNullOrEmpty
-	Get-Member -InputObject $d | Should -Not -BeNullOrEmpty
-	Get-Member -InputObject $e | Should -Not -BeNullOrEmpty
-	Get-Member -InputObject $f | Should -Not -BeNullOrEmpty
+        Get-Member -InputObject $a | Should -Not -BeNullOrEmpty
+        Get-Member -InputObject $b | Should -Not -BeNullOrEmpty
+        Get-Member -InputObject $c | Should -Not -BeNullOrEmpty
+        Get-Member -InputObject $d | Should -Not -BeNullOrEmpty
+        Get-Member -InputObject $e | Should -Not -BeNullOrEmpty
+        Get-Member -InputObject $f | Should -Not -BeNullOrEmpty
     }
 
     It "Should be able to extract a field from string objects, ints, arrays, etc" {
-	$a = 1 #test numbers
-	$b = 1.3
-	$c = $false #test bools
-	$d = @(1,3) # test arrays
-	$e = "anoeduntodeu" #test strings
-	$f = 'asntoheusth' #test strings
+        $a = 1 #test numbers
+        $b = 1.3
+        $c = $false #test bools
+        $d = @(1, 3) # test arrays
+        $e = "anoeduntodeu" #test strings
+        $f = 'asntoheusth' #test strings
 
-	$a | Should -BeOfType 'Int32'
-	$b | Should -BeOfType 'Double'
-	$c | Should -BeOfType 'Boolean'
-	,$d | Should -BeOfType 'Object[]'
-	$e | Should -BeOfType 'String'
-	$f | Should -BeOfType 'String'
+        $a | Should -BeOfType 'Int32'
+        $b | Should -BeOfType 'Double'
+        $c | Should -BeOfType 'Boolean'
+        , $d | Should -BeOfType 'Object[]'
+        $e | Should -BeOfType 'String'
+        $f | Should -BeOfType 'String'
     }
 
     It "Should be able to be called on a newly created PSObject" {
-	$o = New-Object psobject
-	# this creates a dependency on the Add-Member cmdlet.
-	Add-Member -InputObject $o -MemberType NoteProperty -Name proppy -Value "superVal"
+        $o = New-Object psobject
+        # this creates a dependency on the Add-Member cmdlet.
+        Add-Member -InputObject $o -MemberType NoteProperty -Name proppy -Value "superVal"
 
-	Get-Member -InputObject $o | Should -Not -BeNullOrEmpty
+        Get-Member -InputObject $o | Should -Not -BeNullOrEmpty
     }
 
     It "Should be able to be called on IntPtr" {
@@ -47,13 +47,17 @@ Describe "Get-Member" -Tags "CI" {
         $results[0].Name | Should -BeExactly 'Size'
         $results[1].Name | Should -BeExactly 'Zero'
     }
+
+    It "Should work with incomplete parameter '-i'" {
+        $a = 1
+        Get-Member -i $a | Should -Not -BeNullOrEmpty
+    }
 }
 
 Describe "Get-Member DRT Unit Tests" -Tags "CI" {
     Context "Verify Get-Member with Class" {
-		if(-not ([System.Management.Automation.PSTypeName]'Employee').Type)
-		{
-			Add-Type -TypeDefinition @"
+        if (-not ([System.Management.Automation.PSTypeName]'Employee').Type) {
+            Add-Type -TypeDefinition @"
         public class Employee
         {
             private string firstName;
@@ -104,10 +108,10 @@ Describe "Get-Member DRT Unit Tests" -Tags "CI" {
             }
         }
 "@
-		}
+        }
 
         $fileToDeleteName = Join-Path $TestDrive -ChildPath "getMemberTest.ps1xml"
-        $XMLFile= @"
+        $XMLFile = @"
 <Types>
     <Type>
     <Name>Employee</Name>
@@ -175,19 +179,15 @@ Describe "Get-Member DRT Unit Tests" -Tags "CI" {
             $results.Length | Should -Be $methodList.Length
             $methodFound = @()
 
-            for ($i = 0;$i -lt $methodList.Length;$i++)
-            {
-                for ($j = 0;$j -lt $results.Length;$j++)
-                {
-                    if ($results[$j].Name.Equals($methodList[$i]))
-                    {
+            for ($i = 0; $i -lt $methodList.Length; $i++) {
+                for ($j = 0; $j -lt $results.Length; $j++) {
+                    if ($results[$j].Name.Equals($methodList[$i])) {
                         $methodFound += $true
                     }
                 }
             }
 
-            for ($i = 0;$i -lt $methodList.Length;$i++)
-            {
+            for ($i = 0; $i -lt $methodList.Length; $i++) {
                 $methodFound[$i] | Should -BeTrue
             }
         }
@@ -206,12 +206,9 @@ Describe "Get-Member DRT Unit Tests" -Tags "CI" {
             $obj = New-Object -TypeName System.Int32
             $results = $obj | Get-Member -Static
             $members = "MaxValue", "MinValue", "Parse", "TryParse"
-            foreach ($member in $members)
-            {
-                foreach ($result in $results)
-                {
-                    if($result.Name.Equals($member))
-                    {
+            foreach ($member in $members) {
+                foreach ($result in $results) {
+                    if ($result.Name.Equals($member)) {
                         return $true
                     }
                 }
@@ -222,12 +219,9 @@ Describe "Get-Member DRT Unit Tests" -Tags "CI" {
         It "Get the static properties and methods of int instance" {
             $results = 1 | Get-Member -Static
             $members = "MaxValue", "MinValue", "Parse", "TryParse"
-            foreach ($member in $members)
-            {
-                foreach ($result in $results)
-                {
-                    if($result.Name.Equals($member))
-                    {
+            foreach ($member in $members) {
+                foreach ($result in $results) {
+                    if ($result.Name.Equals($member)) {
                         return $true
                     }
                 }
@@ -238,12 +232,9 @@ Describe "Get-Member DRT Unit Tests" -Tags "CI" {
         It "Get the static properties and methods of int instance Wrapped" {
             $results = [pscustomobject]1 | Get-Member -Static
             $members = "MaxValue", "MinValue", "Parse", "TryParse"
-            foreach ($member in $members)
-            {
-                foreach ($result in $results)
-                {
-                    if($result.Name.Equals($member))
-                    {
+            foreach ($member in $members) {
+                foreach ($result in $results) {
+                    if ($result.Name.Equals($member)) {
                         return $true
                     }
                 }
@@ -260,15 +251,12 @@ Describe "Get-Member DRT Unit Tests" -Tags "CI" {
             $results | Where-Object Name -eq CreateNode | Should -Not -BeNullOrEmpty
         }
 
-        It 'Get hidden members'{
+        It 'Get hidden members' {
             $results = 'abc' | Get-Member -force
             $hiddenMembers = "psbase", "psextended", "psadapted", "pstypenames", "psobject"
-            foreach ($member in $hiddenMembers)
-            {
-                foreach ($result in $results)
-                {
-                    if($result.Name.Equals($member))
-                    {
+            foreach ($member in $hiddenMembers) {
+                foreach ($result in $results) {
+                    if ($result.Name.Equals($member)) {
                         return $true
                     }
                 }
@@ -276,15 +264,12 @@ Describe "Get-Member DRT Unit Tests" -Tags "CI" {
             }
         }
 
-        It 'Get Set Property Accessors On PsBase'{
+        It 'Get Set Property Accessors On PsBase' {
             $results = ('abc').psbase | Get-Member -force get_*
             $expectedMembers = "get_Chars", "get_Length"
-            foreach ($member in $expectedMembers)
-            {
-                foreach ($result in $results)
-                {
-                    if($result.Name.Equals($member))
-                    {
+            foreach ($member in $expectedMembers) {
+                foreach ($result in $results) {
+                    if ($result.Name.Equals($member)) {
                         return $true
                     }
                 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Member.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Member.Tests.ps1
@@ -50,7 +50,7 @@ Describe "Get-Member" -Tags "CI" {
 
     It "Should work with incomplete parameter '-i'" {
         $a = 1
-        Get-Member -i $a | Should -Not -BeNullOrEmpty
+        { Get-Member -i $a } | Should -Not -Throw
     }
 }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The current code deliberately filtered out common parameters and preferring specific parameters.  This resulted in tab completion where you only got results if the text matched a cmdlet parameter even though it would also match a common parameter.  Fix is to use the filtering code only if it's not a tab complete situation.  The `tryExactMatching` is only used when the cmdlet is being executed and not when tab complete is being used so we can use that to only exercise the filtering code.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/1265

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
