### PR TITLE
WIP: Fix `-ArgumentList` processing for `Start-Process` for whitespace and embedded quotes

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel; // Win32Exception
 using System.Diagnostics; // Process class
@@ -1876,7 +1877,10 @@ namespace Microsoft.PowerShell.Commands
 
             if (ArgumentList != null)
             {
-                startInfo.Arguments = string.Join(' ', ArgumentList);
+                foreach (var arg in ArgumentList)
+                {
+                    startInfo.ArgumentList.Add(arg);
+                }
             }
 
             if (WorkingDirectory != null)
@@ -2294,7 +2298,7 @@ namespace Microsoft.PowerShell.Commands
             return sf;
         }
 
-        private static StringBuilder BuildCommandLine(string executableFileName, string arguments)
+        private static StringBuilder BuildCommandLine(string executableFileName, Collection<string> arguments)
         {
             StringBuilder builder = new StringBuilder();
             string str = executableFileName.Trim();
@@ -2310,10 +2314,11 @@ namespace Microsoft.PowerShell.Commands
                 builder.Append('"');
             }
 
-            if (!string.IsNullOrEmpty(arguments))
+            foreach (var arg in arguments)
             {
-                builder.Append(' ');
-                builder.Append(arguments);
+                builder.Append(" \"");
+                builder.Append(arg.Replace("\"","\\\""));
+                builder.Append('"');
             }
 
             return builder;
@@ -2360,7 +2365,7 @@ namespace Microsoft.PowerShell.Commands
             string message = string.Empty;
 
             // building the cmdline with the file name given and it's arguments
-            StringBuilder cmdLine = BuildCommandLine(startinfo.FileName, startinfo.Arguments);
+            StringBuilder cmdLine = BuildCommandLine(startinfo.FileName, startinfo.ArgumentList);
 
             try
             {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-Describe "Start-Process" -Tag "Feature","RequireAdminOnWindows" {
+Describe "Start-Process" -Tag "CI" {
 
     BeforeAll {
         $isNanoServer = [System.Management.Automation.Platform]::IsNanoServer
@@ -144,6 +144,22 @@ Describe "Start-Process" -Tag "Feature","RequireAdminOnWindows" {
         $process = Start-Process $pingCommand -ArgumentList '' -PassThru @extraArgs
         $process.Length      | Should -Be 1
         $process.Id          | Should -BeGreaterThan 1
+    }
+
+    It "Should handle arguments with whitespace" {
+        Start-Process -Wait -NoNewWindow testexe.exe -ArgumentList '-echoargs', 'a b', 'c' -RedirectStandardOutput $testdrive/out.txt
+        $output = Get-Content -Path $testdrive/out.txt
+        $output.Count | Should -Be 2
+        $output[0] | Should -BeExactly 'Arg 0 is <a b>'
+        $output[1] | Should -BeExactly 'Arg 1 is <c>'
+    }
+
+    It "Should handle arguments with embedded quotes" {
+        Start-Process -Wait -NoNewWindow testexe.exe -ArgumentList '-echoargs', '"a"', 'c' -RedirectStandardOutput $testdrive/out.txt
+        $output = Get-Content -Path $testdrive/out.txt
+        $output.Count | Should -Be 2
+        $output[0] | Should -BeExactly 'Arg 0 is <"a">'
+        $output[1] | Should -BeExactly 'Arg 1 is <c>'
     }
 }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

`ProcessStartInfo.ArgumentList` can't be used as the current cmdlet supports: `start-process ping -argumentlist "-n 2 localhost"` which would then treat those 3 arguments as 1 and fail.  

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/5576

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
