### PR TITLE
Add any/all lambda containment operators

### DIFF
--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -1305,7 +1305,9 @@ namespace System.Management.Automation
                                                       bool all)
         {
             if (!(right is ScriptBlock predicate))
+            {
                 return ContainsOperatorCompiled(context, getEnumeratorSite, comparerSite, left, right);
+            }
 
             IEnumerator list = getEnumeratorSite.Target.Invoke(getEnumeratorSite, left);
             if (list == null || list is EnumerableOps.NonEnumerableObjectEnumerator)
@@ -1334,7 +1336,9 @@ namespace System.Management.Automation
                         args: Array.Empty<object>()));
                 
                 if(predicateResult ^ all)
+                {
                     return predicateResult;
+                }
             }
 
             return all;

--- a/src/System.Management.Automation/engine/parser/token.cs
+++ b/src/System.Management.Automation/engine/parser/token.cs
@@ -428,6 +428,12 @@ namespace System.Management.Automation.Language
         /// <summary>The null conditional index access operator '?[]'.</summary>
         QuestionLBracket = 104,
 
+        /// <summary>The any containment operator '-any'</summary>
+        Any = 105,
+
+        /// <summary>The all containment operator '-all'</summary>
+        All = 106,
+
         #endregion Operators
 
         #region Keywords
@@ -616,8 +622,8 @@ namespace System.Management.Automation.Language
 
         /// <summary>
         /// The precedence of comparison operators including: '-eq', '-ne', '-ge', '-gt', '-lt', '-le', '-like', '-notlike',
-        /// '-match', '-notmatch', '-replace', '-contains', '-notcontains', '-in', '-notin', '-split', '-join', '-is', '-isnot', '-as',
-        /// and all of the case sensitive variants of these operators, if they exists.
+        /// '-match', '-notmatch', '-replace', '-contains', '-notcontains', '-in', '-notin', '-split', '-join', '-is', '-isnot', 
+        /// '-as', '-any', '-all', and all of the case sensitive variants of these operators, if they exists.
         /// </summary>
         BinaryPrecedenceComparison = 0x5,
 
@@ -878,8 +884,8 @@ namespace System.Management.Automation.Language
             /*     QuestionQuestion */ TokenFlags.BinaryOperator | TokenFlags.BinaryPrecedenceCoalesce,
             /*          QuestionDot */ TokenFlags.SpecialOperator | TokenFlags.DisallowedInRestrictedMode,
             /*     QuestionLBracket */ TokenFlags.None,
-            /*     Reserved slot 7  */ TokenFlags.None,
-            /*     Reserved slot 8  */ TokenFlags.None,
+            /*                  Any */ TokenFlags.BinaryOperator | TokenFlags.BinaryPrecedenceComparison | TokenFlags.DisallowedInRestrictedMode,
+            /*                  All */ TokenFlags.BinaryOperator | TokenFlags.BinaryPrecedenceComparison | TokenFlags.DisallowedInRestrictedMode,
             /*     Reserved slot 9  */ TokenFlags.None,
             /*     Reserved slot 10 */ TokenFlags.None,
             /*     Reserved slot 11 */ TokenFlags.None,

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -664,7 +664,8 @@ namespace System.Management.Automation.Language
         /*13*/  "isplit",               "csplit",               "isnot",                "is",                     /*13*/
         /*14*/  "as",                   "f",                    "and",                  "band",                   /*14*/
         /*15*/  "or",                   "bor",                  "xor",                  "bxor",                   /*15*/
-        /*16*/  "join",                 "shl",                  "shr",                                            /*16*/
+        /*16*/  "join",                 "shl",                  "shr",                  "any",                    /*16*/
+        /*17*/  "all",                                                                                            /*17*/
         };
 
         private static readonly TokenKind[] s_operatorTokenKind = new TokenKind[] {
@@ -683,7 +684,8 @@ namespace System.Management.Automation.Language
         /*13*/  TokenKind.Isplit,       TokenKind.Csplit,       TokenKind.IsNot,        TokenKind.Is,             /*13*/
         /*14*/  TokenKind.As,           TokenKind.Format,       TokenKind.And,          TokenKind.Band,           /*14*/
         /*15*/  TokenKind.Or,           TokenKind.Bor,          TokenKind.Xor,          TokenKind.Bxor,           /*15*/
-        /*16*/  TokenKind.Join,         TokenKind.Shl,          TokenKind.Shr,                                    /*16*/
+        /*16*/  TokenKind.Join,         TokenKind.Shl,          TokenKind.Shr,          TokenKind.Any,            /*16*/
+        /*17*/  TokenKind.All,                                                                                    /*17*/
         };
 
         #endregion Tables for initialization

--- a/src/System.Management.Automation/resources/TabCompletionStrings.resx
+++ b/src/System.Management.Automation/resources/TabCompletionStrings.resx
@@ -264,6 +264,12 @@
   <data name="cnotinOperatorDescription" xml:space="preserve">
     <value>Containment operator - case sensitive. Returns TRUE when the test value (left operand) exactly matches none of the values in the right operand.</value>
   </data>
+  <data name="anyOperatorDescription" xml:space="preserve">
+    <value>Containment lambda operator. Returns TRUE when the predicate (right operand) is TRUE for at least one of the values in the left operand.</value>
+  </data>
+  <data name="allOperatorDescription" xml:space="preserve">
+    <value>Containment lambda operator. Returns TRUE when the predicate (right operand) is TRUE for all of the values in the left operand.</value>
+  </data>
   <data name="splitOperatorDescription" xml:space="preserve">
     <value>Split - case insensitive. Split one or more strings into substrings.
 -Split &lt;String&gt;

--- a/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
@@ -16,9 +16,11 @@ Describe "Tab completion bug fix" -Tags "CI" {
 
     It "Issue#1350 - '1 -a<tab>' should work" {
         $result = TabExpansion2 -inputScript "1 -a" -cursorColumn "1 -a".Length
-        $result.CompletionMatches | Should -HaveCount 2
-        $result.CompletionMatches[0].CompletionText | Should -BeExactly "-and"
-        $result.CompletionMatches[1].CompletionText | Should -BeExactly "-as"
+        $result.CompletionMatches | Should -HaveCount 4
+        $result.CompletionMatches[0].CompletionText | Should -BeExactly "-all"
+        $result.CompletionMatches[1].CompletionText | Should -BeExactly "-and"
+        $result.CompletionMatches[2].CompletionText | Should -BeExactly "-any"
+        $result.CompletionMatches[3].CompletionText | Should -BeExactly "-as"
     }
     It "Issue#2295 - '[pscu<tab>' should expand to [pscustomobject]" {
         $result = TabExpansion2 -inputScript "[pscu" -cursorColumn "[pscu".Length

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1034,7 +1034,7 @@ dir -Recurse `
             $inputStr = "55 -"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
             $res.CompletionMatches | Should -HaveCount ([System.Management.Automation.CompletionCompleters]::CompleteOperator("").Count)
-            $res.CompletionMatches[0].CompletionText | Should -BeExactly '-and'
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly '-all'
         }
     }
 

--- a/test/powershell/Language/Operators/ComparisonOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/ComparisonOperator.Tests.ps1
@@ -41,11 +41,15 @@ Describe "ComparisonOperator" -Tag "CI" {
         @{lhs = "'Hello'"; operator = "-notcontains"; rhs = "'Hello'"; result = $false},
         @{lhs = "'Hello','world'"; operator = "-ccontains"; rhs = "'hello'"; result = $false},
         @{lhs = "'Hello','world'"; operator = "-ccontains"; rhs = "'Hello'"; result = $true}
-        @{lhs = "'Hello','world'"; operator = "-cnotcontains"; rhs = "'Hello'"; result = $false}
+        @{lhs = "'Hello','world'"; operator = "-cnotcontains"; rhs = "'Hello'"; result = $false},
         @{lhs = "'Hello world'"; operator = "-match"; rhs = "'Hello*'"; result = $true},
         @{lhs = "'Hello world'"; operator = "-like"; rhs = "'Hello*'"; result = $true},
         @{lhs = "'Hello world'"; operator = "-notmatch"; rhs = "'Hello*'"; result = $false},
-        @{lhs = "'Hello world'"; operator = "-notlike"; rhs = "'Hello*'"; result = $false}
+        @{lhs = "'Hello world'"; operator = "-notlike"; rhs = "'Hello*'"; result = $false},
+        @{lhs = "'Hello','world'"; operator = "-any"; rhs = '{$_.Length -eq 5}'; result = $true},
+        @{lhs = "'Hello','world'"; operator = "-any"; rhs = '{$_.Lenght -ne 5}'; result = $false},
+        @{lhs = "'Hello','world'"; operator = "-all"; rhs = '{$_ -like "*!*"}'; result = $false},
+        @{lhs = "'Hello','world'"; operator = "-all"; rhs = '{$_ -like "*l?"}'; result = $true}
     ) {
         param($lhs, $operator, $rhs, $result)
         Invoke-Expression "$lhs $operator $rhs" | Should -Be $result

--- a/test/powershell/Language/Operators/ComparisonOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/ComparisonOperator.Tests.ps1
@@ -47,7 +47,7 @@ Describe "ComparisonOperator" -Tag "CI" {
         @{lhs = "'Hello world'"; operator = "-notmatch"; rhs = "'Hello*'"; result = $false},
         @{lhs = "'Hello world'"; operator = "-notlike"; rhs = "'Hello*'"; result = $false},
         @{lhs = "'Hello','world'"; operator = "-any"; rhs = '{$_.Length -eq 5}'; result = $true},
-        @{lhs = "'Hello','world'"; operator = "-any"; rhs = '{$_.Lenght -ne 5}'; result = $false},
+        @{lhs = "'Hello','world'"; operator = "-any"; rhs = '{$_.Length -ne 5}'; result = $false},
         @{lhs = "'Hello','world'"; operator = "-all"; rhs = '{$_ -like "*!*"}'; result = $false},
         @{lhs = "'Hello','world'"; operator = "-all"; rhs = '{$_ -like "*l?"}'; result = $true}
     ) {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request adds 2 new containment operators:
 - `-any` (ex. `1..5 -any { $_ -eq 2 }`)
    - Takes a collection as its `lhs` operand and a predicate as its `rhs` operand. Returns `true` if the predicate is `true` for _any_ lhs value, returns `false` otherwise
 - `-all` (ex. `1..5 -all { $_ -gt 0 }`)
    - Takes a collection as its lhs operand and a predicate as its rhs operand. Returns `true` if the predicate is `true` for _all_ lhs value, returns `false` otherwise

If a non-delegate-like object is passed as the `rhs` operand, we perform a scalar equality comparison against each item in `lhs`.

A related update to the EditorSyntax definition has been prepared here: https://github.com/PowerShell/EditorSyntax/pull/189

<!-- Summarize your PR between here and the checklist. -->

## PR Context

This PR is partly motivated by the discussion in #7925, and my own frustration with having to cast nested loop structures to perform similar containment testing. 

For example, to find a directory in which _all_ files a marked `hidden`:

```powershell
# with the current binary operators
Get-ChildItem -Directory -Recurse |Where {
  $files = @($_ |Get-ChildItem -File -Force) 
  $files.Count -gt 0 -and ($files |Where Attributes -notlike "*hidden*").Count -eq 0
}

# with `-all`
Get-ChildItem -Directory -Recurse |Where {
  @($_ |Get-ChildItem -File -Force) -all {$_.Attributes -like "*hidden*"}
}
```
*(I'm aware that dynamic parameter aliases exist specifically for attribute filtering in the FileSystem provider, but that's sort of missing the point, `-any`/`-all` would work in _any_ context)*
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## TODO:

 - [ ] Should we include a negation? (`-notany`/`-none` and `-notall`)
 - [ ] Should we include case-sensitive variants? (only applies to the `-contains` fallback edge case)
 - [ ] Should we include more/better tests? (for containment operators in general)

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [X] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [X] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
