### PR TITLE
Add `-AsPlainText` to `ConvertFrom-SecureString`

### DIFF
--- a/src/Microsoft.PowerShell.Security/security/SecureStringCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/SecureStringCommands.cs
@@ -361,22 +361,8 @@ namespace Microsoft.PowerShell.Commands
                 }
                 else
                 {
-                    if (!Force)
-                    {
-                        string error =
-                            SecureStringCommands.ForceRequired;
-                        Exception e = new ArgumentException(error);
-                        WriteError(new ErrorRecord(e, "ImportSecureString_ForceRequired", ErrorCategory.InvalidArgument, null));
-                    }
-                    else
-                    {
-                        // The entire purpose of the SecureString is to prevent a secret from being
-                        // permanently stored in memory as a .Net string.  If they use the
-                        // -AsPlainText and -Force flags, they consciously have made the decision to be OK
-                        // with that.
-                        importedString = new SecureString();
-                        foreach (char currentChar in String) { importedString.AppendChar(currentChar); }
-                    }
+                    importedString = new SecureString();
+                    foreach (char currentChar in String) { importedString.AppendChar(currentChar); }
                 }
             }
             catch (ArgumentException e)

--- a/src/Microsoft.PowerShell.Security/security/SecureStringCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/SecureStringCommands.cs
@@ -140,6 +140,12 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
+        /// Switch to get the secure string as plain text.
+        /// </summary>
+        [Parameter(ParameterSetName = "AsPlainText")]
+        public SwitchParameter AsPlainText { get; set; }
+
+        /// <summary>
         /// Processes records from the input pipeline.
         /// For each input object, the command encrypts
         /// and exports the object.
@@ -164,6 +170,19 @@ namespace Microsoft.PowerShell.Commands
             else if (Key != null)
             {
                 encryptionResult = SecureStringHelper.Encrypt(SecureString, Key);
+            }
+            else if (AsPlainText)
+            {
+                IntPtr valuePtr = IntPtr.Zero;
+                try
+                {
+                    valuePtr = Marshal.SecureStringToGlobalAllocUnicode(SecureString);
+                    exportedString = Marshal.PtrToStringUni(valuePtr);
+                }
+                finally
+                {
+                    Marshal.ZeroFreeGlobalAllocUnicode(valuePtr);
+                }
             }
             else
             {

--- a/src/Microsoft.PowerShell.Security/security/SecureStringCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/SecureStringCommands.cs
@@ -140,7 +140,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Switch to get the secure string as plain text.
+        /// Gets or sets a switch to get the secure string as plain text.
         /// </summary>
         [Parameter(ParameterSetName = "AsPlainText")]
         public SwitchParameter AsPlainText { get; set; }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1
@@ -22,10 +22,11 @@ Describe "SecureString conversion tests" -Tags "CI" {
         $ss = ConvertTo-SecureString -AsPlainText -Force abcd
         $ss | Should -BeOfType SecureString
     }
+
     It "can convert back from a secure string" {
         $secret = "abcd"
         $ss1 = ConvertTo-SecureString -AsPlainText -Force $secret
-        $ss2 = convertfrom-securestring $ss1 | convertto-securestring
-        [pscredential]::New("user",$ss2).GetNetworkCredential().Password | Should -Be $secret
+        $ss2 = ConvertFrom-SecureString $ss1 | ConvertTo-SecureString
+        $ss2 | ConvertFrom-SecureString -AsPlainText | Should -Be $secret
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix https://github.com/PowerShell/PowerShell/issues/11067

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
