### PR TITLE
ConvertFrom-Json: Unwrap Collections by default

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertFromJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertFromJsonCommand.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Management.Automation;
-using System.Reflection;
 
 namespace Microsoft.PowerShell.Commands
 {
@@ -42,6 +41,13 @@ namespace Microsoft.PowerShell.Commands
         [Parameter()]
         [ValidateRange(ValidateRangeKind.Positive)]
         public int Depth { get; set; } = 1024;
+
+        /// <summary>
+        /// Gets or sets the switch to prevent ConvertFrom-Json from unravelling collections during deserialization, instead passing them as a single
+        /// object through the pipeline.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter NoEnumerate { get; set; }
 
         #endregion parameters
 
@@ -114,7 +120,7 @@ namespace Microsoft.PowerShell.Commands
                 ThrowTerminatingError(error);
             }
 
-            WriteObject(result);
+            WriteObject(result, !NoEnumerate.IsPresent);
             return (result != null);
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Json.Tests.ps1
@@ -37,6 +37,10 @@ Describe 'ConvertFrom-Json Unit Tests' -tags "CI" {
             @{ AsHashtable = $true  }
             @{ AsHashtable = $false }
         )
+        $testCasesWithAndWithoutNoEnumerateSwitch = @(
+            @{ NoEnumerate = $true  }
+            @{ NoEnumerate = $false }
+        )
     }
 
     It 'Can convert a single-line object with AsHashtable switch set to <AsHashtable>' -TestCases $testCasesWithAndWithoutAsHashtableSwitch {
@@ -105,6 +109,27 @@ Describe 'ConvertFrom-Json Unit Tests' -tags "CI" {
 
         { $nestedJson | ConvertFrom-Json -AsHashtable:$AsHashtable } |
             Should -Throw -ErrorId "System.ArgumentException,Microsoft.PowerShell.Commands.ConvertFromJsonCommand"
+    }
+
+    It 'Can correctly round trip arrays with NoEnumerate switch set to <NoEnumerate>' -TestCases $testCasesWithAndWithoutNoEnumerateSwitch {
+        Param($NoEnumerate)
+        '[ 1, 2 ]' | ConvertFrom-Json -NoEnumerate:$NoEnumerate | ConvertTo-Json -Compress | Should -Be '[1,2]'
+    }
+
+    It 'Unravels array elements when NoEnumerate switch is not set' {
+        ('[ 1, 2 ]' | ConvertFrom-Json | Measure-Object).Count | Should -Be 2
+    }
+
+    It 'Sends a Json array as a single element when NoEnumerate switch is set' {
+        ('[ 1, 2 ]' | ConvertFrom-Json -NoEnumerate | Measure-Object).Count | Should -Be 1
+    }
+
+    It 'Cannot round trip single element arrays without NoEnumerate switch' {
+        '[ 1 ]' | ConvertFrom-Json | ConvertTo-Json | Should -Be 1
+    }
+
+    It 'Can round trip single element arrays with NoEnumerate switch' {
+        '[ 1 ]' | ConvertFrom-Json -NoEnumerate | ConvertTo-Json -Compress | Should -Be '[1]'
     }
 
     It 'Can convert null' {


### PR DESCRIPTION
# PR Summary

Changes the default behavior of ConvertFrom-Json to follow the usual collection-unwrapping behavior. With this change `('[1,2]' | ConvertFrom-Json | Measure-Object).Count` returns 2, instead of 1.

Provides a NoEnumerate switch similar to the Write-Output command to revert to the old behavior.

See issue #3424.

## PR Context

Improves the user experience for the majority of people by changing ConvertFrom-Json's behavior to match the default behavior when dealing with collections. See for example [this](https://stackoverflow.com/questions/44471175/adding-a-specific-property-to-each-json-object-in-an-array-in-powershell/44473567#44473567) or [this](https://stackoverflow.com/questions/53602313/different-evaluation-for-convertfrom-json) stackoverflow question for examples of people falling into this trap.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
- **User-facing changes**
    - [x] Single element Json arrays can no longer be round tripped with ConvertTo-Json.
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/5101
- **Testing - New and feature**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
