### PR TITLE
Update SUPPORT.md to make the new-issues link present the issue-type templates rather than an empty form.

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -10,4 +10,4 @@ If you know how to fix the issue, feel free to send a pull request our way. (The
 [Contribution Guides]: https://github.com/PowerShell/PowerShell/tree/master/.github/CONTRIBUTING.md
 [known issues]: https://docs.microsoft.com/powershell/scripting/whats-new/known-issues-ps6?view=powershell-6
 [GitHub issues]: https://github.com/PowerShell/PowerShell/issues
-[new issue]: https://github.com/PowerShell/PowerShell/issues/new
+[new issue]: https://github.com/PowerShell/PowerShell/issues/new/choose


### PR DESCRIPTION
New-issue link changed from a blank form to the intermediate issue-type-template selection change.

# PR Summary

New-issue link changed from a blank form to the intermediate issue-type-template selection change.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
