### PR TITLE
Make update notification support LTS and default channels

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/UpdatesNotification.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/UpdatesNotification.cs
@@ -21,6 +21,9 @@ namespace Microsoft.PowerShell
     internal static class UpdatesNotification
     {
         private const string UpdateCheckEnvVar = "POWERSHELL_UPDATECHECK";
+        private const string LTSBuildInfoURL = "https://pscoretestdata.blob.core.windows.net/buildinfo/lts.json";
+        private const string StableBuildInfoURL = "https://pscoretestdata.blob.core.windows.net/buildinfo/stable.json";
+        private const string PreviewBuildInfoURL = "https://pscoretestdata.blob.core.windows.net/buildinfo/preview.json";
 
         private static readonly string s_cacheDirectory;
         private static readonly string s_sentinelFileName;
@@ -209,8 +212,8 @@ namespace Microsoft.PowerShell
                     // Do the real update check:
                     //  - Send HTTP request to query for the new release/pre-release;
                     //  - If there is a valid new release that should be reported to the user,
-                    //    create the file `<NotificationType>Update_<tag>_<publish-date>` when no `update` file exists,
-                    //    or rename the existing file to `<NotificationType>Update_<new-version>_<new-publish-date>`.
+                    //    create the file `update<NotificationType>_<tag>_<publish-date>` when no `update` file exists,
+                    //    or rename the existing file to `update<NotificationType>_<new-version>_<new-publish-date>`.
                     SemanticVersion baselineVersion = lastUpdateVersion ?? PSVersionInfo.PSCurrentVersion;
                     Release release = await QueryNewReleaseAsync(baselineVersion);
 
@@ -325,10 +328,10 @@ namespace Microsoft.PowerShell
             bool isStableRelease = string.IsNullOrEmpty(PSVersionInfo.PSCurrentVersion.PreReleaseLabel);
             string[] queryUris = s_notificationType switch
             {
-                NotificationType.LTS => new[] { "https://pscoretestdata.blob.core.windows.net/buildinfo/lts.json" },
+                NotificationType.LTS => new[] { LTSBuildInfoURL },
                 NotificationType.Default => isStableRelease
-                    ? new[] { "https://pscoretestdata.blob.core.windows.net/buildinfo/stable.json" }
-                    : new[] { "https://pscoretestdata.blob.core.windows.net/buildinfo/stable.json", "https://pscoretestdata.blob.core.windows.net/buildinfo/preview.json" },
+                    ? new[] { StableBuildInfoURL }
+                    : new[] { StableBuildInfoURL, PreviewBuildInfoURL },
                 _ => Array.Empty<string>()
             };
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/UpdatesNotification.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/UpdatesNotification.cs
@@ -18,6 +18,9 @@ namespace Microsoft.PowerShell
     /// <summary>
     /// A Helper class for printing notification on PowerShell startup when there is a new update.
     /// </summary>
+    /// <remarks>
+    /// For the detailed design, please take a look at the corresponding RFC.
+    /// </remarks>
     internal static class UpdatesNotification
     {
         private const string UpdateCheckEnvVar = "POWERSHELL_UPDATECHECK";
@@ -25,12 +28,24 @@ namespace Microsoft.PowerShell
         private const string StableBuildInfoURL = "https://pscoretestdata.blob.core.windows.net/buildinfo/stable.json";
         private const string PreviewBuildInfoURL = "https://pscoretestdata.blob.core.windows.net/buildinfo/preview.json";
 
+        /// <summary>
+        /// The version of new update is persisted using a file, not as the file content, but instead baked in the file name in the following template:
+        ///  `update{notification-type}_{version}_{publish-date}` -- held by 's_updateFileNameTemplate',
+        /// while 's_updateFileNamePattern' holds the pattern of this file name.
+        /// </summary>
+        private static readonly string s_updateFileNameTemplate, s_updateFileNamePattern;
+
+        /// <summary>
+        /// For each notification type, we need two files to achieve the synchronization for the update check:
+        ///  `_sentinel{notification-type}_` -- held by 's_sentinelFileName';
+        ///  `sentinel{notification-type}-{year}-{month}-{day}.done`
+        ///     -- held by 's_doneFileNameTemplate', while 's_doneFileNamePattern' holds the pattern of this file name.
+        /// The {notification-type} part will be the integer value of the corresponding `NotificationType` member.
+        /// The {year}-{month}-{day} part will be filled with the date of current day when the update check runs.
+        /// </summary>
+        private static readonly string s_sentinelFileName, s_doneFileNameTemplate, s_doneFileNamePattern;
+
         private static readonly string s_cacheDirectory;
-        private static readonly string s_sentinelFileName;
-        private static readonly string s_doneFileNameTemplate;
-        private static readonly string s_doneFileNamePattern;
-        private static readonly string s_updateFileNameTemplate;
-        private static readonly string s_updateFileNamePattern;
         private static readonly EnumerationOptions s_enumOptions;
         private static readonly NotificationType s_notificationType;
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/UpdatesNotification.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/UpdatesNotification.cs
@@ -24,9 +24,9 @@ namespace Microsoft.PowerShell
     internal static class UpdatesNotification
     {
         private const string UpdateCheckEnvVar = "POWERSHELL_UPDATECHECK";
-        private const string LTSBuildInfoURL = "https://pscoretestdata.blob.core.windows.net/buildinfo/lts.json";
-        private const string StableBuildInfoURL = "https://pscoretestdata.blob.core.windows.net/buildinfo/stable.json";
-        private const string PreviewBuildInfoURL = "https://pscoretestdata.blob.core.windows.net/buildinfo/preview.json";
+        private const string LTSBuildInfoURL = "https://aka.ms/pwsh-buildinfo-lts";
+        private const string StableBuildInfoURL = "https://aka.ms/pwsh-buildinfo-stable";
+        private const string PreviewBuildInfoURL = "https://aka.ms/pwsh-buildinfo-preview";
 
         /// <summary>
         /// The version of new update is persisted using a file, not as the file content, but instead baked in the file name in the following template:

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/UpdatesNotification.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/UpdatesNotification.cs
@@ -20,24 +20,41 @@ namespace Microsoft.PowerShell
     /// </summary>
     internal static class UpdatesNotification
     {
-        private const string UpdateCheckOptOutEnvVar = "POWERSHELL_UPDATECHECK_OPTOUT";
-        private const string Last3ReleasesUri = "https://api.github.com/repos/PowerShell/PowerShell/releases?per_page=3";
-        private const string LatestReleaseUri = "https://api.github.com/repos/PowerShell/PowerShell/releases/latest";
+        private const string UpdateCheckEnvVar = "POWERSHELL_UPDATECHECK";
 
-        private const string SentinelFileName = "_sentinel_";
-        private const string DoneFileNameTemplate = "sentinel-{0}-{1}-{2}.done";
-        private const string DoneFileNamePattern = "sentinel-*.done";
-        private const string UpdateFileNameTemplate = "update_{0}_{1}";
-        private const string UpdateFileNamePattern = "update_v*.*.*_????-??-??";
-
-        private static readonly EnumerationOptions s_enumOptions = new EnumerationOptions();
-        private static readonly string s_cacheDirectory = Path.Combine(Platform.CacheDirectory, PSVersionInfo.GitCommitId);
+        private static readonly string s_cacheDirectory;
+        private static readonly string s_sentinelFileName;
+        private static readonly string s_doneFileNameTemplate;
+        private static readonly string s_doneFileNamePattern;
+        private static readonly string s_updateFileNameTemplate;
+        private static readonly string s_updateFileNamePattern;
+        private static readonly EnumerationOptions s_enumOptions;
+        private static readonly NotificationType s_notificationType;
 
         /// <summary>
         /// Gets a value indicating whether update notification should be done.
         /// </summary>
-        internal static readonly bool CanNotifyUpdates = !Utils.GetOptOutEnvVariableAsBool(UpdateCheckOptOutEnvVar, defaultValue: false)
-            && ExperimentalFeature.IsEnabled("PSUpdatesNotification");
+        internal static readonly bool CanNotifyUpdates;
+
+        static UpdatesNotification()
+        {
+            s_notificationType = GetNotificationType();
+            CanNotifyUpdates = s_notificationType != NotificationType.Off && ExperimentalFeature.IsEnabled("PSUpdatesNotification");
+
+            if (CanNotifyUpdates)
+            {
+                s_enumOptions = new EnumerationOptions();
+                s_cacheDirectory = Path.Combine(Platform.CacheDirectory, PSVersionInfo.GitCommitId);
+
+                // Build the template/pattern strings for the configured notification type.
+                string typeNum = ((int)s_notificationType).ToString();
+                s_sentinelFileName = $"_sentinel{typeNum}_";
+                s_doneFileNameTemplate = $"sentinel{typeNum}-{{0}}-{{1}}-{{2}}.done";
+                s_doneFileNamePattern = $"sentinel{typeNum}-*.done";
+                s_updateFileNameTemplate = $"update{typeNum}_{{0}}_{{1}}";
+                s_updateFileNamePattern = $"update{typeNum}_v*.*.*_????-??-??";
+            }
+        }
 
         // Maybe we shouldn't do update check and show notification when it's from a mini-shell, meaning when
         // 'ConsoleShell.Start' is not called by 'ManagedEntrance.Start'.
@@ -58,9 +75,11 @@ namespace Microsoft.PowerShell
                && lastUpdateVersion != null)
             {
                 string releaseTag = lastUpdateVersion.ToString();
-                string notificationMsgTemplate = string.IsNullOrEmpty(lastUpdateVersion.PreReleaseLabel)
-                    ? ManagedEntranceStrings.StableUpdateNotificationMessage
-                    : ManagedEntranceStrings.PreviewUpdateNotificationMessage;
+                string notificationMsgTemplate = s_notificationType == NotificationType.LTS
+                    ? ManagedEntranceStrings.LTSUpdateNotificationMessage
+                    : string.IsNullOrEmpty(lastUpdateVersion.PreReleaseLabel)
+                        ? ManagedEntranceStrings.StableUpdateNotificationMessage
+                        : ManagedEntranceStrings.PreviewUpdateNotificationMessage;
 
                 string notificationColor = string.Empty;
                 string resetColor = string.Empty;
@@ -141,7 +160,7 @@ namespace Microsoft.PowerShell
             // Construct the sentinel file paths for today's check.
             string todayDoneFileName = string.Format(
                 CultureInfo.InvariantCulture,
-                DoneFileNameTemplate,
+                s_doneFileNameTemplate,
                 today.Year.ToString(),
                 today.Month.ToString(),
                 today.Day.ToString());
@@ -156,9 +175,9 @@ namespace Microsoft.PowerShell
 
             try
             {
-                // Use 'sentinelFilePath' as the file lock.
+                // Use 's_sentinelFileName' as the file lock.
                 // The update-check tasks started by every 'pwsh' process of the same version will compete on holding this file.
-                string sentinelFilePath = Path.Combine(s_cacheDirectory, SentinelFileName);
+                string sentinelFilePath = Path.Combine(s_cacheDirectory, s_sentinelFileName);
                 using (new FileStream(sentinelFilePath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None, bufferSize: 1, FileOptions.DeleteOnClose))
                 {
                     if (File.Exists(todayDoneFilePath))
@@ -170,7 +189,7 @@ namespace Microsoft.PowerShell
 
                     // Now it's guaranteed that this is the only process that reaches here.
                     // Clean up the old '.done' file, there should be only one of it.
-                    foreach (string oldFile in Directory.EnumerateFiles(s_cacheDirectory, DoneFileNamePattern, s_enumOptions))
+                    foreach (string oldFile in Directory.EnumerateFiles(s_cacheDirectory, s_doneFileNamePattern, s_enumOptions))
                     {
                         File.Delete(oldFile);
                     }
@@ -180,8 +199,8 @@ namespace Microsoft.PowerShell
                         // The update file is corrupted, either because more than one update files were found unexpectedly,
                         // or because the update file name failed to be parsed into a release version and a publish date.
                         // This is **very unlikely** to happen unless the file is accidentally altered manually.
-                        // We try to recover here by cleaning up all update files.
-                        foreach (string file in Directory.EnumerateFiles(s_cacheDirectory, UpdateFileNamePattern, s_enumOptions))
+                        // We try to recover here by cleaning up all update files for the configured notification type.
+                        foreach (string file in Directory.EnumerateFiles(s_cacheDirectory, s_updateFileNamePattern, s_enumOptions))
                         {
                             File.Delete(file);
                         }
@@ -190,8 +209,8 @@ namespace Microsoft.PowerShell
                     // Do the real update check:
                     //  - Send HTTP request to query for the new release/pre-release;
                     //  - If there is a valid new release that should be reported to the user,
-                    //    create the file `update_<tag>_<publish-date>` when no `update` file exists,
-                    //    or rename the existing file to `update_<new-version>_<new-publish-date>`.
+                    //    create the file `<NotificationType>Update_<tag>_<publish-date>` when no `update` file exists,
+                    //    or rename the existing file to `<NotificationType>Update_<new-version>_<new-publish-date>`.
                     SemanticVersion baselineVersion = lastUpdateVersion ?? PSVersionInfo.PSCurrentVersion;
                     Release release = await QueryNewReleaseAsync(baselineVersion);
 
@@ -201,7 +220,7 @@ namespace Microsoft.PowerShell
                         const int dateLength = 10;
                         string newUpdateFileName = string.Format(
                             CultureInfo.InvariantCulture,
-                            UpdateFileNameTemplate,
+                            s_updateFileNameTemplate,
                             release.TagName,
                             release.PublishAt.Substring(0, dateLength));
 
@@ -254,7 +273,7 @@ namespace Microsoft.PowerShell
             lastUpdateVersion = null;
             lastUpdateDate = default;
 
-            var files = Directory.EnumerateFiles(s_cacheDirectory, UpdateFileNamePattern, s_enumOptions);
+            var files = Directory.EnumerateFiles(s_cacheDirectory, s_updateFileNamePattern, s_enumOptions);
             var enumerator = files.GetEnumerator();
 
             if (!enumerator.MoveNext())
@@ -272,7 +291,7 @@ namespace Microsoft.PowerShell
                 return false;
             }
 
-            // OK, only found one update file, which is expected.
+            // OK, only found one update file for the configured notification type, which is expected.
             // Now let's parse the file name.
             string updateFileName = Path.GetFileName(updateFilePath);
             int dateStartIndex = updateFileName.LastIndexOf('_') + 1;
@@ -304,7 +323,14 @@ namespace Microsoft.PowerShell
         private static async Task<Release> QueryNewReleaseAsync(SemanticVersion baselineVersion)
         {
             bool isStableRelease = string.IsNullOrEmpty(PSVersionInfo.PSCurrentVersion.PreReleaseLabel);
-            string queryUri = isStableRelease ? LatestReleaseUri : Last3ReleasesUri;
+            string[] queryUris = s_notificationType switch
+            {
+                NotificationType.LTS => new[] { "https://pscoretestdata.blob.core.windows.net/buildinfo/lts.json" },
+                NotificationType.Default => isStableRelease
+                    ? new[] { "https://pscoretestdata.blob.core.windows.net/buildinfo/stable.json" }
+                    : new[] { "https://pscoretestdata.blob.core.windows.net/buildinfo/stable.json", "https://pscoretestdata.blob.core.windows.net/buildinfo/preview.json" },
+                _ => Array.Empty<string>()
+            };
 
             using var client = new HttpClient();
 
@@ -312,52 +338,76 @@ namespace Microsoft.PowerShell
             client.DefaultRequestHeaders.Add("User-Agent", userAgent);
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
-            // Query the GitHub Rest API and throw if the query fails.
-            HttpResponseMessage response = await client.GetAsync(queryUri);
-            response.EnsureSuccessStatusCode();
-
-            using var stream = await response.Content.ReadAsStreamAsync();
-            using var reader = new StreamReader(stream);
-            using var jsonReader = new JsonTextReader(reader);
-
             Release releaseToReturn = null;
+            SemanticVersion highestVersion = baselineVersion;
             var settings = new JsonSerializerSettings() { DateParseHandling = DateParseHandling.None };
             var serializer = JsonSerializer.Create(settings);
 
-            if (isStableRelease)
+            foreach (string queryUri in queryUris)
             {
+                // Query the GitHub Rest API and throw if the query fails.
+                HttpResponseMessage response = await client.GetAsync(queryUri);
+                response.EnsureSuccessStatusCode();
+
+                using var stream = await response.Content.ReadAsStreamAsync();
+                using var reader = new StreamReader(stream);
+                using var jsonReader = new JsonTextReader(reader);
+
                 JObject release = serializer.Deserialize<JObject>(jsonReader);
-                var tagName = release["tag_name"].ToString();
-                var version = SemanticVersion.Parse(tagName.Substring(1));
-
-                if (version > baselineVersion)
-                {
-                    var publishAt = release["published_at"].ToString();
-                    releaseToReturn = new Release(publishAt, tagName);
-                }
-
-                return releaseToReturn;
-            }
-
-            // The current 'pwsh' is a preview release.
-            JArray last3Releases = serializer.Deserialize<JArray>(jsonReader);
-            SemanticVersion highestVersion = baselineVersion;
-
-            for (int i = 0; i < last3Releases.Count; i++)
-            {
-                JToken release = last3Releases[i];
-                var tagName = release["tag_name"].ToString();
+                var tagName = release["ReleaseTag"].ToString();
                 var version = SemanticVersion.Parse(tagName.Substring(1));
 
                 if (version > highestVersion)
                 {
                     highestVersion = version;
-                    var publishAt = release["published_at"].ToString();
+                    var publishAt = release["ReleaseDate"].ToString();
                     releaseToReturn = new Release(publishAt, tagName);
                 }
             }
 
             return releaseToReturn;
+        }
+
+        /// <summary>
+        /// Get the notification type setting.
+        /// </summary>
+        private static NotificationType GetNotificationType()
+        {
+            string str = Environment.GetEnvironmentVariable(UpdateCheckEnvVar);
+            if (string.IsNullOrEmpty(str))
+            {
+                return NotificationType.Default;
+            }
+
+            if (Enum.TryParse(str, ignoreCase: true, out NotificationType type))
+            {
+                return type;
+            }
+
+            return NotificationType.Default;
+        }
+
+        /// <summary>
+        /// Notification type that can be configured.
+        /// </summary>
+        private enum NotificationType
+        {
+            /// <summary>
+            /// Turn off the udpate notification.
+            /// </summary>
+            Off = 0,
+
+            /// <summary>
+            /// Give you the default behaviors:
+            ///  - the preview version 'pwsh' checks for the new preview version and the new GA version.
+            ///  - the GA version 'pwsh' checks for the new GA version only.
+            /// </summary>
+            Default = 1,
+
+            /// <summary>
+            /// Both preview and GA version 'pwsh' checks for the new LTS version only.
+            /// </summary>
+            LTS = 2
         }
 
         private class Release

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -139,6 +139,12 @@ Type 'help' to get help.</value>
   {1}   https://aka.ms/PowerShell-Release?tag=v{0} {4}{2}
 </value>
   </data>
+  <data name="LTSUpdateNotificationMessage" xml:space="preserve">
+    <value>  {1} A new PowerShell LTS release is available: v{0} {2}
+  {1} Upgrade now, or check out the release page at:{3}{2}
+  {1}   https://aka.ms/PowerShell-Release?tag=v{0} {4}{2}
+</value>
+  </data>
   <data name="UsageHelp" xml:space="preserve">
     <value>Usage: pwsh[.exe] [-Login] [[-File] &lt;filePath&gt; [args]]
                   [-Command { - | &lt;script-block&gt; [-args &lt;arg-array&gt;]

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -304,36 +304,6 @@ namespace System.Management.Automation
         internal static string[] AllowedEditionValues = { "Desktop", "Core" };
 
         /// <summary>
-        /// Utility method to interpret the value of an opt-out environment variable.
-        /// e.g. POWERSHELL_TELEMETRY_OPTOUT and POWERSHELL_UPDATECHECK_OPTOUT.
-        /// </summary>
-        /// <param name="name">The name of the environment variable.</param>
-        /// <param name="defaultValue">If the environment variable is not set, use this as the default value.</param>
-        /// <returns>A boolean representing the value of the environment variable.</returns>
-        internal static bool GetOptOutEnvVariableAsBool(string name, bool defaultValue)
-        {
-            string str = Environment.GetEnvironmentVariable(name);
-            if (string.IsNullOrEmpty(str))
-            {
-                return defaultValue;
-            }
-
-            switch (str.ToLowerInvariant())
-            {
-                case "true":
-                case "1":
-                case "yes":
-                    return true;
-                case "false":
-                case "0":
-                case "no":
-                    return false;
-                default:
-                    return defaultValue;
-            }
-        }
-
-        /// <summary>
         /// Helper fn to check byte[] arg for null.
         /// </summary>
         ///<param name="arg"> arg to check </param>

--- a/src/System.Management.Automation/utils/Telemetry.cs
+++ b/src/System.Management.Automation/utils/Telemetry.cs
@@ -105,7 +105,7 @@ namespace Microsoft.PowerShell.Telemetry
         static ApplicationInsightsTelemetry()
         {
             // If we can't send telemetry, there's no reason to do any of this
-            CanSendTelemetry = !Utils.GetOptOutEnvVariableAsBool(name: _telemetryOptoutEnvVar, defaultValue: false);
+            CanSendTelemetry = !GetEnvironmentVariableAsBool(name: _telemetryOptoutEnvVar, defaultValue: false);
             if (CanSendTelemetry)
             {
                 TelemetryConfiguration configuration = TelemetryConfiguration.CreateDefault();
@@ -134,6 +134,35 @@ namespace Microsoft.PowerShell.Telemetry
                     };
 
                 s_uniqueUserIdentifier = GetUniqueIdentifier().ToString();
+            }
+        }
+
+        /// <summary>
+        /// Determine whether the environment variable is set and how.
+        /// </summary>
+        /// <param name="name">The name of the environment variable.</param>
+        /// <param name="defaultValue">If the environment variable is not set, use this as the default value.</param>
+        /// <returns>A boolean representing the value of the environment variable.</returns>
+        private static bool GetEnvironmentVariableAsBool(string name, bool defaultValue)
+        {
+            var str = Environment.GetEnvironmentVariable(name);
+            if (string.IsNullOrEmpty(str))
+            {
+                return defaultValue;
+            }
+
+            switch (str.ToLowerInvariant())
+            {
+                case "true":
+                case "1":
+                case "yes":
+                    return true;
+                case "false":
+                case "0":
+                case "no":
+                    return false;
+                default:
+                    return defaultValue;
             }
         }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Update the feature to support the notification type that can be configured using the environment variable `POWERSHELL_UPDATECHECK`.
This is to address the feedback from powershell committee in the RFC review: https://github.com/PowerShell/PowerShell-RFC/pull/162#issuecomment-541858683, quoted below:
> Coming out of @PowerShell/powershell-committee review, we want to change the environment variable to no longer be a simple opt-out/in but rather a field that can be used to set the "channel". So e.g. a $env:PSNotificationPreference that can be set to Default, Off, or LTS, where the latter would only provide LTS update notifications in their notifications.

`POWERSHELL_UPDATECHECK` accepts 3 values: `Off`, `Default`, and `LTS` (case-insensitive), and the behavior is as follows:
- `Off`: turn off the udpate notification.
- `Default`: give you the default behaviors
   - the preview version 'pwsh' checks for the new preview version and the new GA version.
   - the GA version 'pwsh' checks for the new GA version only.
- `LTS`: both preview and GA version 'pwsh' checks for the new LTS version only.

For a specific version of pwsh and a specific notification type, only one update check task, at most, will run to complete per a day. Other tasks should be able to detect "a check is in progress" or "the check has been done for today" and bail out early, to avoid any unnecessary network IO or CPU cycles.

Note that this is a breaking change comparing to `preview-5` and `preview-6`, because the environment variable name and its accepted values are changed.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
