### PR TITLE
Make approved features non-experimental

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Get-Error.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Get-Error.cs
@@ -11,7 +11,6 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// Class for Get-Error implementation.
     /// </summary>
-    [Experimental("Microsoft.PowerShell.Utility.PSGetError", ExperimentAction.Show)]
     [Cmdlet(VerbsCommon.Get, "Error",
         HelpUri = "https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/get-error?view=powershell-7&WT.mc_id=ps-gethelp",
         DefaultParameterSetName = NewestParameterSetName)]

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/UpdatesNotification.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/UpdatesNotification.cs
@@ -57,7 +57,7 @@ namespace Microsoft.PowerShell
         static UpdatesNotification()
         {
             s_notificationType = GetNotificationType();
-            CanNotifyUpdates = s_notificationType != NotificationType.Off && ExperimentalFeature.IsEnabled("PSUpdatesNotification");
+            CanNotifyUpdates = s_notificationType != NotificationType.Off;
 
             if (CanNotifyUpdates)
             {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/UpdatesNotification.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/UpdatesNotification.cs
@@ -36,8 +36,7 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// Gets a value indicating whether update notification should be done.
         /// </summary>
-        internal static readonly bool CanNotifyUpdates = !Utils.GetOptOutEnvVariableAsBool(UpdateCheckOptOutEnvVar, defaultValue: false)
-            && ExperimentalFeature.IsEnabled("PSUpdatesNotification");
+        internal static readonly bool CanNotifyUpdates = !Utils.GetOptOutEnvVariableAsBool(UpdateCheckOptOutEnvVar, defaultValue: false);
 
         // Maybe we shouldn't do update check and show notification when it's from a mini-shell, meaning when
         // 'ConsoleShell.Start' is not called by 'ManagedEntrance.Start'.

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -109,24 +109,6 @@ namespace System.Management.Automation
                 new ExperimentalFeature(
                     name: "PSCommandNotFoundSuggestion",
                     description: "Recommend potential commands based on fuzzy search on a CommandNotFoundException"),
-                new ExperimentalFeature(
-                    name: "PSForEachObjectParallel",
-                    description: "New parameter set for ForEach-Object to run script blocks in parallel"),
-                new ExperimentalFeature(
-                    name: "PSTernaryOperator",
-                    description: "Support the ternary operator in PowerShell language"),
-                new ExperimentalFeature(
-                    name: "PSErrorView",
-                    description: "New formatting for ErrorRecord"),
-                new ExperimentalFeature(
-                    name: "PSUpdatesNotification",
-                    description: "Print notification message when new releases are available"),
-                new ExperimentalFeature(
-                    name: "PSCoalescingOperators",
-                    description: "Support the null coalescing operator and null coalescing assignment operator in PowerShell language"),
-                new ExperimentalFeature(
-                    name: "PSPipelineChainOperators",
-                    description: "Allow use of && and || as operators between pipeline invocations"),
 #if UNIX
                 new ExperimentalFeature(
                     name: "PSUnixFileStat",
@@ -135,11 +117,6 @@ namespace System.Management.Automation
                 new ExperimentalFeature(
                     name: "PSNullConditionalOperators",
                     description: "Support the null conditional member access operators in PowerShell language"),
-#if !UNIX
-                new ExperimentalFeature(
-                    name: "PSWindowsPowerShellCompatibility",
-                    description: "Load non-PSCore-compatible modules into Windows PowerShell over PS Remoting")
-#endif
             };
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);
 

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4426,7 +4426,7 @@ end {
         internal const ActionPreference DefaultWarningPreference = ActionPreference.Continue;
         internal const ActionPreference DefaultInformationPreference = ActionPreference.SilentlyContinue;
 
-        internal const ErrorView DefaultErrorView = ErrorView.NormalView;
+        internal const ErrorView DefaultErrorView = ErrorView.ConciseView;
         internal const bool DefaultWhatIfPreference = false;
         internal const ConfirmImpact DefaultConfirmPreference = ConfirmImpact.High;
 
@@ -4501,7 +4501,7 @@ end {
                 new ArgumentTypeConverterAttribute(typeof(ActionPreference))),
             new SessionStateVariableEntry(
                 SpecialVariables.ErrorView,
-                ExperimentalFeature.IsEnabled("PSErrorView") ? ErrorView.ConciseView : DefaultErrorView,
+                DefaultErrorView,
                 RunspaceInit.ErrorViewDescription,
                 ScopedItemOptions.None,
                 new ArgumentTypeConverterAttribute(typeof(ErrorView))),

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -234,7 +234,6 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Gets or sets a script block to run in parallel for each pipeline object.
         /// </summary>
-        [Experimental("PSForEachObjectParallel", ExperimentAction.Show)]
         [Parameter(Mandatory = true, ParameterSetName = ForEachObjectCommand.ParallelParameterSet)]
         public ScriptBlock Parallel { get; set; }
 
@@ -242,7 +241,6 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the maximum number of concurrently running scriptblocks on separate threads.
         /// The default number is 5.
         /// </summary>
-        [Experimental("PSForEachObjectParallel", ExperimentAction.Show)]
         [Parameter(ParameterSetName = ForEachObjectCommand.ParallelParameterSet)]
         [ValidateRange(1, Int32.MaxValue)]
         public int ThrottleLimit { get; set; } = 5;
@@ -251,7 +249,6 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets a timeout time in seconds, after which the parallel running scripts will be stopped
         /// The default value is 0, indicating no timeout.
         /// </summary>
-        [Experimental("PSForEachObjectParallel", ExperimentAction.Show)]
         [Parameter(ParameterSetName = ForEachObjectCommand.ParallelParameterSet)]
         [ValidateRange(0, (Int32.MaxValue / 1000))]
         public int TimeoutSeconds { get; set; }
@@ -260,7 +257,6 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets a flag that returns a job object immediately for the parallel operation, instead of returning after
         /// all foreach processing is completed.
         /// </summary>
-        [Experimental("PSForEachObjectParallel", ExperimentAction.Show)]
         [Parameter(ParameterSetName = ForEachObjectCommand.ParallelParameterSet)]
         public SwitchParameter AsJob { get; set; }
 

--- a/src/System.Management.Automation/engine/Modules/AnalysisCache.cs
+++ b/src/System.Management.Automation/engine/Modules/AnalysisCache.cs
@@ -103,12 +103,6 @@ namespace System.Management.Automation
                 var moduleManifestProperties = PsUtils.GetModuleManifestProperties(modulePath, PsUtils.FastModuleManifestAnalysisPropertyNames);
                 if (moduleManifestProperties != null)
                 {
-                    if (!ExperimentalFeature.IsEnabled("PSWindowsPowerShellCompatibility") && ModuleIsEditionIncompatible(modulePath, moduleManifestProperties))
-                    {
-                        ModuleIntrinsics.Tracer.WriteLine($"Module lies on the Windows System32 legacy module path and is incompatible with current PowerShell edition, skipping module: {modulePath}");
-                        return null;
-                    }
-
                     Version version;
                     if (ModuleUtils.IsModuleInVersionSubdirectory(modulePath, out version))
                     {
@@ -490,14 +484,6 @@ namespace System.Management.Automation
         internal static void CacheModuleExports(PSModuleInfo module, ExecutionContext context)
         {
             ModuleIntrinsics.Tracer.WriteLine("Requested caching for {0}", module.Name);
-
-            // Don't cache incompatible modules on the system32 module path even if loaded with
-            // -SkipEditionCheck, since it will break subsequent sessions.
-            if (!ExperimentalFeature.IsEnabled("PSWindowsPowerShellCompatibility") && !module.IsConsideredEditionCompatible)
-            {
-                ModuleIntrinsics.Tracer.WriteLine($"Module '{module.Name}' not edition compatible and not cached.");
-                return;
-            }
 
             DateTime lastWriteTime;
             ModuleCacheEntry moduleCacheEntry;

--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -53,7 +53,7 @@ namespace Microsoft.PowerShell.Commands
         private const string ParameterSet_FQName_ViaPsrpSession = "FullyQualifiedNameAndPSSession";
         private const string ParameterSet_ViaWinCompat = "WinCompat";
         private const string ParameterSet_FQName_ViaWinCompat = "FullyQualifiedNameAndWinCompat";
-        
+
 
         /// <summary>
         /// This parameter specifies whether to import to the current session state
@@ -85,7 +85,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = ParameterSet_Name, Mandatory = true, ValueFromPipeline = true, Position = 0)]
         [Parameter(ParameterSetName = ParameterSet_ViaPsrpSession, Mandatory = true, ValueFromPipeline = true, Position = 0)]
         [Parameter(ParameterSetName = ParameterSet_ViaCimSession, Mandatory = true, ValueFromPipeline = true, Position = 0)]
-        [Parameter("PSWindowsPowerShellCompatibility", ExperimentAction.Show, ParameterSetName = ParameterSet_ViaWinCompat, Mandatory = true, ValueFromPipeline = true, Position = 0)]
+        [Parameter(ParameterSetName = ParameterSet_ViaWinCompat, Mandatory = true, ValueFromPipeline = true, Position = 0)]
         [ValidateTrustedData]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public string[] Name { set; get; } = Array.Empty<string>();
@@ -95,7 +95,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(ParameterSetName = ParameterSet_FQName, Mandatory = true, ValueFromPipeline = true, Position = 0)]
         [Parameter(ParameterSetName = ParameterSet_FQName_ViaPsrpSession, Mandatory = true, ValueFromPipeline = true, Position = 0)]
-        [Parameter("PSWindowsPowerShellCompatibility", ExperimentAction.Show, ParameterSetName = ParameterSet_FQName_ViaWinCompat, Mandatory = true, ValueFromPipeline = true, Position = 0)]
+        [Parameter(ParameterSetName = ParameterSet_FQName_ViaWinCompat, Mandatory = true, ValueFromPipeline = true, Position = 0)]
         [ValidateTrustedData]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public ModuleSpecification[] FullyQualifiedName { get; set; }
@@ -275,7 +275,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = ParameterSet_Name)]
         [Parameter(ParameterSetName = ParameterSet_ViaPsrpSession)]
         [Parameter(ParameterSetName = ParameterSet_ViaCimSession)]
-        [Parameter("PSWindowsPowerShellCompatibility", ExperimentAction.Show, ParameterSetName = ParameterSet_ViaWinCompat)]
+        [Parameter(ParameterSetName = ParameterSet_ViaWinCompat)]
         [Alias("Version")]
         public Version MinimumVersion
         {
@@ -290,7 +290,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = ParameterSet_Name)]
         [Parameter(ParameterSetName = ParameterSet_ViaPsrpSession)]
         [Parameter(ParameterSetName = ParameterSet_ViaCimSession)]
-        [Parameter("PSWindowsPowerShellCompatibility", ExperimentAction.Show, ParameterSetName = ParameterSet_ViaWinCompat)]
+        [Parameter(ParameterSetName = ParameterSet_ViaWinCompat)]
         public string MaximumVersion
         {
             get
@@ -320,7 +320,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = ParameterSet_Name)]
         [Parameter(ParameterSetName = ParameterSet_ViaPsrpSession)]
         [Parameter(ParameterSetName = ParameterSet_ViaCimSession)]
-        [Parameter("PSWindowsPowerShellCompatibility", ExperimentAction.Show, ParameterSetName = ParameterSet_ViaWinCompat)]
+        [Parameter(ParameterSetName = ParameterSet_ViaWinCompat)]
         public Version RequiredVersion
         {
             get { return BaseRequiredVersion; }
@@ -425,8 +425,8 @@ namespace Microsoft.PowerShell.Commands
         /// This parameter causes a module to be loaded into Windows PowerShell.
         /// This is mutually exclusive with SkipEditionCheck parameter.
         /// </summary>
-        [Parameter("PSWindowsPowerShellCompatibility", ExperimentAction.Show, ParameterSetName = ParameterSet_ViaWinCompat, Mandatory = true)]
-        [Parameter("PSWindowsPowerShellCompatibility", ExperimentAction.Show, ParameterSetName = ParameterSet_FQName_ViaWinCompat, Mandatory = true)]
+        [Parameter(ParameterSetName = ParameterSet_ViaWinCompat, Mandatory = true)]
+        [Parameter(ParameterSetName = ParameterSet_FQName_ViaWinCompat, Mandatory = true)]
         [Alias("UseWinPS")]
         public SwitchParameter UseWindowsPowerShell { get; set; }
 

--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -54,7 +54,6 @@ namespace Microsoft.PowerShell.Commands
         private const string ParameterSet_ViaWinCompat = "WinCompat";
         private const string ParameterSet_FQName_ViaWinCompat = "FullyQualifiedNameAndWinCompat";
 
-
         /// <summary>
         /// This parameter specifies whether to import to the current session state
         /// or to the global / top-level session state.

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -2365,11 +2365,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 if (importingModule)
                 {
-                    if (importingModule)
-                    {
-                        IList<PSModuleInfo> moduleProxies = ImportModulesUsingWinCompat(new string [] {moduleManifestPath}, null, new ImportModuleOptions());
-
-                    var moduleProxies = ps.Invoke<PSModuleInfo>();
+                    IList<PSModuleInfo> moduleProxies = ImportModulesUsingWinCompat(new string [] {moduleManifestPath}, null, new ImportModuleOptions());
 
                     // we are loading by a single ManifestPath so expect max of 1
                     if(moduleProxies.Count > 0)

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -955,7 +955,7 @@ namespace System.Management.Automation.Language
                 case TokenKind.MultiplyEquals: et = ExpressionType.Multiply; break;
                 case TokenKind.DivideEquals: et = ExpressionType.Divide; break;
                 case TokenKind.RemainderEquals: et = ExpressionType.Modulo; break;
-                case TokenKind.QuestionQuestionEquals when ExperimentalFeature.IsEnabled("PSCoalescingOperators"): et = ExpressionType.Coalesce; break;
+                case TokenKind.QuestionQuestionEquals: et = ExpressionType.Coalesce; break;
             }
 
             var exprs = new List<Expression>();
@@ -5896,7 +5896,7 @@ namespace System.Management.Automation.Language
                         lhs.Cast(typeof(object)),
                         rhs.Cast(typeof(object)),
                         ExpressionCache.Constant(false));
-                case TokenKind.QuestionQuestion when ExperimentalFeature.IsEnabled("PSCoalescingOperators"):
+                case TokenKind.QuestionQuestion:
                     return Coalesce(lhs, rhs);
             }
 

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -6050,7 +6050,6 @@ namespace System.Management.Automation.Language
                         continue;
 
                     case TokenKind.Ampersand:
-                        // When pipeline chains are not enabled, pipelines always handle backgrounding
                         if (!allowBackground)
                         {
                             // Handled by invoking rule

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -6648,7 +6648,6 @@ namespace System.Management.Automation.Language
             // G  ternary-expression:
             // G      binary-expression   '?'   new-lines:opt   ternary-expression   new-lines:opt   ':'   new-lines:opt   ternary-expression
 
-            // TODO: remove this if-block when making 'ternary operator' an official feature.
             RuntimeHelpers.EnsureSufficientExecutionStack();
             var oldTokenizerMode = _tokenizer.Mode;
             try

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -727,7 +727,7 @@ namespace System.Management.Automation.Language
         internal bool ForceEndNumberOnTernaryOpChars
         {
             get { return _forceEndNumberOnTernaryOpChars; }
-            set { _forceEndNumberOnTernaryOpChars = value && ExperimentalFeature.IsEnabled("PSTernaryOperator"); }
+            set { _forceEndNumberOnTernaryOpChars = value; }
         }
 
         internal bool WantSimpleName { get; set; }
@@ -5015,23 +5015,20 @@ namespace System.Management.Automation.Language
                     return this.NewToken(TokenKind.Colon);
 
                 case '?' when InExpressionMode():
-                    if (ExperimentalFeature.IsEnabled("PSCoalescingOperators"))
+                    c1 = PeekChar();
+
+                    if (c1 == '?')
                     {
+                        SkipChar();
                         c1 = PeekChar();
 
-                        if (c1 == '?')
+                        if (c1 == '=')
                         {
                             SkipChar();
-                            c1 = PeekChar();
-
-                            if (c1 == '=')
-                            {
-                                SkipChar();
-                                return this.NewToken(TokenKind.QuestionQuestionEquals);
-                            }
-
-                            return this.NewToken(TokenKind.QuestionQuestion);
+                            return this.NewToken(TokenKind.QuestionQuestionEquals);
                         }
+
+                        return this.NewToken(TokenKind.QuestionQuestion);
                     }
 
                     return this.NewToken(TokenKind.QuestionMark);

--- a/src/System.Management.Automation/engine/remoting/commands/newrunspacecommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/newrunspacecommand.cs
@@ -161,11 +161,10 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ValueFromPipelineByPropertyName = true,
                    ParameterSetName = NewPSSessionCommand.VMNameParameterSet)]
         public string ConfigurationName { get; set; }
-    
+
         /// <summary>
         /// Gets or sets parameter value that creates connection to a Windows PowerShell process.
         /// </summary>
-        [Experimental("PSWindowsPowerShellCompatibility", ExperimentAction.Show)]
         [Parameter(Mandatory = true, ParameterSetName = NewPSSessionCommand.UseWindowsPowerShellParameterSet)]
         public SwitchParameter UseWindowsPowerShell { get; set; }
 

--- a/test/powershell/Language/Operators/NullConditional.Tests.ps1
+++ b/test/powershell/Language/Operators/NullConditional.Tests.ps1
@@ -3,30 +3,15 @@
 
 Describe 'NullCoalesceOperations' -Tags 'CI' {
     BeforeAll {
-
-        $skipTest = -not $EnabledExperimentalFeatures.Contains('PSCoalescingOperators')
-
-        if ($skipTest) {
-            Write-Verbose "Test Suite Skipped. The test suite requires the experimental feature 'PSCoalescingOperators' to be enabled." -Verbose
-            $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
-            $PSDefaultParameterValues["it:skip"] = $true
-        } else {
-            $someGuid = New-Guid
-            $typesTests = @(
-                @{ name = 'string'; valueToSet = 'hello' }
-                @{ name = 'dotnetType'; valueToSet = $someGuid }
-                @{ name = 'byte'; valueToSet = [byte]0x94 }
-                @{ name = 'intArray'; valueToSet = 1..2 }
-                @{ name = 'stringArray'; valueToSet = 'a'..'c' }
-                @{ name = 'emptyArray'; valueToSet = @(1, 2, 3) }
-            )
-        }
-    }
-
-    AfterAll {
-        if ($skipTest) {
-            $global:PSDefaultParameterValues = $originalDefaultParameterValues
-        }
+        $someGuid = New-Guid
+        $typesTests = @(
+            @{ name = 'string'; valueToSet = 'hello' }
+            @{ name = 'dotnetType'; valueToSet = $someGuid }
+            @{ name = 'byte'; valueToSet = [byte]0x94 }
+            @{ name = 'intArray'; valueToSet = 1..2 }
+            @{ name = 'stringArray'; valueToSet = 'a'..'c' }
+            @{ name = 'emptyArray'; valueToSet = @(1, 2, 3) }
+        )
     }
 
     Context "Null conditional assignment operator ??=" {

--- a/test/powershell/Language/Operators/PipelineChainOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/PipelineChainOperator.Tests.ps1
@@ -3,15 +3,6 @@
 
 Describe "Experimental Feature: && and || operators - Feature-Enabled" -Tag CI {
     BeforeAll {
-        $skipTest = -not $EnabledExperimentalFeatures.Contains('PSPipelineChainOperators')
-        if ($skipTest)
-        {
-            Write-Verbose "Test Suite Skipped: These tests require the PSPipelineChainOperators experimental feature to be enabled" -Verbose
-            $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
-            $PSDefaultParameterValues["it:skip"] = $true
-            return
-        }
-
         function Test-SuccessfulCommand
         {
             Write-Output "SUCCESS"
@@ -133,12 +124,6 @@ Describe "Experimental Feature: && and || operators - Feature-Enabled" -Tag CI {
             @{ Statement = 'testexe -returncode 0 && '; ErrorID = 'EmptyPipelineChainElement'; IncompleteInput = $true }
             @{ Statement = 'testexe -returncode 0 && testexe -returncode 1 && &'; ErrorID = 'MissingExpression' }
         )
-    }
-
-    AfterAll {
-        if ($skipTest) {
-            $PSDefaultParameterValues = $originalDefaultParameterValues
-        }
     }
 
     It "Gets the correct output with statement '<Statement>'" -TestCases $simpleTestCases {

--- a/test/powershell/Language/Operators/TernaryOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/TernaryOperator.Tests.ps1
@@ -3,54 +3,46 @@
 
 Describe "Using of ternary operator" -Tags CI {
     BeforeAll {
-        $skipTest = -not $EnabledExperimentalFeatures.Contains('PSTernaryOperator')
-        if ($skipTest) {
-            Write-Verbose "Test Suite Skipped. The test suite requires the experimental feature 'PSTernaryOperator' to be enabled." -Verbose
-            $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
-            $PSDefaultParameterValues["it:skip"] = $true
-        }
-        else {
-            $testCases = @(
-                ## Condition: variable and constant expressions
-                @{ Script = { $true ? 1 : 2 };  ExpectedValue = 1 }
-                @{ Script = { $true? ?1 :2 };   ExpectedValue = 2 }
-                @{ Script = { ${true}?1:2 };    ExpectedValue = 1 }
-                @{ Script = { 1 ? 1kb : 0xf };  ExpectedValue = 1kb }
-                @{ Script = { 0 ?1kb:0xf };     ExpectedValue = 15 }
-                @{ Script = { 's' ?1kb:0xf };   ExpectedValue = 1kb }
-                @{ Script = { $null ?1kb:0xf }; ExpectedValue = 15 }
-                @{ Script = { '' ?1kb:0xf };    ExpectedValue = 15 }
+        $testCases = @(
+            ## Condition: variable and constant expressions
+            @{ Script = { $true ? 1 : 2 };  ExpectedValue = 1 }
+            @{ Script = { $true? ?1 :2 };   ExpectedValue = 2 }
+            @{ Script = { ${true}?1:2 };    ExpectedValue = 1 }
+            @{ Script = { 1 ? 1kb : 0xf };  ExpectedValue = 1kb }
+            @{ Script = { 0 ?1kb:0xf };     ExpectedValue = 15 }
+            @{ Script = { 's' ?1kb:0xf };   ExpectedValue = 1kb }
+            @{ Script = { $null ?1kb:0xf }; ExpectedValue = 15 }
+            @{ Script = { '' ?1kb:0xf };    ExpectedValue = 15 }
 
-                ## Condition: other primary expressions
-                @{ Script = { 1,2,3,4 ? 'Core' : 'Desktop' };          ExpectedValue = 'Core' }
-                @{ Script = { @(1,2,3,4) ? 'Core' : 'Desktop' };       ExpectedValue = 'Core' }
-                @{ Script = { @{name = 'name'} ? 'Core' : 'Desktop' };  ExpectedValue = 'Core' }
-                @{ Script = { @{name = 'name'}.name ? 'Core' : 'Desktop' }; ExpectedValue = 'Core' }
-                @{ Script = { @{name = 'name'}.Contains('name') ? 'Core' : 'Desktop' }; ExpectedValue = 'Core' }
-                @{ Script = { (Test-Path Env:\NonExist) ? 'true' : 'false' };     ExpectedValue = 'false' }
-                @{ Script = { (Test-Path Env:\PSModulePath) ? 'true' : 'false' }; ExpectedValue = 'true' }
-                @{ Script = { $($p = Get-Process -Id $PID; $p.Name -eq 'pwsh') ? 'Core' : 'Desktop' }; ExpectedValue = 'Core' }
-                @{ Script = { ($a = 1) ? 2 : 3 };  ExpectedValue = 2 }
-                @{ Script = { $($a = 1) ? 2 : 3 }; ExpectedValue = 3 }
-                @{ Script = { (Write-Warning -Message warning -WarningAction SilentlyContinue) ? 1 : 2 }; ExpectedValue = 2 }
-                @{ Script = { (Write-Error -Message error -ErrorAction SilentlyContinue) ? 1 : 2 };     ExpectedValue = 2 }
+            ## Condition: other primary expressions
+            @{ Script = { 1,2,3,4 ? 'Core' : 'Desktop' };          ExpectedValue = 'Core' }
+            @{ Script = { @(1,2,3,4) ? 'Core' : 'Desktop' };       ExpectedValue = 'Core' }
+            @{ Script = { @{name = 'name'} ? 'Core' : 'Desktop' };  ExpectedValue = 'Core' }
+            @{ Script = { @{name = 'name'}.name ? 'Core' : 'Desktop' }; ExpectedValue = 'Core' }
+            @{ Script = { @{name = 'name'}.Contains('name') ? 'Core' : 'Desktop' }; ExpectedValue = 'Core' }
+            @{ Script = { (Test-Path Env:\NonExist) ? 'true' : 'false' };     ExpectedValue = 'false' }
+            @{ Script = { (Test-Path Env:\PSModulePath) ? 'true' : 'false' }; ExpectedValue = 'true' }
+            @{ Script = { $($p = Get-Process -Id $PID; $p.Name -eq 'pwsh') ? 'Core' : 'Desktop' }; ExpectedValue = 'Core' }
+            @{ Script = { ($a = 1) ? 2 : 3 };  ExpectedValue = 2 }
+            @{ Script = { $($a = 1) ? 2 : 3 }; ExpectedValue = 3 }
+            @{ Script = { (Write-Warning -Message warning -WarningAction SilentlyContinue) ? 1 : 2 }; ExpectedValue = 2 }
+            @{ Script = { (Write-Error -Message error -ErrorAction SilentlyContinue) ? 1 : 2 };     ExpectedValue = 2 }
 
-                ## Condition: unary and binary expression expressions
-                @{ Script = { -not $IsCoreCLR ? 'Desktop' : 'Core' };             ExpectedValue = 'Core' }
-                @{ Script = { $PSEdition -eq 'Core' ? 'Core' : 'Desktop' };       ExpectedValue = 'Core' }
-                @{ Script = { $IsCoreCLR -and (Get-Process -Id $PID).Name -eq 'pwsh' ? 'Core' : 'Desktop' }; ExpectedValue = 'Core' }
-                @{ Script = { $IsCoreCLR -and 'pwsh' -match 'p.*h' ? 'Core' : 'Desktop' }; ExpectedValue = 'Core' }
-                @{ Script = { 1,2,3 -contains 2 ? 'Core' : 'Desktop' }; ExpectedValue = 'Core' }
+            ## Condition: unary and binary expression expressions
+            @{ Script = { -not $IsCoreCLR ? 'Desktop' : 'Core' };             ExpectedValue = 'Core' }
+            @{ Script = { $PSEdition -eq 'Core' ? 'Core' : 'Desktop' };       ExpectedValue = 'Core' }
+            @{ Script = { $IsCoreCLR -and (Get-Process -Id $PID).Name -eq 'pwsh' ? 'Core' : 'Desktop' }; ExpectedValue = 'Core' }
+            @{ Script = { $IsCoreCLR -and 'pwsh' -match 'p.*h' ? 'Core' : 'Desktop' }; ExpectedValue = 'Core' }
+            @{ Script = { 1,2,3 -contains 2 ? 'Core' : 'Desktop' }; ExpectedValue = 'Core' }
 
-                ## Nested ternary expressions
-                @{ Script = { $IsCoreCLR ? $false ? 'nested-if-true' : 'nested-if-false' : 'if-false' }; ExpectedValue = 'nested-if-false' }
-                @{ Script = { $IsCoreCLR ? $false ? 'nested-if-true' : $true ? 'nested-nested-if-true' : 'nested-nested-if-false' : 'if-false' }; ExpectedValue = 'nested-nested-if-true' }
+            ## Nested ternary expressions
+            @{ Script = { $IsCoreCLR ? $false ? 'nested-if-true' : 'nested-if-false' : 'if-false' }; ExpectedValue = 'nested-if-false' }
+            @{ Script = { $IsCoreCLR ? $false ? 'nested-if-true' : $true ? 'nested-nested-if-true' : 'nested-nested-if-false' : 'if-false' }; ExpectedValue = 'nested-nested-if-true' }
 
-                ## Binary operator has higher precedence order than ternary
-                @{ Script = { !$IsCoreCLR ? 'Core' : 'Desktop' -eq 'Core' };  ExpectedValue = !$IsCoreCLR ? 'Core' : ('Desktop' -eq 'Core') }
-                @{ Script = { ($IsCoreCLR ? 'Core' : 'Desktop') -eq 'Core' }; ExpectedValue = $true }
-            )
-        }
+            ## Binary operator has higher precedence order than ternary
+            @{ Script = { !$IsCoreCLR ? 'Core' : 'Desktop' -eq 'Core' };  ExpectedValue = !$IsCoreCLR ? 'Core' : ('Desktop' -eq 'Core') }
+            @{ Script = { ($IsCoreCLR ? 'Core' : 'Desktop') -eq 'Core' }; ExpectedValue = $true }
+        )
     }
 
     AfterAll {

--- a/test/powershell/Language/Parser/Parsing.Tests.ps1
+++ b/test/powershell/Language/Parser/Parsing.Tests.ps1
@@ -263,21 +263,6 @@ Describe 'assignment statement parsing' -Tags "CI" {
 }
 
 Describe 'null coalescing assignment statement parsing' -Tag 'CI' {
-    BeforeAll {
-        $skipTest = -not $EnabledExperimentalFeatures.Contains('PSCoalescingOperators')
-        if ($skipTest) {
-            Write-Verbose "Test Suite Skipped. The test suite requires the experimental feature 'PSCoalescingOperators' to be enabled." -Verbose
-            $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
-            $PSDefaultParameterValues["it:skip"] = $true
-        }
-    }
-
-    AfterAll {
-        if ($skipTest) {
-            $global:PSDefaultParameterValues = $originalDefaultParameterValues
-        }
-    }
-
     ShouldBeParseError '1 ??= 1' InvalidLeftHandSide 0
     ShouldBeParseError '@() ??= 1' InvalidLeftHandSide 0
     ShouldBeParseError '@{} ??= 1' InvalidLeftHandSide 0
@@ -287,21 +272,6 @@ Describe 'null coalescing assignment statement parsing' -Tag 'CI' {
 }
 
 Describe 'null coalescing statement parsing' -Tag "CI" {
-    BeforeAll {
-        $skipTest = -not $EnabledExperimentalFeatures.Contains('PSCoalescingOperators')
-        if ($skipTest) {
-            Write-Verbose "Test Suite Skipped. The test suite requires the experimental feature 'PSCoalescingOperators' to be enabled." -Verbose
-            $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
-            $PSDefaultParameterValues["it:skip"] = $true
-        }
-    }
-
-    AfterAll {
-        if ($skipTest) {
-            $global:PSDefaultParameterValues = $originalDefaultParameterValues
-        }
-    }
-
     ShouldBeParseError '$x??=' ExpectedValueExpression 5
     ShouldBeParseError '$x ??Get-Thing' ExpectedValueExpression,UnexpectedToken 5,5
     ShouldBeParseError '$??=$false' ExpectedValueExpression,InvalidLeftHandSide 3,0
@@ -393,42 +363,28 @@ Describe 'Unicode escape sequence parsing' -Tag "CI" {
 
 Describe "Ternary Operator parsing" -Tags CI {
     BeforeAll {
-        $skipTest = -not $EnabledExperimentalFeatures.Contains('PSTernaryOperator')
-        if ($skipTest) {
-            Write-Verbose "Test Suite Skipped. The test suite requires the experimental feature 'PSTernaryOperator' to be enabled." -Verbose
-            $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
-            $PSDefaultParameterValues["it:skip"] = $true
-        }
-        else {
-            $testCases_basic = @(
-                @{ Script = '$true?2:3'; TokenKind = [System.Management.Automation.Language.TokenKind]::Variable; }
-                @{ Script = '$false?';   TokenKind = [System.Management.Automation.Language.TokenKind]::Variable; }
-                @{ Script = '$:abc';     TokenKind = [System.Management.Automation.Language.TokenKind]::Variable; }
-                @{ Script = '$env:abc';  TokenKind = [System.Management.Automation.Language.TokenKind]::Variable; }
-                @{ Script = '$env:123';  TokenKind = [System.Management.Automation.Language.TokenKind]::Variable; }
-                @{ Script = 'a?2:2';     TokenKind = [System.Management.Automation.Language.TokenKind]::Generic;  }
-                @{ Script = '1?2:3';     TokenKind = [System.Management.Automation.Language.TokenKind]::Generic;  }
-                @{ Script = 'a?';        TokenKind = [System.Management.Automation.Language.TokenKind]::Generic;  }
-                @{ Script = 'a?b';       TokenKind = [System.Management.Automation.Language.TokenKind]::Generic;  }
-                @{ Script = '1?';        TokenKind = [System.Management.Automation.Language.TokenKind]::Generic;  }
-                @{ Script = '?2:3';      TokenKind = [System.Management.Automation.Language.TokenKind]::Generic;  }
-            )
+        $testCases_basic = @(
+            @{ Script = '$true?2:3'; TokenKind = [System.Management.Automation.Language.TokenKind]::Variable; }
+            @{ Script = '$false?';   TokenKind = [System.Management.Automation.Language.TokenKind]::Variable; }
+            @{ Script = '$:abc';     TokenKind = [System.Management.Automation.Language.TokenKind]::Variable; }
+            @{ Script = '$env:abc';  TokenKind = [System.Management.Automation.Language.TokenKind]::Variable; }
+            @{ Script = '$env:123';  TokenKind = [System.Management.Automation.Language.TokenKind]::Variable; }
+            @{ Script = 'a?2:2';     TokenKind = [System.Management.Automation.Language.TokenKind]::Generic;  }
+            @{ Script = '1?2:3';     TokenKind = [System.Management.Automation.Language.TokenKind]::Generic;  }
+            @{ Script = 'a?';        TokenKind = [System.Management.Automation.Language.TokenKind]::Generic;  }
+            @{ Script = 'a?b';       TokenKind = [System.Management.Automation.Language.TokenKind]::Generic;  }
+            @{ Script = '1?';        TokenKind = [System.Management.Automation.Language.TokenKind]::Generic;  }
+            @{ Script = '?2:3';      TokenKind = [System.Management.Automation.Language.TokenKind]::Generic;  }
+        )
 
-            $testCases_incomplete = @(
-                @{ Script = '$true ?';     ErrorId = "ExpectedValueExpression";         AstType = [System.Management.Automation.Language.ErrorExpressionAst] }
-                @{ Script = '$true ? 3';   ErrorId = "MissingColonInTernaryExpression"; AstType = [System.Management.Automation.Language.ErrorExpressionAst] }
-                @{ Script = '$true ? 3 :'; ErrorId = "ExpectedValueExpression";         AstType = [System.Management.Automation.Language.TernaryExpressionAst] }
-                @{ Script = "`$true`t?";     ErrorId = "ExpectedValueExpression";         AstType = [System.Management.Automation.Language.ErrorExpressionAst] }
-                @{ Script = "`$true`t?`t3";   ErrorId = "MissingColonInTernaryExpression"; AstType = [System.Management.Automation.Language.ErrorExpressionAst] }
-                @{ Script = "`$true`t?`t3`t:"; ErrorId = "ExpectedValueExpression";         AstType = [System.Management.Automation.Language.TernaryExpressionAst] }
-            )
-        }
-    }
-
-    AfterAll {
-        if ($skipTest) {
-            $global:PSDefaultParameterValues = $originalDefaultParameterValues
-        }
+        $testCases_incomplete = @(
+            @{ Script = '$true ?';     ErrorId = "ExpectedValueExpression";         AstType = [System.Management.Automation.Language.ErrorExpressionAst] }
+            @{ Script = '$true ? 3';   ErrorId = "MissingColonInTernaryExpression"; AstType = [System.Management.Automation.Language.ErrorExpressionAst] }
+            @{ Script = '$true ? 3 :'; ErrorId = "ExpectedValueExpression";         AstType = [System.Management.Automation.Language.TernaryExpressionAst] }
+            @{ Script = "`$true`t?";     ErrorId = "ExpectedValueExpression";         AstType = [System.Management.Automation.Language.ErrorExpressionAst] }
+            @{ Script = "`$true`t?`t3";   ErrorId = "MissingColonInTernaryExpression"; AstType = [System.Management.Automation.Language.ErrorExpressionAst] }
+            @{ Script = "`$true`t?`t3`t:"; ErrorId = "ExpectedValueExpression";         AstType = [System.Management.Automation.Language.TernaryExpressionAst] }
+        )
     }
 
     It "Question-mark and colon parsed correctly in <Script> when not in ternary expression context" -TestCases $testCases_basic {

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageRestriction.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageRestriction.Tests.ps1
@@ -885,23 +885,6 @@ try
 
     Describe "ForEach-Object -Parallel Constrained Language Tests" -Tags 'Feature','RequireAdminOnWindows' {
 
-        BeforeAll {
-
-            $skipTest = -not $EnabledExperimentalFeatures.Contains('PSForEachObjectParallel')
-            if ($skipTest) {
-                Write-Verbose "Test Suite Skipped. The test suite requires the experimental feature 'PSForEachObjectParallel' to be enabled." -Verbose
-                $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
-                $PSDefaultParameterValues["it:skip"] = $true
-            }
-        }
-
-        AfterAll {
-
-            if ($skipTest) {
-                $global:PSDefaultParameterValues = $originalDefaultParameterValues
-            }
-        }
-
         It 'Foreach-Object -Parallel must run in ConstrainedLanguage mode under system lock down' {
 
             try

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
@@ -3,24 +3,7 @@
 
 Describe 'ForEach-Object -Parallel Basic Tests' -Tags 'CI' {
 
-    BeforeAll {
-
-        $skipTest = -not $EnabledExperimentalFeatures.Contains('PSForEachObjectParallel')
-        if ($skipTest) {
-            Write-Verbose "Test Suite Skipped. The test suite requires the experimental feature 'PSForEachObjectParallel' to be enabled." -Verbose
-            $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
-            $PSDefaultParameterValues["it:skip"] = $true
-        }
-        else {
-            $sb = { "Hello!" }
-        }
-    }
-
-    AfterAll {
-
-        if ($skipTest) {
-            $global:PSDefaultParameterValues = $originalDefaultParameterValues
-        }
+        $sb = { "Hello!" }
     }
 
     It "Verifies dollar underbar variable" {
@@ -88,7 +71,7 @@ Describe 'ForEach-Object -Parallel Basic Tests' -Tags 'CI' {
     }
 
     It 'Verifies debug data streaming' {
-    
+
         $actualDebug = 1..1 | ForEach-Object -Parallel { Write-Debug "Debug!" -Debug } -Debug 5>&1
         $actualDebug.Message | Should -BeExactly 'Debug!'
     }
@@ -105,7 +88,7 @@ Describe 'ForEach-Object -Parallel Basic Tests' -Tags 'CI' {
     }
 
     It 'Verifies error for script block piped variable' {
-    
+
         $actualError = $sb | ForEach-Object -Parallel { "Hello" } 2>&1
         $actualError.FullyQualifiedErrorId | Should -BeExactly 'ParallelPipedInputObjectCannotBeScriptBlock,Microsoft.PowerShell.Commands.ForEachObjectCommand'
     }
@@ -125,13 +108,6 @@ Describe 'ForEach-Object -Parallel Basic Tests' -Tags 'CI' {
 Describe 'ForEach-Object -Parallel common parameters' -Tags 'CI' {
 
     BeforeAll {
-
-        $skipTest = -not $EnabledExperimentalFeatures.Contains('PSForEachObjectParallel')
-        if ($skipTest) {
-            Write-Verbose "Test Suite Skipped. The test suite requires the experimental feature 'PSForEachObjectParallel' to be enabled." -Verbose
-            $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
-            $PSDefaultParameterValues["it:skip"] = $true
-        }
 
         # Test cases
         $TestCasesNotSupportedCommonParameters = @(
@@ -182,10 +158,6 @@ Describe 'ForEach-Object -Parallel common parameters' -Tags 'CI' {
     }
 
     AfterAll {
-        if ($skipTest) {
-            $global:PSDefaultParameterValues = $originalDefaultParameterValues
-        }
-
         $global:actualVariable = $null
     }
 
@@ -206,23 +178,6 @@ Describe 'ForEach-Object -Parallel common parameters' -Tags 'CI' {
 }
 
 Describe 'ForEach-Object -Parallel -AsJob Basic Tests' -Tags 'CI' {
-
-    BeforeAll {
-
-        $skipTest = -not $EnabledExperimentalFeatures.Contains('PSForEachObjectParallel')
-        if ($skipTest) {
-            Write-Verbose "Test Suite Skipped. The test suite requires the experimental feature 'PSForEachObjectParallel' to be enabled." -Verbose
-            $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
-            $PSDefaultParameterValues["it:skip"] = $true
-        }
-    }
-
-    AfterAll {
-
-        if ($skipTest) {
-            $global:PSDefaultParameterValues = $originalDefaultParameterValues
-        }
-    }
 
     It 'Verifies TimeoutSeconds parameter is excluded from AsJob' {
 
@@ -360,23 +315,6 @@ Describe 'ForEach-Object -Parallel -AsJob Basic Tests' -Tags 'CI' {
 
 Describe 'ForEach-Object -Parallel Functional Tests' -Tags 'Feature' {
 
-    BeforeAll {
-
-        $skipTest = -not $EnabledExperimentalFeatures.Contains('PSForEachObjectParallel')
-        if ($skipTest) {
-            Write-Verbose "Test Suite Skipped. The test suite requires the experimental feature 'PSForEachObjectParallel' to be enabled." -Verbose
-            $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
-            $PSDefaultParameterValues["it:skip"] = $true
-        }
-    }
-
-    AfterAll {
-
-        if ($skipTest) {
-            $global:PSDefaultParameterValues = $originalDefaultParameterValues
-        }
-    }
-
     It 'Verifies job queuing and throttle limit' {
 
         # Run four job tasks, two in parallel at a time.
@@ -417,7 +355,7 @@ Describe 'ForEach-Object -Parallel Functional Tests' -Tags 'Feature' {
 
     It 'Verifies timeout and throttle parameters' {
 
-        # With ThrottleLimit set to 1, the two 60 second long script blocks will run sequentially, 
+        # With ThrottleLimit set to 1, the two 60 second long script blocks will run sequentially,
         # until the timeout in 5 seconds.
         $results = 1..2 | ForEach-Object -Parallel { "Output $_"; Start-Sleep -Seconds 60 } -TimeoutSeconds 5 -ThrottleLimit 1 2>&1
         $results.Count | Should -BeExactly 2

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
@@ -3,6 +3,7 @@
 
 Describe 'ForEach-Object -Parallel Basic Tests' -Tags 'CI' {
 
+    BeforeAll {
         $sb = { "Hello!" }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
@@ -2,21 +2,6 @@
 # Licensed under the MIT License.
 
 Describe 'Get-Error tests' -Tag CI {
-    BeforeAll {
-        $skipTest = -not $EnabledExperimentalFeatures.Contains('Microsoft.PowerShell.Utility.PSGetError')
-        if ($skipTest) {
-            Write-Verbose "Test Suite Skipped. The test suite requires the experimental feature 'Microsoft.PowerShell.Utility.PSGetError' to be enabled." -Verbose
-            $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
-            $PSDefaultParameterValues["it:skip"] = $true
-        }
-    }
-
-    AfterAll {
-        if ($skipTest) {
-            $global:PSDefaultParameterValues = $originalDefaultParameterValues
-        }
-    }
-
     It 'Get-Error resolves $Error[0] and includes InnerException' {
         try {
             1/0

--- a/test/powershell/engine/Formatting/ErrorView.Tests.ps1
+++ b/test/powershell/engine/Formatting/ErrorView.Tests.ps1
@@ -8,11 +8,7 @@ Describe 'Tests for $ErrorView' -Tag CI {
     }
 
     It '$ErrorView should have correct default value' {
-        $expectedDefault = 'NormalView'
-
-        if ((Get-ExperimentalFeature -Name PSErrorView).Enabled) {
-            $expectedDefault = 'ConciseView'
-        }
+        $expectedDefault = 'ConciseView'
 
         $ErrorView | Should -BeExactly $expectedDefault
     }

--- a/test/tools/TestMetadata.json
+++ b/test/tools/TestMetadata.json
@@ -1,7 +1,5 @@
 {
   "ExperimentalFeatures": {
-    "ExpTest.FeatureOne": [ "test/powershell/engine/ExperimentalFeature/ExperimentalFeature.Basic.Tests.ps1" ],
-    "PSForEachObjectParallel": [ "test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1", "test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageRestriction.Tests.ps1" ],
-    "PSPipelineChainOperators": [ "test/powershell/Language/Operators/PipelineChainOperator.Tests.ps1" ]
+    "ExpTest.FeatureOne": [ "test/powershell/engine/ExperimentalFeature/ExperimentalFeature.Basic.Tests.ps1" ]
   }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

As discussed in @PowerShell/powershell-committee, these features will be out of Experimental status:

```none
PSCoalescingOperators
PSErrorView
PSForEachObjectParallel
PSPipelineChainOperators
PSTernaryOperator
PSUpdatesNotification
PSWindowsPowerShellCompatibility
Microsoft.PowerShell.Utility.PSGetError
```

Code marking them as Experimental has been removed.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/11302
Fix https://github.com/PowerShell/PowerShell/issues/11081

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
