### PR TITLE
Add Culture parameter to Select-String cmdlet

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -1076,6 +1076,89 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
+        /// Gets or sets a culture name.
+        /// </summary>
+        [Parameter]
+        [ValidateSet(typeof(ValidateMatchStringCultureNamesGenerator))]
+        [ValidateNotNull]
+        public string Culture
+        {
+            get
+            {
+                switch (_stringComparison)
+                {
+                    case StringComparison.Ordinal:
+                    case StringComparison.OrdinalIgnoreCase:
+                    {
+                        return "Ordinal";
+                    }
+                    case StringComparison.InvariantCulture:
+                    case StringComparison.InvariantCultureIgnoreCase:
+                    {
+                        return "Invariant";
+                    }
+                    case StringComparison.CurrentCulture:
+                    case StringComparison.CurrentCultureIgnoreCase:
+                    {
+                        return "CurrentCulture";
+                    }
+                }
+
+                return _cultureName;
+            }
+
+            set
+            {
+                _cultureName = value;
+                InitCulture();
+            }
+        }
+
+        private string _cultureName = CultureInfo.CurrentCulture.Name;
+        private StringComparison _stringComparison  = StringComparison.CurrentCultureIgnoreCase;
+        private CompareOptions _compareOptions  = CompareOptions.IgnoreCase;
+        private delegate int CultureInfoIndexOf(String source, String value, int startIndex, int count, CompareOptions options);
+
+        private CultureInfoIndexOf _cultureInfoIndexOf = CultureInfo.CurrentCulture.CompareInfo.IndexOf;
+
+        private void InitCulture()
+        {
+            _stringComparison = default;
+
+            switch (_cultureName)
+            {
+                case "Ordinal":
+                {
+                    _stringComparison = CaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+                    _compareOptions = CaseSensitive ? CompareOptions.Ordinal : CompareOptions.OrdinalIgnoreCase;
+                    _cultureInfoIndexOf = CultureInfo.InvariantCulture.CompareInfo.IndexOf;
+                    break;
+                }
+                case "Invariant":
+                {
+                    _stringComparison = CaseSensitive ? StringComparison.InvariantCulture : StringComparison.InvariantCultureIgnoreCase;
+                    _compareOptions = CaseSensitive ? CompareOptions.None : CompareOptions.IgnoreCase;
+                    _cultureInfoIndexOf = CultureInfo.InvariantCulture.CompareInfo.IndexOf;
+                    break;
+                }
+                case "CurrentCulture":
+                {
+                    _stringComparison = CaseSensitive ? StringComparison.CurrentCulture : StringComparison.CurrentCultureIgnoreCase;
+                    _compareOptions = CaseSensitive ? CompareOptions.None : CompareOptions.IgnoreCase;
+                    _cultureInfoIndexOf = CultureInfo.CurrentCulture.CompareInfo.IndexOf;
+                    break;
+                }
+                default:
+                {
+                    var _cultureInfo = CultureInfo.GetCultureInfo(_cultureName);
+                    _compareOptions = CaseSensitive ? CompareOptions.None : CompareOptions.IgnoreCase;
+                    _cultureInfoIndexOf = _cultureInfo.CompareInfo.IndexOf;
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the current pipeline object.
         /// </summary>
         [Parameter(ValueFromPipeline = true, Mandatory = true, ParameterSetName = ParameterSetObject)]
@@ -1322,6 +1405,15 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void BeginProcessing()
         {
+            if (this.MyInvocation.BoundParameters.ContainsKey(nameof(Culture)) && !this.MyInvocation.BoundParameters.ContainsKey(nameof(SimpleMatch)))
+            {
+                InvalidOperationException exception = new InvalidOperationException(MatchStringStrings.CannotSpecifyCultureWithoutSimpleMatch);
+                ErrorRecord errorRecord = new ErrorRecord(exception, "CannotSpecifyCultureWithoutSimpleMatch", ErrorCategory.InvalidData, null);
+                this.ThrowTerminatingError(errorRecord);
+            }
+
+            InitCulture();
+
             string suppressVt = Environment.GetEnvironmentVariable("__SuppressAnsiEscapeSequences");
             if (!string.IsNullOrEmpty(suppressVt))
             {
@@ -1734,7 +1826,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     string pat = Pattern[patternIndex];
 
-                    int index = operandString.IndexOf(pat, compareOption);
+                    int index = _cultureInfoIndexOf(operandString, pat, 0, operandString.Length, _compareOptions);
                     if (index >= 0)
                     {
                         if (shouldEmphasize)
@@ -1970,6 +2062,27 @@ namespace Microsoft.PowerShell.Commands
             }
 
             return ok;
+        }
+    }
+
+    /// <summary>
+    /// Get list of valid culture names for ValidateSet attribute.
+    /// </summary>
+    public class ValidateMatchStringCultureNamesGenerator : IValidateSetValuesGenerator
+    {
+        string[] IValidateSetValuesGenerator.GetValidValues()
+        {
+            var cultures = CultureInfo.GetCultures(CultureTypes.AllCultures);
+            var result = new List<string>(cultures.Length+3);
+            result.Add("Ordinal");
+            result.Add("Invariant");
+            result.Add("CurrentCulture");
+            foreach (var cultureInfo in cultures)
+            {
+                result.Add(cultureInfo.Name);
+            }
+
+            return result.ToArray();
         }
     }
 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -1090,19 +1090,19 @@ namespace Microsoft.PowerShell.Commands
                     case StringComparison.Ordinal:
                     case StringComparison.OrdinalIgnoreCase:
                     {
-                        return "Ordinal";
+                        return OrdinalCultureName;
                     }
 
                     case StringComparison.InvariantCulture:
                     case StringComparison.InvariantCultureIgnoreCase:
                     {
-                        return "Invariant";
+                        return InvariantCultureName;
                     }
 
                     case StringComparison.CurrentCulture:
                     case StringComparison.CurrentCultureIgnoreCase:
                     {
-                        return "CurrentCulture";
+                        return CurrentCultureName;
                     }
                 }
 
@@ -1115,6 +1115,10 @@ namespace Microsoft.PowerShell.Commands
                 InitCulture();
             }
         }
+
+        internal const string OrdinalCultureName = "Ordinal";
+        internal const string InvariantCultureName = "Invariant";
+        internal const string CurrentCultureName = "Current";
 
         private string _cultureName = CultureInfo.CurrentCulture.Name;
         private StringComparison _stringComparison  = StringComparison.CurrentCultureIgnoreCase;
@@ -1130,7 +1134,7 @@ namespace Microsoft.PowerShell.Commands
 
             switch (_cultureName)
             {
-                case "Ordinal":
+                case OrdinalCultureName:
                 {
                     _stringComparison = CaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
                     _compareOptions = CaseSensitive ? CompareOptions.Ordinal : CompareOptions.OrdinalIgnoreCase;
@@ -1138,7 +1142,7 @@ namespace Microsoft.PowerShell.Commands
                     break;
                 }
 
-                case "Invariant":
+                case InvariantCultureName:
                 {
                     _stringComparison = CaseSensitive ? StringComparison.InvariantCulture : StringComparison.InvariantCultureIgnoreCase;
                     _compareOptions = CaseSensitive ? CompareOptions.None : CompareOptions.IgnoreCase;
@@ -1146,7 +1150,7 @@ namespace Microsoft.PowerShell.Commands
                     break;
                 }
 
-                case "CurrentCulture":
+                case CurrentCultureName:
                 {
                     _stringComparison = CaseSensitive ? StringComparison.CurrentCulture : StringComparison.CurrentCultureIgnoreCase;
                     _compareOptions = CaseSensitive ? CompareOptions.None : CompareOptions.IgnoreCase;
@@ -2080,9 +2084,9 @@ namespace Microsoft.PowerShell.Commands
         {
             var cultures = CultureInfo.GetCultures(CultureTypes.AllCultures);
             var result = new List<string>(cultures.Length + 3);
-            result.Add("Ordinal");
-            result.Add("Invariant");
-            result.Add("CurrentCulture");
+            result.Add(SelectStringCommand.OrdinalCultureName);
+            result.Add(SelectStringCommand.InvariantCultureName);
+            result.Add(SelectStringCommand.CurrentCultureName);
             foreach (var cultureInfo in cultures)
             {
                 result.Add(cultureInfo.Name);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -1835,8 +1835,6 @@ namespace Microsoft.PowerShell.Commands
             }
             else
             {
-                StringComparison compareOption = CaseSensitive ?
-                    StringComparison.CurrentCulture : StringComparison.CurrentCultureIgnoreCase;
                 while (patternIndex < Pattern.Length)
                 {
                     string pat = Pattern[patternIndex];

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -1104,6 +1104,11 @@ namespace Microsoft.PowerShell.Commands
                     {
                         return CurrentCultureName;
                     }
+
+                    default:
+                    {
+                        break;
+                    }
                 }
 
                 return _cultureName;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -1117,7 +1117,8 @@ namespace Microsoft.PowerShell.Commands
         private string _cultureName = CultureInfo.CurrentCulture.Name;
         private StringComparison _stringComparison  = StringComparison.CurrentCultureIgnoreCase;
         private CompareOptions _compareOptions  = CompareOptions.IgnoreCase;
-        private delegate int CultureInfoIndexOf(String source, String value, int startIndex, int count, CompareOptions options);
+
+        private delegate int CultureInfoIndexOf(string source, string value, int startIndex, int count, CompareOptions options);
 
         private CultureInfoIndexOf _cultureInfoIndexOf = CultureInfo.CurrentCulture.CompareInfo.IndexOf;
 
@@ -1134,6 +1135,7 @@ namespace Microsoft.PowerShell.Commands
                     _cultureInfoIndexOf = CultureInfo.InvariantCulture.CompareInfo.IndexOf;
                     break;
                 }
+
                 case "Invariant":
                 {
                     _stringComparison = CaseSensitive ? StringComparison.InvariantCulture : StringComparison.InvariantCultureIgnoreCase;
@@ -1141,6 +1143,7 @@ namespace Microsoft.PowerShell.Commands
                     _cultureInfoIndexOf = CultureInfo.InvariantCulture.CompareInfo.IndexOf;
                     break;
                 }
+
                 case "CurrentCulture":
                 {
                     _stringComparison = CaseSensitive ? StringComparison.CurrentCulture : StringComparison.CurrentCultureIgnoreCase;
@@ -1148,6 +1151,7 @@ namespace Microsoft.PowerShell.Commands
                     _cultureInfoIndexOf = CultureInfo.CurrentCulture.CompareInfo.IndexOf;
                     break;
                 }
+
                 default:
                 {
                     var _cultureInfo = CultureInfo.GetCultureInfo(_cultureName);
@@ -2073,7 +2077,7 @@ namespace Microsoft.PowerShell.Commands
         string[] IValidateSetValuesGenerator.GetValidValues()
         {
             var cultures = CultureInfo.GetCultures(CultureTypes.AllCultures);
-            var result = new List<string>(cultures.Length+3);
+            var result = new List<string>(cultures.Length + 3);
             result.Add("Ordinal");
             result.Add("Invariant");
             result.Add("CurrentCulture");

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -1092,11 +1092,13 @@ namespace Microsoft.PowerShell.Commands
                     {
                         return "Ordinal";
                     }
+
                     case StringComparison.InvariantCulture:
                     case StringComparison.InvariantCultureIgnoreCase:
                     {
                         return "Invariant";
                     }
+
                     case StringComparison.CurrentCulture:
                     case StringComparison.CurrentCultureIgnoreCase:
                     {

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/MatchStringStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/MatchStringStrings.resx
@@ -129,4 +129,7 @@
   <data name="InvalidRegex" xml:space="preserve">
     <value>The string {0} is not a valid regular expression: {1}</value>
   </data>
+  <data name="CannotSpecifyCultureWithoutSimpleMatch" xml:space="preserve">
+    <value>You must specify -Culture parameter only with -SimpleMatch parameter.</value>
+  </data>
 </root>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -262,37 +262,36 @@ Describe "Select-String" -Tags "CI" {
         It "Should accept a culture: '<culture>'" -TestCases: @(
             @{ culture = "Ordinal"},
             @{ culture = "Invariant"},
-            @{ culture = "CurrentCulture"},
+            @{ culture = "Current"},
             @{ culture = "ru-RU"}
         ) {
             param ($culture)
             { "1" | Select-String -Pattern "hello" -Culture $culture -SimpleMatch } | Should -Not -Throw
         }
 
-        It "Should works if -Culture parameter is a culture name" {
-            # Turkish has lower-case and upper-case version of the dotted "i",
-            # so the upper case of "i" (U+0069) isn't "I" (U+0049) but rather U+0130.
-            "file" | Select-String -Pattern "file" -Culture "tr-TR" -SimpleMatch | Should -BeExactly "file"
-            "file" | Select-String -Pattern "fIle" -Culture "tr-TR" -SimpleMatch | Should -BeNullOrEmpty
-            "file" | Select-String -Pattern "fIle" -Culture "tr-TR" -SimpleMatch -CaseSensitive | Should -BeNullOrEmpty
+        It "Should works if -Culture parameter is a culture name: '<culture>'-'<pattern>'-'CaseSensitive:<casesensitive>'" -TestCases: @(
+            @{pattern = 'file'; culture = 'tr-TR';       expected = 'file'; casesensitive = $false }
+            @{pattern = 'fIle'; culture = 'tr-TR';       expected = $null;  casesensitive = $false }
+            @{pattern = 'fIle'; culture = 'tr-TR';       expected = $null;  casesensitive = $true }
+            @{pattern = "f`u{0130}le"; culture = 'tr-TR';expected = 'file'; casesensitive = $false }
+            @{pattern = 'file'; culture = 'en-US';       expected = 'file'; casesensitive = $false }
+            @{pattern = 'fIle'; culture = 'en-US';       expected = 'file'; casesensitive = $false }
+            @{pattern = 'fIle'; culture = 'en-US';       expected = $null;  casesensitive = $true }
+            @{pattern = 'file'; culture = 'Ordinal';     expected = 'file'; casesensitive = $false }
+            @{pattern = 'fIle'; culture = 'Ordinal';     expected = 'file'; casesensitive = $false }
+            @{pattern = 'fIle'; culture = 'Ordinal';     expected = $null;  casesensitive = $true }
+            @{pattern = 'file'; culture = 'Invariant';   expected = 'file'; casesensitive = $false }
+            @{pattern = 'fIle'; culture = 'Invariant';   expected = 'file'; casesensitive = $false }
+            @{pattern = 'fIle'; culture = 'Invariant';   expected = $null;  casesensitive = $true }
+            @{pattern = 'file'; culture = 'Current';     expected = 'file'; casesensitive = $false }
+            @{pattern = 'fIle'; culture = 'Current';     expected = 'file'; casesensitive = $false }
+            @{pattern = 'fIle'; culture = 'Current';     expected = $null;  casesensitive = $true }
+        ) {
+            param ($pattern, $culture, $expected, $casesensitive)
 
-            "file" | Select-String -Pattern "file" -Culture "en-US" -SimpleMatch | Should -BeExactly "file"
-            "file" | Select-String -Pattern "fIle" -Culture "en-US" -SimpleMatch | Should -BeExactly "file"
-            "file" | Select-String -Pattern "fIle" -Culture "en-US" -SimpleMatch -CaseSensitive | Should -BeNullOrEmpty
-
-            "file" | Select-String -Pattern "file" -Culture "Ordinal" -SimpleMatch | Should -BeExactly "file"
-            "file" | Select-String -Pattern "fIle" -Culture "Ordinal" -SimpleMatch | Should -BeExactly "file"
-            "file" | Select-String -Pattern "fIle" -Culture "Ordinal" -SimpleMatch -CaseSensitive | Should -BeNullOrEmpty
-
-            "file" | Select-String -Pattern "file" -Culture "Invariant" -SimpleMatch | Should -BeExactly "file"
-            "file" | Select-String -Pattern "fIle" -Culture "Invariant" -SimpleMatch | Should -BeExactly "file"
-            "file" | Select-String -Pattern "fIle" -Culture "Invariant" -SimpleMatch -CaseSensitive | Should  -BeNullOrEmpty
-
-            if ([CultureInfo]::CurrentCulture.Name -ne "tr-TR") {
-                "file" | Select-String -Pattern "file" -Culture "CurrentCulture" -SimpleMatch | Should -BeExactly "file"
-                "file" | Select-String -Pattern "fIle" -Culture "CurrentCulture" -SimpleMatch | Should -BeExactly "file"
-                "file" | Select-String -Pattern "fIle" -Culture "CurrentCulture" -SimpleMatch -CaseSensitive | Should  -BeNullOrEmpty
+            if ($culture -ne 'Current' -or [CultureInfo]::CurrentCulture.Name -ne "tr-TR") {
+                'file' | Select-String -Pattern $pattern -Culture $culture -SimpleMatch -CaseSensitive:$casesensitive | Should -BeExactly $expected
             }
-        }
+       }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #8180
Add new `Culture` parameter to Select-String cmdlet.

## PR Context

Implement https://github.com/PowerShell/PowerShell-RFC/pull/167 for Select-String cmdlet.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/5090
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
