### PR TITLE
Add an implementation of `Stop-Computer` for Linux and macOS

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
@@ -1181,11 +1181,7 @@ $result
         /// </summary>
         public void Dispose()
         {
-            try
-            {
-                _cancel.Dispose();
-            }
-            catch (ObjectDisposedException) { }
+             _cancel.Dispose();
         }
 
         #endregion "IDisposable Members"

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if UNIX
+
+using System;
+using System.Diagnostics;
+using System.Management.Automation;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.PowerShell.Commands
+{
+    #region Stop-Computer
+
+    /// <summary>
+    /// Cmdlet to stop computer.
+    /// </summary>
+    [Cmdlet(VerbsLifecycle.Stop, "Computer", SupportsShouldProcess = true,
+        HelpUri = "https://go.microsoft.com/fwlink/?LinkID=135263", RemotingCapability = RemotingCapability.SupportedByCommand)]
+    public sealed class StopComputerCommand : PSCmdlet, IDisposable
+    {
+        #region Private Members
+
+        private Process _process = null;
+
+        #endregion
+
+        // TODO: Support remote computers?
+
+        #region "IDisposable Members"
+
+        /// <summary>
+        /// Dispose Method.
+        /// </summary>
+        public void Dispose()
+        {
+            _process.Dispose();
+        }
+
+        #endregion "IDisposable Members"
+
+        #region "Overrides"
+
+        /// <summary>
+        /// BeginProcessing.
+        /// </summary>
+        protected override void BeginProcessing()
+        {
+            doShutdown();
+        }
+
+        /// <summary>
+        /// To implement ^C.
+        /// </summary>
+        protected override void StopProcessing()
+        {
+            if (_process == null) {
+                return;
+            }
+
+            try {
+                if (!_process.HasExited) {
+                    _process.Kill();
+                }
+                WriteObject(_process.ExitCode);
+            }
+            catch (InvalidOperationException) {}
+            catch (NotSupportedException) {}
+        }
+
+        #endregion "Overrides"
+
+        #region "Internals"
+
+        private void doShutdown() {
+            String cmd = "";
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                cmd = "-P now";
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                cmd = "now";
+            }
+
+            _process = new Process()
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "/sbin/shutdown",
+                    Arguments = cmd,
+                    RedirectStandardOutput = false,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                }
+            };
+            _process.Start();
+        }
+        #endregion
+    }
+    #endregion
+}
+#endif

--- a/src/Modules/Unix/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1
+++ b/src/Modules/Unix/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1
@@ -54,5 +54,6 @@ CmdletsToExport=@("Add-Content",
     "Resolve-Path",
     "Set-Content",
     "Set-ItemProperty",
-    "Get-TimeZone")
+    "Get-TimeZone",
+    "Stop-Computer")
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Unimplemented-Cmdlet.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Unimplemented-Cmdlet.Tests.ps1
@@ -13,7 +13,6 @@ Describe "Unimplemented Management Cmdlet Tests" -Tags "CI" {
         "New-Service",
 
         "Restart-Computer",
-        "Stop-Computer",
         "Rename-Computer",
 
         "Get-ComputerInfo",

--- a/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
+++ b/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
@@ -451,7 +451,7 @@ Describe "Verify approved aliases list" -Tags "CI" {
 "Cmdlet",       "Start-Sleep",                      "",                                 $($FullCLR -or $CoreWindows -or $CoreUnix),     "",                     "",                     "None"
 "Cmdlet",       "Start-Transaction",                "",                                 $($FullCLR                               ),     "",                     "",                     ""
 "Cmdlet",       "Start-Transcript",                 "",                                 $($FullCLR -or $CoreWindows -or $CoreUnix),     "",                     "",                     "None"
-"Cmdlet",       "Stop-Computer",                    "",                                 $($FullCLR -or $CoreWindows              ),     "",                     "",                     "Medium"
+"Cmdlet",       "Stop-Computer",                    "",                                 $($FullCLR -or $CoreWindows -or $CoreUnix),     "",                     "",                     "Medium"
 "Cmdlet",       "Stop-Job",                         "",                                 $($FullCLR -or $CoreWindows -or $CoreUnix),     "",                     "",                     "Medium"
 "Cmdlet",       "Stop-Process",                     "",                                 $($FullCLR -or $CoreWindows -or $CoreUnix),     "",                     "",                     "Medium"
 "Cmdlet",       "Stop-Service",                     "",                                 $($FullCLR -or $CoreWindows              ),     "",                     "",                     "Medium"


### PR DESCRIPTION
# PR Summary
Adds an implementation of the Stop-Computer cmdlet for Linux and OS X

## PR Context

Closes #5448

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
- **User-facing changes**
    - [X] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [X] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/5171
- **Testing - New and feature**
    - [X] N/A or can only be tested interactively
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
