### PR TITLE
`Install-Powershell.ps1`: Add parameter to use MSI installation

### DIFF
--- a/tools/install-powershell.ps1
+++ b/tools/install-powershell.ps1
@@ -38,6 +38,12 @@ param(
     [Parameter(ParameterSetName = "MSI")]
     [switch] $Quiet,
 
+    [Parameter(ParameterSetName = "MSI")]
+    [switch] $AddExplorerContextMenu,
+
+    [Parameter(ParameterSetName = "MSI")]
+    [switch] $EnablePSRemoting,
+
     [Parameter()]
     [switch] $Preview
 )
@@ -68,6 +74,14 @@ if (-not $UseMSI) {
 } else {
     if (-not $IsWinEnv) {
         throw "-UseMSI is only supported on Windows"
+    } else {
+        $MSIArguments = @()
+        if($AddExplorerContextMenu) {
+            $MSIArguments += "ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1"
+        }
+        if($EnablePSRemoting) {
+            $MSIArguments += "ENABLE_PSREMOTING=1"
+        }
     }
 }
 
@@ -300,12 +314,20 @@ try {
         if ($IsWinEnv) {
             if ($UseMSI -and $Quiet) {
                 Write-Verbose "Performing quiet install"
-                $process = Start-Process msiexec -ArgumentList "/i", $packagePath, "/quiet" -Wait -PassThru
+                $ArgumentList=@("/i", $packagePath, "/quiet")
+                if($MSIArguments) {
+                    $ArgumentList+=$MSIArguments
+                }
+                $process = Start-Process msiexec -ArgumentList $ArgumentList -Wait -PassThru
                 if ($process.exitcode -ne 0) {
                     throw "Quiet install failed, please rerun install without -Quiet switch or ensure you have administrator rights"
                 }
             } elseif ($UseMSI) {
-                Start-Process $packagePath -Wait
+                if($MSIArguments) {
+                    Start-Process $packagePath -ArgumentList $MSIArguments -Wait
+                } else {
+                    Start-Process $packagePath -Wait
+                }
             } else {
                 Expand-ArchiveInternal -Path $packagePath -DestinationPath $contentPath
             }
@@ -356,12 +378,20 @@ try {
         if ($IsWinEnv) {
             if ($UseMSI -and $Quiet) {
                 Write-Verbose "Performing quiet install"
-                $process = Start-Process msiexec -ArgumentList "/i", $packagePath, "/quiet" -Wait -PassThru
+                $ArgumentList=@("/i", $packagePath, "/quiet")
+                if($MSIArguments) {
+                    $ArgumentList+=$MSIArguments
+                }
+                $process = Start-Process msiexec -ArgumentList $ArgumentList -Wait -PassThru
                 if ($process.exitcode -ne 0) {
                     throw "Quiet install failed, please rerun install without -Quiet switch or ensure you have administrator rights"
                 }
             } elseif ($UseMSI) {
-                Start-Process $packagePath -Wait
+                if($MSIArguments) {
+                    Start-Process $packagePath -ArgumentList $MSIArguments -Wait
+                } else {
+                    Start-Process $packagePath -Wait
+                }
             } else {
                 Expand-ArchiveInternal -Path $packagePath -DestinationPath $contentPath
             }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
Added Parameter `-AddExplorerContextMenu` and `-EnablePSRemoting` to use MSI properties.
Documented [here](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-windows?view=powershell-6#administrative-install-from-the-command-line)

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
