### PR TITLE
Group-Object - Use Case-Sensitive Hashtable for -CaseSensitive -AsHashtable

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Group-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Group-Object.cs
@@ -518,7 +518,16 @@ namespace Microsoft.PowerShell.Commands
             {
                 if (AsHashTable)
                 {
-                    Hashtable hashtable = CollectionsUtil.CreateCaseInsensitiveHashtable();
+                    Hashtable hashtable;
+                    if (CaseSensitive.IsPresent)
+                    {
+                        hashtable = new Hashtable();
+                    }
+                    else
+                    {
+                        hashtable = CollectionsUtil.CreateCaseInsensitiveHashtable();
+                    }
+
                     try
                     {
                         if (AsString)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Group-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Group-Object.cs
@@ -516,18 +516,12 @@ namespace Microsoft.PowerShell.Commands
             s_tracer.WriteLine(_groups.Count);
             if (_groups.Count > 0)
             {
-                if (AsHashTable)
+                if (AsHashTable.IsPresent)
                 {
-                    Hashtable hashtable;
-                    if (CaseSensitive.IsPresent)
-                    {
-                        hashtable = new Hashtable();
-                    }
-                    else
-                    {
-                        hashtable = CollectionsUtil.CreateCaseInsensitiveHashtable();
-                    }
-
+                    StringComparer comparer = CaseSensitive.IsPresent
+                        ? StringComparer.CurrentCulture
+                        : StringComparer.CurrentCultureIgnoreCase;
+                    var hashtable = new Hashtable(comparer);
                     try
                     {
                         if (AsString)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Group-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Group-Object.Tests.ps1
@@ -177,19 +177,16 @@ Describe "Check 'Culture' parameter in order object cmdlets (Group-Object, Sort-
     }
 
     It 'should not throw a key duplication error with -CaseSensitive -AsHashtable' {
-        $script = {
-            $capitonyms = @(
-                [PSCustomObject]@{
-                    Capitonym = 'Bill'
-                }
-                [PSCustomObject]@{
-                    Capitonym = 'bill'
-                }
-            )
+        $capitonyms = @(
+            [PSCustomObject]@{
+                Capitonym = 'Bill'
+            }
+            [PSCustomObject]@{
+                Capitonym = 'bill'
+            }
+        )
 
-            $capitonyms | Group-Object Capitonym -AsHashTable -CaseSensitive
-        }
-
-        $script | Should -Not -Throw
+        [hashtable] $Result = $capitonyms | Group-Object -Property Capitonym -AsHashTable -CaseSensitive
+        $Result.Keys | Should -BeIn @( 'Bill', 'bill' )
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Group-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Group-Object.Tests.ps1
@@ -186,7 +186,8 @@ Describe "Check 'Culture' parameter in order object cmdlets (Group-Object, Sort-
             }
         )
 
-        [hashtable] $Result = $capitonyms | Group-Object -Property Capitonym -AsHashTable -CaseSensitive
+        $Result = $capitonyms | Group-Object -Property Capitonym -AsHashTable -CaseSensitive
+        $Result | Should -BeOfType [HashTable]
         $Result.Keys | Should -BeIn @( 'Bill', 'bill' )
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Group-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Group-Object.Tests.ps1
@@ -173,6 +173,23 @@ Describe "Check 'Culture' parameter in order object cmdlets (Group-Object, Sort-
             $testCulture = "1049"
         }
 
-        {$testObject | Group-Object -Culture $testCulture } | Should -Not -Throw
+        { $testObject | Group-Object -Culture $testCulture } | Should -Not -Throw
+    }
+
+    It 'should not throw a key duplication error with -CaseSensitive -AsHashtable' {
+        $script = {
+            $capitonyms = @(
+                [PSCustomObject]@{
+                    Capitonym = 'Bill'
+                }
+                [PSCustomObject]@{
+                    Capitonym = 'bill'
+                }
+            )
+
+            $capitonyms | Group-Object Capitonym -AsHashTable -CaseSensitive
+        }
+
+        $script | Should -Not -Throw
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Prior to this change, `Group-Object -AsHashtable -CaseSensitive` would give a key duplication error when given entries that only differ by casing. This was due to always using a case-insensitive hashtable, despite the request for `-CaseSensitive` behaviour.

This change allows `Group-Object -CaseSensitive -AsHashtable` to create and return a case-sensitive hashtable to enable this use case.

## PR Context

Resolves #10441

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
