### PR TITLE
Update calculation of char width to respect CJK chars correctly

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
@@ -2794,18 +2794,18 @@ namespace Microsoft.PowerShell
         {
             // The following is based on http://www.cl.cam.ac.uk/~mgk25/c/wcwidth.c
             // which is derived from https://www.unicode.org/Public/UCD/latest/ucd/EastAsianWidth.txt
-
             bool isWide = c >= 0x1100 &&
                 (c <= 0x115f || /* Hangul Jamo init. consonants */
                  c == 0x2329 || c == 0x232a ||
-                 (c >= 0x2e80 && c <= 0xa4cf &&
+                 ((uint)(c - 0x2e80) <= (0xa4cf - 0x2e80) &&
                   c != 0x303f) || /* CJK ... Yi */
-                 (c >= 0xac00 && c <= 0xd7a3) || /* Hangul Syllables */
-                 (c >= 0xf900 && c <= 0xfaff) || /* CJK Compatibility Ideographs */
-                 (c >= 0xfe10 && c <= 0xfe19) || /* Vertical forms */
-                 (c >= 0xfe30 && c <= 0xfe6f) || /* CJK Compatibility Forms */
-                 (c >= 0xff00 && c <= 0xff60) || /* Fullwidth Forms */
-                 (c >= 0xffe0 && c <= 0xffe6));
+                 ((uint)(c - 0xac00) <= (0xd7a3 - 0xac00)) || /* Hangul Syllables */
+                 ((uint)(c - 0xf900) <= (0xfaff - 0xf900)) || /* CJK Compatibility Ideographs */
+                 ((uint)(c - 0xfe10) <= (0xfe19 - 0xfe10)) || /* Vertical forms */
+                 ((uint)(c - 0xfe30) <= (0xfe6f - 0xfe30)) || /* CJK Compatibility Forms */
+                 ((uint)(c - 0xff00) <= (0xff60 - 0xff00)) || /* Fullwidth Forms */
+                 ((uint)(c - 0xffe0) <= (0xffe6 - 0xffe0)));
+
             // We can ignore these ranges because .Net strings use surrogate pairs
             // for this range and we do not handle surrogage pairs.
             // (c >= 0x20000 && c <= 0x2fffd) ||

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
@@ -2781,7 +2781,36 @@ namespace Microsoft.PowerShell
                 }
             }
 
-            return str.Length - offset - escapeSequenceAdjustment;
+            int length = 0;
+            foreach (char c in str)
+            {
+                length += LengthInBufferCells(c);
+            }
+
+            return length - offset - escapeSequenceAdjustment;
+        }
+
+        internal static int LengthInBufferCells(char c)
+        {
+            // The following is based on http://www.cl.cam.ac.uk/~mgk25/c/wcwidth.c
+            // which is derived from https://www.unicode.org/Public/UCD/latest/ucd/EastAsianWidth.txt
+
+            bool isWide = c >= 0x1100 &&
+                (c <= 0x115f || /* Hangul Jamo init. consonants */
+                 c == 0x2329 || c == 0x232a ||
+                 (c >= 0x2e80 && c <= 0xa4cf &&
+                  c != 0x303f) || /* CJK ... Yi */
+                 (c >= 0xac00 && c <= 0xd7a3) || /* Hangul Syllables */
+                 (c >= 0xf900 && c <= 0xfaff) || /* CJK Compatibility Ideographs */
+                 (c >= 0xfe10 && c <= 0xfe19) || /* Vertical forms */
+                 (c >= 0xfe30 && c <= 0xfe6f) || /* CJK Compatibility Forms */
+                 (c >= 0xff00 && c <= 0xff60) || /* Fullwidth Forms */
+                 (c >= 0xffe0 && c <= 0xffe6));
+            // We can ignore these ranges because .Net strings use surrogate pairs
+            // for this range and we do not handle surrogage pairs.
+            // (c >= 0x20000 && c <= 0x2fffd) ||
+            // (c >= 0x30000 && c <= 0x3fffd)
+            return 1 + (isWide ? 1 : 0);
         }
 
 #if !UNIX
@@ -2949,33 +2978,6 @@ namespace Microsoft.PowerShell
         }
 
         #endregion helper
-
-        #region
-
-        internal static int LengthInBufferCells(char c)
-        {
-            // The following is based on http://www.cl.cam.ac.uk/~mgk25/c/wcwidth.c
-            // which is derived from https://www.unicode.org/Public/UCD/latest/ucd/EastAsianWidth.txt
-
-            bool isWide = c >= 0x1100 &&
-                (c <= 0x115f || /* Hangul Jamo init. consonants */
-                 c == 0x2329 || c == 0x232a ||
-                 (c >= 0x2e80 && c <= 0xa4cf &&
-                  c != 0x303f) || /* CJK ... Yi */
-                 (c >= 0xac00 && c <= 0xd7a3) || /* Hangul Syllables */
-                 (c >= 0xf900 && c <= 0xfaff) || /* CJK Compatibility Ideographs */
-                 (c >= 0xfe10 && c <= 0xfe19) || /* Vertical forms */
-                 (c >= 0xfe30 && c <= 0xfe6f) || /* CJK Compatibility Forms */
-                 (c >= 0xff00 && c <= 0xff60) || /* Fullwidth Forms */
-                 (c >= 0xffe0 && c <= 0xffe6));
-            // We can ignore these ranges because .Net strings use surrogate pairs
-            // for this range and we do not handle surrogage pairs.
-            // (c >= 0x20000 && c <= 0x2fffd) ||
-            // (c >= 0x30000 && c <= 0x3fffd)
-            return 1 + (isWide ? 1 : 0);
-        }
-
-        #endregion
 
         #region SendInput
 

--- a/src/System.Management.Automation/FormatAndOutput/common/ILineOutput.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ILineOutput.cs
@@ -69,7 +69,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         {
             // The following is based on http://www.cl.cam.ac.uk/~mgk25/c/wcwidth.c
             // which is derived from https://www.unicode.org/Public/UCD/latest/ucd/EastAsianWidth.txt
-
             bool isWide = c >= 0x1100 &&
                 (c <= 0x115f || /* Hangul Jamo init. consonants */
                  c == 0x2329 || c == 0x232a ||
@@ -81,6 +80,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                  (c >= 0xfe30 && c <= 0xfe6f) || /* CJK Compatibility Forms */
                  (c >= 0xff00 && c <= 0xff60) || /* Fullwidth Forms */
                  (c >= 0xffe0 && c <= 0xffe6));
+
             // We can ignore these ranges because .Net strings use surrogate pairs
             // for this range and we do not handle surrogage pairs.
             // (c >= 0x20000 && c <= 0x2fffd) ||

--- a/src/System.Management.Automation/FormatAndOutput/common/ILineOutput.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ILineOutput.cs
@@ -29,7 +29,14 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         internal virtual int Length(string str, int offset)
         {
-            return str.Length - offset;
+            int length = 0;
+
+            foreach (char c in str)
+            {
+                length += LengthInBufferCells(c);
+            }
+
+            return length - offset;
         }
 
         internal virtual int Length(char character) { return 1; }
@@ -57,6 +64,29 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         }
 
         #region Helpers
+
+        protected static int LengthInBufferCells(char c)
+        {
+            // The following is based on http://www.cl.cam.ac.uk/~mgk25/c/wcwidth.c
+            // which is derived from https://www.unicode.org/Public/UCD/latest/ucd/EastAsianWidth.txt
+
+            bool isWide = c >= 0x1100 &&
+                (c <= 0x115f || /* Hangul Jamo init. consonants */
+                 c == 0x2329 || c == 0x232a ||
+                 (c >= 0x2e80 && c <= 0xa4cf &&
+                  c != 0x303f) || /* CJK ... Yi */
+                 (c >= 0xac00 && c <= 0xd7a3) || /* Hangul Syllables */
+                 (c >= 0xf900 && c <= 0xfaff) || /* CJK Compatibility Ideographs */
+                 (c >= 0xfe10 && c <= 0xfe19) || /* Vertical forms */
+                 (c >= 0xfe30 && c <= 0xfe6f) || /* CJK Compatibility Forms */
+                 (c >= 0xff00 && c <= 0xff60) || /* Fullwidth Forms */
+                 (c >= 0xffe0 && c <= 0xffe6));
+            // We can ignore these ranges because .Net strings use surrogate pairs
+            // for this range and we do not handle surrogage pairs.
+            // (c >= 0x20000 && c <= 0x2fffd) ||
+            // (c >= 0x30000 && c <= 0x3fffd)
+            return 1 + (isWide ? 1 : 0);
+        }
 
         /// <summary>
         /// Given a string and a number of display cells, it computes how many

--- a/src/System.Management.Automation/FormatAndOutput/common/ILineOutput.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ILineOutput.cs
@@ -72,14 +72,14 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             bool isWide = c >= 0x1100 &&
                 (c <= 0x115f || /* Hangul Jamo init. consonants */
                  c == 0x2329 || c == 0x232a ||
-                 (c >= 0x2e80 && c <= 0xa4cf &&
+                 ((uint)(c - 0x2e80) <= (0xa4cf - 0x2e80) &&
                   c != 0x303f) || /* CJK ... Yi */
-                 (c >= 0xac00 && c <= 0xd7a3) || /* Hangul Syllables */
-                 (c >= 0xf900 && c <= 0xfaff) || /* CJK Compatibility Ideographs */
-                 (c >= 0xfe10 && c <= 0xfe19) || /* Vertical forms */
-                 (c >= 0xfe30 && c <= 0xfe6f) || /* CJK Compatibility Forms */
-                 (c >= 0xff00 && c <= 0xff60) || /* Fullwidth Forms */
-                 (c >= 0xffe0 && c <= 0xffe6));
+                 ((uint)(c - 0xac00) <= (0xd7a3 - 0xac00)) || /* Hangul Syllables */
+                 ((uint)(c - 0xf900) <= (0xfaff - 0xf900)) || /* CJK Compatibility Ideographs */
+                 ((uint)(c - 0xfe10) <= (0xfe19 - 0xfe10)) || /* Vertical forms */
+                 ((uint)(c - 0xfe30) <= (0xfe6f - 0xfe30)) || /* CJK Compatibility Forms */
+                 ((uint)(c - 0xff00) <= (0xff60 - 0xff00)) || /* Fullwidth Forms */
+                 ((uint)(c - 0xffe0) <= (0xffe6 - 0xffe0)));
 
             // We can ignore these ranges because .Net strings use surrogate pairs
             // for this range and we do not handle surrogage pairs.

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-List.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-List.Tests.ps1
@@ -159,4 +159,24 @@ Describe "Format-List DRT basic functionality" -Tags "CI" {
         $result | Should -Match "Name\s*:\s*test.txt"
         $result | Should -Match "Length\s*:\s*5"
     }
+
+    It "Format-List should work with double byte wide chars" {
+        $obj = [pscustomobject]@{
+            "哇" = "62";
+            "dbda" = "KM";
+            "消息" = "千"
+        }
+
+        $expected = @"
+
+哇   : 62
+dbda : KM
+消息 : 千
+
+
+
+"@
+
+        $obj | Format-List | Out-String | Should -BeExactly $expected
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
@@ -812,4 +812,23 @@ A Name                                  B
             $output = [pscustomobject] @{ one = 1 } | Format-Table @{ l='one'; e='one'; width=10; alignment='center' } | Out-String
             $output.Replace("`r","").Replace(" ",".").Replace("`n","^") | Should -BeExactly $expectedTable.Replace("`r","").Replace(" ",".").Replace("`n","^")
         }
+
+        It "Should be formatted correctly with double byte wide chars" {
+            $obj = [pscustomobject]@{
+                "哇" = "62";
+                "dbda" = "KM";
+                "消息" = "千"
+            }
+
+            $expected = @"
+
+哇 dbda 消息
+-- ---- ----
+62 KM   千
+
+
+"@
+
+            $obj | Format-Table | Out-String | Should -BeExactly $expected
+        }
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Need to fix in two places to correctly calculate length of string in buffer cells if the string contains double wide chars.  When used interactively, the console host does the calculation, so need to make a method that was only used on Windows available for all platforms and use it to calculate length in buffer cells.  When formatting goes through `Out-String`, then it uses the default length calculation in line output so that needed to use the same method.  Since the code is in two different assemblies, there is two copies of the same code.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/11232

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
