### PR TITLE
Fix `ConciseView` to show Activity instead of myCommand

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1104,6 +1104,9 @@ namespace System.Management.Automation.Runspaces
                                         if ($_.Exception -and $_.Exception.WasThrownFromThrowStatement) {
                                             $reason = 'Exception'
                                         }
+                                        elseif ($_.CategoryInfo.Activity) {
+                                            $reason = $_.CategoryInfo.Activity
+                                        }
                                         elseif ($myinv.MyCommand) {
                                             $reason = $myinv.MyCommand
                                         }

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1104,10 +1104,12 @@ namespace System.Management.Automation.Runspaces
                                         if ($_.Exception -and $_.Exception.WasThrownFromThrowStatement) {
                                             $reason = 'Exception'
                                         }
-                                        elseif ($myinv.MyCommand -and $null -ne (Get-Command -Name $myinv.MyCommand))
+                                        # MyCommand can be the script block, so we don't want to show that so check if it's an actual command
+                                        elseif ($myinv.MyCommand -and (Get-Command -Name $myinv.MyCommand -ErrorAction Ignore))
                                         {
                                             $reason = $myinv.MyCommand
                                         }
+                                        # If it's a scriptblock, better to show the command in the scriptblock that had the error
                                         elseif ($_.CategoryInfo.Activity) {
                                             $reason = $_.CategoryInfo.Activity
                                         }

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1104,6 +1104,10 @@ namespace System.Management.Automation.Runspaces
                                         if ($_.Exception -and $_.Exception.WasThrownFromThrowStatement) {
                                             $reason = 'Exception'
                                         }
+                                        elseif ($myinv.MyCommand -and $null -ne (Get-Command -Name $myinv.MyCommand))
+                                        {
+                                            $reason = $myinv.MyCommand
+                                        }
                                         elseif ($_.CategoryInfo.Activity) {
                                             $reason = $_.CategoryInfo.Activity
                                         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
@@ -30,7 +30,7 @@ Describe "Stream writer tests" -Tags "CI" {
         It "Should write error messages to the error stream" {
             Write-Error "Testing Error" 2>&1 > $targetfile
             # The contents of the error stream should contain the expected text
-            $targetfile | Should -FileContentMatch ": Testing Error"
+            $targetfile | Should -FileContentMatch "Testing Error"
         }
 
         It "Should write debug messages to the debug stream" {

--- a/test/powershell/engine/Formatting/ErrorView.Tests.ps1
+++ b/test/powershell/engine/Formatting/ErrorView.Tests.ps1
@@ -50,7 +50,7 @@ Describe 'Tests for $ErrorView' -Tag CI {
             $e = pwsh -noprofile -command "1;2;Write-Error 'myError'"
             $e[0] | Should -Be 1
             $e[1] | Should -Be 2
-            $e[2] | Should -BeLike "*Write-Error: *myError*" # wildcard due to VT100
+            $e[2] | Should -BeLike "*Write-Error:*myError*" # wildcard due to VT100
         }
     }
 }

--- a/test/powershell/engine/Formatting/ErrorView.Tests.ps1
+++ b/test/powershell/engine/Formatting/ErrorView.Tests.ps1
@@ -50,5 +50,12 @@ Describe 'Tests for $ErrorView' -Tag CI {
             $e = pwsh -noprofile -command 'Write-Error 'myError' -ErrorAction SilentlyContinue; $error[0] | Out-String'
             [string]::Join('', $e).Trim() | Should -BeLike "*Write-Error:*myError*" # wildcard due to VT100
         }
+
+        It "Function shows up correctly" {
+            function test-myerror { [cmdletbinding()] param() write-error 'myError' }
+
+            $e = pwsh -noprofile -command 'function test-myerror { [cmdletbinding()] param() write-error "myError" }; test-myerror -ErrorAction SilentlyContinue; $error[0] | Out-String'
+            [string]::Join('', $e).Trim() | Should -BeLike "*test-myerror:*myError*" # wildcard due to VT100
+        }
     }
 }

--- a/test/powershell/engine/Formatting/ErrorView.Tests.ps1
+++ b/test/powershell/engine/Formatting/ErrorView.Tests.ps1
@@ -47,10 +47,8 @@ Describe 'Tests for $ErrorView' -Tag CI {
         }
 
         It "Activity shows up correctly for scriptblocks" {
-            $e = pwsh -noprofile -command "1;2;Write-Error 'myError'"
-            $e[0] | Should -Be 1
-            $e[1] | Should -Be 2
-            $e[2] | Should -BeLike "*Write-Error:*myError*" # wildcard due to VT100
+            $e = pwsh -noprofile -command 'Write-Error 'myError' -ErrorAction SilentlyContinue; $error[0] | Out-String'
+            [string]::Join('', $e).Trim() | Should -BeLike "*Write-Error:*myError*" # wildcard due to VT100
         }
     }
 }

--- a/test/powershell/engine/Formatting/ErrorView.Tests.ps1
+++ b/test/powershell/engine/Formatting/ErrorView.Tests.ps1
@@ -45,5 +45,12 @@ Describe 'Tests for $ErrorView' -Tag CI {
             Start-Job -ScriptBlock { get-item (new-guid) } | Wait-Job | Receive-Job -ErrorVariable e -ErrorAction SilentlyContinue
             ($e | Out-String).Trim().Count | Should -Be 1
         }
+
+        It "Activity shows up correctly for scriptblocks" {
+            $e = pwsh -noprofile -command "1;2;Write-Error 'myError'"
+            $e[0] | Should -Be 1
+            $e[1] | Should -Be 2
+            $e[2] | Should -BeLike "*Write-Error: *myError*" # wildcard due to VT100
+        }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

`ConciseView` shows MyCommand as the prefix to the error message, but for a scriptblock, MyCommand is the whole scriptblock.  Fix is to use CategoryInfo.Activity if available first.  Also handle case where it's a script function by seeing if it's a command and showing MyCommand in that case rather than the Activity.

Before and after
![img](https://i.imgur.com/RKtWAP3.png)

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
