### PR TITLE
Update setting PSModulePath to concatenate the process + machine env var

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -1155,7 +1155,7 @@ namespace System.Management.Automation
                         else if (insertPosition > result.Length)
                         {
                             // handle case where path is a singleton with no path seperator already
-                            result.Append(Path.PathSeparator + subPathToAdd);
+                            result.Append(Path.PathSeparator).Append(subPathToAdd);
                         }
                         else // insert at the requested location (this is used by DSC (<Program Files> location) and by 'user-specific location' (SpecialFolder.MyDocuments or EVT.User))
                         {

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -1284,7 +1284,7 @@ namespace System.Management.Automation
             // otherwise, the user modified it and we should use the process one
             if (string.CompareOrdinal(GetExpandedEnvironmentVariable(Constants.PSModulePathEnvVar, EnvironmentVariableTarget.User), currentModulePath) == 0)
             {
-                currentModulePath += Path.PathSeparator + GetExpandedEnvironmentVariable(Constants.PSModulePathEnvVar, EnvironmentVariableTarget.Machine);
+                currentModulePath = currentModulePath + Path.PathSeparator + GetExpandedEnvironmentVariable(Constants.PSModulePathEnvVar, EnvironmentVariableTarget.Machine);
             }
 #endif
             string allUsersModulePath = PowerShellConfig.Instance.GetModulePath(ConfigScope.AllUsers);

--- a/test/powershell/engine/Module/ModulePath.Tests.ps1
+++ b/test/powershell/engine/Module/ModulePath.Tests.ps1
@@ -70,12 +70,13 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
 
         $env:PSModulePath = ""
         $defaultModulePath = & $powershell -nopro -c '$env:PSModulePath'
+        $pathSeparator = [System.IO.Path]::PathSeparator
 
-        $paths = $defaultModulePath -split [System.IO.Path]::PathSeparator
+        $paths = $defaultModulePath.Replace("$pathSeparator$pathSeparator", "$pathSeparator") -split $pathSeparator
 
         if ($IsWindows)
         {
-            $paths.Count | Should -Be 4
+            $paths.Count | Should -Be 6
         }
         else
         {
@@ -85,10 +86,7 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
         $paths[0].TrimEnd([System.IO.Path]::DirectorySeparatorChar) | Should -Be $expectedUserPath
         $paths[1].TrimEnd([System.IO.Path]::DirectorySeparatorChar) | Should -Be $expectedSharedPath
         $paths[2].TrimEnd([System.IO.Path]::DirectorySeparatorChar) | Should -Be $expectedSystemPath
-        if ($IsWindows)
-        {
-            $paths[3].TrimEnd([System.IO.Path]::DirectorySeparatorChar) | Should -Be $expectedWindowsPowerShellPSHomePath
-        }
+        $defaultModulePath | Should -BeLike "*$expectedWindowsPowerShellPSHomePath*"
     }
 
     It "Works with pshome module path derived from a different PowerShell instance" -Skip:(!$IsCoreCLR -or $skipNoPwsh) {
@@ -104,18 +102,11 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
             $env:PSModulePath = $fakePSHomeModuleDir
             $newModulePath = & $powershell -nopro -c '$env:PSModulePath'
             $paths = $newModulePath -split [System.IO.Path]::PathSeparator
-
             $paths.Count | Should -Be 4
-
             $paths[0] | Should -Be $expectedUserPath
             $paths[1] | Should -Be $expectedSharedPath
             $paths[2] | Should -Be $expectedSystemPath
             $paths[3] | Should -Be $fakePSHomeModuleDir
-            if ($IsWindows)
-            {
-                $expectedWindowsPowerShellPSHomePath | Should -Not -BeIn $paths
-            }
-
         } finally {
 
             ## Remove 'powershell' and 'pwsh.deps.json' from the fake PSHome folder
@@ -180,9 +171,14 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
     }
 
     It 'Windows PowerShell does not inherit path defined in powershell.config.json' -Skip:(!$IsWindows) {
-        $userConfig = '{ "PSModulePath": "myUserPath" }'
-        Set-Content -Path $userConfigPath -Value $userConfig -Force
-        $out = pwsh -noprofile -command 'powershell.exe -noprofile -command $env:PSModulePath'
-        $out | Should -Not -BeLike 'myUserPath;*'
+        try {
+            $userConfig = '{ "PSModulePath": "myUserPath" }'
+            Set-Content -Path $userConfigPath -Value $userConfig -Force
+            $out = pwsh -noprofile -command 'powershell.exe -noprofile -command $env:PSModulePath'
+            $out | Should -Not -BeLike 'myUserPath;*'
+        }
+        finally {
+            Remove-Item -Path $userConfigPath -Force
+        }
     }
 }

--- a/test/powershell/engine/Module/ModulePath.Tests.ps1
+++ b/test/powershell/engine/Module/ModulePath.Tests.ps1
@@ -76,6 +76,7 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
 
         if ($IsWindows)
         {
+write-verbose -verbose ($paths | out-string)
             $paths.Count | Should -Be 6
         }
         else

--- a/test/powershell/engine/Module/ModulePath.Tests.ps1
+++ b/test/powershell/engine/Module/ModulePath.Tests.ps1
@@ -76,8 +76,13 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
 
         if ($IsWindows)
         {
-write-verbose -verbose ($paths | out-string)
-            $paths.Count | Should -Be 6
+            $expectedPaths = 3 # user, shared, pshome
+            $userPaths = [System.Environment]::GetEnvironmentVariable("PSModulePath", [System.EnvironmentVariableTarget]::User)
+            $expectedPaths += $userPaths ? $userPaths.Split($pathSeparator).Count : 0
+            $machinePaths = [System.Environment]::GetEnvironmentVariable("PSModulePath", [System.EnvironmentVariableTarget]::Machine)
+            $expectedPaths += $machinePaths ? $machinePaths.Split($pathSeparator).Count : 0
+
+            $paths.Count | Should -Be $expectedPaths
         }
         else
         {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The problem is that Windows treats User scope env vars as the preferred value over Machine scope env vars.  So if a user has PSModulePath defined in their User scope, then the Machine scope one isn't used.  In other words, the Process scope env var is the same as the User scope env var.  However, Windows treats PATH differently in that it concatenates PATH from User scope with PATH from Machine scope.  PSModulePath works like PATH so it should also do the same thing that Windows doesn't automatically do.  You can observe this with just cmd.exe.

The fix here is to start with env var inherited by Process.  If it's the same as the one in User scope, it means the user hasn't modified it and it's incomplete, so we append the Machine scope one.  If it's different, we just use the Process one.  

Also fixed an issue where PSModulePath was a single path without a path separator.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/11172

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
