### PR TITLE
Resolve -WindowStyle Hidden console flashing

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -578,7 +578,6 @@ namespace Microsoft.PowerShell
                             consoleAllocated = AllocConsole();
                             ConsoleControl.SetConsoleMode(style);
                         }
-
                     }
                     catch (PSInvalidCastException)
                     {
@@ -1486,7 +1485,7 @@ namespace Microsoft.PowerShell
 #if !UNIX
         private bool _removeWorkingDirectoryTrailingCharacter = false;
 
-        [DllImport("kernel32.dll")]
+        [DllImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool AllocConsole();
 
@@ -1494,9 +1493,6 @@ namespace Microsoft.PowerShell
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool AttachConsole(int dwProcessId);
 
-        [DllImport("kernel32.dll", SetLastError=true, ExactSpelling=true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool FreeConsole();
 #endif
     }
 }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -525,8 +525,10 @@ namespace Microsoft.PowerShell
             }
 
             bool noexitSeen = false;
+#if !UNIX
             bool consoleAllocated = false;
             bool consoleAttached = false;
+#endif
             for (int i = 0; i < args.Length; ++i)
             {
                 (string SwitchKey, bool ShouldBreak) switchKeyResults = GetSwitchKey(args, ref i, parser: null, ref noexitSeen);

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostRawUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostRawUserInterface.cs
@@ -35,8 +35,16 @@ namespace Microsoft.PowerShell
         internal
         ConsoleHostRawUserInterface(ConsoleHostUserInterface mshConsole) : base()
         {
-            defaultForeground = ForegroundColor;
-            defaultBackground = BackgroundColor;
+            try
+            {
+                defaultForeground = ForegroundColor;
+                defaultBackground = BackgroundColor;
+            }
+            catch (HostException)
+            {
+                // Ignore this as it means we're running -WindowStyle Hidden
+            }
+
             parent = mshConsole;
             // cacheKeyEvent is a value type and initialized automatically
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ManagedEntrance.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ManagedEntrance.cs
@@ -32,6 +32,18 @@ namespace Microsoft.PowerShell
         /// </param>
         public static int Start(string consoleFilePath, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 2)]string[] args, int argc)
         {
+#if DEBUG
+            if (args.Length > 0 && !string.IsNullOrEmpty(args[0]) && args[0].Equals("-isswait", StringComparison.OrdinalIgnoreCase))
+            {
+                Console.WriteLine("Attach the debugger to continue...");
+                while (!System.Diagnostics.Debugger.IsAttached)
+                {
+                    Thread.Sleep(100);
+                }
+
+                System.Diagnostics.Debugger.Break();
+            }
+#endif
             // Warm up some components concurrently on background threads.
             EarlyStartup.Init();
 
@@ -54,18 +66,6 @@ namespace Microsoft.PowerShell
             Thread.CurrentThread.CurrentUICulture = NativeCultureResolver.UICulture;
             Thread.CurrentThread.CurrentCulture = NativeCultureResolver.Culture;
 
-#if DEBUG
-            if (args.Length > 0 && !string.IsNullOrEmpty(args[0]) && args[0].Equals("-isswait", StringComparison.OrdinalIgnoreCase))
-            {
-                Console.WriteLine("Attach the debugger to continue...");
-                while (!System.Diagnostics.Debugger.IsAttached)
-                {
-                    Thread.Sleep(100);
-                }
-
-                System.Diagnostics.Debugger.Break();
-            }
-#endif
             int exitCode = 0;
             try
             {

--- a/src/System.Management.Automation/engine/PSConfiguration.cs
+++ b/src/System.Management.Automation/engine/PSConfiguration.cs
@@ -439,7 +439,7 @@ namespace System.Management.Automation.Configuration
 
             if (configData != emptyConfig && configData.TryGetValue(key, StringComparison.OrdinalIgnoreCase, out JToken jToken))
             {
-                return jToken.ToObject<T>(serializer);
+                return jToken.ToObject<T>(serializer) ?? defaultValue;
             }
 
             return defaultValue;

--- a/src/powershell-win-core/powershell-win-core.csproj
+++ b/src/powershell-win-core/powershell-win-core.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Description>PowerShell on Windows top-level project</Description>
     <AssemblyName>pwsh</AssemblyName>
-    <OutputType>Exe</OutputType>
+    <OutputType>WinExe</OutputType>
     <TieredCompilation>true</TieredCompilation>
     <TieredCompilationQuickJit>true</TieredCompilationQuickJit>
     <RuntimeIdentifiers>win7-x86;win7-x64</RuntimeIdentifiers>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #3028

## PR Context

#10962 is direct implementation of pwshw idea. pwshw is only one option from many in the complex topic dicussed in #3028. The PR seems add more flexibility and allow to experiment with console, non-console, pseudo-console and GUI modes, allow to implement pwshw in the same way as we did for `preview-pwsh`, and also fix `-WindowStyle Hidden` scenario.

Update: I think follow work should be:

- create xUnit tests for command line parser
- refactor command line parser 
  - make it static
  - move out execution code from parser (parser should only parse)
  - merge EarlyParser and parser

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
