### PR TITLE
WIP: Add new binary lambda containment operators (-any/-all)

### DIFF
--- a/src/System.Management.Automation/engine/parser/token.cs
+++ b/src/System.Management.Automation/engine/parser/token.cs
@@ -413,6 +413,11 @@ namespace System.Management.Automation.Language
         /// <summary>The PS class base class and implemented interfaces operator ':'. Also used in base class ctor calls.</summary>
         Colon = 99,
 
+        /// <summary>Any operator '-any'</summary>
+        Any = 100,
+
+        /// <summary>All operator '-all'</summary>
+        All = 101,
         #endregion Operators
 
         #region Keywords
@@ -598,7 +603,7 @@ namespace System.Management.Automation.Language
 
         /// <summary>
         /// The precedence of comparison operators including: '-eq', '-ne', '-ge', '-gt', '-lt', '-le', '-like', '-notlike',
-        /// '-match', '-notmatch', '-replace', '-contains', '-notcontains', '-in', '-notin', '-split', '-join', '-is', '-isnot', '-as',
+        /// '-match', '-notmatch', '-replace', '-contains', '-notcontains', '-in', '-notin', '-split', '-join', '-is', '-isnot', '-as', '-any', '-all', 
         /// and all of the case sensitive variants of these operators, if they exists.
         /// </summary>
         BinaryPrecedenceComparison = 3,
@@ -847,8 +852,8 @@ namespace System.Management.Automation.Language
             /*                  Shl */ TokenFlags.BinaryOperator | TokenFlags.BinaryPrecedenceComparison | TokenFlags.CanConstantFold,
             /*                  Shr */ TokenFlags.BinaryOperator | TokenFlags.BinaryPrecedenceComparison | TokenFlags.CanConstantFold,
             /*                Colon */ TokenFlags.SpecialOperator | TokenFlags.DisallowedInRestrictedMode,
-            /*     Reserved slot 2  */ TokenFlags.None,
-            /*     Reserved slot 3  */ TokenFlags.None,
+            /*                  Any */ TokenFlags.BinaryOperator | TokenFlags.BinaryPrecedenceComparison,
+            /*                  All */ TokenFlags.BinaryOperator | TokenFlags.BinaryPrecedenceComparison,
             /*     Reserved slot 4  */ TokenFlags.None,
             /*     Reserved slot 5  */ TokenFlags.None,
             /*     Reserved slot 6  */ TokenFlags.None,
@@ -1045,8 +1050,8 @@ namespace System.Management.Automation.Language
             /*                  Shl */ "-shl",
             /*                  Shr */ "-shr",
             /*                Colon */ ":",
-            /*    Reserved slot 2   */ string.Empty,
-            /*    Reserved slot 3   */ string.Empty,
+            /*                  Any */ "-any",
+            /*                  All */ "-all",
             /*    Reserved slot 4   */ string.Empty,
             /*    Reserved slot 5   */ string.Empty,
             /*    Reserved slot 6   */ string.Empty,

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -637,7 +637,8 @@ namespace System.Management.Automation.Language
         /*13*/  "isplit",               "csplit",               "isnot",                "is",                     /*13*/
         /*14*/  "as",                   "f",                    "and",                  "band",                   /*14*/
         /*15*/  "or",                   "bor",                  "xor",                  "bxor",                   /*15*/
-        /*16*/  "join",                 "shl",                  "shr",                                            /*16*/
+        /*16*/  "join",                 "shl",                  "shr",                  "any",                    /*16*/
+        /*17*/  "all",                                                                                            /*17*/
         };
 
         private static readonly TokenKind[] s_operatorTokenKind = new TokenKind[] {
@@ -656,7 +657,8 @@ namespace System.Management.Automation.Language
         /*13*/  TokenKind.Isplit,       TokenKind.Csplit,       TokenKind.IsNot,        TokenKind.Is,             /*13*/
         /*14*/  TokenKind.As,           TokenKind.Format,       TokenKind.And,          TokenKind.Band,           /*14*/
         /*15*/  TokenKind.Or,           TokenKind.Bor,          TokenKind.Xor,          TokenKind.Bxor,           /*15*/
-        /*16*/  TokenKind.Join,         TokenKind.Shl,          TokenKind.Shr,                                    /*16*/
+        /*16*/  TokenKind.Join,         TokenKind.Shl,          TokenKind.Shr,          TokenKind.Any,            /*16*/
+        /*17*/  TokenKind.All,                                                                                    /*17*/
         };
 
         #endregion Tables for initialization

--- a/src/System.Management.Automation/resources/TabCompletionStrings.resx
+++ b/src/System.Management.Automation/resources/TabCompletionStrings.resx
@@ -329,4 +329,10 @@
   <data name="shrOperatorDescription" xml:space="preserve">
     <value>Shift Right bit operator. Inserts zero in the left-most bit position. For signed values, sign bit is preserved.</value>
   </data>
+  <data name="allOperatorDescription" xml:space="preserve">
+    <value>All operator. Returns TRUE when all of the left hand values are TRUE for the right hand predicate</value>
+  </data>
+  <data name="anyOperatorDescription" xml:space="preserve">
+    <value>Any operator. Returns TRUE when any of the left hand values are TRUE for the right hand predicate</value>
+  </data>
 </root>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request adds 2 new containment operators:
 - `-any` (ex. `1..5 -any { $_ -eq 2 }`)
    - Takes a collection as its `lhs` operand and a predicate as its `rhs` operand. Returns `true` if the predicate is `true` for _any_ lhs value, returns `false` otherwise
 - `-all` (ex. `1..5 -all { $_ -gt 0 }`)
    - Takes a collection as its lhs operand and a predicate as its rhs operand. Returns `true` if the predicate is `true` for _all_ lhs value, returns `false` otherwise

If a non-delegate-like object is passed as the `rhs` operand, we perform a scalar equality comparison against each item in `lhs`.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

This PR is partly motivated by the discussion in #7925, and my own frustration with having to cast nested loop structures to perform similar containment testing. 

For example, to find a directory in which _all_ files a marked `hidden`:

```powershell
# with the current binary operators
Get-ChildItem -Directory -Recurse |Where {
  $files = @($_ |Get-ChildItem -File -Force) 
  $files.Count -gt 0 -and ($files |Where Attributes -notlike "*hidden*").Count -eq 0
}

# with `-all`
Get-ChildItem -Directory -Recurse |Where {
  @($_ |Get-ChildItem -File -Force) -all {$_.Attributes -like "*hidden*"}
}
```
*(I'm aware that dynamic parameter aliases exist specifically for attribute filtering in the FileSystem provider, but that's sort of missing the point, `-any`/`-all` would work in _any_ context)*
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## TODO:

 - [ ] Should we include a negation? (`-notany`/`-none` and `-notall`)
 - [ ] Should we include case-sensitive variants? (only applies to the `-contains` fallback edge case)
 - [ ] Tests

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [X] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
