### PR TITLE
Fix a regression in formatting caused by the 'FirstOrDefault' primitive added in 7.0.0-Preview1

### DIFF
--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -1983,13 +1983,39 @@ namespace System.Management.Automation
 
         #endregion base
     }
+
+    /// <summary>
+    /// The abstract cache entry type.
+    /// All specific cache entry types should derive from it.
+    /// </summary>
+    internal abstract class CacheEntry
+    {
+        /// <summary>
+        /// Gets the boolean value to indicate if the member is hidden.
+        /// </summary>
+        /// <remarks>
+        /// Currently, we only check the 'HiddenAttribute' declared for properties and methods,
+        /// because it can be done for them through the 'hidden' keyword in PowerShell Class.
+        ///
+        /// We can't currently write a parameterized property in a PowerShell class so it's not too important
+        /// to check for the 'HiddenAttribute' for parameterized properties. But if someone added the attribute
+        /// to their C#, it'd be good to set this property correctly.
+        /// </remarks>
+        internal virtual bool IsHidden => false;
+    }
+
     /// <summary>
     /// Ordered and case insensitive hashtable.
     /// </summary>
     internal class CacheTable
     {
+        /// <summary>
+        /// An object collection is used to help make populating method cache table more efficient
+        /// <see cref="DotNetAdapter.PopulateMethodReflectionTable(Type, CacheTable, BindingFlags)"/>.
+        /// </summary>
         internal Collection<object> memberCollection;
         private Dictionary<string, int> _indexes;
+
         internal CacheTable()
         {
             memberCollection = new Collection<object>();
@@ -2012,17 +2038,30 @@ namespace System.Management.Automation
                     return null;
                 }
 
-                return this.memberCollection[indexObj];
+                return memberCollection[indexObj];
             }
         }
 
+        /// <summary>
+        /// Get the first no-hidden member that satisfies the predicate.
+        /// </summary>
+        /// <remarks>
+        /// Hidden members are not returned for any fuzzy searches (searching by 'match' or enumerating a collection).
+        /// A hidden member is returned only if the member name is explicitly looked for.
+        /// </remarks>
         internal object GetFirstOrDefault(MemberNamePredicate predicate)
         {
             foreach (var entry in _indexes)
             {
                 if (predicate(entry.Key))
                 {
-                    return this.memberCollection[entry.Value];
+                    object member = memberCollection[entry.Value];
+                    if (member is CacheEntry cacheEntry && cacheEntry.IsHidden)
+                    {
+                        continue;
+                    }
+
+                    return member;
                 }
             }
 
@@ -2565,9 +2604,9 @@ namespace System.Management.Automation
         private static readonly Dictionary<Type, Dictionary<string, EventCacheEntry>> s_staticEventCacheTable
             = new Dictionary<Type, Dictionary<string, EventCacheEntry>>();
 
-        internal class MethodCacheEntry
+        internal class MethodCacheEntry : CacheEntry
         {
-            internal MethodInformation[] methodInformationStructures;
+            internal readonly MethodInformation[] methodInformationStructures;
             /// <summary>
             /// Cache delegate to the ctor of PSMethod&lt;&gt; with a template parameter derived from the methodInformationStructures.
             /// </summary>
@@ -2585,9 +2624,33 @@ namespace System.Management.Automation
                     return methodInformationStructures[i];
                 }
             }
+
+            private bool? _isHidden;
+            internal override bool IsHidden
+            {
+                get
+                {
+                    if (_isHidden == null)
+                    {
+                        bool hasHiddenAttribute = false;
+                        foreach (var method in methodInformationStructures)
+                        {
+                            if (method.method.GetCustomAttributes(typeof(HiddenAttribute), inherit: false).Length != 0)
+                            {
+                                hasHiddenAttribute = true;
+                                break;
+                            }
+                        }
+
+                        _isHidden = hasHiddenAttribute;
+                    }
+
+                    return _isHidden.Value;
+                }
+            }
         }
 
-        internal class EventCacheEntry
+        internal class EventCacheEntry : CacheEntry
         {
             internal EventInfo[] events;
 
@@ -2597,7 +2660,7 @@ namespace System.Management.Automation
             }
         }
 
-        internal class ParameterizedPropertyCacheEntry
+        internal class ParameterizedPropertyCacheEntry : CacheEntry
         {
             internal MethodInformation[] getterInformation;
             internal MethodInformation[] setterInformation;
@@ -2676,7 +2739,7 @@ namespace System.Management.Automation
             }
         }
 
-        internal class PropertyCacheEntry
+        internal class PropertyCacheEntry : CacheEntry
         {
             internal delegate object GetterDelegate(object instance);
             internal delegate void SetterDelegate(object instance, object setValue);
@@ -2915,6 +2978,20 @@ namespace System.Management.Automation
             internal bool writeOnly;
             internal bool isStatic;
             internal Type propertyType;
+
+            private bool? _isHidden;
+            internal override bool IsHidden
+            {
+                get
+                {
+                    if (_isHidden == null)
+                    {
+                        _isHidden = member.GetCustomAttributes(typeof(HiddenAttribute), inherit: false).Length != 0;
+                    }
+
+                    return _isHidden.Value;
+                }
+            }
 
             private AttributeCollection _attributes;
             internal AttributeCollection Attributes
@@ -3578,8 +3655,7 @@ namespace System.Management.Automation
                 case null:
                     return null;
                 case PropertyCacheEntry cacheEntry when lookingForProperties:
-                    var isHidden = cacheEntry.member.GetCustomAttributes(typeof(HiddenAttribute), false).Any();
-                    return new PSProperty(cacheEntry.member.Name, this, obj, cacheEntry) { IsHidden = isHidden } as T;
+                    return new PSProperty(cacheEntry.member.Name, this, obj, cacheEntry) { IsHidden = cacheEntry.IsHidden } as T;
                 case ParameterizedPropertyCacheEntry paramCacheEntry when lookingForParameterizedProperties:
 
                     // TODO: check for HiddenAttribute
@@ -3612,17 +3688,8 @@ namespace System.Management.Automation
 
             var isCtor = methods[0].method is ConstructorInfo;
             bool isSpecial = !isCtor && methods[0].method.IsSpecialName;
-            bool isHidden = false;
-            foreach (var method in methods.methodInformationStructures)
-            {
-                if (method.method.GetCustomAttributes(typeof(HiddenAttribute), false).Any())
-                {
-                    isHidden = true;
-                    break;
-                }
-            }
 
-            return PSMethod.Create(methods[0].method.Name, this, obj, methods, isSpecial, isHidden) as T;
+            return PSMethod.Create(methods[0].method.Name, this, obj, methods, isSpecial, methods.IsHidden) as T;
         }
 
         internal T GetDotNetProperty<T>(object obj, string propertyName) where T : PSMemberInfo
@@ -3712,10 +3779,12 @@ namespace System.Management.Automation
                     {
                         if (!ignoreDuplicates || (members[propertyEntry.member.Name] == null))
                         {
-                            var isHidden = propertyEntry.member.GetCustomAttributes(typeof(HiddenAttribute), false).Any();
-                            members.Add(new PSProperty(propertyEntry.member.Name, this,
-                                obj, propertyEntry)
-                            { IsHidden = isHidden } as T);
+                            members.Add(
+                                new PSProperty(
+                                    name: propertyEntry.member.Name,
+                                    adapter: this,
+                                    baseObject: obj,
+                                    adapterData: propertyEntry) { IsHidden = propertyEntry.IsHidden } as T);
                         }
                     }
                 }
@@ -3754,17 +3823,7 @@ namespace System.Management.Automation
                 if (!ignoreDuplicates || (members[name] == null))
                 {
                     bool isSpecial = !isCtor && method[0].method.IsSpecialName;
-                    bool isHidden = false;
-                    foreach (var m in method.methodInformationStructures)
-                    {
-                        if (m.method.GetCustomAttributes(typeof(HiddenAttribute), false).Any())
-                        {
-                            isHidden = true;
-                            break;
-                        }
-                    }
-
-                    members.Add(PSMethod.Create(name, this, obj, method, isSpecial, isHidden) as T);
+                    members.Add(PSMethod.Create(name, this, obj, method, isSpecial, method.IsHidden) as T);
                 }
             }
         }

--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -2043,7 +2043,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Get the first no-hidden member that satisfies the predicate.
+        /// Get the first non-hidden member that satisfies the predicate.
         /// </summary>
         /// <remarks>
         /// Hidden members are not returned for any fuzzy searches (searching by 'match' or enumerating a collection).

--- a/src/System.Management.Automation/engine/ManagementObjectAdapter.cs
+++ b/src/System.Management.Automation/engine/ManagementObjectAdapter.cs
@@ -32,7 +32,7 @@ namespace System.Management.Automation
         /// by Get-Member cmdlet, original MethodData and computed method information such
         /// as whether a method is static etc.
         /// </summary>
-        internal class WMIMethodCacheEntry
+        internal class WMIMethodCacheEntry : CacheEntry
         {
             public string Name { get; }
 

--- a/test/powershell/engine/Formatting/BugFix.Tests.ps1
+++ b/test/powershell/engine/Formatting/BugFix.Tests.ps1
@@ -45,7 +45,6 @@ Describe "Hidden properties should not be returned by the 'FirstOrDefault' primi
 
         class Params2 {
             $Param = 'Foo'
-            [String]ToString() { return 'MyString' }
         }
 
         $outstring = [Params2]::new() | Out-String

--- a/test/powershell/engine/Formatting/BugFix.Tests.ps1
+++ b/test/powershell/engine/Formatting/BugFix.Tests.ps1
@@ -10,6 +10,11 @@ Describe "Hidden properties should not be returned by the 'FirstOrDefault' primi
 
         $outstring = [Empty]::new() | Out-String
         $outstring.Trim() | Should -BeExactly "MyString"
+
+        class Empty2 { }
+
+        $outstring = [Empty2]::new() | Out-String
+        $outstring.Trim() | Should -BeLike "*.Empty2"
     }
 
     It "Formatting for an object with only hidden property should use 'ToString'" {
@@ -20,6 +25,13 @@ Describe "Hidden properties should not be returned by the 'FirstOrDefault' primi
 
         $outstring = [Hidden]::new() | Out-String
         $outstring.Trim() | Should -BeExactly "MyString"
+
+        class Hidden2 {
+            hidden $Param = 'Foo'
+        }
+
+        $outstring = [Hidden2]::new() | Out-String
+        $outstring.Trim() | Should -BeLike "*.Hidden2"
     }
 
     It 'Formatting for an object with no-hidden property should use the default view' {
@@ -29,6 +41,14 @@ Describe "Hidden properties should not be returned by the 'FirstOrDefault' primi
         }
 
         $outstring = [Params]::new() | Out-String
+        $outstring.Trim() | Should -BeExactly "Param$([System.Environment]::NewLine)-----$([System.Environment]::NewLine)Foo"
+
+        class Params2 {
+            $Param = 'Foo'
+            [String]ToString() { return 'MyString' }
+        }
+
+        $outstring = [Params2]::new() | Out-String
         $outstring.Trim() | Should -BeExactly "Param$([System.Environment]::NewLine)-----$([System.Environment]::NewLine)Foo"
     }
 }

--- a/test/powershell/engine/Formatting/BugFix.Tests.ps1
+++ b/test/powershell/engine/Formatting/BugFix.Tests.ps1
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-Describe 'Bug fixes related to formatting' -Tag CI {
+Describe "Hidden properties should not be returned by the 'FirstOrDefault' primitive" -Tag CI {
 
     It "Formatting for an object with no property/field should use 'ToString'" {
         class Empty {

--- a/test/powershell/engine/Formatting/BugFix.Tests.ps1
+++ b/test/powershell/engine/Formatting/BugFix.Tests.ps1
@@ -1,0 +1,34 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+Describe 'Bug fixes related to formatting' -Tag CI {
+
+    It "Formatting for an object with no property/field should use 'ToString'" {
+        class Empty {
+            [String]ToString() { return 'MyString' }
+        }
+
+        $outstring = [Empty]::new() | Out-String
+        $outstring.Trim() | Should -BeExactly "MyString"
+    }
+
+    It "Formatting for an object with only hidden property should use 'ToString'" {
+        class Hidden {
+            hidden $Param = 'Foo'
+            [String]ToString() { return 'MyString' }
+        }
+
+        $outstring = [Hidden]::new() | Out-String
+        $outstring.Trim() | Should -BeExactly "MyString"
+    }
+
+    It 'Formatting for an object with no-hidden property should use the default view' {
+        class Params {
+            $Param = 'Foo'
+            [String]ToString() { return 'MyString' }
+        }
+
+        $outstring = [Params]::new() | Out-String
+        $outstring.Trim() | Should -BeExactly "Param$([System.Environment]::NewLine)-----$([System.Environment]::NewLine)Foo"
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #10554

Hidden members should not be returned by any fuzzy searches, such as searching by 'match' or enumerating the collection. They are returned only if the member names are explicitly looked for. `FirstOrDefault` is a fuzzy search, so it should ignore the hidden members.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
