### PR TITLE
Fix `Start-Job -WorkingDirectory` with whitespace

### DIFF
--- a/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
@@ -58,7 +58,7 @@ namespace System.Management.Automation.Runspaces
                     CultureInfo.InvariantCulture,
                     "{0} -wd \"{1}\"",
                     processArguments,
-                    workingDirectory);
+                    workingDirectory.Replace("\"","\"\""));
             }
 
             if (initializationScript != null)

--- a/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
@@ -58,7 +58,7 @@ namespace System.Management.Automation.Runspaces
                     CultureInfo.InvariantCulture,
                     "{0} -wd \"{1}\"",
                     processArguments,
-                    workingDirectory.Replace("\"","\"\""));
+                    workingDirectory.Replace("\"", "\"\""));
             }
 
             if (initializationScript != null)

--- a/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
@@ -41,7 +41,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PowerShellProcessInstance"/> class. Initializes the underlying dotnet process class. 
+        /// Initializes a new instance of the <see cref="PowerShellProcessInstance"/> class. Initializes the underlying dotnet process class.
         /// </summary>
         /// <param name="powerShellVersion">Specifies the version of powershell.</param>
         /// <param name="credential">Specifies a user account credentials.</param>
@@ -56,7 +56,7 @@ namespace System.Management.Automation.Runspaces
             {
                 processArguments = string.Format(
                     CultureInfo.InvariantCulture,
-                    "{0} -wd {1}",
+                    "{0} -wd \"{1}\"",
                     processArguments,
                     workingDirectory);
             }
@@ -105,7 +105,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PowerShellProcessInstance"/> class. Initializes the underlying dotnet process class. 
+        /// Initializes a new instance of the <see cref="PowerShellProcessInstance"/> class. Initializes the underlying dotnet process class.
         /// </summary>
         /// <param name="powerShellVersion"></param>
         /// <param name="credential"></param>

--- a/test/powershell/engine/Job/Jobs.Tests.ps1
+++ b/test/powershell/engine/Job/Jobs.Tests.ps1
@@ -77,9 +77,17 @@ Describe 'Basic Job Tests' -Tags 'CI' {
             $ProgressMsg[0].StatusDescription | Should -BeExactly 2
         }
 
-        It 'Can use the user specified working directory parameter' {
+        It 'Can use the user specified working directory parameter with whitespace' {
+            $path = Join-Path -Path $TestDrive -ChildPath "My Dir"
+            $null = New-Item -ItemType Directory -Path "$path"
+            $job = Start-Job -ScriptBlock { $pwd } -WorkingDirectory $path | Wait-Job
+            $jobOutput = Receive-Job $job
+            $jobOutput | Should -BeExactly $path.ToString()
+        }
+
+        It 'Can use the user specified working directory parameter with quote' -Skip:($IsWindows) {
             $path = Join-Path -Path $TestDrive -ChildPath "My ""Dir"
-            $null = New-Item -ItemType Directory -Path $path
+            $null = New-Item -ItemType Directory -Path "$path"
             $job = Start-Job -ScriptBlock { $pwd } -WorkingDirectory $path | Wait-Job
             $jobOutput = Receive-Job $job
             $jobOutput | Should -BeExactly $path.ToString()

--- a/test/powershell/engine/Job/Jobs.Tests.ps1
+++ b/test/powershell/engine/Job/Jobs.Tests.ps1
@@ -78,7 +78,7 @@ Describe 'Basic Job Tests' -Tags 'CI' {
         }
 
         It 'Can use the user specified working directory parameter' {
-            $path = Join-Path -Path $TestDrive -ChildPath "My Dir"
+            $path = Join-Path -Path $TestDrive -ChildPath "My ""Dir"
             $null = New-Item -ItemType Directory -Path $path
             $job = Start-Job -ScriptBlock { $pwd } -WorkingDirectory $path | Wait-Job
             $jobOutput = Receive-Job $job

--- a/test/powershell/engine/Job/Jobs.Tests.ps1
+++ b/test/powershell/engine/Job/Jobs.Tests.ps1
@@ -78,9 +78,11 @@ Describe 'Basic Job Tests' -Tags 'CI' {
         }
 
         It 'Can use the user specified working directory parameter' {
-            $job = Start-Job -ScriptBlock { $pwd } -WorkingDirectory $TestDrive | Wait-Job
+            $path = Join-Path -Path $TestDrive -ChildPath "My Dir"
+            $null = New-Item -ItemType Directory -Path $path
+            $job = Start-Job -ScriptBlock { $pwd } -WorkingDirectory $path | Wait-Job
             $jobOutput = Receive-Job $job
-            $jobOutput | Should -BeExactly $TestDrive.ToString()
+            $jobOutput | Should -BeExactly $path.ToString()
         }
 
         It 'Throws an error when the working directory parameter is <case>' -TestCases $invalidPathTestCases {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

`Start-Job -WorkingDirectory` fails if the path contains whitespace as the argument isn't quoted.  Fix is to add quotes around the path.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
