### PR TITLE
Fix setting original path of filesystem object to not have extra trailing slash

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -159,7 +159,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
 
-                if (path.EndsWith(StringLiterals.DefaultPathSeparator))
+                if (path.EndsWith(StringLiterals.DefaultPathSeparator) && !exactPath.EndsWith(StringLiterals.DefaultPathSeparator))
                 {
                     return exactPath + StringLiterals.DefaultPathSeparator;
                 }

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -146,7 +146,12 @@ namespace Microsoft.PowerShell.Commands
                     else if (string.IsNullOrEmpty(item))
                     {
                         // This handles the trailing slash case
-                        continue;
+                        if (!exactPath.EndsWith(StringLiterals.DefaultPathSeparator))
+                        {
+                            exactPath += StringLiterals.DefaultPathSeparator;
+                        }
+
+                        break;
                     }
                     else if (item.Contains('~'))
                     {
@@ -157,11 +162,6 @@ namespace Microsoft.PowerShell.Commands
                     {
                         exactPath = Directory.GetFileSystemEntries(exactPath, item).First();
                     }
-                }
-
-                if (path.EndsWith(StringLiterals.DefaultPathSeparator) && !exactPath.EndsWith(StringLiterals.DefaultPathSeparator))
-                {
-                    return exactPath + StringLiterals.DefaultPathSeparator;
                 }
 
                 return exactPath;

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
@@ -61,6 +61,11 @@ Describe "Get-Item" -Tags "CI" {
         $result.Exists | Should -BeTrue
     }
 
+    It "Should return correct result for ToString() on root of drive" {
+        $root = $IsWindows ? "${env:SystemDrive}\" : "/"
+        (Get-Item -Path $root).ToString() | Should -BeExactly $root
+    }
+
     Context "Test for Include, Exclude, and Filter" {
         BeforeAll {
             ${testBaseDir} = "${TESTDRIVE}/IncludeExclude"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

In the method to build the correct casing of a path, it handled the root of the drive, but later in the loop since the original path had a trailing slash, it added another one.  Fix is to detect if the resulting path already has a trailing slash and don't add it.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/10956

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
