### PR TITLE
Add `-Shuffle` switch to `Get-Random` command

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommand.cs
@@ -28,6 +28,7 @@ namespace Microsoft.PowerShell.Commands
 
         private const string RandomNumberParameterSet = "RandomNumberParameterSet";
         private const string RandomListItemParameterSet = "RandomListItemParameterSet";
+        private const string ShuffleSet = "ShuffleSet";
         private static readonly object[] _nullInArray = new object[] { null };
 
         private enum MyParameterSet
@@ -50,7 +51,8 @@ namespace Microsoft.PowerShell.Commands
                     {
                         _effectiveParameterSet = MyParameterSet.RandomListItem;
                     }
-                    else if (ParameterSetName.Equals(GetRandomCommand.RandomListItemParameterSet, StringComparison.OrdinalIgnoreCase))
+                    else if (ParameterSetName.Equals(GetRandomCommand.RandomListItemParameterSet, StringComparison.OrdinalIgnoreCase) ||
+                             ParameterSetName.Equals(GetRandomCommand.ShuffleSet, StringComparison.OrdinalIgnoreCase))
                     {
                         _effectiveParameterSet = MyParameterSet.RandomListItem;
                     }
@@ -276,6 +278,7 @@ namespace Microsoft.PowerShell.Commands
         /// List from which random elements are chosen.
         /// </summary>
         [Parameter(ParameterSetName = RandomListItemParameterSet, ValueFromPipeline = true, Position = 0, Mandatory = true)]
+        [Parameter(ParameterSetName = ShuffleSet, ValueFromPipeline = true, Position = 0, Mandatory = true)]
         [System.Management.Automation.AllowNull]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public object[] InputObject { get; set; }
@@ -283,9 +286,20 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Number of items to output (number of list items or of numbers).
         /// </summary>
-        [Parameter]
+        [Parameter(ParameterSetName = RandomNumberParameterSet)]
+        [Parameter(ParameterSetName = RandomListItemParameterSet)]
         [ValidateRange(1, int.MaxValue)]
         public int Count { get; set; } = 1;
+
+        #endregion
+
+        #region Shuffle parameter
+
+        /// <summary>
+        /// If specified, then the command will return all input objects in randomized order
+        /// </summary>
+        [Parameter(ParameterSetName = ShuffleSet, Mandatory = true)]
+        public SwitchParameter Shuffle { get; set; }
 
         #endregion
 
@@ -492,29 +506,39 @@ namespace Microsoft.PowerShell.Commands
         {
             if (EffectiveParameterSet == MyParameterSet.RandomListItem)
             {
-                // this allows for $null to be in an array passed to InputObject
-                foreach (object item in InputObject ?? _nullInArray)
+                if (ParameterSetName == ShuffleSet)
                 {
-                    // (3)
-                    if (_numberOfProcessedListItems < Count)
+                    // this allows for $null to be in an array passed to InputObject
+                    foreach (object item in InputObject ?? _nullInArray)
                     {
-                        Debug.Assert(_chosenListItems.Count == _numberOfProcessedListItems, "Initial K elements should all be included in chosenListItems");
                         _chosenListItems.Add(item);
                     }
-                    else
+                }
+                else
+                {
+                    foreach (object item in InputObject ?? _nullInArray)
                     {
-                        Debug.Assert(_chosenListItems.Count == Count, "After processing K initial elements, the length of chosenItems should stay equal to K");
-
-                        // (1)
-                        if (Generator.Next(_numberOfProcessedListItems + 1) < Count)
+                        // (3)
+                        if (_numberOfProcessedListItems < Count)
                         {
-                            // (2)
-                            int indexToReplace = Generator.Next(_chosenListItems.Count);
-                            _chosenListItems[indexToReplace] = item;
+                            Debug.Assert(_chosenListItems.Count == _numberOfProcessedListItems, "Initial K elements should all be included in chosenListItems");
+                            _chosenListItems.Add(item);
                         }
-                    }
+                        else
+                        {
+                            Debug.Assert(_chosenListItems.Count == Count, "After processing K initial elements, the length of chosenItems should stay equal to K");
 
-                    _numberOfProcessedListItems++;
+                            // (1)
+                            if (Generator.Next(_numberOfProcessedListItems + 1) < Count)
+                            {
+                                // (2)
+                                int indexToReplace = Generator.Next(_chosenListItems.Count);
+                                _chosenListItems[indexToReplace] = item;
+                            }
+                        }
+
+                        _numberOfProcessedListItems++;
+                    }
                 }
             }
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommand.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerShell.Commands
 
         private const string RandomNumberParameterSet = "RandomNumberParameterSet";
         private const string RandomListItemParameterSet = "RandomListItemParameterSet";
-        private const string ShuffleSet = "ShuffleSet";
+        private const string ShuffleParameterSet = "ShuffleParameterSet";
         private static readonly object[] _nullInArray = new object[] { null };
 
         private enum MyParameterSet
@@ -51,8 +51,8 @@ namespace Microsoft.PowerShell.Commands
                     {
                         _effectiveParameterSet = MyParameterSet.RandomListItem;
                     }
-                    else if (ParameterSetName.Equals(GetRandomCommand.RandomListItemParameterSet, StringComparison.OrdinalIgnoreCase) ||
-                             ParameterSetName.Equals(GetRandomCommand.ShuffleSet, StringComparison.OrdinalIgnoreCase))
+                    else if (ParameterSetName == GetRandomCommand.RandomListItemParameterSet
+                        || ParameterSetName == GetRandomCommand.ShuffleParameterSet)
                     {
                         _effectiveParameterSet = MyParameterSet.RandomListItem;
                     }
@@ -278,7 +278,7 @@ namespace Microsoft.PowerShell.Commands
         /// List from which random elements are chosen.
         /// </summary>
         [Parameter(ParameterSetName = RandomListItemParameterSet, ValueFromPipeline = true, Position = 0, Mandatory = true)]
-        [Parameter(ParameterSetName = ShuffleSet, ValueFromPipeline = true, Position = 0, Mandatory = true)]
+        [Parameter(ParameterSetName = ShuffleParameterSet, ValueFromPipeline = true, Position = 0, Mandatory = true)]
         [System.Management.Automation.AllowNull]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public object[] InputObject { get; set; }
@@ -296,9 +296,9 @@ namespace Microsoft.PowerShell.Commands
         #region Shuffle parameter
 
         /// <summary>
-        /// If specified, then the command will return all input objects in randomized order.
+        /// Gets or sets whether the command should return all input objects in randomized order.
         /// </summary>
-        [Parameter(ParameterSetName = ShuffleSet, Mandatory = true)]
+        [Parameter(ParameterSetName = ShuffleParameterSet, Mandatory = true)]
         public SwitchParameter Shuffle { get; set; }
 
         #endregion
@@ -506,7 +506,7 @@ namespace Microsoft.PowerShell.Commands
         {
             if (EffectiveParameterSet == MyParameterSet.RandomListItem)
             {
-                if (ParameterSetName == ShuffleSet)
+                if (ParameterSetName == ShuffleParameterSet)
                 {
                     // this allows for $null to be in an array passed to InputObject
                     foreach (object item in InputObject ?? _nullInArray)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommand.cs
@@ -296,7 +296,7 @@ namespace Microsoft.PowerShell.Commands
         #region Shuffle parameter
 
         /// <summary>
-        /// If specified, then the command will return all input objects in randomized order
+        /// If specified, then the command will return all input objects in randomized order.
         /// </summary>
         [Parameter(ParameterSetName = ShuffleSet, Mandatory = true)]
         public SwitchParameter Shuffle { get; set; }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Random.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Random.Tests.ps1
@@ -156,6 +156,18 @@ Describe "Get-Random" -Tags "CI" {
         $randomNumber[6] | Should -BeNullOrEmpty
     }
 
+    It "Should return all the numbers for array of 1,2,3,5,8,13 in randomized order when the Shuffle switch is used" {
+        $randomNumber = Get-Random -InputObject 1, 2, 3, 5, 8, 13 -Shuffle
+        $randomNumber.Count | Should -Be 6
+        $randomNumber[0] | Should -BeIn 1, 2, 3, 5, 8, 13
+        $randomNumber[1] | Should -BeIn 1, 2, 3, 5, 8, 13
+        $randomNumber[2] | Should -BeIn 1, 2, 3, 5, 8, 13
+        $randomNumber[3] | Should -BeIn 1, 2, 3, 5, 8, 13
+        $randomNumber[4] | Should -BeIn 1, 2, 3, 5, 8, 13
+        $randomNumber[5] | Should -BeIn 1, 2, 3, 5, 8, 13
+        $randomNumber[6] | Should -BeNullOrEmpty
+    }
+
     It "Should return for a string collection " {
         $randomNumber = Get-Random -InputObject "red", "yellow", "blue"
         $randomNumber | Should -Be ("red" -or "yellow" -or "blue")
@@ -173,7 +185,7 @@ Describe "Get-Random" -Tags "CI" {
         $firstRandomNumber | Should -Not -Be $secondRandomNumber
     }
 
-    It "Should return the same number for hexadecimal number and regular number when the switch SetSeed it used " {
+    It "Should return the same number for hexadecimal number and regular number when the switch SetSeed is used " {
         $firstRandomNumber = Get-Random 0x07FFFFFFFF -SetSeed 20
         $secondRandomNumber = Get-Random 34359738367 -SetSeed 20
         $firstRandomNumber | Should -Be @secondRandomNumber

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Random.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Random.Tests.ps1
@@ -159,13 +159,7 @@ Describe "Get-Random" -Tags "CI" {
     It "Should return all the numbers for array of 1,2,3,5,8,13 in randomized order when the Shuffle switch is used" {
         $randomNumber = Get-Random -InputObject 1, 2, 3, 5, 8, 13 -Shuffle
         $randomNumber.Count | Should -Be 6
-        $randomNumber[0] | Should -BeIn 1, 2, 3, 5, 8, 13
-        $randomNumber[1] | Should -BeIn 1, 2, 3, 5, 8, 13
-        $randomNumber[2] | Should -BeIn 1, 2, 3, 5, 8, 13
-        $randomNumber[3] | Should -BeIn 1, 2, 3, 5, 8, 13
-        $randomNumber[4] | Should -BeIn 1, 2, 3, 5, 8, 13
-        $randomNumber[5] | Should -BeIn 1, 2, 3, 5, 8, 13
-        $randomNumber[6] | Should -BeNullOrEmpty
+        $randomNumber | Should -BeIn 1, 2, 3, 5, 8, 13
     }
 
     It "Should return for a string collection " {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Added `-Shuffle` switch to Get-Random command. Also added test for this feature.

## PR Context

Fix #11022 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
