### PR TITLE
Use culture invariant to-string convertor for lval in replace operator

### DIFF
--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -22,6 +22,14 @@ namespace System.Management.Automation
 
         internal const string EngineSource = "PSEngine";
 
+        /// <summary>
+        /// Experimental feature: Use culture invariant to-string convertor for lval in replace operator.
+        /// </summary>
+        public static readonly ExperimentalFeature PSCultureInvariantReplaceOperator =
+            new ExperimentalFeature(
+                name: nameof(PSCultureInvariantReplaceOperator),
+                description: "Use culture invariant to-string convertor for lval in replace operator");
+
         #endregion
 
         #region Instance Members
@@ -117,6 +125,7 @@ namespace System.Management.Automation
                 new ExperimentalFeature(
                     name: "PSNullConditionalOperators",
                     description: "Support the null conditional member access operators in PowerShell language"),
+                PSCultureInvariantReplaceOperator,
             };
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);
 

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -22,14 +22,6 @@ namespace System.Management.Automation
 
         internal const string EngineSource = "PSEngine";
 
-        /// <summary>
-        /// Experimental feature: Use culture invariant to-string convertor for lval in replace operator.
-        /// </summary>
-        public static readonly ExperimentalFeature PSCultureInvariantReplaceOperator =
-            new ExperimentalFeature(
-                name: nameof(PSCultureInvariantReplaceOperator),
-                description: "Use culture invariant to-string convertor for lval in replace operator");
-
         #endregion
 
         #region Instance Members
@@ -125,7 +117,9 @@ namespace System.Management.Automation
                 new ExperimentalFeature(
                     name: "PSNullConditionalOperators",
                     description: "Support the null conditional member access operators in PowerShell language"),
-                PSCultureInvariantReplaceOperator,
+                new ExperimentalFeature(
+                    name: "PSCultureInvariantReplaceOperator",
+                    description: "Use culture invariant to-string convertor for lval in replace operator"),
             };
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);
 

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -1367,7 +1367,7 @@ namespace System.Management.Automation
                             return Microsoft.PowerShell.ToStringCodeMethods.Type(type);
                         }
 
-                        return obj.ToString() ?? string.Empty;
+                        return obj.ToString();
                     }
 
                     return objFormattable.ToString(format, formatProvider);

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -1367,7 +1367,7 @@ namespace System.Management.Automation
                             return Microsoft.PowerShell.ToStringCodeMethods.Type(type);
                         }
 
-                        return obj.ToString();
+                        return obj.ToString() ?? string.Empty;
                     }
 
                     return objFormattable.ToString(format, formatProvider);

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -970,7 +970,7 @@ namespace System.Management.Automation
                 string lvalString;
                 if (ExperimentalFeature.IsEnabled("PSCultureInvariantReplaceOperator"))
                 {
-                    lvalString = PSObject.ToStringParser(context, lval) ?? string.Empty;
+                    lvalString = PSObject.ToStringParser(context, lval);
                 }
                 else
                 {

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -967,7 +967,15 @@ namespace System.Management.Automation
             IEnumerator list = LanguagePrimitives.GetEnumerator(lval);
             if (list == null)
             {
-                string lvalString = PSObject.ToStringParser(context, lval) ?? string.Empty;
+                string lvalString;
+                if (ExperimentalFeature.PSCultureInvariantReplaceOperator.Enabled)
+                {
+                    lvalString = PSObject.ToStringParser(context, lval) ?? string.Empty;
+                }
+                else
+                {
+                    lvalString = lval?.ToString() ?? string.Empty;
+                }
 
                 return ReplaceOperatorImpl(context, lvalString, rr, substitute);
             }

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -968,7 +968,7 @@ namespace System.Management.Automation
             if (list == null)
             {
                 string lvalString;
-                if (ExperimentalFeature.PSCultureInvariantReplaceOperator.Enabled)
+                if (ExperimentalFeature.IsEnabled("PSCultureInvariantReplaceOperator"))
                 {
                     lvalString = PSObject.ToStringParser(context, lval) ?? string.Empty;
                 }

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -967,7 +967,7 @@ namespace System.Management.Automation
             IEnumerator list = LanguagePrimitives.GetEnumerator(lval);
             if (list == null)
             {
-                string lvalString = lval?.ToString() ?? string.Empty;
+                string lvalString = PSObject.ToStringParser(context, lval) ?? string.Empty;
 
                 return ReplaceOperatorImpl(context, lvalString, rr, substitute);
             }

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -970,7 +970,7 @@ namespace System.Management.Automation
                 string lvalString;
                 if (ExperimentalFeature.IsEnabled("PSCultureInvariantReplaceOperator"))
                 {
-                    lvalString = PSObject.ToStringParser(context, lval);
+                    lvalString = PSObject.ToStringParser(context, lval) ?? string.Empty;
                 }
                 else
                 {

--- a/test/powershell/Language/Operators/ReplaceOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/ReplaceOperator.Tests.ps1
@@ -67,7 +67,7 @@ Describe "Replace Operator" -Tags CI {
 
     Describe "Culture-invariance tests for -split and -replace" -Tags CI {
         BeforeAll {
-            $skipTest = -not [ExperimentalFeature]::PSCultureInvariantReplaceOperator.Enabled
+            $skipTest = -not [ExperimentalFeature]::IsEnabled("PSCultureInvariantReplaceOperator")
             if ($skipTest) {
                 Write-Verbose "Test Suite Skipped. The test suite requires the experimental feature 'PSCultureInvariantReplaceOperator' to be enabled." -Verbose
                 $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()

--- a/test/powershell/Language/Operators/ReplaceOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/ReplaceOperator.Tests.ps1
@@ -64,4 +64,24 @@ Describe "Replace Operator" -Tags CI {
             $res | Should -BeExactly "ID XXXX123"
         }
     }
+
+    Describe "Culture-invariance tests for -split and -replace" {
+        BeforeAll {
+            $prevCulture = [cultureinfo]::CurrentCulture
+            # The French culture uses "," as the decimal mark.
+            [cultureinfo]::CurrentCulture = 'fr'
+        }
+
+        AfterAll {
+            [cultureinfo]::CurrentCulture = $prevCulture
+        }
+
+        It "-split: LHS stringification is not culture-sensitive" {
+          1.2 -split ',' | Should -Be '1.2'
+        }
+
+        It "-replace: LHS stringification is not culture-sensitive" {
+          1.2 -replace ',' | Should -Be '1.2'
+        }
+    }
 }

--- a/test/powershell/Language/Operators/ReplaceOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/ReplaceOperator.Tests.ps1
@@ -67,13 +67,24 @@ Describe "Replace Operator" -Tags CI {
 
     Describe "Culture-invariance tests for -split and -replace" -Tags CI {
         BeforeAll {
-            $prevCulture = [cultureinfo]::CurrentCulture
-            # The French culture uses "," as the decimal mark.
-            [cultureinfo]::CurrentCulture = 'fr'
+            $skipTest = -not [ExperimentalFeature]::PSCultureInvariantReplaceOperator.Enabled
+            if ($skipTest) {
+                Write-Verbose "Test Suite Skipped. The test suite requires the experimental feature 'PSCultureInvariantReplaceOperator' to be enabled." -Verbose
+                $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
+                $PSDefaultParameterValues["it:skip"] = $true
+            } else {
+                $prevCulture = [cultureinfo]::CurrentCulture
+                # The French culture uses "," as the decimal mark.
+                [cultureinfo]::CurrentCulture = 'fr'
+            }
         }
 
         AfterAll {
-            [cultureinfo]::CurrentCulture = $prevCulture
+            if ($skipTest) {
+                $global:PSDefaultParameterValues = $originalDefaultParameterValues
+            } else {
+                [cultureinfo]::CurrentCulture = $prevCulture
+            }
         }
 
         It "-split: LHS stringification is not culture-sensitive" {

--- a/test/powershell/Language/Operators/ReplaceOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/ReplaceOperator.Tests.ps1
@@ -65,7 +65,7 @@ Describe "Replace Operator" -Tags CI {
         }
     }
 
-    Describe "Culture-invariance tests for -split and -replace" {
+    Describe "Culture-invariance tests for -split and -replace" -Tags CI {
         BeforeAll {
             $prevCulture = [cultureinfo]::CurrentCulture
             # The French culture uses "," as the decimal mark.

--- a/test/tools/TestMetadata.json
+++ b/test/tools/TestMetadata.json
@@ -1,5 +1,6 @@
 {
   "ExperimentalFeatures": {
-    "ExpTest.FeatureOne": [ "test/powershell/engine/ExperimentalFeature/ExperimentalFeature.Basic.Tests.ps1" ]
+    "ExpTest.FeatureOne": [ "test/powershell/engine/ExperimentalFeature/ExperimentalFeature.Basic.Tests.ps1" ],
+    "PSCultureInvariantReplaceOperator": [ "test/powershell/Language/Operators/ReplaceOperator.Tests.ps1" ]
   }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #10948

## PR Context

Options for the fix:
- lval.ToString()
    That is before the fix.
- Convert.ToString(lval, CultureInfo.InvariantCulture)
    Makes lval conversion being culture invariant.
- PSObject.ToStringParser(context, lval)
    Current fix. Makes lval conversion being culture invariant and add PowerShell magic conversions if lval is PSObject (ex., follow ETS) [See](https://github.com/PowerShell/PowerShell/blob/96eb361af8d04d7821343ea2d59f61f0efcdd54c/src/System.Management.Automation/engine/MshObject.cs#L1270)
    In the case behavior is as for -match operator
- PSObject.ToStringParser(context, PSObject.AsPSObject(lval))
    The same as previous but always use PowerShell magic conversions (follow ETS).
    In the case behavior is as for `-join` operator (with performance issue because of mandatory wrapping to PSObject)

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
