### PR TITLE
Fix Issue in Select-Object where Hashtable members (e.g., `Keys`) cannot be used with -Property or -ExpandProperty

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/Mshexpression.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/Mshexpression.cs
@@ -296,19 +296,16 @@ namespace Microsoft.PowerShell.Commands
                 return retVal;
             }
 
-            foreach (PSPropertyExpression resolvedName in ResolveNames(wrappedTarget, expand))
+            foreach (PSPropertyExpression resolvedName in ResolveNames(target, expand))
             {
                 PSPropertyExpressionResult result = resolvedName.GetValue(wrappedTarget, eatExceptions);
-                retVal.Add(result);
-            }
 
-            if (retVal.Count == 0 && wasHashtable)
-            {
-                foreach (PSPropertyExpression resolvedName in ResolveNames(target, expand))
+                if (result.Result == null && wasHashtable)
                 {
-                    PSPropertyExpressionResult result = resolvedName.GetValue(target, eatExceptions);
-                    retVal.Add(result);
+                    result = resolvedName.GetValue(target, eatExceptions);
                 }
+
+                retVal.Add(result);
             }
 
             return retVal;
@@ -372,8 +369,8 @@ namespace Microsoft.PowerShell.Commands
             // that property expressions can work on it.
             if (PSObject.Base(target) is Hashtable targetAsHash)
             {
-                target = (PSObject)(LanguagePrimitives.ConvertPSObjectToType(targetAsHash, typeof(PSObject), false, null, true));
                 wrapped = true;
+                return (PSObject)(LanguagePrimitives.ConvertPSObjectToType(targetAsHash, typeof(PSObject), false, null, true));
             }
 
             return target;

--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/Mshexpression.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/Mshexpression.cs
@@ -363,7 +363,12 @@ namespace Microsoft.PowerShell.Commands
             if (PSObject.Base(target) is Hashtable targetAsHash)
             {
                 wrapped = true;
-                return (PSObject)(LanguagePrimitives.ConvertPSObjectToType(targetAsHash, typeof(PSObject), false, null, true));
+                return (PSObject)(LanguagePrimitives.ConvertPSObjectToType(
+                    targetAsHash,
+                    typeof(PSObject),
+                    recursion: false,
+                    formatProvider: null,
+                    ignoreUnknownMembers: true));
             }
 
             return target;

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
@@ -17,7 +17,11 @@ Describe "Select-Object" -Tags "CI" {
     It "Should treat input as a single object with the inputObject parameter" {
         $result = $(Select-Object -InputObject $dirObject -Last $TestLength).Length
         $expected = $dirObject.Length
-        { $dirObject | Select-Object } | Should -Not -Throw
+        $result | Should -Be $expected
+    }
+
+    It "Should be able to use the alias" {
+        { $dirObject | select } | Should -Not -Throw
     }
 
     It "Should have same result when using alias" {
@@ -128,6 +132,11 @@ Describe "Select-Object DRT basic functionality" -Tags "CI" {
         $e = { "bar" | Select-Object -Prop {} -ErrorAction Stop } |
             Should -Throw -ErrorId "EmptyScriptBlockAndNoName,Microsoft.PowerShell.Commands.SelectObjectCommand" -PassThru
         $e.CategoryInfo | Should -Match "PSArgumentException"
+    }
+
+    It "Select-Object with Property First Last Overlap should work" {
+        $results = $employees | Select-Object -Property "YearsInMS", "L*" -First 2 -Last 3
+        $results.Count | Should -Be 4
     }
 
     It "Select-Object with string property should work" {
@@ -340,8 +349,6 @@ Describe "Select-Object with Property = '*'" -Tags "CI" {
         $obj.psobject.TypeNames.Count | Should -Be 3
         $obj.psobject.TypeNames[0] | Should -BeLike "Selected*"
         $obj.psobject.TypeNames[1] | Should -Not -BeLike "Selected*"
-        $p = Get-Process -Id $pid | Select-Object -Property Process* -ExcludeProperty ProcessorAffinity -ExpandProperty Modules
-        $p[0].psobject.Properties.Item("ProcessorAffinity") | Should -BeNullOrEmpty
         $obj.psobject.TypeNames[2] | Should -Not -BeLike "Selected*"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
@@ -125,7 +125,7 @@ Describe "Select-Object DRT basic functionality" -Tags "CI" {
     }
 
     It "Select-Object with empty script block property should throw" {
-        $e = { "bar" | Select-Object -Prop { } -ErrorAction Stop } |
+        $e = { "bar" | Select-Object -Prop {} -ErrorAction Stop } |
             Should -Throw -ErrorId "EmptyScriptBlockAndNoName,Microsoft.PowerShell.Commands.SelectObjectCommand" -PassThru
         $e.CategoryInfo | Should -Match "PSArgumentException"
     }
@@ -383,22 +383,5 @@ Describe 'Select-Object behaviour with hashtable entries and actual members' -Ta
         $result.Count | Should -Be 3
 
         $hashtable | Select-Object -ExpandProperty Count | Should -Be 3
-    }
-
-    It 'should get the hashtable Count member' {
-        $hashtable = @{ a = 10; b = 20; c = 30 }
-        $result = $hashtable | Select-Object -Property Count
-        $result.Count | Should -Be 3
-
-        $hashtable | Select-Object -ExpandProperty Count | Should -Be 3
-    }
-
-    It 'should get the Length member from a hashtable' {
-        $hashtable = @{ a = 10; b = 20; c = 30 }
-
-        $result = $hashtable | Select-Object -Property Length
-        $result.Length | Should -Be 1
-
-        $hashtable | Select-Object -ExpandProperty Length | Should -Be 1
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
@@ -370,7 +370,7 @@ Describe "Select-Object with Property = '*'" -Tags "CI" {
     }
 }
 
-Describe 'Select-Object behaviour with hashtable entries and actual members' {
+Describe 'Select-Object behaviour with hashtable entries and actual members' -Tags CI {
 
     It 'can retrieve a hashtable entry as a property' {
         $hashtable = @{ Entry = 100 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
@@ -6,129 +6,129 @@ Add-TestDynamicType
 
 Describe "Select-Object" -Tags "CI" {
     BeforeEach {
-        $dirObject = GetFileMock
-        $TestLength = 3
+	$dirObject  = GetFileMock
+	$TestLength = 3
     }
 
     It "Handle piped input without error" {
-        { $dirObject | Select-Object } | Should -Not -Throw
+	{ $dirObject | Select-Object } | Should -Not -Throw
     }
 
     It "Should treat input as a single object with the inputObject parameter" {
         $result = $(Select-Object -inputObject $dirObject -last $TestLength).Length
         $expected = $dirObject.Length
-
-        $result | Should -Be $expected
-    }
-
-    It "Should be able to use the alias" {
-        { $dirObject | select } | Should -Not -Throw
+	{ $dirObject | select } | Should -Not -Throw
     }
 
     It "Should have same result when using alias" {
-        $result = $dirObject | select
-        $expected = $dirObject | Select-Object
+	$result   = $dirObject | select
+	$expected = $dirObject | Select-Object
 
-        $result | Should -Be $expected
+	$result | Should -Be $expected
     }
 
     It "Should return correct object with First parameter" {
-        $result = $dirObject | Select-Object -First $TestLength
+	$result = $dirObject | Select-Object -First $TestLength
 
-        $result.Length | Should -Be $TestLength
+	$result.Length | Should -Be $TestLength
 
-        for ($i = 0; $i -lt $TestLength; $i++) {
-            $result[$i].Name | Should -Be $dirObject[$i].Name
-        }
+	for ($i=0; $i -lt $TestLength; $i++)
+	{
+	    $result[$i].Name | Should -Be $dirObject[$i].Name
+	}
     }
 
     It "Should return correct object with Last parameter" {
-        $result = $dirObject | Select-Object -Last $TestLength
+	$result = $dirObject | Select-Object -Last $TestLength
 
-        $result.Length | Should -Be $TestLength
+	$result.Length | Should -Be $TestLength
 
-        for ($i = 0; $i -lt $TestLength; $i++) {
-            $result[$i].Name | Should -Be $dirObject[$dirObject.Length - $TestLength + $i].Name
-        }
+	for ($i=0; $i -lt $TestLength; $i++)
+	{
+	    $result[$i].Name | Should -Be $dirObject[$dirObject.Length - $TestLength + $i].Name
+	}
     }
 
     It "Should work correctly with Unique parameter" {
-        $result = ("a", "b", "c", "a", "a", "a" | Select-Object -Unique).Length
-        $expected = 3
+	$result   = ("a","b","c","a","a","a" | Select-Object -Unique).Length
+	$expected = 3
 
-        $result | Should -Be $expected
+	$result | Should -Be $expected
     }
 
     It "Should return correct object with Skip parameter" {
-        $result = $dirObject | Select-Object -Skip $TestLength
+	$result = $dirObject | Select-Object -Skip $TestLength
 
-        $result.Length | Should -Be ($dirObject.Length - $TestLength)
+	$result.Length       | Should -Be ($dirObject.Length - $TestLength)
 
-        for ($i = 0; $i -lt $TestLength; $i++) {
-            $result[$i].Name | Should -Be $dirObject[$TestLength + $i].Name
-        }
+	for ($i=0; $i -lt $TestLength; $i++)
+	{
+	    $result[$i].Name | Should -Be $dirObject[$TestLength + $i].Name
+	}
     }
 
     It "Should return an object with selected columns" {
-        $result = $dirObject | Select-Object -Property Name, Size
+	$result = $dirObject | Select-Object -Property Name, Size
 
-        $result.Length | Should -Be $dirObject.Length
-        $result[0].Name | Should -Be $dirObject[0].Name
-        $result[0].Size | Should -Be $dirObject[0].Size
-        $result[0].Mode | Should -BeNullOrEmpty
+	$result.Length  | Should -Be $dirObject.Length
+	$result[0].Name | Should -Be $dirObject[0].Name
+	$result[0].Size | Should -Be $dirObject[0].Size
+	$result[0].Mode | Should -BeNullOrEmpty
     }
 
     It "Should send output to pipe properly" {
-        { $dirObject | Select-Object -Unique | pipelineConsume } | Should -Not -Throw
+	{$dirObject | Select-Object -Unique | pipelineConsume} | Should -Not -Throw
     }
 
     It "Should select array indices with Index parameter" {
-        $firstIndex = 2
-        $secondIndex = 4
-        $result = $dirObject | Select-Object -Index $firstIndex, $secondIndex
+	$firstIndex  = 2
+	$secondIndex = 4
+	$result      = $dirObject | Select-Object -Index $firstIndex, $secondIndex
 
-        $result[0].Name | Should -Be $dirObject[$firstIndex].Name
-        $result[1].Name | Should -Be $dirObject[$secondIndex].Name
+	$result[0].Name | Should -Be $dirObject[$firstIndex].Name
+	$result[1].Name | Should -Be $dirObject[$secondIndex].Name
     }
 
     # Note that these two tests will modify original values of $dirObject
 
     It "Should not wait when used without -Wait option" {
-        $orig1 = $dirObject[0].Size
-        $orig2 = $dirObject[$TestLength].Size
-        $result = $dirObject | addOneToSizeProperty | Select-Object -First $TestLength
+	$orig1  = $dirObject[0].Size
+	$orig2  = $dirObject[$TestLength].Size
+	$result = $dirObject | addOneToSizeProperty | Select-Object -First $TestLength
 
-        $result[0].Size | Should -Be ($orig1 + 1)
-        $dirObject[0].Size | Should -Be ($orig1 + 1)
-        $dirObject[$TestLength].Size | Should -Be $orig2
+	$result[0].Size              | Should -Be ($orig1 + 1)
+	$dirObject[0].Size           | Should -Be ($orig1 + 1)
+	$dirObject[$TestLength].Size | Should -Be $orig2
     }
 
     It "Should wait when used with -Wait option" {
-        $orig1 = $dirObject[0].Size
-        $orig2 = $dirObject[$TestLength].Size
-        $result = $dirObject | addOneToSizeProperty | Select-Object -First $TestLength -Wait
+	$orig1  = $dirObject[0].Size
+	$orig2  = $dirObject[$TestLength].Size
+	$result = $dirObject | addOneToSizeProperty | Select-Object -First $TestLength -Wait
 
-        $result[0].Size | Should -Be ($orig1 + 1)
-        $dirObject[0].Size | Should -Be ($orig1 + 1)
-        $dirObject[$TestLength].Size | Should -Be ($orig2 + 1)
-    }
+	$result[0].Size              | Should -Be ($orig1 + 1)
+	$dirObject[0].Size           | Should -Be ($orig1 + 1)
+	$dirObject[$TestLength].Size | Should -Be ($orig2 + 1)
+	}
 
-    It "Should not leak 'StopUpstreamCommandsException' internal exception for stopping upstream" {
-        1, 2 | Select-Object -First 1 -ErrorVariable err
-        $err | Should -BeNullOrEmpty
-    }
+	It "Should not leak 'StopUpstreamCommandsException' internal exception for stopping upstream" {
+		1,2 | Select-Object -First 1 -ErrorVariable err
+		$err | Should -BeNullOrEmpty
+	}
 }
 
 Describe "Select-Object DRT basic functionality" -Tags "CI" {
-    BeforeAll {
-        $employees = [pscustomobject]@{"FirstName" = "joseph"; "LastName" = "smith"; "YearsInMS" = 15 },
-        [pscustomobject]@{"FirstName" = "paul"; "LastName" = "smith"; "YearsInMS" = 15 },
-        [pscustomobject]@{"FirstName" = "mary"; "LastName" = "soe"; "YearsInMS" = 5 },
-        [pscustomobject]@{"FirstName" = "edmund"; "LastName" = "bush"; "YearsInMS" = 9 }
-    }
+	BeforeAll {
+		$employees = [pscustomobject]@{"FirstName"="joseph"; "LastName"="smith"; "YearsInMS"=15},
+                            [pscustomobject]@{"FirstName"="paul"; "LastName"="smith"; "YearsInMS"=15},
+                            [pscustomobject]@{"FirstName"="mary"; "LastName"="soe"; "YearsInMS"=5},
+                            [pscustomobject]@{"FirstName"="edmund"; "LastName"="bush"; "YearsInMS"=9}
+	}
 
+	It "Select-Object with empty script block property should throw"{
+		$e = { "bar" | Select-Object -Prop {} -ErrorAction Stop } |
     It "Select-Object with empty script block property should throw" {
-        $e = { "bar" | Select-Object -Prop {} -ErrorAction Stop } |
+        $e = { "bar" | Select-Object -Prop { } -ErrorAction Stop } |
             Should -Throw -ErrorId "EmptyScriptBlockAndNoName,Microsoft.PowerShell.Commands.SelectObjectCommand" -PassThru
         $e.CategoryInfo | Should -Match "PSArgumentException"
     }
@@ -137,115 +137,100 @@ Describe "Select-Object DRT basic functionality" -Tags "CI" {
         $result = "bar" | Select-Object -Prop foo | Measure-Object
         $result.Count | Should -Be 1
     }
+	}
 
-    It "Select-Object with Property First Last Overlap should work" {
-        $results = $employees | Select-Object -Property "YearsInMS", "L*" -First 2 -Last 3
+	It "Select-Object with Property First Last should work"{
+		$results = $employees | Select-Object -Property "YearsInMS", "L*" -First 2 -Last 1
 
-        $results.Count | Should -Be 4
+		$results.Count | Should -Be 3
 
-        $results[0].LastName | Should -Be $employees[0].LastName
-        $results[1].LastName | Should -Be $employees[1].LastName
-        $results[2].LastName | Should -Be $employees[2].LastName
-        $results[3].LastName | Should -Be $employees[3].LastName
+		$results[0].LastName | Should -Be $employees[0].LastName
+		$results[1].LastName | Should -Be $employees[1].LastName
+		$results[2].LastName | Should -Be $employees[3].LastName
 
-        $results[0].YearsInMS | Should -Be $employees[0].YearsInMS
-        $results[1].YearsInMS | Should -Be $employees[1].YearsInMS
-        $results[2].YearsInMS | Should -Be $employees[2].YearsInMS
-        $results[3].YearsInMS | Should -Be $employees[3].YearsInMS
-    }
+		$results[0].YearsInMS | Should -Be $employees[0].YearsInMS
+		$results[1].YearsInMS | Should -Be $employees[1].YearsInMS
+		$results[2].YearsInMS | Should -Be $employees[3].YearsInMS
+	}
 
-    It "Select-Object with Property First Last should work" {
-        $results = $employees | Select-Object -Property "YearsInMS", "L*" -First 2 -Last 1
+	It "Select-Object with Property First should work"{
+		$results = $employees | Select-Object -Property "YearsInMS", "L*" -First 2
 
-        $results.Count | Should -Be 3
+		$results.Count | Should -Be 2
 
-        $results[0].LastName | Should -Be $employees[0].LastName
-        $results[1].LastName | Should -Be $employees[1].LastName
-        $results[2].LastName | Should -Be $employees[3].LastName
+		$results[0].LastName | Should -Be $employees[0].LastName
+		$results[1].LastName | Should -Be $employees[1].LastName
 
-        $results[0].YearsInMS | Should -Be $employees[0].YearsInMS
-        $results[1].YearsInMS | Should -Be $employees[1].YearsInMS
-        $results[2].YearsInMS | Should -Be $employees[3].YearsInMS
-    }
+		$results[0].YearsInMS | Should -Be $employees[0].YearsInMS
+		$results[1].YearsInMS | Should -Be $employees[1].YearsInMS
+	}
 
-    It "Select-Object with Property First should work" {
-        $results = $employees | Select-Object -Property "YearsInMS", "L*" -First 2
+	It "Select-Object with Property First Zero should work"{
+		$results = $employees | Select-Object -Property "YearsInMS", "L*" -First 0
 
-        $results.Count | Should -Be 2
+		$results.Count | Should -Be 0
+	}
 
-        $results[0].LastName | Should -Be $employees[0].LastName
-        $results[1].LastName | Should -Be $employees[1].LastName
+	It "Select-Object with Property Last Zero should work"{
+		$results = $employees | Select-Object -Property "YearsInMS", "L*" -Last 0
 
-        $results[0].YearsInMS | Should -Be $employees[0].YearsInMS
-        $results[1].YearsInMS | Should -Be $employees[1].YearsInMS
-    }
+		$results.Count | Should -Be 0
+	}
 
-    It "Select-Object with Property First Zero should work" {
-        $results = $employees | Select-Object -Property "YearsInMS", "L*" -First 0
+	It "Select-Object with Unique should work"{
+		$results = $employees | Select-Object -Property "YearsInMS", "L*" -Unique:$true
 
-        $results.Count | Should -Be 0
-    }
+		$results.Count | Should -Be 3
 
-    It "Select-Object with Property Last Zero should work" {
-        $results = $employees | Select-Object -Property "YearsInMS", "L*" -Last 0
+		$results[0].LastName | Should -Be $employees[1].LastName
+		$results[1].LastName | Should -Be $employees[2].LastName
+		$results[2].LastName | Should -Be $employees[3].LastName
 
-        $results.Count | Should -Be 0
-    }
+		$results[0].YearsInMS | Should -Be $employees[1].YearsInMS
+		$results[1].YearsInMS | Should -Be $employees[2].YearsInMS
+		$results[2].YearsInMS | Should -Be $employees[3].YearsInMS
+	}
 
-    It "Select-Object with Unique should work" {
-        $results = $employees | Select-Object -Property "YearsInMS", "L*" -Unique:$true
+	It "Select-Object with Simple should work"{
+		$employee1 = [pscustomobject]@{"FirstName"="joesph"; "LastName"="smith"; "YearsInMS"=15}
+		$employee2 = [pscustomobject]@{"FirstName"="paul"; "LastName"="smith"; "YearsInMS"=15}
+		$employee3 = [pscustomobject]@{"FirstName"="mary"; "LastName"="soe"; "YearsInMS"=15}
+		$employees3 = @($employee1,$employee2,$employee3,$employee4)
+		$results = $employees3 | Select-Object -Property "FirstName", "YearsInMS"
 
-        $results.Count | Should -Be 3
+		$results.Count | Should -Be 3
 
-        $results[0].LastName | Should -Be $employees[1].LastName
-        $results[1].LastName | Should -Be $employees[2].LastName
-        $results[2].LastName | Should -Be $employees[3].LastName
+		$results[0].FirstName | Should -Be $employees3[0].FirstName
+		$results[1].FirstName | Should -Be $employees3[1].FirstName
+		$results[2].FirstName | Should -Be $employees3[2].FirstName
 
-        $results[0].YearsInMS | Should -Be $employees[1].YearsInMS
-        $results[1].YearsInMS | Should -Be $employees[2].YearsInMS
-        $results[2].YearsInMS | Should -Be $employees[3].YearsInMS
-    }
+		$results[0].YearsInMS | Should -Be $employees3[0].YearsInMS
+		$results[1].YearsInMS | Should -Be $employees3[1].YearsInMS
+		$results[2].YearsInMS | Should -Be $employees3[2].YearsInMS
+	}
 
-    It "Select-Object with Simple should work" {
-        $employee1 = [pscustomobject]@{"FirstName" = "joesph"; "LastName" = "smith"; "YearsInMS" = 15 }
-        $employee2 = [pscustomobject]@{"FirstName" = "paul"; "LastName" = "smith"; "YearsInMS" = 15 }
-        $employee3 = [pscustomobject]@{"FirstName" = "mary"; "LastName" = "soe"; "YearsInMS" = 15 }
-        $employees3 = @($employee1, $employee2, $employee3, $employee4)
-        $results = $employees3 | Select-Object -Property "FirstName", "YearsInMS"
+	It "Select-Object with no input should work"{
+		$results = $null | Select-Object -Property "FirstName", "YearsInMS", "FirstNa*"
+		$results.Count | Should -Be 0
+	}
 
-        $results.Count | Should -Be 3
+	It "Select-Object with Start-Time In Idle Process should work" {
+		$results = Get-Process * | Select-Object ProcessName
+		$results.Count | Should -Not -Be 0
+	}
 
-        $results[0].FirstName | Should -Be $employees3[0].FirstName
-        $results[1].FirstName | Should -Be $employees3[1].FirstName
-        $results[2].FirstName | Should -Be $employees3[2].FirstName
+	It "Select-Object with Skip should work"{
+		$results = "1","2","3" | Select-Object -Skip 1
+		$results.Count | Should -Be 2
+		$results[0] | Should -Be 2
+		$results[1] | Should -Be 3
+	}
 
-        $results[0].YearsInMS | Should -Be $employees3[0].YearsInMS
-        $results[1].YearsInMS | Should -Be $employees3[1].YearsInMS
-        $results[2].YearsInMS | Should -Be $employees3[2].YearsInMS
-    }
-
-    It "Select-Object with no input should work" {
-        $results = $null | Select-Object -Property "FirstName", "YearsInMS", "FirstNa*"
-        $results.Count | Should -Be 0
-    }
-
-    It "Select-Object with Start-Time In Idle Process should work" {
-        $results = Get-Process * | Select-Object ProcessName
-        $results.Count | Should -Not -Be 0
-    }
-
-    It "Select-Object with Skip should work" {
-        $results = "1", "2", "3" | Select-Object -Skip 1
-        $results.Count | Should -Be 2
-        $results[0] | Should -Be 2
-        $results[1] | Should -Be 3
-    }
-
-    It "Select-Object with Index should work" {
-        $results = "1", "2", "3" | Select-Object -Index 2
-        $results.Count | Should -Be 1
-        $results[0] | Should -BeExactly "3"
-    }
+	It "Select-Object with Index should work"{
+		$results = "1","2","3" | Select-Object -Index 2
+		$results.Count | Should -Be 1
+		$results[0] | Should -BeExactly "3"
+	}
 
     It "Select-Object with SkipIndex should work" {
         $results = "1", "2", "3" | Select-Object -SkipIndex 0, 2
@@ -259,7 +244,7 @@ Describe "Select-Object DRT basic functionality" -Tags "CI" {
         $results -join ',' | Should -BeExactly "0,1,2,3,4,9,10"
     }
 
-    It "Select-Object should handle dynamic (DLR) properties" {
+    It "Select-Object should handle dynamic (DLR) properties"{
         $dynObj = [TestDynamic]::new()
         $results = $dynObj, $dynObj | Select-Object -ExpandProperty FooProp
         $results.Count | Should -Be 2
@@ -267,7 +252,7 @@ Describe "Select-Object DRT basic functionality" -Tags "CI" {
         $results[1] | Should -Be 123
     }
 
-    It "Select-Object should handle dynamic (DLR) properties without GetDynamicMemberNames hint" {
+    It "Select-Object should handle dynamic (DLR) properties without GetDynamicMemberNames hint"{
         $dynObj = [TestDynamic]::new()
         $results = $dynObj, $dynObj | Select-Object -ExpandProperty HiddenProp
         $results.Count | Should -Be 2
@@ -275,7 +260,7 @@ Describe "Select-Object DRT basic functionality" -Tags "CI" {
         $results[1] | Should -Be 789
     }
 
-    It "Select-Object should handle wildcarded dynamic (DLR) properties when hinted by GetDynamicMemberNames" {
+    It "Select-Object should handle wildcarded dynamic (DLR) properties when hinted by GetDynamicMemberNames"{
         $dynObj = [TestDynamic]::new()
         $results = $dynObj, $dynObj | Select-Object -ExpandProperty FooP*
         $results.Count | Should -Be 2
@@ -283,7 +268,7 @@ Describe "Select-Object DRT basic functionality" -Tags "CI" {
         $results[1] | Should -Be 123
     }
 
-    It "Select-Object should work when multiple dynamic (DLR) properties match" {
+    It "Select-Object should work when multiple dynamic (DLR) properties match"{
         $dynObj = [TestDynamic]::new()
         $results = $dynObj, $dynObj | Select-Object *Prop
         $results.Count | Should -Be 2
@@ -293,9 +278,9 @@ Describe "Select-Object DRT basic functionality" -Tags "CI" {
         $results[1].BarProp | Should -Be 456
     }
 
-    It "Select-Object -ExpandProperty should yield errors if multiple dynamic (DLR) properties match" {
+    It "Select-Object -ExpandProperty should yield errors if multiple dynamic (DLR) properties match"{
         $dynObj = [TestDynamic]::new()
-        $e = { $results = $dynObj, $dynObj | Select-Object -ExpandProperty *Prop -ErrorAction Stop } |
+        $e = { $results = $dynObj, $dynObj | Select-Object -ExpandProperty *Prop -ErrorAction Stop} |
             Should -Throw -PassThru -ErrorId "MutlipleExpandProperties,Microsoft.PowerShell.Commands.SelectObjectCommand"
         $e.CategoryInfo | Should -Match "PSArgumentException"
     }
@@ -303,52 +288,67 @@ Describe "Select-Object DRT basic functionality" -Tags "CI" {
 
 Describe "Select-Object with Property = '*'" -Tags "CI" {
 
-    # Issue #2420
-    It "Select-Object with implicit Property = '*' don't return property named '*'" {
-        $results = [pscustomobject]@{Thing = "thing1" } | Select-Object -ExcludeProperty thing
-        $results.psobject.Properties.Item("*") | Should -BeNullOrEmpty
-    }
+        # Issue #2420
+	It "Select-Object with implicit Property = '*' don't return property named '*'"{
+		$results = [pscustomobject]@{Thing="thing1"} | Select-Object -ExcludeProperty thing
+		$results.psobject.Properties.Item("*") | Should -BeNullOrEmpty
+	}
 
-    # Issue #2420
-    It "Select-Object with explicit Property = '*' don't return property named '*'" {
-        $results = [pscustomobject]@{Thing = "thing1" } | Select-Object -Property * -ExcludeProperty thing
-        $results.psobject.Properties.Item("*") | Should -BeNullOrEmpty
-    }
+        # Issue #2420
+	It "Select-Object with explicit Property = '*' don't return property named '*'"{
+		$results = [pscustomobject]@{Thing="thing1"} | Select-Object -Property * -ExcludeProperty thing
+		$results.psobject.Properties.Item("*") | Should -BeNullOrEmpty
+	}
 
-    # Issue #2351
-    It "Select-Object with implicit Property = '*' exclude single property" {
-        $results = [pscustomobject]@{Thing = "thing1" } | Select-Object -ExcludeProperty thing
-        $results.psobject.Properties.Item("Thing") | Should -BeNullOrEmpty
-        $results.psobject.Properties.Item("*") | Should -BeNullOrEmpty
-    }
+        # Issue #2351
+	It "Select-Object with implicit Property = '*' exclude single property"{
+		$results = [pscustomobject]@{Thing="thing1"} | Select-Object -ExcludeProperty thing
+		$results.psobject.Properties.Item("Thing") | Should -BeNullOrEmpty
+		$results.psobject.Properties.Item("*") | Should -BeNullOrEmpty
+	}
 
-    # Issue #2351
-    It "Select-Object with explicit Property = '*' exclude single property" {
-        $results = [pscustomobject]@{Thing = "thing1" } | Select-Object -Property * -ExcludeProperty thing
-        $results.psobject.Properties.Item("Thing") | Should -BeNullOrEmpty
-        $results.psobject.Properties.Item("*") | Should -BeNullOrEmpty
-    }
+        # Issue #2351
+	It "Select-Object with explicit Property = '*' exclude single property"{
+		$results = [pscustomobject]@{Thing="thing1"} | Select-Object -Property * -ExcludeProperty thing
+		$results.psobject.Properties.Item("Thing") | Should -BeNullOrEmpty
+		$results.psobject.Properties.Item("*") | Should -BeNullOrEmpty
+	}
 
-    # Issue #2351
-    It "Select-Object with implicit Property = '*' exclude not single property" {
-        $results = [pscustomobject]@{Thing = "thing1"; Param2 = "param2" } | Select-Object -ExcludeProperty Param2
-        $results.Param2 | Should -BeNullOrEmpty
-        $results.Thing | Should -BeExactly "thing1"
-    }
+        # Issue #2351
+	It "Select-Object with implicit Property = '*' exclude not single property"{
+		$results = [pscustomobject]@{Thing="thing1";Param2="param2"} | Select-Object -ExcludeProperty Param2
+		$results.Param2 | Should -BeNullOrEmpty
+		$results.Thing | Should -BeExactly "thing1"
+	}
 
-    # Issue #2351
-    It "Select-Object with explicit Property = '*' exclude not single property" {
-        $results = [pscustomobject]@{Thing = "thing1"; Param2 = "param2" } | Select-Object -Property * -ExcludeProperty Param2
-        $results.Param2 | Should -BeNullOrEmpty
-        $results.Thing | Should -BeExactly "thing1"
-    }
+        # Issue #2351
+	It "Select-Object with explicit Property = '*' exclude not single property"{
+		$results = [pscustomobject]@{Thing="thing1";Param2="param2"} | Select-Object -Property * -ExcludeProperty Param2
+		$results.Param2 | Should -BeNullOrEmpty
+		$results.Thing | Should -BeExactly "thing1"
+	}
 
     It "Select-Object with ExpandProperty and Property don't skip processing ExcludeProperty" {
-        $p = Get-Process -Id $pid | Select-Object -Property Process* -ExcludeProperty ProcessorAffinity -ExpandProperty Modules
-        $p[0].psobject.Properties.Item("ProcessorAffinity") | Should -BeNullOrEmpty
+		$p = Get-Process -Id $PID | Select-Object -Property Process* -ExcludeProperty ProcessorAffinity -ExpandProperty Modules
+		$p[0].psobject.Properties.Item("ProcessorAffinity") | Should -BeNullOrEmpty
     }
 
     It "Select-Object add 'Selected.*' type only once" {
+        $obj = [PSCustomObject]@{ Name = 1 }
+
+        $obj.psobject.TypeNames.Count | Should -Be 2
+        $obj.psobject.TypeNames | Should -Not -BeLike "Selected*"
+
+        $obj = $obj | Select-Object
+
+        $obj.psobject.TypeNames.Count | Should -Be 3
+        $obj.psobject.TypeNames[0] | Should -BeLike "Selected*"
+        $obj.psobject.TypeNames[1] | Should -Not -BeLike "Selected*"
+        $p = Get-Process -Id $pid | Select-Object -Property Process* -ExcludeProperty ProcessorAffinity -ExpandProperty Modules
+        $p[0].psobject.Properties.Item("ProcessorAffinity") | Should -BeNullOrEmpty
+        $obj.psobject.TypeNames[2] | Should -Not -BeLike "Selected*"
+    }
+}
         $obj = [PSCustomObject]@{ Name = 1 }
 
         $obj.psobject.TypeNames.Count | Should -Be 2
@@ -399,5 +399,30 @@ Describe 'Select-Object behaviour with hashtable entries and actual members' -Ta
         $result.Keys | Should -Be 10
 
         $hashtable | Select-Object -ExpandProperty Keys | Should -Be 10
+    }
+
+    It 'should get the hashtable Count member' {
+        $hashtable = @{ a = 10; b = 20; c = 30 }
+        $result = $hashtable | Select-Object -Property Count
+        $result.Count | Should -Be 3
+
+        $hashtable | Select-Object -ExpandProperty Count | Should -Be 3
+    }
+
+    It 'should get the hashtable Count member' {
+        $hashtable = @{ a = 10; b = 20; c = 30 }
+        $result = $hashtable | Select-Object -Property Count
+        $result.Count | Should -Be 3
+
+        $hashtable | Select-Object -ExpandProperty Count | Should -Be 3
+    }
+
+    It 'should get the Length member from a hashtable' {
+        $hashtable = @{ a = 10; b = 20; c = 30 }
+
+        $result = $hashtable | Select-Object -Property Length
+        $result.Length | Should -Be 1
+
+        $hashtable | Select-Object -ExpandProperty Length | Should -Be 1
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
@@ -128,7 +128,7 @@ Describe "Select-Object DRT basic functionality" -Tags "CI" {
     }
 
     It "Select-Object with empty script block property should throw" {
-        $e = { "bar" | Select-Object -Prop { } -ErrorAction Stop } |
+        $e = { "bar" | Select-Object -Prop {} -ErrorAction Stop } |
             Should -Throw -ErrorId "EmptyScriptBlockAndNoName,Microsoft.PowerShell.Commands.SelectObjectCommand" -PassThru
         $e.CategoryInfo | Should -Match "PSArgumentException"
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
@@ -369,3 +369,35 @@ Describe "Select-Object with Property = '*'" -Tags "CI" {
         $obj.psobject.TypeNames[2] | Should -Not -BeLike "Selected*"
     }
 }
+
+Describe 'Select-Object behaviour with hashtable entries and actual members' {
+
+    It 'can retrieve a hashtable entry as a property' {
+        $hashtable = @{ Entry = 100 }
+
+        $result = $hashtable | Select-Object -Property Entry
+        $result.Entry | Should -Be 100
+
+        $hashtable |
+            Select-Object -ExpandProperty Entry |
+            Should -Be 100
+    }
+
+    It 'can retrieve true hashtable members' {
+        $hashtable = @{ Value = 10 }
+        $result = $hashtable | Select-Object -Property Keys
+        $result.Keys | Should -Be 'Value'
+
+        $hashtable |
+            Select-Object -ExpandProperty Keys |
+            Should -Be 'Value'
+    }
+
+    It 'should prioritise hashtable entries where available' {
+        $hashtable = @{ Keys = 10 }
+        $result = $hashtable | Select-Object -Property Keys
+        $result.Keys | Should -Be 10
+
+        $hashtable | Select-Object -ExpandProperty Keys | Should -Be 10
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
@@ -6,249 +6,246 @@ Add-TestDynamicType
 
 Describe "Select-Object" -Tags "CI" {
     BeforeEach {
-	$dirObject  = GetFileMock
-	$TestLength = 3
+        $dirObject = GetFileMock
+        $TestLength = 3
     }
 
     It "Handle piped input without error" {
-	{ $dirObject | Select-Object } | Should -Not -Throw
+        { $dirObject | Select-Object } | Should -Not -Throw
     }
 
     It "Should treat input as a single object with the inputObject parameter" {
-	$result   = $(Select-Object -InputObject $dirObject -Last $TestLength).Length
-	$expected = $dirObject.Length
+        $result = $(Select-Object -inputObject $dirObject -last $TestLength).Length
+        $expected = $dirObject.Length
 
-	$result | Should -Be $expected
+        $result | Should -Be $expected
     }
 
     It "Should be able to use the alias" {
-	{ $dirObject | select } | Should -Not -Throw
+        { $dirObject | select } | Should -Not -Throw
     }
 
     It "Should have same result when using alias" {
-	$result   = $dirObject | select
-	$expected = $dirObject | Select-Object
+        $result = $dirObject | select
+        $expected = $dirObject | Select-Object
 
-	$result | Should -Be $expected
+        $result | Should -Be $expected
     }
 
     It "Should return correct object with First parameter" {
-	$result = $dirObject | Select-Object -First $TestLength
+        $result = $dirObject | Select-Object -First $TestLength
 
-	$result.Length | Should -Be $TestLength
+        $result.Length | Should -Be $TestLength
 
-	for ($i=0; $i -lt $TestLength; $i++)
-	{
-	    $result[$i].Name | Should -Be $dirObject[$i].Name
-	}
+        for ($i = 0; $i -lt $TestLength; $i++) {
+            $result[$i].Name | Should -Be $dirObject[$i].Name
+        }
     }
 
     It "Should return correct object with Last parameter" {
-	$result = $dirObject | Select-Object -Last $TestLength
+        $result = $dirObject | Select-Object -Last $TestLength
 
-	$result.Length | Should -Be $TestLength
+        $result.Length | Should -Be $TestLength
 
-	for ($i=0; $i -lt $TestLength; $i++)
-	{
-	    $result[$i].Name | Should -Be $dirObject[$dirObject.Length - $TestLength + $i].Name
-	}
+        for ($i = 0; $i -lt $TestLength; $i++) {
+            $result[$i].Name | Should -Be $dirObject[$dirObject.Length - $TestLength + $i].Name
+        }
     }
 
     It "Should work correctly with Unique parameter" {
-	$result   = ("a","b","c","a","a","a" | Select-Object -Unique).Length
-	$expected = 3
+        $result = ("a", "b", "c", "a", "a", "a" | Select-Object -Unique).Length
+        $expected = 3
 
-	$result | Should -Be $expected
+        $result | Should -Be $expected
     }
 
     It "Should return correct object with Skip parameter" {
-	$result = $dirObject | Select-Object -Skip $TestLength
+        $result = $dirObject | Select-Object -Skip $TestLength
 
-	$result.Length       | Should -Be ($dirObject.Length - $TestLength)
+        $result.Length | Should -Be ($dirObject.Length - $TestLength)
 
-	for ($i=0; $i -lt $TestLength; $i++)
-	{
-	    $result[$i].Name | Should -Be $dirObject[$TestLength + $i].Name
-	}
+        for ($i = 0; $i -lt $TestLength; $i++) {
+            $result[$i].Name | Should -Be $dirObject[$TestLength + $i].Name
+        }
     }
 
     It "Should return an object with selected columns" {
-	$result = $dirObject | Select-Object -Property Name, Size
+        $result = $dirObject | Select-Object -Property Name, Size
 
-	$result.Length  | Should -Be $dirObject.Length
-	$result[0].Name | Should -Be $dirObject[0].Name
-	$result[0].Size | Should -Be $dirObject[0].Size
-	$result[0].Mode | Should -BeNullOrEmpty
+        $result.Length | Should -Be $dirObject.Length
+        $result[0].Name | Should -Be $dirObject[0].Name
+        $result[0].Size | Should -Be $dirObject[0].Size
+        $result[0].Mode | Should -BeNullOrEmpty
     }
 
     It "Should send output to pipe properly" {
-	{$dirObject | Select-Object -Unique | pipelineConsume} | Should -Not -Throw
+        { $dirObject | Select-Object -Unique | pipelineConsume } | Should -Not -Throw
     }
 
     It "Should select array indices with Index parameter" {
-	$firstIndex  = 2
-	$secondIndex = 4
-	$result      = $dirObject | Select-Object -Index $firstIndex, $secondIndex
+        $firstIndex = 2
+        $secondIndex = 4
+        $result = $dirObject | Select-Object -Index $firstIndex, $secondIndex
 
-	$result[0].Name | Should -Be $dirObject[$firstIndex].Name
-	$result[1].Name | Should -Be $dirObject[$secondIndex].Name
+        $result[0].Name | Should -Be $dirObject[$firstIndex].Name
+        $result[1].Name | Should -Be $dirObject[$secondIndex].Name
     }
 
     # Note that these two tests will modify original values of $dirObject
 
     It "Should not wait when used without -Wait option" {
-	$orig1  = $dirObject[0].Size
-	$orig2  = $dirObject[$TestLength].Size
-	$result = $dirObject | addOneToSizeProperty | Select-Object -First $TestLength
+        $orig1 = $dirObject[0].Size
+        $orig2 = $dirObject[$TestLength].Size
+        $result = $dirObject | addOneToSizeProperty | Select-Object -First $TestLength
 
-	$result[0].Size              | Should -Be ($orig1 + 1)
-	$dirObject[0].Size           | Should -Be ($orig1 + 1)
-	$dirObject[$TestLength].Size | Should -Be $orig2
+        $result[0].Size | Should -Be ($orig1 + 1)
+        $dirObject[0].Size | Should -Be ($orig1 + 1)
+        $dirObject[$TestLength].Size | Should -Be $orig2
     }
 
     It "Should wait when used with -Wait option" {
-	$orig1  = $dirObject[0].Size
-	$orig2  = $dirObject[$TestLength].Size
-	$result = $dirObject | addOneToSizeProperty | Select-Object -First $TestLength -Wait
+        $orig1 = $dirObject[0].Size
+        $orig2 = $dirObject[$TestLength].Size
+        $result = $dirObject | addOneToSizeProperty | Select-Object -First $TestLength -Wait
 
-	$result[0].Size              | Should -Be ($orig1 + 1)
-	$dirObject[0].Size           | Should -Be ($orig1 + 1)
-	$dirObject[$TestLength].Size | Should -Be ($orig2 + 1)
-	}
+        $result[0].Size | Should -Be ($orig1 + 1)
+        $dirObject[0].Size | Should -Be ($orig1 + 1)
+        $dirObject[$TestLength].Size | Should -Be ($orig2 + 1)
+    }
 
-	It "Should not leak 'StopUpstreamCommandsException' internal exception for stopping upstream" {
-		1,2 | Select-Object -First 1 -ErrorVariable err
-		$err | Should -BeNullOrEmpty
-	}
+    It "Should not leak 'StopUpstreamCommandsException' internal exception for stopping upstream" {
+        1, 2 | Select-Object -First 1 -ErrorVariable err
+        $err | Should -BeNullOrEmpty
+    }
 }
 
 Describe "Select-Object DRT basic functionality" -Tags "CI" {
-	BeforeAll {
-		$employees = [pscustomobject]@{"FirstName"="joseph"; "LastName"="smith"; "YearsInMS"=15},
-                            [pscustomobject]@{"FirstName"="paul"; "LastName"="smith"; "YearsInMS"=15},
-                            [pscustomobject]@{"FirstName"="mary"; "LastName"="soe"; "YearsInMS"=5},
-                            [pscustomobject]@{"FirstName"="edmund"; "LastName"="bush"; "YearsInMS"=9}
-	}
+    BeforeAll {
+        $employees = [pscustomobject]@{"FirstName" = "joseph"; "LastName" = "smith"; "YearsInMS" = 15 },
+        [pscustomobject]@{"FirstName" = "paul"; "LastName" = "smith"; "YearsInMS" = 15 },
+        [pscustomobject]@{"FirstName" = "mary"; "LastName" = "soe"; "YearsInMS" = 5 },
+        [pscustomobject]@{"FirstName" = "edmund"; "LastName" = "bush"; "YearsInMS" = 9 }
+    }
 
-	It "Select-Object with empty script block property should throw"{
-		$e = { "bar" | Select-Object -Prop {} -ErrorAction Stop } |
-			Should -Throw -ErrorId "EmptyScriptBlockAndNoName,Microsoft.PowerShell.Commands.SelectObjectCommand" -PassThru
-		$e.CategoryInfo | Should -Match "PSArgumentException"
-	}
+    It "Select-Object with empty script block property should throw" {
+        $e = { "bar" | Select-Object -Prop { } -ErrorAction Stop } |
+            Should -Throw -ErrorId "EmptyScriptBlockAndNoName,Microsoft.PowerShell.Commands.SelectObjectCommand" -PassThru
+        $e.CategoryInfo | Should -Match "PSArgumentException"
+    }
 
-	It "Select-Object with string property should work"{
-		$result = "bar" | Select-Object -Prop foo | Measure-Object
-		$result.Count | Should -Be 1
-	}
+    It "Select-Object with string property should work" {
+        $result = "bar" | Select-Object -Prop foo | Measure-Object
+        $result.Count | Should -Be 1
+    }
 
-	It "Select-Object with Property First Last Overlap should work"{
-		$results = $employees | Select-Object -Property "YearsInMS", "L*" -First 2 -Last 3
+    It "Select-Object with Property First Last Overlap should work" {
+        $results = $employees | Select-Object -Property "YearsInMS", "L*" -First 2 -Last 3
 
-		$results.Count | Should -Be 4
+        $results.Count | Should -Be 4
 
-		$results[0].LastName | Should -Be $employees[0].LastName
-		$results[1].LastName | Should -Be $employees[1].LastName
-		$results[2].LastName | Should -Be $employees[2].LastName
-		$results[3].LastName | Should -Be $employees[3].LastName
+        $results[0].LastName | Should -Be $employees[0].LastName
+        $results[1].LastName | Should -Be $employees[1].LastName
+        $results[2].LastName | Should -Be $employees[2].LastName
+        $results[3].LastName | Should -Be $employees[3].LastName
 
-		$results[0].YearsInMS | Should -Be $employees[0].YearsInMS
-		$results[1].YearsInMS | Should -Be $employees[1].YearsInMS
-		$results[2].YearsInMS | Should -Be $employees[2].YearsInMS
-		$results[3].YearsInMS | Should -Be $employees[3].YearsInMS
-	}
+        $results[0].YearsInMS | Should -Be $employees[0].YearsInMS
+        $results[1].YearsInMS | Should -Be $employees[1].YearsInMS
+        $results[2].YearsInMS | Should -Be $employees[2].YearsInMS
+        $results[3].YearsInMS | Should -Be $employees[3].YearsInMS
+    }
 
-	It "Select-Object with Property First Last should work"{
-		$results = $employees | Select-Object -Property "YearsInMS", "L*" -First 2 -Last 1
+    It "Select-Object with Property First Last should work" {
+        $results = $employees | Select-Object -Property "YearsInMS", "L*" -First 2 -Last 1
 
-		$results.Count | Should -Be 3
+        $results.Count | Should -Be 3
 
-		$results[0].LastName | Should -Be $employees[0].LastName
-		$results[1].LastName | Should -Be $employees[1].LastName
-		$results[2].LastName | Should -Be $employees[3].LastName
+        $results[0].LastName | Should -Be $employees[0].LastName
+        $results[1].LastName | Should -Be $employees[1].LastName
+        $results[2].LastName | Should -Be $employees[3].LastName
 
-		$results[0].YearsInMS | Should -Be $employees[0].YearsInMS
-		$results[1].YearsInMS | Should -Be $employees[1].YearsInMS
-		$results[2].YearsInMS | Should -Be $employees[3].YearsInMS
-	}
+        $results[0].YearsInMS | Should -Be $employees[0].YearsInMS
+        $results[1].YearsInMS | Should -Be $employees[1].YearsInMS
+        $results[2].YearsInMS | Should -Be $employees[3].YearsInMS
+    }
 
-	It "Select-Object with Property First should work"{
-		$results = $employees | Select-Object -Property "YearsInMS", "L*" -First 2
+    It "Select-Object with Property First should work" {
+        $results = $employees | Select-Object -Property "YearsInMS", "L*" -First 2
 
-		$results.Count | Should -Be 2
+        $results.Count | Should -Be 2
 
-		$results[0].LastName | Should -Be $employees[0].LastName
-		$results[1].LastName | Should -Be $employees[1].LastName
+        $results[0].LastName | Should -Be $employees[0].LastName
+        $results[1].LastName | Should -Be $employees[1].LastName
 
-		$results[0].YearsInMS | Should -Be $employees[0].YearsInMS
-		$results[1].YearsInMS | Should -Be $employees[1].YearsInMS
-	}
+        $results[0].YearsInMS | Should -Be $employees[0].YearsInMS
+        $results[1].YearsInMS | Should -Be $employees[1].YearsInMS
+    }
 
-	It "Select-Object with Property First Zero should work"{
-		$results = $employees | Select-Object -Property "YearsInMS", "L*" -First 0
+    It "Select-Object with Property First Zero should work" {
+        $results = $employees | Select-Object -Property "YearsInMS", "L*" -First 0
 
-		$results.Count | Should -Be 0
-	}
+        $results.Count | Should -Be 0
+    }
 
-	It "Select-Object with Property Last Zero should work"{
-		$results = $employees | Select-Object -Property "YearsInMS", "L*" -Last 0
+    It "Select-Object with Property Last Zero should work" {
+        $results = $employees | Select-Object -Property "YearsInMS", "L*" -Last 0
 
-		$results.Count | Should -Be 0
-	}
+        $results.Count | Should -Be 0
+    }
 
-	It "Select-Object with Unique should work"{
-		$results = $employees | Select-Object -Property "YearsInMS", "L*" -Unique:$true
+    It "Select-Object with Unique should work" {
+        $results = $employees | Select-Object -Property "YearsInMS", "L*" -Unique:$true
 
-		$results.Count | Should -Be 3
+        $results.Count | Should -Be 3
 
-		$results[0].LastName | Should -Be $employees[1].LastName
-		$results[1].LastName | Should -Be $employees[2].LastName
-		$results[2].LastName | Should -Be $employees[3].LastName
+        $results[0].LastName | Should -Be $employees[1].LastName
+        $results[1].LastName | Should -Be $employees[2].LastName
+        $results[2].LastName | Should -Be $employees[3].LastName
 
-		$results[0].YearsInMS | Should -Be $employees[1].YearsInMS
-		$results[1].YearsInMS | Should -Be $employees[2].YearsInMS
-		$results[2].YearsInMS | Should -Be $employees[3].YearsInMS
-	}
+        $results[0].YearsInMS | Should -Be $employees[1].YearsInMS
+        $results[1].YearsInMS | Should -Be $employees[2].YearsInMS
+        $results[2].YearsInMS | Should -Be $employees[3].YearsInMS
+    }
 
-	It "Select-Object with Simple should work"{
-		$employee1 = [pscustomobject]@{"FirstName"="joesph"; "LastName"="smith"; "YearsInMS"=15}
-		$employee2 = [pscustomobject]@{"FirstName"="paul"; "LastName"="smith"; "YearsInMS"=15}
-		$employee3 = [pscustomobject]@{"FirstName"="mary"; "LastName"="soe"; "YearsInMS"=15}
-		$employees3 = @($employee1,$employee2,$employee3,$employee4)
-		$results = $employees3 | Select-Object -Property "FirstName", "YearsInMS"
+    It "Select-Object with Simple should work" {
+        $employee1 = [pscustomobject]@{"FirstName" = "joesph"; "LastName" = "smith"; "YearsInMS" = 15 }
+        $employee2 = [pscustomobject]@{"FirstName" = "paul"; "LastName" = "smith"; "YearsInMS" = 15 }
+        $employee3 = [pscustomobject]@{"FirstName" = "mary"; "LastName" = "soe"; "YearsInMS" = 15 }
+        $employees3 = @($employee1, $employee2, $employee3, $employee4)
+        $results = $employees3 | Select-Object -Property "FirstName", "YearsInMS"
 
-		$results.Count | Should -Be 3
+        $results.Count | Should -Be 3
 
-		$results[0].FirstName | Should -Be $employees3[0].FirstName
-		$results[1].FirstName | Should -Be $employees3[1].FirstName
-		$results[2].FirstName | Should -Be $employees3[2].FirstName
+        $results[0].FirstName | Should -Be $employees3[0].FirstName
+        $results[1].FirstName | Should -Be $employees3[1].FirstName
+        $results[2].FirstName | Should -Be $employees3[2].FirstName
 
-		$results[0].YearsInMS | Should -Be $employees3[0].YearsInMS
-		$results[1].YearsInMS | Should -Be $employees3[1].YearsInMS
-		$results[2].YearsInMS | Should -Be $employees3[2].YearsInMS
-	}
+        $results[0].YearsInMS | Should -Be $employees3[0].YearsInMS
+        $results[1].YearsInMS | Should -Be $employees3[1].YearsInMS
+        $results[2].YearsInMS | Should -Be $employees3[2].YearsInMS
+    }
 
-	It "Select-Object with no input should work"{
-		$results = $null | Select-Object -Property "FirstName", "YearsInMS", "FirstNa*"
-		$results.Count | Should -Be 0
-	}
+    It "Select-Object with no input should work" {
+        $results = $null | Select-Object -Property "FirstName", "YearsInMS", "FirstNa*"
+        $results.Count | Should -Be 0
+    }
 
-	It "Select-Object with Start-Time In Idle Process should work" {
-		$results = Get-Process * | Select-Object ProcessName
-		$results.Count | Should -Not -Be 0
-	}
+    It "Select-Object with Start-Time In Idle Process should work" {
+        $results = Get-Process * | Select-Object ProcessName
+        $results.Count | Should -Not -Be 0
+    }
 
-	It "Select-Object with Skip should work"{
-		$results = "1","2","3" | Select-Object -Skip 1
-		$results.Count | Should -Be 2
-		$results[0] | Should -Be 2
-		$results[1] | Should -Be 3
-	}
+    It "Select-Object with Skip should work" {
+        $results = "1", "2", "3" | Select-Object -Skip 1
+        $results.Count | Should -Be 2
+        $results[0] | Should -Be 2
+        $results[1] | Should -Be 3
+    }
 
-	It "Select-Object with Index should work"{
-		$results = "1","2","3" | Select-Object -Index 2
-		$results.Count | Should -Be 1
-		$results[0] | Should -BeExactly "3"
-	}
+    It "Select-Object with Index should work" {
+        $results = "1", "2", "3" | Select-Object -Index 2
+        $results.Count | Should -Be 1
+        $results[0] | Should -BeExactly "3"
+    }
 
     It "Select-Object with SkipIndex should work" {
         $results = "1", "2", "3" | Select-Object -SkipIndex 0, 2
@@ -262,7 +259,7 @@ Describe "Select-Object DRT basic functionality" -Tags "CI" {
         $results -join ',' | Should -BeExactly "0,1,2,3,4,9,10"
     }
 
-    It "Select-Object should handle dynamic (DLR) properties"{
+    It "Select-Object should handle dynamic (DLR) properties" {
         $dynObj = [TestDynamic]::new()
         $results = $dynObj, $dynObj | Select-Object -ExpandProperty FooProp
         $results.Count | Should -Be 2
@@ -270,7 +267,7 @@ Describe "Select-Object DRT basic functionality" -Tags "CI" {
         $results[1] | Should -Be 123
     }
 
-    It "Select-Object should handle dynamic (DLR) properties without GetDynamicMemberNames hint"{
+    It "Select-Object should handle dynamic (DLR) properties without GetDynamicMemberNames hint" {
         $dynObj = [TestDynamic]::new()
         $results = $dynObj, $dynObj | Select-Object -ExpandProperty HiddenProp
         $results.Count | Should -Be 2
@@ -278,7 +275,7 @@ Describe "Select-Object DRT basic functionality" -Tags "CI" {
         $results[1] | Should -Be 789
     }
 
-    It "Select-Object should handle wildcarded dynamic (DLR) properties when hinted by GetDynamicMemberNames"{
+    It "Select-Object should handle wildcarded dynamic (DLR) properties when hinted by GetDynamicMemberNames" {
         $dynObj = [TestDynamic]::new()
         $results = $dynObj, $dynObj | Select-Object -ExpandProperty FooP*
         $results.Count | Should -Be 2
@@ -286,7 +283,7 @@ Describe "Select-Object DRT basic functionality" -Tags "CI" {
         $results[1] | Should -Be 123
     }
 
-    It "Select-Object should work when multiple dynamic (DLR) properties match"{
+    It "Select-Object should work when multiple dynamic (DLR) properties match" {
         $dynObj = [TestDynamic]::new()
         $results = $dynObj, $dynObj | Select-Object *Prop
         $results.Count | Should -Be 2
@@ -296,9 +293,9 @@ Describe "Select-Object DRT basic functionality" -Tags "CI" {
         $results[1].BarProp | Should -Be 456
     }
 
-    It "Select-Object -ExpandProperty should yield errors if multiple dynamic (DLR) properties match"{
+    It "Select-Object -ExpandProperty should yield errors if multiple dynamic (DLR) properties match" {
         $dynObj = [TestDynamic]::new()
-        $e = { $results = $dynObj, $dynObj | Select-Object -ExpandProperty *Prop -ErrorAction Stop} |
+        $e = { $results = $dynObj, $dynObj | Select-Object -ExpandProperty *Prop -ErrorAction Stop } |
             Should -Throw -PassThru -ErrorId "MutlipleExpandProperties,Microsoft.PowerShell.Commands.SelectObjectCommand"
         $e.CategoryInfo | Should -Match "PSArgumentException"
     }
@@ -306,49 +303,49 @@ Describe "Select-Object DRT basic functionality" -Tags "CI" {
 
 Describe "Select-Object with Property = '*'" -Tags "CI" {
 
-        # Issue #2420
-	It "Select-Object with implicit Property = '*' don't return property named '*'"{
-		$results = [pscustomobject]@{Thing="thing1"} | Select-Object -ExcludeProperty thing
-		$results.psobject.Properties.Item("*") | Should -BeNullOrEmpty
-	}
+    # Issue #2420
+    It "Select-Object with implicit Property = '*' don't return property named '*'" {
+        $results = [pscustomobject]@{Thing = "thing1" } | Select-Object -ExcludeProperty thing
+        $results.psobject.Properties.Item("*") | Should -BeNullOrEmpty
+    }
 
-        # Issue #2420
-	It "Select-Object with explicit Property = '*' don't return property named '*'"{
-		$results = [pscustomobject]@{Thing="thing1"} | Select-Object -Property * -ExcludeProperty thing
-		$results.psobject.Properties.Item("*") | Should -BeNullOrEmpty
-	}
+    # Issue #2420
+    It "Select-Object with explicit Property = '*' don't return property named '*'" {
+        $results = [pscustomobject]@{Thing = "thing1" } | Select-Object -Property * -ExcludeProperty thing
+        $results.psobject.Properties.Item("*") | Should -BeNullOrEmpty
+    }
 
-        # Issue #2351
-	It "Select-Object with implicit Property = '*' exclude single property"{
-		$results = [pscustomobject]@{Thing="thing1"} | Select-Object -ExcludeProperty thing
-		$results.psobject.Properties.Item("Thing") | Should -BeNullOrEmpty
-		$results.psobject.Properties.Item("*") | Should -BeNullOrEmpty
-	}
+    # Issue #2351
+    It "Select-Object with implicit Property = '*' exclude single property" {
+        $results = [pscustomobject]@{Thing = "thing1" } | Select-Object -ExcludeProperty thing
+        $results.psobject.Properties.Item("Thing") | Should -BeNullOrEmpty
+        $results.psobject.Properties.Item("*") | Should -BeNullOrEmpty
+    }
 
-        # Issue #2351
-	It "Select-Object with explicit Property = '*' exclude single property"{
-		$results = [pscustomobject]@{Thing="thing1"} | Select-Object -Property * -ExcludeProperty thing
-		$results.psobject.Properties.Item("Thing") | Should -BeNullOrEmpty
-		$results.psobject.Properties.Item("*") | Should -BeNullOrEmpty
-	}
+    # Issue #2351
+    It "Select-Object with explicit Property = '*' exclude single property" {
+        $results = [pscustomobject]@{Thing = "thing1" } | Select-Object -Property * -ExcludeProperty thing
+        $results.psobject.Properties.Item("Thing") | Should -BeNullOrEmpty
+        $results.psobject.Properties.Item("*") | Should -BeNullOrEmpty
+    }
 
-        # Issue #2351
-	It "Select-Object with implicit Property = '*' exclude not single property"{
-		$results = [pscustomobject]@{Thing="thing1";Param2="param2"} | Select-Object -ExcludeProperty Param2
-		$results.Param2 | Should -BeNullOrEmpty
-		$results.Thing | Should -BeExactly "thing1"
-	}
+    # Issue #2351
+    It "Select-Object with implicit Property = '*' exclude not single property" {
+        $results = [pscustomobject]@{Thing = "thing1"; Param2 = "param2" } | Select-Object -ExcludeProperty Param2
+        $results.Param2 | Should -BeNullOrEmpty
+        $results.Thing | Should -BeExactly "thing1"
+    }
 
-        # Issue #2351
-	It "Select-Object with explicit Property = '*' exclude not single property"{
-		$results = [pscustomobject]@{Thing="thing1";Param2="param2"} | Select-Object -Property * -ExcludeProperty Param2
-		$results.Param2 | Should -BeNullOrEmpty
-		$results.Thing | Should -BeExactly "thing1"
-	}
+    # Issue #2351
+    It "Select-Object with explicit Property = '*' exclude not single property" {
+        $results = [pscustomobject]@{Thing = "thing1"; Param2 = "param2" } | Select-Object -Property * -ExcludeProperty Param2
+        $results.Param2 | Should -BeNullOrEmpty
+        $results.Thing | Should -BeExactly "thing1"
+    }
 
     It "Select-Object with ExpandProperty and Property don't skip processing ExcludeProperty" {
-		$p = Get-Process -Id $PID | Select-Object -Property Process* -ExcludeProperty ProcessorAffinity -ExpandProperty Modules
-		$p[0].psobject.Properties.Item("ProcessorAffinity") | Should -BeNullOrEmpty
+        $p = Get-Process -Id $pid | Select-Object -Property Process* -ExcludeProperty ProcessorAffinity -ExpandProperty Modules
+        $p[0].psobject.Properties.Item("ProcessorAffinity") | Should -BeNullOrEmpty
     }
 
     It "Select-Object add 'Selected.*' type only once" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
@@ -6,127 +6,124 @@ Add-TestDynamicType
 
 Describe "Select-Object" -Tags "CI" {
     BeforeEach {
-	$dirObject  = GetFileMock
-	$TestLength = 3
+        $dirObject = GetFileMock
+        $TestLength = 3
     }
 
     It "Handle piped input without error" {
-	{ $dirObject | Select-Object } | Should -Not -Throw
+        { $dirObject | Select-Object } | Should -Not -Throw
     }
 
     It "Should treat input as a single object with the inputObject parameter" {
-        $result = $(Select-Object -inputObject $dirObject -last $TestLength).Length
+        $result = $(Select-Object -InputObject $dirObject -Last $TestLength).Length
         $expected = $dirObject.Length
-	{ $dirObject | select } | Should -Not -Throw
+        { $dirObject | Select-Object } | Should -Not -Throw
     }
 
     It "Should have same result when using alias" {
-	$result   = $dirObject | select
-	$expected = $dirObject | Select-Object
+        $result = $dirObject | Select-Object
+        $expected = $dirObject | Select-Object
 
-	$result | Should -Be $expected
+        $result | Should -Be $expected
     }
 
     It "Should return correct object with First parameter" {
-	$result = $dirObject | Select-Object -First $TestLength
+        $result = $dirObject | Select-Object -First $TestLength
 
-	$result.Length | Should -Be $TestLength
+        $result.Length | Should -Be $TestLength
 
-	for ($i=0; $i -lt $TestLength; $i++)
-	{
-	    $result[$i].Name | Should -Be $dirObject[$i].Name
-	}
+        for ($i = 0; $i -lt $TestLength; $i++) {
+            $result[$i].Name | Should -Be $dirObject[$i].Name
+        }
     }
 
     It "Should return correct object with Last parameter" {
-	$result = $dirObject | Select-Object -Last $TestLength
+        $result = $dirObject | Select-Object -Last $TestLength
 
-	$result.Length | Should -Be $TestLength
+        $result.Length | Should -Be $TestLength
 
-	for ($i=0; $i -lt $TestLength; $i++)
-	{
-	    $result[$i].Name | Should -Be $dirObject[$dirObject.Length - $TestLength + $i].Name
-	}
+        for ($i = 0; $i -lt $TestLength; $i++) {
+            $result[$i].Name | Should -Be $dirObject[$dirObject.Length - $TestLength + $i].Name
+        }
     }
 
     It "Should work correctly with Unique parameter" {
-	$result   = ("a","b","c","a","a","a" | Select-Object -Unique).Length
-	$expected = 3
+        $result = ("a", "b", "c", "a", "a", "a" | Select-Object -Unique).Length
+        $expected = 3
 
-	$result | Should -Be $expected
+        $result | Should -Be $expected
     }
 
     It "Should return correct object with Skip parameter" {
-	$result = $dirObject | Select-Object -Skip $TestLength
+        $result = $dirObject | Select-Object -Skip $TestLength
 
-	$result.Length       | Should -Be ($dirObject.Length - $TestLength)
+        $result.Length       | Should -Be ($dirObject.Length - $TestLength)
 
-	for ($i=0; $i -lt $TestLength; $i++)
-	{
-	    $result[$i].Name | Should -Be $dirObject[$TestLength + $i].Name
-	}
+        for ($i = 0; $i -lt $TestLength; $i++) {
+            $result[$i].Name | Should -Be $dirObject[$TestLength + $i].Name
+        }
     }
 
     It "Should return an object with selected columns" {
-	$result = $dirObject | Select-Object -Property Name, Size
+        $result = $dirObject | Select-Object -Property Name, Size
 
-	$result.Length  | Should -Be $dirObject.Length
-	$result[0].Name | Should -Be $dirObject[0].Name
-	$result[0].Size | Should -Be $dirObject[0].Size
-	$result[0].Mode | Should -BeNullOrEmpty
+        $result.Length  | Should -Be $dirObject.Length
+        $result[0].Name | Should -Be $dirObject[0].Name
+        $result[0].Size | Should -Be $dirObject[0].Size
+        $result[0].Mode | Should -BeNullOrEmpty
     }
 
     It "Should send output to pipe properly" {
-	{$dirObject | Select-Object -Unique | pipelineConsume} | Should -Not -Throw
+        { $dirObject | Select-Object -Unique | pipelineConsume } | Should -Not -Throw
     }
 
     It "Should select array indices with Index parameter" {
-	$firstIndex  = 2
-	$secondIndex = 4
-	$result      = $dirObject | Select-Object -Index $firstIndex, $secondIndex
+        $firstIndex = 2
+        $secondIndex = 4
+        $result = $dirObject | Select-Object -Index $firstIndex, $secondIndex
 
-	$result[0].Name | Should -Be $dirObject[$firstIndex].Name
-	$result[1].Name | Should -Be $dirObject[$secondIndex].Name
+        $result[0].Name | Should -Be $dirObject[$firstIndex].Name
+        $result[1].Name | Should -Be $dirObject[$secondIndex].Name
     }
 
     # Note that these two tests will modify original values of $dirObject
 
     It "Should not wait when used without -Wait option" {
-	$orig1  = $dirObject[0].Size
-	$orig2  = $dirObject[$TestLength].Size
-	$result = $dirObject | addOneToSizeProperty | Select-Object -First $TestLength
+        $orig1 = $dirObject[0].Size
+        $orig2 = $dirObject[$TestLength].Size
+        $result = $dirObject | addOneToSizeProperty | Select-Object -First $TestLength
 
-	$result[0].Size              | Should -Be ($orig1 + 1)
-	$dirObject[0].Size           | Should -Be ($orig1 + 1)
-	$dirObject[$TestLength].Size | Should -Be $orig2
+        $result[0].Size              | Should -Be ($orig1 + 1)
+        $dirObject[0].Size           | Should -Be ($orig1 + 1)
+        $dirObject[$TestLength].Size | Should -Be $orig2
     }
 
     It "Should wait when used with -Wait option" {
-	$orig1  = $dirObject[0].Size
-	$orig2  = $dirObject[$TestLength].Size
-	$result = $dirObject | addOneToSizeProperty | Select-Object -First $TestLength -Wait
+        $orig1 = $dirObject[0].Size
+        $orig2 = $dirObject[$TestLength].Size
+        $result = $dirObject | addOneToSizeProperty | Select-Object -First $TestLength -Wait
 
-	$result[0].Size              | Should -Be ($orig1 + 1)
-	$dirObject[0].Size           | Should -Be ($orig1 + 1)
-	$dirObject[$TestLength].Size | Should -Be ($orig2 + 1)
-	}
+        $result[0].Size              | Should -Be ($orig1 + 1)
+        $dirObject[0].Size           | Should -Be ($orig1 + 1)
+        $dirObject[$TestLength].Size | Should -Be ($orig2 + 1)
+    }
 
-	It "Should not leak 'StopUpstreamCommandsException' internal exception for stopping upstream" {
-		1,2 | Select-Object -First 1 -ErrorVariable err
-		$err | Should -BeNullOrEmpty
-	}
+    It "Should not leak 'StopUpstreamCommandsException' internal exception for stopping upstream" {
+        1, 2 | Select-Object -First 1 -ErrorVariable err
+        $err | Should -BeNullOrEmpty
+    }
 }
 
 Describe "Select-Object DRT basic functionality" -Tags "CI" {
-	BeforeAll {
-		$employees = [pscustomobject]@{"FirstName"="joseph"; "LastName"="smith"; "YearsInMS"=15},
-                            [pscustomobject]@{"FirstName"="paul"; "LastName"="smith"; "YearsInMS"=15},
-                            [pscustomobject]@{"FirstName"="mary"; "LastName"="soe"; "YearsInMS"=5},
-                            [pscustomobject]@{"FirstName"="edmund"; "LastName"="bush"; "YearsInMS"=9}
-	}
+    BeforeAll {
+        $employees = @(
+            [pscustomobject]@{"FirstName" = "joseph"; "LastName" = "smith"; "YearsInMS" = 15 }
+            [pscustomobject]@{"FirstName" = "paul"; "LastName" = "smith"; "YearsInMS" = 15 }
+            [pscustomobject]@{"FirstName" = "mary"; "LastName" = "soe"; "YearsInMS" = 5 }
+            [pscustomobject]@{"FirstName" = "edmund"; "LastName" = "bush"; "YearsInMS" = 9 }
+        )
+    }
 
-	It "Select-Object with empty script block property should throw"{
-		$e = { "bar" | Select-Object -Prop {} -ErrorAction Stop } |
     It "Select-Object with empty script block property should throw" {
         $e = { "bar" | Select-Object -Prop { } -ErrorAction Stop } |
             Should -Throw -ErrorId "EmptyScriptBlockAndNoName,Microsoft.PowerShell.Commands.SelectObjectCommand" -PassThru
@@ -137,100 +134,99 @@ Describe "Select-Object DRT basic functionality" -Tags "CI" {
         $result = "bar" | Select-Object -Prop foo | Measure-Object
         $result.Count | Should -Be 1
     }
-	}
 
-	It "Select-Object with Property First Last should work"{
-		$results = $employees | Select-Object -Property "YearsInMS", "L*" -First 2 -Last 1
+    It "Select-Object with Property First Last should work" {
+        $results = $employees | Select-Object -Property "YearsInMS", "L*" -First 2 -Last 1
 
-		$results.Count | Should -Be 3
+        $results.Count | Should -Be 3
 
-		$results[0].LastName | Should -Be $employees[0].LastName
-		$results[1].LastName | Should -Be $employees[1].LastName
-		$results[2].LastName | Should -Be $employees[3].LastName
+        $results[0].LastName | Should -Be $employees[0].LastName
+        $results[1].LastName | Should -Be $employees[1].LastName
+        $results[2].LastName | Should -Be $employees[3].LastName
 
-		$results[0].YearsInMS | Should -Be $employees[0].YearsInMS
-		$results[1].YearsInMS | Should -Be $employees[1].YearsInMS
-		$results[2].YearsInMS | Should -Be $employees[3].YearsInMS
-	}
+        $results[0].YearsInMS | Should -Be $employees[0].YearsInMS
+        $results[1].YearsInMS | Should -Be $employees[1].YearsInMS
+        $results[2].YearsInMS | Should -Be $employees[3].YearsInMS
+    }
 
-	It "Select-Object with Property First should work"{
-		$results = $employees | Select-Object -Property "YearsInMS", "L*" -First 2
+    It "Select-Object with Property First should work" {
+        $results = $employees | Select-Object -Property "YearsInMS", "L*" -First 2
 
-		$results.Count | Should -Be 2
+        $results.Count | Should -Be 2
 
-		$results[0].LastName | Should -Be $employees[0].LastName
-		$results[1].LastName | Should -Be $employees[1].LastName
+        $results[0].LastName | Should -Be $employees[0].LastName
+        $results[1].LastName | Should -Be $employees[1].LastName
 
-		$results[0].YearsInMS | Should -Be $employees[0].YearsInMS
-		$results[1].YearsInMS | Should -Be $employees[1].YearsInMS
-	}
+        $results[0].YearsInMS | Should -Be $employees[0].YearsInMS
+        $results[1].YearsInMS | Should -Be $employees[1].YearsInMS
+    }
 
-	It "Select-Object with Property First Zero should work"{
-		$results = $employees | Select-Object -Property "YearsInMS", "L*" -First 0
+    It "Select-Object with Property First Zero should work" {
+        $results = $employees | Select-Object -Property "YearsInMS", "L*" -First 0
 
-		$results.Count | Should -Be 0
-	}
+        $results.Count | Should -Be 0
+    }
 
-	It "Select-Object with Property Last Zero should work"{
-		$results = $employees | Select-Object -Property "YearsInMS", "L*" -Last 0
+    It "Select-Object with Property Last Zero should work" {
+        $results = $employees | Select-Object -Property "YearsInMS", "L*" -Last 0
 
-		$results.Count | Should -Be 0
-	}
+        $results.Count | Should -Be 0
+    }
 
-	It "Select-Object with Unique should work"{
-		$results = $employees | Select-Object -Property "YearsInMS", "L*" -Unique:$true
+    It "Select-Object with Unique should work" {
+        $results = $employees | Select-Object -Property "YearsInMS", "L*" -Unique:$true
 
-		$results.Count | Should -Be 3
+        $results.Count | Should -Be 3
 
-		$results[0].LastName | Should -Be $employees[1].LastName
-		$results[1].LastName | Should -Be $employees[2].LastName
-		$results[2].LastName | Should -Be $employees[3].LastName
+        $results[0].LastName | Should -Be $employees[1].LastName
+        $results[1].LastName | Should -Be $employees[2].LastName
+        $results[2].LastName | Should -Be $employees[3].LastName
 
-		$results[0].YearsInMS | Should -Be $employees[1].YearsInMS
-		$results[1].YearsInMS | Should -Be $employees[2].YearsInMS
-		$results[2].YearsInMS | Should -Be $employees[3].YearsInMS
-	}
+        $results[0].YearsInMS | Should -Be $employees[1].YearsInMS
+        $results[1].YearsInMS | Should -Be $employees[2].YearsInMS
+        $results[2].YearsInMS | Should -Be $employees[3].YearsInMS
+    }
 
-	It "Select-Object with Simple should work"{
-		$employee1 = [pscustomobject]@{"FirstName"="joesph"; "LastName"="smith"; "YearsInMS"=15}
-		$employee2 = [pscustomobject]@{"FirstName"="paul"; "LastName"="smith"; "YearsInMS"=15}
-		$employee3 = [pscustomobject]@{"FirstName"="mary"; "LastName"="soe"; "YearsInMS"=15}
-		$employees3 = @($employee1,$employee2,$employee3,$employee4)
-		$results = $employees3 | Select-Object -Property "FirstName", "YearsInMS"
+    It "Select-Object with Simple should work" {
+        $employee1 = [pscustomobject]@{"FirstName" = "joesph"; "LastName" = "smith"; "YearsInMS" = 15 }
+        $employee2 = [pscustomobject]@{"FirstName" = "paul"; "LastName" = "smith"; "YearsInMS" = 15 }
+        $employee3 = [pscustomobject]@{"FirstName" = "mary"; "LastName" = "soe"; "YearsInMS" = 15 }
+        $employees3 = @($employee1, $employee2, $employee3, $employee4)
+        $results = $employees3 | Select-Object -Property "FirstName", "YearsInMS"
 
-		$results.Count | Should -Be 3
+        $results.Count | Should -Be 3
 
-		$results[0].FirstName | Should -Be $employees3[0].FirstName
-		$results[1].FirstName | Should -Be $employees3[1].FirstName
-		$results[2].FirstName | Should -Be $employees3[2].FirstName
+        $results[0].FirstName | Should -Be $employees3[0].FirstName
+        $results[1].FirstName | Should -Be $employees3[1].FirstName
+        $results[2].FirstName | Should -Be $employees3[2].FirstName
 
-		$results[0].YearsInMS | Should -Be $employees3[0].YearsInMS
-		$results[1].YearsInMS | Should -Be $employees3[1].YearsInMS
-		$results[2].YearsInMS | Should -Be $employees3[2].YearsInMS
-	}
+        $results[0].YearsInMS | Should -Be $employees3[0].YearsInMS
+        $results[1].YearsInMS | Should -Be $employees3[1].YearsInMS
+        $results[2].YearsInMS | Should -Be $employees3[2].YearsInMS
+    }
 
-	It "Select-Object with no input should work"{
-		$results = $null | Select-Object -Property "FirstName", "YearsInMS", "FirstNa*"
-		$results.Count | Should -Be 0
-	}
+    It "Select-Object with no input should work" {
+        $results = $null | Select-Object -Property "FirstName", "YearsInMS", "FirstNa*"
+        $results.Count | Should -Be 0
+    }
 
-	It "Select-Object with Start-Time In Idle Process should work" {
-		$results = Get-Process * | Select-Object ProcessName
-		$results.Count | Should -Not -Be 0
-	}
+    It "Select-Object with Start-Time In Idle Process should work" {
+        $results = Get-Process * | Select-Object ProcessName
+        $results.Count | Should -Not -Be 0
+    }
 
-	It "Select-Object with Skip should work"{
-		$results = "1","2","3" | Select-Object -Skip 1
-		$results.Count | Should -Be 2
-		$results[0] | Should -Be 2
-		$results[1] | Should -Be 3
-	}
+    It "Select-Object with Skip should work" {
+        $results = "1", "2", "3" | Select-Object -Skip 1
+        $results.Count | Should -Be 2
+        $results[0] | Should -Be 2
+        $results[1] | Should -Be 3
+    }
 
-	It "Select-Object with Index should work"{
-		$results = "1","2","3" | Select-Object -Index 2
-		$results.Count | Should -Be 1
-		$results[0] | Should -BeExactly "3"
-	}
+    It "Select-Object with Index should work" {
+        $results = "1", "2", "3" | Select-Object -Index 2
+        $results.Count | Should -Be 1
+        $results[0] | Should -BeExactly "3"
+    }
 
     It "Select-Object with SkipIndex should work" {
         $results = "1", "2", "3" | Select-Object -SkipIndex 0, 2
@@ -244,7 +240,7 @@ Describe "Select-Object DRT basic functionality" -Tags "CI" {
         $results -join ',' | Should -BeExactly "0,1,2,3,4,9,10"
     }
 
-    It "Select-Object should handle dynamic (DLR) properties"{
+    It "Select-Object should handle dynamic (DLR) properties" {
         $dynObj = [TestDynamic]::new()
         $results = $dynObj, $dynObj | Select-Object -ExpandProperty FooProp
         $results.Count | Should -Be 2
@@ -252,7 +248,7 @@ Describe "Select-Object DRT basic functionality" -Tags "CI" {
         $results[1] | Should -Be 123
     }
 
-    It "Select-Object should handle dynamic (DLR) properties without GetDynamicMemberNames hint"{
+    It "Select-Object should handle dynamic (DLR) properties without GetDynamicMemberNames hint" {
         $dynObj = [TestDynamic]::new()
         $results = $dynObj, $dynObj | Select-Object -ExpandProperty HiddenProp
         $results.Count | Should -Be 2
@@ -260,7 +256,7 @@ Describe "Select-Object DRT basic functionality" -Tags "CI" {
         $results[1] | Should -Be 789
     }
 
-    It "Select-Object should handle wildcarded dynamic (DLR) properties when hinted by GetDynamicMemberNames"{
+    It "Select-Object should handle wildcarded dynamic (DLR) properties when hinted by GetDynamicMemberNames" {
         $dynObj = [TestDynamic]::new()
         $results = $dynObj, $dynObj | Select-Object -ExpandProperty FooP*
         $results.Count | Should -Be 2
@@ -268,7 +264,7 @@ Describe "Select-Object DRT basic functionality" -Tags "CI" {
         $results[1] | Should -Be 123
     }
 
-    It "Select-Object should work when multiple dynamic (DLR) properties match"{
+    It "Select-Object should work when multiple dynamic (DLR) properties match" {
         $dynObj = [TestDynamic]::new()
         $results = $dynObj, $dynObj | Select-Object *Prop
         $results.Count | Should -Be 2
@@ -278,9 +274,9 @@ Describe "Select-Object DRT basic functionality" -Tags "CI" {
         $results[1].BarProp | Should -Be 456
     }
 
-    It "Select-Object -ExpandProperty should yield errors if multiple dynamic (DLR) properties match"{
+    It "Select-Object -ExpandProperty should yield errors if multiple dynamic (DLR) properties match" {
         $dynObj = [TestDynamic]::new()
-        $e = { $results = $dynObj, $dynObj | Select-Object -ExpandProperty *Prop -ErrorAction Stop} |
+        $e = { $results = $dynObj, $dynObj | Select-Object -ExpandProperty *Prop -ErrorAction Stop } |
             Should -Throw -PassThru -ErrorId "MutlipleExpandProperties,Microsoft.PowerShell.Commands.SelectObjectCommand"
         $e.CategoryInfo | Should -Match "PSArgumentException"
     }
@@ -288,49 +284,49 @@ Describe "Select-Object DRT basic functionality" -Tags "CI" {
 
 Describe "Select-Object with Property = '*'" -Tags "CI" {
 
-        # Issue #2420
-	It "Select-Object with implicit Property = '*' don't return property named '*'"{
-		$results = [pscustomobject]@{Thing="thing1"} | Select-Object -ExcludeProperty thing
-		$results.psobject.Properties.Item("*") | Should -BeNullOrEmpty
-	}
+    # Issue #2420
+    It "Select-Object with implicit Property = '*' don't return property named '*'" {
+        $results = [pscustomobject]@{Thing = "thing1" } | Select-Object -ExcludeProperty thing
+        $results.psobject.Properties.Item("*") | Should -BeNullOrEmpty
+    }
 
-        # Issue #2420
-	It "Select-Object with explicit Property = '*' don't return property named '*'"{
-		$results = [pscustomobject]@{Thing="thing1"} | Select-Object -Property * -ExcludeProperty thing
-		$results.psobject.Properties.Item("*") | Should -BeNullOrEmpty
-	}
+    # Issue #2420
+    It "Select-Object with explicit Property = '*' don't return property named '*'" {
+        $results = [pscustomobject]@{Thing = "thing1" } | Select-Object -Property * -ExcludeProperty thing
+        $results.psobject.Properties.Item("*") | Should -BeNullOrEmpty
+    }
 
-        # Issue #2351
-	It "Select-Object with implicit Property = '*' exclude single property"{
-		$results = [pscustomobject]@{Thing="thing1"} | Select-Object -ExcludeProperty thing
-		$results.psobject.Properties.Item("Thing") | Should -BeNullOrEmpty
-		$results.psobject.Properties.Item("*") | Should -BeNullOrEmpty
-	}
+    # Issue #2351
+    It "Select-Object with implicit Property = '*' exclude single property" {
+        $results = [pscustomobject]@{Thing = "thing1" } | Select-Object -ExcludeProperty thing
+        $results.psobject.Properties.Item("Thing") | Should -BeNullOrEmpty
+        $results.psobject.Properties.Item("*") | Should -BeNullOrEmpty
+    }
 
-        # Issue #2351
-	It "Select-Object with explicit Property = '*' exclude single property"{
-		$results = [pscustomobject]@{Thing="thing1"} | Select-Object -Property * -ExcludeProperty thing
-		$results.psobject.Properties.Item("Thing") | Should -BeNullOrEmpty
-		$results.psobject.Properties.Item("*") | Should -BeNullOrEmpty
-	}
+    # Issue #2351
+    It "Select-Object with explicit Property = '*' exclude single property" {
+        $results = [pscustomobject]@{Thing = "thing1" } | Select-Object -Property * -ExcludeProperty thing
+        $results.psobject.Properties.Item("Thing") | Should -BeNullOrEmpty
+        $results.psobject.Properties.Item("*") | Should -BeNullOrEmpty
+    }
 
-        # Issue #2351
-	It "Select-Object with implicit Property = '*' exclude not single property"{
-		$results = [pscustomobject]@{Thing="thing1";Param2="param2"} | Select-Object -ExcludeProperty Param2
-		$results.Param2 | Should -BeNullOrEmpty
-		$results.Thing | Should -BeExactly "thing1"
-	}
+    # Issue #2351
+    It "Select-Object with implicit Property = '*' exclude not single property" {
+        $results = [pscustomobject]@{Thing = "thing1"; Param2 = "param2" } | Select-Object -ExcludeProperty Param2
+        $results.Param2 | Should -BeNullOrEmpty
+        $results.Thing | Should -BeExactly "thing1"
+    }
 
-        # Issue #2351
-	It "Select-Object with explicit Property = '*' exclude not single property"{
-		$results = [pscustomobject]@{Thing="thing1";Param2="param2"} | Select-Object -Property * -ExcludeProperty Param2
-		$results.Param2 | Should -BeNullOrEmpty
-		$results.Thing | Should -BeExactly "thing1"
-	}
+    # Issue #2351
+    It "Select-Object with explicit Property = '*' exclude not single property" {
+        $results = [pscustomobject]@{Thing = "thing1"; Param2 = "param2" } | Select-Object -Property * -ExcludeProperty Param2
+        $results.Param2 | Should -BeNullOrEmpty
+        $results.Thing | Should -BeExactly "thing1"
+    }
 
     It "Select-Object with ExpandProperty and Property don't skip processing ExcludeProperty" {
-		$p = Get-Process -Id $PID | Select-Object -Property Process* -ExcludeProperty ProcessorAffinity -ExpandProperty Modules
-		$p[0].psobject.Properties.Item("ProcessorAffinity") | Should -BeNullOrEmpty
+        $p = Get-Process -Id $PID | Select-Object -Property Process* -ExcludeProperty ProcessorAffinity -ExpandProperty Modules
+        $p[0].psobject.Properties.Item("ProcessorAffinity") | Should -BeNullOrEmpty
     }
 
     It "Select-Object add 'Selected.*' type only once" {
@@ -346,26 +342,6 @@ Describe "Select-Object with Property = '*'" -Tags "CI" {
         $obj.psobject.TypeNames[1] | Should -Not -BeLike "Selected*"
         $p = Get-Process -Id $pid | Select-Object -Property Process* -ExcludeProperty ProcessorAffinity -ExpandProperty Modules
         $p[0].psobject.Properties.Item("ProcessorAffinity") | Should -BeNullOrEmpty
-        $obj.psobject.TypeNames[2] | Should -Not -BeLike "Selected*"
-    }
-}
-        $obj = [PSCustomObject]@{ Name = 1 }
-
-        $obj.psobject.TypeNames.Count | Should -Be 2
-        $obj.psobject.TypeNames | Should -Not -BeLike "Selected*"
-
-        $obj = $obj | Select-Object
-
-        $obj.psobject.TypeNames.Count | Should -Be 3
-        $obj.psobject.TypeNames[0] | Should -BeLike "Selected*"
-        $obj.psobject.TypeNames[1] | Should -Not -BeLike "Selected*"
-        $obj.psobject.TypeNames[2] | Should -Not -BeLike "Selected*"
-
-        $obj = $obj | Select-Object
-
-        $obj.psobject.TypeNames.Count | Should -Be 3
-        $obj.psobject.TypeNames[0] | Should -BeLike "Selected*"
-        $obj.psobject.TypeNames[1] | Should -Not -BeLike "Selected*"
         $obj.psobject.TypeNames[2] | Should -Not -BeLike "Selected*"
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Prior to this PR, a hashtable piped into `Select-Object -[Expand]Property Keys` where the user expected `Keys` to retrieve the _property value_ from the hashtable rather than the _dictionary entry_ would return no value (in the case of -ExpandProperty, an error would be emitted, stating that the property could not be found).

This PR fixes this issue, and examines hashtable members as well as their key/value entries. The logic is designed such that hashtable key/values are still prioritised over hashtable members, so if a user creates a hashtable such as `@{ Keys = "None" }` and then selects the `Keys` property via Select-Object, it will have the same result as using `$ht.Keys` already does: the returned value will always prioritise an actual key/value entry over the hashtable members.

Note that this means creating a hashtable with a key named `Keys` will prevent access to the `Keys` member on the hashtable in this manner. This new behaviour is consistent with existing behaviour with retrieval of hashtable keys, and also consistent with dot-property access behaviour with hashtables -- you can access `$ht.Keys` up until you add a key with the name `Keys`, at which point you will always get that key value back.

Tests have been added to cover these cases explicitly.

## PR Context

Users should be able to utilise hashtables as actual hashtable objects as well as pseudo-PSObjects where appropriate. It is disingenuous for these commands to pretend hashtables don't have other members which may be desired in some circumstances.

This PR fixes #11094 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [x] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
