### PR TITLE
Update Get-Error to not modify the original $Error object

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Get-Error.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Get-Error.cs
@@ -77,7 +77,7 @@ namespace Microsoft.PowerShell.Commands
 
             foreach (object errorRecord in errorRecords)
             {
-                PSObject obj = PSObject.AsPSObject(errorRecord, storeTypeNameAndInstanceMembersLocally: true);
+                var obj = PSObject.AsPSObject(errorRecord, storeTypeNameAndInstanceMembersLocally: true);
 
                 if (obj.TypeNames.Contains("System.Management.Automation.ErrorRecord"))
                 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Get-Error.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Get-Error.cs
@@ -77,7 +77,7 @@ namespace Microsoft.PowerShell.Commands
 
             foreach (object errorRecord in errorRecords)
             {
-                PSObject obj = PSObject.AsPSObject(errorRecord);
+                PSObject obj = PSObject.AsPSObject(errorRecord, storeTypeNameAndInstanceMembersLocally: true);
 
                 if (obj.TypeNames.Contains("System.Management.Automation.ErrorRecord"))
                 {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
@@ -108,4 +108,16 @@ Describe 'Get-Error tests' -Tag CI {
         $err.PSObject.TypeNames | Should -Contain 'System.Exception'
         $err.PSObject.TypeNames | Should -Not -Contain 'System.Exception#PSExtendedError'
     }
+
+    It 'Get-Error will not modify the original error object' {
+        try {
+            1 / 0
+        }
+        catch {
+        }
+
+        $null = Get-Error
+
+        $Error[0].pstypenames | Should -Be System.Management.Automation.ErrorRecord, System.Object
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

`Get-Error` currently modifies the original $Error object specifically the pstypenames.  Fix is to use an overload when constructing the PSObject to copy it.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/11122

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
