### PR TITLE
Fix error message during symlink deletion

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -3049,12 +3049,12 @@ namespace Microsoft.PowerShell.Commands
             {
                 try
                 {
-                    directory.Delete();
+                    directory.Delete(recurse);
                 }
                 catch (Exception e)
                 {
-                    string error = StringUtil.Format(FileSystemProviderStrings.CannotRemoveItem, directory.FullName);
-                    Exception exception = new IOException(error, e);
+                    string error = StringUtil.Format(FileSystemProviderStrings.CannotRemoveItem, directory.FullName, e.Message);
+                    var exception = new IOException(error, e);
                     WriteError(new ErrorRecord(exception, "DeleteSymbolicLinkFailed", ErrorCategory.WriteError, directory));
                 }
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -3055,7 +3055,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     string error = StringUtil.Format(FileSystemProviderStrings.CannotRemoveItem, directory.FullName, e.Message);
                     var exception = new IOException(error, e);
-                    WriteError(new ErrorRecord(exception, "DeleteSymbolicLinkFailed", ErrorCategory.WriteError, directory));
+                    WriteError(new ErrorRecord(exception, errorId: "DeleteSymbolicLinkFailed", ErrorCategory.WriteError, directory));
                 }
 
                 return;

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -3049,7 +3049,12 @@ namespace Microsoft.PowerShell.Commands
             {
                 try
                 {
-                    directory.Delete(recurse);
+                    // TODO:
+                    // Different symlinks seem to vary by behavior.
+                    // In particular, OneDrive symlinks won't remove without recurse,
+                    // but the .NET API here does not allow us to distinguish them.
+                    // We may need to revisit using p/Invokes here to get the right behavior
+                    directory.Delete();
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

I hit an issue trying to delete a directory under OneDrive like this:

```
At C:\Users\roholt\OneDrive - Microsoft\Dev\PowerShellEditorServices\PowerShellEditorServices.build.ps1:126 char:5
+     Remove-Item $PSScriptRoot\.tmp -Recurse -Force -ErrorAction Ignor …
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C:\Users\roholt\OneDrive - Microsoft\Dev\PowerShellEditorServices [master ≡ +0 ~2 -0 !] [DBG]>> s
At C:\Users\roholt\OneDrive - Microsoft\Dev\PowerShellEditorServices\PowerShellEditorServices.build.ps1:127 char:5
+     Remove-Item $PSScriptRoot\module\PowerShellEditorServices\bin -Re …
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C:\Users\roholt\OneDrive - Microsoft\Dev\PowerShellEditorServices [master ≡ +0 ~2 -0 !] [DBG]>> Remove-Item "$root/module/PowerShellEditorServices/bin" -Recurse -Force -Verbose
Remove-Item: Index (zero based) must be greater than or equal to zero and less than the size of the argument list.
```

Expanding the error revealed this:

```

ProviderInvocationException :
    ProviderInfo   : Microsoft.PowerShell.Core\FileSystem
    ErrorRecord    :
        Exception             :
            TargetSite :
                Name          : AppendFormatHelper
                DeclaringType : System.Text.StringBuilder
                MemberType    : Method
                Module        : System.Private.CoreLib.dll
            StackTrace :
   at System.Text.StringBuilder.AppendFormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.String.FormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.Management.Automation.Internal.StringUtil.Format(String formatSpec, Object o)
   at Microsoft.PowerShell.Commands.FileSystemProvider.RemoveDirectoryInfoItem(DirectoryInfo directory, Boolean recurse, Boolean force, Boolean rootOfRemoval)
   at Microsoft.PowerShell.Commands.FileSystemProvider.RemoveItem(String path, Boolean recurse)
   at System.Management.Automation.SessionStateInternal.RemoveItem(CmdletProvider providerInstance, String path, Boolean recurse, CmdletProviderContext context)
            Message    : Index (zero based) must be greater than or equal to zero and less than the size of the argument list.
            Source     : System.Private.CoreLib
            HResult    : -2146233033
        CategoryInfo          : InvalidOperation: (:) [], FormatException
        FullyQualifiedErrorId : RemoveItemProviderException
    Message        : Attempting to perform the RemoveItem operation on the 'FileSystem' provider failed for path 'C:\Users\roholt\OneDrive - Microsoft\Dev\PowerShellEditorServices\module\PowerShellEditorServices\bin'. Index (zero based) must be greater than or equal to zero and less than the size of the argument
list.
    TargetSite     :
        Name          : RemoveItem
        DeclaringType : System.Management.Automation.SessionStateInternal
        MemberType    : Method
        Module        : System.Management.Automation.dll
    StackTrace     :
   at System.Management.Automation.SessionStateInternal.RemoveItem(CmdletProvider providerInstance, String path, Boolean recurse, CmdletProviderContext context)
   at System.Management.Automation.SessionStateInternal.RemoveItem(String providerId, String path, Boolean recurse, CmdletProviderContext context)
   at Microsoft.PowerShell.Commands.RemoveItemCommand.ProcessRecord()
   at System.Management.Automation.CommandProcessor.ProcessRecord()
    InnerException :
        TargetSite :
            Name          : AppendFormatHelper
            DeclaringType : System.Text.StringBuilder
            MemberType    : Method
            Module        : System.Private.CoreLib.dll
        StackTrace :
   at System.Text.StringBuilder.AppendFormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.String.FormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.Management.Automation.Internal.StringUtil.Format(String formatSpec, Object o)
   at Microsoft.PowerShell.Commands.FileSystemProvider.RemoveDirectoryInfoItem(DirectoryInfo directory, Boolean recurse, Boolean force, Boolean rootOfRemoval)
   at Microsoft.PowerShell.Commands.FileSystemProvider.RemoveItem(String path, Boolean recurse)
   at System.Management.Automation.SessionStateInternal.RemoveItem(CmdletProvider providerInstance, String path, Boolean recurse, CmdletProviderContext context)
        Message    : Index (zero based) must be greater than or equal to zero and less than the size of the argument list.
        Source     : System.Private.CoreLib
        HResult    : -2146233033
    Source         : System.Management.Automation
    HResult        : -2146233087
ProviderInfo                : Microsoft.PowerShell.Core\FileSystem
ErrorRecord                 :
    Exception             :
        TargetSite :
            Name          : AppendFormatHelper
            DeclaringType : System.Text.StringBuilder
            MemberType    : Method
            Module        : System.Private.CoreLib.dll
        StackTrace :
   at System.Text.StringBuilder.AppendFormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.String.FormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.Management.Automation.Internal.StringUtil.Format(String formatSpec, Object o)
   at Microsoft.PowerShell.Commands.FileSystemProvider.RemoveDirectoryInfoItem(DirectoryInfo directory, Boolean recurse, Boolean force, Boolean rootOfRemoval)
   at Microsoft.PowerShell.Commands.FileSystemProvider.RemoveItem(String path, Boolean recurse)
   at System.Management.Automation.SessionStateInternal.RemoveItem(CmdletProvider providerInstance, String path, Boolean recurse, CmdletProviderContext context)
        Message    : Index (zero based) must be greater than or equal to zero and less than the size of the argument list.
        Source     : System.Private.CoreLib
        HResult    : -2146233033
    CategoryInfo          : NotSpecified: (:) [Remove-Item], FormatException
    FullyQualifiedErrorId : System.FormatException,Microsoft.PowerShell.Commands.RemoveItemCommand
    InvocationInfo        :
        MyCommand        : Remove-Item
        ScriptLineNumber : 1
        OffsetInLine     : 1
        HistoryId        : 34
        Line             : Remove-Item "$root/module/PowerShellEditorServices/bin" -Recurse -Force -Verbose
        PositionMessage  : At line:1 char:1
                           + Remove-Item "$root/module/PowerShellEditorServices/bin" -Recurse -For …
                           + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        InvocationName   : Remove-Item
        CommandOrigin    : Internal
    ScriptStackTrace      : at <ScriptBlock>, C:\Users\roholt\OneDrive - Microsoft\Dev\PowerShellEditorServices\PowerShellEditorServices.build.ps1: line 127
                            at *Task, C:\Users\roholt\Documents\PowerShell\Modules\InvokeBuild\5.4.1\Invoke-Build.ps1: line 526
                            at <ScriptBlock><End>, C:\Users\roholt\Documents\PowerShell\Modules\InvokeBuild\5.4.1\Invoke-Build.ps1: line 684
                            at <ScriptBlock>, <No file>: line 1
    PipelineIterationInfo :



TargetSite                  :
    Name          : Invoke
    DeclaringType : System.Management.Automation.Runspaces.PipelineBase
    MemberType    : Method
    Module        : System.Management.Automation.dll
StackTrace                  :
   at System.Management.Automation.Runspaces.PipelineBase.Invoke(IEnumerable input)
   at System.Management.Automation.PowerShell.Worker.ConstructPipelineAndDoWork(Runspace rs, Boolean performSyncInvoke)
   at System.Management.Automation.PowerShell.CoreInvokeHelper[TInput,TOutput](PSDataCollection`1 input, PSDataCollection`1 output, PSInvocationSettings settings)
   at System.Management.Automation.PowerShell.CoreInvoke[TInput,TOutput](PSDataCollection`1 input, PSDataCollection`1 output, PSInvocationSettings settings)
   at System.Management.Automation.PowerShell.InvokeWithDebugger(IEnumerable`1 input, IList`1 output, PSInvocationSettings settings, Boolean invokeMustRun)
   at System.Management.Automation.ScriptDebugger.ProcessCommand(PSCommand command, PSDataCollection`1 output)
   at Microsoft.PowerShell.ConsoleHost.InputLoop.ProcessDebugCommand(String cmd, Exception& e)
Message                     : Index (zero based) must be greater than or equal to zero and less than the size of the argument list.
Data                        : System.Collections.ListDictionaryInternal
InnerException              :
    TargetSite :
        Name          : AppendFormatHelper
        DeclaringType : System.Text.StringBuilder
        MemberType    : Method
        Module        : System.Private.CoreLib.dll
    StackTrace :
   at System.Text.StringBuilder.AppendFormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.String.FormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.Management.Automation.Internal.StringUtil.Format(String formatSpec, Object o)
   at Microsoft.PowerShell.Commands.FileSystemProvider.RemoveDirectoryInfoItem(DirectoryInfo directory, Boolean recurse, Boolean force, Boolean rootOfRemoval)
   at Microsoft.PowerShell.Commands.FileSystemProvider.RemoveItem(String path, Boolean recurse)
   at System.Management.Automation.SessionStateInternal.RemoveItem(CmdletProvider providerInstance, String path, Boolean recurse, CmdletProviderContext context)
    Message    : Index (zero based) must be greater than or equal to zero and less than the size of the argument list.
    Source     : System.Private.CoreLib
    HResult    : -2146233033
Source                      : System.Management.Automation
HResult                     : -2146233087

```

The directory looked like this:

```
 gi "$root/module/PowerShellEditorServices/bin"  | fl * -force

PSPath              : Microsoft.PowerShell.Core\FileSystem::C:\Users\roholt\OneDrive - Microsoft\Dev\PowerShellEditorServices\module\PowerShellEditorServices\bin
PSParentPath        : Microsoft.PowerShell.Core\FileSystem::C:\Users\roholt\OneDrive - Microsoft\Dev\PowerShellEditorServices\module\PowerShellEditorServices
PSChildName         : bin
PSDrive             : C
PSProvider          : Microsoft.PowerShell.Core\FileSystem
PSIsContainer       : True
Mode                : la---
ModeWithoutHardLink : la---
BaseName            : bin
Target              :
LinkType            :
Parent              : C:\Users\roholt\OneDrive - Microsoft\Dev\PowerShellEditorServices\module\PowerShellEditorServices
Root                : C:\
FullName            : C:\Users\roholt\OneDrive - Microsoft\Dev\PowerShellEditorServices\module\PowerShellEditorServices\bin
Extension           :
Name                : bin
Exists              : True
CreationTime        : 12/10/2019 3:41:06 PM
CreationTimeUtc     : 12/10/2019 11:41:06 PM
LastAccessTime      : 12/12/2019 9:49:09 AM
LastAccessTimeUtc   : 12/12/2019 5:49:09 PM
LastWriteTime       : 12/10/2019 3:41:06 PM
LastWriteTimeUtc    : 12/10/2019 11:41:06 PM
Attributes          : Directory, Archive, ReparsePoint

```

I've tried writing tests that look like this:

```
    Describe -Name "Symbolic links" -Tag "RequireAdminOnWindows" {
        BeforeEach {
            $testDir = New-Item -Path $TestDrive -Name "testdir" -ItemType Directory
        }

        AfterEach {
            if (Test-Path $testDir)
            {
                Remove-Item $testDir -Force -Recurse
            }
        }

        It "Should be able to delete a symlink to the directory" {
            $subDir = New-Item -ItemType Directory -Path $testDir -Name "subdir"
            New-Item -ItemType File -Path $subDir -Name "txt" -Value "nothing to see here"
            $symlink = New-Item -Name "kwyjibo" -Path $TestDrive -ItemType SymbolicLink -Target $testDir

            Remove-Item $symlink -Recurse -Force

            Test-Path $testDir | Should -BeTrue
            Get-ChildItem $testDir | Should -HaveCount 0
        }

        It "Should fail properly when a symlink cannot be deleted" {
            $subDir = New-Item -ItemType Directory -Path $testDir -Name "subdir"
            New-Item -ItemType File -Path $subDir -Name "txt" -Value "nothing to see here" -Force
            $file = New-Item -ItemType File -Path $subDir -Name "txt" -Value "nothing to see here"
            $symlink = New-Item -Name "kwyjibo" -Path $TestDrive -ItemType SymbolicLink -Target $testDir

            $file = [System.IO.File]::Open($file, 'open', 'read', 'none')
            try
            {
                Remove-Item $symlink -Recurse -Force

                Test-Path $testDir | Should -BeTrue
                Get-ChildItem $testDir | Should -HaveCount 0
            }
            finally
            {
                $file.Close()
                $file.Dispose()
            }
        }
    }
```

However, they don't fail like OneDrive symlinks do and I'm not sure how to emulate this behaviour.

This is a very simple fix though: the recurse parameter needed to be passed to `Delete()` and the error message needed its second argument passed through.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
