### PR TITLE
Enable build of x86 MSIX package

### DIFF
--- a/tools/releaseBuild/azureDevOps/templates/upload.yml
+++ b/tools/releaseBuild/azureDevOps/templates/upload.yml
@@ -50,4 +50,4 @@ steps:
     Destination: AzureBlob
     storage: '$(StorageAccount)'
     ContainerName: '$(AzureVersion)'
-  condition: and(succeeded(), eq('${{ parameters.msix }}', 'yes'))
+  condition: and(succeeded(), eq('${{ parameters.msix }}', 'yes'), ne(variables['SHOULD_SIGN'], 'true'))

--- a/tools/releaseBuild/azureDevOps/templates/upload.yml
+++ b/tools/releaseBuild/azureDevOps/templates/upload.yml
@@ -50,4 +50,4 @@ steps:
     Destination: AzureBlob
     storage: '$(StorageAccount)'
     ContainerName: '$(AzureVersion)'
-  condition: and(succeeded(), eq('${{ parameters.msix }}', 'yes'), ne(variables['SHOULD_SIGN'], 'true'))
+  condition: and(succeeded(), eq('${{ parameters.msix }}', 'yes'), eq(variables['SHOULD_SIGN'], 'true'))

--- a/tools/releaseBuild/azureDevOps/templates/windows-package-signing.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-package-signing.yml
@@ -38,6 +38,7 @@ jobs:
       $authenticodefiles = @(
         "$(System.ArtifactsDirectory)\signed\PowerShell-$(Version)-win-x64.msi"
         "$(System.ArtifactsDirectory)\signed\PowerShell-$(Version)-win-x86.msi"
+        "$(System.ArtifactsDirectory)\signed\PowerShell-$(Version)-win-x86.msix"
         "$(System.ArtifactsDirectory)\signed\PowerShell-$(Version)-win-x64.msix"
         "$(System.ArtifactsDirectory)\signed\PowerShell-$(Version)-win-arm32.msix"
         "$(System.ArtifactsDirectory)\signed\PowerShell-$(Version)-win-arm64.msix"
@@ -70,7 +71,6 @@ jobs:
     parameters:
       architecture: x86
       version: $(version)
-      msix: no
 
   - template: upload.yml
     parameters:


### PR DESCRIPTION
Enable build of x86 MSIX package

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

We should support x86 architecture for MSIX package.  Tooling already supports building, just need to publish in our release pipeline.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
