### PR TITLE
Fix for issue on raspbian for setting date of file changes in UnixStat Experimental Feature

### DIFF
--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -864,9 +864,29 @@ namespace System.Management.Automation
                     cs.GroupId = css.GroupId;
                     cs.HardlinkCount = css.HardlinkCount;
                     cs.Size = css.Size;
-                    cs.AccessTime = DateTime.UnixEpoch.AddSeconds(css.AccessTime).ToLocalTime();
-                    cs.ModifiedTime = DateTime.UnixEpoch.AddSeconds(css.ModifiedTime).ToLocalTime();
-                    cs.StatusChangeTime = DateTime.UnixEpoch.AddSeconds(css.StatusChangeTime).ToLocalTime();
+                    // These can sometime throw if we get an unreasonable number back
+                    // As a fallback, set the time to UnixEpoch
+                    try {
+                        cs.AccessTime = DateTime.UnixEpoch.AddSeconds(css.AccessTime).ToLocalTime();
+                    }
+                    catch {
+                        cs.AccessTime = DateTime.UnixEpoch.ToLocalTime();
+                    }
+
+                    try {
+                        cs.ModifiedTime = DateTime.UnixEpoch.AddSeconds(css.ModifiedTime).ToLocalTime();
+                    }
+                    catch {
+                        cs.ModifiedTime = DateTime.UnixEpoch.ToLocalTime();
+                    }
+
+                    try {
+                        cs.StatusChangeTime = DateTime.UnixEpoch.AddSeconds(css.StatusChangeTime).ToLocalTime();
+                    }
+                    catch {
+                        cs.StatusChangeTime = DateTime.UnixEpoch.ToLocalTime();
+                    }
+
                     cs.BlockSize = css.BlockSize;
                     cs.DeviceId = css.DeviceId;
                     cs.NumberOfBlocks = css.NumberOfBlocks;

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -864,26 +864,33 @@ namespace System.Management.Automation
                     cs.GroupId = css.GroupId;
                     cs.HardlinkCount = css.HardlinkCount;
                     cs.Size = css.Size;
-                    // These can sometime throw if we get an unreasonable number back
-                    // As a fallback, set the time to UnixEpoch
-                    try {
+
+                    // These can sometime throw if we get too large a number back (seen on Raspbian).
+                    // As a fallback, set the time to UnixEpoch.
+                    try
+                    {
                         cs.AccessTime = DateTime.UnixEpoch.AddSeconds(css.AccessTime).ToLocalTime();
                     }
-                    catch {
+                    catch
+                    {
                         cs.AccessTime = DateTime.UnixEpoch.ToLocalTime();
                     }
 
-                    try {
+                    try
+                    {
                         cs.ModifiedTime = DateTime.UnixEpoch.AddSeconds(css.ModifiedTime).ToLocalTime();
                     }
-                    catch {
+                    catch
+                    {
                         cs.ModifiedTime = DateTime.UnixEpoch.ToLocalTime();
                     }
 
-                    try {
+                    try
+                    {
                         cs.StatusChangeTime = DateTime.UnixEpoch.AddSeconds(css.StatusChangeTime).ToLocalTime();
                     }
-                    catch {
+                    catch
+                    {
                         cs.StatusChangeTime = DateTime.UnixEpoch.ToLocalTime();
                     }
 


### PR DESCRIPTION
If the date setting throws, set the default to UnixEpoch

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

On Raspbian sometimes the date can't be constructed, so in that case just set the date to UnixEpoch

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
