### PR TITLE
Make `ConvertTo-Json` treat `[AutomationNull]::Value` and `[NullString]::Value` as $null

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Management.Automation;
+using System.Management.Automation.Language;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -496,6 +497,11 @@ namespace Microsoft.PowerShell.Commands
         {
             context.CancellationToken.ThrowIfCancellationRequested();
 
+            if (LanguagePrimitives.IsNull(obj))
+            {
+                return null;
+            }
+
             PSObject pso = obj as PSObject;
 
             if (pso != null)
@@ -507,18 +513,21 @@ namespace Microsoft.PowerShell.Commands
             bool isPurePSObj = false;
             bool isCustomObj = false;
 
-            if (obj == null
-                || DBNull.Value.Equals(obj)
-                || obj is string
-                || obj is char
-                || obj is bool
-                || obj is DateTime
-                || obj is DateTimeOffset
-                || obj is Guid
-                || obj is Uri
-                || obj is double
-                || obj is float
-                || obj is decimal)
+            if (obj == NullString.Value
+                || obj == DBNull.Value)
+            {
+                rv = null;
+            }
+            else if (obj is string
+                    || obj is char
+                    || obj is bool
+                    || obj is DateTime
+                    || obj is DateTimeOffset
+                    || obj is Guid
+                    || obj is Uri
+                    || obj is double
+                    || obj is float
+                    || obj is decimal)
             {
                 rv = obj;
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
@@ -69,4 +69,23 @@ Describe 'ConvertTo-Json' -tags "CI" {
         ConvertTo-Json -Compress $null | Should -Be 'null'
         1, $null, 2 | ConvertTo-Json -Compress | Should -Be '[1,null,2]'
     }
+
+    It "Should handle 'AutomationNull.Value' and 'NullString.Value' correctly" {
+        [ordered]@{
+            a = $null;
+            b = [System.Management.Automation.Internal.AutomationNull]::Value;
+            c = [System.DBNull]::Value;
+            d = [NullString]::Value
+        } | ConvertTo-Json -Compress | Should -BeExactly '{"a":null,"b":null,"c":null,"d":null}'
+
+        ConvertTo-Json -Compress ([System.Management.Automation.Internal.AutomationNull]::Value) | Should -BeExactly 'null'
+        ConvertTo-Json -Compress ([NullString]::Value) | Should -BeExactly 'null'
+
+        ConvertTo-Json -Compress @(
+            $null,
+            [System.Management.Automation.Internal.AutomationNull]::Value,
+            [System.DBNull]::Value,
+            [NullString]::Value
+        ) | Should -BeExactly '[null,null,null,null]'
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
@@ -88,4 +88,19 @@ Describe 'ConvertTo-Json' -tags "CI" {
             [NullString]::Value
         ) | Should -BeExactly '[null,null,null,null]'
     }
+
+    It "Should handle the ETS properties added to 'DBNull.Value' and 'NullString.Value'" {
+        try
+        {
+            $p1 = Add-Member -InputObject ([System.DBNull]::Value) -MemberType NoteProperty -Name dbnull -Value 'dbnull' -PassThru
+            $p2 = Add-Member -InputObject ([NullString]::Value) -MemberType NoteProperty -Name nullstr -Value 'nullstr' -PassThru
+
+            $p1, $p2 | ConvertTo-Json -Compress | Should -BeExactly '[{"value":null,"dbnull":"dbnull"},{"value":null,"nullstr":"nullstr"}]'
+        }
+        finally
+        {
+            $p1.psobject.Properties.Remove('dbnull')
+            $p2.psobject.Properties.Remove('nullstr')
+        }
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
@@ -78,8 +78,8 @@ Describe 'ConvertTo-Json' -tags "CI" {
             d = [NullString]::Value
         } | ConvertTo-Json -Compress | Should -BeExactly '{"a":null,"b":null,"c":null,"d":null}'
 
-        ConvertTo-Json -Compress ([System.Management.Automation.Internal.AutomationNull]::Value) | Should -BeExactly 'null'
-        ConvertTo-Json -Compress ([NullString]::Value) | Should -BeExactly 'null'
+        ConvertTo-Json ([System.Management.Automation.Internal.AutomationNull]::Value) | Should -BeExactly 'null'
+        ConvertTo-Json ([NullString]::Value) | Should -BeExactly 'null'
 
         ConvertTo-Json -Compress @(
             $null,


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #9231

Make `ConvertTo-Json` treat `[AutomationNull]::Value` and `[NullString]::Value` as `$null`

This is a breaking change given the fact that `[AutomationNull]::Value` and `[NullString]::Value` are deserailized into an empty object `{}` today and will be `null` after this change.
**However, it's hard to believe anyone is depending on the current wrong behavior.**

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: #9231
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
