### PR TITLE
Add OutputType to `Get-Error` cmdlet and preserve original typenames

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Get-Error.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Get-Error.cs
@@ -21,6 +21,8 @@ namespace Microsoft.PowerShell.Commands
         internal const string ErrorParameterSetName = "Error";
         internal const string NewestParameterSetName = "Newest";
         internal const string AliasNewest = "Last";
+        internal const string ErrorRecordPSExtendedError = "System.Management.Automation.ErrorRecord#PSExtendedError";
+        internal const string ExceptionPSExtendedError = "System.Exception#PSExtendedError";
 
         /// <summary>
         /// Gets or sets the error object to resolve.
@@ -79,21 +81,21 @@ namespace Microsoft.PowerShell.Commands
 
                 if (obj.TypeNames.Contains("System.Management.Automation.ErrorRecord"))
                 {
-                    if (!obj.TypeNames.Contains("System.Management.Automation.ErrorRecord#PSExtendedError"))
+                    if (!obj.TypeNames.Contains(ErrorRecordPSExtendedError))
                     {
-                        obj.TypeNames.Insert(0, "System.Management.Automation.ErrorRecord#PSExtendedError");
+                        obj.TypeNames.Insert(0, ErrorRecordPSExtendedError);
 
-                        // Need to remove so this rendering doesn't take precedence
+                        // Need to remove so this rendering doesn't take precedence as ErrorRecords is "OutOfBand"
                         obj.TypeNames.Remove("System.Management.Automation.ErrorRecord");
                     }
                 }
                 else if (obj.TypeNames.Contains("System.Exception"))
                 {
-                    if (!obj.TypeNames.Contains("System.Exception#PSExtendedError"))
+                    if (!obj.TypeNames.Contains(ExceptionPSExtendedError))
                     {
-                        obj.TypeNames.Insert(0, "System.Exception#PSExtendedError");
+                        obj.TypeNames.Insert(0, ExceptionPSExtendedError);
 
-                        // Need to remove so this rendering doesn't take precedence
+                        // Need to remove so this rendering doesn't take precedence as Exception is "OutOfBand"
                         obj.TypeNames.Remove("System.Exception");
                     }
                 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Get-Error.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Get-Error.cs
@@ -15,7 +15,7 @@ namespace Microsoft.PowerShell.Commands
     [Cmdlet(VerbsCommon.Get, "Error",
         HelpUri = "https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/get-error?view=powershell-7&WT.mc_id=ps-gethelp",
         DefaultParameterSetName = NewestParameterSetName)]
-    [OutputType(typeof(ErrorRecord), typeof(Exception))]
+    [OutputType("PSExtendedError")]
     public sealed class GetErrorCommand : PSCmdlet
     {
         internal const string ErrorParameterSetName = "Error";

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Get-Error.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Get-Error.cs
@@ -15,7 +15,7 @@ namespace Microsoft.PowerShell.Commands
     [Cmdlet(VerbsCommon.Get, "Error",
         HelpUri = "https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/get-error?view=powershell-7&WT.mc_id=ps-gethelp",
         DefaultParameterSetName = NewestParameterSetName)]
-    [OutputType("System.Management.Automation.ErrorRecord#PSExtendedError","System.Exception#PSExtendedError")]
+    [OutputType("System.Management.Automation.ErrorRecord#PSExtendedError", "System.Exception#PSExtendedError")]
     public sealed class GetErrorCommand : PSCmdlet
     {
         internal const string ErrorParameterSetName = "Error";

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Get-Error.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Get-Error.cs
@@ -15,7 +15,7 @@ namespace Microsoft.PowerShell.Commands
     [Cmdlet(VerbsCommon.Get, "Error",
         HelpUri = "https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/get-error?view=powershell-7&WT.mc_id=ps-gethelp",
         DefaultParameterSetName = NewestParameterSetName)]
-    [OutputType(typeof(ErrorRecord), typeof(Exception))]
+    [OutputType("System.Management.Automation.ErrorRecord#PSExtendedError","System.Exception#PSExtendedError")]
     public sealed class GetErrorCommand : PSCmdlet
     {
         internal const string ErrorParameterSetName = "Error";

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Get-Error.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Get-Error.cs
@@ -89,7 +89,8 @@ namespace Microsoft.PowerShell.Commands
                         obj.TypeNames.Remove("System.Management.Automation.ErrorRecord");
                     }
                 }
-                else if (obj.TypeNames.Contains("System.Exception"))
+
+                if (obj.TypeNames.Contains("System.Exception"))
                 {
                     if (!obj.TypeNames.Contains(ExceptionPSExtendedError))
                     {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Get-Error.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Get-Error.cs
@@ -15,6 +15,7 @@ namespace Microsoft.PowerShell.Commands
     [Cmdlet(VerbsCommon.Get, "Error",
         HelpUri = "https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/get-error?view=powershell-7&WT.mc_id=ps-gethelp",
         DefaultParameterSetName = NewestParameterSetName)]
+    [OutputType(typeof(ErrorRecord), typeof(Exception))]
     public sealed class GetErrorCommand : PSCmdlet
     {
         internal const string ErrorParameterSetName = "Error";

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -137,13 +137,17 @@ namespace System.Management.Automation.Runspaces
                 "System.Management.Automation.ScriptBlock",
                 ViewsOf_System_Management_Automation_ScriptBlock());
 
-            yield return new ExtendedTypeDefinition(
-                "PSExtendedError",
+            var tdPSExtendedError = new ExtendedTypeDefinition(
+                "System.Management.Automation.ErrorRecord#PSExtendedError",
                 ViewsOf_System_Management_Automation_GetError());
+            tdPSExtendedError.TypeNames.Add("System.Exception#PSExtendedError");
+            yield return tdPSExtendedError;
 
-            yield return new ExtendedTypeDefinition(
+            var tdErrorRecord_Exception = new ExtendedTypeDefinition(
                 "System.Management.Automation.ErrorRecord",
                 ViewsOf_System_Management_Automation_ErrorRecord());
+            tdErrorRecord_Exception.TypeNames.Add("System.Exception");
+            yield return tdErrorRecord_Exception;
 
             yield return new ExtendedTypeDefinition(
                 "System.Management.Automation.WarningRecord",
@@ -156,10 +160,6 @@ namespace System.Management.Automation.Runspaces
             yield return new ExtendedTypeDefinition(
                 "System.Management.Automation.InformationRecord",
                 ViewsOf_System_Management_Automation_InformationRecord());
-
-            yield return new ExtendedTypeDefinition(
-                "System.Exception",
-                ViewsOf_System_Exception());
 
             yield return new ExtendedTypeDefinition(
                 "System.Management.Automation.CommandParameterSetInfo",
@@ -913,6 +913,16 @@ namespace System.Management.Automation.Runspaces
                                 $output.ToString()
                             }
 
+                            # Add back original typename and remove PSExtendedError
+                            if ($_.PSObject.TypeNames.Contains('System.Management.Automation.ErrorRecord#PSExtendedError')) {
+                                $_.PSObject.TypeNames.Add('System.Management.Automation.ErrorRecord')
+                                $null = $_.PSObject.TypeNames.Remove('System.Management.Automation.ErrorRecord#PSExtendedError')
+                            }
+                            elseif ($_.PSObject.TypeNames.Contains('System.Exception#PSExtendedError')) {
+                                $_.PSObject.TypeNames.Add('System.Exception')
+                                $null = $_.PSObject.TypeNames.Remove('System.Exception#PSExtendedError')
+                            }
+
                             Show-ErrorRecord $_
                         ")
                     .EndEntry()
@@ -1050,7 +1060,7 @@ namespace System.Management.Automation.Runspaces
                                         $prefix = ''
                                         $newline = [Environment]::Newline
 
-                                        if ($myinv -and $myinv.ScriptName -or $myinv.ScriptLineNumber -gt 1 -or $_.CategoryInfo.Category -eq 'ParserError') {
+                                        if ($myinv -and $myinv.ScriptName -or $myinv.ScriptLineNumber -gt 1 -or $err.CategoryInfo.Category -eq 'ParserError') {
                                             if ($myinv.ScriptName) {
                                                 $posmsg = ""${resetcolor}$($myinv.ScriptName)${newline}""
                                             }
@@ -1085,22 +1095,22 @@ namespace System.Management.Automation.Runspaces
                                             $message = ""${prefix}${offsetWhitespace}^ ""
                                         }
 
-                                        if (! $_.ErrorDetails -or ! $_.ErrorDetails.Message) {
+                                        if (! $err.ErrorDetails -or ! $err.ErrorDetails.Message) {
                                             # we use `n instead of $newline here because that's what is in the message
-                                            if ($_.CategoryInfo.Category -eq 'ParserError' -and $_.Exception.Message.Contains(""~`n"")) {
+                                            if ($err.CategoryInfo.Category -eq 'ParserError' -and $err.Exception.Message.Contains(""~`n"")) {
                                                 # need to parse out the relevant part of the pre-rendered positionmessage
-                                                $message += $_.Exception.Message.split(""~`n"")[1].split(""${newline}${newline}"")[0]
+                                                $message += $err.Exception.Message.split(""~`n"")[1].split(""${newline}${newline}"")[0]
                                             }
                                             else {
-                                                $message += $_.Exception.Message
+                                                $message += $err.Exception.Message
                                             }
                                         }
                                         else {
-                                            $message += $_.ErrorDetails.Message
+                                            $message += $err.ErrorDetails.Message
                                         }
 
                                         # if rendering line information, break up the message if it's wider than the console
-                                        if ($myinv -and $myinv.ScriptName -or $_.CategoryInfo.Category -eq 'ParserError') {
+                                        if ($myinv -and $myinv.ScriptName -or $err.CategoryInfo.Category -eq 'ParserError') {
                                             $prefixLength = Get-RawStringLength -string $prefix
                                             $prefixVtLength = $prefix.Length - $prefixLength
 
@@ -1129,7 +1139,7 @@ namespace System.Management.Automation.Runspaces
                                         $posmsg += ""${errorColor}"" + $message
 
                                         $reason = 'Error'
-                                        if ($_.Exception -and $_.Exception.WasThrownFromThrowStatement) {
+                                        if ($err.Exception -and $err.Exception.WasThrownFromThrowStatement) {
                                             $reason = 'Exception'
                                         }
                                         elseif ($myinv.MyCommand) {
@@ -1138,11 +1148,11 @@ namespace System.Management.Automation.Runspaces
                                         elseif ($myinv.InvocationName) {
                                             $reason = $myinv.InvocationName
                                         }
-                                        elseif ($_.CategoryInfo.Category) {
-                                            $reason = $_.CategoryInfo.Category
+                                        elseif ($err.CategoryInfo.Category) {
+                                            $reason = $err.CategoryInfo.Category
                                         }
-                                        elseif ($_.CategoryInfo.Reason) {
-                                            $reason = $_.CategoryInfo.Reason
+                                        elseif ($err.CategoryInfo.Reason) {
+                                            $reason = $err.CategoryInfo.Reason
                                         }
 
                                         $errorMsg = 'Error'
@@ -1150,16 +1160,23 @@ namespace System.Management.Automation.Runspaces
                                         ""${errorColor}${reason}: ${posmsg}${resetcolor}""
                                     }
 
-                                    if ($_.FullyQualifiedErrorId -eq 'NativeCommandErrorMessage' -or $_.FullyQualifiedErrorId -eq 'NativeCommandError') {
-                                        $_.Exception.Message
+                                    $myinv = $_.InvocationInfo
+                                    $err = $_
+                                    if (!$myinv -and $_.ErrorRecord -and $_.ErrorRecord.InvocationInfo) {
+                                        $err = $_.ErrorRecord
+                                        $myinv = $err.InvocationInfo
+                                    }
+
+                                    if ($err.FullyQualifiedErrorId -eq 'NativeCommandErrorMessage' -or $err.FullyQualifiedErrorId -eq 'NativeCommandError') {
+                                        $err.Exception.Message
                                     }
                                     else
                                     {
-                                        $myinv = $_.InvocationInfo
+                                        $myinv = $err.InvocationInfo
                                         if ($ErrorView -eq 'ConciseView') {
                                             $posmsg = Get-ConciseViewPositionMessage
                                         }
-                                        elseif ($myinv -and ($myinv.MyCommand -or ($_.CategoryInfo.Category -ne 'ParserError'))) {
+                                        elseif ($myinv -and ($myinv.MyCommand -or ($err.CategoryInfo.Category -ne 'ParserError'))) {
                                             $posmsg = $myinv.PositionMessage
                                         } else {
                                             $posmsg = ''
@@ -1170,8 +1187,8 @@ namespace System.Management.Automation.Runspaces
                                             $posmsg = ""`n"" + $posmsg
                                         }
 
-                                        if ( & { Set-StrictMode -Version 1; $_.PSMessageDetails } ) {
-                                            $posmsg = ' : ' +  $_.PSMessageDetails + $posmsg
+                                        if ($err.PSMessageDetails) {
+                                            $posmsg = ' : ' +  $err.PSMessageDetails + $posmsg
                                         }
 
                                         if ($ErrorView -eq 'ConciseView') {
@@ -1180,23 +1197,23 @@ namespace System.Management.Automation.Runspaces
 
                                         $indent = 4
 
-                                        $errorCategoryMsg = & { Set-StrictMode -Version 1; $_.ErrorCategory_Message }
+                                        $errorCategoryMsg = $err.ErrorCategory_Message
 
                                         if ($null -ne $errorCategoryMsg)
                                         {
-                                            $indentString = '+ CategoryInfo          : ' + $_.ErrorCategory_Message
+                                            $indentString = '+ CategoryInfo          : ' + $err.ErrorCategory_Message
                                         }
                                         else
                                         {
-                                            $indentString = '+ CategoryInfo          : ' + $_.CategoryInfo
+                                            $indentString = '+ CategoryInfo          : ' + $err.CategoryInfo
                                         }
 
                                         $posmsg += ""`n"" + $indentString
 
-                                        $indentString = ""+ FullyQualifiedErrorId : "" + $_.FullyQualifiedErrorId
+                                        $indentString = ""+ FullyQualifiedErrorId : "" + $err.FullyQualifiedErrorId
                                         $posmsg += ""`n"" + $indentString
 
-                                        $originInfo = & { Set-StrictMode -Version 1; $_.OriginInfo }
+                                        $originInfo = $err.OriginInfo
 
                                         if (($null -ne $originInfo) -and ($null -ne $originInfo.PSComputerName))
                                         {
@@ -1205,12 +1222,12 @@ namespace System.Management.Automation.Runspaces
                                         }
 
                                         if ($ErrorView -eq 'CategoryView') {
-                                            $_.CategoryInfo.GetMessage()
+                                            $err.CategoryInfo.GetMessage()
                                         }
-                                        elseif (! $_.ErrorDetails -or ! $_.ErrorDetails.Message) {
-                                            $_.Exception.Message + $posmsg + ""`n""
+                                        elseif (! $err.ErrorDetails -or ! $err.ErrorDetails.Message) {
+                                            $err.Exception.Message + $posmsg + ""`n""
                                         } else {
-                                            $_.ErrorDetails.Message + $posmsg
+                                            $err.ErrorDetails.Message + $posmsg
                                         }
                                     }
                                 ")
@@ -1244,16 +1261,6 @@ namespace System.Management.Automation.Runspaces
                 CustomControl.Create(outOfBand: true)
                     .StartEntry()
                         .AddScriptBlockExpressionBinding(@"$_.ToString()")
-                    .EndEntry()
-                .EndControl());
-        }
-
-        private static IEnumerable<FormatViewDefinition> ViewsOf_System_Exception()
-        {
-            yield return new FormatViewDefinition("Exception",
-                CustomControl.Create(outOfBand: true)
-                    .StartEntry()
-                        .AddScriptBlockExpressionBinding(@"$_.Message")
                     .EndEntry()
                 .EndControl());
         }

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -137,17 +137,17 @@ namespace System.Management.Automation.Runspaces
                 "System.Management.Automation.ScriptBlock",
                 ViewsOf_System_Management_Automation_ScriptBlock());
 
-            var tdPSExtendedError = new ExtendedTypeDefinition(
+            var extendedError = new ExtendedTypeDefinition(
                 "System.Management.Automation.ErrorRecord#PSExtendedError",
                 ViewsOf_System_Management_Automation_GetError());
-            tdPSExtendedError.TypeNames.Add("System.Exception#PSExtendedError");
-            yield return tdPSExtendedError;
+            extendedError.TypeNames.Add("System.Exception#PSExtendedError");
+            yield return extendedError;
 
-            var tdErrorRecord_Exception = new ExtendedTypeDefinition(
+            var errorRecord_Exception = new ExtendedTypeDefinition(
                 "System.Management.Automation.ErrorRecord",
                 ViewsOf_System_Management_Automation_ErrorRecord());
-            tdErrorRecord_Exception.TypeNames.Add("System.Exception");
-            yield return tdErrorRecord_Exception;
+            errorRecord_Exception.TypeNames.Add("System.Exception");
+            yield return errorRecord_Exception;
 
             yield return new ExtendedTypeDefinition(
                 "System.Management.Automation.WarningRecord",

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
@@ -28,13 +28,13 @@ Describe 'Get-Error tests' -Tag CI {
         $out | Should -BeLikeExactly '*InnerException*'
 
         $err = Get-Error
-        $err.GetType().Name | Should -BeExactly 'ErrorRecord'
+        $err | Should -BeOfType [System.Management.Automation.ErrorRecord]
         $err.PSObject.TypeNames | Should -Not -Contain 'System.Management.Automation.ErrorRecord'
         $err.PSObject.TypeNames | Should -Contain 'System.Management.Automation.ErrorRecord#PSExtendedError'
 
         # need to exercise the formatter
         $null = $err | Out-String
-        $err.GetType().Name | Should -BeExactly 'ErrorRecord'
+        $err | Should -BeOfType [System.Management.Automation.ErrorRecord]
         $err.PSObject.TypeNames | Should -Contain 'System.Management.Automation.ErrorRecord'
         $err.PSObject.TypeNames | Should -Not -Contain 'System.Management.Automation.ErrorRecord#PSExtendedError'
     }
@@ -91,14 +91,21 @@ Describe 'Get-Error tests' -Tag CI {
     }
 
     It 'Get-Error will handle Exceptions' {
-        try {
-            Invoke-Expression '1/d'
-        }
-        catch {
-        }
+        $e = [Exception]::new('myexception')
+        $error.Insert(0, $e)
 
         $out = Get-Error | Out-String
-        $out | Should -BeLikeExactly '*ExpectedValueExpression*'
-        $out | Should -BeLikeExactly '*UnexpectedToken*'
+        $out | Should -BeLikeExactly '*myexception*'
+
+        $err = Get-Error
+        $err | Should -BeOfType [System.Exception]
+        $err.PSObject.TypeNames | Should -Not -Contain 'System.Exception'
+        $err.PSObject.TypeNames | Should -Contain 'System.Exception#PSExtendedError'
+
+        # need to exercise the formatter
+        $null = $err | Out-String
+        $err | Should -BeOfType [System.Exception]
+        $err.PSObject.TypeNames | Should -Contain 'System.Exception'
+        $err.PSObject.TypeNames | Should -Not -Contain 'System.Exception#PSExtendedError'
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
@@ -28,6 +28,9 @@ Describe 'Get-Error tests' -Tag CI {
         $out | Should -BeLikeExactly '*InnerException*'
 
         $err = Get-Error
+        $err.GetType().Name | Should -BeExactly 'ErrorRecord'
+        $err.PSObject.TypeNames | Should -Not -Contain 'System.Management.Automation.ErrorRecord'
+        $err.PSObject.TypeNames | Should -Contain 'System.Management.Automation.ErrorRecord#PSExtendedError'
 
         # need to exercise the formatter
         $null = $err | Out-String

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
@@ -32,7 +32,7 @@ Describe 'Get-Error tests' -Tag CI {
         $err.PSObject.TypeNames | Should -Not -Contain 'System.Management.Automation.ErrorRecord'
         $err.PSObject.TypeNames | Should -Contain 'System.Management.Automation.ErrorRecord#PSExtendedError'
 
-        # need to exercise the formatter
+        # need to exercise the formatter to validate that the internal types are removed from the error object
         $null = $err | Out-String
         $err | Should -BeOfType [System.Management.Automation.ErrorRecord]
         $err.PSObject.TypeNames | Should -Contain 'System.Management.Automation.ErrorRecord'
@@ -102,7 +102,7 @@ Describe 'Get-Error tests' -Tag CI {
         $err.PSObject.TypeNames | Should -Not -Contain 'System.Exception'
         $err.PSObject.TypeNames | Should -Contain 'System.Exception#PSExtendedError'
 
-        # need to exercise the formatter
+        # need to exercise the formatter to validate that the internal types are removed from the error object
         $null = $err | Out-String
         $err | Should -BeOfType [System.Exception]
         $err.PSObject.TypeNames | Should -Contain 'System.Exception'

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
@@ -26,6 +26,14 @@ Describe 'Get-Error tests' -Tag CI {
 
         $out = Get-Error | Out-String
         $out | Should -BeLikeExactly '*InnerException*'
+
+        $err = Get-Error
+
+        # need to exercise the formatter
+        $null = $err | Out-String
+        $err.GetType().Name | Should -BeExactly 'ErrorRecord'
+        $err.PSObject.TypeNames | Should -Contain 'System.Management.Automation.ErrorRecord'
+        $err.PSObject.TypeNames | Should -Not -Contain 'System.Management.Automation.ErrorRecord#PSExtendedError'
     }
 
     It 'Get-Error -Newest `<count>` works: <scenario>' -TestCases @(


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Cmdlet was missing declaring OutputType which is `ErrorRecord#PSExtendedError` and `Exception#PSExtendedError`.  Added OutputType attribute.  Cmdlet adds the `PSExtendedError` typename and removes `Exception` and `ErrorRecord` typenames so that the formatting is used.  The formatter then removes `PSExtendedError` and puts back the original typename so that `$Error` should be the same before calling `Get-Error`.  While testing, had to make some changes to how InvocationInfo is retrieved so that ParseException which contains a nested ErrorRecord which as InvocationInfo is handled correctly.  Combined Exception and ErrorRecord formatter into one.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
