### PR TITLE
Fix apartment thread state check on non-Windows platforms.

### DIFF
--- a/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
@@ -4499,7 +4499,9 @@ namespace System.Management.Automation
                 {
                     if (pool != null)
                     {
+#if !UNIX
                         VerifyThreadSettings(settings, pool.ApartmentState, pool.ThreadOptions, false);
+#endif
 
                         // getting the runspace asynchronously so that Stop can be supported from a different
                         // thread.
@@ -4512,7 +4514,9 @@ namespace System.Management.Automation
                         rsToUse = _rsConnection as Runspace;
                         if (rsToUse != null)
                         {
+#if !UNIX
                             VerifyThreadSettings(settings, rsToUse.ApartmentState, rsToUse.ThreadOptions, false);
+#endif
 
                             if (rsToUse.RunspaceStateInfo.State != RunspaceState.Opened)
                             {
@@ -4777,7 +4781,9 @@ namespace System.Management.Automation
                 {
                     if (pool != null)
                     {
+#if !UNIX
                         VerifyThreadSettings(settings, pool.ApartmentState, pool.ThreadOptions, pool.IsRemote);
+#endif
 
                         pool.AssertPoolIsOpen();
 
@@ -4854,7 +4860,9 @@ namespace System.Management.Automation
                         LocalRunspace rs = _rsConnection as LocalRunspace;
                         if (rs != null)
                         {
+#if !UNIX
                             VerifyThreadSettings(settings, rs.ApartmentState, rs.ThreadOptions, false);
+#endif
 
                             if (rs.RunspaceStateInfo.State != RunspaceState.Opened)
                             {
@@ -4904,6 +4912,8 @@ namespace System.Management.Automation
             return _invokeAsyncResult;
         }
 
+        // Apartment thread state does not apply to non-Windows platforms.
+#if !UNIX
         /// <summary>
         /// Verifies the settings for ThreadOptions and ApartmentState.
         /// </summary>
@@ -4938,6 +4948,7 @@ namespace System.Management.Automation
                 }
             }
         }
+#endif
 
         /// <summary>
         /// </summary>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR removes the apartment thread state check when invoking a script on a PowerShell object for non-Windows platforms.

## PR Context

I found this while testing SSH remoting on non-Windows platforms.  Entering into an interactive session on an SSH remote connection between PS6 and PS7 results in an error.  The error is due to the apartment thread state check, which should not apply to UNIX platforms.  This is a regression.

The fix is to simply remove the check since it is not needed for UNIX platforms.

```powershell
# PS 6 on Ubuntu platform making a remote connection to PS 7 on Ubuntu platform.
PS > $session = New-PSSession -Host UbuntuPS7
PS > Enter-PSSession $session
Enter-PSSession : When the runspace is set to use the current thread, the apartment state in the invocation settings must match that of the current thread.
At line:1 char:1
+ Enter-PSSession -Session $s
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : NotSpecified: (:) [Enter-PSSession], InvalidOperationException
+ FullyQualifiedErrorId : RemotePSInvocationStateInfoReason
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
