### PR TITLE
Using .Net Core intrinsic type converter

### DIFF
--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -1502,7 +1502,7 @@ namespace System.Management.Automation
             }
 
             typesXmlConverter = TypeDescriptor.GetConverter(type);
-            if (typesXmlConverter != null)
+            if (typesXmlConverter != null && typesXmlConverter.GetType() != typeof(TypeConverter))
             {
                 s_tracer.WriteLine("Use intrinsic type converter");
                 return typesXmlConverter;

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -1490,13 +1490,6 @@ namespace System.Management.Automation
                 return typesXmlConverter;
             }
 
-            typesXmlConverter = TypeDescriptor.GetConverter(type);
-            if (typesXmlConverter != null)
-            {
-                s_tracer.WriteLine("Use intrinsic type converter");
-                return typesXmlConverter;
-            }
-
             var typeConverters = type.GetCustomAttributes(typeof(TypeConverterAttribute), false);
             foreach (var typeConverter in typeConverters)
             {
@@ -1506,6 +1499,13 @@ namespace System.Management.Automation
 
                 // The return statement makes sure we only process the first TypeConverterAttribute
                 return NewConverterInstance(assemblyQualifiedtypeName);
+            }
+
+            typesXmlConverter = TypeDescriptor.GetConverter(type);
+            if (typesXmlConverter != null)
+            {
+                s_tracer.WriteLine("Use intrinsic type converter");
+                return typesXmlConverter;
             }
 
             return null;

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -5527,7 +5527,7 @@ namespace System.Management.Automation
                 }
             }
 
-            if (TypeDescriptor.GetConverter(type) != null)
+            if (Convert.GetTypeCode(type) != TypeCode.Object && TypeDescriptor.GetConverter(type) != null)
             {
                 return true;
             }

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -2571,8 +2571,6 @@ namespace System.Management.Automation
                                     "InvalidCastTypeConvertersConvertTo", e,
                                     ExtendedTypeSystem.InvalidCastExceptionWithInnerException,
                                     valueToConvert.ToString(), resultType.ToString(), e.Message);
-                                result = null;
-                                return false;
                             }
                         }
                         else
@@ -2601,8 +2599,6 @@ namespace System.Management.Automation
                                     "InvalidCastPSTypeConvertersConvertTo", e,
                                     ExtendedTypeSystem.InvalidCastExceptionWithInnerException,
                                     valueToConvert.ToString(), resultType.ToString(), e.Message);
-                                result = null;
-                                return false;
                             }
                         }
                         else
@@ -2636,8 +2632,6 @@ namespace System.Management.Automation
                                 exc = new PSInvalidCastException("InvalidCastTypeConvertersConvertFrom", e,
                                     ExtendedTypeSystem.InvalidCastExceptionWithInnerException,
                                     valueToConvert.ToString(), resultType.ToString(), e.Message);
-                                result = null;
-                                return false;
                             }
                         }
                         else
@@ -2665,8 +2659,6 @@ namespace System.Management.Automation
                                 exc = new PSInvalidCastException("InvalidCastPSTypeConvertersConvertFrom", e,
                                     ExtendedTypeSystem.InvalidCastExceptionWithInnerException,
                                     valueToConvert.ToString(), resultType.ToString(), e.Message);
-                                result = null;
-                                return false;
                             }
                         }
                         else

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -2811,36 +2811,6 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// We need to add this built-in converter because in FullCLR, System.Uri has a TypeConverter attribute
-        /// declared: [TypeConverter(typeof(UriTypeConverter))], so the conversion from 'string' to 'Uri' is
-        /// actually taken care of by 'UriTypeConverter'. However, the type 'UriTypeConverter' is not available
-        /// in CoreCLR, and thus the conversion from 'string' to 'Uri' would show a different behavior.
-        ///
-        /// Therefore, we just add this built-in string-to-uri converter using the same logic 'UriTypeConverter'
-        /// is using in FullCLR, so the conversion behavior will be the same on desktop powershell and powershell core.
-        /// </summary>
-        private static Uri ConvertStringToUri(object valueToConvert,
-                                              Type resultType,
-                                              bool recursion,
-                                              PSObject originalValueToConvert,
-                                              IFormatProvider formatProvider,
-                                              TypeTable backupTable)
-        {
-            try
-            {
-                Diagnostics.Assert(valueToConvert is string, "Value to convert must be a string");
-                return new Uri((string)valueToConvert, UriKind.RelativeOrAbsolute);
-            }
-            catch (Exception uriException)
-            {
-                typeConversion.WriteLine("Exception in Uri constructor: \"{0}\".", uriException.Message);
-                throw new PSInvalidCastException("InvalidCastFromStringToUri", uriException,
-                    ExtendedTypeSystem.InvalidCastExceptionWithInnerException,
-                    valueToConvert.ToString(), resultType.ToString(), uriException.Message);
-            }
-        }
-
-        /// <summary>
         /// Attempts to use Parser.ScanNumber to get the value of a numeric string.
         /// </summary>
         /// <param name="strToConvert">The string to convert to a number.</param>
@@ -4525,7 +4495,6 @@ namespace System.Management.Automation
                 CacheConversion<Regex>(typeofString, typeof(Regex), LanguagePrimitives.ConvertStringToRegex, ConversionRank.Language);
                 CacheConversion<char[]>(typeofString, typeof(char[]), LanguagePrimitives.ConvertStringToCharArray, ConversionRank.StringToCharArray);
                 CacheConversion<Type>(typeofString, typeof(Type), LanguagePrimitives.ConvertStringToType, ConversionRank.Language);
-                CacheConversion<Uri>(typeofString, typeof(Uri), LanguagePrimitives.ConvertStringToUri, ConversionRank.Language);
                 CacheConversion<object>(typeofString, typeofDecimal, LanguagePrimitives.ConvertStringToDecimal, ConversionRank.NumericString);
                 CacheConversion<object>(typeofString, typeofFloat, LanguagePrimitives.ConvertStringToReal, ConversionRank.NumericString);
                 CacheConversion<object>(typeofString, typeofDouble, LanguagePrimitives.ConvertStringToReal, ConversionRank.NumericString);

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -5733,8 +5733,8 @@ namespace System.Management.Automation
                 converter = FigurePropertyConversion(fromType, toType, ref rank);
             }
 
-            if (TypeConverterPossiblyExists(fromType) || TypeConverterPossiblyExists(toType) || TypeConverterPossiblyExists(fromType, toType)
-                || (converter != null && valueDependentConversion != null))
+            if (TypeConverterPossiblyExists(fromType) || TypeConverterPossiblyExists(toType)
+                || (converter != null && valueDependentConversion != null) || (converter == null && TypeConverterPossiblyExists(fromType, toType)))
             {
                 ConvertCheckingForCustomConverter customConverter = new ConvertCheckingForCustomConverter();
                 customConverter.tryfirstConverter = valueDependentConversion;

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -1502,7 +1502,7 @@ namespace System.Management.Automation
             }
 
             typesXmlConverter = TypeDescriptor.GetConverter(type);
-            if (typesXmlConverter != null)
+            if (typesXmlConverter != null && typesXmlConverter.GetType() != typeof(TypeConverter))
             {
                 s_tracer.WriteLine("Use intrinsic type converter");
                 return typesXmlConverter;
@@ -5534,25 +5534,11 @@ namespace System.Management.Automation
                 return true;
             }
 
-            return false;
-        }
-
-        private static bool TypeConverterPossiblyExists(Type fromType, Type toType)
-        {
-            var converter = TypeDescriptor.GetConverter(fromType);
+            var converter = TypeDescriptor.GetConverter(type);
 
             // Generic TypeConverter can convert all types to string
             // this violates specific type conversions so we exclude it.
-            if (converter.GetType() != typeof(TypeConverter) && converter.CanConvertTo(toType))
-            {
-                return true;
-            }
-
-            converter = TypeDescriptor.GetConverter(toType);
-
-            // Generic TypeConverter can convert all types to string
-            // this violates specific type conversions so we exclude it.
-            if (converter.GetType() != typeof(TypeConverter) && converter.CanConvertFrom(fromType))
+            if (converter.GetType() != typeof(TypeConverter))
             {
                 return true;
             }
@@ -5734,7 +5720,7 @@ namespace System.Management.Automation
             }
 
             if (TypeConverterPossiblyExists(fromType) || TypeConverterPossiblyExists(toType)
-                || (converter != null && valueDependentConversion != null) || (converter == null && TypeConverterPossiblyExists(fromType, toType)))
+                || (converter != null && valueDependentConversion != null))
             {
                 ConvertCheckingForCustomConverter customConverter = new ConvertCheckingForCustomConverter();
                 customConverter.tryfirstConverter = valueDependentConversion;

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -5545,9 +5545,8 @@ namespace System.Management.Automation
                 }
             }
 
-            // GetCustomAttributes returns IEnumerable<Attribute> in CoreCLR
-            var typeConverters = type.GetCustomAttributes(typeof(TypeConverterAttribute), false);
-            if (typeConverters.Any())
+            var typeAttr = (TypeConverterAttribute)TypeDescriptor.GetAttributes(type)[typeof(TypeConverterAttribute)];
+            if (typeAttr != null)
             {
                 return true;
             }

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -5556,25 +5556,31 @@ namespace System.Management.Automation
         {
             convertViaTypeConverter = null;
 
-            var converter = TypeDescriptor.GetConverter(fromType);
+            var typeConverter = TypeDescriptor.GetConverter(fromType);
 
             // Generic TypeConverter can convert all types to string
             // this violates specific type conversions so we exclude it.
-            if (converter != null && converter.GetType() != typeof(TypeConverter) && converter.CanConvertTo(toType))
+            if (typeConverter != null && typeConverter.GetType() != typeof(TypeConverter) && typeConverter.CanConvertTo(toType))
             {
-                convertViaTypeConverter = new ConvertViaTypeConverter();
-                convertViaTypeConverter.convertTo = true;
+                convertViaTypeConverter = new ConvertViaTypeConverter()
+                {
+                    converter = typeConverter,
+                    convertTo = true
+                };
                 return true;
             }
 
-            converter = TypeDescriptor.GetConverter(toType);
+            typeConverter = TypeDescriptor.GetConverter(toType);
 
             // Generic TypeConverter can convert all types to string
             // this violates specific type conversions so we exclude it.
-            if (converter != null && converter.GetType() != typeof(TypeConverter) && converter.CanConvertFrom(fromType))
+            if (typeConverter != null && typeConverter.GetType() != typeof(TypeConverter) && typeConverter.CanConvertFrom(fromType))
             {
-                convertViaTypeConverter = new ConvertViaTypeConverter();
-                convertViaTypeConverter.convertTo = false;
+                convertViaTypeConverter = new ConvertViaTypeConverter()
+                {
+                    converter = typeConverter,
+                    convertTo = false
+                };
                 return true;
             }
 

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -4123,31 +4123,34 @@ namespace System.Management.Automation
             {
                 var value  = originalValueToConvert ?? valueToConvert;
                 InvalidCastException exc = null;
-                if (converter != null && convertTo)
-                {
-                    try
-                    {
-                        var result = converter.ConvertTo(null, GetCultureFromFormatProvider(formatProvider), value, resultType);
-                        typeConversion.WriteLine("TypeConvert ConvertTo Conversion succeeded.");
-                        return result;
-                    }
-                    catch (InvalidCastException e)
-                    {
-                        exc = e;
-                    }
-                }
 
                 if (converter != null)
                 {
-                    try
+                    if (convertTo)
                     {
-                        var result = converter.ConvertFrom(null, GetCultureFromFormatProvider(formatProvider), value);
-                        typeConversion.WriteLine("TypeConvert ConvertFrom Conversion succeeded.");
-                        return result;
+                        try
+                        {
+                            var result = converter.ConvertTo(null, GetCultureFromFormatProvider(formatProvider), value, resultType);
+                            typeConversion.WriteLine("TypeConvert ConvertTo Conversion succeeded.");
+                            return result;
+                        }
+                        catch (InvalidCastException e)
+                        {
+                            exc = e;
+                        }
                     }
-                    catch (InvalidCastException e)
+                    else
                     {
-                        exc = e;
+                        try
+                        {
+                            var result = converter.ConvertFrom(null, GetCultureFromFormatProvider(formatProvider), value);
+                            typeConversion.WriteLine("TypeConvert ConvertFrom Conversion succeeded.");
+                            return result;
+                        }
+                        catch (InvalidCastException e)
+                        {
+                            exc = e;
+                        }
                     }
                 }
 

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -1490,6 +1490,13 @@ namespace System.Management.Automation
                 return typesXmlConverter;
             }
 
+            typesXmlConverter = TypeDescriptor.GetConverter(type);
+            if (typesXmlConverter != null)
+            {
+                s_tracer.WriteLine("Use intrinsic type converter");
+                return typesXmlConverter;
+            }
+
             var typeConverters = type.GetCustomAttributes(typeof(TypeConverterAttribute), false);
             foreach (var typeConverter in typeConverters)
             {
@@ -5518,6 +5525,11 @@ namespace System.Management.Automation
                 {
                     return true;
                 }
+            }
+
+            if (TypeDescriptor.GetConverter(type) != null)
+            {
+                return true;
             }
 
             // GetCustomAttributes returns IEnumerable<Attribute> in CoreCLR

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -5527,7 +5527,8 @@ namespace System.Management.Automation
                 }
             }
 
-            if (Convert.GetTypeCode(type) != TypeCode.Object && TypeDescriptor.GetConverter(type) != null)
+            var converter = TypeDescriptor.GetConverter(type);
+            if (converter.GetType() != typeof(TypeConverter))
             {
                 return true;
             }

--- a/test/powershell/Host/Startup.Tests.ps1
+++ b/test/powershell/Host/Startup.Tests.ps1
@@ -68,7 +68,6 @@ Describe "Validate start of console host" -Tag CI {
             $allowedAssemblies += @(
                 'Microsoft.PowerShell.CoreCLR.Eventing.dll'
                 'System.DirectoryServices.dll'
-                'System.Drawing.Primitives.dll'
                 'System.Management.dll'
                 'System.Security.Claims.dll'
                 'System.Security.Cryptography.Primitives.dll'

--- a/test/powershell/Host/Startup.Tests.ps1
+++ b/test/powershell/Host/Startup.Tests.ps1
@@ -26,6 +26,7 @@ Describe "Validate start of console host" -Tag CI {
             'System.Diagnostics.Process.dll'
             'System.Diagnostics.TraceSource.dll'
             'System.Diagnostics.Tracing.dll'
+            'System.Drawing.Primitives.dll'
             'System.IO.FileSystem.AccessControl.dll'
             'System.IO.FileSystem.dll'
             'System.IO.FileSystem.DriveInfo.dll'

--- a/test/powershell/Host/Startup.Tests.ps1
+++ b/test/powershell/Host/Startup.Tests.ps1
@@ -26,7 +26,6 @@ Describe "Validate start of console host" -Tag CI {
             'System.Diagnostics.Process.dll'
             'System.Diagnostics.TraceSource.dll'
             'System.Diagnostics.Tracing.dll'
-            'System.Drawing.Primitives.dll'
             'System.IO.FileSystem.AccessControl.dll'
             'System.IO.FileSystem.dll'
             'System.IO.FileSystem.DriveInfo.dll'
@@ -69,6 +68,7 @@ Describe "Validate start of console host" -Tag CI {
             $allowedAssemblies += @(
                 'Microsoft.PowerShell.CoreCLR.Eventing.dll'
                 'System.DirectoryServices.dll'
+                'System.Drawing.Primitives.dll'
                 'System.Management.dll'
                 'System.Security.Claims.dll'
                 'System.Security.Cryptography.Primitives.dll'

--- a/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
+++ b/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
@@ -43,7 +43,7 @@ Describe "Language Primitive Tests" -Tags "CI" {
     It "Convertion with 'TypeConverterAttribute' should be before convertion with .Net Core intrinsic type convertor" {
         $result = [System.Management.Automation.LanguagePrimitives]::ConvertTo('*Method*', [System.Management.Automation.PSMemberTypes])
         $result | Should -BeOfType [System.Management.Automation.PSMemberTypes]
-        $result | Should -Be [System.Management.Automation.PSMemberTypes]::Methods
+        $result | Should -BeExactly 'Methods'
     }
 
     It "Casting recursive array to bool should not cause crash" {

--- a/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
+++ b/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
@@ -38,10 +38,6 @@ Describe "Language Primitive Tests" -Tags "CI" {
         $result | Should -BeOfType [System.Drawing.Point]
         $result.X | Should -Be 2
         $result.Y | Should -Be 3
-
-        $result = [System.Management.Automation.LanguagePrimitives]::ConvertTo('http://test.site.com', [System.Uri])
-        $result | Should -BeOfType [System.Uri]
-        $result.AbsoluteUri | Should -Be 'http://test.site.com'
     }
 
     It "Convertion with 'TypeConverterAttribute' should be before convertion with .Net Core intrinsic type convertor" {

--- a/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
+++ b/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
@@ -38,6 +38,10 @@ Describe "Language Primitive Tests" -Tags "CI" {
         $result | Should -BeOfType [System.Drawing.Point]
         $result.X | Should -Be 2
         $result.Y | Should -Be 3
+
+        $result = [System.Management.Automation.LanguagePrimitives]::ConvertTo('http://test.site.com', [System.Uri])
+        $result | Should -BeOfType [System.Uri]
+        $result.AbsoluteUri | Should -Be 'http://test.site.com/'
     }
 
     It "Convertion with 'TypeConverterAttribute' should be before convertion with .Net Core intrinsic type convertor" {

--- a/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
+++ b/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
@@ -38,6 +38,10 @@ Describe "Language Primitive Tests" -Tags "CI" {
         $result | Should -BeOfType [System.Drawing.Point]
         $result.X | Should -Be 2
         $result.Y | Should -Be 3
+
+        $result = [System.Management.Automation.LanguagePrimitives]::ConvertTo('http://test.site.com', [System.Uri])
+        $result | Should -BeOfType [System.Uri]
+        $result.AbsoluteUri | Should -Be 'http://test.site.com'
     }
 
     It "Convertion with 'TypeConverterAttribute' should be before convertion with .Net Core intrinsic type convertor" {

--- a/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
+++ b/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
@@ -40,6 +40,12 @@ Describe "Language Primitive Tests" -Tags "CI" {
         $result.Y | Should -Be 3
     }
 
+    It "Convertion with 'TypeConverterAttribute' should be before convertion with .Net Core intrinsic type convertor" {
+        $result = [System.Management.Automation.LanguagePrimitives]::ConvertTo('*Method*', [System.Management.Automation.PSMemberTypes])
+        $result | Should -BeOfType [System.Management.Automation.PSMemberTypes]
+        $result | Should -Be [System.Management.Automation.PSMemberTypes]::Methods
+    }
+
     It "Casting recursive array to bool should not cause crash" {
         $a[0] = $a = [PSObject](, 1)
         [System.Management.Automation.LanguagePrimitives]::IsTrue($a) | Should -BeTrue

--- a/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
+++ b/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
@@ -22,10 +22,22 @@ Describe "Language Primitive Tests" -Tags "CI" {
         { $mshObj -eq [System.Management.Automation.LanguagePrimitives]::ConvertTo($mshObj, [Object]) } | Should -BeTrue
     }
 
-    It "Test Conversion of an IEnumerable to object[]" {
+    It "Test conversion of an IEnumerable to object[]" {
         $col = [System.Diagnostics.Process]::GetCurrentProcess().Modules
         $ObjArray = [System.Management.Automation.LanguagePrimitives]::ConvertTo($col, [object[]])
         $ObjArray.Length | Should -Be $col.Count
+    }
+
+    It "Test convertion with .Net Core intrinsic type convertor" {
+        $result = [System.Management.Automation.LanguagePrimitives]::ConvertTo('2,3', [System.Drawing.Point])
+        $result | Should -BeOfType [System.Drawing.Point]
+        $result.X | Should -Be 2
+        $result.Y | Should -Be 3
+
+        $result = [System.Management.Automation.LanguagePrimitives]::ConvertTo([PSObject]'2,3', [System.Drawing.Point])
+        $result | Should -BeOfType [System.Drawing.Point]
+        $result.X | Should -Be 2
+        $result.Y | Should -Be 3
     }
 
     It "Casting recursive array to bool should not cause crash" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #9863
Fix #10864

Using .Net Core intrinsic type converter in custom type conversions.

## PR Context

Previous .Net versions used TypeConverterAttribute to assign a type converter to the type.
Now the design was changed https://github.com/dotnet/corefx/issues/38374#issuecomment-500541150 and Core team recommendation is to consider using TypeDescriptor.GetConverter() to get these converters for [some .Net Core types](https://github.com/dotnet/corefx/blob/3a879b1a861946bf04cc3278d13df63e09dbe018/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs#L107-L140)

https://github.com/dotnet/corefx/blob/3a879b1a861946bf04cc3278d13df63e09dbe018/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs#L127-L134

like System.Drawing.Color, System.Drawing.Point.

- TypeDescriptor.GetConverter() processes TypeConverterAttribute but only for classes derived from TypeConverter class. So that PSTypeConverter class is changed to derive from TypeConverter.

- IsCustomTypeConversion doesn't throw and allow fallback. This address a scenario if we found a PowerShell converter, then a converter based on TypeConverterAttribute and the last throws at conversion time - after that now we can fallback to PowerShell converter.

- Remove Linq in TypeConverterAttribute search (using CoreFX pattern).

- Put PSTypeConverter before TypeConverter in IsCustomTypeConversion() because now first derived from second.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
