### PR TITLE
Stop setting $? to true for subpipelines and subexpressions

### DIFF
--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -3270,31 +3270,6 @@ namespace System.Management.Automation.Language
             }
         }
 
-        private bool MustSetSuccessAfterEvaluating(StatementBlockAst statementBlockAst)
-        {
-            if (statementBlockAst.Traps != null && statementBlockAst.Traps.Count > 0)
-            {
-                return false;
-            }
-
-            if (statementBlockAst.Statements == null)
-            {
-                return true;
-            }
-
-            switch (statementBlockAst.Statements.Count)
-            {
-                case 0:
-                    return true;
-
-                case 1:
-                    return MustSetSuccessAfterEvaluating(statementBlockAst.Statements[0]);
-
-                default:
-                    return false;
-            }
-        }
-
         private bool MustSetSuccessAfterEvaluating(ExpressionAst expressionAst)
         {
             switch (expressionAst)
@@ -3303,16 +3278,20 @@ namespace System.Management.Automation.Language
                     return MustSetSuccessAfterEvaluating(parenExpression.Pipeline);
 
                 case SubExpressionAst subExpressionAst:
-                    // SubExpressionAsts contain statement blocks.
-                    // The compiler already adds the needed $? = $true when compiling the statement block,
-                    // so no need to add extra runtime overhead here.
-                    return false;
+                    return subExpressionAst.SubExpression.Statements.Count == 0;
 
                 case ArrayExpressionAst arrayExpressionAst:
-                    // ArrayExpressionAsts can contain statement blocks,
-                    // but may still be optimised when the underlying expression is pure.
-                    // So we must check here.
-                    return MustSetSuccessAfterEvaluating(arrayExpressionAst.SubExpression);
+                    switch (arrayExpressionAst.SubExpression.Statements.Count)
+                    {
+                        case 0:
+                            return true;
+
+                        case 1:
+                            return MustSetSuccessAfterEvaluating(arrayExpressionAst.SubExpression.Statements[0]);
+
+                        default:
+                            return false;
+                    }
 
                 default:
                     return true;

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -3326,6 +3326,12 @@ namespace System.Management.Automation.Language
                             return true;
 
                         case 1:
+                            // Single expressions with a trap are handled as statements
+                            if (arrayExpressionAst.SubExpression.Traps != null)
+                            {
+                                return false;
+                            }
+
                             // Pure, single statement expressions need $? set
                             // For example @("One") and @("One", "Two")
                             return ShouldSetExecutionStatusToSuccess(arrayExpressionAst.SubExpression.Statements[0]);

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -3327,6 +3327,7 @@ namespace System.Management.Automation.Language
 
                         case 1:
                             // Single expressions with a trap are handled as statements
+                            // For example: @(trap { continue } "Value")
                             if (arrayExpressionAst.SubExpression.Traps != null)
                             {
                                 return false;

--- a/test/powershell/Language/Operators/PipelineChainOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/PipelineChainOperator.Tests.ps1
@@ -264,7 +264,8 @@ function Test-FullyTerminatingError
     It "Gets the correct output with statement '<Statement>'" -TestCases $simpleTestCases {
         param($Statement, $Output)
 
-        Invoke-Expression -Command $Statement 2>$null | Should -Be $Output
+        $result = Invoke-Expression -Command $Statement 2>$null
+        $result | Should -Be $Output
     }
 
     It "Sets the variable correctly with statement '<Statement>'" -TestCases $variableTestCases {

--- a/test/powershell/Language/Operators/PipelineChainOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/PipelineChainOperator.Tests.ps1
@@ -89,6 +89,13 @@ Describe "Experimental Feature: && and || operators - Feature-Enabled" -Tag CI {
             @{ Statement = '0,1 | % { testexe -returncode $_ } && testexe -returncode 0'; Output = @('0','1','0') }
             @{ Statement = '1,2 | % { testexe -returncode $_ } && testexe -returncode 0'; Output = @('1','2','0') }
 
+            # Subpipeline and subexpression cases
+            @{ Statement = '(testexe -returncode 0 && testexe -returncode 1) && "Hi"'; Output = @('0','1') }
+            @{ Statement = '$(testexe -returncode 0 && testexe -returncode 1) && "Hi"'; Output = @('0','1') }
+            @{ Statement = '(testexe -returncode 0 && testexe -returncode 1) || "Bad"'; Output = @('0','1','Bad') }
+            @{ Statement = '$(testexe -returncode 0 && testexe -returncode 1) && "Bad"'; Output = @('0','1') }
+            @{ Statement = '(testexe -returncode 1 || testexe -returncode 1) && "Hi"'; Output = @('1','1') }
+
             # Control flow statements
             @{ Statement = 'foreach ($v in 0,1,2) { testexe -returncode $v || $(break) }'; Output = @('0', '1') }
             @{ Statement = 'foreach ($v in 0,1,2) { testexe -returncode $v || $(continue); $v + 1 }'; Output = @('0', 1, '1', '2') }

--- a/test/powershell/Language/Operators/PipelineChainOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/PipelineChainOperator.Tests.ps1
@@ -141,6 +141,92 @@ Describe "Experimental Feature: && and || operators - Feature-Enabled" -Tag CI {
         }
     }
 
+    It "Gets the correct output with statement '<Statement>'" -TestCases $simpleTestCases {
+        param($Statement, $Output)
+
+        $result = Invoke-Expression -Command $Statement 2>$null
+        $result | Should -Be $Output
+    }
+
+    It "Sets the variable correctly with statement '<Statement>'" -TestCases $variableTestCases {
+        param($Statement, $Variables)
+
+        Invoke-Expression -Command $Statement
+        foreach ($variableName in $Variables.get_Keys())
+        {
+            (Get-Variable -Name $variableName -ErrorAction Ignore).Value | Should -Be $Variables[$variableName] -Because "variable is '`$$variableName'"
+        }
+    }
+
+    It "Runs the statement chain '<Statement>' as a job" -TestCases $jobTestCases {
+        param($Statement, $Output, $Variable)
+
+        $resultJob = Invoke-Expression -Command $Statement
+
+        if ($Variable)
+        {
+            $resultJob = (Get-Variable $Variable).Value
+        }
+
+        $resultJob | Wait-Job | Receive-Job | Should -Be $Output
+    }
+
+    It "Rejects invalid syntax usage in '<Statement>'" -TestCases $invalidSyntaxCases {
+        param([string]$Statement, [string]$ErrorID, [bool]$IncompleteInput)
+
+        $tokens = $errors = $null
+        [System.Management.Automation.Language.Parser]::ParseInput($Statement, [ref]$tokens, [ref]$errors)
+
+        $errors.Count | Should -BeExactly 1
+        $errors[0].ErrorId | Should -BeExactly $ErrorID
+        $errors[0].IncompleteInput | Should -Be $IncompleteInput
+    }
+
+    Context "File redirection with && and ||" {
+        BeforeAll {
+            $redirectionTestCases = @(
+                @{ Statement = "testexe -returncode 0 > '$TestDrive/1.txt' && testexe -returncode 1 > '$TestDrive/2.txt'"; Files = @{ "$TestDrive/1.txt" = '0'; "$TestDrive/2.txt" = '1' } }
+                @{ Statement = "testexe -returncode 1 > '$TestDrive/1.txt' && testexe -returncode 1 > '$TestDrive/2.txt'"; Files = @{ "$TestDrive/1.txt" = '1'; "$TestDrive/2.txt" = $null } }
+                @{ Statement = "testexe -returncode 1 > '$TestDrive/1.txt' || testexe -returncode 1 > '$TestDrive/2.txt'"; Files = @{ "$TestDrive/1.txt" = '1'; "$TestDrive/2.txt" = '1' } }
+                @{ Statement = "testexe -returncode 0 > '$TestDrive/1.txt' || testexe -returncode 1 > '$TestDrive/2.txt'"; Files = @{ "$TestDrive/1.txt" = '0'; "$TestDrive/2.txt" = $null } }
+                @{ Statement = "(testexe -returncode 0 && testexe -returncode 1) > '$TestDrive/3.txt'"; Files = @{ "$TestDrive/3.txt" = "0$([System.Environment]::NewLine)1$([System.Environment]::NewLine)" } }
+                @{ Statement = "(testexe -returncode 0 && testexe -returncode 1 > '$TestDrive/2.txt') > '$TestDrive/3.txt'"; Files = @{ "$TestDrive/2.txt" = '1'; "$TestDrive/3.txt" = '0' } }
+                @{ Statement = "(testexe -returncode 0 > '$TestDrive/1.txt' && testexe -returncode 1 > '$TestDrive/2.txt') > '$TestDrive/3.txt'"; Files = @{ "$TestDrive/1.txt" = '0'; "$TestDrive/2.txt" = '1'; "$TestDrive/3.txt" = '' } }
+            )
+        }
+
+        BeforeEach {
+            Remove-Item -Path $TestDrive/*
+        }
+
+        It "Handles redirection correctly with statement '<Statement>'" -TestCases $redirectionTestCases {
+            param($Statement, $Files)
+
+            Invoke-Expression -Command $Statement
+
+            foreach ($file in $Files.get_Keys())
+            {
+                $expectedValue = $Files[$file]
+
+                if ($null -eq $expectedValue)
+                {
+                    $file | Should -Not -Exist
+                    continue
+                }
+
+                # Special case for empty file
+                if ($expectedValue -eq '')
+                {
+                    (Get-Item $file).Length | Should -Be 0
+                    continue
+                }
+
+
+                $file | Should -FileContentMatchMultiline $expectedValue
+            }
+        }
+    }
+
     Context "Pipeline chain error semantics" {
         BeforeAll {
             $pwsh = [powershell]::Create()
@@ -265,92 +351,6 @@ function Test-FullyTerminatingError
 
             $result | Should -Be $Output
             $pwsh.Streams.Error | Should -Be $NTErrors
-        }
-    }
-
-    It "Gets the correct output with statement '<Statement>'" -TestCases $simpleTestCases {
-        param($Statement, $Output)
-
-        $result = Invoke-Expression -Command $Statement 2>$null
-        $result | Should -Be $Output
-    }
-
-    It "Sets the variable correctly with statement '<Statement>'" -TestCases $variableTestCases {
-        param($Statement, $Variables)
-
-        Invoke-Expression -Command $Statement
-        foreach ($variableName in $Variables.get_Keys())
-        {
-            (Get-Variable -Name $variableName -ErrorAction Ignore).Value | Should -Be $Variables[$variableName] -Because "variable is '`$$variableName'"
-        }
-    }
-
-    It "Runs the statement chain '<Statement>' as a job" -TestCases $jobTestCases {
-        param($Statement, $Output, $Variable)
-
-        $resultJob = Invoke-Expression -Command $Statement
-
-        if ($Variable)
-        {
-            $resultJob = (Get-Variable $Variable).Value
-        }
-
-        $resultJob | Wait-Job | Receive-Job | Should -Be $Output
-    }
-
-    It "Rejects invalid syntax usage in '<Statement>'" -TestCases $invalidSyntaxCases {
-        param([string]$Statement, [string]$ErrorID, [bool]$IncompleteInput)
-
-        $tokens = $errors = $null
-        [System.Management.Automation.Language.Parser]::ParseInput($Statement, [ref]$tokens, [ref]$errors)
-
-        $errors.Count | Should -BeExactly 1
-        $errors[0].ErrorId | Should -BeExactly $ErrorID
-        $errors[0].IncompleteInput | Should -Be $IncompleteInput
-    }
-
-    Context "File redirection with && and ||" {
-        BeforeAll {
-            $redirectionTestCases = @(
-                @{ Statement = "testexe -returncode 0 > '$TestDrive/1.txt' && testexe -returncode 1 > '$TestDrive/2.txt'"; Files = @{ "$TestDrive/1.txt" = '0'; "$TestDrive/2.txt" = '1' } }
-                @{ Statement = "testexe -returncode 1 > '$TestDrive/1.txt' && testexe -returncode 1 > '$TestDrive/2.txt'"; Files = @{ "$TestDrive/1.txt" = '1'; "$TestDrive/2.txt" = $null } }
-                @{ Statement = "testexe -returncode 1 > '$TestDrive/1.txt' || testexe -returncode 1 > '$TestDrive/2.txt'"; Files = @{ "$TestDrive/1.txt" = '1'; "$TestDrive/2.txt" = '1' } }
-                @{ Statement = "testexe -returncode 0 > '$TestDrive/1.txt' || testexe -returncode 1 > '$TestDrive/2.txt'"; Files = @{ "$TestDrive/1.txt" = '0'; "$TestDrive/2.txt" = $null } }
-                @{ Statement = "(testexe -returncode 0 && testexe -returncode 1) > '$TestDrive/3.txt'"; Files = @{ "$TestDrive/3.txt" = "0$([System.Environment]::NewLine)1$([System.Environment]::NewLine)" } }
-                @{ Statement = "(testexe -returncode 0 && testexe -returncode 1 > '$TestDrive/2.txt') > '$TestDrive/3.txt'"; Files = @{ "$TestDrive/2.txt" = '1'; "$TestDrive/3.txt" = '0' } }
-                @{ Statement = "(testexe -returncode 0 > '$TestDrive/1.txt' && testexe -returncode 1 > '$TestDrive/2.txt') > '$TestDrive/3.txt'"; Files = @{ "$TestDrive/1.txt" = '0'; "$TestDrive/2.txt" = '1'; "$TestDrive/3.txt" = '' } }
-            )
-        }
-
-        BeforeEach {
-            Remove-Item -Path $TestDrive/*
-        }
-
-        It "Handles redirection correctly with statement '<Statement>'" -TestCases $redirectionTestCases {
-            param($Statement, $Files)
-
-            Invoke-Expression -Command $Statement
-
-            foreach ($file in $Files.get_Keys())
-            {
-                $expectedValue = $Files[$file]
-
-                if ($null -eq $expectedValue)
-                {
-                    $file | Should -Not -Exist
-                    continue
-                }
-
-                # Special case for empty file
-                if ($expectedValue -eq '')
-                {
-                    (Get-Item $file).Length | Should -Be 0
-                    continue
-                }
-
-
-                $file | Should -FileContentMatchMultiline $expectedValue
-            }
         }
     }
 

--- a/test/powershell/Language/Operators/PipelineChainOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/PipelineChainOperator.Tests.ps1
@@ -221,7 +221,6 @@ Describe "Experimental Feature: && and || operators - Feature-Enabled" -Tag CI {
                     continue
                 }
 
-
                 $file | Should -FileContentMatchMultiline $expectedValue
             }
         }

--- a/test/powershell/Language/Scripting/DollarHook.Tests.ps1
+++ b/test/powershell/Language/Scripting/DollarHook.Tests.ps1
@@ -12,64 +12,77 @@ Describe 'Tests for setting $? for execution success' -Tag 'CI' {
             $script:hookValues.Add($Value)
         }
 
-        $testCases = @(
-            # Cmdlets
-            @{ Script = 'Write-Output "Hi"; Hook $?'; Results = @($true) }
-            @{ Script = 'Write-Error "Bad"; Hook $?'; Results = @($false) }
-            @{ Script = 'Write-Error "Bad"; Hook $?; Hook $?'; Results = @($false, $true) }
-
-            # Native executables
-            @{ Script = 'testexe -returncode 0; Hook $?'; Results = @($true) }
-            @{ Script = 'testexe -returncode 1; Hook $?; Hook $?'; Results = @($false, $true) }
-
-            # Pure values
-            @{ Script = '"Hi"; Hook $?'; Results = @($true) }
-            @{ Script = 'Write-Error "Bad"; "Hi"; Hook $?'; Results = @($true) }
-
-            # Paren expressions (subpipelines)
-            @{ Script = '(Write-Output "Hi"); Hook $?'; Results = @($true) }
-            @{ Script = 'Write-Error "Bad"; ("Hi"); Hook $?'; Results = @($true) }
-            @{ Script = '(Write-Error "Bad"); Hook $?; Hook $?'; Results = @($false, $true) }
-            @{ Script = '(testexe -returncode 0); Hook $?'; Results = @($true) }
-            @{ Script = '(testexe -returncode 1); Hook $?; Hook $?'; Results = @($false, $true) }
-
-            # Subexpressions
-            @{ Script = '$("Hi"); Hook $?'; Results = @($true) }
-            @{ Script = 'Write-Error "Bad"; $("Hi"); Hook $?'; Results = @($true) }
-            @{ Script = '$(); Hook $?'; Results = @($true) }
-            @{ Script = 'Write-Error "Bad"; $(); Hook $?'; Results = @($true) }
-            @{ Script = '$(Write-Error "Bad"); Hook $?; Hook $?'; Results = @($false, $true) }
-            @{ Script = '$(testexe -returncode 1); Hook $?; Hook $?'; Results = @($false, $true) }
-            @{ Script = 'Write-Error "Bad"; $(trap { continue }); Hook $?'; Results = @($true) }
-            @{ Script = 'Write-Error "Bad"; $(trap { continue } "Hi"); Hook $?'; Results = @($true) }
-
-            # Array expressions
-            @{ Script = '@("Hi"); Hook $?'; Results = @($true) }
-            @{ Script = '@(); Hook $?'; Results = @($true) }
-            @{ Script = 'Write-Error "Bad"; @("Hi"); Hook $?'; Results = @($true) }
-            @{ Script = 'Write-Error "Bad"; @(); Hook $?'; Results = @($true) }
-            @{ Script = 'Write-Error "Bad"; @("Hi", "There"); Hook $?'; Results = @($true) }
-            @{ Script = 'Write-Error "Bad"; @("Hi"; "There"); Hook $?'; Results = @($true) }
-            @{ Script = 'Write-Error "Bad"; @(trap { continue }); Hook $?'; Results = @($true) }
-            @{ Script = 'Write-Error "Bad"; @(trap { continue } "Hi"); Hook $?'; Results = @($true) }
-            @{ Script = 'Write-Error "Bad"; @(trap { continue } "Hi", "There"); Hook $?'; Results = @($true) }
-            @{ Script = '@(Write-Error "Bad"); Hook $?; Hook $?'; Results = @($false, $true) }
-            @{ Script = '@(Write-Error "Bad"; "Hi"); Hook $?; Hook $?'; Results = @($true, $true) }
-            @{ Script = '@("Hi"; Write-Error "Bad"); Hook $?; Hook $?'; Results = @($false, $true) }
-            @{ Script = '@(Write-Error "Bad"; Write-Output "Hi"); Hook $?; Hook $?'; Results = @($true, $true) }
-            @{ Script = '@(Write-Output "Hi"; Write-Error "Bad"); Hook $?; Hook $?'; Results = @($false, $true) }
-        )
     }
 
     AfterEach {
         $script:hookValues.Clear()
     }
 
-    It 'Sets $? for case ''<Script>''' -TestCases $testCases {
+    It 'Sets $? for case ''<Script>''' -TestCases @(
+        # Cmdlets
+        @{ Script = 'Write-Output "Hi"; Hook $?'; Results = @($true) }
+        @{ Script = 'Write-Error "Bad"; Hook $?'; Results = @($false) }
+        @{ Script = 'Write-Error "Bad"; Hook $?; Hook $?'; Results = @($false, $true) }
+
+        # Native executables
+        @{ Script = 'testexe -returncode 0; Hook $?'; Results = @($true) }
+        @{ Script = 'testexe -returncode 1; Hook $?; Hook $?'; Results = @($false, $true) }
+
+        # Pure values
+        @{ Script = '"Hi"; Hook $?'; Results = @($true) }
+        @{ Script = 'Write-Error "Bad"; "Hi"; Hook $?'; Results = @($true) }
+
+        # Paren expressions (subpipelines)
+        @{ Script = '(Write-Output "Hi"); Hook $?'; Results = @($true) }
+        @{ Script = 'Write-Error "Bad"; ("Hi"); Hook $?'; Results = @($true) }
+        @{ Script = '(Write-Error "Bad"); Hook $?; Hook $?'; Results = @($false, $true) }
+        @{ Script = '(testexe -returncode 0); Hook $?'; Results = @($true) }
+        @{ Script = '(testexe -returncode 1); Hook $?; Hook $?'; Results = @($false, $true) }
+
+        # Subexpressions
+        @{ Script = '$("Hi"); Hook $?'; Results = @($true) }
+        @{ Script = 'Write-Error "Bad"; $("Hi"); Hook $?'; Results = @($true) }
+        @{ Script = '$(); Hook $?'; Results = @($true) }
+        @{ Script = 'Write-Error "Bad"; $(); Hook $?'; Results = @($true) }
+        @{ Script = '$(Write-Error "Bad"); Hook $?; Hook $?'; Results = @($false, $true) }
+        @{ Script = '$(testexe -returncode 1); Hook $?; Hook $?'; Results = @($false, $true) }
+        @{ Script = 'Write-Error "Bad"; $(trap { continue }); Hook $?'; Results = @($true) }
+        @{ Script = 'Write-Error "Bad"; $(trap { continue } "Hi"); Hook $?'; Results = @($true) }
+
+        # Array expressions
+        @{ Script = '@("Hi"); Hook $?'; Results = @($true) }
+        @{ Script = '@(); Hook $?'; Results = @($true) }
+        @{ Script = 'Write-Error "Bad"; @("Hi"); Hook $?'; Results = @($true) }
+        @{ Script = 'Write-Error "Bad"; @(); Hook $?'; Results = @($true) }
+        @{ Script = 'Write-Error "Bad"; @("Hi", "There"); Hook $?'; Results = @($true) }
+        @{ Script = 'Write-Error "Bad"; @("Hi"; "There"); Hook $?'; Results = @($true) }
+        @{ Script = 'Write-Error "Bad"; @(trap { continue }); Hook $?'; Results = @($true) }
+        @{ Script = 'Write-Error "Bad"; @(trap { continue } "Hi"); Hook $?'; Results = @($true) }
+        @{ Script = 'Write-Error "Bad"; @(trap { continue } "Hi", "There"); Hook $?'; Results = @($true) }
+        @{ Script = '@(Write-Error "Bad"); Hook $?; Hook $?'; Results = @($false, $true) }
+        @{ Script = '@(Write-Error "Bad"; "Hi"); Hook $?; Hook $?'; Results = @($true, $true) }
+        @{ Script = '@("Hi"; Write-Error "Bad"); Hook $?; Hook $?'; Results = @($false, $true) }
+        @{ Script = '@(Write-Error "Bad"; Write-Output "Hi"); Hook $?; Hook $?'; Results = @($true, $true) }
+        @{ Script = '@(Write-Output "Hi"; Write-Error "Bad"); Hook $?; Hook $?'; Results = @($false, $true) }
+    ) {
         param([string]$Script, [object[]]$Results)
 
         Invoke-Expression $Script 2>&1 > $null
 
         $script:hookValues | Should -Be $Results
+    }
+
+    It 'Sets $? correctly for string expression ''<Expression>''' -TestCases @(
+        @{ Expression = '"Hi"; Hook $?'; HookResults = $($true); PipelineResults = @('Hi') }
+        @{ Expression = '"Hi $("Good")"; Hook $?'; HookResults = $($true); PipelineResults = @('Hi Good') }
+        @{ Expression = '"Hi $(Write-Error "Bad")"; Hook $?'; HookResults = $($true); PipelineResults = @('Hi ') }
+        @{ Expression = '"Hi $(Write-Output "Good")"; Hook $?'; HookResults = $($true); PipelineResults = @('Hi Good') }
+    ) {
+        param([string]$Expression, [object[]]$HookResults, [object[]]$PipelineResults)
+
+        $output = Invoke-Expression $Expression 2>$null
+
+        $script:hookValues | Should -Be $HookResults
+        $output | Should -Be $PipelineResults
     }
 }

--- a/test/powershell/Language/Scripting/DollarHook.Tests.ps1
+++ b/test/powershell/Language/Scripting/DollarHook.Tests.ps1
@@ -1,0 +1,39 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+Describe 'Tests for setting $? for execution success' -Tag 'CI' {
+    BeforeAll {
+        $script:hookValues = [System.Collections.Generic.List[bool]]::new()
+
+        function Hook
+        {
+            param([Parameter(Position = 0)][bool]$Value)
+
+            $script:hookValues.Add($Value)
+        }
+
+        $testCases = @(
+            @{ Script = '"Hi"; Hook $?'; Results = @($true) }
+            @{ Script = 'Write-Output "Hi"; Hook $?'; Results = @($true) }
+            @{ Script = 'Write-Error "Bad"; Hook $?'; Results = @($false) }
+            @{ Script = 'Write-Error "Bad"; Hook $?; Hook $?'; Results = @($false, $true) }
+            @{ Script = '(Write-Output "Hi"); Hook $?'; Results = @($true) }
+            @{ Script = '("Hi"); Hook $?'; Results = @($true) }
+            @{ Script = '$("Hi"); Hook $?'; Results = @($true) }
+            @{ Script = '(Write-Error "Bad"); Hook $?; Hook $?'; Results = @($false, $true) }
+            @{ Script = '$(Write-Error "Bad"); Hook $?; Hook $?'; Results = @($false, $true) }
+        )
+    }
+
+    AfterEach {
+        $script:hookValues.Clear()
+    }
+
+    It 'Sets $? for case ''<Script>''' -TestCases $testCases {
+        param([string]$Script, [object[]]$Results)
+
+        Invoke-Expression $Script 2>&1 > $null
+
+        $script:hookValues | Should -Be $Results
+    }
+}

--- a/test/powershell/Language/Scripting/DollarHook.Tests.ps1
+++ b/test/powershell/Language/Scripting/DollarHook.Tests.ps1
@@ -22,6 +22,11 @@ Describe 'Tests for setting $? for execution success' -Tag 'CI' {
             @{ Script = '$("Hi"); Hook $?'; Results = @($true) }
             @{ Script = '(Write-Error "Bad"); Hook $?; Hook $?'; Results = @($false, $true) }
             @{ Script = '$(Write-Error "Bad"); Hook $?; Hook $?'; Results = @($false, $true) }
+            @{ Script = 'testexe -returncode 0; Hook $?'; Results = @($true) }
+            @{ Script = 'testexe -returncode 1; Hook $?; Hook $?'; Results = @($false, $true) }
+            @{ Script = '(testexe -returncode 0); Hook $?'; Results = @($true) }
+            @{ Script = '(testexe -returncode 1); Hook $?; Hook $?'; Results = @($false, $true) }
+            @{ Script = '$(testexe -returncode 1); Hook $?; Hook $?'; Results = @($false, $true) }
         )
     }
 

--- a/test/powershell/Language/Scripting/DollarHook.Tests.ps1
+++ b/test/powershell/Language/Scripting/DollarHook.Tests.ps1
@@ -13,20 +13,46 @@ Describe 'Tests for setting $? for execution success' -Tag 'CI' {
         }
 
         $testCases = @(
-            @{ Script = '"Hi"; Hook $?'; Results = @($true) }
+            # Cmdlets
             @{ Script = 'Write-Output "Hi"; Hook $?'; Results = @($true) }
             @{ Script = 'Write-Error "Bad"; Hook $?'; Results = @($false) }
             @{ Script = 'Write-Error "Bad"; Hook $?; Hook $?'; Results = @($false, $true) }
-            @{ Script = '(Write-Output "Hi"); Hook $?'; Results = @($true) }
-            @{ Script = '("Hi"); Hook $?'; Results = @($true) }
-            @{ Script = '$("Hi"); Hook $?'; Results = @($true) }
-            @{ Script = '(Write-Error "Bad"); Hook $?; Hook $?'; Results = @($false, $true) }
-            @{ Script = '$(Write-Error "Bad"); Hook $?; Hook $?'; Results = @($false, $true) }
+
+            # Native executables
             @{ Script = 'testexe -returncode 0; Hook $?'; Results = @($true) }
             @{ Script = 'testexe -returncode 1; Hook $?; Hook $?'; Results = @($false, $true) }
+
+            # Pure values
+            @{ Script = '"Hi"; Hook $?'; Results = @($true) }
+            @{ Script = 'Write-Error "Bad"; "Hi"; Hook $?'; Results = @($true) }
+
+            # Paren expressions (subpipelines)
+            @{ Script = '(Write-Output "Hi"); Hook $?'; Results = @($true) }
+            @{ Script = 'Write-Error "Bad"; ("Hi"); Hook $?'; Results = @($true) }
+            @{ Script = '(Write-Error "Bad"); Hook $?; Hook $?'; Results = @($false, $true) }
             @{ Script = '(testexe -returncode 0); Hook $?'; Results = @($true) }
             @{ Script = '(testexe -returncode 1); Hook $?; Hook $?'; Results = @($false, $true) }
+
+            # Subexpressions
+            @{ Script = '$("Hi"); Hook $?'; Results = @($true) }
+            @{ Script = 'Write-Error "Bad"; $("Hi"); Hook $?'; Results = @($true) }
+            @{ Script = '$(); Hook $?'; Results = @($true) }
+            @{ Script = 'Write-Error "Bad"; $(); Hook $?'; Results = @($true) }
+            @{ Script = '$(Write-Error "Bad"); Hook $?; Hook $?'; Results = @($false, $true) }
             @{ Script = '$(testexe -returncode 1); Hook $?; Hook $?'; Results = @($false, $true) }
+
+            # Array expressions
+            @{ Script = '@("Hi"); Hook $?'; Results = @($true) }
+            @{ Script = '@(); Hook $?'; Results = @($true) }
+            @{ Script = 'Write-Error "Bad"; @("Hi"); Hook $?'; Results = @($true) }
+            @{ Script = 'Write-Error "Bad"; @(); Hook $?'; Results = @($true) }
+            @{ Script = 'Write-Error "Bad"; @("Hi", "There"); Hook $?'; Results = @($true) }
+            @{ Script = 'Write-Error "Bad"; @("Hi"; "There"); Hook $?'; Results = @($true) }
+            @{ Script = '@(Write-Error "Bad"); Hook $?; Hook $?'; Results = @($false, $true) }
+            @{ Script = '@(Write-Error "Bad"; "Hi"); Hook $?; Hook $?'; Results = @($true, $true) }
+            @{ Script = '@("Hi"; Write-Error "Bad"); Hook $?; Hook $?'; Results = @($false, $true) }
+            @{ Script = '@(Write-Error "Bad"; Write-Output "Hi"); Hook $?; Hook $?'; Results = @($true, $true) }
+            @{ Script = '@(Write-Output "Hi"; Write-Error "Bad"); Hook $?; Hook $?'; Results = @($false, $true) }
         )
     }
 

--- a/test/powershell/Language/Scripting/DollarHook.Tests.ps1
+++ b/test/powershell/Language/Scripting/DollarHook.Tests.ps1
@@ -40,6 +40,8 @@ Describe 'Tests for setting $? for execution success' -Tag 'CI' {
             @{ Script = 'Write-Error "Bad"; $(); Hook $?'; Results = @($true) }
             @{ Script = '$(Write-Error "Bad"); Hook $?; Hook $?'; Results = @($false, $true) }
             @{ Script = '$(testexe -returncode 1); Hook $?; Hook $?'; Results = @($false, $true) }
+            @{ Script = 'Write-Error "Bad"; $(trap { continue }); Hook $?'; Results = @($true) }
+            @{ Script = 'Write-Error "Bad"; $(trap { continue } "Hi"); Hook $?'; Results = @($true) }
 
             # Array expressions
             @{ Script = '@("Hi"); Hook $?'; Results = @($true) }
@@ -48,6 +50,9 @@ Describe 'Tests for setting $? for execution success' -Tag 'CI' {
             @{ Script = 'Write-Error "Bad"; @(); Hook $?'; Results = @($true) }
             @{ Script = 'Write-Error "Bad"; @("Hi", "There"); Hook $?'; Results = @($true) }
             @{ Script = 'Write-Error "Bad"; @("Hi"; "There"); Hook $?'; Results = @($true) }
+            @{ Script = 'Write-Error "Bad"; @(trap { continue }); Hook $?'; Results = @($true) }
+            @{ Script = 'Write-Error "Bad"; @(trap { continue } "Hi"); Hook $?'; Results = @($true) }
+            @{ Script = 'Write-Error "Bad"; @(trap { continue } "Hi", "There"); Hook $?'; Results = @($true) }
             @{ Script = '@(Write-Error "Bad"); Hook $?; Hook $?'; Results = @($false, $true) }
             @{ Script = '@(Write-Error "Bad"; "Hi"); Hook $?; Hook $?'; Results = @($true, $true) }
             @{ Script = '@("Hi"; Write-Error "Bad"); Hook $?; Hook $?'; Results = @($false, $true) }


### PR DESCRIPTION
# PR Summary

This PR alters the way we compile subpipelines `(...)`, subexpressions `$(...)` and array expressions `@()` so that `$?` is not automatically true after them in the pipeline, but instead depends on the pipeline or statements they executed.

I've added tests for the various behaviours of this, plus some extra tests for pipeline chain operators, which this aids the UX of.

I've structured my changes by commit, so you'll probably find it easier to read this PR from commit to commit.

## PR Context

In https://github.com/PowerShell/PowerShell/pull/9849, the `&&` and `||` operators were introduced, but currently suffer from the implementation of `$?`. Specifically:

```powershell
Write-Error "Bad" || Write-Output "Hi" # Outputs "Hi"

(Write-Error "Bad") || Write-Output "Hi" # Outputs only the error
```

This makes pipeline chain operators hard to use insofar as they can't be rearranged conveniently by means of parentheses.

In this PR, we change the implementation so that expression-only pipelines only have `$?` forcibly set when they are a pure value, expressions that actually execute their commands with `$?` set by the subpipeline.

## Further considerations

- This PR likely requires an RFC, which I can begin authoring immediately and will link back here
- Calling `Write-Error` from within another function still has that function leaving `$?` as true. I looked into changing that behaviour briefly and it would be fairly complicated.
- This PR doesn't try to expose new mechanisms for cmdlets to set `$?`

As a final note, looking into how to change this, it seems that while this behaviour may or may not have been originally intended, it occurs because we fix an assumption where all expressions in the pipeline are treated like *pure* expressions, which are optimised to be evaluated without the pipeline so need a `$? = $true` added after them. So theoretically this change also is a small (very small) performance improvement.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
