### PR TITLE
Update formatter to not write newlines if content is empty

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
@@ -49,14 +49,24 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             // we always start with no indentation
             _indentationManager.Clear();
 
+            bool hasContent = false;
             foreach (FormatEntry fe in formatValueList)
             {
-                // operate on each directive inside the list,
-                // carrying the indentation from invocation to invocation
-                GenerateFormatEntryDisplay(fe, 0);
+                if (fe.formatValueList.Count > 0)
+                {
+                    hasContent = true;
+
+                    // operate on each directive inside the list,
+                    // carrying the indentation from invocation to invocation
+                    GenerateFormatEntryDisplay(fe, 0);
+                }
             }
+
             // make sure that, if we have pending text in the buffer it gets flushed
-            WriteToScreen();
+            if (hasContent)
+            {
+                WriteToScreen();
+            }
         }
 
         /// <summary>
@@ -132,12 +142,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             int firstLineIndentation = _indentationManager.FirstLineIndentation;
 
             // VALIDITY CHECKS:
-
-            // check if there's anything to write
-            if (_stringBuffer.Length == 0)
-            {
-                return;
-            }
 
             // check the useful ("active") width
             int usefulWidth = _textColumns - rightIndentation - leftIndentation;

--- a/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
@@ -133,6 +133,12 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
             // VALIDITY CHECKS:
 
+            // check if there's anything to write
+            if (_stringBuffer.Length == 0)
+            {
+                return;
+            }
+
             // check the useful ("active") width
             int usefulWidth = _textColumns - rightIndentation - leftIndentation;
             if (usefulWidth <= 0)

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Complex.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Complex.cs
@@ -281,7 +281,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     // do the formatting and we will be done
                     if (cpt.control == null || cpt.control is FieldControlBody)
                     {
-
                         if (val == null)
                         {
                             return;

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Complex.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Complex.cs
@@ -281,11 +281,10 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     // do the formatting and we will be done
                     if (cpt.control == null || cpt.control is FieldControlBody)
                     {
-                        // Since it is a leaf node we just consider it an empty string and go
-                        // on with formatting
+
                         if (val == null)
                         {
-                            val = string.Empty;
+                            return;
                         }
 
                         FieldFormattingDirective fieldFormattingDirective = null;

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Complex.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Complex.cs
@@ -283,6 +283,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     {
                         if (val == null)
                         {
+                            // Since it is a leaf node we just ignore it
                             return;
                         }
 
@@ -778,4 +779,3 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         private int _enumerationLimit;
     }
 }
-

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Custom.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Custom.Tests.ps1
@@ -439,7 +439,6 @@ SelectScriptBlock
     }
 }
 
-
 Describe "Custom formatting returning nothing" -Tags "CI" {
   BeforeAll {
       $formatFilePath = Join-Path $TestDrive 'UpdateFormatDataTests.format.ps1xml'

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Custom.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Custom.Tests.ps1
@@ -499,6 +499,7 @@ Describe "Custom formatting returning nothing" -Tags "CI" {
 
 
 
+
 '@ -replace '\r?\n', "^"
 
       $ps.Invoke() -replace '\r?\n', "^" | Should -BeExactly $expectedOutput

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Custom.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Custom.Tests.ps1
@@ -457,7 +457,7 @@ Describe "Custom formatting returning nothing" -Tags "CI" {
                           <CustomItem>
                               <ExpressionBinding>
                                   <ScriptBlock>
-                                    ""
+                                    $null
                                   </ScriptBlock>
                               </ExpressionBinding>
                           </CustomItem>
@@ -496,7 +496,6 @@ Describe "Custom formatting returning nothing" -Tags "CI" {
 
       # one newline for start, one for grouping, and one for end
       $expectedOutput = @'
-
 
 
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Custom.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Custom.Tests.ps1
@@ -479,7 +479,7 @@ Describe "Custom formatting returning nothing" -Tags "CI" {
   }
 
   AfterAll {
-      $rs.Close()
+      $rs.Dispose()
       $ps.Dispose()
   }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Currently, the formatter uses `WriteLine()` on the content expecting it to be not empty.  If the custom format explicitly doesn't write anything, it ends up as a newline.  Fix is to check that there is something to write, otherwise bail out early.  With this change, an empty string still results in a newline, but `$null` skips writing the newline.

## PR Context

Affects a custom formatter I'm writing that requires output to not have trailing newlines.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
