### PR TITLE
Fix error-reporting in some WinCompat scenarios

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -1881,7 +1881,7 @@ namespace Microsoft.PowerShell.Commands
 
         internal override IList<PSModuleInfo> ImportModulesUsingWinCompat(IEnumerable<string> moduleNames, IEnumerable<ModuleSpecification> moduleFullyQualifiedNames, ImportModuleOptions importModuleOptions)
         {
-            IList<PSModuleInfo> moduleProxyList = null;
+            IList<PSModuleInfo> moduleProxyList = new List<PSModuleInfo>();
             var WindowsPowerShellCompatRemotingSession = CreateWindowsPowerShellCompatResources();
             if (WindowsPowerShellCompatRemotingSession != null)
             {

--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -1881,19 +1881,20 @@ namespace Microsoft.PowerShell.Commands
 
         internal override IList<PSModuleInfo> ImportModulesUsingWinCompat(IEnumerable<string> moduleNames, IEnumerable<ModuleSpecification> moduleFullyQualifiedNames, ImportModuleOptions importModuleOptions)
         {
-            IList<PSModuleInfo> moduleProxyList = new List<PSModuleInfo>();
-            var WindowsPowerShellCompatRemotingSession = CreateWindowsPowerShellCompatResources();
-            if (WindowsPowerShellCompatRemotingSession != null)
+            PSSession WindowsPowerShellCompatRemotingSession = CreateWindowsPowerShellCompatResources();
+            if (WindowsPowerShellCompatRemotingSession == null)
             {
-                moduleProxyList = ImportModule_RemotelyViaPsrpSession(importModuleOptions, moduleNames, moduleFullyQualifiedNames, WindowsPowerShellCompatRemotingSession, true);
-                foreach(PSModuleInfo moduleProxy in moduleProxyList)
-                {
-                    moduleProxy.IsWindowsPowerShellCompatModule = true;
-                    System.Threading.Interlocked.Increment(ref s_WindowsPowerShellCompatUsageCounter);
+                return new List<PSModuleInfo>();
+            }
 
-                    string message = StringUtil.Format(Modules.WinCompatModuleWarning, moduleProxy.Name, WindowsPowerShellCompatRemotingSession.Name);
-                    WriteWarning(message);
-                }
+            var moduleProxyList = ImportModule_RemotelyViaPsrpSession(importModuleOptions, moduleNames, moduleFullyQualifiedNames, WindowsPowerShellCompatRemotingSession, usingWinCompat: true);
+            foreach(PSModuleInfo moduleProxy in moduleProxyList)
+            {
+                moduleProxy.IsWindowsPowerShellCompatModule = true;
+                System.Threading.Interlocked.Increment(ref s_WindowsPowerShellCompatUsageCounter);
+
+                string message = StringUtil.Format(Modules.WinCompatModuleWarning, moduleProxy.Name, WindowsPowerShellCompatRemotingSession.Name);
+                WriteWarning(message);
             }
 
             return moduleProxyList;

--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -1870,24 +1870,33 @@ namespace Microsoft.PowerShell.Commands
             {
                 if (this.UseWindowsPowerShell)
                 {
-                    var WindowsPowerShellCompatRemotingSession = CreateWindowsPowerShellCompatResources();
-                    if (WindowsPowerShellCompatRemotingSession != null)
-                    {
-                        foreach(PSModuleInfo moduleProxy in ImportModule_RemotelyViaPsrpSession(importModuleOptions, this.Name, this.FullyQualifiedName, WindowsPowerShellCompatRemotingSession, true))
-                        {
-                            moduleProxy.IsWindowsPowerShellCompatModule = true;
-                            System.Threading.Interlocked.Increment(ref s_WindowsPowerShellCompatUsageCounter);
-
-                            string message = StringUtil.Format(Modules.WinCompatModuleWarning, moduleProxy.Name, WindowsPowerShellCompatRemotingSession.Name);
-                            WriteWarning(message);
-                        }
-                    }
+                    ImportModulesUsingWinCompat(this.Name, this.FullyQualifiedName, importModuleOptions);
                 }
             }
             else
             {
                 Dbg.Assert(false, "Unrecognized parameter set");
             }
+        }
+
+        internal override IList<PSModuleInfo> ImportModulesUsingWinCompat(IEnumerable<string> moduleNames, IEnumerable<ModuleSpecification> moduleFullyQualifiedNames, ImportModuleOptions importModuleOptions)
+        {
+            IList<PSModuleInfo> moduleProxyList = null;
+            var WindowsPowerShellCompatRemotingSession = CreateWindowsPowerShellCompatResources();
+            if (WindowsPowerShellCompatRemotingSession != null)
+            {
+                moduleProxyList = ImportModule_RemotelyViaPsrpSession(importModuleOptions, moduleNames, moduleFullyQualifiedNames, WindowsPowerShellCompatRemotingSession, true);
+                foreach(PSModuleInfo moduleProxy in moduleProxyList)
+                {
+                    moduleProxy.IsWindowsPowerShellCompatModule = true;
+                    System.Threading.Interlocked.Increment(ref s_WindowsPowerShellCompatUsageCounter);
+
+                    string message = StringUtil.Format(Modules.WinCompatModuleWarning, moduleProxy.Name, WindowsPowerShellCompatRemotingSession.Name);
+                    WriteWarning(message);
+                }
+            }
+
+            return moduleProxyList;
         }
 
         private void SetModuleBaseForEngineModules(string moduleName, System.Management.Automation.ExecutionContext context)

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -2367,7 +2367,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     if (importingModule)
                     {
-                        var moduleProxies = ImportModulesUsingWinCompat(new string [] {moduleManifestPath}, null, new ImportModuleOptions());
+                        IList<PSModuleInfo> moduleProxies = ImportModulesUsingWinCompat(new string [] {moduleManifestPath}, null, new ImportModuleOptions());
 
                         // we are loading by a single ManifestPath so expect max of 1
                         if(moduleProxies.Count > 0) 

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -2367,14 +2367,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     if (importingModule)
                     {
-                        var commandInfo = new CmdletInfo("Import-Module", typeof(ImportModuleCommand));
-                        using var ps = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace);
-                        ps.AddCommand(commandInfo);
-                        ps.AddParameter("PassThru", true);
-                        ps.AddParameter("Name", moduleManifestPath);
-                        ps.AddParameter("UseWindowsPowerShell", true);
-
-                        var moduleProxies = ps.Invoke<PSModuleInfo>();
+                        var moduleProxies = ImportModulesUsingWinCompat(new string [] {moduleManifestPath}, null, new ImportModuleOptions());
 
                         // we are loading by a single ManifestPath so expect max of 1
                         if(moduleProxies.Count > 0) 
@@ -4866,6 +4859,8 @@ namespace Microsoft.PowerShell.Commands
                 }
             }
         }
+
+        internal virtual IList<PSModuleInfo> ImportModulesUsingWinCompat(IEnumerable<string> moduleNames, IEnumerable<ModuleSpecification> moduleFullyQualifiedNames, ImportModuleOptions importModuleOptions) {throw new System.NotImplementedException();}
 
         private void RemoveTypesAndFormatting(
             IList<string> formatFilesToRemove,

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -382,7 +382,7 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "CI" {
 
         It "Verify that Error/Warning are generated with default ErrorAction/WarningAction" -Skip:(-not $IsWindows) {
 
-            $out = pwsh -NoProfile -NonInteractive -c "[System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('TestWindowsPowerShellPSHomeLocation', `'$basePath`');Import-Module $ModuleName"
+            $out = & "$PSHOME\pwsh.exe" -NoProfile -NonInteractive -c "[System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('TestWindowsPowerShellPSHomeLocation', `'$basePath`');Import-Module $ModuleName"
 
             # above should generate 1 error and 1 warning
             $out.Count | Should -BeExactly 2
@@ -392,7 +392,7 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "CI" {
 
         It "Verify that Error/Warning are Not generated with ErrorAction/WarningAction = Ignore" -Skip:(-not $IsWindows) {
 
-            $out = pwsh -NoProfile -NonInteractive -c "[System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('TestWindowsPowerShellPSHomeLocation', `'$basePath`');Import-Module $ModuleName -ErrorAction Ignore -WarningAction Ignore"
+            $out = & "$PSHOME\pwsh.exe" -NoProfile -NonInteractive -c "[System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('TestWindowsPowerShellPSHomeLocation', `'$basePath`');Import-Module $ModuleName -ErrorAction Ignore -WarningAction Ignore"
 
             # above should not generate any errors or warnings
             $out.Count | Should -BeExactly 0

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -367,7 +367,7 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "CI" {
     BeforeAll {
         $ModuleName = "DesktopModule"
         $basePath = Join-Path $TestDrive "WinCompatModules"
-        remove-item $basePath -Recurse -ErrorAction SilentlyContinue
+        Remove-Item -Path $basePath -Recurse -ErrorAction SilentlyContinue
         # create an incompatible module that generates an error on import
         New-EditionCompatibleModule -ModuleName $ModuleName -CompatiblePSEditions "Desktop" -Dir $basePath -ErrorGenerationCode '1/0;'
     }


### PR DESCRIPTION
# PR Summary

This PR is basically a refactoring/optimization of certain WinCompat scenarios that replaces `PowerShell.Create().AddCommand(ImportModuleCommand).Invoke()` with a direct call to the target code that does WinCompat-loading of the module.
- this fixes error-reporting in some WinCompat scenarios like issue #11202 
- this makes WinCompat respect error/warning settings of `CommandDiscovery/ModuleAutoload` scenarios which improves user experience like in issue #11241
- this slightly improves performance because we replace a `PowerShell.Create().Invoke()` with a simple function call.


<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
