### PR TITLE
Test-Connection: Fallback to hop IP Address on -Traceroute without -ResolveDestination

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -1024,8 +1024,8 @@ namespace Microsoft.PowerShell.Commands
             {
                 get
                 {
-                    if (_status.Address?.ToString() == IPAddress.Any.ToString()
-                        || _status.Address?.ToString() == IPAddress.IPv6Any.ToString())
+                    if (_status.Address == IPAddress.Any
+                        || _status.Address == IPAddress.IPv6Any)
                     {
                         // There was no response to the ping (TimedOut).
                         return null;

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -381,7 +381,11 @@ namespace Microsoft.PowerShell.Commands
 #endif
                 var hopAddressString = discoveryReply.Address.ToString();
 
-                InitProcessPing(hopAddressString, out string routerName, out _);
+                string routerName = null;
+                if (!InitProcessPing(hopAddressString, out routerName, out _))
+                {
+                    routerName = hopAddressString;
+                }
 
                 // In traceroutes we don't use 'Count' parameter.
                 // If we change 'DefaultTraceRoutePingCount' we should change 'ConsoleTraceRouteReply' resource string.

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -381,8 +381,16 @@ namespace Microsoft.PowerShell.Commands
 #endif
                 var hopAddressString = discoveryReply.Address.ToString();
 
-                if (!TryResolveNameOrAddress(hopAddressString, out string routerName, out _))
+                try
                 {
+                    if (!TryResolveNameOrAddress(hopAddressString, out string routerName, out _))
+                    {
+                        routerName = hopAddressString;
+                    }
+                }
+                catch
+                {
+                    // Swallow hostname resolve exceptions and continue with traceroute
                     routerName = hopAddressString;
                 }
 

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -381,7 +381,7 @@ namespace Microsoft.PowerShell.Commands
 #endif
                 var hopAddressString = discoveryReply.Address.ToString();
 
-                string routerName = null;
+                string routerName = hopAddressString;
                 try
                 {
                     if (!TryResolveNameOrAddress(hopAddressString, out routerName, out _))
@@ -392,7 +392,6 @@ namespace Microsoft.PowerShell.Commands
                 catch
                 {
                     // Swallow hostname resolve exceptions and continue with traceroute
-                    routerName = hopAddressString;
                 }
 
                 // In traceroutes we don't use 'Count' parameter.

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -1022,10 +1022,23 @@ namespace Microsoft.PowerShell.Commands
             /// <value></value>
             public string? Hostname
             {
-                get => _status.Destination != IPAddress.Any.ToString()
-                    && _status.Destination != IPAddress.IPv6Any.ToString()
-                        ? _status.Destination
-                        : null;
+                get
+                {
+                    if (_status.Address?.ToString() == IPAddress.Any.ToString()
+                        || _status.Address?.ToString() == IPAddress.IPv6Any.ToString())
+                    {
+                        // There was no response to the ping (TimedOut).
+                        return null;
+                    }
+
+                    if (_status.Destination == string.Empty)
+                    {
+                        // There was a response, but the destination field is empty; use DisplayAddress.
+                        return _status.DisplayAddress;
+                    }
+
+                    return _status.Destination;
+                }
             }
 
             /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -389,8 +389,8 @@ namespace Microsoft.PowerShell.Commands
                 {
                     try
                     {
-#if !UNIX
-                        if (ResolveDestination.IsPresent && routerName == string.Empty)
+                        if (routerName == string.Empty
+                            || ResolveDestination.IsPresent && routerName == hopAddressString)
                         {
                             try
                             {
@@ -401,7 +401,6 @@ namespace Microsoft.PowerShell.Commands
                                 // Swallow host resolve exceptions and just use the IP address.
                             }
                         }
-#endif
 
                         reply = SendCancellablePing(hopAddress, timeout, buffer, pingOptions, timer);
 
@@ -409,9 +408,7 @@ namespace Microsoft.PowerShell.Commands
                         {
                             var status = new PingStatus(
                                 Source,
-                                routerName != string.Empty
-                                    ? routerName
-                                    : hopAddressString,
+                                routerName,
                                 reply,
                                 reply.Status == IPStatus.Success
                                     ? reply.RoundtripTime

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -285,7 +285,7 @@ namespace Microsoft.PowerShell.Commands
 
         private void ProcessConnectionByTCPPort(string targetNameOrAddress)
         {
-            if (!CanResolveNameOrAddress(targetNameOrAddress, out _, out IPAddress? targetAddress))
+            if (!TryResolveNameOrAddress(targetNameOrAddress, out _, out IPAddress? targetAddress))
             {
                 return;
             }
@@ -336,7 +336,7 @@ namespace Microsoft.PowerShell.Commands
         {
             byte[] buffer = GetSendBuffer(BufferSize);
 
-            if (!CanResolveNameOrAddress(targetNameOrAddress, out string resolvedTargetName, out IPAddress? targetAddress))
+            if (!TryResolveNameOrAddress(targetNameOrAddress, out string resolvedTargetName, out IPAddress? targetAddress))
             {
                 return;
             }
@@ -381,7 +381,7 @@ namespace Microsoft.PowerShell.Commands
 #endif
                 var hopAddressString = discoveryReply.Address.ToString();
 
-                if (!CanResolveNameOrAddress(hopAddressString, out string routerName, out _))
+                if (!TryResolveNameOrAddress(hopAddressString, out string routerName, out _))
                 {
                     routerName = hopAddressString;
                 }
@@ -465,7 +465,7 @@ namespace Microsoft.PowerShell.Commands
         private void ProcessMTUSize(string targetNameOrAddress)
         {
             PingReply? reply, replyResult = null;
-            if (!CanResolveNameOrAddress(targetNameOrAddress, out string resolvedTargetName, out IPAddress? targetAddress))
+            if (!TryResolveNameOrAddress(targetNameOrAddress, out string resolvedTargetName, out IPAddress? targetAddress))
             {
                 return;
             }
@@ -568,7 +568,7 @@ namespace Microsoft.PowerShell.Commands
 
         private void ProcessPing(string targetNameOrAddress)
         {
-            if (!CanResolveNameOrAddress(targetNameOrAddress, out string resolvedTargetName, out IPAddress? targetAddress))
+            if (!TryResolveNameOrAddress(targetNameOrAddress, out string resolvedTargetName, out IPAddress? targetAddress))
             {
                 return;
             }
@@ -633,7 +633,7 @@ namespace Microsoft.PowerShell.Commands
 
         #endregion PingTest
 
-        private bool CanResolveNameOrAddress(
+        private bool TryResolveNameOrAddress(
             string targetNameOrAddress,
             out string resolvedTargetName,
             [NotNullWhen(true)]

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -285,7 +285,7 @@ namespace Microsoft.PowerShell.Commands
 
         private void ProcessConnectionByTCPPort(string targetNameOrAddress)
         {
-            if (!InitProcessPing(targetNameOrAddress, out _, out IPAddress? targetAddress))
+            if (!CanResolveNameOrAddress(targetNameOrAddress, out _, out IPAddress? targetAddress))
             {
                 return;
             }
@@ -336,7 +336,7 @@ namespace Microsoft.PowerShell.Commands
         {
             byte[] buffer = GetSendBuffer(BufferSize);
 
-            if (!InitProcessPing(targetNameOrAddress, out string resolvedTargetName, out IPAddress? targetAddress))
+            if (!CanResolveNameOrAddress(targetNameOrAddress, out string resolvedTargetName, out IPAddress? targetAddress))
             {
                 return;
             }
@@ -381,7 +381,7 @@ namespace Microsoft.PowerShell.Commands
 #endif
                 var hopAddressString = discoveryReply.Address.ToString();
 
-                if (!InitProcessPing(hopAddressString, out string routerName, out _))
+                if (!CanResolveNameOrAddress(hopAddressString, out string routerName, out _))
                 {
                     routerName = hopAddressString;
                 }
@@ -465,7 +465,7 @@ namespace Microsoft.PowerShell.Commands
         private void ProcessMTUSize(string targetNameOrAddress)
         {
             PingReply? reply, replyResult = null;
-            if (!InitProcessPing(targetNameOrAddress, out string resolvedTargetName, out IPAddress? targetAddress))
+            if (!CanResolveNameOrAddress(targetNameOrAddress, out string resolvedTargetName, out IPAddress? targetAddress))
             {
                 return;
             }
@@ -568,7 +568,7 @@ namespace Microsoft.PowerShell.Commands
 
         private void ProcessPing(string targetNameOrAddress)
         {
-            if (!InitProcessPing(targetNameOrAddress, out string resolvedTargetName, out IPAddress? targetAddress))
+            if (!CanResolveNameOrAddress(targetNameOrAddress, out string resolvedTargetName, out IPAddress? targetAddress))
             {
                 return;
             }
@@ -633,7 +633,7 @@ namespace Microsoft.PowerShell.Commands
 
         #endregion PingTest
 
-        private bool InitProcessPing(
+        private bool CanResolveNameOrAddress(
             string targetNameOrAddress,
             out string resolvedTargetName,
             [NotNullWhen(true)]

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -381,9 +381,10 @@ namespace Microsoft.PowerShell.Commands
 #endif
                 var hopAddressString = discoveryReply.Address.ToString();
 
+                string routerName = null;
                 try
                 {
-                    if (!TryResolveNameOrAddress(hopAddressString, out string routerName, out _))
+                    if (!TryResolveNameOrAddress(hopAddressString, out routerName, out _))
                     {
                         routerName = hopAddressString;
                     }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -381,8 +381,7 @@ namespace Microsoft.PowerShell.Commands
 #endif
                 var hopAddressString = discoveryReply.Address.ToString();
 
-                string routerName = null;
-                if (!InitProcessPing(hopAddressString, out routerName, out _))
+                if (!InitProcessPing(hopAddressString, out string routerName, out _))
                 {
                     routerName = hopAddressString;
                 }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -402,13 +402,16 @@ namespace Microsoft.PowerShell.Commands
                             }
                         }
 #endif
+
                         reply = SendCancellablePing(hopAddress, timeout, buffer, pingOptions, timer);
 
                         if (!Quiet.IsPresent)
                         {
                             var status = new PingStatus(
                                 Source,
-                                routerName,
+                                routerName != string.Empty
+                                    ? routerName
+                                    : hopAddressString,
                                 reply,
                                 reply.Status == IPStatus.Success
                                     ? reply.RoundtripTime
@@ -1031,12 +1034,7 @@ namespace Microsoft.PowerShell.Commands
                         return null;
                     }
 
-                    if (_status.Destination == string.Empty)
-                    {
-                        // There was a response, but the destination field is empty; use DisplayAddress.
-                        return _status.DisplayAddress;
-                    }
-
+                    // We have a usable IP address from this ping reply.
                     return _status.Destination;
                 }
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -279,7 +279,7 @@ Describe "Test-Connection" -tags "CI" {
         It 'has a non-null value for Destination for reachable hosts' {
             $results = Test-Connection 127.0.0.1 -Traceroute
 
-            $results.Destination | Should -Not -BeNullOrEmpty
+            $results.Hostname | Should -Not -BeNullOrEmpty
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -275,6 +275,12 @@ Describe "Test-Connection" -tags "CI" {
         It 'returns false without error if MaxHops is exceeded during -Traceroute -Quiet' {
             Test-Connection 8.8.8.8 -Traceroute -MaxHops 2 -Quiet | Should -BeFalse
         }
+
+        It 'has a non-null value for Destination for reachable hosts' {
+            $results = Test-Connection 127.0.0.1 -Traceroute
+
+            $results.Destination | Should -Not -BeNullOrEmpty
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

When doing traceroutes, Destination of the PingStatus is set as the router name.
If no router name is available, it ends up as string.Empty.

This PR changes the logic in `ProcessTraceroute()` to instead assign the `hopAddressString` value as the `Destination` field for the `PingStatus` object created if there is no `routerName` available.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

Fixes #11334

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
