### PR TITLE
Improvements in breakpoint APIs for remote scenarios

### DIFF
--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -2809,12 +2809,12 @@ namespace System.Management.Automation
 
         private Debugger GetRunspaceDebugger(int runspaceId)
         {
-            if(!Runspace.RunspaceDictionary.TryGetValue(runspaceId, out WeakReference<Runspace> wr))
+            if (!Runspace.RunspaceDictionary.TryGetValue(runspaceId, out WeakReference<Runspace> wr))
             {
                 throw new PSArgumentException(string.Format(DebuggerStrings.InvalidRunspaceId, runspaceId));
             }
 
-            if(!wr.TryGetTarget(out Runspace rs))
+            if (!wr.TryGetTarget(out Runspace rs))
             {
                 throw new PSArgumentException(DebuggerStrings.UnableToGetRunspace);
             }

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -2811,7 +2811,7 @@ namespace System.Management.Automation
         {
             if(!Runspace.RunspaceDictionary.TryGetValue(runspaceId, out WeakReference<Runspace> wr))
             {
-                throw new PSArgumentException(DebuggerStrings.InvalidRunspaceId);
+                throw new PSArgumentException(string.Format(DebuggerStrings.InvalidRunspaceId, runspaceId));
             }
 
             if(!wr.TryGetTarget(out Runspace rs))

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -622,20 +622,23 @@ namespace System.Management.Automation
         /// Get a breakpoint by id, primarily for Enable/Disable/Remove-PSBreakpoint cmdlets.
         /// </summary>
         /// <param name="id">Id of the breakpoint you want.</param>
-        public virtual Breakpoint GetBreakpoint(int id) =>
+        /// <param name="runspaceId"></param>
+        public virtual Breakpoint GetBreakpoint(int id, int? runspaceId = null) =>
             throw new PSNotImplementedException();
 
         /// <summary>
         /// Adds the provided set of breakpoints to the debugger.
         /// </summary>
         /// <param name="breakpoints">Breakpoints.</param>
-        public virtual void SetBreakpoints(IEnumerable<Breakpoint> breakpoints) =>  
+        /// <param name="runspaceId"></param>
+        public virtual void SetBreakpoints(IEnumerable<Breakpoint> breakpoints, int? runspaceId = null) =>  
             throw new PSNotImplementedException();
 
         /// <summary>
         /// Returns breakpoints primarily for the Get-PSBreakpoint cmdlet.
         /// </summary>
-        public virtual List<Breakpoint> GetBreakpoints() =>
+        /// <param name="runspaceId"></param>
+        public virtual List<Breakpoint> GetBreakpoints(int? runspaceId = null) =>
             throw new PSNotImplementedException();
 
         /// <summary>
@@ -644,8 +647,9 @@ namespace System.Management.Automation
         /// <param name="command">The name of the command that will trigger the breakpoint. This value is required and may not be null.</param>
         /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
         /// <param name="path">The path to the script file where the breakpoint may be hit. If null, the breakpoint may be hit anywhere the command is invoked.</param>
+        /// <param name="runspaceId"></param>
         /// <returns>The command breakpoint that was set.</returns>
-        public virtual CommandBreakpoint SetCommandBreakpoint(string command, ScriptBlock action = null, string path = null) =>
+        public virtual CommandBreakpoint SetCommandBreakpoint(string command, ScriptBlock action = null, string path = null, int? runspaceId = null) =>
             throw new PSNotImplementedException();
 
         /// <summary>
@@ -655,8 +659,9 @@ namespace System.Management.Automation
         /// <param name="line">The line in the script file where the breakpoint may be hit. This value is required and must be greater than or equal to 1.</param>
         /// <param name="column">The column in the script file where the breakpoint may be hit. If 0, the breakpoint will trigger on any statement on the line.</param>
         /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
+        /// <param name="runspaceId"></param>
         /// <returns>The line breakpoint that was set.</returns>
-        public virtual LineBreakpoint SetLineBreakpoint(string path, int line, int column = 0, ScriptBlock action = null) =>
+        public virtual LineBreakpoint SetLineBreakpoint(string path, int line, int column = 0, ScriptBlock action = null, int? runspaceId = null) =>
             throw new PSNotImplementedException();
 
         /// <summary>
@@ -666,32 +671,36 @@ namespace System.Management.Automation
         /// <param name="accessMode">The variable access mode that will trigger the breakpoint. By default variable breakpoints will trigger only when the variable is updated.</param>
         /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
         /// <param name="path">The path to the script file where the breakpoint may be hit. If null, the breakpoint may be hit anywhere the variable is accessed using the specified access mode.</param>
+        /// <param name="runspaceId"></param>
         /// <returns>The variable breakpoint that was set.</returns>
-        public virtual VariableBreakpoint SetVariableBreakpoint(string variableName, VariableAccessMode accessMode = VariableAccessMode.Write, ScriptBlock action = null, string path = null) =>
+        public virtual VariableBreakpoint SetVariableBreakpoint(string variableName, VariableAccessMode accessMode = VariableAccessMode.Write, ScriptBlock action = null, string path = null, int? runspaceId = null) =>
             throw new PSNotImplementedException();
 
         /// <summary>
         /// Removes a breakpoint from the debugger.
         /// </summary>
         /// <param name="breakpoint">The breakpoint to remove from the debugger. This value is required and may not be null.</param>
+        /// <param name="runspaceId"></param>
         /// <returns>True if the breakpoint was removed from the debugger; false otherwise.</returns>
-        public virtual bool RemoveBreakpoint(Breakpoint breakpoint) =>
+        public virtual bool RemoveBreakpoint(Breakpoint breakpoint, int? runspaceId = null) =>
             throw new PSNotImplementedException();
 
         /// <summary>
         /// Enables a breakpoint in the debugger.
         /// </summary>
         /// <param name="breakpoint">The breakpoint to enable in the debugger. This value is required and may not be null.</param>
+        /// <param name="runspaceId"></param>
         /// <returns>The updated breakpoint if it was found; null if the breakpoint was not found in the debugger.</returns>
-        public virtual Breakpoint EnableBreakpoint(Breakpoint breakpoint) =>
+        public virtual Breakpoint EnableBreakpoint(Breakpoint breakpoint, int? runspaceId = null) =>
             throw new PSNotImplementedException();
 
         /// <summary>
         /// Disables a breakpoint in the debugger.
         /// </summary>
         /// <param name="breakpoint">The breakpoint to enable in the debugger. This value is required and may not be null.</param>
+        /// <param name="runspaceId"></param>
         /// <returns>The updated breakpoint if it was found; null if the breakpoint was not found in the debugger.</returns>
-        public virtual Breakpoint DisableBreakpoint(Breakpoint breakpoint) =>
+        public virtual Breakpoint DisableBreakpoint(Breakpoint breakpoint, int? runspaceId = null) =>
             throw new PSNotImplementedException();
 
         /// <summary>
@@ -2591,8 +2600,15 @@ namespace System.Management.Automation
         /// Adds the provided set of breakpoints to the debugger.
         /// </summary>
         /// <param name="breakpoints"></param>
-        public override void SetBreakpoints(IEnumerable<Breakpoint> breakpoints)
+        /// <param name="runspaceId"></param>
+        public override void SetBreakpoints(IEnumerable<Breakpoint> breakpoints, int? runspaceId = null)
         {
+            if (runspaceId.HasValue)
+            {
+                GetRunspaceDebugger(runspaceId.Value).SetBreakpoints(breakpoints);
+                return;
+            }
+
             foreach (Breakpoint bp in breakpoints)
             {
                 switch (bp)
@@ -2616,8 +2632,14 @@ namespace System.Management.Automation
         /// Get a breakpoint by id, primarily for Enable/Disable/Remove-PSBreakpoint cmdlets.
         /// </summary>
         /// <param name="id">Id of the breakpoint you want.</param>
-        public override Breakpoint GetBreakpoint(int id)
+        /// <param name="runspaceId"></param>
+        public override Breakpoint GetBreakpoint(int id, int? runspaceId = null)
         {
+            if (runspaceId.HasValue)
+            {
+                return GetRunspaceDebugger(runspaceId.Value).GetBreakpoint(id);
+            }
+
             _idToBreakpoint.TryGetValue(id, out Breakpoint breakpoint);
             return breakpoint;
         }
@@ -2625,8 +2647,14 @@ namespace System.Management.Automation
         /// <summary>
         /// Returns breakpoints primarily for the Get-PSBreakpoint cmdlet.
         /// </summary>
-        public override List<Breakpoint> GetBreakpoints()
+        /// <param name="runspaceId"></param>
+        public override List<Breakpoint> GetBreakpoints(int? runspaceId = null)
         {
+            if (runspaceId.HasValue)
+            {
+                return GetRunspaceDebugger(runspaceId.Value).GetBreakpoints();
+            }
+
             return (from bp in _idToBreakpoint.Values orderby bp.Id select bp).ToList();
         }
 
@@ -2636,9 +2664,15 @@ namespace System.Management.Automation
         /// <param name="command">The name of the command that will trigger the breakpoint. This value is required and may not be null.</param>
         /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
         /// <param name="path">The path to the script file where the breakpoint may be hit. If null, the breakpoint may be hit anywhere the command is invoked.</param>
+        /// <param name="runspaceId"></param>
         /// <returns></returns>
-        public override CommandBreakpoint SetCommandBreakpoint(string command, ScriptBlock action = null, string path = null)
+        public override CommandBreakpoint SetCommandBreakpoint(string command, ScriptBlock action = null, string path = null, int? runspaceId = null)
         {
+            if (runspaceId.HasValue)
+            {
+                return GetRunspaceDebugger(runspaceId.Value).SetCommandBreakpoint(command, action, path);
+            }
+
             Diagnostics.Assert(!string.IsNullOrEmpty(command), "Caller to verify command is not null or empty.");
 
             WildcardPattern pattern = WildcardPattern.Get(command, WildcardOptions.Compiled | WildcardOptions.IgnoreCase);
@@ -2654,9 +2688,15 @@ namespace System.Management.Automation
         /// <param name="line">The line in the script file where the breakpoint may be hit. This value is required and must be greater than or equal to 1.</param>
         /// <param name="column">The column in the script file where the breakpoint may be hit. If 0, the breakpoint will trigger on any statement on the line.</param>
         /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
+        /// <param name="runspaceId"></param>
         /// <returns></returns>
-        public override LineBreakpoint SetLineBreakpoint(string path, int line, int column = 0, ScriptBlock action = null)
+        public override LineBreakpoint SetLineBreakpoint(string path, int line, int column = 0, ScriptBlock action = null, int? runspaceId = null)
         {
+            if (runspaceId.HasValue)
+            {
+                return GetRunspaceDebugger(runspaceId.Value).SetLineBreakpoint(path, line, column, action);
+            }
+
             Diagnostics.Assert(path != null, "Caller to verify path is not null.");
             Diagnostics.Assert(line > 0, "Caller to verify line is greater than 0.");
 
@@ -2671,9 +2711,15 @@ namespace System.Management.Automation
         /// <param name="accessMode">The variable access mode that will trigger the breakpoint. By default variable breakpoints will trigger only when the variable is updated.</param>
         /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
         /// <param name="path">The path to the script file where the breakpoint may be hit. If null, the breakpoint may be hit anywhere the variable is accessed using the specified access mode.</param>
+        /// <param name="runspaceId"></param>
         /// <returns></returns>
-        public override VariableBreakpoint SetVariableBreakpoint(string variableName, VariableAccessMode accessMode = VariableAccessMode.Write, ScriptBlock action = null, string path = null)
+        public override VariableBreakpoint SetVariableBreakpoint(string variableName, VariableAccessMode accessMode = VariableAccessMode.Write, ScriptBlock action = null, string path = null, int? runspaceId = null)
         {
+            if (runspaceId.HasValue)
+            {
+                return GetRunspaceDebugger(runspaceId.Value).SetVariableBreakpoint(variableName, accessMode, action, path);
+            }
+
             Diagnostics.Assert(!string.IsNullOrEmpty(variableName), "Caller to verify variableName is not null or empty.");
 
             CheckForBreakpointSupport();
@@ -2681,8 +2727,13 @@ namespace System.Management.Automation
         }
 
         // This is the implementation of the Remove-PSBreakpoint cmdlet.
-        public override bool RemoveBreakpoint(Breakpoint breakpoint)
+        public override bool RemoveBreakpoint(Breakpoint breakpoint, int? runspaceId = null)
         {
+            if (runspaceId.HasValue)
+            {
+                return GetRunspaceDebugger(runspaceId.Value).RemoveBreakpoint(breakpoint);
+            }
+
             Diagnostics.Assert(breakpoint != null, "Caller to verify the breakpoint is not null.");
 
             if (_idToBreakpoint.Remove(breakpoint.Id, out _))
@@ -2702,10 +2753,14 @@ namespace System.Management.Automation
             return false;
         }
 
-
         // This is the implementation of the Enable-PSBreakpoint cmdlet.
-        public override Breakpoint EnableBreakpoint(Breakpoint breakpoint)
+        public override Breakpoint EnableBreakpoint(Breakpoint breakpoint, int? runspaceId = null)
         {
+            if (runspaceId.HasValue)
+            {
+                return GetRunspaceDebugger(runspaceId.Value).EnableBreakpoint(breakpoint);
+            }
+
             Diagnostics.Assert(breakpoint != null, "Caller to verify the breakpoint is not null.");
 
             if (_idToBreakpoint.TryGetValue(breakpoint.Id, out _))
@@ -2720,8 +2775,13 @@ namespace System.Management.Automation
         }
 
         // This is the implementation of the Disable-PSBreakpoint cmdlet.
-        public override Breakpoint DisableBreakpoint(Breakpoint breakpoint)
+        public override Breakpoint DisableBreakpoint(Breakpoint breakpoint, int? runspaceId = null)
         {
+            if (runspaceId.HasValue)
+            {
+                return GetRunspaceDebugger(runspaceId.Value).DisableBreakpoint(breakpoint);
+            }
+
             Diagnostics.Assert(breakpoint != null, "Caller to verify the breakpoint is not null.");
 
             if (_idToBreakpoint.TryGetValue(breakpoint.Id, out _))
@@ -2733,6 +2793,22 @@ namespace System.Management.Automation
             }
 
             return null;
+        }
+
+        private Debugger GetRunspaceDebugger(int runspaceId)
+        {
+            if(!Runspace.RunspaceDictionary.TryGetValue(runspaceId, out WeakReference<Runspace> wr))
+            {
+                throw new PSArgumentException("Invalid runspace id.");
+            }
+
+
+            if(!wr.TryGetTarget(out Runspace rs))
+            {
+                throw new PSArgumentException("Unable to get Runspace.");
+            }
+
+            return rs.Debugger;
         }
 
         #endregion Breakpoints
@@ -4084,8 +4160,9 @@ namespace System.Management.Automation
         /// Adds the provided set of breakpoints to the debugger.
         /// </summary>
         /// <param name="breakpoints">Breakpoints.</param>
-        public override void SetBreakpoints(IEnumerable<Breakpoint> breakpoints) =>
-            _wrappedDebugger.SetBreakpoints(breakpoints);
+        /// <param name="runspaceId"></param>
+        public override void SetBreakpoints(IEnumerable<Breakpoint> breakpoints, int? runspaceId = null) =>
+            _wrappedDebugger.SetBreakpoints(breakpoints, runspaceId);
 
         /// <summary>
         /// Process debugger or PowerShell command/script.
@@ -4123,29 +4200,29 @@ namespace System.Management.Automation
             return _wrappedDebugger.ProcessCommand(command, output);
         }
 
-        public override Breakpoint GetBreakpoint(int id) =>
-            _wrappedDebugger.GetBreakpoint(id);
+        public override Breakpoint GetBreakpoint(int id, int? runspaceId = null) =>
+            _wrappedDebugger.GetBreakpoint(id, runspaceId);
 
-        public override List<Breakpoint> GetBreakpoints() =>
-            _wrappedDebugger.GetBreakpoints();
+        public override List<Breakpoint> GetBreakpoints(int? runspaceId = null) =>
+            _wrappedDebugger.GetBreakpoints(runspaceId);
 
-        public override CommandBreakpoint SetCommandBreakpoint(string command, ScriptBlock action = null, string path = null) =>
-            _wrappedDebugger.SetCommandBreakpoint(command, action, path);
+        public override CommandBreakpoint SetCommandBreakpoint(string command, ScriptBlock action = null, string path = null, int? runspaceId = null) =>
+            _wrappedDebugger.SetCommandBreakpoint(command, action, path, runspaceId);
 
-        public override LineBreakpoint SetLineBreakpoint(string path, int line, int column = 0, ScriptBlock action = null) =>
-            _wrappedDebugger.SetLineBreakpoint(path, line, column, action);
+        public override LineBreakpoint SetLineBreakpoint(string path, int line, int column = 0, ScriptBlock action = null, int? runspaceId = null) =>
+            _wrappedDebugger.SetLineBreakpoint(path, line, column, action, runspaceId);
 
-        public override VariableBreakpoint SetVariableBreakpoint(string variableName, VariableAccessMode accessMode = VariableAccessMode.Write, ScriptBlock action = null, string path = null) =>
-            _wrappedDebugger.SetVariableBreakpoint(variableName, accessMode, action, path);
+        public override VariableBreakpoint SetVariableBreakpoint(string variableName, VariableAccessMode accessMode = VariableAccessMode.Write, ScriptBlock action = null, string path = null, int? runspaceId = null) =>
+            _wrappedDebugger.SetVariableBreakpoint(variableName, accessMode, action, path, runspaceId);
 
-        public override bool RemoveBreakpoint(Breakpoint breakpoint) =>
-            _wrappedDebugger.RemoveBreakpoint(breakpoint);
+        public override bool RemoveBreakpoint(Breakpoint breakpoint, int? runspaceId = null) =>
+            _wrappedDebugger.RemoveBreakpoint(breakpoint, runspaceId);
 
-        public override Breakpoint EnableBreakpoint(Breakpoint breakpoint) =>
-            _wrappedDebugger.EnableBreakpoint(breakpoint);
+        public override Breakpoint EnableBreakpoint(Breakpoint breakpoint, int? runspaceId = null) =>
+            _wrappedDebugger.EnableBreakpoint(breakpoint, runspaceId);
 
-        public override Breakpoint DisableBreakpoint(Breakpoint breakpoint) =>
-            _wrappedDebugger.DisableBreakpoint(breakpoint);
+        public override Breakpoint DisableBreakpoint(Breakpoint breakpoint, int? runspaceId = null) =>
+            _wrappedDebugger.DisableBreakpoint(breakpoint, runspaceId);
 
         /// <summary>
         /// SetDebuggerAction.

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -4223,6 +4223,7 @@ namespace System.Management.Automation
         /// Returns breakpoints on a runspace.
         /// </summary>
         /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>A list of breakpoints in a runspace.</returns>
         public override List<Breakpoint> GetBreakpoints(int? runspaceId = null) =>
             _wrappedDebugger.GetBreakpoints(runspaceId);
 

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -2811,13 +2811,13 @@ namespace System.Management.Automation
         {
             if(!Runspace.RunspaceDictionary.TryGetValue(runspaceId, out WeakReference<Runspace> wr))
             {
-                throw new PSArgumentException("Invalid runspace id.");
+                throw new PSArgumentException(DebuggerStrings.InvalidRunspaceId);
             }
 
 
             if(!wr.TryGetTarget(out Runspace rs))
             {
-                throw new PSArgumentException("Unable to get Runspace.");
+                throw new PSArgumentException(DebuggerStrings.UnableToGetRunspace);
             }
 
             return rs.Debugger;

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -622,7 +622,7 @@ namespace System.Management.Automation
         /// Get a breakpoint by id, primarily for Enable/Disable/Remove-PSBreakpoint cmdlets.
         /// </summary>
         /// <param name="id">Id of the breakpoint you want.</param>
-        /// <param name="runspaceId"></param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         public virtual Breakpoint GetBreakpoint(int id, int? runspaceId = null) =>
             throw new PSNotImplementedException();
 
@@ -630,14 +630,14 @@ namespace System.Management.Automation
         /// Adds the provided set of breakpoints to the debugger.
         /// </summary>
         /// <param name="breakpoints">Breakpoints.</param>
-        /// <param name="runspaceId"></param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         public virtual void SetBreakpoints(IEnumerable<Breakpoint> breakpoints, int? runspaceId = null) =>  
             throw new PSNotImplementedException();
 
         /// <summary>
         /// Returns breakpoints primarily for the Get-PSBreakpoint cmdlet.
         /// </summary>
-        /// <param name="runspaceId"></param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         public virtual List<Breakpoint> GetBreakpoints(int? runspaceId = null) =>
             throw new PSNotImplementedException();
 
@@ -647,7 +647,7 @@ namespace System.Management.Automation
         /// <param name="command">The name of the command that will trigger the breakpoint. This value is required and may not be null.</param>
         /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
         /// <param name="path">The path to the script file where the breakpoint may be hit. If null, the breakpoint may be hit anywhere the command is invoked.</param>
-        /// <param name="runspaceId"></param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         /// <returns>The command breakpoint that was set.</returns>
         public virtual CommandBreakpoint SetCommandBreakpoint(string command, ScriptBlock action = null, string path = null, int? runspaceId = null) =>
             throw new PSNotImplementedException();
@@ -659,7 +659,7 @@ namespace System.Management.Automation
         /// <param name="line">The line in the script file where the breakpoint may be hit. This value is required and must be greater than or equal to 1.</param>
         /// <param name="column">The column in the script file where the breakpoint may be hit. If 0, the breakpoint will trigger on any statement on the line.</param>
         /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
-        /// <param name="runspaceId"></param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         /// <returns>The line breakpoint that was set.</returns>
         public virtual LineBreakpoint SetLineBreakpoint(string path, int line, int column = 0, ScriptBlock action = null, int? runspaceId = null) =>
             throw new PSNotImplementedException();
@@ -671,7 +671,7 @@ namespace System.Management.Automation
         /// <param name="accessMode">The variable access mode that will trigger the breakpoint. By default variable breakpoints will trigger only when the variable is updated.</param>
         /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
         /// <param name="path">The path to the script file where the breakpoint may be hit. If null, the breakpoint may be hit anywhere the variable is accessed using the specified access mode.</param>
-        /// <param name="runspaceId"></param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         /// <returns>The variable breakpoint that was set.</returns>
         public virtual VariableBreakpoint SetVariableBreakpoint(string variableName, VariableAccessMode accessMode = VariableAccessMode.Write, ScriptBlock action = null, string path = null, int? runspaceId = null) =>
             throw new PSNotImplementedException();
@@ -680,7 +680,7 @@ namespace System.Management.Automation
         /// Removes a breakpoint from the debugger.
         /// </summary>
         /// <param name="breakpoint">The breakpoint to remove from the debugger. This value is required and may not be null.</param>
-        /// <param name="runspaceId"></param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         /// <returns>True if the breakpoint was removed from the debugger; false otherwise.</returns>
         public virtual bool RemoveBreakpoint(Breakpoint breakpoint, int? runspaceId = null) =>
             throw new PSNotImplementedException();
@@ -689,7 +689,7 @@ namespace System.Management.Automation
         /// Enables a breakpoint in the debugger.
         /// </summary>
         /// <param name="breakpoint">The breakpoint to enable in the debugger. This value is required and may not be null.</param>
-        /// <param name="runspaceId"></param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         /// <returns>The updated breakpoint if it was found; null if the breakpoint was not found in the debugger.</returns>
         public virtual Breakpoint EnableBreakpoint(Breakpoint breakpoint, int? runspaceId = null) =>
             throw new PSNotImplementedException();
@@ -698,7 +698,7 @@ namespace System.Management.Automation
         /// Disables a breakpoint in the debugger.
         /// </summary>
         /// <param name="breakpoint">The breakpoint to enable in the debugger. This value is required and may not be null.</param>
-        /// <param name="runspaceId"></param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         /// <returns>The updated breakpoint if it was found; null if the breakpoint was not found in the debugger.</returns>
         public virtual Breakpoint DisableBreakpoint(Breakpoint breakpoint, int? runspaceId = null) =>
             throw new PSNotImplementedException();
@@ -2599,8 +2599,8 @@ namespace System.Management.Automation
         /// <summary>
         /// Adds the provided set of breakpoints to the debugger.
         /// </summary>
-        /// <param name="breakpoints"></param>
-        /// <param name="runspaceId"></param>
+        /// <param name="breakpoints">The breakpoints to set.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         public override void SetBreakpoints(IEnumerable<Breakpoint> breakpoints, int? runspaceId = null)
         {
             if (runspaceId.HasValue)
@@ -2632,7 +2632,7 @@ namespace System.Management.Automation
         /// Get a breakpoint by id, primarily for Enable/Disable/Remove-PSBreakpoint cmdlets.
         /// </summary>
         /// <param name="id">Id of the breakpoint you want.</param>
-        /// <param name="runspaceId"></param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         public override Breakpoint GetBreakpoint(int id, int? runspaceId = null)
         {
             if (runspaceId.HasValue)
@@ -2647,7 +2647,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Returns breakpoints primarily for the Get-PSBreakpoint cmdlet.
         /// </summary>
-        /// <param name="runspaceId"></param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         public override List<Breakpoint> GetBreakpoints(int? runspaceId = null)
         {
             if (runspaceId.HasValue)
@@ -2664,7 +2664,7 @@ namespace System.Management.Automation
         /// <param name="command">The name of the command that will trigger the breakpoint. This value is required and may not be null.</param>
         /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
         /// <param name="path">The path to the script file where the breakpoint may be hit. If null, the breakpoint may be hit anywhere the command is invoked.</param>
-        /// <param name="runspaceId"></param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         /// <returns></returns>
         public override CommandBreakpoint SetCommandBreakpoint(string command, ScriptBlock action = null, string path = null, int? runspaceId = null)
         {
@@ -2688,7 +2688,7 @@ namespace System.Management.Automation
         /// <param name="line">The line in the script file where the breakpoint may be hit. This value is required and must be greater than or equal to 1.</param>
         /// <param name="column">The column in the script file where the breakpoint may be hit. If 0, the breakpoint will trigger on any statement on the line.</param>
         /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
-        /// <param name="runspaceId"></param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         /// <returns></returns>
         public override LineBreakpoint SetLineBreakpoint(string path, int line, int column = 0, ScriptBlock action = null, int? runspaceId = null)
         {
@@ -2711,7 +2711,7 @@ namespace System.Management.Automation
         /// <param name="accessMode">The variable access mode that will trigger the breakpoint. By default variable breakpoints will trigger only when the variable is updated.</param>
         /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
         /// <param name="path">The path to the script file where the breakpoint may be hit. If null, the breakpoint may be hit anywhere the variable is accessed using the specified access mode.</param>
-        /// <param name="runspaceId"></param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         /// <returns></returns>
         public override VariableBreakpoint SetVariableBreakpoint(string variableName, VariableAccessMode accessMode = VariableAccessMode.Write, ScriptBlock action = null, string path = null, int? runspaceId = null)
         {
@@ -2726,7 +2726,11 @@ namespace System.Management.Automation
             return AddVariableBreakpoint(new VariableBreakpoint(path, variableName, accessMode, action));
         }
 
-        // This is the implementation of the Remove-PSBreakpoint cmdlet.
+        /// <summary>
+        /// This is the implementation of the Remove-PSBreakpoint cmdlet.
+        /// </summary>
+        /// <param name="breakpoint">Id of the breakpoint you want.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         public override bool RemoveBreakpoint(Breakpoint breakpoint, int? runspaceId = null)
         {
             if (runspaceId.HasValue)
@@ -2753,7 +2757,11 @@ namespace System.Management.Automation
             return false;
         }
 
-        // This is the implementation of the Enable-PSBreakpoint cmdlet.
+        /// <summary>
+        /// This is the implementation of the Enable-PSBreakpoint cmdlet.
+        /// </summary>
+        /// <param name="breakpoint">Id of the breakpoint you want.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         public override Breakpoint EnableBreakpoint(Breakpoint breakpoint, int? runspaceId = null)
         {
             if (runspaceId.HasValue)
@@ -2774,7 +2782,11 @@ namespace System.Management.Automation
             return null;
         }
 
-        // This is the implementation of the Disable-PSBreakpoint cmdlet.
+        /// <summary>
+        /// This is the implementation of the Disable-PSBreakpoint cmdlet.
+        /// </summary>
+        /// <param name="breakpoint">Id of the breakpoint you want.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         public override Breakpoint DisableBreakpoint(Breakpoint breakpoint, int? runspaceId = null)
         {
             if (runspaceId.HasValue)
@@ -4160,7 +4172,7 @@ namespace System.Management.Automation
         /// Adds the provided set of breakpoints to the debugger.
         /// </summary>
         /// <param name="breakpoints">Breakpoints.</param>
-        /// <param name="runspaceId"></param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         public override void SetBreakpoints(IEnumerable<Breakpoint> breakpoints, int? runspaceId = null) =>
             _wrappedDebugger.SetBreakpoints(breakpoints, runspaceId);
 

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -2689,7 +2689,7 @@ namespace System.Management.Automation
         /// <param name="column">The column in the script file where the breakpoint may be hit. If 0, the breakpoint will trigger on any statement on the line.</param>
         /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
         /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
-        /// <returns></returns>
+        /// <returns>A LineBreakpoint</returns>
         public override LineBreakpoint SetLineBreakpoint(string path, int line, int column = 0, ScriptBlock action = null, int? runspaceId = null)
         {
             if (runspaceId.HasValue)
@@ -2712,7 +2712,7 @@ namespace System.Management.Automation
         /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
         /// <param name="path">The path to the script file where the breakpoint may be hit. If null, the breakpoint may be hit anywhere the variable is accessed using the specified access mode.</param>
         /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
-        /// <returns></returns>
+        /// <returns>A VariableBreakpoint that was set.</returns>
         public override VariableBreakpoint SetVariableBreakpoint(string variableName, VariableAccessMode accessMode = VariableAccessMode.Write, ScriptBlock action = null, string path = null, int? runspaceId = null)
         {
             if (runspaceId.HasValue)
@@ -2813,7 +2813,6 @@ namespace System.Management.Automation
             {
                 throw new PSArgumentException(DebuggerStrings.InvalidRunspaceId);
             }
-
 
             if(!wr.TryGetTarget(out Runspace rs))
             {
@@ -4212,27 +4211,80 @@ namespace System.Management.Automation
             return _wrappedDebugger.ProcessCommand(command, output);
         }
 
+        /// <summary>
+        /// Get a breakpoint by id.
+        /// </summary>
+        /// <param name="id">Id of the breakpoint you want.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         public override Breakpoint GetBreakpoint(int id, int? runspaceId = null) =>
             _wrappedDebugger.GetBreakpoint(id, runspaceId);
 
+        /// <summary>
+        /// Returns breakpoints on a runspace.
+        /// </summary>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         public override List<Breakpoint> GetBreakpoints(int? runspaceId = null) =>
             _wrappedDebugger.GetBreakpoints(runspaceId);
 
+        /// <summary>
+        /// Sets a command breakpoint in the debugger.
+        /// </summary>
+        /// <param name="command">The name of the command that will trigger the breakpoint. This value is required and may not be null.</param>
+        /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
+        /// <param name="path">The path to the script file where the breakpoint may be hit. If null, the breakpoint may be hit anywhere the command is invoked.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The command breakpoint that was set.</returns>
         public override CommandBreakpoint SetCommandBreakpoint(string command, ScriptBlock action = null, string path = null, int? runspaceId = null) =>
             _wrappedDebugger.SetCommandBreakpoint(command, action, path, runspaceId);
 
+        /// <summary>
+        /// Sets a line breakpoint in the debugger.
+        /// </summary>
+        /// <param name="path">The path to the script file where the breakpoint may be hit. This value is required and may not be null.</param>
+        /// <param name="line">The line in the script file where the breakpoint may be hit. This value is required and must be greater than or equal to 1.</param>
+        /// <param name="column">The column in the script file where the breakpoint may be hit. If 0, the breakpoint will trigger on any statement on the line.</param>
+        /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The line breakpoint that was set.</returns>
         public override LineBreakpoint SetLineBreakpoint(string path, int line, int column = 0, ScriptBlock action = null, int? runspaceId = null) =>
             _wrappedDebugger.SetLineBreakpoint(path, line, column, action, runspaceId);
 
+        /// <summary>
+        /// Sets a variable breakpoint in the debugger.
+        /// </summary>
+        /// <param name="variableName">The name of the variable that will trigger the breakpoint. This value is required and may not be null.</param>
+        /// <param name="accessMode">The variable access mode that will trigger the breakpoint. By default variable breakpoints will trigger only when the variable is updated.</param>
+        /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
+        /// <param name="path">The path to the script file where the breakpoint may be hit. If null, the breakpoint may be hit anywhere the variable is accessed using the specified access mode.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The variable breakpoint that was set.</returns>
         public override VariableBreakpoint SetVariableBreakpoint(string variableName, VariableAccessMode accessMode = VariableAccessMode.Write, ScriptBlock action = null, string path = null, int? runspaceId = null) =>
             _wrappedDebugger.SetVariableBreakpoint(variableName, accessMode, action, path, runspaceId);
 
+        /// <summary>
+        /// Removes a breakpoint from the debugger.
+        /// </summary>
+        /// <param name="breakpoint">The breakpoint to remove from the debugger. This value is required and may not be null.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>True if the breakpoint was removed from the debugger; false otherwise.</returns>
         public override bool RemoveBreakpoint(Breakpoint breakpoint, int? runspaceId = null) =>
             _wrappedDebugger.RemoveBreakpoint(breakpoint, runspaceId);
 
+        /// <summary>
+        /// Enables a breakpoint in the debugger.
+        /// </summary>
+        /// <param name="breakpoint">The breakpoint to enable in the debugger. This value is required and may not be null.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The updated breakpoint if it was found; null if the breakpoint was not found in the debugger.</returns>
         public override Breakpoint EnableBreakpoint(Breakpoint breakpoint, int? runspaceId = null) =>
             _wrappedDebugger.EnableBreakpoint(breakpoint, runspaceId);
 
+        /// <summary>
+        /// Disables a breakpoint in the debugger.
+        /// </summary>
+        /// <param name="breakpoint">The breakpoint to enable in the debugger. This value is required and may not be null.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The updated breakpoint if it was found; null if the breakpoint was not found in the debugger.</returns>
         public override Breakpoint DisableBreakpoint(Breakpoint breakpoint, int? runspaceId = null) =>
             _wrappedDebugger.DisableBreakpoint(breakpoint, runspaceId);
 

--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -1091,7 +1091,7 @@ namespace System.Management.Automation.PSTasks
         /// Adds the provided set of breakpoints to the debugger.
         /// </summary>
         /// <param name="breakpoints">List of breakpoints.</param>
-        /// <param name="runspaceId"></param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         public override void SetBreakpoints(IEnumerable<Breakpoint> breakpoints, int? runspaceId = null) =>
             _wrappedDebugger.SetBreakpoints(breakpoints, runspaceId);
 

--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -1104,24 +1104,73 @@ namespace System.Management.Automation.PSTasks
             _wrappedDebugger.SetDebuggerAction(resumeAction);
         }
 
+        /// <summary>
+        /// Get a breakpoint by id, primarily for Enable/Disable/Remove-PSBreakpoint cmdlets.
+        /// </summary>
+        /// <param name="id">Id of the breakpoint you want.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         public override Breakpoint GetBreakpoint(int id, int? runspaceId = null) =>
             _wrappedDebugger.GetBreakpoint(id, runspaceId);
 
+        /// <summary>
+        /// Sets a command breakpoint in the debugger.
+        /// </summary>
+        /// <param name="command">The name of the command that will trigger the breakpoint. This value is required and may not be null.</param>
+        /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
+        /// <param name="path">The path to the script file where the breakpoint may be hit. If null, the breakpoint may be hit anywhere the command is invoked.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The command breakpoint that was set.</returns>
         public override CommandBreakpoint SetCommandBreakpoint(string command, ScriptBlock action = null, string path = null, int? runspaceId = null) =>
             _wrappedDebugger.SetCommandBreakpoint(command, action, path, runspaceId);
 
+        /// <summary>
+        /// Sets a variable breakpoint in the debugger.
+        /// </summary>
+        /// <param name="variableName">The name of the variable that will trigger the breakpoint. This value is required and may not be null.</param>
+        /// <param name="accessMode">The variable access mode that will trigger the breakpoint. By default variable breakpoints will trigger only when the variable is updated.</param>
+        /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
+        /// <param name="path">The path to the script file where the breakpoint may be hit. If null, the breakpoint may be hit anywhere the variable is accessed using the specified access mode.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The variable breakpoint that was set.</returns>
         public override VariableBreakpoint SetVariableBreakpoint(string variableName, VariableAccessMode accessMode = VariableAccessMode.Write, ScriptBlock action = null, string path = null, int? runspaceId = null) =>
             _wrappedDebugger.SetVariableBreakpoint(variableName, accessMode, action, path, runspaceId);
 
+        /// <summary>
+        /// Sets a line breakpoint in the debugger.
+        /// </summary>
+        /// <param name="path">The path to the script file where the breakpoint may be hit. This value is required and may not be null.</param>
+        /// <param name="line">The line in the script file where the breakpoint may be hit. This value is required and must be greater than or equal to 1.</param>
+        /// <param name="column">The column in the script file where the breakpoint may be hit. If 0, the breakpoint will trigger on any statement on the line.</param>
+        /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The line breakpoint that was set.</returns>
         public override LineBreakpoint SetLineBreakpoint(string path, int line, int column = 0, ScriptBlock action = null, int? runspaceId = null) =>
             _wrappedDebugger.SetLineBreakpoint(path, line, column, action, runspaceId);
 
+        /// <summary>
+        /// Enables a breakpoint in the debugger.
+        /// </summary>
+        /// <param name="breakpoint">The breakpoint to enable in the debugger. This value is required and may not be null.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The updated breakpoint if it was found; null if the breakpoint was not found in the debugger.</returns>
         public override Breakpoint EnableBreakpoint(Breakpoint breakpoint, int? runspaceId = null) =>
             _wrappedDebugger.EnableBreakpoint(breakpoint, runspaceId);
 
+        /// <summary>
+        /// Disables a breakpoint in the debugger.
+        /// </summary>
+        /// <param name="breakpoint">The breakpoint to enable in the debugger. This value is required and may not be null.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The updated breakpoint if it was found; null if the breakpoint was not found in the debugger.</returns>
         public override Breakpoint DisableBreakpoint(Breakpoint breakpoint, int? runspaceId = null) =>
             _wrappedDebugger.DisableBreakpoint(breakpoint, runspaceId);
 
+        /// <summary>
+        /// Removes a breakpoint from the debugger.
+        /// </summary>
+        /// <param name="breakpoint">The breakpoint to remove from the debugger. This value is required and may not be null.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>True if the breakpoint was removed from the debugger; false otherwise.</returns>
         public override bool RemoveBreakpoint(Breakpoint breakpoint, int? runspaceId = null) =>
             _wrappedDebugger.RemoveBreakpoint(breakpoint, runspaceId);
 

--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -1109,8 +1109,17 @@ namespace System.Management.Automation.PSTasks
         /// </summary>
         /// <param name="id">Id of the breakpoint you want.</param>
         /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The breakpoint with the specified id.</returns>
         public override Breakpoint GetBreakpoint(int id, int? runspaceId = null) =>
             _wrappedDebugger.GetBreakpoint(id, runspaceId);
+
+        /// <summary>
+        /// Returns breakpoints on a runspace.
+        /// </summary>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>A list of breakpoints in a runspace.</returns>
+        public override List<Breakpoint> GetBreakpoints(int? runspaceId = null) =>
+            _wrappedDebugger.GetBreakpoints(runspaceId);
 
         /// <summary>
         /// Sets a command breakpoint in the debugger.

--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -1091,8 +1091,9 @@ namespace System.Management.Automation.PSTasks
         /// Adds the provided set of breakpoints to the debugger.
         /// </summary>
         /// <param name="breakpoints">List of breakpoints.</param>
-        public override void SetBreakpoints(IEnumerable<Breakpoint> breakpoints) =>
-            _wrappedDebugger.SetBreakpoints(breakpoints);
+        /// <param name="runspaceId"></param>
+        public override void SetBreakpoints(IEnumerable<Breakpoint> breakpoints, int? runspaceId = null) =>
+            _wrappedDebugger.SetBreakpoints(breakpoints, runspaceId);
 
         /// <summary>
         /// Sets the debugger resume action.
@@ -1103,26 +1104,26 @@ namespace System.Management.Automation.PSTasks
             _wrappedDebugger.SetDebuggerAction(resumeAction);
         }
 
-        public override Breakpoint GetBreakpoint(int id) =>
-            _wrappedDebugger.GetBreakpoint(id);
+        public override Breakpoint GetBreakpoint(int id, int? runspaceId = null) =>
+            _wrappedDebugger.GetBreakpoint(id, runspaceId);
 
-        public override CommandBreakpoint SetCommandBreakpoint(string command, ScriptBlock action = null, string path = null) =>
-            _wrappedDebugger.SetCommandBreakpoint(command, action, path);
+        public override CommandBreakpoint SetCommandBreakpoint(string command, ScriptBlock action = null, string path = null, int? runspaceId = null) =>
+            _wrappedDebugger.SetCommandBreakpoint(command, action, path, runspaceId);
 
-        public override VariableBreakpoint SetVariableBreakpoint(string variableName, VariableAccessMode accessMode = VariableAccessMode.Write, ScriptBlock action = null, string path = null) =>
-            _wrappedDebugger.SetVariableBreakpoint(variableName, accessMode, action, path);
+        public override VariableBreakpoint SetVariableBreakpoint(string variableName, VariableAccessMode accessMode = VariableAccessMode.Write, ScriptBlock action = null, string path = null, int? runspaceId = null) =>
+            _wrappedDebugger.SetVariableBreakpoint(variableName, accessMode, action, path, runspaceId);
 
-        public override LineBreakpoint SetLineBreakpoint(string path, int line, int column = 0, ScriptBlock action = null) =>
-            _wrappedDebugger.SetLineBreakpoint(path, line, column, action);
+        public override LineBreakpoint SetLineBreakpoint(string path, int line, int column = 0, ScriptBlock action = null, int? runspaceId = null) =>
+            _wrappedDebugger.SetLineBreakpoint(path, line, column, action, runspaceId);
 
-        public override Breakpoint EnableBreakpoint(Breakpoint breakpoint) =>
-            _wrappedDebugger.EnableBreakpoint(breakpoint);
+        public override Breakpoint EnableBreakpoint(Breakpoint breakpoint, int? runspaceId = null) =>
+            _wrappedDebugger.EnableBreakpoint(breakpoint, runspaceId);
 
-        public override Breakpoint DisableBreakpoint(Breakpoint breakpoint) =>
-            _wrappedDebugger.DisableBreakpoint(breakpoint);
+        public override Breakpoint DisableBreakpoint(Breakpoint breakpoint, int? runspaceId = null) =>
+            _wrappedDebugger.DisableBreakpoint(breakpoint, runspaceId);
 
-        public override bool RemoveBreakpoint(Breakpoint breakpoint) =>
-            _wrappedDebugger.RemoveBreakpoint(breakpoint);
+        public override bool RemoveBreakpoint(Breakpoint breakpoint, int? runspaceId = null) =>
+            _wrappedDebugger.RemoveBreakpoint(breakpoint, runspaceId);
 
         /// <summary>
         /// Stops a running command.

--- a/src/System.Management.Automation/engine/remoting/client/Job.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job.cs
@@ -3917,27 +3917,80 @@ namespace System.Management.Automation
         public override void SetBreakpoints(IEnumerable<Breakpoint> breakpoints, int? runspaceId = null) =>
             _wrappedDebugger.SetBreakpoints(breakpoints, runspaceId);
 
+        /// <summary>
+        /// Get a breakpoint by id, primarily for Enable/Disable/Remove-PSBreakpoint cmdlets.
+        /// </summary>
+        /// <param name="id">Id of the breakpoint you want.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         public override Breakpoint GetBreakpoint(int id, int? runspaceId = null) =>
             _wrappedDebugger.GetBreakpoint(id, runspaceId);
 
+        /// <summary>
+        /// Returns breakpoints on a runspace.
+        /// </summary>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         public override List<Breakpoint> GetBreakpoints(int? runspaceId = null) =>
             _wrappedDebugger.GetBreakpoints(runspaceId);
 
+        /// <summary>
+        /// Sets a command breakpoint in the debugger.
+        /// </summary>
+        /// <param name="command">The name of the command that will trigger the breakpoint. This value is required and may not be null.</param>
+        /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
+        /// <param name="path">The path to the script file where the breakpoint may be hit. If null, the breakpoint may be hit anywhere the command is invoked.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The command breakpoint that was set.</returns>
         public override CommandBreakpoint SetCommandBreakpoint(string command, ScriptBlock action = null, string path = null, int? runspaceId = null) =>
             _wrappedDebugger.SetCommandBreakpoint(command, action, path, runspaceId);
 
+        /// <summary>
+        /// Sets a line breakpoint in the debugger.
+        /// </summary>
+        /// <param name="path">The path to the script file where the breakpoint may be hit. This value is required and may not be null.</param>
+        /// <param name="line">The line in the script file where the breakpoint may be hit. This value is required and must be greater than or equal to 1.</param>
+        /// <param name="column">The column in the script file where the breakpoint may be hit. If 0, the breakpoint will trigger on any statement on the line.</param>
+        /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The line breakpoint that was set.</returns>
         public override LineBreakpoint SetLineBreakpoint(string path, int line, int column = 0, ScriptBlock action = null, int? runspaceId = null) =>
             _wrappedDebugger.SetLineBreakpoint(path, line, column, action, runspaceId);
 
+        /// <summary>
+        /// Sets a variable breakpoint in the debugger.
+        /// </summary>
+        /// <param name="variableName">The name of the variable that will trigger the breakpoint. This value is required and may not be null.</param>
+        /// <param name="accessMode">The variable access mode that will trigger the breakpoint. By default variable breakpoints will trigger only when the variable is updated.</param>
+        /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
+        /// <param name="path">The path to the script file where the breakpoint may be hit. If null, the breakpoint may be hit anywhere the variable is accessed using the specified access mode.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The variable breakpoint that was set.</returns>
         public override VariableBreakpoint SetVariableBreakpoint(string variableName, VariableAccessMode accessMode = VariableAccessMode.Write, ScriptBlock action = null, string path = null, int? runspaceId = null) =>
             _wrappedDebugger.SetVariableBreakpoint(variableName, accessMode, action, path, runspaceId);
 
+        /// <summary>
+        /// Removes a breakpoint from the debugger.
+        /// </summary>
+        /// <param name="breakpoint">The breakpoint to remove from the debugger. This value is required and may not be null.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>True if the breakpoint was removed from the debugger; false otherwise.</returns>
         public override bool RemoveBreakpoint(Breakpoint breakpoint, int? runspaceId = null) =>
             _wrappedDebugger.RemoveBreakpoint(breakpoint, runspaceId);
 
+        /// <summary>
+        /// Enables a breakpoint in the debugger.
+        /// </summary>
+        /// <param name="breakpoint">The breakpoint to enable in the debugger. This value is required and may not be null.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The updated breakpoint if it was found; null if the breakpoint was not found in the debugger.</returns>
         public override Breakpoint EnableBreakpoint(Breakpoint breakpoint, int? runspaceId = null) =>
             _wrappedDebugger.EnableBreakpoint(breakpoint, runspaceId);
 
+        /// <summary>
+        /// Disables a breakpoint in the debugger.
+        /// </summary>
+        /// <param name="breakpoint">The breakpoint to enable in the debugger. This value is required and may not be null.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The updated breakpoint if it was found; null if the breakpoint was not found in the debugger.</returns>
         public override Breakpoint DisableBreakpoint(Breakpoint breakpoint, int? runspaceId = null) =>
             _wrappedDebugger.DisableBreakpoint(breakpoint, runspaceId);
 

--- a/src/System.Management.Automation/engine/remoting/client/Job.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job.cs
@@ -3913,7 +3913,7 @@ namespace System.Management.Automation
         /// Adds the provided set of breakpoints to the debugger.
         /// </summary>
         /// <param name="breakpoints">Breakpoints to set.</param>
-        /// <param name="runspaceId"></param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         public override void SetBreakpoints(IEnumerable<Breakpoint> breakpoints, int? runspaceId = null) =>
             _wrappedDebugger.SetBreakpoints(breakpoints, runspaceId);
 

--- a/src/System.Management.Automation/engine/remoting/client/Job.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job.cs
@@ -3922,6 +3922,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="id">Id of the breakpoint you want.</param>
         /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>A a breakpoint with the specified id.</returns>
         public override Breakpoint GetBreakpoint(int id, int? runspaceId = null) =>
             _wrappedDebugger.GetBreakpoint(id, runspaceId);
 
@@ -3929,6 +3930,7 @@ namespace System.Management.Automation
         /// Returns breakpoints on a runspace.
         /// </summary>
         /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>A list of breakpoints in a runspace.</returns>
         public override List<Breakpoint> GetBreakpoints(int? runspaceId = null) =>
             _wrappedDebugger.GetBreakpoints(runspaceId);
 

--- a/src/System.Management.Automation/engine/remoting/client/Job.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job.cs
@@ -3913,32 +3913,33 @@ namespace System.Management.Automation
         /// Adds the provided set of breakpoints to the debugger.
         /// </summary>
         /// <param name="breakpoints">Breakpoints to set.</param>
-        public override void SetBreakpoints(IEnumerable<Breakpoint> breakpoints) =>
-            _wrappedDebugger.SetBreakpoints(breakpoints);
+        /// <param name="runspaceId"></param>
+        public override void SetBreakpoints(IEnumerable<Breakpoint> breakpoints, int? runspaceId = null) =>
+            _wrappedDebugger.SetBreakpoints(breakpoints, runspaceId);
 
-        public override Breakpoint GetBreakpoint(int id) =>
-            _wrappedDebugger.GetBreakpoint(id);
+        public override Breakpoint GetBreakpoint(int id, int? runspaceId = null) =>
+            _wrappedDebugger.GetBreakpoint(id, runspaceId);
 
-        public override List<Breakpoint> GetBreakpoints() =>
-            _wrappedDebugger.GetBreakpoints();
+        public override List<Breakpoint> GetBreakpoints(int? runspaceId = null) =>
+            _wrappedDebugger.GetBreakpoints(runspaceId);
 
-        public override CommandBreakpoint SetCommandBreakpoint(string command, ScriptBlock action = null, string path = null) =>
-            _wrappedDebugger.SetCommandBreakpoint(command, action, path);
+        public override CommandBreakpoint SetCommandBreakpoint(string command, ScriptBlock action = null, string path = null, int? runspaceId = null) =>
+            _wrappedDebugger.SetCommandBreakpoint(command, action, path, runspaceId);
 
-        public override LineBreakpoint SetLineBreakpoint(string path, int line, int column = 0, ScriptBlock action = null) =>
-            _wrappedDebugger.SetLineBreakpoint(path, line, column, action);
+        public override LineBreakpoint SetLineBreakpoint(string path, int line, int column = 0, ScriptBlock action = null, int? runspaceId = null) =>
+            _wrappedDebugger.SetLineBreakpoint(path, line, column, action, runspaceId);
 
-        public override VariableBreakpoint SetVariableBreakpoint(string variableName, VariableAccessMode accessMode = VariableAccessMode.Write, ScriptBlock action = null, string path = null) =>
-            _wrappedDebugger.SetVariableBreakpoint(variableName, accessMode, action, path);
+        public override VariableBreakpoint SetVariableBreakpoint(string variableName, VariableAccessMode accessMode = VariableAccessMode.Write, ScriptBlock action = null, string path = null, int? runspaceId = null) =>
+            _wrappedDebugger.SetVariableBreakpoint(variableName, accessMode, action, path, runspaceId);
 
-        public override bool RemoveBreakpoint(Breakpoint breakpoint) =>
-            _wrappedDebugger.RemoveBreakpoint(breakpoint);
+        public override bool RemoveBreakpoint(Breakpoint breakpoint, int? runspaceId = null) =>
+            _wrappedDebugger.RemoveBreakpoint(breakpoint, runspaceId);
 
-        public override Breakpoint EnableBreakpoint(Breakpoint breakpoint) =>
-            _wrappedDebugger.EnableBreakpoint(breakpoint);
+        public override Breakpoint EnableBreakpoint(Breakpoint breakpoint, int? runspaceId = null) =>
+            _wrappedDebugger.EnableBreakpoint(breakpoint, runspaceId);
 
-        public override Breakpoint DisableBreakpoint(Breakpoint breakpoint) =>
-            _wrappedDebugger.DisableBreakpoint(breakpoint);
+        public override Breakpoint DisableBreakpoint(Breakpoint breakpoint, int? runspaceId = null) =>
+            _wrappedDebugger.DisableBreakpoint(breakpoint, runspaceId);
 
         /// <summary>
         /// Sets the debugger resume action.

--- a/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
+++ b/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
@@ -2010,7 +2010,7 @@ namespace System.Management.Automation
         /// Adds the provided set of breakpoints to the debugger.
         /// </summary>
         /// <param name="breakpoints">Breakpoints to set.</param>
-        /// <param name="runspaceId"></param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         public override void SetBreakpoints(IEnumerable<Breakpoint> breakpoints, int? runspaceId = null)
         {
             // This is supported only for PowerShell versions >= 7.0
@@ -2033,7 +2033,7 @@ namespace System.Management.Automation
         /// Get a breakpoint by id, primarily for Enable/Disable/Remove-PSBreakpoint cmdlets.
         /// </summary>
         /// <param name="id">Id of the breakpoint you want.</param>
-        /// <param name="runspaceId"></param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         public override Breakpoint GetBreakpoint(int id, int? runspaceId = null)
         {
             // This is supported only for PowerShell versions >= 7.0
@@ -2055,6 +2055,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Returns breakpoints primarily for the Get-PSBreakpoint cmdlet.
         /// </summary>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         public override List<Breakpoint> GetBreakpoints(int? runspaceId = null)
         {
             // This is supported only for PowerShell versions >= 7.0

--- a/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
+++ b/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
@@ -2616,7 +2616,10 @@ namespace System.Management.Automation
             out Exception exception)
         {
             exception = null;
-            if (item == null) { return false; }
+            if (item == null)
+            {
+                return false;
+            }
 
             bool haveExceptionType = false;
             foreach (var typeName in item.TypeNames)

--- a/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
+++ b/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
@@ -2112,26 +2112,17 @@ namespace System.Management.Automation
 
             Breakpoint breakpoint = new LineBreakpoint(path, line, column, action);
 
-            using (PowerShell ps = GetNestedPowerShell())
+            var functionParameters = new Dictionary<string, object>
             {
-                ps.AddCommand(RemoteDebuggingCommands.SetBreakpoint).AddParameter("Breakpoint", breakpoint);
-                
-                if (runspaceId.HasValue)
-                {
-                    ps.AddParameter("RunspaceId", runspaceId.Value);
-                }
+                { "Breakpoint", breakpoint },
+            };
 
-                Collection<PSObject> output = ps.Invoke<PSObject>();
-                foreach (var item in output)
-                {
-                    if (item?.BaseObject is LineBreakpoint bp)
-                    {
-                        return bp;
-                    }
-                }
+            if (runspaceId.HasValue)
+            {
+                functionParameters.Add("RunspaceId", runspaceId.Value);
             }
 
-            return null;
+            return InvokeRemoteBreakpointFunction<LineBreakpoint>(RemoteDebuggingCommands.SetBreakpoint, functionParameters);
         }
 
         public override VariableBreakpoint SetVariableBreakpoint(string variableName, VariableAccessMode accessMode = VariableAccessMode.Write, ScriptBlock action = null, string path = null, int? runspaceId = null)

--- a/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
+++ b/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
@@ -2034,6 +2034,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="id">Id of the breakpoint you want.</param>
         /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The breakpoint with the specified id.</returns>
         public override Breakpoint GetBreakpoint(int id, int? runspaceId = null)
         {
             // This is supported only for PowerShell versions >= 7.0
@@ -2056,6 +2057,7 @@ namespace System.Management.Automation
         /// Returns breakpoints primarily for the Get-PSBreakpoint cmdlet.
         /// </summary>
         /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>A list of breakpoints in a runspace.</returns>
         public override List<Breakpoint> GetBreakpoints(int? runspaceId = null)
         {
             // This is supported only for PowerShell versions >= 7.0

--- a/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
+++ b/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
@@ -2085,7 +2085,6 @@ namespace System.Management.Automation
                     }
                     else if (TryGetRemoteDebuggerException(item, out Exception ex))
                     {
-                        // Check for remote debugger exception and throw here.
                         throw ex;
                     }
                 }
@@ -2911,7 +2910,6 @@ namespace System.Management.Automation
                         return (T)item.BaseObject;
                     }
 
-                    // Check for remote debugger exception object and throw here.
                     if (TryGetRemoteDebuggerException(item, out Exception ex))
                     {
                         throw ex;

--- a/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
+++ b/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
@@ -2092,6 +2092,14 @@ namespace System.Management.Automation
             return breakpoints;
         }
 
+        /// <summary>
+        /// Sets a command breakpoint in the debugger.
+        /// </summary>
+        /// <param name="command">The name of the command that will trigger the breakpoint. This value is required and may not be null.</param>
+        /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
+        /// <param name="path">The path to the script file where the breakpoint may be hit. If null, the breakpoint may be hit anywhere the command is invoked.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The command breakpoint that was set.</returns>
         public override CommandBreakpoint SetCommandBreakpoint(string command, ScriptBlock action = null, string path = null, int? runspaceId = null)
         {
             // This is supported only for PowerShell versions >= 7.0
@@ -2111,6 +2119,15 @@ namespace System.Management.Automation
             return InvokeRemoteBreakpointFunction<CommandBreakpoint>(RemoteDebuggingCommands.SetBreakpoint, functionParameters);
         }
 
+        /// <summary>
+        /// Sets a line breakpoint in the debugger.
+        /// </summary>
+        /// <param name="path">The path to the script file where the breakpoint may be hit. This value is required and may not be null.</param>
+        /// <param name="line">The line in the script file where the breakpoint may be hit. This value is required and must be greater than or equal to 1.</param>
+        /// <param name="column">The column in the script file where the breakpoint may be hit. If 0, the breakpoint will trigger on any statement on the line.</param>
+        /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The line breakpoint that was set.</returns>
         public override LineBreakpoint SetLineBreakpoint(string path, int line, int column = 0, ScriptBlock action = null, int? runspaceId = null)
         {
             // This is supported only for PowerShell versions >= 7.0
@@ -2131,6 +2148,15 @@ namespace System.Management.Automation
             return InvokeRemoteBreakpointFunction<LineBreakpoint>(RemoteDebuggingCommands.SetBreakpoint, functionParameters);
         }
 
+        /// <summary>
+        /// Sets a variable breakpoint in the debugger.
+        /// </summary>
+        /// <param name="variableName">The name of the variable that will trigger the breakpoint. This value is required and may not be null.</param>
+        /// <param name="accessMode">The variable access mode that will trigger the breakpoint. By default variable breakpoints will trigger only when the variable is updated.</param>
+        /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
+        /// <param name="path">The path to the script file where the breakpoint may be hit. If null, the breakpoint may be hit anywhere the variable is accessed using the specified access mode.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The variable breakpoint that was set.</returns>
         public override VariableBreakpoint SetVariableBreakpoint(string variableName, VariableAccessMode accessMode = VariableAccessMode.Write, ScriptBlock action = null, string path = null, int? runspaceId = null)
         {
             // This is supported only for PowerShell versions >= 7.0
@@ -2151,6 +2177,12 @@ namespace System.Management.Automation
             return InvokeRemoteBreakpointFunction<VariableBreakpoint>(RemoteDebuggingCommands.SetBreakpoint, functionParameters);
         }
 
+        /// <summary>
+        /// Removes a breakpoint from the debugger.
+        /// </summary>
+        /// <param name="breakpoint">The breakpoint to remove from the debugger. This value is required and may not be null.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>True if the breakpoint was removed from the debugger; false otherwise.</returns>
         public override bool RemoveBreakpoint(Breakpoint breakpoint, int? runspaceId = null)
         {
             // This is supported only for PowerShell versions >= 7.0
@@ -2174,6 +2206,12 @@ namespace System.Management.Automation
             return InvokeRemoteBreakpointFunction<bool>(RemoteDebuggingCommands.RemoveBreakpoint, functionParameters);
         }
 
+        /// <summary>
+        /// Enables a breakpoint in the debugger.
+        /// </summary>
+        /// <param name="breakpoint">The breakpoint to enable in the debugger. This value is required and may not be null.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The updated breakpoint if it was found; null if the breakpoint was not found in the debugger.</returns>
         public override Breakpoint EnableBreakpoint(Breakpoint breakpoint, int? runspaceId = null)
         {
             // This is supported only for PowerShell versions >= 7.0
@@ -2197,6 +2235,12 @@ namespace System.Management.Automation
             return InvokeRemoteBreakpointFunction<Breakpoint>(RemoteDebuggingCommands.EnableBreakpoint, functionParameters);
         }
 
+        /// <summary>
+        /// Disables a breakpoint in the debugger.
+        /// </summary>
+        /// <param name="breakpoint">The breakpoint to enable in the debugger. This value is required and may not be null.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The updated breakpoint if it was found; null if the breakpoint was not found in the debugger.</returns>
         public override Breakpoint DisableBreakpoint(Breakpoint breakpoint, int? runspaceId = null)
         {
             // This is supported only for PowerShell versions >= 7.0

--- a/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
+++ b/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
@@ -2018,7 +2018,7 @@ namespace System.Management.Automation
 
             var functionParameters = new Dictionary<string, object>
             {
-                { "Breakpoint", breakpoints },
+                { "BreakpointList", breakpoints },
             };
 
             if (runspaceId.HasValue)

--- a/src/System.Management.Automation/engine/remoting/server/ServerPowerShellDriver.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerPowerShellDriver.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Management.Automation.Internal;
 using System.Management.Automation.Remoting;
 using System.Management.Automation.Runspaces;
@@ -304,6 +305,14 @@ namespace System.Management.Automation
                                 new PSInvocationStateInfo(
                                     PSInvocationState.Completed, null));
                         });
+            }
+        }
+
+        internal void AddToOutput(IEnumerable<object> data)
+        {
+            foreach (object item in data)
+            {
+                _localPowerShellOutput.Add(new PSObject(item));
             }
         }
 

--- a/src/System.Management.Automation/engine/remoting/server/ServerPowerShellDriver.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerPowerShellDriver.cs
@@ -290,6 +290,7 @@ namespace System.Management.Automation
         /// commands that sets debugger state but doesn't run any command
         /// on the server runspace.
         /// </summary>
+        /// <param name="output">The output from preprocessing that we want to send to the client.</param>
         internal void RunNoOpCommand(IReadOnlyCollection<object> output)
         {
             if (LocalPowerShell != null)

--- a/src/System.Management.Automation/engine/remoting/server/ServerPowerShellDriver.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerPowerShellDriver.cs
@@ -290,7 +290,7 @@ namespace System.Management.Automation
         /// commands that sets debugger state but doesn't run any command
         /// on the server runspace.
         /// </summary>
-        internal void RunNoOpCommand()
+        internal void RunNoOpCommand(IReadOnlyCollection<object> output)
         {
             if (LocalPowerShell != null)
             {
@@ -301,18 +301,18 @@ namespace System.Management.Automation
                                 new PSInvocationStateInfo(
                                     PSInvocationState.Running, null));
 
+                            foreach (var item in output)
+                            {
+                                if (item != null)
+                                {
+                                    _localPowerShellOutput.Add(PSObject.AsPSObject(item));
+                                }
+                            }
+
                             LocalPowerShell.SetStateChanged(
                                 new PSInvocationStateInfo(
                                     PSInvocationState.Completed, null));
                         });
-            }
-        }
-
-        internal void AddToOutput(IEnumerable<object> data)
-        {
-            foreach (object item in data)
-            {
-                _localPowerShellOutput.Add(new PSObject(item));
             }
         }
 

--- a/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
@@ -1461,12 +1461,13 @@ namespace System.Management.Automation
                 var bps = new List<Breakpoint>();
                 if (breakpoints != null)
                 {
-                    foreach (object bpObj in breakpoints)
+                    foreach (object obj in breakpoints)
                     {
-                        if (!LanguagePrimitives.TryConvertTo<Breakpoint>(bpObj, out Breakpoint bp))
+                        if (!LanguagePrimitives.TryConvertTo<Breakpoint>(obj, out Breakpoint bp))
                         {
                             throw new PSArgumentException(DebuggerStrings.BreakpointListContainedANonBreakpoint);
                         }
+
                         bps.Add(bp);
                     }
                 }

--- a/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
@@ -1271,9 +1271,9 @@ namespace System.Management.Automation
         /// Parses special debugger commands and converts to equivalent script for remote execution as needed.
         /// </summary>
         /// <param name="commands">PSCommand.</param>
-        /// <param name="serverRemoteDebugger"></param>
+        /// <param name="serverRemoteDebugger">The debugger that can be used to invoke debug operations via API.</param>
+        /// <param name="preProcessOutput">A Collection that can be used to send output to the client.</param>
         /// <param name="commandArgument">Command argument.</param>
-        /// <param name="preProcessOutput"></param>
         /// <returns>PreProcessCommandResult type if preprocessing occurred.</returns>
         private static PreProcessCommandResult PreProcessDebuggerCommand(
             PSCommand commands,
@@ -1284,7 +1284,7 @@ namespace System.Management.Automation
             commandArgument = new DebuggerCommandArgument();
             PreProcessCommandResult result = PreProcessCommandResult.None;
 
-            if ((commands.Commands.Count == 0) || (commands.Commands[0].IsScript))
+            if (commands.Commands.Count == 0 || commands.Commands[0].IsScript)
             {
                 return result;
             }
@@ -1452,7 +1452,6 @@ namespace System.Management.Automation
                 }
 
                 result = PreProcessCommandResult.BreakpointManagement;
-
             }
             else if (commandText.Equals(RemoteDebuggingCommands.RemoveBreakpoint, StringComparison.OrdinalIgnoreCase))
             {
@@ -1472,7 +1471,6 @@ namespace System.Management.Automation
                         : serverRemoteDebugger.RemoveBreakpoint(breakpoint, runspaceId));
 
                 result = PreProcessCommandResult.BreakpointManagement;
-
             }
             else if (commandText.Equals(RemoteDebuggingCommands.EnableBreakpoint, StringComparison.OrdinalIgnoreCase))
             {
@@ -1528,7 +1526,7 @@ namespace System.Management.Automation
 
         private static T GetParameter<T>(Command command, string parameterName)
         {
-            if(command.Parameters?.Count == 0)
+            if (command.Parameters?.Count == 0)
             {
                 throw new PSArgumentException(parameterName);
             }
@@ -1537,7 +1535,7 @@ namespace System.Management.Automation
             {
                 if (string.Equals(param.Name, parameterName, StringComparison.OrdinalIgnoreCase))
                 {
-                    return (T) param.Value;
+                    return (T)param.Value;
                 }
             }
 
@@ -1551,7 +1549,7 @@ namespace System.Management.Automation
                 value = GetParameter<T>(command, parameterName);
                 return true;
             }
-            catch(Exception ex) when(ex is PSArgumentException || ex is InvalidCastException)
+            catch (Exception ex) when(ex is PSArgumentException || ex is InvalidCastException)
             {
                 value = default(T);
                 return false;

--- a/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
@@ -1856,7 +1856,7 @@ namespace System.Management.Automation
         /// Adds the provided set of breakpoints to the debugger.
         /// </summary>
         /// <param name="breakpoints">List of breakpoints.</param>
-        /// <param name="runspaceId"></param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         public override void SetBreakpoints(IEnumerable<Breakpoint> breakpoints, int? runspaceId = null) =>
             _wrappedDebugger.Value.SetBreakpoints(breakpoints, runspaceId);
 

--- a/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
@@ -1256,7 +1256,7 @@ namespace System.Management.Automation
             SetPreserveUnhandledBreakpointMode,
 
             /// <summary>
-            /// BreakpointManagement.
+            /// The PreProcessCommandResult used for managing breakpoints.
             /// </summary>
             BreakpointManagement,
         };
@@ -1276,7 +1276,7 @@ namespace System.Management.Automation
         /// Pre-processor for debugger commands.
         /// Parses special debugger commands and converts to equivalent script for remote execution as needed.
         /// </summary>
-        /// <param name="commands">PSCommand.</param>
+        /// <param name="commands">The PSCommand.</param>
         /// <param name="serverRemoteDebugger">The debugger that can be used to invoke debug operations via API.</param>
         /// <param name="preProcessOutput">A Collection that can be used to send output to the client.</param>
         /// <param name="commandArgument">Command argument.</param>
@@ -1414,7 +1414,6 @@ namespace System.Management.Automation
                 // Input parameters:
                 // [-Id <int>]
                 // Returns Breakpoint object(s).
-
                 TryGetParameter<int?>(command, "RunspaceId", out int? runspaceId);
                 if (TryGetParameter<int>(command, "Id", out int breakpointId))
                 {
@@ -1437,7 +1436,6 @@ namespace System.Management.Automation
                 // -Breakpoint <Breakpoint> or -BreakpointList <IEnumerable<Breakpoint>>
                 // [-RunspaceId <int?>]
                 // Returns Breakpoint object(s).
-
                 TryGetParameter<Breakpoint>(command, "Breakpoint", out Breakpoint breakpoint);
                 TryGetParameter<IEnumerable<Breakpoint>>(command, "BreakpointList", out IEnumerable<Breakpoint> breakpoints);
                 if (breakpoint == null && breakpoints == null)
@@ -1458,7 +1456,6 @@ namespace System.Management.Automation
                 }
 
                 result = PreProcessCommandResult.BreakpointManagement;
-
             }
             else if (commandText.Equals(RemoteDebuggingCommands.RemoveBreakpoint, StringComparison.OrdinalIgnoreCase))
             {
@@ -1467,7 +1464,6 @@ namespace System.Management.Automation
                 // -Id <int>
                 // [-RunspaceId <int?>]
                 // Returns bool.
-
                 int breakpointId = GetParameter<int>(command, "Id");
                 TryGetParameter<int?>(command, "RunspaceId", out int? runspaceId);
 
@@ -1478,7 +1474,6 @@ namespace System.Management.Automation
                         : serverRemoteDebugger.RemoveBreakpoint(breakpoint, runspaceId));
 
                 result = PreProcessCommandResult.BreakpointManagement;
-
             }
             else if (commandText.Equals(RemoteDebuggingCommands.EnableBreakpoint, StringComparison.OrdinalIgnoreCase))
             {
@@ -1487,7 +1482,6 @@ namespace System.Management.Automation
                 // -Id <int>
                 // [-RunspaceId <int?>]
                 // Returns Breakpoint object.
-
                 int breakpointId = GetParameter<int>(command, "Id");
                 TryGetParameter<int?>(command, "RunspaceId", out int? runspaceId);
 
@@ -1506,7 +1500,6 @@ namespace System.Management.Automation
                 // -Id <int>
                 // [-RunspaceId <int?>]
                 // Returns Breakpoint object.
-
                 int breakpointId = GetParameter<int>(command, "Id");
                 TryGetParameter<int?>(command, "RunspaceId", out int? runspaceId);
 
@@ -1534,7 +1527,7 @@ namespace System.Management.Automation
 
         private static T GetParameter<T>(Command command, string parameterName)
         {
-            if(command.Parameters?.Count == 0)
+            if (command.Parameters?.Count == 0)
             {
                 throw new PSArgumentException(parameterName);
             }
@@ -1543,7 +1536,7 @@ namespace System.Management.Automation
             {
                 if (string.Equals(param.Name, parameterName, StringComparison.OrdinalIgnoreCase))
                 {
-                    return (T) param.Value;
+                    return (T)param.Value;
                 }
             }
 
@@ -1557,7 +1550,7 @@ namespace System.Management.Automation
                 value = GetParameter<T>(command, parameterName);
                 return true;
             }
-            catch(Exception ex) when(ex is PSArgumentException || ex is InvalidCastException)
+            catch (Exception ex) when(ex is PSArgumentException || ex is InvalidCastException)
             {
                 value = default(T);
                 return false;

--- a/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
@@ -1408,7 +1408,6 @@ namespace System.Management.Automation
                 // Input parameters:
                 // [-Id <int>]
                 // Returns Breakpoint object(s).
-                // at this time.
 
                 TryGetParameter<int?>(command, "RunspaceId", out int? runspaceId);
                 if (TryGetParameter<int>(command, "Id", out int breakpointId))
@@ -1431,6 +1430,7 @@ namespace System.Management.Automation
                 // Input parameters:
                 // -Breakpoint <Breakpoint> or -BreakpointList <IEnumerable<Breakpoint>>
                 // [-RunspaceId <int?>]
+                // Returns Breakpoint object(s).
 
                 TryGetParameter<Breakpoint>(command, "Breakpoint", out Breakpoint breakpoint);
                 TryGetParameter<IEnumerable<Breakpoint>>(command, "BreakpointList", out IEnumerable<Breakpoint> breakpoints);
@@ -1460,6 +1460,7 @@ namespace System.Management.Automation
                 // Input parameters:
                 // -Id <int>
                 // [-RunspaceId <int?>]
+                // Returns bool.
 
                 int breakpointId = GetParameter<int>(command, "Id");
                 TryGetParameter<int?>(command, "RunspaceId", out int? runspaceId);
@@ -1479,6 +1480,7 @@ namespace System.Management.Automation
                 // Input parameters:
                 // -Id <int>
                 // [-RunspaceId <int?>]
+                // Returns Breakpoint object.
 
                 int breakpointId = GetParameter<int>(command, "Id");
                 TryGetParameter<int?>(command, "RunspaceId", out int? runspaceId);
@@ -1497,6 +1499,7 @@ namespace System.Management.Automation
                 // Input parameters:
                 // -Id <int>
                 // [-RunspaceId <int?>]
+                // Returns Breakpoint object.
 
                 int breakpointId = GetParameter<int>(command, "Id");
                 TryGetParameter<int?>(command, "RunspaceId", out int? runspaceId);

--- a/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
@@ -1337,7 +1337,10 @@ namespace System.Management.Automation
                     {
                         resumeAction = (DebuggerResumeAction)resumeObject.BaseObject;
                     }
-                    catch (InvalidCastException) { }
+                    catch (InvalidCastException)
+                    {
+                        // Do nothing.
+                    }
                 }
 
                 commandArgument.ResumeAction = resumeAction ?? throw new PSArgumentException("ResumeAction");
@@ -1362,7 +1365,10 @@ namespace System.Management.Automation
                     {
                         mode = (DebugModes)modeObject.BaseObject;
                     }
-                    catch (InvalidCastException) { }
+                    catch (InvalidCastException)
+                    {
+                        // Do nothing.
+                    }
                 }
 
                 commandArgument.Mode = mode ?? throw new PSArgumentException("Mode");
@@ -1402,7 +1408,10 @@ namespace System.Management.Automation
                     {
                         mode = (UnhandledBreakpointProcessingMode)modeObject.BaseObject;
                     }
-                    catch (InvalidCastException) { }
+                    catch (InvalidCastException)
+                    {
+                        // Do nothing.
+                    }
                 }
 
                 commandArgument.UnhandledBreakpointMode = mode ?? throw new PSArgumentException("Mode");
@@ -1867,6 +1876,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="id">Id of the breakpoint you want.</param>
         /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The breakpoint with the specified id.</returns>
         public override Breakpoint GetBreakpoint(int id, int? runspaceId = null) =>
             _wrappedDebugger.Value.GetBreakpoint(id, runspaceId);
 
@@ -1874,6 +1884,7 @@ namespace System.Management.Automation
         /// Returns breakpoints on a runspace.
         /// </summary>
         /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>A list of breakpoints in a runspace.</returns>
         public override List<Breakpoint> GetBreakpoints(int? runspaceId = null) =>
             _wrappedDebugger.Value.GetBreakpoints(runspaceId);
 

--- a/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
@@ -1442,7 +1442,7 @@ namespace System.Management.Automation
                 TryGetParameter<IEnumerable<Breakpoint>>(command, "BreakpointList", out IEnumerable<Breakpoint> breakpoints);
                 if (breakpoint == null && breakpoints == null)
                 {
-                    throw new PSArgumentException("Breakpoint or BreakpointList must be specified");
+                    throw new PSArgumentException(DebuggerStrings.BreakpointOrBreakpointListNotSpecified);
                 }
 
                 TryGetParameter<int?>(command, "RunspaceId", out int? runspaceId);
@@ -1869,27 +1869,80 @@ namespace System.Management.Automation
         public override void SetBreakpoints(IEnumerable<Breakpoint> breakpoints, int? runspaceId = null) =>
             _wrappedDebugger.Value.SetBreakpoints(breakpoints, runspaceId);
 
+        /// <summary>
+        /// Get a breakpoint by id, primarily for Enable/Disable/Remove-PSBreakpoint cmdlets.
+        /// </summary>
+        /// <param name="id">Id of the breakpoint you want.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         public override Breakpoint GetBreakpoint(int id, int? runspaceId = null) =>
             _wrappedDebugger.Value.GetBreakpoint(id, runspaceId);
 
+        /// <summary>
+        /// Returns breakpoints on a runspace.
+        /// </summary>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
         public override List<Breakpoint> GetBreakpoints(int? runspaceId = null) =>
             _wrappedDebugger.Value.GetBreakpoints(runspaceId);
 
+        /// <summary>
+        /// Sets a command breakpoint in the debugger.
+        /// </summary>
+        /// <param name="command">The name of the command that will trigger the breakpoint. This value is required and may not be null.</param>
+        /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
+        /// <param name="path">The path to the script file where the breakpoint may be hit. If null, the breakpoint may be hit anywhere the command is invoked.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The command breakpoint that was set.</returns>
         public override CommandBreakpoint SetCommandBreakpoint(string command, ScriptBlock action = null, string path = null, int? runspaceId = null) =>
             _wrappedDebugger.Value.SetCommandBreakpoint(command, action, path, runspaceId);
 
+        /// <summary>
+        /// Sets a line breakpoint in the debugger.
+        /// </summary>
+        /// <param name="path">The path to the script file where the breakpoint may be hit. This value is required and may not be null.</param>
+        /// <param name="line">The line in the script file where the breakpoint may be hit. This value is required and must be greater than or equal to 1.</param>
+        /// <param name="column">The column in the script file where the breakpoint may be hit. If 0, the breakpoint will trigger on any statement on the line.</param>
+        /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The line breakpoint that was set.</returns>
         public override LineBreakpoint SetLineBreakpoint(string path, int line, int column = 0, ScriptBlock action = null, int? runspaceId = null) =>
             _wrappedDebugger.Value.SetLineBreakpoint(path, line, column, action, runspaceId);
 
+        /// <summary>
+        /// Sets a variable breakpoint in the debugger.
+        /// </summary>
+        /// <param name="variableName">The name of the variable that will trigger the breakpoint. This value is required and may not be null.</param>
+        /// <param name="accessMode">The variable access mode that will trigger the breakpoint. By default variable breakpoints will trigger only when the variable is updated.</param>
+        /// <param name="action">The action to take when the breakpoint is hit. If null, PowerShell will break into the debugger when the breakpoint is hit.</param>
+        /// <param name="path">The path to the script file where the breakpoint may be hit. If null, the breakpoint may be hit anywhere the variable is accessed using the specified access mode.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The variable breakpoint that was set.</returns>
         public override VariableBreakpoint SetVariableBreakpoint(string variableName, VariableAccessMode accessMode = VariableAccessMode.Write, ScriptBlock action = null, string path = null, int? runspaceId = null) =>
             _wrappedDebugger.Value.SetVariableBreakpoint(variableName, accessMode, action, path, runspaceId);
 
+        /// <summary>
+        /// Removes a breakpoint from the debugger.
+        /// </summary>
+        /// <param name="breakpoint">The breakpoint to remove from the debugger. This value is required and may not be null.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>True if the breakpoint was removed from the debugger; false otherwise.</returns>
         public override bool RemoveBreakpoint(Breakpoint breakpoint, int? runspaceId = null) =>
             _wrappedDebugger.Value.RemoveBreakpoint(breakpoint, runspaceId);
 
+        /// <summary>
+        /// Enables a breakpoint in the debugger.
+        /// </summary>
+        /// <param name="breakpoint">The breakpoint to enable in the debugger. This value is required and may not be null.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The updated breakpoint if it was found; null if the breakpoint was not found in the debugger.</returns>
         public override Breakpoint EnableBreakpoint(Breakpoint breakpoint, int? runspaceId = null) =>
             _wrappedDebugger.Value.EnableBreakpoint(breakpoint, runspaceId);
 
+        /// <summary>
+        /// Disables a breakpoint in the debugger.
+        /// </summary>
+        /// <param name="breakpoint">The breakpoint to enable in the debugger. This value is required and may not be null.</param>
+        /// <param name="runspaceId">The runspace id of the runspace you want to interact with. Defaults to null (current runspace).</param>
+        /// <returns>The updated breakpoint if it was found; null if the breakpoint was not found in the debugger.</returns>
         public override Breakpoint DisableBreakpoint(Breakpoint breakpoint, int? runspaceId = null) =>
             _wrappedDebugger.Value.DisableBreakpoint(breakpoint, runspaceId);
 

--- a/src/System.Management.Automation/resources/DebuggerStrings.resx
+++ b/src/System.Management.Automation/resources/DebuggerStrings.resx
@@ -250,12 +250,15 @@ The current session does not support debugging; operation will continue.
     <value>The debugger detach command is not applicable.  The detach command only applies when debugging jobs and runspaces with the Debug-Job or Debug-Runspace cmdlets.</value>
   </data>
   <data name="InvalidRunspaceId" xml:space="preserve">
-    <value>Invalid runspace id.</value>
+    <value>Invalid runspace id: {0}</value>
   </data>
   <data name="UnableToGetRunspace" xml:space="preserve">
     <value>Unable to get Runspace.</value>
   </data>
   <data name="BreakpointOrBreakpointListNotSpecified" xml:space="preserve">
     <value>Breakpoint or BreakpointList must be specified.</value>
+  </data>
+  <data name="BreakpointListContainedANonBreakpoint" xml:space="preserve">
+    <value>The BreakpointList contained an item that was not a breakpoint.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/DebuggerStrings.resx
+++ b/src/System.Management.Automation/resources/DebuggerStrings.resx
@@ -255,4 +255,7 @@ The current session does not support debugging; operation will continue.
   <data name="UnableToGetRunspace" xml:space="preserve">
     <value>Unable to get Runspace.</value>
   </data>
+  <data name="BreakpointOrBreakpointListNotSpecified" xml:space="preserve">
+    <value>Breakpoint or BreakpointList must be specified.</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/resources/DebuggerStrings.resx
+++ b/src/System.Management.Automation/resources/DebuggerStrings.resx
@@ -249,4 +249,10 @@ The current session does not support debugging; operation will continue.
   <data name="InvalidDetachCommand" xml:space="preserve">
     <value>The debugger detach command is not applicable.  The detach command only applies when debugging jobs and runspaces with the Debug-Job or Debug-Runspace cmdlets.</value>
   </data>
+  <data name="InvalidRunspaceId" xml:space="preserve">
+    <value>Invalid runspace id.</value>
+  </data>
+  <data name="UnableToGetRunspace" xml:space="preserve">
+    <value>Unable to get Runspace.</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
+++ b/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
@@ -1693,4 +1693,7 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
   <data name="EnterPSHostProcessCmdletDisabled" xml:space="preserve">
     <value>Enter-PSHostProcess cmdlet is disabled because an application control policy such as 'AppLocker' or 'Windows Defender Application Control' is in enforcement.</value>
   </data>
+  <data name="RemoteDebuggerError" xml:space="preserve">
+    <value>Remote debugger exception: {0}, error message: {1}</value>
+  </data>
 </root>

--- a/test/powershell/SDK/Breakpoint.Tests.ps1
+++ b/test/powershell/SDK/Breakpoint.Tests.ps1
@@ -165,4 +165,60 @@ Describe 'Breakpoint SDK Unit Tests' -Tags 'CI' {
             $jobRunspace.Debugger.RemoveBreakpoint($bp) | Should -BeFalse
         }
     }
+
+    Context 'Manage breakpoints in another runspace' {
+        BeforeAll {
+            $runspace = [runspacefactory]::CreateRunspace()
+            $runspace.Open()
+        }
+
+        AfterAll {
+            $runspace.Close()
+            $runspace.Dispose()
+        }
+
+        It 'Can set command breakpoints' {
+            $host.Runspace.Debugger.SetCommandBreakpoint('Test-ThisCommandDoesNotExist', $null, $null, $runspace.Id) | Should -BeOfType [System.Management.Automation.CommandBreakpoint]
+        }
+
+        It 'Can set variable breakpoints' {
+            $host.Runspace.Debugger.SetVariableBreakpoint('DebugPreference', 'ReadWrite', { continue }, $null, $runspace.Id) | Should -BeOfType [System.Management.Automation.VariableBreakpoint]
+        }
+
+        It 'Can set line breakpoints' {
+            $host.Runspace.Debugger.SetLineBreakpoint($PSCommandPath, 1, 1, { continue }, $runspace.Id) | Should -BeOfType [System.Management.Automation.LineBreakpoint]
+        }
+
+        It 'Can get breakpoints' {
+            $host.Runspace.Debugger.GetBreakpoints($runspace.Id) | Should -HaveCount 3
+        }
+
+        It 'Can disable breakpoints' {
+            foreach ($bp in $host.Runspace.Debugger.GetBreakpoints($runspace.Id)) {
+                $bp = $host.Runspace.Debugger.DisableBreakpoint($bp, $runspace.Id)
+                $bp.Enabled | Should -BeFalse
+            }
+        }
+
+        It 'Can enable breakpoints' {
+            foreach ($bp in $host.Runspace.Debugger.GetBreakpoints($runspace.Id)) {
+                $bp = $host.Runspace.Debugger.EnableBreakpoint($bp, $runspace.Id)
+                $bp.Enabled | Should -BeTrue
+            }
+        }
+
+        It 'Doesn''t manipulate any breakpoints in the default runspace' {
+            $host.Runspace.Debugger.GetBreakpoints() | Should -BeNullOrEmpty
+        }
+
+        It 'Can remove breakpoints' {
+            foreach ($bp in $host.Runspace.Debugger.GetBreakpoints($runspace.Id)) {
+                $host.Runspace.Debugger.RemoveBreakpoint($bp, $runspace.Id) | Should -BeTrue
+            }
+        }
+
+        It 'Returns an empty collection when there are no breakpoints' {
+            $host.Runspace.Debugger.GetBreakpoints($runspace.Id) | Should -HaveCount 0
+        }
+    }
 }

--- a/test/powershell/SDK/Breakpoint.Tests.ps1
+++ b/test/powershell/SDK/Breakpoint.Tests.ps1
@@ -78,15 +78,15 @@ Describe 'Breakpoint SDK Unit Tests' -Tags 'CI' {
     Context 'Managing breakpoints in a remote runspace via the SDK' {
 
         It 'Can set command breakpoints' {
-            $jobRunspace.Debugger.SetCommandBreakpoint('Write-Verbose', { break }) | Should -BeNullOrEmpty
+            $jobRunspace.Debugger.SetCommandBreakpoint('Write-Verbose', { break }) | Should -BeOfType [System.Management.Automation.CommandBreakpoint]
         }
 
         It 'Can set variable breakpoints' {
-            $jobRunspace.Debugger.SetVariableBreakpoint('DebugPreference', 'ReadWrite', { break }) | Should -BeNullOrEmpty
+            $jobRunspace.Debugger.SetVariableBreakpoint('DebugPreference', 'ReadWrite', { break }) | Should -BeOfType [System.Management.Automation.VariableBreakpoint]
         }
 
         It 'Can set line breakpoints' {
-            $jobRunspace.Debugger.SetLineBreakpoint($PSCommandPath, 1, 1, { break }) | Should -BeNullOrEmpty
+            $jobRunspace.Debugger.SetLineBreakpoint($PSCommandPath, 1, 1, { break }) | Should -BeOfType [System.Management.Automation.LineBreakpoint]
         }
 
         It 'Can get breakpoints' {
@@ -96,13 +96,15 @@ Describe 'Breakpoint SDK Unit Tests' -Tags 'CI' {
 
         It 'Can disable breakpoints' {
             foreach ($bp in $jobRunspace.Debugger.GetBreakpoints()) {
-                $jobRunspace.Debugger.DisableBreakpoint($bp) | Should -BeNullOrEmpty
+                $bp = $jobRunspace.Debugger.DisableBreakpoint($bp)
+                $bp.Enabled | Should -BeFalse
             }
         }
 
         It 'Can enable breakpoints' {
             foreach ($bp in $jobRunspace.Debugger.GetBreakpoints()) {
-                $jobRunspace.Debugger.EnableBreakpoint($bp) | Should -BeNullOrEmpty
+                $bp = $jobRunspace.Debugger.EnableBreakpoint($bp)
+                $bp.Enabled | Should -BeTrue
             }
         }
 
@@ -116,7 +118,7 @@ Describe 'Breakpoint SDK Unit Tests' -Tags 'CI' {
 
         It 'Can remove breakpoints' {
             foreach ($bp in $jobRunspace.Debugger.GetBreakpoints()) {
-                $jobRunspace.Debugger.RemoveBreakpoint($bp) | Should -BeFalse
+                $jobRunspace.Debugger.RemoveBreakpoint($bp) | Should -BeTrue
             }
         }
 

--- a/test/powershell/SDK/Breakpoint.Tests.ps1
+++ b/test/powershell/SDK/Breakpoint.Tests.ps1
@@ -52,14 +52,14 @@ Describe 'Breakpoint SDK Unit Tests' -Tags 'CI' {
 
         It 'Can disable breakpoints' {
             foreach ($bp in $host.Runspace.Debugger.GetBreakpoints()) {
-                $bp = $host.Runspace.Debugger.DisableBreakpoint($bp)                
+                $bp = $host.Runspace.Debugger.DisableBreakpoint($bp)
                 $bp.Enabled | Should -BeFalse
             }
         }
 
         It 'Can enable breakpoints' {
             foreach ($bp in $host.Runspace.Debugger.GetBreakpoints()) {
-                $bp = $host.Runspace.Debugger.EnableBreakpoint($bp)                
+                $bp = $host.Runspace.Debugger.EnableBreakpoint($bp)
                 $bp.Enabled | Should -BeTrue
             }
         }
@@ -78,15 +78,15 @@ Describe 'Breakpoint SDK Unit Tests' -Tags 'CI' {
     Context 'Managing breakpoints in a remote runspace via the SDK' {
 
         It 'Can set command breakpoints' {
-            $jobRunspace.Debugger.SetCommandBreakpoint('Write-Verbose', { break }) | Should -BeOfType [System.Management.Automation.CommandBreakpoint]
+            $jobRunspace.Debugger.SetCommandBreakpoint('Write-Verbose', { break }) | Should -BeNullOrEmpty
         }
 
         It 'Can set variable breakpoints' {
-            $jobRunspace.Debugger.SetVariableBreakpoint('DebugPreference', 'ReadWrite', { break }) | Should -BeOfType [System.Management.Automation.VariableBreakpoint]
+            $jobRunspace.Debugger.SetVariableBreakpoint('DebugPreference', 'ReadWrite', { break }) | Should -BeNullOrEmpty
         }
 
         It 'Can set line breakpoints' {
-            $jobRunspace.Debugger.SetLineBreakpoint($PSCommandPath, 1, 1, { break }) | Should -BeOfType [System.Management.Automation.LineBreakpoint]
+            $jobRunspace.Debugger.SetLineBreakpoint($PSCommandPath, 1, 1, { break }) | Should -BeNullOrEmpty
         }
 
         It 'Can get breakpoints' {
@@ -96,15 +96,13 @@ Describe 'Breakpoint SDK Unit Tests' -Tags 'CI' {
 
         It 'Can disable breakpoints' {
             foreach ($bp in $jobRunspace.Debugger.GetBreakpoints()) {
-                $bp = $jobRunspace.Debugger.DisableBreakpoint($bp)                
-                $bp.Enabled | Should -BeFalse
+                $jobRunspace.Debugger.DisableBreakpoint($bp) | Should -BeNullOrEmpty
             }
         }
 
         It 'Can enable breakpoints' {
             foreach ($bp in $jobRunspace.Debugger.GetBreakpoints()) {
-                $bp = $jobRunspace.Debugger.EnableBreakpoint($bp)                
-                $bp.Enabled | Should -BeTrue
+                $jobRunspace.Debugger.EnableBreakpoint($bp) | Should -BeNullOrEmpty
             }
         }
 
@@ -118,7 +116,7 @@ Describe 'Breakpoint SDK Unit Tests' -Tags 'CI' {
 
         It 'Can remove breakpoints' {
             foreach ($bp in $jobRunspace.Debugger.GetBreakpoints()) {
-                $jobRunspace.Debugger.RemoveBreakpoint($bp) | Should -BeTrue
+                $jobRunspace.Debugger.RemoveBreakpoint($bp) | Should -BeFalse
             }
         }
 
@@ -127,11 +125,10 @@ Describe 'Breakpoint SDK Unit Tests' -Tags 'CI' {
         }
     }
 
-    Context 'Handling empty collections and  errors while managing breakpoints in the host runspace via the SDK' {
+    Context 'Handling empty collections and errors while managing breakpoints in the host runspace via the SDK' {
 
         BeforeAll {
-            $bp = $host.Runspace.Debugger.SetCommandBreakpoint('Test-ThisCommandDoesNotExist')
-            $host.Runspace.Debugger.RemoveBreakpoint($bp) > $null
+            $bp = [System.Management.Automation.CommandBreakpoint]::new($TestDrive, $null, 'Test-ThisCommandDoesNotExist')
         }
 
         It 'Returns false when trying to disable a breakpoint that does not exist' {

--- a/test/powershell/SDK/Breakpoint.Tests.ps1
+++ b/test/powershell/SDK/Breakpoint.Tests.ps1
@@ -34,6 +34,12 @@ Describe 'Breakpoint SDK Unit Tests' -Tags 'CI' {
 
     Context 'Managing breakpoints in the host runspace via the SDK' {
 
+        AfterAll {
+            foreach ($bp in $host.Runspace.Debugger.GetBreakpoints()) {
+                $host.Runspace.Debugger.RemoveBreakpoint($bp) | Should -BeTrue
+            }
+        }
+
         It 'Can set command breakpoints' {
             $host.Runspace.Debugger.SetCommandBreakpoint('Test-ThisCommandDoesNotExist') | Should -BeOfType [System.Management.Automation.CommandBreakpoint]
         }
@@ -73,9 +79,26 @@ Describe 'Breakpoint SDK Unit Tests' -Tags 'CI' {
         It 'Returns an empty collection when there are no breakpoints' {
             $host.Runspace.Debugger.GetBreakpoints() | Should -HaveCount 0
         }
+
+        It 'Can set multiple breakpoints' {
+            $breakpoints = [System.Collections.Generic.List[System.Management.Automation.Breakpoint]] @(
+                [System.Management.Automation.LineBreakpoint]::new("/Path/to/foo.ps1", 1)
+                [System.Management.Automation.LineBreakpoint]::new("/Path/to/foo.ps1", 2)
+                [System.Management.Automation.LineBreakpoint]::new("/Path/to/foo.ps1", 3)
+            )
+
+            $host.Runspace.Debugger.SetBreakpoints($breakpoints)
+            $host.Runspace.Debugger.GetBreakpoints() | Should -HaveCount 3
+        }
     }
 
     Context 'Managing breakpoints in a remote runspace via the SDK' {
+
+        AfterAll {
+            foreach ($bp in $jobRunspace.Debugger.GetBreakpoints()) {
+                $jobRunspace.Debugger.RemoveBreakpoint($bp) | Should -BeTrue
+            }
+        }
 
         It 'Can set command breakpoints' {
             $jobRunspace.Debugger.SetCommandBreakpoint('Write-Verbose', { break }) | Should -BeOfType [System.Management.Automation.CommandBreakpoint]
@@ -124,6 +147,17 @@ Describe 'Breakpoint SDK Unit Tests' -Tags 'CI' {
 
         It 'Returns an empty collection when there are no breakpoints' {
             $jobRunspace.Debugger.GetBreakpoints() | Should -HaveCount 0
+        }
+
+        It 'Can set multiple breakpoints' {
+            $breakpoints = [System.Collections.Generic.List[System.Management.Automation.Breakpoint]] @(
+                [System.Management.Automation.LineBreakpoint]::new("/Path/to/foo.ps1", 1)
+                [System.Management.Automation.LineBreakpoint]::new("/Path/to/foo.ps1", 2)
+                [System.Management.Automation.LineBreakpoint]::new("/Path/to/foo.ps1", 3)
+            )
+
+            $jobRunspace.Debugger.SetBreakpoints($breakpoints)
+            $jobRunspace.Debugger.GetBreakpoints() | Should -HaveCount 3
         }
     }
 
@@ -219,6 +253,17 @@ Describe 'Breakpoint SDK Unit Tests' -Tags 'CI' {
 
         It 'Returns an empty collection when there are no breakpoints' {
             $host.Runspace.Debugger.GetBreakpoints($runspace.Id) | Should -HaveCount 0
+        }
+
+        It 'Can set multiple breakpoints' {
+            $breakpoints = [System.Collections.Generic.List[System.Management.Automation.Breakpoint]] @(
+                [System.Management.Automation.LineBreakpoint]::new("/Path/to/foo.ps1", 1)
+                [System.Management.Automation.LineBreakpoint]::new("/Path/to/foo.ps1", 2)
+                [System.Management.Automation.LineBreakpoint]::new("/Path/to/foo.ps1", 3)
+            )
+
+            $host.Runspace.Debugger.SetBreakpoints($breakpoints, $runspace.Id)
+            $host.Runspace.Debugger.GetBreakpoints($runspace.Id) | Should -HaveCount 3
         }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This addresses two things:
* gives the ability to set a breakpoint remotely on a runspace even if it's busy
* gives the ability to set a breakpoint on a specific runspace

This is only added to the API surface for the PowerShell extension. In theory the breakpoint cmdlets can take advantage of this in the future.

## PR Context

This will light up a scenario in the PowerShell Editor Services so that when you click to add a breakpoint, that breakpoint will be applied even if the PowerShell Integrated Console is busy running the `Debug-Runspace`.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [x] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [x] Experimental feature name(s): Microsoft.PowerShell.Utility.PSManageBreakpointsInRunspace
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [x] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
