### PR TITLE
Do not resolve types from assemblies that are loaded in separate AssemblyLoadContext

### DIFF
--- a/src/System.Management.Automation/utils/ClrFacade.cs
+++ b/src/System.Management.Automation/utils/ClrFacade.cs
@@ -59,7 +59,7 @@ namespace System.Management.Automation
         internal static IEnumerable<Assembly> GetAssemblies(string namespaceQualifiedTypeName = null)
         {
             return PSAssemblyLoadContext.GetAssembly(namespaceQualifiedTypeName) ??
-                   AppDomain.CurrentDomain.GetAssemblies().Where(a =>
+                   AssemblyLoadContext.Default.Assemblies.Where(a =>
                        !a.FullName.StartsWith(TypeDefiner.DynamicClassAssemblyFullNamePrefix, StringComparison.Ordinal));
         }
 

--- a/test/powershell/engine/Basic/Assembly.LoadedInSeparateALC.Tests.ps1
+++ b/test/powershell/engine/Basic/Assembly.LoadedInSeparateALC.Tests.ps1
@@ -1,0 +1,66 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+Describe "Assembly loaded in a separate AssemblyLoadContext should not be seen by PowerShell type resolution" -Tags "CI" {
+    BeforeAll {
+        $codeVersion1 = @'
+        using System.Reflection;
+
+        [assembly: AssemblyVersion("1.0.0.0")]
+
+        namespace ALC.Test {
+            public class Blah { public static string GetVersion() { return "1.0.0.0"; } }
+        }
+'@
+
+        $codeVersion2 = @'
+        using System.Reflection;
+
+        [assembly: AssemblyVersion("2.0.0.0")]
+
+        namespace ALC.Test {
+            public class Blah { public static string GetVersion() { return "2.0.0.0"; } }
+        }
+'@
+
+        $tempFolderPath = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), "ALCTest")
+        $v1_Folder = [System.IO.Path]::Combine($tempFolderPath, "V1")
+        $v2_Folder = [System.IO.Path]::Combine($tempFolderPath, "V2")
+
+        $null = New-Item $tempFolderPath -ItemType Directory -Force
+        $null = New-Item $v1_Folder -ItemType Directory -Force
+        $null = New-Item $v2_Folder -ItemType Directory -Force
+
+        $v1_assembly_file = [System.IO.Path]::Combine($v1_Folder, "Test.dll")
+        $v2_assembly_file = [System.IO.Path]::Combine($v2_Folder, "Test.dll")
+
+        if (-not (Test-Path $v1_assembly_file)) {
+            Add-Type -TypeDefinition $codeVersion1 -OutputAssembly $v1_assembly_file
+        }
+
+        if (-not (Test-Path $v2_assembly_file)) {
+            Add-Type -TypeDefinition $codeVersion2 -OutputAssembly $v2_assembly_file
+        }
+
+        ## Load the V2 assembly in a separate ALC
+        $alc = [System.Runtime.Loader.AssemblyLoadContext]::new("MyALC", $false)
+        $v2_Assembly = $alc.LoadFromAssemblyPath($v2_assembly_file)
+        ## Load the V1 assembly in the default ALC
+        $v1_Assembly = [System.Reflection.Assembly]::LoadFrom($v1_assembly_file)
+
+        $v1_Blah_AssemblyQualifiedName = "[ALC.Test.Blah, {0}]" -f $v1_Assembly.FullName
+        $v2_Blah_AssemblyQualifiedName = "[ALC.Test.Blah, {0}]" -f $v2_Assembly.FullName
+    }
+
+    It "Type from the assembly loaded into a separate ALC should not be resolved by PowerShell" {
+        ## Type resolution should only find the assembly loaded in the default ALC.
+        [ALC.Test.Blah]::GetVersion() | Should -BeExactly "1.0.0.0"
+
+        ## Type resolution should fail even with the AssemblyQualifiedName for the 2.0 assembly that was loaded in the separate ALC.
+        $resolve_v1_Blah_script = [scriptblock]::Create("{0}::GetVersion()" -f $v1_Blah_AssemblyQualifiedName)
+        $resolve_v2_Blah_script = [scriptblock]::Create($v2_Blah_AssemblyQualifiedName)
+
+        $resolve_v2_Blah_script | Should -Throw -ErrorId 'TypeNotFound'
+        & $resolve_v1_Blah_script | Should -BeExactly "1.0.0.0"
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

In .NET Core 2.1, `[System.AppDomain]::CurrentDomain.GetAssemblies()` only returns the assemblies loaded in the default load context.
In .NET Core 3.0, `[System.AppDomain]::CurrentDomain.GetAssemblies()` is changed to return all assemblies loaded in the `AppDomain`, including the assemblies loaded into other AssemblyLoadContext (ALC) instances.
This results in our type resolution to behave inconsistently:
 - for assembly-name-fully-qualified type name, powershell cannot resolve a type when the assembly is loaded in a separate ALC.
 - for fully-qualified type name (without assembly name part), when 2 versions of the same assembly get loaded in two ALC, powershell will resolve the type to the first assembly that got loaded. This behavior is close to undefined because sometimes you cannot control the order of loading.

This PR changes to use `AssemblyLoadContext.Default.Assemblies` (new API added in .NET Core 3) to make sure assemblies loaded in other ALC are invisible to PowerShell type resolution.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
