### PR TITLE
ConvertTo-Csv / Export-Csv - Serialize IDictionary objects with key/value pairs as properties

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
@@ -737,14 +738,18 @@ namespace Microsoft.PowerShell.Commands
                 // Write property information
                 string properties = _helper.ConvertPropertyNamesCSV(_propertyNames);
                 if (!properties.Equals(string.Empty))
+                {
                     WriteCsvLine(properties);
+                }
             }
 
             string csv = _helper.ConvertPSObjectToCSV(InputObject, _propertyNames);
 
-            // write to the console
+            // Write to the output stream
             if (csv != string.Empty)
+            {
                 WriteCsvLine(csv);
+            }
         }
 
         #endregion Overrides
@@ -908,16 +913,36 @@ namespace Microsoft.PowerShell.Commands
                 throw new InvalidOperationException(CsvCommandStrings.BuildPropertyNamesMethodShouldBeCalledOnlyOncePerCmdletInstance);
             }
 
-            // serialize only Extended and Adapted properties..
-            PSMemberInfoCollection<PSPropertyInfo> srcPropertiesToSearch =
-                new PSMemberInfoIntegratingCollection<PSPropertyInfo>(
-                    source,
-                    PSObject.GetPropertyCollection(PSMemberViewTypes.Extended | PSMemberViewTypes.Adapted));
-
             propertyNames = new Collection<string>();
-            foreach (PSPropertyInfo prop in srcPropertiesToSearch)
+            if (source.BaseObject is IDictionary dictionary)
             {
-                propertyNames.Add(prop.Name);
+                foreach (var key in dictionary.Keys)
+                {
+                    propertyNames.Add(LanguagePrimitives.ConvertTo<string>(key));
+                }
+
+                // Add additional extended members added to the dictionary object, if any
+                var propertiesToSearch = new PSMemberInfoIntegratingCollection<PSPropertyInfo>(
+                    source,
+                    PSObject.GetPropertyCollection(PSMemberViewTypes.Extended));
+
+                foreach (var prop in propertiesToSearch)
+                {
+                    propertyNames.Add(prop.Name);
+                }
+            }
+            else
+            {
+                // serialize only Extended and Adapted properties..
+                PSMemberInfoCollection<PSPropertyInfo> srcPropertiesToSearch =
+                    new PSMemberInfoIntegratingCollection<PSPropertyInfo>(
+                        source,
+                        PSObject.GetPropertyCollection(PSMemberViewTypes.Extended | PSMemberViewTypes.Adapted));
+
+                foreach (PSPropertyInfo prop in srcPropertiesToSearch)
+                {
+                    propertyNames.Add(prop.Name);
+                }
             }
 
             return propertyNames;
@@ -1014,10 +1039,26 @@ namespace Microsoft.PowerShell.Commands
                     _outputString.Append(_delimiter);
                 }
 
-                // If property is not present, assume value is null and skip it.
-                if (mshObject.Properties[propertyName] is PSPropertyInfo property)
+                string value = null;
+                if (mshObject.BaseObject is IDictionary dictionary)
                 {
-                    var value = GetToStringValueForProperty(property);
+                    if (dictionary.Contains(propertyName))
+                    {
+                        value = dictionary[propertyName].ToString();
+                    }
+                    else if (mshObject.Properties[propertyName] is PSPropertyInfo property)
+                    {
+                        value = GetToStringValueForProperty(property);
+                    }
+                }
+                else if (mshObject.Properties[propertyName] is PSPropertyInfo property)
+                {
+                    value = GetToStringValueForProperty(property);
+                }
+
+                // If value is null, assume property is not present and skip it.
+                if (value != null)
+                {
 
                     if (_quoteFields != null)
                     {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -933,7 +933,7 @@ namespace Microsoft.PowerShell.Commands
             }
             else
             {
-                // serialize only Extended and Adapted properties..
+                // serialize only Extended and Adapted properties.
                 PSMemberInfoCollection<PSPropertyInfo> srcPropertiesToSearch =
                     new PSMemberInfoIntegratingCollection<PSPropertyInfo>(
                         source,
@@ -1059,7 +1059,6 @@ namespace Microsoft.PowerShell.Commands
                 // If value is null, assume property is not present and skip it.
                 if (value != null)
                 {
-
                     if (_quoteFields != null)
                     {
                         if (_quoteFields.TryGetValue(propertyName, out _))


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

> Updates `ConvertTo-Csv` and `Export-Csv` to handle `IDictionary` objects.

With this change, the behaviour for `IDictionary` inputs are changed in `ConvertTo-Csv` and `Export-Csv`:

1. If the `InputObject` is _not_ `IDictionary`, behaviour remains as per existing behaviour.
1. If the `InputObject` **is** `IDictionary`:
  - When pulling property names, we **only** check the dictionary's `Keys` _and_ any additional instance properties (e.g., those added with `Add-Member` or `Select-Object`)
  - When looking for values, we first check the dictionary to see if the key is present. If it is, use the corresponding value. If it is not, we also check any instance properties with the same name and use those values if available.

The reason we also check for any instance properties is based on the assumption that if a user is adding extra properties to their IDictionary objects, they likely want to keep them as intact as possible.

We do however ignore standard properties completely, since with IDictionary objects these are typically of little value when serialized to string.

Note that since both Export-Csv and ConvertTo-Csv utilise the same helper methods, tests were only added to the ConvertTo-Csv test file in order to minimise the duplication of code.

### Example

![Example of ConvertTo-Csv with hashtables as input, then again with instance properties attached to the hashtable.](https://media.discordapp.net/attachments/511027662915895307/642919632683925515/unknown.png)

## PR Context

Resolves #10999 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/5104
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
