### PR TITLE
Allow `pwsh` to inherit `$env:PSModulePath` and enable `powershell.exe` to start correctly

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -1269,6 +1269,7 @@ namespace System.Management.Automation
                 {
                     insertIndex += personalModulePath.Length + 1;
                 }
+
                 currentProcessModulePath = AddToPath(currentProcessModulePath, sharedModulePath, insertIndex);
 
                 insertIndex = PathContainsSubstring(currentProcessModulePath, sharedModulePath);
@@ -1276,6 +1277,7 @@ namespace System.Management.Automation
                 {
                     insertIndex += sharedModulePath.Length + 1;
                 }
+
                 currentProcessModulePath = AddToPath(currentProcessModulePath, systemModulePathToUse, insertIndex);
             }
 
@@ -1296,17 +1298,16 @@ namespace System.Management.Automation
 #if !UNIX
         /// <summary>
         /// Returns a PSModulePath suiteable for Windows PowerShell by removing this PowerShell's specific
-        /// paths from current PSModulePath and appending it to fresh PSModulePath from registry removing
-        /// any paths the user may have removed explicitly.
+        /// paths from current PSModulePath.
         /// </summary>
+        /// <returns>
+        /// Returns appropriate PSModulePath for Windows PowerShell.
+        /// </returns>
         internal static string GetWindowsPowerShellModulePath()
         {
             string currentModulePath = GetModulePath();
 
-            currentModulePath = currentModulePath.
-                Replace(GetPersonalModulePath(), "").
-                Replace(GetSharedModulePath(), "").
-                Replace(GetPSHomeModulePath(), "");
+            currentModulePath = currentModulePath.Replace(GetPersonalModulePath(), string.Empty).Replace(GetSharedModulePath(), string.Empty).Replace(GetPSHomeModulePath(), string.Empty);
 
             var modulePathList = new List<string>();
             foreach (var path in currentModulePath.Split(';'))

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -1269,7 +1269,7 @@ namespace System.Management.Automation
                 }
             }
 
-            return string.Join(Path.PathSeparator, modulePathList.ToArray());
+            return string.Join(Path.PathSeparator, modulePathList);
         }
 #endif
 

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -1249,9 +1249,11 @@ namespace System.Management.Automation
                     currentProcessModulePath += hklmMachineModulePath; // += EVT.Machine
                 }
 
+#if !UNIX
                 // Add Windows Modules path
                 currentProcessModulePath += Path.PathSeparator;
                 currentProcessModulePath += GetWindowsPowerShellPSHomeModulePath();
+#endif
             }
             // EVT.Process exists
             // Now handle the case where the environment variable is already set.

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -1309,19 +1309,24 @@ namespace System.Management.Automation
         {
             string currentModulePath = GetModulePath();
 
-            currentModulePath = currentModulePath.Replace(GetPersonalModulePath(), string.Empty).Replace(GetSharedModulePath(), string.Empty).Replace(GetPSHomeModulePath(), string.Empty);
-
-            var modulePathList = new List<string>();
-            foreach (var path in currentModulePath.Split(';'))
+            if (currentModulePath != null)
             {
-                // skip empty paths we removed
-                if (!string.IsNullOrEmpty(path))
+                currentModulePath = currentModulePath.Replace(GetPersonalModulePath(), string.Empty).Replace(GetSharedModulePath(), string.Empty).Replace(GetPSHomeModulePath(), string.Empty);
+
+                var modulePathList = new List<string>();
+                foreach (var path in currentModulePath.Split(';'))
                 {
-                    modulePathList.Add(path);
+                    // skip empty paths we removed
+                    if (!string.IsNullOrEmpty(path))
+                    {
+                        modulePathList.Add(path);
+                    }
                 }
+
+                return string.Join(Path.PathSeparator, modulePathList.ToArray());
             }
 
-            return string.Join(Path.PathSeparator, modulePathList.ToArray());
+            return null;
         }
 #endif
 

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -410,7 +410,8 @@ namespace System.Management.Automation
             ProcessStartInfo startInfo = GetProcessStartInfo(redirectOutput, redirectError, redirectInput, soloCommand);
 
 #if !UNIX
-            if (this.Path.ToLowerInvariant().EndsWith("powershell.exe") || this.Path.ToLowerInvariant().EndsWith("powershell_ise.exe"))
+            string commandPath = this.Path.ToLowerInvariant();
+            if (commandPath.EndsWith("powershell.exe") || commandPath.EndsWith("powershell_ise.exe"))
             {
                 // if starting Windows PowerShell, need to remove PowerShell specific segments of PSModulePath
                 string psmodulepath = ModuleIntrinsics.GetWindowsPowerShellModulePath();

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -410,8 +410,7 @@ namespace System.Management.Automation
             ProcessStartInfo startInfo = GetProcessStartInfo(redirectOutput, redirectError, redirectInput, soloCommand);
 
 #if !UNIX
-            string[] windowsPowerShellExecutables = { "powershell.exe", "powershell_ise.exe" };
-            if (this.Path.ToLower().EndsWith("powershell.exe") || this.Path.ToLower().EndsWith("powershell_ise.exe"))
+            if (this.Path.ToLowerInvariant().EndsWith("powershell.exe") || this.Path.ToLowerInvariant().EndsWith("powershell_ise.exe"))
             {
                 // if starting Windows PowerShell, need to remove PowerShell specific segments of PSModulePath
                 string psmodulepath = ModuleIntrinsics.GetWindowsPowerShellModulePath();

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -409,6 +409,19 @@ namespace System.Management.Automation
             // Get the start info for the process.
             ProcessStartInfo startInfo = GetProcessStartInfo(redirectOutput, redirectError, redirectInput, soloCommand);
 
+#if !UNIX
+            string[] windowsPowerShellExecutables = { "powershell.exe", "powershell_ise.exe" };
+            if (this.Path.ToLower().EndsWith("powershell.exe") || this.Path.ToLower().EndsWith("powershell_ise.exe"))
+            {
+                // if starting Windows PowerShell, need to remove PowerShell specific segments of PSModulePath
+                string psmodulepath = ModuleIntrinsics.GetWindowsPowerShellModulePath();
+                startInfo.Environment["PSModulePath"] = psmodulepath;
+
+                // must set UseShellExecute to false if we modify the environment block
+                startInfo.UseShellExecute = false;
+            }
+#endif
+
             if (this.Command.Context.CurrentPipelineStopping)
             {
                 throw new PipelineStoppedException();

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -17,9 +17,10 @@ Describe "TabCompletion" -Tags CI {
     }
 
     It 'Should complete abbreviated function' {
-        $res = (TabExpansion2 -inputScript 'pschrl' -cursorColumn 'pschr'.Length).CompletionMatches.CompletionText
+        function Test-AbbreviatedFunctionExpansion {}
+        $res = (TabExpansion2 -inputScript 't-afe' -cursorColumn 't-afe'.Length).CompletionMatches.CompletionText
         $res.Count | Should -BeGreaterOrEqual 1
-        $res | Should -BeExactly 'PSConsoleHostReadLine'
+        $res | Should -BeExactly 'Test-AbbreviatedFunctionExpansion'
     }
 
     It 'Should complete native exe' -Skip:(!$IsWindows) {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -32,7 +32,7 @@ Describe "Import-Module" -Tags "CI" {
     }
 
     It "should be able to load a module with a trailing directory separator: <modulePath>" -TestCases @(
-        @{ modulePath = (Get-Module -ListAvailable $moduleName).ModuleBase + [System.IO.Path]::DirectorySeparatorChar; expectedName = $moduleName },
+        @{ modulePath = (Get-Module -ListAvailable $moduleName)[0].ModuleBase + [System.IO.Path]::DirectorySeparatorChar; expectedName = $moduleName },
         @{ modulePath = Join-Path -Path $TestDrive -ChildPath "\Modules\TestModule\"; expectedName = "TestModule" }
     ) {
         param( $modulePath, $expectedName )
@@ -41,7 +41,7 @@ Describe "Import-Module" -Tags "CI" {
     }
 
     It "should be able to add a module with using ModuleInfo switch" {
-        $a = Get-Module -ListAvailable $moduleName
+        $a = (Get-Module -ListAvailable $moduleName)[0]
         { Import-Module -ModuleInfo $a } | Should -Not -Throw
         (Get-Module -Name $moduleName).Name | Should -BeExactly $moduleName
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/certificateCommon.psm1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/certificateCommon.psm1
@@ -146,22 +146,15 @@ function Install-TestCertificates
         # PKI module is not available for PowerShell, so we need to use Windows PowerShell to import the cert
         $fullPowerShell = Join-Path "$env:SystemRoot" "System32\WindowsPowerShell\v1.0\powershell.exe"
 
-        try {
-            $modulePathCopy = $env:PSModulePath
-            $env:PSModulePath = $null
-
-            $command = @"
+        $command = @"
 Import-PfxCertificate $script:certLocation -CertStoreLocation cert:\CurrentUser\My | ForEach-Object PSPath
 Import-Certificate $script:badCertLocation -CertStoreLocation Cert:\CurrentUser\My | ForEach-Object PSPath
 "@
-            $certPaths = & $fullPowerShell -NoProfile -NonInteractive -Command $command
-            $certPaths.Count | Should -Be 2 | Out-Null
+        $certPaths = & $fullPowerShell -NoProfile -NonInteractive -Command $command
+        $certPaths.Count | Should -Be 2 | Out-Null
 
-            $script:importedCert = Get-ChildItem $certPaths[0]
-            $script:testBadCert  = Get-ChildItem $certPaths[1]
-        } finally {
-            $env:PSModulePath = $modulePathCopy
-        }
+        $script:importedCert = Get-ChildItem $certPaths[0]
+        $script:testBadCert  = Get-ChildItem $certPaths[1]
     }
     elseif($IsWindows)
     {

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/certificateCommon.psm1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/certificateCommon.psm1
@@ -62,7 +62,7 @@ OksttXT1kXf+aez9EzDlsgQU4ck78h0WTy01zHLwSKNWK4wFFQM=
 
     $dataEnciphermentCert = $dataEnciphermentCert -replace '\s',''
     $certBytes = [Convert]::FromBase64String($dataEnciphermentCert)
-    $certLocation = Join-Path ([System.IO.Path]::GetTempPath()) "ProtectedEventLogging.pfx"
+    $certLocation = Join-Path $TestDrive "ProtectedEventLogging.pfx"
     [IO.File]::WriteAllBytes($certLocation, $certBytes)
 
     return $certLocation
@@ -127,7 +127,7 @@ nMbw+XY4C8xdDnHfS6mF+Hol98dURB/MC/x3sZ3gSjKo
 
     $codeSigningCert = $codeSigningCert -replace '\s',''
     $certBytes = [Convert]::FromBase64String($codeSigningCert)
-    $certLocation = Join-Path ([System.IO.Path]::GetTempPath()) "CMSTestBadCert"
+    $certLocation = Join-Path $TestDrive "CMSTestBadCert"
     [IO.File]::WriteAllBytes($certLocation, $certBytes)
 
     return $certLocation
@@ -146,15 +146,22 @@ function Install-TestCertificates
         # PKI module is not available for PowerShell, so we need to use Windows PowerShell to import the cert
         $fullPowerShell = Join-Path "$env:SystemRoot" "System32\WindowsPowerShell\v1.0\powershell.exe"
 
-        $command = @"
-(Import-PfxCertificate $script:certLocation -CertStoreLocation cert:\CurrentUser\My).PSPath
-(Import-Certificate $script:badCertLocation -CertStoreLocation Cert:\CurrentUser\My).PSPath
-"@
-        $certPaths = & $fullPowerShell -NoProfile -NonInteractive -Command $command
-        $certPaths.Count | Should -Be 2 | Out-Null
+        try {
+            $modulePathCopy = $env:PSModulePath
+            $env:PSModulePath = $null
 
-        $script:importedCert = Get-ChildItem $certPaths[0]
-        $script:testBadCert  = Get-ChildItem $certPaths[1]
+            $command = @"
+Import-PfxCertificate $script:certLocation -CertStoreLocation cert:\CurrentUser\My | ForEach-Object PSPath
+Import-Certificate $script:badCertLocation -CertStoreLocation Cert:\CurrentUser\My | ForEach-Object PSPath
+"@
+            $certPaths = & $fullPowerShell -NoProfile -NonInteractive -Command $command
+            $certPaths.Count | Should -Be 2 | Out-Null
+
+            $script:importedCert = Get-ChildItem $certPaths[0]
+            $script:testBadCert  = Get-ChildItem $certPaths[1]
+        } finally {
+            $env:PSModulePath = $modulePathCopy
+        }
     }
     elseif($IsWindows)
     {

--- a/test/powershell/engine/Module/ModulePath.Tests.ps1
+++ b/test/powershell/engine/Module/ModulePath.Tests.ps1
@@ -93,6 +93,7 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
             $paths[0] | Should -Be $expectedUserPath
             $paths[1] | Should -Be $expectedSharedPath
             $paths[2] | Should -Be $expectedSystemPath
+            $paths[3] | Should -Be $fakePSHomeModuleDir
             if ($IsWindows)
             {
                 $expectedWindowsPowerShellPSHomePath | Should -Not -BeIn $paths

--- a/test/powershell/engine/Module/ModulePath.Tests.ps1
+++ b/test/powershell/engine/Module/ModulePath.Tests.ps1
@@ -74,7 +74,7 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
         }
     }
 
-    It "works with pshome module path derived from a different PowerShell instance" -Skip:(!$IsCoreCLR -or $skipNoPwsh) {
+    It "Works with pshome module path derived from a different PowerShell instance" -Skip:(!$IsCoreCLR -or $skipNoPwsh) {
 
         ## Create 'powershell' and 'pwsh.deps.json' in the fake PSHome folder,
         ## so that the module path calculation logic would believe it's real.

--- a/test/powershell/engine/Module/ModulePath.Tests.ps1
+++ b/test/powershell/engine/Module/ModulePath.Tests.ps1
@@ -74,7 +74,7 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
         }
     }
 
-    It "ignore pshome module path derived from a different PowerShell instance" -Skip:(!$IsCoreCLR -or $skipNoPwsh) {
+    It "works with pshome module path derived from a different PowerShell instance" -Skip:(!$IsCoreCLR -or $skipNoPwsh) {
 
         ## Create 'powershell' and 'pwsh.deps.json' in the fake PSHome folder,
         ## so that the module path calculation logic would believe it's real.
@@ -88,14 +88,7 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
             $newModulePath = & $powershell -nopro -c '$env:PSModulePath'
             $paths = $newModulePath -split [System.IO.Path]::PathSeparator
 
-            if ($IsWindows)
-            {
-                $paths.Count | Should -Be 4
-            }
-            else
-            {
-                $paths.Count | Should -Be 3
-            }
+            $paths.Count | Should -Be 4
 
             $paths[0] | Should -Be $expectedUserPath
             $paths[1] | Should -Be $expectedSharedPath
@@ -157,7 +150,9 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
 
     It 'Windows PowerShell does not inherit PowerShell paths' -Skip:(!$IsWindows) {
         $out = powershell.exe -noprofile -command '$env:PSModulePath'
-        $out | Should -Not -BeLike '*\powershell\*'
+        $out | Should -Not -Contain $expectedUserPath
+        $out | Should -Not -Contain $expectedSharedPath
+        $out | Should -Not -Contain $expectedSystemPath
     }
 
     It 'Windows PowerShell inherits user added paths' -Skip:(!$IsWindows) {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Since `$env:PSModulePath` is shared across all instances of PowerShell, PowerShell 7 needs to ensure it inherits the env var, but put its paths in front.  If starting Windows PowerShell, it will special case `powershell.exe` and `powershell_ise.exe` removing PowerShell 7 specific paths creating a new environment for the new process.

This is a breaking change as previously, if `pwsh` detects it is started from PowerShell, it will clear out `$env:PSModulePath` and create it from scratch.  This change will preserve additions from the system or user env vars but not all have the complicated logic in Windows PowerShell.  It will always add user module path, shared module path, and $PSHome module path if it's not already there on startup.

## PR Context

Fix #9957
Fix #9921
Fix #7082
Fix #6850
Fix #10620

Implement https://github.com/PowerShell/PowerShell-RFC/pull/233

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
