### PR TITLE
Handle case where Host may not return Rows or Cols of screen

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -987,8 +987,25 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     columnWidthsHint = tableHint.columnWidths;
                 }
 
-                _consoleHeight = GetConsoleWindowHeight(this.InnerCommand._lo.RowNumber);
-                _consoleWidth = GetConsoleWindowWidth(this.InnerCommand._lo.ColumnNumber);
+                try
+                {
+                    _consoleHeight = GetConsoleWindowHeight(this.InnerCommand._lo.RowNumber);
+                }
+                catch (Exception)
+                {
+                    // Some hosts may not implement getting the Rows so we default to 35
+                    _consoleHeight = 35;
+                }
+
+                try
+                {
+                    _consoleWidth = GetConsoleWindowWidth(this.InnerCommand._lo.ColumnNumber);
+                }
+                catch (Exception)
+                {
+                    // Some hosts may not implement getting the Cols so we default to 120
+                    _consoleHeight = 120;
+                }
 
                 int columns = this.CurrentTableHeaderInfo.tableColumnInfoList.Count;
                 if (columns == 0)

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -987,25 +987,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     columnWidthsHint = tableHint.columnWidths;
                 }
 
-                try
-                {
-                    _consoleHeight = GetConsoleWindowHeight(this.InnerCommand._lo.RowNumber);
-                }
-                catch (Exception)
-                {
-                    // Some hosts may not implement getting the Rows so we default to 35
-                    _consoleHeight = 35;
-                }
-
-                try
-                {
-                    _consoleWidth = GetConsoleWindowWidth(this.InnerCommand._lo.ColumnNumber);
-                }
-                catch (Exception)
-                {
-                    // Some hosts may not implement getting the Cols so we default to 120
-                    _consoleHeight = 120;
-                }
+                _consoleHeight = GetConsoleWindowHeight(this.InnerCommand._lo.RowNumber);
+                _consoleWidth = GetConsoleWindowWidth(this.InnerCommand._lo.ColumnNumber);
 
                 int columns = this.CurrentTableHeaderInfo.tableColumnInfoList.Count;
                 if (columns == 0)

--- a/src/System.Management.Automation/FormatAndOutput/out-console/ConsoleLineOutput.cs
+++ b/src/System.Management.Automation/FormatAndOutput/out-console/ConsoleLineOutput.cs
@@ -94,7 +94,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             {
                 return _rawUserInterface.LengthInBufferCells(str, offset);
             }
-            catch (Exception ex) when (ex is HostException || ex is NotImplementedException)
+            catch
             {
                 // thrown when external host rawui is not implemented, in which case
                 // we will fallback to the default value.
@@ -109,7 +109,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             {
                 return _rawUserInterface.LengthInBufferCells(str);
             }
-            catch (Exception ex) when (ex is HostException || ex is NotImplementedException)
+            catch
             {
                 // thrown when external host rawui is not implemented, in which case
                 // we will fallback to the default value.
@@ -124,7 +124,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             {
                 return _rawUserInterface.LengthInBufferCells(character);
             }
-            catch (Exception ex) when (ex is HostException || ex is NotImplementedException)
+            catch
             {
                 // thrown when external host rawui is not implemented, in which case
                 // we will fallback to the default value.
@@ -179,7 +179,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 {
                     return _forceNewLine ? raw.BufferSize.Width - 1 : raw.BufferSize.Width;
                 }
-                catch (Exception ex) when (ex is HostException || ex is NotImplementedException)
+                catch
                 {
                     // thrown when external host rawui is not implemented, in which case
                     // we will fallback to the default value.
@@ -205,7 +205,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 {
                     return raw.WindowSize.Height;
                 }
-                catch (Exception ex) when (ex is HostException || ex is NotImplementedException)
+                catch
                 {
                     // thrown when external host rawui is not implemented, in which case
                     // we will fallback to the default value.


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

In the case where the Host doesn't implement WindowSize so that Rows and Cols can be returned, this is handled locally.  But if used over interactive remote session, the remoting layer throws a remoting exception.  To handle this case, catch any exception trying to retrieve those values and use a default value so that formatting still renders.  The previous fix for this was too specific in the Exceptions caught that it didn't catch a remoting Exception.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
