### PR TITLE
Added setting to disable implicit WinPS module loading

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -2390,10 +2390,8 @@ namespace Microsoft.PowerShell.Commands
                             moduleManifestPath,
                             string.Join(',', inferredCompatiblePSEditions));
 
-                        InvalidOperationException ioe = new InvalidOperationException(message);
-
                         ErrorRecord er = new ErrorRecord(
-                            ioe,
+                            new InvalidOperationException(message),
                             nameof(Modules) + "_" + nameof(Modules.ImplicitWinCompatDisabled),
                             ErrorCategory.ResourceUnavailable,
                             moduleManifestPath);

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -2363,18 +2363,60 @@ namespace Microsoft.PowerShell.Commands
             bool isConsideredCompatible = ModuleUtils.IsPSEditionCompatible(moduleManifestPath, inferredCompatiblePSEditions);
             if (!BaseSkipEditionCheck && !isConsideredCompatible)
             {
-                if (importingModule)
+                if (PowerShellConfig.Instance.IsImplicitWinCompatEnabled())
                 {
-                    IList<PSModuleInfo> moduleProxies = ImportModulesUsingWinCompat(new string [] {moduleManifestPath}, null, new ImportModuleOptions());
+                    if (importingModule)
+                    {
+                        IList<PSModuleInfo> moduleProxies = ImportModulesUsingWinCompat(new string [] {moduleManifestPath}, null, new ImportModuleOptions());
 
-                    // we are loading by a single ManifestPath so expect max of 1
-                    if(moduleProxies.Count > 0)
-                    {
-                        return moduleProxies[0];
+                        // we are loading by a single ManifestPath so expect max of 1
+                        if(moduleProxies.Count > 0)
+                        {
+                            return moduleProxies[0];
+                        }
+                        else
+                        {
+                            return null;
+                        }
                     }
-                    else
+                }
+                else
+                {
+                    containedErrors = true;
+                    if (writingErrors)
                     {
-                        return null;
+                        message = StringUtil.Format(
+                            Modules.ImplicitWinCompatDisabled,
+                            moduleManifestPath,
+                            string.Join(',', inferredCompatiblePSEditions));
+
+                        InvalidOperationException ioe = new InvalidOperationException(message);
+
+                        ErrorRecord er = new ErrorRecord(
+                            ioe,
+                            nameof(Modules) + "_" + nameof(Modules.ImplicitWinCompatDisabled),
+                            ErrorCategory.ResourceUnavailable,
+                            moduleManifestPath);
+
+                        WriteError(er);
+                    }
+
+                    if (bailOnFirstError)
+                    {
+                        // If we're trying to load the module, return null so that caches
+                        // are not polluted
+                        if (importingModule)
+                        {
+                            return null;
+                        }
+
+                        // If we return null with Get-Module, a fake module info will be created. Since
+                        // we want to suppress output of the module, we need to do that here.
+                        return new PSModuleInfo(moduleManifestPath, context: null, sessionState: null)
+                        {
+                            HadErrorsLoading = true,
+                            IsConsideredEditionCompatible = false,
+                        };
                     }
                 }
             }

--- a/src/System.Management.Automation/engine/PSConfiguration.cs
+++ b/src/System.Management.Automation/engine/PSConfiguration.cs
@@ -49,6 +49,7 @@ namespace System.Management.Automation.Configuration
     {
         private const string ConfigFileName = "powershell.config.json";
         private const string ExecutionPolicyDefaultShellKey = "Microsoft.PowerShell:ExecutionPolicy";
+        private const string DisableImplicitWinCompatKey = "DisableImplicitWinCompat";
 
         // Provide a singleton
         internal static readonly PowerShellConfig Instance = new PowerShellConfig();
@@ -216,18 +217,14 @@ namespace System.Management.Automation.Configuration
 
         internal bool IsImplicitWinCompatEnabled()
         {
-            bool? settingValue = ReadValueFromFile<bool?>(ConfigScope.CurrentUser, "ImplicitWinCompatEnabled", null);
+            bool? settingValue = ReadValueFromFile<bool?>(ConfigScope.CurrentUser, DisableImplicitWinCompatKey);
             if (!settingValue.HasValue)
             {
-                settingValue = ReadValueFromFile<bool?>(ConfigScope.AllUsers, "ImplicitWinCompatEnabled", null);
-                if (!settingValue.HasValue)
-                {
-                    // if the setting is not mentioned in configuration files, then the default value is True
-                    settingValue = true;
-                }
+                // if the setting is not mentioned in configuration files, then the default DisableImplicitWinCompat value is False
+                settingValue = ReadValueFromFile<bool?>(ConfigScope.AllUsers, DisableImplicitWinCompatKey, defaultValue: false);
             }
 
-            return settingValue.Value;
+            return !settingValue.Value;
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/PSConfiguration.cs
+++ b/src/System.Management.Automation/engine/PSConfiguration.cs
@@ -214,6 +214,22 @@ namespace System.Management.Automation.Configuration
             }
         }
 
+        internal bool IsImplicitWinCompatEnabled()
+        {
+            bool? settingValue = ReadValueFromFile<bool?>(ConfigScope.CurrentUser, "ImplicitWinCompatEnabled", null);
+            if (!settingValue.HasValue)
+            {
+                settingValue = ReadValueFromFile<bool?>(ConfigScope.AllUsers, "ImplicitWinCompatEnabled", null);
+                if (!settingValue.HasValue)
+                {
+                    // if the setting is not mentioned in configuration files, then the default value is True
+                    settingValue = true;
+                }
+            }
+
+            return settingValue.Value;
+        }
+
         /// <summary>
         /// Corresponding settings of the original Group Policies.
         /// </summary>

--- a/src/System.Management.Automation/resources/Modules.resx
+++ b/src/System.Management.Automation/resources/Modules.resx
@@ -595,7 +595,7 @@
     <value>Module '{0}' does not support current PowerShell edition '{1}'. Its supported editions are '{2}'. Use 'Import-Module -SkipEditionCheck' to ignore the compatibility of this module.</value>
   </data>
   <data name="ImplicitWinCompatDisabled" xml:space="preserve">
-    <value>Module '{0}' supports PowerShell edition '{1}' and can not be loaded implicitly using Windows Compatibility feature because it is disabled in the settings file; try using 'Import-Module -UseWindowsPowerShell' or 'Import-Module -SkipEditionCheck'.</value>
+    <value>Module '{0}' supports PowerShell edition '{1}' and cannot be loaded implicitly using the Windows Compatibility feature because it is disabled in the settings file. Use 'Import-Module -UseWindowsPowerShell' to load this module with Windows PowerShell or 'Import-Module -SkipEditionCheck' to try to load the module with the current PowerShell.</value>
   </data>
   <data name="ExperimentalFeatureNameMissingOrEmpty" xml:space="preserve">
     <value>A non-empty string value should be specified for an experimental feature declared in the module manifest.</value>

--- a/src/System.Management.Automation/resources/Modules.resx
+++ b/src/System.Management.Automation/resources/Modules.resx
@@ -594,6 +594,9 @@
   <data name="PSEditionNotSupported" xml:space="preserve">
     <value>Module '{0}' does not support current PowerShell edition '{1}'. Its supported editions are '{2}'. Use 'Import-Module -SkipEditionCheck' to ignore the compatibility of this module.</value>
   </data>
+  <data name="ImplicitWinCompatDisabled" xml:space="preserve">
+    <value>Module '{0}' supports PowerShell edition '{1}' and can not be loaded implicitly using Windows Compatibility feature because it is disabled in the settings file; try using 'Import-Module -UseWindowsPowerShell' or 'Import-Module -SkipEditionCheck'.</value>
+  </data>
   <data name="ExperimentalFeatureNameMissingOrEmpty" xml:space="preserve">
     <value>A non-empty string value should be specified for an experimental feature declared in the module manifest.</value>
   </data>

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -440,7 +440,7 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "CI" {
             $ConfigPath = Join-Path $TestDrive 'powershell.config.json'
             '{"DisableImplicitWinCompat" : "True"}' | Out-File -Force $ConfigPath
             pwsh -NoProfile -NonInteractive -settingsFile $ConfigPath -c "[System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('TestWindowsPowerShellPSHomeLocation', `'$basePath`');Import-Module $ModuleName2" *> $LogPath
-            $LogPath | Should -FileContentMatch 'can not be loaded implicitly using Windows Compatibility'
+            $LogPath | Should -FileContentMatch 'cannot be loaded implicitly using Windows Compatibility'
         }
 
         It "Fails to auto-import incompatible module during CommandDiscovery\ModuleAutoload if implicit WinCompat is Disabled in config " -Skip:(-not $IsWindows) {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -130,7 +130,7 @@ function New-TestNestedModule
     # Create the manifest
     [scriptblock]::Create($newManifestCmd).Invoke()
 }
-
+<#
 Describe "Get-Module with CompatiblePSEditions-checked paths" -Tag "CI" {
 
     BeforeAll {
@@ -389,7 +389,7 @@ Describe "Import-Module from CompatiblePSEditions-checked paths" -Tag "CI" {
         }
     }
 }
-
+#>
 Describe "Additional tests for Import-Module with WinCompat" -Tag "CI" {
     BeforeAll {
         $ModuleName = "DesktopModule"
@@ -440,7 +440,7 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "CI" {
             $ConfigPath = Join-Path $TestDrive 'powershell.config.json'
             '{"DisableImplicitWinCompat" : "True"}' | Out-File -Force $ConfigPath
             pwsh -NoProfile -NonInteractive -settingsFile $ConfigPath -c "[System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('TestWindowsPowerShellPSHomeLocation', `'$basePath`');Import-Module $ModuleName2" *> $LogPath
-            $LogPath | Should -FileContentMatch 'cannot be loaded implicitly using Windows Compatibility'
+            $LogPath | Should -FileContentMatch 'cannot be loaded implicitly using the Windows Compatibility'
         }
 
         It "Fails to auto-import incompatible module during CommandDiscovery\ModuleAutoload if implicit WinCompat is Disabled in config " -Skip:(-not $IsWindows) {
@@ -460,7 +460,7 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "CI" {
         }
     }
 }
-
+<#
 Describe "PSModulePath changes interacting with other PowerShell processes" -Tag "Feature" {
     $PSDefaultParameterValues = @{ 'It:Skip' = (-not $IsWindows) }
 
@@ -1086,4 +1086,4 @@ Describe "Import-Module nested module behaviour with Edition checking" -Tag "Fea
             }
         }
     }
-}
+}#>

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -130,7 +130,7 @@ function New-TestNestedModule
     # Create the manifest
     [scriptblock]::Create($newManifestCmd).Invoke()
 }
-<#
+
 Describe "Get-Module with CompatiblePSEditions-checked paths" -Tag "CI" {
 
     BeforeAll {
@@ -389,7 +389,7 @@ Describe "Import-Module from CompatiblePSEditions-checked paths" -Tag "CI" {
         }
     }
 }
-#>
+
 Describe "Additional tests for Import-Module with WinCompat" -Tag "CI" {
     BeforeAll {
         $ModuleName = "DesktopModule"
@@ -411,7 +411,7 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "CI" {
             Restore-ModulePath
         }
 
-        <#It "Verify that Error is generated with default ErrorAction" -Skip:(-not $IsWindows) {
+        It "Verify that Error is generated with default ErrorAction" -Skip:(-not $IsWindows) {
             $LogPath = Join-Path $TestDrive (New-Guid).ToString()
             pwsh -NoProfile -NonInteractive -c "[System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('TestWindowsPowerShellPSHomeLocation', `'$basePath`');Import-Module $ModuleName" *> $LogPath
             $LogPath | Should -FileContentMatch 'divide by zero'
@@ -433,31 +433,34 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "CI" {
             $LogPath = Join-Path $TestDrive (New-Guid).ToString()
             pwsh -NoProfile -NonInteractive -c "[System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('TestWindowsPowerShellPSHomeLocation', `'$basePath`');Import-Module $ModuleName -WarningAction Ignore" *> $LogPath
             $LogPath | Should -Not -FileContentMatch 'loaded in Windows PowerShell'
-        }#>
+        }
 
         It "Fails to import incompatible module if implicit WinCompat is disabled in config " -Skip:(-not $IsWindows) {
             $LogPath = Join-Path $TestDrive (New-Guid).ToString()
             $ConfigPath = Join-Path $TestDrive 'powershell.config.json'
-            '{"ImplicitWinCompatEnabled" : "False"}' | Out-File -Force $ConfigPath
+            '{"DisableImplicitWinCompat" : "True"}' | Out-File -Force $ConfigPath
             pwsh -NoProfile -NonInteractive -settingsFile $ConfigPath -c "[System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('TestWindowsPowerShellPSHomeLocation', `'$basePath`');Import-Module $ModuleName2" *> $LogPath
-            $c = gc $LogPath -Raw
-            Write-Verbose -Verbose $c
             $LogPath | Should -FileContentMatch 'can not be loaded implicitly using Windows Compatibility'
         }
 
-        It "Fails to auto-import incompatible module during CommandDiscovery\ModuleAutoload if implicit WinCompat is disabled in config " -Skip:(-not $IsWindows) {
+        It "Fails to auto-import incompatible module during CommandDiscovery\ModuleAutoload if implicit WinCompat is Disabled in config " -Skip:(-not $IsWindows) {
             $LogPath = Join-Path $TestDrive (New-Guid).ToString()
             $ConfigPath = Join-Path $TestDrive 'powershell.config.json'
-            '{"ImplicitWinCompatEnabled" : "False"}' | Out-File -Force $ConfigPath
+            '{"DisableImplicitWinCompat" : "True"}' | Out-File -Force $ConfigPath
             pwsh -NoProfile -NonInteractive -settingsFile $ConfigPath -c "[System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('TestWindowsPowerShellPSHomeLocation', `'$basePath`'); Test-$ModuleName2" *> $LogPath
-
-            $c = gc $LogPath -Raw
-            Write-Verbose -Verbose $c
             $LogPath | Should -FileContentMatch 'not recognized as the name of a cmdlet'
+        }
+
+        It "Successfully auto-imports incompatible module during CommandDiscovery\ModuleAutoload if implicit WinCompat is Enabled in config " -Skip:(-not $IsWindows) {
+            $LogPath = Join-Path $TestDrive (New-Guid).ToString()
+            $ConfigPath = Join-Path $TestDrive 'powershell.config.json'
+            '{"DisableImplicitWinCompat" : "False"}' | Out-File -Force $ConfigPath
+            pwsh -NoProfile -NonInteractive -settingsFile $ConfigPath -c "[System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('TestWindowsPowerShellPSHomeLocation', `'$basePath`'); Test-$ModuleName2" *> $LogPath
+            $LogPath | Should -FileContentMatch 'True'
         }
     }
 }
-<#
+
 Describe "PSModulePath changes interacting with other PowerShell processes" -Tag "Feature" {
     $PSDefaultParameterValues = @{ 'It:Skip' = (-not $IsWindows) }
 
@@ -1084,4 +1087,3 @@ Describe "Import-Module nested module behaviour with Edition checking" -Tag "Fea
         }
     }
 }
-#>

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -130,7 +130,7 @@ function New-TestNestedModule
     # Create the manifest
     [scriptblock]::Create($newManifestCmd).Invoke()
 }
-<#
+
 Describe "Get-Module with CompatiblePSEditions-checked paths" -Tag "CI" {
 
     BeforeAll {
@@ -389,7 +389,7 @@ Describe "Import-Module from CompatiblePSEditions-checked paths" -Tag "CI" {
         }
     }
 }
-#>
+
 Describe "Additional tests for Import-Module with WinCompat" -Tag "CI" {
     BeforeAll {
         $ModuleName = "DesktopModule"
@@ -460,7 +460,7 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "CI" {
         }
     }
 }
-<#
+
 Describe "PSModulePath changes interacting with other PowerShell processes" -Tag "Feature" {
     $PSDefaultParameterValues = @{ 'It:Skip' = (-not $IsWindows) }
 
@@ -1086,4 +1086,4 @@ Describe "Import-Module nested module behaviour with Edition checking" -Tag "Fea
             }
         }
     }
-}#>
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -391,9 +391,13 @@ Describe "Import-Module from CompatiblePSEditions-checked paths" -Tag "CI" {
 }
 
 Describe "Additional tests for Import-Module with WinCompat" -Tag "Feature" {
-    $PSDefaultParameterValues = @{ 'It:Skip' = (-not $IsWindows) }
 
     BeforeAll {
+        $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
+        if ( ! $IsWindows ) {
+            $PSDefaultParameterValues["it:skip"] = $true
+        }
+
         $ModuleName = "DesktopModule"
         $ModuleName2 = "DesktopModule2"
         $basePath = Join-Path $TestDrive "WinCompatModules"
@@ -402,6 +406,10 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "Feature" {
         New-EditionCompatibleModule -ModuleName $ModuleName -CompatiblePSEditions "Desktop" -Dir $basePath -ErrorGenerationCode '1/0;'
         # create an incompatible module
         New-EditionCompatibleModule -ModuleName $ModuleName2 -CompatiblePSEditions "Desktop" -Dir $basePath
+    }
+
+    AfterAll {
+        $global:PSDefaultParameterValues = $originalDefaultParameterValues
     }
 
     Context "Tests that ErrorAction/WarningAction have effect when Import-Module with WinCompat is used" {
@@ -464,7 +472,17 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "Feature" {
 }
 
 Describe "PSModulePath changes interacting with other PowerShell processes" -Tag "Feature" {
-    $PSDefaultParameterValues = @{ 'It:Skip' = (-not $IsWindows) }
+
+    BeforeAll {
+        $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
+        if ( ! $IsWindows ) {
+            $PSDefaultParameterValues["it:skip"] = $true
+        }
+    }
+
+    AfterAll {
+        $global:PSDefaultParameterValues = $originalDefaultParameterValues
+    }
 
     Context "System32 module path prepended to PSModulePath" {
         BeforeAll {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -390,7 +390,9 @@ Describe "Import-Module from CompatiblePSEditions-checked paths" -Tag "CI" {
     }
 }
 
-Describe "Additional tests for Import-Module with WinCompat" -Tag "CI" {
+Describe "Additional tests for Import-Module with WinCompat" -Tag "Feature" {
+    $PSDefaultParameterValues = @{ 'It:Skip' = (-not $IsWindows) }
+
     BeforeAll {
         $ModuleName = "DesktopModule"
         $ModuleName2 = "DesktopModule2"
@@ -411,31 +413,31 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "CI" {
             Restore-ModulePath
         }
 
-        It "Verify that Error is generated with default ErrorAction" -Skip:(-not $IsWindows) {
+        It "Verify that Error is generated with default ErrorAction" {
             $LogPath = Join-Path $TestDrive (New-Guid).ToString()
             pwsh -NoProfile -NonInteractive -c "[System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('TestWindowsPowerShellPSHomeLocation', `'$basePath`');Import-Module $ModuleName" *> $LogPath
             $LogPath | Should -FileContentMatch 'divide by zero'
         }
 
-        It "Verify that Warning is generated with default WarningAction" -Skip:(-not $IsWindows) {
+        It "Verify that Warning is generated with default WarningAction" {
             $LogPath = Join-Path $TestDrive (New-Guid).ToString()
             pwsh -NoProfile -NonInteractive -c "[System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('TestWindowsPowerShellPSHomeLocation', `'$basePath`');Import-Module $ModuleName" *> $LogPath
             $LogPath | Should -FileContentMatch 'loaded in Windows PowerShell'
         }
 
-        It "Verify that Error is Not generated with -ErrorAction Ignore" -Skip:(-not $IsWindows) {
+        It "Verify that Error is Not generated with -ErrorAction Ignore" {
             $LogPath = Join-Path $TestDrive (New-Guid).ToString()
             pwsh -NoProfile -NonInteractive -c "[System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('TestWindowsPowerShellPSHomeLocation', `'$basePath`');Import-Module $ModuleName -ErrorAction Ignore" *> $LogPath
             $LogPath | Should -Not -FileContentMatch 'divide by zero'
         }
 
-        It "Verify that Warning is Not generated with -WarningAction Ignore" -Skip:(-not $IsWindows) {
+        It "Verify that Warning is Not generated with -WarningAction Ignore" {
             $LogPath = Join-Path $TestDrive (New-Guid).ToString()
             pwsh -NoProfile -NonInteractive -c "[System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('TestWindowsPowerShellPSHomeLocation', `'$basePath`');Import-Module $ModuleName -WarningAction Ignore" *> $LogPath
             $LogPath | Should -Not -FileContentMatch 'loaded in Windows PowerShell'
         }
 
-        It "Fails to import incompatible module if implicit WinCompat is disabled in config " -Skip:(-not $IsWindows) {
+        It "Fails to import incompatible module if implicit WinCompat is disabled in config" {
             $LogPath = Join-Path $TestDrive (New-Guid).ToString()
             $ConfigPath = Join-Path $TestDrive 'powershell.config.json'
             '{"DisableImplicitWinCompat" : "True"}' | Out-File -Force $ConfigPath
@@ -443,7 +445,7 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "CI" {
             $LogPath | Should -FileContentMatch 'cannot be loaded implicitly using the Windows Compatibility'
         }
 
-        It "Fails to auto-import incompatible module during CommandDiscovery\ModuleAutoload if implicit WinCompat is Disabled in config " -Skip:(-not $IsWindows) {
+        It "Fails to auto-import incompatible module during CommandDiscovery\ModuleAutoload if implicit WinCompat is Disabled in config" {
             $LogPath = Join-Path $TestDrive (New-Guid).ToString()
             $ConfigPath = Join-Path $TestDrive 'powershell.config.json'
             '{"DisableImplicitWinCompat" : "True"}' | Out-File -Force $ConfigPath
@@ -451,7 +453,7 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "CI" {
             $LogPath | Should -FileContentMatch 'not recognized as the name of a cmdlet'
         }
 
-        It "Successfully auto-imports incompatible module during CommandDiscovery\ModuleAutoload if implicit WinCompat is Enabled in config " -Skip:(-not $IsWindows) {
+        It "Successfully auto-imports incompatible module during CommandDiscovery\ModuleAutoload if implicit WinCompat is Enabled in config" {
             $LogPath = Join-Path $TestDrive (New-Guid).ToString()
             $ConfigPath = Join-Path $TestDrive 'powershell.config.json'
             '{"DisableImplicitWinCompat" : "False"}' | Out-File -Force $ConfigPath


### PR DESCRIPTION
# PR Summary
This adds a Boolean `DisableImplicitWinCompat` setting that can be set in `powershell.config.json` to disable **implicit** WinPS module loading.
Previously this code was under experimental feature check that was recently removed by `Make approved features non-experimental` PR.
This setting does not affect `Import-Module -UseWindowsPowerShell` or `Import-Module -SkipEditionCheck` parameter functionality.

Fix #11309 

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
