### PR TITLE
Fix use of accent colors for hosts that don't support them

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -759,7 +759,14 @@ namespace System.Management.Automation.Runspaces
                                 $newline = [Environment]::Newline
                                 $output = [System.Text.StringBuilder]::new()
                                 $prefix = ' ' * $indent
-                                $accentColor = Get-VT100Color $Host.PrivateData.FormatAccentColor
+
+                                if ($null -ne $Host.PrivateData.FormatAccentColor) {
+                                    $accentColor = Get-VT100Color $Host.PrivateData.FormatAccentColor
+                                }
+                                else {
+                                    $accentColor = Get-VT100Color [Console]::ForegroundColor
+                                }
+
                                 $expandTypes = @(
                                     'Microsoft.Rest.HttpRequestMessageWrapper'
                                     'Microsoft.Rest.HttpResponseMessageWrapper'
@@ -1006,7 +1013,13 @@ namespace System.Management.Automation.Runspaces
                                         $accentColor = ''
                                         if ($Host.PrivateData) {
                                             $errorColor = Get-VT100Color -color $Host.PrivateData.ErrorForegroundColor
-                                            $accentColor = Get-VT100Color -color $Host.PrivateData.ErrorAccentColor
+
+                                            if ($null -ne $Host.PrivateData.ErrorAccentColor) {
+                                                $accentColor = Get-VT100Color -color $Host.PrivateData.ErrorAccentColor
+                                            }
+                                            else {
+                                                $accentColor = $errorColor
+                                            }
                                         }
 
                                         $posmsg = ''

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -759,12 +759,10 @@ namespace System.Management.Automation.Runspaces
                                 $newline = [Environment]::Newline
                                 $output = [System.Text.StringBuilder]::new()
                                 $prefix = ' ' * $indent
+                                $accentColor = ''
 
-                                if ($null -ne $Host.PrivateData.FormatAccentColor) {
-                                    $accentColor = Get-VT100Color $Host.PrivateData.FormatAccentColor
-                                }
-                                else {
-                                    $accentColor = Get-VT100Color [Console]::ForegroundColor
+                                if ($null -ne $Host.PrivateData) {
+                                    $accentColor = Get-VT100Color ($Host.PrivateData.FormatAccentColor ?? $Host.PrivateData.ErrorForegroundColor)
                                 }
 
                                 $expandTypes = @(
@@ -1011,15 +1009,10 @@ namespace System.Management.Automation.Runspaces
 
                                         $errorColor = ''
                                         $accentColor = ''
-                                        if ($Host.PrivateData) {
-                                            $errorColor = Get-VT100Color -color $Host.PrivateData.ErrorForegroundColor
 
-                                            if ($null -ne $Host.PrivateData.ErrorAccentColor) {
-                                                $accentColor = Get-VT100Color -color $Host.PrivateData.ErrorAccentColor
-                                            }
-                                            else {
-                                                $accentColor = $errorColor
-                                            }
+                                        if ($null -ne $Host.PrivateData) {
+                                            $errorColor = Get-VT100Color $Host.PrivateData.ErrorForegroundColor
+                                            $accentColor = Get-VT100Color ($Host.PrivateData.ErrorAccentColor ?? $errorColor)
                                         }
 
                                         $posmsg = ''


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

For existing hosts that don't expose the new Accent colors, need to default to a different color.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [x] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
