### PR TITLE
Fix Start-Job working directory path with trailing back slash

### DIFF
--- a/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
@@ -72,7 +72,7 @@ namespace System.Management.Automation.Runspaces
             if (!string.IsNullOrWhiteSpace(workingDirectory))
             {
                 _startInfo.ArgumentList.Add("-wd");
-                _startInfo.ArgumentList.Add(workingDirectory.Replace("\"", "\"\""));
+                _startInfo.ArgumentList.Add(workingDirectory);
             }
 
             if (initializationScript != null)

--- a/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
@@ -50,38 +50,11 @@ namespace System.Management.Automation.Runspaces
         /// <param name="workingDirectory">Specifies the initial working directory for the new powershell process.</param>
         public PowerShellProcessInstance(Version powerShellVersion, PSCredential credential, ScriptBlock initializationScript, bool useWow64, string workingDirectory)
         {
-            string processArguments = " -s -NoLogo -NoProfile";
-
-            if (!string.IsNullOrWhiteSpace(workingDirectory))
-            {
-                processArguments = string.Format(
-                    CultureInfo.InvariantCulture,
-                    "{0} -wd \"{1}\"",
-                    processArguments,
-                    workingDirectory.Replace("\"", "\"\"").Replace("\\", "\\\\"));
-            }
-
-            if (initializationScript != null)
-            {
-                string scripBlockAsString = initializationScript.ToString();
-                if (!string.IsNullOrEmpty(scripBlockAsString))
-                {
-                    string encodedCommand =
-                        Convert.ToBase64String(Encoding.Unicode.GetBytes(scripBlockAsString));
-                    processArguments = string.Format(
-                        CultureInfo.InvariantCulture,
-                        "{0} -EncodedCommand {1}",
-                        processArguments,
-                        encodedCommand);
-                }
-            }
-
             // 'WindowStyle' is used only if 'UseShellExecute' is 'true'. Since 'UseShellExecute' is set
             // to 'false' in our use, we can ignore the 'WindowStyle' setting in the initialization below.
             _startInfo = new ProcessStartInfo
             {
                 FileName = PwshExePath,
-                Arguments = processArguments,
                 UseShellExecute = false,
                 RedirectStandardInput = true,
                 RedirectStandardOutput = true,
@@ -91,6 +64,27 @@ namespace System.Management.Automation.Runspaces
                 LoadUserProfile = true,
 #endif
             };
+
+            _startInfo.ArgumentList.Add("-s");
+            _startInfo.ArgumentList.Add("-NoLogo");
+            _startInfo.ArgumentList.Add("-NoProfile");
+
+            if (!string.IsNullOrWhiteSpace(workingDirectory))
+            {
+                _startInfo.ArgumentList.Add("-wd");
+                _startInfo.ArgumentList.Add(workingDirectory.Replace("\"", "\"\""));
+            }
+
+            if (initializationScript != null)
+            {
+                var scriptBlockString = initializationScript.ToString();
+                if (!string.IsNullOrEmpty(scriptBlockString))
+                {
+                    var encodedCommand = Convert.ToBase64String(Encoding.Unicode.GetBytes(scriptBlockString));
+                    _startInfo.ArgumentList.Add("-EncodedCommand");
+                    _startInfo.ArgumentList.Add(encodedCommand);
+                }
+            }
 
             if (credential != null)
             {

--- a/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
@@ -58,7 +58,7 @@ namespace System.Management.Automation.Runspaces
                     CultureInfo.InvariantCulture,
                     "{0} -wd \"{1}\"",
                     processArguments,
-                    workingDirectory.Replace("\"", "\"\""));
+                    workingDirectory.Replace("\"", "\"\"").Replace("\\", "\\\\"));
             }
 
             if (initializationScript != null)

--- a/test/powershell/engine/Job/Jobs.Tests.ps1
+++ b/test/powershell/engine/Job/Jobs.Tests.ps1
@@ -94,6 +94,17 @@ Describe 'Basic Job Tests' -Tags 'CI' {
             $jobOutput | Should -BeExactly $path.ToString()
         }
 
+        It 'Verifies the working directory parameter path with trailing backslash' -Skip:(! $IsWindows) {
+            $path = 'C:\'
+            if (! (Test-Path -Path $path))
+            {
+                Write-Warning "Test skipped because there is no prerequisite 'C:\' file system root."
+                return
+            }
+            $location = Start-Job { $pwd } -WorkingDirectory $path | Receive-Job -Wait -AutoRemoveJob
+            $location.Path | Should -BeExactly $path
+        }
+
         It 'Throws an error when the working directory parameter is <case>' -TestCases $invalidPathTestCases {
             param($path, $case, $expectedErrorId)
 

--- a/test/powershell/engine/Job/Jobs.Tests.ps1
+++ b/test/powershell/engine/Job/Jobs.Tests.ps1
@@ -95,14 +95,8 @@ Describe 'Basic Job Tests' -Tags 'CI' {
         }
 
         It 'Verifies the working directory parameter path with trailing backslash' -Skip:(! $IsWindows) {
-            $path = 'C:\'
-            if (! (Test-Path -Path $path))
-            {
-                Write-Warning "Test skipped because there is no prerequisite 'C:\' file system root."
-                return
-            }
-            $location = Start-Job { $pwd } -WorkingDirectory $path | Receive-Job -Wait -AutoRemoveJob
-            $location.Path | Should -BeExactly $path
+            $job = Start-Job { $pwd } -WorkingDirectory '\' | Wait-Job
+            $job.JobStateInfo.State | Should -BeExactly 'Completed'
         }
 
         It 'Throws an error when the working directory parameter is <case>' -TestCases $invalidPathTestCases {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This fixes a bug where a working directory path with a trailing back slash causes Start-Job to fail.

## PR Context

Windows command line parsing will drop any trailing back slash in the argument list.  The fix is to escape all back slash characters in the Start-Job working directory path, before including it in the argument list.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
