### PR TITLE
Refactor and implement `Restart-Computer` for `Un*x` and macOS

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
@@ -134,7 +134,7 @@ namespace Microsoft.PowerShell.Commands
 #region "Internals"
 
         /// <summary>
-        /// Run a command
+        /// Run a command.
         /// </summary>
         protected void RunCommand(String command, String args) {
             String cmd = "";

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Diagnostics;
 using System.Management.Automation;
+using System.Management.Automation.Internal;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.PowerShell.Commands
@@ -52,14 +53,14 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void BeginProcessing()
         {
-            var args = "";
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                args = "-P now";
-            }
+            var args = "-P now";
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 args = "now";
+            }
+            if (InternalTestHooks.TestStopComputer)
+            {
+                return;
             }
             RunCommand("/sbin/shutdown", args);
         }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
@@ -29,6 +29,19 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void BeginProcessing()
         {
+            if (InternalTestHooks.TestStopComputer)
+            {
+                var retVal = InternalTestHooks.TestStopComputerResults;
+                if (retVal != 0)
+                {
+                    string errMsg = StringUtil.Format("Command returned 0x{0:X}", retVal);
+                    ErrorRecord error = new ErrorRecord(
+                        new InvalidOperationException(errMsg), "Command Failed", ErrorCategory.OperationStopped, "localhost");
+                    WriteError(error);
+                }
+                return;
+            }
+
             RunCommand("/sbin/shutdown", "-r now");
         }
 #endregion "Overrides"
@@ -60,8 +73,17 @@ namespace Microsoft.PowerShell.Commands
             }
             if (InternalTestHooks.TestStopComputer)
             {
+                var retVal = InternalTestHooks.TestStopComputerResults;
+                if (retVal != 0)
+                {
+                    string errMsg = StringUtil.Format("Command returned 0x{0:X}", retVal);
+                    ErrorRecord error = new ErrorRecord(
+                        new InvalidOperationException(errMsg), "Command Failed", ErrorCategory.OperationStopped, "localhost");
+                    WriteError(error);
+                }
                 return;
             }
+
             RunCommand("/sbin/shutdown", args);
         }
 #endregion "Overrides"

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
@@ -90,7 +90,7 @@ namespace Microsoft.PowerShell.Commands
     }
 
     /// <summary>
-    /// A base class for cmdlets that can run shell commands
+    /// A base class for cmdlets that can run shell commands.
     /// </summary>
     public class CommandLineCmdletBase : PSCmdlet, IDisposable
     {

--- a/src/Modules/Unix/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1
+++ b/src/Modules/Unix/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1
@@ -55,5 +55,6 @@ CmdletsToExport=@("Add-Content",
     "Set-Content",
     "Set-ItemProperty",
     "Get-TimeZone",
-    "Stop-Computer")
+    "Stop-Computer",
+    "Restart-Computer")
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
@@ -28,19 +28,13 @@ try
             Restart-Computer -ErrorAction Stop | Should -BeNullOrEmpty
         }
 
-        It "Should support -computer parameter" {
-            if ( ! $IsWindows ) {
-                return
-            }
+        It "Should support -computer parameter" -Skip:(!$IsWindows) {
             Set-TesthookResult -testhookName $restartTesthookResultName -value $defaultResultValue
             $computerNames = "localhost","${env:COMPUTERNAME}"
             Restart-Computer -Computer $computerNames -ErrorAction Stop | Should -BeNullOrEmpty
         }
 
-        It "Should support WsmanAuthentication types" {
-            if ( ! $IsWindows ) {
-                return
-            }
+        It "Should support WsmanAuthentication types" -Skip:(!$IsWindows) {
             $authChoices = "Default","Basic","Negotiate","CredSSP","Digest","Kerberos"
             foreach ( $auth in $authChoices ) {
                 Restart-Computer -WsmanAuthentication $auth | Should -BeNullOrEmpty
@@ -50,10 +44,7 @@ try
         # this requires setting a test hook, so we wrap the execution with try/finally of the
         # set operation. Internally, we want to suppress the progress, so
         # that is also wrapped in try/finally
-        It "Should wait for a remote system" {
-            if ( ! $IsWindows ) {
-                return
-            }
+        It "Should wait for a remote system" -Skip:(!$IsWindows) {
             try
             {
                 Enable-Testhook -testhookname TestWaitStopComputer
@@ -85,37 +76,24 @@ try
                 $RestartError.Exception.Message | Should -Match 0x300000
             }
 
-            It "Should produce an error when 'Delay' is specified" {
-                if ( ! $IsWindows ) {
-                    return
-                }
+            It "Should produce an error when 'Delay' is specified" -Skip:(!$IsWindows) {
                 { Restart-Computer -Delay 30 } | Should -Throw -ErrorId "RestartComputerInvalidParameter,Microsoft.PowerShell.Commands.RestartComputerCommand"
             }
 
-            It "Should not support timeout on Unix" {
-                if ( ! $IsWindows ) {
-                    { Restart-Computer -timeout 3 -ErrorAction Stop } | Should -Throw -ErrorId "NamedParameterNotFound,Microsoft.PowerShell.Commands.RestartComputerCommand"
-                }
+            It "Should not support timeout on Unix" -Skip:($IsWindows) {
+                { Restart-Computer -timeout 3 -ErrorAction Stop } | Should -Throw -ErrorId "NamedParameterNotFound,Microsoft.PowerShell.Commands.RestartComputerCommand"
             }
 
-            It "Should not support Delay on Unix" {
-                if ( ! $IsWindows ) {
-                    { Restart-Computer -Delay 30 } | Should -Throw -ErrorId "NamedParameterNotFound,Microsoft.PowerShell.Commands.RestartComputerCommand"
-                }
+            It "Should not support Delay on Unix" -Skip:($IsWindows) {
+                { Restart-Computer -Delay 30 } | Should -Throw -ErrorId "NamedParameterNotFound,Microsoft.PowerShell.Commands.RestartComputerCommand"
             }
 
-            It "Should not support timeout on localhost" {
-                if ( ! $IsWindows ) {
-                    return
-                }
+            It "Should not support timeout on localhost" -Skip:(!$IsWindows) {
                 Set-TesthookResult -testhookName $restartTesthookResultName -value $defaultResultValue
                 { Restart-Computer -timeout 3 -ErrorAction Stop } | Should -Throw -ErrorId "RestartComputerInvalidParameter,Microsoft.PowerShell.Commands.RestartComputerCommand"
             }
 
-            It "Should not support timeout on localhost" {
-                if ( ! $IsWindows ) {
-                    return
-                }
+            It "Should not support timeout on localhost" -Skip:(!$IsWindows) {
                 Set-TesthookResult -testhookName $restartTesthookResultName -value $defaultResultValue
                 { Restart-Computer -timeout 3 -ErrorAction Stop } | Should -Throw -ErrorId "RestartComputerInvalidParameter,Microsoft.PowerShell.Commands.RestartComputerCommand"
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
@@ -9,7 +9,6 @@ $DefaultResultValue = 0
 try
 {
     # set up for testing
-    $PSDefaultParameterValues["it:skip"] = ! $IsWindows
     Enable-Testhook -testhookName $restartTesthookName
 
     Describe "Restart-Computer" -Tag Feature,RequireAdminOnWindows {
@@ -30,12 +29,18 @@ try
         }
 
         It "Should support -computer parameter" {
+            if ( ! $IsWindows ) {
+                return
+            }
             Set-TesthookResult -testhookName $restartTesthookResultName -value $defaultResultValue
             $computerNames = "localhost","${env:COMPUTERNAME}"
             Restart-Computer -Computer $computerNames -ErrorAction Stop | Should -BeNullOrEmpty
         }
 
         It "Should support WsmanAuthentication types" {
+            if ( ! $IsWindows ) {
+                return
+            }
             $authChoices = "Default","Basic","Negotiate","CredSSP","Digest","Kerberos"
             foreach ( $auth in $authChoices ) {
                 Restart-Computer -WsmanAuthentication $auth | Should -BeNullOrEmpty
@@ -46,6 +51,9 @@ try
         # set operation. Internally, we want to suppress the progress, so
         # that is also wrapped in try/finally
         It "Should wait for a remote system" {
+            if ( ! $IsWindows ) {
+                return
+            }
             try
             {
                 Enable-Testhook -testhookname TestWaitStopComputer
@@ -78,15 +86,36 @@ try
             }
 
             It "Should produce an error when 'Delay' is specified" {
+                if ( ! $IsWindows ) {
+                    return
+                }
                 { Restart-Computer -Delay 30 } | Should -Throw -ErrorId "RestartComputerInvalidParameter,Microsoft.PowerShell.Commands.RestartComputerCommand"
             }
 
+            It "Should not support timeout on Unix" {
+                if ( ! $IsWindows ) {
+                    { Restart-Computer -timeout 3 -ErrorAction Stop } | Should -Throw -ErrorId "NamedParameterNotFound,Microsoft.PowerShell.Commands.RestartComputerCommand"
+                }
+            }
+
+            It "Should not support Delay on Unix" {
+                if ( ! $IsWindows ) {
+                    { Restart-Computer -Delay 30 } | Should -Throw -ErrorId "NamedParameterNotFound,Microsoft.PowerShell.Commands.RestartComputerCommand"
+                }
+            }
+
             It "Should not support timeout on localhost" {
+                if ( ! $IsWindows ) {
+                    return
+                }
                 Set-TesthookResult -testhookName $restartTesthookResultName -value $defaultResultValue
                 { Restart-Computer -timeout 3 -ErrorAction Stop } | Should -Throw -ErrorId "RestartComputerInvalidParameter,Microsoft.PowerShell.Commands.RestartComputerCommand"
             }
 
             It "Should not support timeout on localhost" {
+                if ( ! $IsWindows ) {
+                    return
+                }
                 Set-TesthookResult -testhookName $restartTesthookResultName -value $defaultResultValue
                 { Restart-Computer -timeout 3 -ErrorAction Stop } | Should -Throw -ErrorId "RestartComputerInvalidParameter,Microsoft.PowerShell.Commands.RestartComputerCommand"
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Stop-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Stop-Computer.Tests.ps1
@@ -10,7 +10,7 @@ $DefaultResultValue = 0
 try
 {
     # set up for testing
-    $PSDefaultParameterValues["it:skip"] = ! $IsWindows
+    # $PSDefaultParameterValues["it:skip"] = ! $IsWindows
     Enable-Testhook -testhookName $stopTesthook
 
     Describe "Stop-Computer" -Tag Feature {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Stop-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Stop-Computer.Tests.ps1
@@ -10,7 +10,6 @@ $DefaultResultValue = 0
 try
 {
     # set up for testing
-    # $PSDefaultParameterValues["it:skip"] = ! $IsWindows
     Enable-Testhook -testhookName $stopTesthook
 
     Describe "Stop-Computer" -Tag Feature {
@@ -31,12 +30,18 @@ try
         }
 
         It "Should support -Computer parameter" {
+            if ( ! $IsWindows ) {
+                return
+            }
             Set-TesthookResult -testhookName $stopTesthookResultName -Value $defaultResultValue
             $computerNames = "localhost","${env:COMPUTERNAME}"
             Stop-Computer -Computer $computerNames -ErrorAction Stop | Should -BeNullOrEmpty
         }
 
         It "Should support WsmanAuthentication types" {
+            if ( ! $IsWindows ) {
+                return
+            }
             $authChoices = "Default","Basic","Negotiate","CredSSP","Digest","Kerberos"
             foreach ( $auth in $authChoices ) {
                 Stop-Computer -WsmanAuthentication $auth | Should -BeNullOrEmpty

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Stop-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Stop-Computer.Tests.ps1
@@ -29,19 +29,13 @@ try
             Stop-Computer -ErrorAction Stop | Should -BeNullOrEmpty
         }
 
-        It "Should support -Computer parameter" {
-            if ( ! $IsWindows ) {
-                return
-            }
+        It "Should support -Computer parameter" -Skip:(!$IsWindows) {
             Set-TesthookResult -testhookName $stopTesthookResultName -Value $defaultResultValue
             $computerNames = "localhost","${env:COMPUTERNAME}"
             Stop-Computer -Computer $computerNames -ErrorAction Stop | Should -BeNullOrEmpty
         }
 
-        It "Should support WsmanAuthentication types" {
-            if ( ! $IsWindows ) {
-                return
-            }
+        It "Should support WsmanAuthentication types" -Skip:(!$IsWindows) {
             $authChoices = "Default","Basic","Negotiate","CredSSP","Digest","Kerberos"
             foreach ( $auth in $authChoices ) {
                 Stop-Computer -WsmanAuthentication $auth | Should -BeNullOrEmpty

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Unimplemented-Cmdlet.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Unimplemented-Cmdlet.Tests.ps1
@@ -12,7 +12,6 @@ Describe "Unimplemented Management Cmdlet Tests" -Tags "CI" {
         "Set-Service",
         "New-Service",
 
-        "Restart-Computer",
         "Rename-Computer",
 
         "Get-ComputerInfo",

--- a/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
+++ b/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
@@ -407,7 +407,7 @@ Describe "Verify approved aliases list" -Tags "CI" {
 "Cmdlet",       "Rename-ItemProperty",              "",                                 $($FullCLR -or $CoreWindows -or $CoreUnix),     "",                     "",                     "Medium"
 "Cmdlet",       "Reset-ComputerMachinePassword",    "",                                 $($FullCLR                               ),     "",                     "",                     ""
 "Cmdlet",       "Resolve-Path",                     "",                                 $($FullCLR -or $CoreWindows -or $CoreUnix),     "",                     "",                     "None"
-"Cmdlet",       "Restart-Computer",                 "",                                 $($FullCLR -or $CoreWindows              ),     "",                     "",                     "Medium"
+"Cmdlet",       "Restart-Computer",                 "",                                 $($FullCLR -or $CoreWindows -or $CoreUnix),     "",                     "",                     "Medium"
 "Cmdlet",       "Restart-Service",                  "",                                 $($FullCLR -or $CoreWindows              ),     "",                     "",                     "Medium"
 "Cmdlet",       "Restore-Computer",                 "",                                 $($FullCLR                               ),     "",                     "",                     ""
 "Cmdlet",       "Resume-Job",                       "",                                 $($FullCLR                               ),     "",                     "",                     ""


### PR DESCRIPTION
# PR Summary
Implement the `Restart-Computer` command for Un*x and MacOS

## PR Context
Compliment to the recent implementation of `Stop-Computer` (#11151)

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
- **User-facing changes**
    - [X] Not Applicable
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
