### PR TITLE
Remove the unused setting key `ConsolePrompting` and avoid unnecessary string creation when querying `ExecutionPolicy` setting

### DIFF
--- a/src/System.Management.Automation/engine/PSConfiguration.cs
+++ b/src/System.Management.Automation/engine/PSConfiguration.cs
@@ -167,8 +167,8 @@ namespace System.Management.Automation.Configuration
 
         internal void SetExecutionPolicy(ConfigScope scope, string shellId, string executionPolicy)
         {
-            string valueName = GetExecutionPolicySettingKey(shellId);
-            WriteValueToFile<string>(scope, valueName, executionPolicy);
+            string key = GetExecutionPolicySettingKey(shellId);
+            WriteValueToFile<string>(scope, key, executionPolicy);
         }
 
         private string GetExecutionPolicySettingKey(string shellId)

--- a/src/System.Management.Automation/engine/PSConfiguration.cs
+++ b/src/System.Management.Automation/engine/PSConfiguration.cs
@@ -47,7 +47,8 @@ namespace System.Management.Automation.Configuration
     /// </remarks>
     internal sealed class PowerShellConfig
     {
-        private const string configFileName = "powershell.config.json";
+        private const string ConfigFileName = "powershell.config.json";
+        private const string ExecutionPolicyDefaultShellKey = "Microsoft.PowerShell:ExecutionPolicy";
 
         // Provide a singleton
         internal static readonly PowerShellConfig Instance = new PowerShellConfig();
@@ -79,13 +80,13 @@ namespace System.Management.Automation.Configuration
         {
             // Sets the system-wide configuration file.
             systemWideConfigDirectory = Utils.DefaultPowerShellAppBase;
-            systemWideConfigFile = Path.Combine(systemWideConfigDirectory, configFileName);
+            systemWideConfigFile = Path.Combine(systemWideConfigDirectory, ConfigFileName);
 
             // Sets the per-user configuration directory
             // Note: This directory may or may not exist depending upon the execution scenario.
             // Writes will attempt to create the directory if it does not already exist.
             perUserConfigDirectory = Platform.ConfigDirectory;
-            perUserConfigFile = Path.Combine(perUserConfigDirectory, configFileName);
+            perUserConfigFile = Path.Combine(perUserConfigDirectory, ConfigFileName);
 
             emptyConfig = new JObject();
             configRoots = new JObject[2];
@@ -153,49 +154,28 @@ namespace System.Management.Automation.Configuration
         /// <returns>The execution policy if found. Null otherwise.</returns>
         internal string GetExecutionPolicy(ConfigScope scope, string shellId)
         {
-            string execPolicy = null;
-
-            string valueName = string.Concat(shellId, ":", "ExecutionPolicy");
-            string rawExecPolicy = ReadValueFromFile<string>(scope, valueName);
-
-            if (!string.IsNullOrEmpty(rawExecPolicy))
-            {
-                execPolicy = rawExecPolicy;
-            }
-
-            return execPolicy;
+            string key = GetExecutionPolicySettingKey(shellId);
+            string execPolicy = ReadValueFromFile<string>(scope, key);
+            return string.IsNullOrEmpty(execPolicy) ? null : execPolicy;
         }
 
         internal void RemoveExecutionPolicy(ConfigScope scope, string shellId)
         {
-            string valueName = string.Concat(shellId, ":", "ExecutionPolicy");
-            RemoveValueFromFile<string>(scope, valueName);
+            string key = GetExecutionPolicySettingKey(shellId);
+            RemoveValueFromFile<string>(scope, key);
         }
 
         internal void SetExecutionPolicy(ConfigScope scope, string shellId, string executionPolicy)
         {
-            string valueName = string.Concat(shellId, ":", "ExecutionPolicy");
+            string valueName = GetExecutionPolicySettingKey(shellId);
             WriteValueToFile<string>(scope, valueName, executionPolicy);
         }
 
-        /// <summary>
-        /// Existing Key = HKLM\SOFTWARE\Microsoft\PowerShell\1\ShellIds
-        /// Proposed value = existing default. Probably "1"
-        ///
-        /// Schema:
-        /// {
-        ///     "ConsolePrompting" : bool
-        /// }
-        /// </summary>
-        /// <returns>Whether console prompting should happen. If the value cannot be read it defaults to false.</returns>
-        internal bool GetConsolePrompting()
+        private string GetExecutionPolicySettingKey(string shellId)
         {
-            return ReadValueFromFile<bool>(ConfigScope.AllUsers, "ConsolePrompting");
-        }
-
-        internal void SetConsolePrompting(bool shouldPrompt)
-        {
-            WriteValueToFile<bool>(ConfigScope.AllUsers, "ConsolePrompting", shouldPrompt);
+            return shellId == Utils.DefaultPowerShellShellID
+                ? ExecutionPolicyDefaultShellKey
+                : string.Concat(shellId, ":", "ExecutionPolicy");
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/PSConfiguration.cs
+++ b/src/System.Management.Automation/engine/PSConfiguration.cs
@@ -173,7 +173,7 @@ namespace System.Management.Automation.Configuration
 
         private string GetExecutionPolicySettingKey(string shellId)
         {
-            return shellId == Utils.DefaultPowerShellShellID
+            return string.Equals(shellId, Utils.DefaultPowerShellShellID, StringComparison.Ordinal)
                 ? ExecutionPolicyDefaultShellKey
                 : string.Concat(shellId, ":", "ExecutionPolicy");
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Remove the unused setting key `ConsolePrompting` and avoid unnecessary string creation when querying `ExecutionPolicy` setting
The `ConsolePrompting` setting is not used anywhere because the functionality depended on it was not supporting and had been removed in #4995

The changes to `GetExecutionPolicy`, `RemoveExecutionPolicy` and `SetExecutionPolicy` avoid unnecessary string allocation for the default PowerShell shell Id.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
