### PR TITLE
Remove the not-working 'run Update-Help from Get-Help when Get-Help runs for the first time' functionality

### DIFF
--- a/src/System.Management.Automation/engine/PSConfiguration.cs
+++ b/src/System.Management.Automation/engine/PSConfiguration.cs
@@ -198,27 +198,6 @@ namespace System.Management.Automation.Configuration
             WriteValueToFile<bool>(ConfigScope.AllUsers, "ConsolePrompting", shouldPrompt);
         }
 
-        /// <summary>
-        /// Existing Key = HKLM\SOFTWARE\Microsoft\PowerShell
-        /// Proposed value = Existing default. Probably "0"
-        ///
-        /// Schema:
-        /// {
-        ///     "DisablePromptToUpdateHelp" : bool
-        /// }
-        /// </summary>
-        /// <returns>Boolean indicating whether Update-Help should prompt. If the value cannot be read, it defaults to false.</returns>
-        internal bool GetDisablePromptToUpdateHelp()
-        {
-            return ReadValueFromFile<bool>(ConfigScope.AllUsers, "DisablePromptToUpdateHelp");
-        }
-
-        internal void SetDisablePromptToUpdateHelp(bool prompt)
-        {
-            WriteValueToFile<bool>(ConfigScope.AllUsers, "DisablePromptToUpdateHelp", prompt);
-        }
-
-        /// <summary>
         /// Get the names of experimental features enabled in the config file.
         /// </summary>
         internal string[] GetExperimentalFeatures()

--- a/src/System.Management.Automation/help/HelpCommands.cs
+++ b/src/System.Management.Automation/help/HelpCommands.cs
@@ -246,19 +246,6 @@ namespace Microsoft.PowerShell.Commands
         protected override void BeginProcessing()
         {
             _timer.Start();
-
-            if (!Online.IsPresent && UpdatableHelpSystem.ShouldPromptToUpdateHelp() && HostUtilities.IsProcessInteractive(MyInvocation) && HasInternetConnection())
-            {
-                if (ShouldContinue(HelpDisplayStrings.UpdateHelpPromptBody, HelpDisplayStrings.UpdateHelpPromptTitle))
-                {
-                    System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace).AddCommand("Update-Help").Invoke();
-#if LEGACYTELEMETRY
-                    _updatedHelp = true;
-#endif
-                }
-
-                UpdatableHelpSystem.SetDisablePromptToUpdateHelp();
-            }
         }
 
         /// <summary>
@@ -714,15 +701,6 @@ namespace Microsoft.PowerShell.Commands
             };
 
             WriteProgress(record);
-        }
-
-        /// <summary>
-        /// Checks if we can connect to the internet.
-        /// </summary>
-        /// <returns></returns>
-        private bool HasInternetConnection()
-        {
-            return true; // TODO:CORECLR wininet.dll is not present on NanoServer
         }
 
         #region Helper methods for verification of parameters against NoLanguage mode

--- a/src/System.Management.Automation/help/UpdatableHelpSystem.cs
+++ b/src/System.Management.Automation/help/UpdatableHelpSystem.cs
@@ -1500,52 +1500,6 @@ namespace System.Management.Automation.Help
             return string.IsNullOrEmpty(defaultSourcePath) ? null : defaultSourcePath;
         }
 
-        /// <summary>
-        /// Sets the DisablePromptToUpdatableHelp regkey.
-        /// </summary>
-        internal static void SetDisablePromptToUpdateHelp()
-        {
-            try
-            {
-                PowerShellConfig.Instance.SetDisablePromptToUpdateHelp(true);
-            }
-            catch (UnauthorizedAccessException)
-            {
-                // Ignore AccessDenied related exceptions
-            }
-            catch (SecurityException)
-            {
-                // Ignore AccessDenied related exceptions
-            }
-        }
-
-        /// <summary>
-        /// Checks if it is necessary to prompt to update help.
-        /// </summary>
-        /// <returns></returns>
-        internal static bool ShouldPromptToUpdateHelp()
-        {
-#if UNIX
-            // TODO: This workaround needs to be removed once updatable help
-            //       works on Linux.
-            return false;
-#else
-            try
-            {
-                if (!Utils.IsAdministrator())
-                {
-                    return false;
-                }
-
-                return PowerShellConfig.Instance.GetDisablePromptToUpdateHelp();
-            }
-            catch (SecurityException)
-            {
-                return false;
-            }
-#endif
-        }
-
         #endregion
 
         #region Events

--- a/src/System.Management.Automation/help/UpdateHelpCommand.cs
+++ b/src/System.Management.Automation/help/UpdateHelpCommand.cs
@@ -143,9 +143,6 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void BeginProcessing()
         {
-            // Disable Get-Help prompt
-            UpdatableHelpSystem.SetDisablePromptToUpdateHelp();
-
             if (_path == null)
             {
                 // Pull default source path from GP

--- a/src/System.Management.Automation/resources/HelpDisplayStrings.resx
+++ b/src/System.Management.Automation/resources/HelpDisplayStrings.resx
@@ -449,12 +449,6 @@ To update help again, add the Force parameter to your command.</value>
   <data name="RootElementMustBeHelpItems" xml:space="preserve">
     <value>The root level element of the help content must be "helpItems".</value>
   </data>
-  <data name="UpdateHelpPromptBody" xml:space="preserve">
-    <value>The Update-Help cmdlet downloads the most current Help files for PowerShell modules, and installs them on your computer. For more information about the Update-Help cmdlet, see https://go.microsoft.com/fwlink/?LinkId=210614.</value>
-  </data>
-  <data name="UpdateHelpPromptTitle" xml:space="preserve">
-    <value>Do you want to run Update-Help?</value>
-  </data>
   <data name="SaveProgressActivityForModule" xml:space="preserve">
     <value>Saving Help for module {0}</value>
   </data>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #7452

Background about the setting `DisablePromptToUpdateHelp`:

In Windows PowerShell, `DisablePromptToUpdateHelp` is a registry key property set at `HKLM\SOFTWARE\Microsoft\PowerShell`.
**It's not really a setting for user to configure PowerShell, but instead, an implementation detail.** It's used by `Get-Help` to tell if `Update-Help` has been run yet. On a fresh Windows, `DisablePromptToUpdateHelp` is not set, so `Get-Help` running in a admin privilege PowerShell session will prompt user to ask if the user wants to run `Update-Help` to download help content for all the modules in module path. `DisablePromptToUpdateHelp` then is set to `1` after the prompt (`Update-Help` will set it to `1` too), so the code that prompt and run `Update-Help` in `Get-Help` is guaranteed to execute only once.

**This feature never worked in `pwsh`**, because when moving the registry settings to the `powershell.config.json` file, `UpdatableHelpSystem.ShouldPromptToUpdateHelp()` was not updated correctly to keep the previous behavior. However, that was not a bad thing because the previous behavior in Windows PowerShell is not appropriate to `pwsh` anymore:
- for `powershell.exe`, there is only one instance of PowerShell, so the `DisablePromptToUpdateHelp` key in registry can guarantee the prompt from `Get-Help` shows up only once. 
- for `pwsh.exe`, there can be many instances of PowerShell, and they all depend on their own `$PSHOME\powershell.config.json`, so even if `Update-Help` has been run, a new instance of `pwsh` would still show the prompt when you run `Get-Help` in it. This is not desirable.

Given the fact that:
1. this feature never worked in `pwsh` and there has been no complaint about it;
2. the feature implementation in Windows PowerShell doesn't work for `pwsh`

I propose to remove this functionality from `pwsh`, so as to remove the `DisablePromptToUpdateHelp` setting from `powershell.config.json` file (it should never be there as an implementation detail).
If we decide to bring back this functionality to `pwsh` in future, the implementation definitely needs to be re-written.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
