### PR TITLE
Use async streams in Invoke-RestMethod

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -382,10 +382,12 @@ namespace Microsoft.PowerShell.Commands
         {
             if (response == null) { throw new ArgumentNullException("response"); }
 
-            Stream responseStream = StreamHelper.GetResponseStream(response);
+            var baseResponseStream = StreamHelper.GetResponseStream(response);
 
             if (ShouldWriteToPipeline)
             {
+                using (BufferingStreamReader responseStream = new BufferingStreamReader(baseResponseStream))
+
                 // First see if it is an RSS / ATOM feed, in which case we can
                 // stream it - unless the user has overridden it with a return type of "XML"
                 if (TryProcessFeedStream(responseStream))
@@ -454,10 +456,9 @@ namespace Microsoft.PowerShell.Commands
                     WriteObject(obj);
                 }
             }
-
-            if (ShouldSaveToOutFile)
+            else if (ShouldSaveToOutFile)
             {
-                StreamHelper.SaveStreamToFile(responseStream, QualifiedOutFile, this, _cancelToken);
+                StreamHelper.SaveStreamToFile(baseResponseStream, QualifiedOutFile, this, _cancelToken);
             }
 
             if (!string.IsNullOrEmpty(StatusCodeVariable))

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -85,7 +85,7 @@ namespace Microsoft.PowerShell.Commands
 
         #region Helper Methods
 
-        private bool TryProcessFeedStream(BufferingStreamReader responseStream)
+        private bool TryProcessFeedStream(Stream responseStream)
         {
             bool isRssOrFeed = false;
 
@@ -382,95 +382,94 @@ namespace Microsoft.PowerShell.Commands
         {
             if (response == null) { throw new ArgumentNullException("response"); }
 
-            using (BufferingStreamReader responseStream = new BufferingStreamReader(StreamHelper.GetResponseStream(response)))
+            Stream responseStream = StreamHelper.GetResponseStream(response);
+
+            if (ShouldWriteToPipeline)
             {
-                if (ShouldWriteToPipeline)
+                // First see if it is an RSS / ATOM feed, in which case we can
+                // stream it - unless the user has overridden it with a return type of "XML"
+                if (TryProcessFeedStream(responseStream))
                 {
-                    // First see if it is an RSS / ATOM feed, in which case we can
-                    // stream it - unless the user has overridden it with a return type of "XML"
-                    if (TryProcessFeedStream(responseStream))
+                    // Do nothing, content has been processed.
+                }
+                else
+                {
+                    // determine the response type
+                    RestReturnType returnType = CheckReturnType(response);
+
+                    // Try to get the response encoding from the ContentType header.
+                    Encoding encoding = null;
+                    string charSet = response.Content.Headers.ContentType?.CharSet;
+                    if (!string.IsNullOrEmpty(charSet))
                     {
-                        // Do nothing, content has been processed.
+                        // NOTE: Don't use ContentHelper.GetEncoding; it returns a
+                        // default which bypasses checking for a meta charset value.
+                        StreamHelper.TryGetEncoding(charSet, out encoding);
                     }
+
+                    if (string.IsNullOrEmpty(charSet) && returnType == RestReturnType.Json)
+                    {
+                        encoding = Encoding.UTF8;
+                    }
+
+                    object obj = null;
+                    Exception ex = null;
+
+                    string str = StreamHelper.DecodeStream(responseStream, ref encoding);
+
+                    string encodingVerboseName;
+                    try
+                    {
+                        encodingVerboseName = string.IsNullOrEmpty(encoding.HeaderName) ? encoding.EncodingName : encoding.HeaderName;
+                    }
+                    catch (NotSupportedException)
+                    {
+                        encodingVerboseName = encoding.EncodingName;
+                    }
+                    // NOTE: Tests use this verbose output to verify the encoding.
+                    WriteVerbose(string.Format
+                    (
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        "Content encoding: {0}",
+                        encodingVerboseName)
+                    );
+                    bool convertSuccess = false;
+
+                    if (returnType == RestReturnType.Json)
+                    {
+                        convertSuccess = TryConvertToJson(str, out obj, ref ex) || TryConvertToXml(str, out obj, ref ex);
+                    }
+                    // default to try xml first since it's more common
                     else
                     {
-                        // determine the response type
-                        RestReturnType returnType = CheckReturnType(response);
-
-                        // Try to get the response encoding from the ContentType header.
-                        Encoding encoding = null;
-                        string charSet = response.Content.Headers.ContentType?.CharSet;
-                        if (!string.IsNullOrEmpty(charSet))
-                        {
-                            // NOTE: Don't use ContentHelper.GetEncoding; it returns a
-                            // default which bypasses checking for a meta charset value.
-                            StreamHelper.TryGetEncoding(charSet, out encoding);
-                        }
-
-                        if (string.IsNullOrEmpty(charSet) && returnType == RestReturnType.Json)
-                        {
-                            encoding = Encoding.UTF8;
-                        }
-
-                        object obj = null;
-                        Exception ex = null;
-
-                        string str = StreamHelper.DecodeStream(responseStream, ref encoding);
-
-                        string encodingVerboseName;
-                        try
-                        {
-                            encodingVerboseName = string.IsNullOrEmpty(encoding.HeaderName) ? encoding.EncodingName : encoding.HeaderName;
-                        }
-                        catch (NotSupportedException)
-                        {
-                            encodingVerboseName = encoding.EncodingName;
-                        }
-                        // NOTE: Tests use this verbose output to verify the encoding.
-                        WriteVerbose(string.Format
-                        (
-                            System.Globalization.CultureInfo.InvariantCulture,
-                            "Content encoding: {0}",
-                            encodingVerboseName)
-                        );
-                        bool convertSuccess = false;
-
-                        if (returnType == RestReturnType.Json)
-                        {
-                            convertSuccess = TryConvertToJson(str, out obj, ref ex) || TryConvertToXml(str, out obj, ref ex);
-                        }
-                        // default to try xml first since it's more common
-                        else
-                        {
-                            convertSuccess = TryConvertToXml(str, out obj, ref ex) || TryConvertToJson(str, out obj, ref ex);
-                        }
-
-                        if (!convertSuccess)
-                        {
-                            // fallback to string
-                            obj = str;
-                        }
-
-                        WriteObject(obj);
+                        convertSuccess = TryConvertToXml(str, out obj, ref ex) || TryConvertToJson(str, out obj, ref ex);
                     }
-                }
 
-                if (ShouldSaveToOutFile)
-                {
-                    StreamHelper.SaveStreamToFile(responseStream, QualifiedOutFile, this);
-                }
+                    if (!convertSuccess)
+                    {
+                        // fallback to string
+                        obj = str;
+                    }
 
-                if (!string.IsNullOrEmpty(StatusCodeVariable))
-                {
-                    PSVariableIntrinsics vi = SessionState.PSVariable;
-                    vi.Set(StatusCodeVariable, (int)response.StatusCode);
+                    WriteObject(obj);
                 }
+            }
 
-                if (!string.IsNullOrEmpty(ResponseHeadersVariable))
-                {
-                    PSVariableIntrinsics vi = SessionState.PSVariable;
-                    vi.Set(ResponseHeadersVariable, WebResponseHelper.GetHeadersDictionary(response));
-                }
+            if (ShouldSaveToOutFile)
+            {
+                StreamHelper.SaveStreamToFile(responseStream, QualifiedOutFile, this, _cancelToken);
+            }
+
+            if (!string.IsNullOrEmpty(StatusCodeVariable))
+            {
+                PSVariableIntrinsics vi = SessionState.PSVariable;
+                vi.Set(StatusCodeVariable, (int)response.StatusCode);
+            }
+
+            if (!string.IsNullOrEmpty(ResponseHeadersVariable))
+            {
+                PSVariableIntrinsics vi = SessionState.PSVariable;
+                vi.Set(ResponseHeadersVariable, WebResponseHelper.GetHeadersDictionary(response));
             }
         }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -386,7 +386,7 @@ namespace Microsoft.PowerShell.Commands
 
             if (ShouldWriteToPipeline)
             {
-                using (BufferingStreamReader responseStream = new BufferingStreamReader(baseResponseStream))
+                using var responseStream = new BufferingStreamReader(baseResponseStream);
 
                 // First see if it is an RSS / ATOM feed, in which case we can
                 // stream it - unless the user has overridden it with a return type of "XML"
@@ -458,7 +458,7 @@ namespace Microsoft.PowerShell.Commands
             }
             else if (ShouldSaveToOutFile)
             {
-                StreamHelper.SaveStreamToFile(baseResponseStream, QualifiedOutFile, this, _cancelToken);
+                StreamHelper.SaveStreamToFile(baseResponseStream, QualifiedOutFile, this, _cancelToken.Token);
             }
 
             if (!string.IsNullOrEmpty(StatusCodeVariable))

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -911,7 +911,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Cancellation token source.
         /// </summary>
-        private CancellationTokenSource _cancelToken = null;
+        internal CancellationTokenSource _cancelToken = null;
 
         /// <summary>
         /// Parse Rel Links.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeWebRequestCommand.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeWebRequestCommand.CoreClr.cs
@@ -51,7 +51,7 @@ namespace Microsoft.PowerShell.Commands
 
             if (ShouldSaveToOutFile)
             {
-                StreamHelper.SaveStreamToFile(responseStream, QualifiedOutFile, this, _cancelToken);
+                StreamHelper.SaveStreamToFile(responseStream, QualifiedOutFile, this, _cancelToken.Token);
             }
         }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeWebRequestCommand.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeWebRequestCommand.CoreClr.cs
@@ -51,7 +51,7 @@ namespace Microsoft.PowerShell.Commands
 
             if (ShouldSaveToOutFile)
             {
-                StreamHelper.SaveStreamToFile(responseStream, QualifiedOutFile, this);
+                StreamHelper.SaveStreamToFile(responseStream, QualifiedOutFile, this, _cancelToken);
             }
         }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -298,14 +298,15 @@ namespace Microsoft.PowerShell.Commands
                     Task.Delay(1000).Wait(cancellationToken);
                 }
                 while (!copyTask.IsCompleted && !cancellationToken.IsCancellationRequested);
+
+                if (copyTask.IsCompleted)
+                {
+                    record.StatusDescription = StringUtil.Format(WebCmdletStrings.WriteRequestComplete, output.Position);
+                    cmdlet.WriteProgress(record);
+                }
             }
             catch (OperationCanceledException)
             {
-            }
-            finally
-            {
-                record.StatusDescription = StringUtil.Format(WebCmdletStrings.WriteRequestComplete, output.Position);
-                cmdlet.WriteProgress(record);
             }
         }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -287,7 +287,7 @@ namespace Microsoft.PowerShell.Commands
             ProgressRecord record = new ProgressRecord(
                 ActivityId,
                 WebCmdletStrings.WriteRequestProgressActivity,
-                string.Empty);
+                WebCmdletStrings.WriteRequestProgressStatus);
             try
             {
                 do

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -297,7 +297,7 @@ namespace Microsoft.PowerShell.Commands
 
                     Task.Delay(1000).Wait(cancellationToken);
                 }
-                while (!copyTask.IsCompleted);
+                while (!copyTask.IsCompleted && !cancellationToken.IsCancellationRequested);
             }
             catch (OperationCanceledException)
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -320,7 +320,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 using (FileStream output = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.Read))
                 {
-                    WriteToStream(stream, output, cmdlet,cts);
+                    WriteToStream(stream, output, cmdlet, cts);
                 }
             }
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -9,6 +9,8 @@ using System.Management.Automation.Internal;
 using System.Net.Http;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.PowerShell.Commands
 {
@@ -99,7 +101,7 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="bufferSize"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public override System.Threading.Tasks.Task CopyToAsync(Stream destination, int bufferSize, System.Threading.CancellationToken cancellationToken)
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
         {
             Initialize();
             return base.CopyToAsync(destination, bufferSize, cancellationToken);
@@ -124,7 +126,7 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="count"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public override System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken)
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             Initialize();
             return base.ReadAsync(buffer, offset, count, cancellationToken);
@@ -175,7 +177,7 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="count"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public override System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken)
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             Initialize();
             return base.WriteAsync(buffer, offset, count, cancellationToken);
@@ -273,47 +275,27 @@ namespace Microsoft.PowerShell.Commands
 
         #region Static Methods
 
-        internal static void WriteToStream(Stream input, Stream output, PSCmdlet cmdlet)
+        internal static void WriteToStream(Stream input, Stream output, PSCmdlet cmdlet, CancellationTokenSource cts)
         {
-            byte[] data = new byte[ChunkSize];
-
-            int read = 0;
-            long totalWritten = 0;
-            do
+            if (cmdlet == null)
             {
-                if (cmdlet != null)
-                {
-                    ProgressRecord record = new ProgressRecord(ActivityId,
-                        WebCmdletStrings.WriteRequestProgressActivity,
-                        StringUtil.Format(WebCmdletStrings.WriteRequestProgressStatus, totalWritten));
-                    cmdlet.WriteProgress(record);
-                }
-
-                read = input.Read(data, 0, ChunkSize);
-
-                if (0 < read)
-                {
-                    output.Write(data, 0, read);
-                    totalWritten += read;
-                }
-            } while (read != 0);
-
-            if (cmdlet != null)
-            {
-                ProgressRecord record = new ProgressRecord(ActivityId,
-                    WebCmdletStrings.WriteRequestProgressActivity,
-                    StringUtil.Format(WebCmdletStrings.WriteRequestComplete, totalWritten));
-                record.RecordType = ProgressRecordType.Completed;
-                cmdlet.WriteProgress(record);
+                throw new ArgumentNullException(nameof(cmdlet));
             }
 
-            output.Flush();
-        }
+            var copyTask = input.CopyToAsync(output, cts.Token);
 
-        internal static void WriteToStream(byte[] input, Stream output)
-        {
-            output.Write(input, 0, input.Length);
-            output.Flush();
+            ProgressRecord record = new ProgressRecord(
+                ActivityId,
+                WebCmdletStrings.WriteRequestProgressActivity,
+                StringUtil.Format(WebCmdletStrings.WriteRequestComplete, 0));
+            do
+            {
+                record.StatusDescription = StringUtil.Format(WebCmdletStrings.WriteRequestComplete, output.Position);
+                cmdlet.WriteProgress(record);
+
+                Task.Delay(1000).Wait(cts.Token);
+            }
+            while (!cts.IsCancellationRequested && !copyTask.IsCompleted);
         }
 
         /// <summary>
@@ -323,21 +305,22 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="stream"></param>
         /// <param name="filePath"></param>
         /// <param name="cmdlet"></param>
-        internal static void SaveStreamToFile(Stream stream, string filePath, PSCmdlet cmdlet)
+        /// <param name="cts"></param>
+        internal static void SaveStreamToFile(Stream stream, string filePath, PSCmdlet cmdlet, CancellationTokenSource cts)
         {
             // If the web cmdlet should resume, append the file instead of overwriting.
             if (cmdlet is WebRequestPSCmdlet webCmdlet && webCmdlet.ShouldResume)
             {
                 using (FileStream output = new FileStream(filePath, FileMode.Append, FileAccess.Write, FileShare.Read))
                 {
-                    WriteToStream(stream, output, cmdlet);
+                    WriteToStream(stream, output, cmdlet, cts);
                 }
             }
             else
             {
-                using (FileStream output = File.Create(filePath))
+                using (FileStream output = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.Read))
                 {
-                    WriteToStream(stream, output, cmdlet);
+                    WriteToStream(stream, output, cmdlet,cts);
                 }
             }
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -287,7 +287,7 @@ namespace Microsoft.PowerShell.Commands
             ProgressRecord record = new ProgressRecord(
                 ActivityId,
                 WebCmdletStrings.WriteRequestProgressActivity,
-                StringUtil.Format(WebCmdletStrings.WriteRequestComplete, 0));
+                string.Empty);
             try
             {
                 do
@@ -299,9 +299,13 @@ namespace Microsoft.PowerShell.Commands
                 }
                 while (!copyTask.IsCompleted);
             }
-            catch
+            catch (OperationCanceledException)
             {
-                // Catch OperationCanceledException from Wait()
+            }
+            finally
+            {
+                record.StatusDescription = StringUtil.Format(WebCmdletStrings.WriteRequestComplete, output.Position);
+                cmdlet.WriteProgress(record);
             }
         }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #4129

- Use async stream methods in Invoke-RestMethod to save a large file (> 2Gb) to output file as binary
- Now we can interrupt downloading large file by Ctrl-C
- Now output file is readable at download time and we can see a size of the file

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
