### PR TITLE
Handle exception if enumerating files fails when rebuilding path to have correct casing

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -161,14 +161,22 @@ namespace Microsoft.PowerShell.Commands
                     else
                     {
                         // Use GetFileSystemEntries to get the correct casing of this element
-                        var entries = Directory.GetFileSystemEntries(exactPath, item);
-                        if (entries.Length > 0)
+                        try
                         {
-                            exactPath = entries.First();
+                            var entries = Directory.GetFileSystemEntries(exactPath, item);
+                            if (entries.Length > 0)
+                            {
+                                exactPath = entries.First();
+                            }
+                            else
+                            {
+                                // If previous call didn't return anything, something failed so we just return the path we were given
+                                return path;
+                            }
                         }
-                        else
+                        catch
                         {
-                            // If previous call didn't return anything, something failed so we just return the path we were given
+                            // If we can't enumerate, we stop and just return the original path
                             return path;
                         }
                     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -279,6 +279,23 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
         }
     }
 
+    Context "Appx path" {
+        BeforeAll {
+            $skipTest = $true
+            if ($IsWindows -and (Get-Command -Name Get-AppxPackage) -and (Get-AppxPackage Microsoft.WindowsCalculator)) {
+                $skipTest = $false
+            }
+        }
+
+        It "Can get an appx package item" -Skip:$skipTest {
+            $pkgDir = (Get-AppxPackage Microsoft.WindowsCalculator).InstallLocation
+
+            Get-Item $pkgDir\Calculator.exe -ErrorAction Stop | Should -BeOfType [System.IO.FileInfo]
+            Get-Item -Path $pkgDir -ErrorAction Stop | Should -BeOfType [System.IO.DirectoryInfo]
+            Get-ChildItem -Path $pkgDir -ErrorAction Stop | Should -Not -BeNullOrEmpty
+        }
+    }
+
     Context "Validate basic host navigation functionality" {
         BeforeAll {
             #build semi-complex directory structure to test navigation within

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -288,7 +288,7 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
         }
 
         It "Can get an appx package item" -Skip:$skipTest {
-            $pkgDir = (Get-AppxPackage Microsoft.WindowsCalculator).InstallLocation
+            $pkgDir = (Get-AppxPackage)[0].InstallLocation
 
             Get-Item $pkgDir\Calculator.exe -ErrorAction Stop | Should -BeOfType [System.IO.FileInfo]
             Get-Item -Path $pkgDir -ErrorAction Stop | Should -BeOfType [System.IO.DirectoryInfo]


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

In the code to reconstruct a path with correct casing, it has to go through each segment and use enumeration to get the correct case.  On some directories the user may not have permission to enumerate although they can still read a file/folder within that directory.  Fix is if there is an exception during enumeration, fail gracefully by just returning back the original path.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/11013

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
