### PR TITLE
Add property, method, and indexed item splatting support

### DIFF
--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -4028,16 +4028,29 @@ namespace System.Management.Automation.Language
                     var splatTest = element;
                     bool splatted = false;
 
-                    UsingExpressionAst usingExpression = element as UsingExpressionAst;
-                    if (usingExpression != null)
+                    if (splatTest is UsingExpressionAst usingExpression)
                     {
                         splatTest = usingExpression.SubExpression;
                     }
 
-                    while (splatTest is MemberExpressionAst memberExpression)
+                    var done = false;
+                    do
                     {
-                        splatTest = memberExpression.Expression;
-                    }
+                        switch (splatTest)
+                        {
+                            case MemberExpressionAst memberExpression:
+                                splatTest = memberExpression.Expression;
+                                break;
+
+                            case IndexExpressionAst indexExpression:
+                                splatTest = indexExpression.Target;
+                                break;
+
+                            default:
+                                done = true;
+                                break;
+                        }
+                    } while (!done);
 
                     if (splatTest is VariableExpressionAst variableExpression)
                     {

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -4034,8 +4034,12 @@ namespace System.Management.Automation.Language
                         splatTest = usingExpression.SubExpression;
                     }
 
-                    VariableExpressionAst variableExpression = splatTest as VariableExpressionAst;
-                    if (variableExpression != null)
+                    while (splatTest is MemberExpressionAst memberExpression)
+                    {
+                        splatTest = memberExpression.Expression;
+                    }
+
+                    if (splatTest is VariableExpressionAst variableExpression)
                     {
                         splatted = variableExpression.Splatted;
                     }

--- a/src/System.Management.Automation/engine/parser/SemanticChecks.cs
+++ b/src/System.Management.Automation/engine/parser/SemanticChecks.cs
@@ -1039,6 +1039,7 @@ namespace System.Management.Automation.Language
             if (variableExpressionAst.Splatted &&
                 !(variableExpressionAst.Parent is CommandAst) &&
                 !(variableExpressionAst.Parent is MemberExpressionAst) &&
+                !(variableExpressionAst.Parent is IndexExpressionAst) &&
                 !(variableExpressionAst.Parent is UsingExpressionAst))
             {
                 if (variableExpressionAst.Parent is ArrayLiteralAst && variableExpressionAst.Parent.Parent is CommandAst)

--- a/src/System.Management.Automation/engine/parser/SemanticChecks.cs
+++ b/src/System.Management.Automation/engine/parser/SemanticChecks.cs
@@ -1036,7 +1036,10 @@ namespace System.Management.Automation.Language
 
         public override AstVisitAction VisitVariableExpression(VariableExpressionAst variableExpressionAst)
         {
-            if (variableExpressionAst.Splatted && !(variableExpressionAst.Parent is CommandAst) && !(variableExpressionAst.Parent is UsingExpressionAst))
+            if (variableExpressionAst.Splatted &&
+                !(variableExpressionAst.Parent is CommandAst) &&
+                !(variableExpressionAst.Parent is MemberExpressionAst) &&
+                !(variableExpressionAst.Parent is UsingExpressionAst))
             {
                 if (variableExpressionAst.Parent is ArrayLiteralAst && variableExpressionAst.Parent.Parent is CommandAst)
                 {

--- a/test/powershell/Language/Scripting/Splatting.Tests.ps1
+++ b/test/powershell/Language/Scripting/Splatting.Tests.ps1
@@ -2,6 +2,45 @@
 # Licensed under the MIT License.
 
 Describe 'Tests for splatting' -Tags 'CI' {
+    Context 'Basic splatting' {
+        BeforeAll {
+            function Test-Splat {
+                [CmdletBinding(DefaultParameterSetName = 'Default')]
+                param(
+                    [Parameter(Position = 0, ParameterSetName = 'Value')]
+                    [ValidateNotNullOrEmpty()]
+                    [string]
+                    $Value,
+
+                    [Parameter(Position = 0, ParameterSetName = 'Value2')]
+                    [ValidateNotNullOrEmpty()]
+                    [int]
+                    $Value2
+                )
+                $PSCmdlet.ParameterSetName
+            }
+        }
+
+        It 'Should splat hashtables properly' {
+            $testObject = @{
+                Value2 = 42
+            }
+            Test-Splat @testObject | Should -BeExactly 'Value2'
+        }
+
+        It 'Should splat arrays properly' {
+            $testObject = @(
+                'Does it splat?'
+            )
+            Test-Splat @testObject | Should -BeExactly 'Value'
+        }
+
+        It 'Should splat values properly' {
+            $testObject = 42
+            Test-Splat @testObject | Should -BeExactly 'Value2'
+        }
+    }
+
     Context 'Splatting members and indexed data' {
         BeforeAll {
             function Test-Splat {
@@ -22,26 +61,26 @@ Describe 'Tests for splatting' -Tags 'CI' {
         }
 
         It 'Should splat property values properly' {
-            $o = [pscustomobject]@{
+            $testObject = [pscustomobject]@{
                 Parameters = @{
                     Value = 'Does it splat?'
                 }
             }
-            Test-Splat @o.Parameters | Should -BeExactly 'Value'
+            Test-Splat @testObject.Parameters | Should -BeExactly 'Value'
         }
 
         It 'Should splat method results properly' {
-            $o = [pscustomobject]@{
+            $testObject = [pscustomobject]@{
                 Parameters = @{
                     Value = 'Does it splat?'
                 }
             }
-            Add-Member -InputObject $o -Name GetParams -MemberType ScriptMethod -Value { $this.Parameters }
-            Test-Splat @o.GetParams() | Should -BeExactly 'Value'
+            Add-Member -InputObject $testObject -Name GetParams -MemberType ScriptMethod -Value { $this.Parameters }
+            Test-Splat @testObject.GetParams() | Should -BeExactly 'Value'
         }
 
         It 'Should splat indexed method results properly' {
-            $o = [pscustomobject]@{
+            $testObject = [pscustomobject]@{
                 Parameters = @(
                     @{
                         Value = 'Will this splat?'
@@ -51,12 +90,12 @@ Describe 'Tests for splatting' -Tags 'CI' {
                     }
                 )
             }
-            Add-Member -InputObject $o -Name GetParams -MemberType ScriptMethod -Value { $this.Parameters }
-            Test-Splat @o.GetParams()[1] | Should -BeExactly 'Value2'
+            Add-Member -InputObject $testObject -Name GetParams -MemberType ScriptMethod -Value { $this.Parameters }
+            Test-Splat @testObject.GetParams()[1] | Should -BeExactly 'Value2'
         }
 
         It 'Should splat indexed data properly' {
-            $o = @(
+            $testObject = @(
                 @{
                     Value = 'Will this splat?'
                 }
@@ -64,19 +103,19 @@ Describe 'Tests for splatting' -Tags 'CI' {
                     Value2 = 'Or this?'
                 }
             )
-            Test-Splat @o[1] | Should -BeExactly 'Value2'
+            Test-Splat @testObject[1] | Should -BeExactly 'Value2'
         }
 
         It 'Should splat multiple members properly' {
-            $o = [pscustomobject]@{
+            $testObject = [pscustomobject]@{
                 Parameters = @{
                     Nested = @{
                         Value = 'Does it splat?'
                     }
                 }
             }
-            Add-Member -InputObject $o -Name GetParams -MemberType ScriptMethod -Value { $this.Parameters }
-            Test-Splat @o.GetParams().Nested | Should -BeExactly 'Value'
+            Add-Member -InputObject $testObject -Name GetParams -MemberType ScriptMethod -Value { $this.Parameters }
+            Test-Splat @testObject.GetParams().Nested | Should -BeExactly 'Value'
         }
 
         It 'Should splat $PSCmdlet.MyInvocation.BoundParameters properly' {
@@ -107,7 +146,7 @@ Describe 'Tests for splatting' -Tags 'CI' {
         }
 
         It 'Should splat indexed data and using: properly' {
-            $o = @(
+            $testObject = @(
                 @{
                     InputObject = 'First'
                 }
@@ -115,12 +154,12 @@ Describe 'Tests for splatting' -Tags 'CI' {
                     InputObject = 'Second'
                 }
             )
-            Add-Member -InputObject $o -Name GetParams -MemberType ScriptMethod -Value { $this.Parameters[$args[0]] }
-            1..1 | ForEach-Object -Parallel { Write-Output @using:o[1] } | Should -BeExactly 'Second'
+            Add-Member -InputObject $testObject -Name GetParams -MemberType ScriptMethod -Value { $this.Parameters[$args[0]] }
+            1..1 | ForEach-Object -Parallel { Write-Output @using:testObject[1] } | Should -BeExactly 'Second'
         }
 
         It 'Should splat with properties and indexed data and using: properly' {
-            $o = [pscustomobject]@{
+            $testObject = [pscustomobject]@{
                 Parameters = @(
                     @{
                         InputObject = 'First'
@@ -130,8 +169,8 @@ Describe 'Tests for splatting' -Tags 'CI' {
                     }
                 )
             }
-            Add-Member -InputObject $o -Name GetParams -MemberType ScriptMethod -Value { $this.Parameters[$args[0]] }
-            1..1 | ForEach-Object -Parallel { Write-Output @using:o.Parameters[1] } | Should -BeExactly 'Second'
+            Add-Member -InputObject $testObject -Name GetParams -MemberType ScriptMethod -Value { $this.Parameters[$args[0]] }
+            1..1 | ForEach-Object -Parallel { Write-Output @using:testObject.Parameters[1] } | Should -BeExactly 'Second'
         }
     }
 }

--- a/test/powershell/Language/Scripting/Splatting.Tests.ps1
+++ b/test/powershell/Language/Scripting/Splatting.Tests.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 Describe 'Tests for splatting' -Tags 'CI' {
-    Context 'Splatting members' {
+    Context 'Splatting members and indexed data' {
         BeforeAll {
             function Test-Splat {
                 [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -10,7 +10,12 @@ Describe 'Tests for splatting' -Tags 'CI' {
                     [Parameter(ParameterSetName = 'Value')]
                     [ValidateNotNullOrEmpty()]
                     [string]
-                    $Value
+                    $Value,
+
+                    [Parameter(ParameterSetName = 'Value2')]
+                    [ValidateNotNullOrEmpty()]
+                    [string]
+                    $Value2
                 )
                 $PSCmdlet.ParameterSetName
             }
@@ -35,6 +40,33 @@ Describe 'Tests for splatting' -Tags 'CI' {
             Test-Splat @o.GetParams() | Should -BeExactly 'Value'
         }
 
+        It 'Should splat indexed method results properly' {
+            $o = [pscustomobject]@{
+                Parameters = @(
+                    @{
+                        Value = 'Will this splat?'
+                    }
+                    @{
+                        Value2 = 'Or this?'
+                    }
+                )
+            }
+            Add-Member -InputObject $o -Name GetParams -MemberType ScriptMethod -Value { $this.Parameters }
+            Test-Splat @o.GetParams()[1] | Should -BeExactly 'Value2'
+        }
+
+        It 'Should splat indexed data properly' {
+            $o = @(
+                @{
+                    Value = 'Will this splat?'
+                }
+                @{
+                    Value2 = 'Or this?'
+                }
+            )
+            Test-Splat @o[1] | Should -BeExactly 'Value2'
+        }
+
         It 'Should splat multiple members properly' {
             $o = [pscustomobject]@{
                 Parameters = @{
@@ -55,6 +87,51 @@ Describe 'Tests for splatting' -Tags 'CI' {
                 )
                 Test-Splat @PSCmdlet.MyInvocation.BoundParameters
             } -Value 'Hello' | Should -BeExactly 'Value'
+        }
+    }
+
+    Context 'Splatting members and indexed data with the using statement' {
+        BeforeAll {
+            $skipTest = -not $EnabledExperimentalFeatures.Contains('PSForEachObjectParallel')
+            if ($skipTest) {
+                Write-Verbose "Tests Skipped. These tests require the experimental feature 'PSForEachObjectParallel' to be enabled." -Verbose
+                $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
+                $PSDefaultParameterValues["it:skip"] = $true
+            }
+        }
+
+        AfterAll {
+            if ($skipTest) {
+                $global:PSDefaultParameterValues = $originalDefaultParameterValues
+            }
+        }
+
+        It 'Should splat indexed data and using: properly' {
+            $o = @(
+                @{
+                    InputObject = 'First'
+                }
+                @{
+                    InputObject = 'Second'
+                }
+            )
+            Add-Member -InputObject $o -Name GetParams -MemberType ScriptMethod -Value { $this.Parameters[$args[0]] }
+            1..1 | ForEach-Object -Parallel { Write-Output @using:o[1] } | Should -BeExactly 'Second'
+        }
+
+        It 'Should splat with properties and indexed data and using: properly' {
+            $o = [pscustomobject]@{
+                Parameters = @(
+                    @{
+                        InputObject = 'First'
+                    }
+                    @{
+                        InputObject = 'Second'
+                    }
+                )
+            }
+            Add-Member -InputObject $o -Name GetParams -MemberType ScriptMethod -Value { $this.Parameters[$args[0]] }
+            1..1 | ForEach-Object -Parallel { Write-Output @using:o.Parameters[1] } | Should -BeExactly 'Second'
         }
     }
 }

--- a/test/powershell/Language/Scripting/Splatting.Tests.ps1
+++ b/test/powershell/Language/Scripting/Splatting.Tests.ps1
@@ -145,7 +145,7 @@ Describe 'Tests for splatting' -Tags 'CI' {
             }
         }
 
-        It 'Should splat indexed data and 'using:' properly' {
+        It 'Should splat indexed data and ''using:'' properly' {
             $testObject = @(
                 @{
                     InputObject = 'First'
@@ -158,7 +158,7 @@ Describe 'Tests for splatting' -Tags 'CI' {
             1..1 | ForEach-Object -Parallel { Write-Output @using:testObject[1] } | Should -BeExactly 'Second'
         }
 
-        It 'Should splat with properties and indexed data and 'using:' properly' {
+        It 'Should splat with properties and indexed data and ''using:'' properly' {
             $testObject = [pscustomobject]@{
                 Parameters = @(
                     @{

--- a/test/powershell/Language/Scripting/Splatting.Tests.ps1
+++ b/test/powershell/Language/Scripting/Splatting.Tests.ps1
@@ -106,7 +106,7 @@ Describe 'Tests for splatting' -Tags 'CI' {
             }
         }
 
-        It 'Should splat indexed data and using: properly' {
+        It 'Should splat indexed data and 'using:' properly' {
             $o = @(
                 @{
                     InputObject = 'First'

--- a/test/powershell/Language/Scripting/Splatting.Tests.ps1
+++ b/test/powershell/Language/Scripting/Splatting.Tests.ps1
@@ -1,0 +1,60 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+Describe 'Tests for splatting' -Tags 'CI' {
+    Context 'Splatting members' {
+        BeforeAll {
+            function Test-Splat {
+                [CmdletBinding(DefaultParameterSetName = 'Default')]
+                param(
+                    [Parameter(ParameterSetName = 'Value')]
+                    [ValidateNotNullOrEmpty()]
+                    [string]
+                    $Value
+                )
+                $PSCmdlet.ParameterSetName
+            }
+        }
+
+        It 'Should splat property values properly' {
+            $o = [pscustomobject]@{
+                Parameters = @{
+                    Value = 'Does it splat?'
+                }
+            }
+            Test-Splat @o.Parameters | Should -BeExactly 'Value'
+        }
+
+        It 'Should splat method results properly' {
+            $o = [pscustomobject]@{
+                Parameters = @{
+                    Value = 'Does it splat?'
+                }
+            }
+            Add-Member -InputObject $o -Name GetParams -MemberType ScriptMethod -Value { $this.Parameters }
+            Test-Splat @o.GetParams() | Should -BeExactly 'Value'
+        }
+
+        It 'Should splat multiple members properly' {
+            $o = [pscustomobject]@{
+                Parameters = @{
+                    Nested = @{
+                        Value = 'Does it splat?'
+                    }
+                }
+            }
+            Add-Member -InputObject $o -Name GetParams -MemberType ScriptMethod -Value { $this.Parameters }
+            Test-Splat @o.GetParams().Nested | Should -BeExactly 'Value'
+        }
+
+        It 'Should splat $PSCmdlet.MyInvocation.BoundParameters properly' {
+            & {
+                [CmdletBinding()]
+                param(
+                    $Value
+                )
+                Test-Splat @PSCmdlet.MyInvocation.BoundParameters
+            } -Value 'Hello' | Should -BeExactly 'Value'
+        }
+    }
+}

--- a/test/powershell/Language/Scripting/Splatting.Tests.ps1
+++ b/test/powershell/Language/Scripting/Splatting.Tests.ps1
@@ -119,7 +119,7 @@ Describe 'Tests for splatting' -Tags 'CI' {
             1..1 | ForEach-Object -Parallel { Write-Output @using:o[1] } | Should -BeExactly 'Second'
         }
 
-        It 'Should splat with properties and indexed data and using: properly' {
+        It 'Should splat with properties and indexed data and 'using:' properly' {
             $o = [pscustomobject]@{
                 Parameters = @(
                     @{


### PR DESCRIPTION
# PR Summary

Like PR's #10984 and #10073, this PR enhances the splatting capabilities in PowerShell.

With this PR in place, users are able to splat members (properties and methods) as well as indexed items into an invocation. It doesn't matter how many levels deep you go with your expression.

Examples:

```powershell
# Splat a property
Get-Date @data.Parameters

# Splat the results of a method
Get-Date @data.GetParams()

# Splat a nested property
Get-Process @PSCmdlet.MyInvocation.BoundParameters

# Splat a property from the result of a method
Test-Splat @result.GetParameterSets().Value

# Splat an item from a collection
Test-Splat @parameterSet[0]
```

The only question I have is whether or not this functionality needs to be behind an experimental feature. If you review the code changes, you'll see that adding this support was very, very easy, and I believe the changes are low risk, so I don't know that it is worth the added complexity of wrapping these in an experimental feature.

## PR Context

This functionality has already been identified as desirable for PowerShell as part of [RFC0002](https://github.com/PowerShell/PowerShell-RFC/blob/e09b14fe01b636ea38260da9e70ff024dc32936b/2-Draft-Accepted/RFC0002-Generalized-Splatting.md).

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [X] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
