### PR TITLE
Add `Type` member to Exceptions containing type of exception for `Get-Error`

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -771,6 +771,11 @@ namespace System.Management.Automation.Runspaces
                                     'System.Management.Automation.InvocationInfo'
                                 )
 
+                                # if object is an Exception, add an ExceptionType property
+                                if ($obj -is [Exception]) {
+                                    $obj | Add-Member -NotePropertyName ExceptionType -NotePropertyValue $obj.GetType().FullName -ErrorAction Ignore
+                                }
+
                                 # first find the longest property so we can indent properly
                                 $propLength = 0
                                 foreach ($prop in $obj.PSObject.Properties) {

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -773,7 +773,7 @@ namespace System.Management.Automation.Runspaces
 
                                 # if object is an Exception, add an ExceptionType property
                                 if ($obj -is [Exception]) {
-                                    $obj | Add-Member -NotePropertyName ExceptionType -NotePropertyValue $obj.GetType().FullName -ErrorAction Ignore
+                                    $obj | Add-Member -NotePropertyName Type -NotePropertyValue $obj.GetType().FullName -ErrorAction Ignore
                                 }
 
                                 # first find the longest property so we can indent properly

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
@@ -90,4 +90,16 @@ Describe 'Get-Error tests' -Tag CI {
         $out | Should -BeLikeExactly '*ExpectedValueExpression*'
         $out | Should -BeLikeExactly '*UnexpectedToken*'
     }
+
+    It 'Get-Error adds ExceptionType for Exceptions' {
+        try {
+            [System.Net.DNS]::GetHostByName((New-Guid))
+        }
+        catch {
+        }
+
+        $out = Get-Error | Out-String
+        $out | Should -BeLikeExactly '*ExceptionType*'
+        $out | Should -BeLikeExactly '*System.Net.Internals.SocketExceptionFactory+ExtendedSocketException*'
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
@@ -99,7 +99,7 @@ Describe 'Get-Error tests' -Tag CI {
         }
 
         $out = Get-Error | Out-String
-        $out | Should -BeLikeExactly '*ExceptionType*'
+        $out | Should -BeLikeExactly '*Type*'
 
         if ($IsWindows) {
             $expectedExceptionType = "System.Management.Automation.ParentContainsErrorRecordException"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
@@ -100,6 +100,14 @@ Describe 'Get-Error tests' -Tag CI {
 
         $out = Get-Error | Out-String
         $out | Should -BeLikeExactly '*ExceptionType*'
-        $out | Should -BeLikeExactly '*System.Net.Internals.SocketExceptionFactory+ExtendedSocketException*'
+
+        if ($IsWindows) {
+            $expectedExceptionType = "System.Management.Automation.ParentContainsErrorRecordException"
+        }
+        else {
+            $expectedExceptionType = "System.Net.Internals.SocketExceptionFactory+ExtendedSocketException"
+        }
+
+        $out | Should -BeLikeExactly "*$expectedExceptionType*"
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

For `Get-Error` cmdlet, if the object (or nested object) is an Exception, we add an `ExceptionType` property that has the full type name.  The Exception type is useful information and this change doesn't require the user to explore the error object to get it.

Example:

```powershell
PS> 1/0
RuntimeException: Attempted to divide by zero.
PS> gerr

Exception             :
    ExceptionType  : System.Management.Automation.RuntimeException
    ErrorRecord    :
        Exception             :
            ExceptionType : System.Management.Automation.ParentContainsErrorRecordException
            Message       : Attempted to divide by zero.
            HResult       : -2146233087
        CategoryInfo          : NotSpecified: (:) [], ParentContainsErrorRecordException
        FullyQualifiedErrorId : RuntimeException
        InvocationInfo        :
            ScriptLineNumber : 1
            OffsetInLine     : 1
            HistoryId        : -1
            Line             : 1/0
            PositionMessage  : At line:1 char:1
                               + 1/0
                               + ~~~
            CommandOrigin    : Internal
        ScriptStackTrace      : at <ScriptBlock>, <No file>: line 1
    TargetSite     :
        Name          : Divide
        DeclaringType : System.Management.Automation.IntOps
        MemberType    : Method
        Module        : System.Management.Automation.dll
    StackTrace     :
   at System.Management.Automation.IntOps.Divide(Int32 lhs, Int32 rhs) in /Users/steve/repos/PowerShell/src/System.Management.Automation/engine/runtime/Operations/NumericOps.cs:line 61
   at System.Dynamic.UpdateDelegates.UpdateAndExecute2[T0,T1,TRet](CallSite site, T0 arg0, T1 arg1)
   at System.Management.Automation.Interpreter.DynamicInstruction`3.Run(InterpretedFrame frame) in /Users/steve/repos/PowerShell/src/System.Management.Automation/engine/interpreter/DynamicInstructions.Generated.cs:line 166
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame) in /Users/steve/repos/PowerShell/src/System.Management.Automation/engine/interpreter/ControlFlowInstructions.cs:line 357
    Message        : Attempted to divide by zero.
    Data           : System.Collections.ListDictionaryInternal
    InnerException :
        ExceptionType : System.DivideByZeroException
        Message       : Attempted to divide by zero.
        HResult       : -2147352558
    Source         : System.Management.Automation
    HResult        : -2146233087
CategoryInfo          : NotSpecified: (:) [], RuntimeException
FullyQualifiedErrorId : RuntimeException
InvocationInfo        :
    ScriptLineNumber : 1
    OffsetInLine     : 1
    HistoryId        : -1
    Line             : 1/0
    PositionMessage  : At line:1 char:1
                       + 1/0
                       + ~~~
    CommandOrigin    : Internal
ScriptStackTrace      : at <ScriptBlock>, <No file>: line 1
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
