### PR TITLE
Port ConvertTo-Json to .Net Core Json API

### DIFF
--- a/src/Modules/Unix/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
+++ b/src/Modules/Unix/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
@@ -35,6 +35,10 @@ PrivateData = @{
   PSData = @{
     ExperimentalFeatures = @(
       @{
+        Name        = 'Microsoft.PowerShell.Utility.NewConvertToJson'
+        Description = 'New implementation of ConvertTo-Json cmdlet based on System.Text.Json.'
+      }
+      @{
         Name        = 'Microsoft.PowerShell.Utility.PSManageBreakpointsInRunspace'
         Description = 'Enables -BreakAll parameter on Debug-Runspace and Debug-Job cmdlets to allow users to decide if they want PowerShell to break immediately in the current location when they attach a debugger. Enables -Runspace parameter on *-PSBreakpoint cmdlets to support management of breakpoints in another runspace.'
       }

--- a/src/Modules/Windows/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
+++ b/src/Modules/Windows/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
@@ -34,6 +34,10 @@ PrivateData = @{
   PSData = @{
     ExperimentalFeatures = @(
       @{
+        Name        = 'Microsoft.PowerShell.Utility.NewConvertToJson'
+        Description = 'New implementation of ConvertTo-Json cmdlet based on System.Text.Json.'
+      }
+      @{
         Name        = 'Microsoft.PowerShell.Utility.PSManageBreakpointsInRunspace'
         Description = 'Enables -BreakAll parameter on Debug-Runspace and Debug-Job cmdlets to allow users to decide if they want PowerShell to break immediately in the current location when they attach a debugger. Enables -Runspace parameter on *-PSBreakpoint cmdlets to support management of breakpoints in another runspace.'
       }

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -1106,6 +1106,32 @@ namespace System.Management.Automation
         /// </summary>
         public override PSMemberTypes MemberType => PSMemberTypes.Property;
 
+        /// <summary>
+        /// Indicates whether one or more attributes
+        /// of the specified type or of its derived types is applied to this member.
+        /// </summary>
+        /// <param name="attributeType">Attribute type to search.</param>
+        /// <returns>
+        /// True if the property has the attribute.
+        /// </returns>
+        public bool IsDefined(Type attributeType)
+        {
+            if (adapter == null)
+            {
+                return false;
+            }
+
+            foreach (var attr in adapter.BasePropertyAttributes(this))
+            {
+                if (attributeType.IsAssignableFrom(attr.GetType()))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         private object GetAdaptedValue()
         {
             if (this.isDeserialized)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
@@ -8,6 +8,9 @@
 # This 'Describe' is for tests that were converted from utscripts (SDXROOT/admin/monad/tests/monad/DRT/utscripts)
 # and C# tests (SDXROOT/admin/monad/tests/monad/DRT/commands/utility/UnitTests) to Pester.
 #
+
+$notNewConvertToJson = -not $EnabledExperimentalFeatures.Contains('Microsoft.PowerShell.Utility.NewConvertToJson')
+
 Describe "Json Tests" -Tags "Feature" {
 
     BeforeAll {
@@ -41,7 +44,11 @@ Describe "Json Tests" -Tags "Feature" {
             # Test follow-up for bug WinBlue: 163372 - ConvertTo-JSON has hard coded english error message.
             $process = Get-Process -Id $PID
             $hash = @{ $process = "def" }
-            $expectedFullyQualifiedErrorId = "NonStringKeyInDictionary,Microsoft.PowerShell.Commands.ConvertToJsonCommand"
+            if ($notNewConvertToJson) {
+                $expectedFullyQualifiedErrorId = "NonStringKeyInDictionary,Microsoft.PowerShell.Commands.ConvertToJsonCommand"
+            } else {
+                $expectedFullyQualifiedErrorId = "System.Text.Json.JsonException,Microsoft.PowerShell.Commands.ConvertToJsonCommand"
+            }
 
             { ConvertTo-Json -InputObject $hash } | Should -Throw -ErrorId $expectedFullyQualifiedErrorId
         }
@@ -1006,8 +1013,8 @@ Describe "Validate Json serialization" -Tags "CI" {
              }
             @{
                 TestInput = 127
-                ToJson = '""'
-                FromJson = ''
+                ToJson = if ($notNewConvertToJson) { '""' } else { '"\u007F"' }
+                FromJson = if ($notNewConvertToJson) { '' } else { "`u{007F}" }
              }
         )
 
@@ -1306,7 +1313,7 @@ Describe "Validate Json serialization" -Tags "CI" {
             ValidateProperties -serialized $result.SerializedViaJson -expected $result.Expected -properties $propertiesToValidate
         }
 
-        It "Validate 'Get-Command Get-help' output with Json conversion" {
+        It "Validate 'Get-Command Get-help' output with Json conversion" -Pending:(!$notNewConvertToJson) {
 
             $result = @{
                 Expected = @(Get-Command Get-help)
@@ -1317,7 +1324,7 @@ Describe "Validate Json serialization" -Tags "CI" {
             ValidateProperties -serialized $result.SerializedViaJson -expected $result.Expected -properties $propertiesToValidate
         }
 
-        It "Validate 'Get-Command Get-Help, Get-command, Get-Member' output with Json conversion" {
+        It "Validate 'Get-Command Get-Help, Get-command, Get-Member' output with Json conversion" -Pending:(!$notNewConvertToJson) {
 
             $result = @{
                 Expected = @(Get-Command Get-Help, Get-Command, Get-Member)
@@ -1407,7 +1414,10 @@ Describe "Json Bug fixes"  -Tags "Feature" {
 
             if ($testCase.ShouldThrow)
             {
-                { $previous | ConvertTo-Json -Depth $testCase.MaxDepth } | Should -Throw -ErrorId $testCase.FullyQualifiedErrorId
+                $exc = { $previous | ConvertTo-Json -Depth $testCase.MaxDepth } | Should -PassThru -Throw -ErrorId $testCase.FullyQualifiedErrorId
+                if (!$notNewConvertToJson) {
+                    $exc.Exception.TargetSite.Name | Should -BeExactly $testCase.TargetSiteName
+                }
             }
             else
             {
@@ -1416,27 +1426,60 @@ Describe "Json Bug fixes"  -Tags "Feature" {
         }
     }
 
-    $testCases = @(
-        @{
-            Name = "ConvertTo-Json -Depth 101 throws MaximumAllowedDepthReached when the user specifies a depth greater than 100."
-            NumberOfElements = 10
-            MaxDepth = 101
-            FullyQualifiedErrorId = "ReachedMaximumDepthAllowed,Microsoft.PowerShell.Commands.ConvertToJsonCommand"
-            ShouldThrow = $true
-        }
-        @{
-            Name = "ConvertTo-Json and ConvertFrom-Json work for any depth less than or equal to 100."
-            NumberOfElements = 100
-            MaxDepth = 100
-            ShouldThrow = $false
-        }
-        @{
-            Name = "ConvertTo-Json and ConvertFrom-Json work for depth 100 with an object larger than 100."
-            NumberOfElements = 105
-            MaxDepth = 100
-            ShouldThrow = $false
-        }
-    )
+    if ($notNewConvertToJson) {
+        $testCases = @(
+            @{
+                Name = "ConvertTo-Json -Depth 101 throws MaximumAllowedDepthReached when the user specifies a depth greater than 100."
+                NumberOfElements = 10
+                MaxDepth = 101
+                FullyQualifiedErrorId = "ReachedMaximumDepthAllowed,Microsoft.PowerShell.Commands.ConvertToJsonCommand"
+                ShouldThrow = $true
+            }
+            @{
+                Name = "ConvertTo-Json and ConvertFrom-Json work for any depth less than or equal to 100."
+                NumberOfElements = 100
+                MaxDepth = 100
+                ShouldThrow = $false
+            }
+            @{
+                Name = "ConvertTo-Json and ConvertFrom-Json work for depth 100 with an object larger than 100."
+                NumberOfElements = 105
+                MaxDepth = 100
+                ShouldThrow = $false
+            }
+        )
+    } else {
+        $testCases = @(
+            @{
+                Name = "ConvertTo-Json -Depth 1001 throws MaximumAllowedDepthReached when the user specifies a depth greater than 1000."
+                NumberOfElements = 10
+                MaxDepth = 1001
+                FullyQualifiedErrorId = "ReachedMaximumDepthAllowed,Microsoft.PowerShell.Commands.ConvertToJsonCommand"
+                TargetSiteName = "ThrowTerminatingError"
+                ShouldThrow = $true
+            }
+            @{
+                Name = "ConvertTo-Json -Depth 100 throws JsonException (CycleDetected) when the user specifies a depth greater or equal than 100."
+                NumberOfElements = 100
+                MaxDepth = 100
+                FullyQualifiedErrorId = "System.Text.Json.JsonException,Microsoft.PowerShell.Commands.ConvertToJsonCommand"
+                TargetSiteName = "ThrowJsonException_SerializerCycleDetected"
+                ShouldThrow = $true
+            }
+            @{
+                Name = "ConvertTo-Json -Depth 100 does not throw (no cycle detection throw) for any depth less than to 100."
+                NumberOfElements = 99
+                MaxDepth = 100
+                ShouldThrow = $false
+            }
+            @{
+                Name = "ConvertTo-Json and ConvertFrom-Json work for depth 100 with an object larger than 100."
+                NumberOfElements = 999
+                MaxDepth = 1000
+                ShouldThrow = $false
+            }
+        )
+    }
 
     foreach ($testCase in $testCases)
     {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
@@ -1507,7 +1507,7 @@ Describe "Json Bug fixes"  -Tags "Feature" {
         $result.Count | Should -Be 3
     }
 
-    It 'ConvertTo-Json will output warning if depth is exceeded.' {
+    It 'ConvertTo-Json will output warning if depth is exceeded.' -Pending:($notNewConvertToJson) {
         $a = @{ a = @{ b = @{ c = @{ d = 1 } } } }
         $json = $a | ConvertTo-Json -Depth 2 -WarningVariable warningMessage -WarningAction SilentlyContinue
         $json | Should -Not -BeNullOrEmpty

--- a/test/xUnit/csharp/test_Json.cs
+++ b/test/xUnit/csharp/test_Json.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Collections.Specialized;
+using System.Management.Automation;
+using System.Management.Automation.Internal;
+using System.Threading;
+using System.Reflection;
+using Microsoft.PowerShell.Commands;
+using Xunit;
+
+namespace PSTests.Parallel
+{
+    public static class JsonTests
+    {
+        [Fact]
+        public static void TestConvertToJsonBasic()
+        {
+            var context = new JsonObject.ConvertToJsonContext(maxDepth: 3, enumsAsStrings: false, compressOutput: true);
+            string expected = "{\"name\":\"req\",\"type\":\"http\"}";
+            OrderedDictionary hash = new OrderedDictionary {
+                {"name", "req"},
+                {"type", "http"}
+            };
+            string json = JsonObject.ConvertToJson2(hash, in context);
+            Assert.Equal(expected, json);
+
+            hash.Add("self", hash);
+            Assert.Throws<System.Text.Json.JsonException>(() => JsonObject.ConvertToJson2(hash, context));
+        }
+
+        [Fact]
+        public static void TestConvertToJsonWithEnum()
+        {
+            var context = new JsonObject.ConvertToJsonContext(maxDepth: 2, enumsAsStrings: false, compressOutput: true);
+            string expected = "{\"type\":1}";
+            Hashtable hash = new Hashtable {
+                {"type", CommandTypes.Alias}
+            };
+            string json = JsonObject.ConvertToJson2(hash, in context);
+            Assert.Equal(expected, json);
+
+            context = new JsonObject.ConvertToJsonContext(maxDepth: 2, enumsAsStrings: true, compressOutput: true);
+            json = JsonObject.ConvertToJson2(hash, in context);
+            expected = "{\"type\":\"Alias\"}";
+            Assert.Equal(expected, json);
+        }
+
+        [Fact]
+        public static void TestConvertToJsonWithoutCompress()
+        {
+            var context = new JsonObject.ConvertToJsonContext(maxDepth: 2, enumsAsStrings: true, compressOutput: false);
+            string expected = @"{
+  ""type"": ""Alias""
+}";
+            Hashtable hash = new Hashtable {
+                {"type", CommandTypes.Alias}
+            };
+            string json = JsonObject.ConvertToJson2(hash, in context);
+            Assert.Equal(expected, json);
+        }
+
+        [Fact (Skip = "Cancellation is not implemented")]
+        public static void TestConvertToJsonCancellation()
+        {
+            var source = new CancellationTokenSource();
+            var context = new JsonObject.ConvertToJsonContext(
+                maxDepth: 4,
+                enumsAsStrings: true,
+                compressOutput: false,
+                source.Token,
+                Newtonsoft.Json.StringEscapeHandling.Default,
+                targetCmdlet: null);
+
+            source.Cancel();
+            Hashtable hash = new Hashtable {
+                {"type", CommandTypes.Alias}
+            };
+
+            string json = JsonObject.ConvertToJson2(hash, in context);
+            Assert.Null(json);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Address #8393

1. Move to new .Net Core Json API. Detects and throws on cycles and depth.
2. Add PSObject, DBNull, NullString, Enum64 Json converters
3. Add JsonIgnoreAttribute support. Address #6847
4. Set Depth default to 64 (.Net Core default). It is good compromise: still no hangs and exceptions for common scenarios but noticeable delays are if problems exist.
5. Set MaxDepthAllowed = 1000. It is .Net Core limitation.
6. Fix #9847 as side effect.
7. Escaping based on new .Net Core Json API. 'Default' is nearly like previous. 'EscapeHtml' - more differences, 'EscapeNonAscii' now like 'Default' but could be improved but I did not found noticeable using EscapeHtml and EscapeNonAscii on GitHub.
8. Cancellation doesn't work (I guess only hosted scenarios are affected). Underlying sync API don't support this. I did not found reasons to switch to async Json API. See https://github.com/dotnet/runtime/issues/611
9. Depth parameter is renamed to MaxDepth to more accurately reflect the new semantics.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
