### PR TITLE
Add back `Clear-RecycleBin` for Windows

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/Microsoft.PowerShell.Commands.Management.csproj
+++ b/src/Microsoft.PowerShell.Commands.Management/Microsoft.PowerShell.Commands.Management.csproj
@@ -15,7 +15,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="commands\management\ClearRecycleBinCommand.cs" />
     <Compile Remove="commands\management\ControlPanelItemCommand.cs" />
     <Compile Remove="commands\management\CommitTransactionCommand.cs" />
     <Compile Remove="commands\management\Eventlog.cs" />
@@ -39,7 +38,6 @@
     <Compile Remove="gen\ControlPanelResources.cs" />
     <Compile Remove="gen\WmiResources.cs" />
     <Compile Remove="gen\ManagementMshSnapInResources.cs" />
-    <Compile Remove="gen\ClearRecycleBinResources.cs" />
     <Compile Remove="gen\ClipboardResources.cs" />
 
     <EmbeddedResource Remove="resources\EventlogResources.resx" />
@@ -48,7 +46,6 @@
     <EmbeddedResource Remove="resources\ControlPanelResources.resx" />
     <EmbeddedResource Remove="resources\WmiResources.resx" />
     <EmbeddedResource Remove="resources\ManagementMshSnapInResources.resx" />
-    <EmbeddedResource Remove="resources\ClearRecycleBinResources.resx" />
     <EmbeddedResource Remove="resources\ClipboardResources.resx" />
   </ItemGroup>
 

--- a/src/Modules/Windows/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1
+++ b/src/Modules/Windows/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1
@@ -67,5 +67,6 @@ CmdletsToExport=@("Add-Content",
     "Get-ComputerInfo",
     "Get-TimeZone",
     "Set-TimeZone",
-    "Get-HotFix")
+    "Get-HotFix",
+    "Clear-RecycleBin")
 }

--- a/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
+++ b/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
@@ -195,7 +195,7 @@ Describe "Verify approved aliases list" -Tags "CI" {
 "Cmdlet",       "Clear-History",                    "",                                 $($FullCLR -or $CoreWindows -or $CoreUnix),     "",                     "",                     "Medium"
 "Cmdlet",       "Clear-Item",                       "",                                 $($FullCLR -or $CoreWindows -or $CoreUnix),     "",                     "",                     "Medium"
 "Cmdlet",       "Clear-ItemProperty",               "",                                 $($FullCLR -or $CoreWindows -or $CoreUnix),     "",                     "",                     "Medium"
-"Cmdlet",       "Clear-RecycleBin",                 "",                                 $($FullCLR                               ),     "",                     "",                     ""
+"Cmdlet",       "Clear-RecycleBin",                 "",                                 $($FullCLR -or $CoreWindows              ),     "",                     "",                     "High"
 "Cmdlet",       "Clear-Variable",                   "",                                 $($FullCLR -or $CoreWindows -or $CoreUnix),     "",                     "",                     "Medium"
 "Cmdlet",       "Compare-Object",                   "",                                 $($FullCLR -or $CoreWindows -or $CoreUnix),     "",                     "",                     "None"
 "Cmdlet",       "Complete-Transaction",             "",                                 $($FullCLR                               ),     "",                     "",                     ""


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add back `Clear-RecycleBin` cmdlet for Windows for parity with Windows PowerShell.  Addressed misuse of GetLastError() by removing error handling since the API returns error only if recycle bin is empty already which is not useful for this cmdlet.

## PR Context

FIx https://github.com/PowerShell/PowerShell/issues/6743

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/5005
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
