### PR TITLE
Port GetProcessorArchitecture()

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -1837,7 +1837,7 @@ namespace Microsoft.PowerShell.Commands
             else if ((requiredProcessorArchitecture != ProcessorArchitecture.None) &&
                      (requiredProcessorArchitecture != ProcessorArchitecture.MSIL))
             {
-                ProcessorArchitecture currentArchitecture = PsUtils.GetProcessorArchitecture();
+                ProcessorArchitecture currentArchitecture = typeof(object).Assembly.GetName().ProcessorArchitecture;
 
                 if (currentArchitecture != requiredProcessorArchitecture)
                 {

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -1839,7 +1839,6 @@ namespace Microsoft.PowerShell.Commands
             {
                 ProcessorArchitecture currentArchitecture = PsUtils.GetProcessorArchitecture();
 
-                // For ARM Architectures, we need to do additional string-level comparison
                 if (currentArchitecture != requiredProcessorArchitecture)
                 {
                     containedErrors = true;

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -1837,23 +1837,16 @@ namespace Microsoft.PowerShell.Commands
             else if ((requiredProcessorArchitecture != ProcessorArchitecture.None) &&
                      (requiredProcessorArchitecture != ProcessorArchitecture.MSIL))
             {
-                bool isRunningOnArm = false;
-                ProcessorArchitecture currentArchitecture = PsUtils.GetProcessorArchitecture(out isRunningOnArm);
+                ProcessorArchitecture currentArchitecture = PsUtils.GetProcessorArchitecture();
 
                 // For ARM Architectures, we need to do additional string-level comparison
-                if ((currentArchitecture != requiredProcessorArchitecture && !isRunningOnArm) ||
-                    (isRunningOnArm &&
-                     !requiredProcessorArchitecture.ToString()
-                         .Equals(PsUtils.ArmArchitecture, StringComparison.OrdinalIgnoreCase)))
+                if (currentArchitecture != requiredProcessorArchitecture)
                 {
                     containedErrors = true;
                     if (writingErrors)
                     {
-                        string actualCurrentArchitecture = isRunningOnArm
-                            ? PsUtils.ArmArchitecture
-                            : currentArchitecture.ToString();
                         message = StringUtil.Format(Modules.InvalidProcessorArchitecture,
-                            actualCurrentArchitecture, moduleManifestPath, requiredProcessorArchitecture);
+                            currentArchitecture, moduleManifestPath, requiredProcessorArchitecture);
                         InvalidOperationException ioe = new InvalidOperationException(message);
                         ErrorRecord er = new ErrorRecord(ioe, "Modules_InvalidProcessorArchitecture",
                             ErrorCategory.ResourceUnavailable, moduleManifestPath);

--- a/src/System.Management.Automation/utils/PsUtils.cs
+++ b/src/System.Management.Automation/utils/PsUtils.cs
@@ -24,8 +24,6 @@ namespace System.Management.Automation
     /// </summary>
     internal static class PsUtils
     {
-        internal static string ArmArchitecture = "ARM";
-
         /// <summary>
         /// Safely retrieves the MainModule property of a
         /// process. Version 2.0 and below of the .NET Framework are
@@ -140,26 +138,23 @@ namespace System.Management.Automation
         /// If powershell is running inside Wow64, then <see cref="ProcessorArchitecture.X86"/> is returned.
         /// </summary>
         /// <returns>Processor architecture for the current process.</returns>
-        internal static ProcessorArchitecture GetProcessorArchitecture(out bool isRunningOnArm)
+        internal static ProcessorArchitecture GetProcessorArchitecture()
         {
-            var sysInfo = new NativeMethods.SYSTEM_INFO();
-            NativeMethods.GetSystemInfo(ref sysInfo);
+            Architecture architecture = RuntimeInformation.ProcessArchitecture;
             ProcessorArchitecture result;
-            isRunningOnArm = false;
-            switch (sysInfo.wProcessorArchitecture)
+            switch (architecture)
             {
-                case NativeMethods.PROCESSOR_ARCHITECTURE_IA64:
-                    result = ProcessorArchitecture.IA64;
-                    break;
-                case NativeMethods.PROCESSOR_ARCHITECTURE_AMD64:
-                    result = ProcessorArchitecture.Amd64;
-                    break;
-                case NativeMethods.PROCESSOR_ARCHITECTURE_INTEL:
+                case Architecture.X86:
                     result = ProcessorArchitecture.X86;
                     break;
-                case NativeMethods.PROCESSOR_ARCHITECTURE_ARM:
-                    result = ProcessorArchitecture.None;
-                    isRunningOnArm = true;
+
+                case Architecture.X64:
+                    result = ProcessorArchitecture.Amd64;
+                    break;
+
+                case Architecture.Arm:
+                case Architecture.Arm64:
+                    result = ProcessorArchitecture.Arm;
                     break;
 
                 default:

--- a/src/System.Management.Automation/utils/PsUtils.cs
+++ b/src/System.Management.Automation/utils/PsUtils.cs
@@ -8,14 +8,10 @@ using System.IO;
 using System.Linq;
 using System.Management.Automation.Language;
 using System.Net.NetworkInformation;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Security;
 using System.Text;
 using System.Xml;
-
-using Microsoft.Win32;
 
 namespace System.Management.Automation
 {
@@ -196,31 +192,6 @@ namespace System.Management.Automation
 
         private static class NativeMethods
         {
-            internal const ushort PROCESSOR_ARCHITECTURE_INTEL = 0;
-            internal const ushort PROCESSOR_ARCHITECTURE_ARM = 5;
-            internal const ushort PROCESSOR_ARCHITECTURE_IA64 = 6;
-            internal const ushort PROCESSOR_ARCHITECTURE_AMD64 = 9;
-            internal const ushort PROCESSOR_ARCHITECTURE_UNKNOWN = 0xFFFF;
-
-            [StructLayout(LayoutKind.Sequential)]
-            internal struct SYSTEM_INFO
-            {
-                public ushort wProcessorArchitecture;
-                public ushort wReserved;
-                public uint dwPageSize;
-                public IntPtr lpMinimumApplicationAddress;
-                public IntPtr lpMaximumApplicationAddress;
-                public UIntPtr dwActiveProcessorMask;
-                public uint dwNumberOfProcessors;
-                public uint dwProcessorType;
-                public uint dwAllocationGranularity;
-                public ushort wProcessorLevel;
-                public ushort wProcessorRevision;
-            };
-
-            [DllImport(PinvokeDllNames.GetSystemInfoDllName)]
-            internal static extern void GetSystemInfo(ref SYSTEM_INFO lpSystemInfo);
-
             [DllImport(PinvokeDllNames.GetCurrentThreadIdDllName)]
             internal static extern uint GetCurrentThreadId();
         }

--- a/src/System.Management.Automation/utils/PsUtils.cs
+++ b/src/System.Management.Automation/utils/PsUtils.cs
@@ -140,29 +140,7 @@ namespace System.Management.Automation
         /// <returns>Processor architecture for the current process.</returns>
         internal static ProcessorArchitecture GetProcessorArchitecture()
         {
-            Architecture architecture = RuntimeInformation.ProcessArchitecture;
-            ProcessorArchitecture result;
-            switch (architecture)
-            {
-                case Architecture.X86:
-                    result = ProcessorArchitecture.X86;
-                    break;
-
-                case Architecture.X64:
-                    result = ProcessorArchitecture.Amd64;
-                    break;
-
-                case Architecture.Arm:
-                case Architecture.Arm64:
-                    result = ProcessorArchitecture.Arm;
-                    break;
-
-                default:
-                    result = ProcessorArchitecture.None;
-                    break;
-            }
-
-            return result;
+            return typeof(object).Assembly.GetName().ProcessorArchitecture;
         }
 
         /// <summary>

--- a/src/System.Management.Automation/utils/PsUtils.cs
+++ b/src/System.Management.Automation/utils/PsUtils.cs
@@ -134,16 +134,6 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Returns processor architecture for the current process.
-        /// If powershell is running inside Wow64, then <see cref="ProcessorArchitecture.X86"/> is returned.
-        /// </summary>
-        /// <returns>Processor architecture for the current process.</returns>
-        internal static ProcessorArchitecture GetProcessorArchitecture()
-        {
-            return typeof(object).Assembly.GetName().ProcessorArchitecture;
-        }
-
-        /// <summary>
         /// Return true/false to indicate whether the processor architecture is ARM.
         /// </summary>
         /// <returns></returns>

--- a/test/powershell/engine/Module/NewModuleManifest.Tests.ps1
+++ b/test/powershell/engine/Module/NewModuleManifest.Tests.ps1
@@ -141,7 +141,7 @@ Describe "New-ModuleManifest tests" -tags "CI" {
 
         # Skip tests if the module architecture does not match the platform architecture
         # but X86 works on Amd64/X64 and Arm works on Arm64.
-        if ($moduleArch -ne $arch -and -not ($moduleArch -eq "X86" -and $arch -eq "Amd64") -and -not ($moduleArch -eq "Arm" -and $arch -eq "Arm64"))
+        if ($moduleArch -ne $arch -and -not ($moduleArch -eq "X86" -and $arch -eq "Amd64" -and $IsWindows) -and -not ($moduleArch -eq "Arm" -and $arch -eq "Arm64"))
         {
             Set-ItResult -Skipped -Because "the $moduleArch assembly architecture is not supported on the $arch platform"
             return


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #4474
Fix  #6533

Before the change GetProcessorArchitecture() call Windows P/Invoke so on Unix it would throw if user loaded a module with ProcessorArchitecture value in the module manifest. Now we use ProcessorArchitecture from current assembly.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
