### PR TITLE
Fix regression in Get-PSCallStack

### DIFF
--- a/src/System.Management.Automation/engine/TypeTable_Types_Ps1Xml.cs
+++ b/src/System.Management.Automation/engine/TypeTable_Types_Ps1Xml.cs
@@ -6058,7 +6058,7 @@ namespace System.Management.Automation.Runspaces
           {
           if ($argumentsBuilder.Length -gt 1)
           {
-          $argumentsBuilder.Append(string.Empty, string.Empty);
+          $argumentsBuilder.Append("", "");
           }
 
           $argumentsBuilder.Append($entry.Key).Append(""="")
@@ -6073,7 +6073,7 @@ namespace System.Management.Automation.Runspaces
           {
           if ($argumentsBuilder.Length -gt 1)
           {
-          $argumentsBuilder.Append(string.Empty, string.Empty)
+          $argumentsBuilder.Append("", "")
           }
 
           if ($arg)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-PSCallStack.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-PSCallStack.Tests.ps1
@@ -82,7 +82,7 @@ Describe "Get-PSCallStack DRT Unit Tests" -Tags "CI" {
         $results[0].Command | Should -Be $scriptFileName
         $results[0].ScriptName | Should -Be $scriptFilePath
         $results[0].ScriptLineNumber | Should -Be 3
-        $results[0].InvocationInfo.ScriptLineNumber | Should -Be 77
+        $results[0].InvocationInfo.ScriptLineNumber | Should -Be 80
 
         $results[1].Command | Should -Be $scriptFileName
         $results[1].ScriptName | Should -Be $scriptFilePath

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-PSCallStack.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-PSCallStack.Tests.ps1
@@ -49,17 +49,20 @@ Describe "Get-PSCallStack DRT Unit Tests" -Tags "CI" {
         $results[0].ScriptName | Should -Be $scriptFilePath
         $results[0].ScriptLineNumber | Should -Be 27
         $results[0].InvocationInfo.ScriptLineNumber | Should -Be 9
+        $results[0].Location | Should -Match $scriptFileName
 
         $results[1].Command | Should -BeExactly "foo"
         $results[1].ScriptName | Should -Be $scriptFilePath
         $results[1].ScriptLineNumber | Should -Be 9
         $results[1].InvocationInfo.ScriptLineNumber | Should -Be 32
+        $results[1].Location | Should -Match $scriptFileName
 
         #InvocationInfo.ScriptLineNumber: Gets the line number of the script that contains the command
         $results[2].Command | Should -Be $scriptFileName
         $results[2].ScriptName | Should -Be $scriptFilePath
         $results[2].ScriptLineNumber | Should -Be 32
         $results[2].InvocationInfo.ScriptLineNumber | Should -Be 46
+        $results[2].Location | Should -Match $scriptFileName
     }
 
     It "Verify that the script block of a trap statement shows up on the call stack" {
@@ -85,5 +88,9 @@ Describe "Get-PSCallStack DRT Unit Tests" -Tags "CI" {
         $results[1].ScriptName | Should -Be $scriptFilePath
         $results[1].ScriptLineNumber | Should -Be 7
         $results[1].InvocationInfo.ScriptLineNumber | Should -Be 77
+    }
+
+    It "Get-PSCallStack returns Arguments" {
+        & { (Get-PSCallStack)[0].Arguments } 'foo'  | Should -Match 'foo'
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-PSCallStack.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-PSCallStack.Tests.ps1
@@ -87,7 +87,7 @@ Describe "Get-PSCallStack DRT Unit Tests" -Tags "CI" {
         $results[1].Command | Should -Be $scriptFileName
         $results[1].ScriptName | Should -Be $scriptFilePath
         $results[1].ScriptLineNumber | Should -Be 7
-        $results[1].InvocationInfo.ScriptLineNumber | Should -Be 77
+        $results[1].InvocationInfo.ScriptLineNumber | Should -Be 80
     }
 
     It "Get-PSCallStack returns Arguments" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-PSCallStack.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-PSCallStack.Tests.ps1
@@ -91,6 +91,8 @@ Describe "Get-PSCallStack DRT Unit Tests" -Tags "CI" {
     }
 
     It "Get-PSCallStack returns Arguments" {
-        & { (Get-PSCallStack)[0].Arguments } 'foo'  | Should -Match 'foo'
+        & { (Get-PSCallStack)[0].Arguments } 'foo' | Should -Match 'foo'
+        & { param ($x)  (Get-PSCallStack)[0].Arguments } 'foo' | Should -Match 'foo'
+        & { (Get-PSCallStack)[0].Arguments } 'foo' 'bar' | Should -Match 'foo, bar'
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #11208

## PR Context

The regression comes from #6950

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
