### PR TITLE
Do not check commands for wildcard characters.

### DIFF
--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -1436,15 +1436,6 @@ namespace System.Management.Automation
 
             do // false loop
             {
-                // If the command name contains any wildcard characters
-                // we can't do the path lookup
-
-                if (WildcardPattern.ContainsWildcardCharacters(possiblePath))
-                {
-                    result = CanDoPathLookupResult.WildcardCharacters;
-                    break;
-                }
-
                 try
                 {
                     if (Path.IsPathRooted(possiblePath))

--- a/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
+++ b/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
@@ -170,6 +170,28 @@ Describe "Command Discovery tests" -Tags "CI" {
         }
     }
 
+    Context "Execute scripts by literal file name only via `$env:PATH." {
+        BeforeAll {
+            $originalPath = $env:PATH
+            $dir = Convert-Path TestDrive:
+            "'hi1'" | Set-Content -LiteralPath $dir/script.ps1
+            "'hi2'" | Set-Content -LiteralPath $dir/script[1].ps1
+            $env:PATH += [IO.Path]::PathSeparator + $dir
+        }
+
+        AfterAll {
+            $env:PATH = $originalPath
+        }
+
+        It "Finds and executes a script with a vanilla file name." {
+            script.ps1 | Should -Be 'hi1'
+        }
+
+        It "Finds and executes a script whose file name looks like a wildcard." {
+            script[1].ps1 | Should -Be 'hi2'
+        }
+    }
+
     Context "Get-Command should use globbing first for scripts" {
         BeforeAll {
             $firstResult = '[first script]'


### PR DESCRIPTION
# PR Summary

Remove the check in CanDoPathLookup for wildcard characters in the command, as it prevents a PATH search of the command if it contains wildcard characters.

Fixes #10997

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
