### PR TITLE
First batch of new Pester tests for debugger functionality

### DIFF
--- a/test/powershell/Language/Scripting/Debugging/DebuggerCommand.Tests.ps1
+++ b/test/powershell/Language/Scripting/Debugging/DebuggerCommand.Tests.ps1
@@ -214,14 +214,13 @@ Describe 'Basic debugger command tests' -tag 'CI' {
         }
 
         It 'Should only have CallStackFrame output from the callstack command' {
-            $results[0].Output | Should -BeOfType System.Management.Automation.CallStackFrame
+            $result['k'].Output | Should -BeOfType System.Management.Automation.CallStackFrame
         }
 
         It '''k'' and ''Get-PSCallStack'' should show identical script listings' {
             [string[]]$result['k'] -join [Environment]::NewLine | Should -BeExactly ([string[]]$result['Get-PSCallStack'] -join [Environment]::NewLine)
         }
     }
-
 }
 
 Describe 'Simple debugger stepping command tests' -tag 'CI' {

--- a/test/powershell/Language/Scripting/Debugging/DebuggerCommand.Tests.ps1
+++ b/test/powershell/Language/Scripting/Debugging/DebuggerCommand.Tests.ps1
@@ -214,7 +214,7 @@ Describe 'Basic debugger command tests' -tag 'CI' {
         }
 
         It 'Should only have CallStackFrame output from the callstack command' {
-            $result['k'].Output | Should -BeOfType System.Management.Automation.CallStackFrame
+            $result['k'] | Should -BeOfType System.Management.Automation.CallStackFrame
         }
 
         It '''k'' and ''Get-PSCallStack'' should show identical script listings' {

--- a/test/powershell/Language/Scripting/Debugging/Debugging.Tests.ps1
+++ b/test/powershell/Language/Scripting/Debugging/Debugging.Tests.ps1
@@ -76,7 +76,7 @@ Describe 'Basic breakpoint tests' -tag 'CI' {
 <# 17 #>
 <# 18 #> Test-PSRemoveBreakpoint -WhatIf
 '@
-        $testScriptPath = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), 'BreakpointTestScript.ps1')
+        $testScriptPath = [System.IO.Path]::Combine($testDrive.FullName, 'BreakpointTestScript.ps1')
         [System.IO.File]::WriteAllText($testScriptPath, $testScript)
 
         $bpActionScript = {

--- a/test/powershell/engine/Api/DebuggerAPI.Tests.ps1
+++ b/test/powershell/engine/Api/DebuggerAPI.Tests.ps1
@@ -1,0 +1,129 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+Describe 'Debugger APIs' -Tags 'CI' {
+    Context 'Debugger API Tests' {
+        BeforeAll {
+            function Assert-RunspaceDebuggerIsNotStopped {
+                [CmdletBinding()]
+                param(
+                    [Parameter(Mandatory)]
+                    [runspace]
+                    $Runspace
+                )
+                $Runspace.Debugger.InBreakpoint | Should -BeFalse
+            }
+
+            function Test-ForException {
+                [CmdletBinding()]
+                param(
+                    [Parameter(Mandatory)]
+                    [scriptblock]
+                    $ScriptBlock,
+
+                    [Parameter(Mandatory)]
+                    [System.Type]
+                    $ExceptionType
+                )
+                $errorRecord = $ScriptBlock | Should -Throw -ErrorId $ExceptionType.Name -PassThru
+                $errorRecord.Exception.InnerException | Should -BeOfType $ExceptionType
+            }
+
+            $runspace = [System.Management.Automation.Runspaces.RunspaceFactory]::CreateRunspace()
+            $runspace.Open()
+        }
+
+        AfterAll {
+            if ($runspace -ne $null) {
+                $runspace.Close()
+                $runspace.Dispose()
+            }
+        }
+
+        BeforeEach {
+            $runspace.Debugger.SetDebugMode([System.Management.Automation.DebugModes]::LocalScript -bor [System.Management.Automation.DebugModes]::RemoteScript)
+        }
+
+        It 'Properly updates Debugger.DebugMode when invoking Debugger.SetDebugMode(<DebugMode>)' -TestCases @(
+            @{
+                DebugMode = [System.Management.Automation.DebugModes]::None
+            }
+            @{
+                DebugMode = [System.Management.Automation.DebugModes]::Default
+            }
+            @{
+                DebugMode = [System.Management.Automation.DebugModes]::LocalScript
+            }
+            @{
+                DebugMode = [System.Management.Automation.DebugModes]::RemoteScript
+            }
+            @{
+                DebugMode = [System.Management.Automation.DebugModes]::LocalScript -bor [System.Management.Automation.DebugModes]::RemoteScript
+            }
+        ) {
+            param(
+                $DebugMode
+            )
+            $runspace.Debugger.SetDebugMode($DebugMode)
+            $runspace.Debugger.DebugMode | Should -Be $DebugMode
+        }
+
+        It 'Turns off the debugger when invoking Debugger.SetDebugMode(None)' {
+            $runspace.Debugger.SetDebugMode([System.Management.Automation.DebugModes]::None)
+            $runspace.Debugger.IsActive | Should -BeFalse
+        }
+
+        It 'Debugger.SetDebuggerAction throws a PSNotSupportedException when invoked while the debugger is inactive' {
+            Test-ForException -ScriptBlock {
+                $runspace.Debugger.SetDebuggerAction([System.Management.Automation.DebuggerResumeAction]::Continue)
+            } -ExceptionType System.Management.Automation.PSNotSupportedException
+        }
+
+        It 'Debugger.GetDebuggerStopArgs returns null when the debugger is not stopped' {
+            Assert-RunspaceDebuggerIsNotStopped -Runspace $runspace
+            $runspace.Debugger.GetDebuggerStopArgs() | Should -Be $null
+        }
+
+        It 'Debugger.ProcessCommand throws a PSArgumentNullException when invoked with a null ''command'' argument' {
+            Test-ForException -ScriptBlock {
+                $runspace.Debugger.ProcessCommand($null, [System.Management.Automation.PSDataCollection[PSObject]]::new())
+            } -ExceptionType System.Management.Automation.PSArgumentNullException
+        }
+
+        It 'Debugger.ProcessCommand throws a PSArgumentNullException when invoked with a null ''output'' argument' {
+            Test-ForException -ScriptBlock {
+                $runspace.Debugger.ProcessCommand([System.Management.Automation.PSCommand]::new(), $null)
+            } -ExceptionType System.Management.Automation.PSArgumentNullException
+        }
+
+        It 'Debugger.ProcessCommand throws a PSInvalidOperationException when invoked while the debugger is not stopped' {
+            Assert-RunspaceDebuggerIsNotStopped -Runspace $runspace
+            Test-ForException -ScriptBlock {
+                $runspace.Debugger.ProcessCommand([System.Management.Automation.PSCommand]::new(), [System.Management.Automation.PSDataCollection[PSObject]]::new())
+            } -ExceptionType System.Management.Automation.PSInvalidOperationException
+        }
+
+        It 'Debugger.GetCallStack returns an empty stack from a runspace with nothing running' {
+            @($runspace.Debugger.GetCallStack()) | Should -HaveCount 0
+        }
+
+        It 'Debugger.SetParent throws a PSNotImplementedException in a script debugger' {
+            $runspace.Debugger.PSTypeNames | Should -Contain 'System.Management.Automation.ScriptDebugger'
+            Test-ForException -ScriptBlock {
+                $runspace.Debugger.SetParent($runspace.Debugger, $null, $null, $null, $null)
+            } -ExceptionType System.Management.Automation.PSNotImplementedException
+        }
+
+        It 'Debugger.SetDebuggerStepMode should throw a PSInvalidOperationException when the debugger is disabled' {
+            $runspace.Debugger.SetDebugMode([System.Management.Automation.DebugModes]::None)
+            Test-ForException -ScriptBlock {
+                $runspace.Debugger.SetDebuggerStepMode($true)
+            } -ExceptionType System.Management.Automation.PSInvalidOperationException
+        }
+
+        It 'Debugger.SetDebuggerStepMode should make the debugger active when the debugger is enabled' {
+            $runspace.Debugger.SetDebuggerStepMode($true)
+            $runspace.Debugger.IsActive | Should -BeTrue
+        }
+    }
+}

--- a/test/tools/Modules/HelpersDebugger/HelpersDebugger.psd1
+++ b/test/tools/Modules/HelpersDebugger/HelpersDebugger.psd1
@@ -4,7 +4,7 @@
 @{
     RootModule = 'HelpersDebugger.psm1'
 
-    ModuleVersion = '1.0'
+    ModuleVersion = '1.0.1'
 
     GUID = '37a454d7-8acd-40e6-8a2c-43c9d46b1b0c'
 

--- a/test/tools/Modules/HelpersDebugger/HelpersDebugger.psm1
+++ b/test/tools/Modules/HelpersDebugger/HelpersDebugger.psm1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # Ensure that terminating errors terminate when importing the module.
-trap {throw $_}
+trap { throw $_ }
 
 # Strict mode FTW.
 Set-StrictMode -Version Latest
@@ -13,21 +13,40 @@ Export-ModuleMember
 # Grab the internal ScriptPosition property once and re-use it in the ps1xml file
 $internalExtentProperty = [System.Management.Automation.InvocationInfo].GetProperty('ScriptPosition', [System.Reflection.BindingFlags]'NonPublic,Instance')
 
-# A debugger handler that can be used to automatically control the debugger
+# A dictionary to track runspaces whose debugger has been registered,
+# along with their debug command queue and results collection
+$runspacesRegistered = @{}
+
+# A debugger handler that can be used to run debugger commands
 $debuggerStopHandler = {
+    [CmdletBinding()]
+    [System.Diagnostics.DebuggerHidden()]
     param($s, $e)
-    # If we're not handling a debugger stop event during the execution of
-    # Test-Debugger, then simply continue execution
-    if (@(Get-Variable -Name dbgCmdQueue,dbgResults -Scope Script -ErrorAction Ignore).Count -ne 2) {
+    # Manually reference the runspacesRegistered from the module (this is
+    # because we won't have access to script scope when invoking script files)
+    $rsData = & (Get-Module -Name HelpersDebugger) {$runspacesRegistered}
+    # Lookup the runspace associated with the current debugger to make sure we
+    # have collections we can work with
+    $runspaceFound = $false
+    foreach ($runspace in $rsData.Keys) {
+        if ($runspace.Debugger -eq $s) {
+            $runspaceFound = $true
+            break
+        }
+    }
+    # If no runspace was found, or if we don't have collections to work with
+    # in this event handler, then we're not handling a debugger stop event
+    # during the execution of Test-Debugger, and we can continue execution
+    if (-not $runspaceFound -or $rsData[$runspace] -eq $null) {
         $e.ResumeAction = [System.Management.Automation.DebuggerResumeAction]::Continue
         return
     }
     do {
-        if ($script:dbgCmdQueue.Count -eq 0) {
+        if ($rsData[$runspace].DbgCmdQueue.Count -eq 0) {
             # If there are no more commands to process, continue execution
             $stringDbgCommand = 'c'
         } else {
-            $stringDbgCommand = $script:dbgCmdQueue.Dequeue()
+            $stringDbgCommand = $rsData[$runspace].DbgCmdQueue.Dequeue()
         }
         $dbgCmd = [System.Management.Automation.PSCommand]::new()
         $dbgCmd.AddScript($stringDbgCommand) > $null
@@ -36,33 +55,69 @@ $debuggerStopHandler = {
         if ($stringDbgCommand -eq '$?' -and $output.Count -eq 1) {
             $output[0] = $PSDebugContext.Trigger -isnot [System.Management.Automation.ErrorRecord]
         }
-        $script:dbgResults += [pscustomobject]@{
-            PSTypeName          = 'DebuggerCommandResult'
-            Command             = $stringDbgCommand
-            Context             = $PSDebugContext
-            Output              = $output
-            EvaluatedByDebugger = $result.EvaluatedByDebugger
-            ResumeAction        = $result.ResumeAction
-        }
+        $rsData[$runspace].DbgResults.Add([pscustomobject]@{
+                PSTypeName          = 'DebuggerCommandResult'
+                Command             = $stringDbgCommand
+                Context             = $PSDebugContext
+                Output              = $output
+                EvaluatedByDebugger = $result.EvaluatedByDebugger
+                ResumeAction        = $result.ResumeAction
+            })
     } while ($result -eq $null -or $result.ResumeAction -eq $null)
     $e.ResumeAction = $result.ResumeAction
 }
 
-# A flag to identify if the debugger handler has been added or not
-$debuggerStopHandlerRegistered = $false
+# A debugger handler that is invoked when a breakpoint is updated
+$breakpointUpdatedHandler = {
+    [CmdletBinding()]
+    [System.Diagnostics.DebuggerHidden()]
+    param($s, $e)
+    # Manually reference the runspacesRegistered from the module (this is
+    # because we won't have access to script scope when invoking script files)
+    $rsData = & (Get-Module -Name HelpersDebugger) {$runspacesRegistered}
+    # Lookup the runspace associated with the current debugger to make sure we
+    # have collections we can work with
+    $runspaceFound = $false
+    foreach ($runspace in $rsData.Keys) {
+        if ($runspace.Debugger -eq $s) {
+            $runspaceFound = $true
+            break
+        }
+    }
+    # If no runspace was found, or if we don't have collections to work with
+    # in this event handler, then we're not handling a breakpoint updated event
+    # during the execution of Test-Debugger, so there is nothing to do
+    if (-not $runspaceFound -or $rsData[$runspace] -eq $null) {
+        return
+    }
+    # Capture the breakpoint update details so that we can verify them later
+    $rsData[$runspace].BpsUpdated.Add([pscustomobject]@{
+        PSTypeName          = 'UpdatedBreakpoint'
+        Breakpoint          = $e.Breakpoint
+        BreakpointCount     = $e.BreakpointCount
+        UpdateType          = $e.UpdateType
+    })
+}
 
 function Register-DebuggerHandler {
     [CmdletBinding()]
     [OutputType([System.Void])]
-    param()
+    param(
+        [ValidateNotNull()]
+        [runspace]
+        $Runspace = $host.Runspace
+    )
     try {
         $callerEAP = $ErrorActionPreference
-        # We disable debugger interactivity so that all debugger events go through
-        # the DebuggerStop event only (i.e. breakpoints don't actually generate a
-        # prompt for user interaction)
-        $host.DebuggerEnabled = $false
-        $host.Runspace.Debugger.add_DebuggerStop($script:debuggerStopHandler)
-        $script:debuggerStopHandlerRegistered = $true
+        if (-not $script:runspacesRegistered.ContainsKey($Runspace)) {
+            $Runspace.Debugger.add_DebuggerStop($script:debuggerStopHandler)
+            $Runspace.Debugger.add_BreakpointUpdated($script:breakpointUpdatedHandler)
+            $script:runspacesRegistered.Add($Runspace, $null)
+            # Disable debugger interactivity so that all debugger events go
+            # through the DebuggerStop event only (i.e. breakpoints don't
+            # actually generate a prompt for user interaction)
+            $host.DebuggerEnabled = $false
+        }
     } catch {
         Write-Error -ErrorRecord $_ -ErrorAction $callerEAP
     }
@@ -72,12 +127,23 @@ Export-ModuleMember -Function Register-DebuggerHandler
 function Unregister-DebuggerHandler {
     [CmdletBinding()]
     [OutputType([System.Void])]
-    param()
+    param(
+        [ValidateNotNull()]
+        [runspace]
+        $Runspace = $host.Runspace
+    )
     try {
         $callerEAP = $ErrorActionPreference
-        $host.Runspace.Debugger.remove_DebuggerStop($script:debuggerStopHandler)
-        $host.DebuggerEnabled = $true
-        $script:debuggerStopHandlerRegistered = $false
+        if ($script:runspacesRegistered.ContainsKey($Runspace)) {
+            $Runspace.Debugger.remove_DebuggerStop($script:debuggerStopHandler)
+            $Runspace.Debugger.remove_BreakpointUpdated($script:breakpointUpdatedHandler)
+            $script:runspacesRegistered.Remove($Runspace)
+            # Re-enable debugger interactivity so that breakpoints generate a
+            # prompt for user interaction
+            if ($script:runspacesRegistered.Count -eq 0) {
+                $host.DebuggerEnabled = $true
+            }
+        }
     } catch {
         Write-Error -ErrorRecord $_ -ErrorAction $callerEAP
     }
@@ -85,37 +151,62 @@ function Unregister-DebuggerHandler {
 Export-ModuleMember -Function Unregister-DebuggerHandler
 
 function Test-Debugger {
-    [CmdletBinding()]
-    [OutputType('DebuggerCommandResult')]
+    [CmdletBinding(DefaultParameterSetName = 'DebuggerCommands')]
+    [OutputType('DebuggerCommandResult', ParameterSetName = 'DebuggerCommands')]
+    [OutputType('UpdatedBreakpoint', ParameterSetName = 'BreakpointUpdates')]
     param(
-        [Parameter(Position=0, Mandatory)]
+        [Parameter(Position = 0, Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias('sb')]
-        [ScriptBlock]
+        [scriptblock]
         $ScriptBlock,
 
-        [Parameter()]
+        [Parameter(ParameterSetName = 'DebuggerCommands')]
         [ValidateNotNullOrEmpty()]
         [string[]]
-        $CommandQueue
+        $CommandQueue,
+
+        [Parameter(ParameterSetName = 'BreakpointUpdates')]
+        [ValidateRange(1, [int]::MaxValue)]
+        [int]
+        $BreakpointUpdates,
+
+        [ValidateNotNull()]
+        [runspace]
+        $Runspace = $host.Runspace
     )
     try {
         $callerEAP = $ErrorActionPreference
-        #  If the debugger is not set up properly, notify the user with an error message
-        if (-not $script:debuggerStopHandlerRegistered -or $host.DebuggerEnabled) {
+        # If the debugger is not set up properly, notify the user with an
+        # error message
+        if (-not $script:runspacesRegistered.ContainsKey($Runspace) -or $host.DebuggerEnabled) {
             $message = 'You must invoke Register-DebuggerHandler before invoking Test-Debugger, and Unregister-DebuggerHandler after invoking Test-Debugger. As a best practice, invoke Register-DebuggerHandler in the BeforeAll block and Unregister-DebuggerHandler in the AfterAll block of your test script.'
             $exception = [System.InvalidOperationException]::new($message)
             $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, $exception.GetType().Name, 'InvalidOperation', $null)
             throw $errorRecord
         }
-        $script:dbgResults = @()
-        $script:dbgCmdQueue = [System.Collections.Queue]::new()
+        # If the runspace debugger is already running a test, notify the user
+        # with an error message
+        if ($script:runspacesRegistered[$Runspace] -ne $null) {
+            $message = "You can only run one debugger command test per runspace at a time. Runspace '$($Runspace.InstanceId)' is currently busy running another debugger command test."
+            $exception = [System.InvalidOperationException]::new($message)
+            $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, $exception.GetType().Name, 'InvalidOperation', $null)
+            throw $errorRecord
+        }
+        # Setup collections for debug commands and for the results of those
+        # debug commands
+        $dbgCmdQueue = [System.Collections.Queue]::new()
         foreach ($command in $CommandQueue) {
-            $script:dbgCmdQueue.Enqueue($command)
+            $dbgCmdQueue.Enqueue($command)
+        }
+        $script:runspacesRegistered[$Runspace] = [ordered]@{
+            DbgCmdQueue = $dbgCmdQueue
+            DbgResults  = [System.Collections.ArrayList]::new()
+            BpsUpdated  = [System.Collections.ArrayList]::new()
         }
         # We re-create the script block before invoking it to ensure that it will
         # work regardless of where the script itself was defined in the test file.
-        # We also silence any standard output because this invocation is about the
+        # We also discard any standard output because this invocation is about the
         # debugger output, not the output of the script itself.
         & {
             [System.Diagnostics.DebuggerStepThrough()]
@@ -123,17 +214,41 @@ function Test-Debugger {
             param()
             try {
                 $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
-                [ScriptBlock]::Create($ScriptBlock).Invoke() > $null
+                if ($Runspace -eq $host.Runspace) {
+                    [scriptblock]::Create($ScriptBlock).Invoke() > $null
+                } else {
+                    [powershell]::Create($Runspace).AddScript($ScriptBlock).Invoke() > $null
+                }
             } catch {
                 Write-Error -ErrorRecord $_ -ErrorAction Stop
             }
         }
-        $script:dbgResults
+        switch ($PSCmdlet.ParameterSetName) {
+            'DebuggerCommands' {
+                # Return the results of the debugger commands that were processed
+                $script:runspacesRegistered[$Runspace].DbgResults
+                break
+            }
+
+            'BreakpointUpdates' {
+                # Wait a short time for breakpoint updates to complete
+                $now = [DateTime]::UtcNow
+                while ($script:runspacesRegistered[$Runspace].BpsUpdated.Count -lt $BreakpointUpdates) {
+                    Start-Sleep -Milliseconds 100
+                    if ([DateTime]::UtcNow.Subtract($now).TotalMilliseconds -gt 1000) {
+                        Write-Warning -Message "Only received $($script:runspacesRegistered[$Runspace].BpsUpdated.Count) of ${BreakpointUpdates} breakpoint update records before timeout."
+                        break
+                    }
+                }
+                # Return the breakpoint update records that have been received
+                $script:runspacesRegistered[$Runspace].BpsUpdated
+                break
+            }
+        }
     } catch {
         Write-Error -ErrorRecord $_ -ErrorAction $callerEAP
     } finally {
-        Remove-Variable -Name dbgResults -Scope Script -ErrorAction Ignore
-        Remove-Variable -Name dbgCmdQueue -Scope Script -ErrorAction Ignore
+        $script:runspacesRegistered[$Runspace] = $null
     }
 }
 Export-ModuleMember -Function Test-Debugger
@@ -141,7 +256,7 @@ Export-ModuleMember -Function Test-Debugger
 function Get-DebuggerExtent {
     [CmdletBinding()]
     param(
-        [Parameter(Position=0, Mandatory, ValueFromPipeline)]
+        [Parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [ValidateNotNull()]
         [PSTypeName('DebuggerCommandResult')]
         $DebuggerCommandResult
@@ -157,19 +272,19 @@ function Get-DebuggerExtent {
 }
 
 function ShouldHaveExtent {
-    [CmdletBinding(DefaultParameterSetName='SingleLineExtent')]
+    [CmdletBinding(DefaultParameterSetName = 'SingleLineExtent')]
     param(
-        [Parameter(Position=0, Mandatory, ValueFromPipeline)]
+        [Parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [ValidateNotNull()]
         [PSTypeName('DebuggerCommandResult')]
         $DebuggerCommandResult,
 
-        [Parameter(Mandatory, ParameterSetName='SingleLineExtent')]
+        [Parameter(Mandatory, ParameterSetName = 'SingleLineExtent')]
         [ValidateRange(1, [int]::MaxValue)]
         [int]
         $Line,
 
-        [Parameter(Mandatory, ParameterSetName='MultilineExtent')]
+        [Parameter(Mandatory, ParameterSetName = 'MultilineExtent')]
         [ValidateRange(1, [int]::MaxValue)]
         [int]
         $FromLine,
@@ -179,7 +294,7 @@ function ShouldHaveExtent {
         [int]
         $FromColumn,
 
-        [Parameter(Mandatory, ParameterSetName='MultilineExtent')]
+        [Parameter(Mandatory, ParameterSetName = 'MultilineExtent')]
         [ValidateRange(1, [int]::MaxValue)]
         [int]
         $ToLine,
@@ -191,9 +306,9 @@ function ShouldHaveExtent {
     )
     process {
         $extent = Get-DebuggerExtent -DebuggerCommandResult $DebuggerCommandResult
-        $extent.StartLineNumber | Should -Be $(if ($PSCmdlet.ParameterSetName -eq 'SingleLineExtent') {$Line} else {$FromLine})
+        $extent.StartLineNumber | Should -Be $(if ($PSCmdlet.ParameterSetName -eq 'SingleLineExtent') { $Line } else { $FromLine })
         $extent.StartColumnNumber | Should -Be $FromColumn
-        $extent.EndLineNumber | Should -Be $(if ($PSCmdlet.ParameterSetName -eq 'SingleLineExtent') {$Line} else {$ToLine})
+        $extent.EndLineNumber | Should -Be $(if ($PSCmdlet.ParameterSetName -eq 'SingleLineExtent') { $Line } else { $ToLine })
         $extent.EndColumnNumber | Should -Be $ToColumn
     }
 }
@@ -202,12 +317,12 @@ Export-ModuleMember -Function ShouldHaveExtent
 function ShouldHaveSameExtentAs {
     [CmdletBinding()]
     param(
-        [Parameter(Position=0, Mandatory, ValueFromPipeline)]
+        [Parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [ValidateNotNull()]
         [PSTypeName('DebuggerCommandResult')]
         $SourceDebuggerCommandResult,
 
-        [Parameter(Position=1, Mandatory)]
+        [Parameter(Position = 1, Mandatory)]
         [ValidateNotNull()]
         [Alias('DebuggerCommandResult')]
         [PSTypeName('DebuggerCommandResult')]


### PR DESCRIPTION
# PR Summary

- updated HelpersDebugger module to support more debugging scenarios with PowerShell
- added tests for `BreakpointUpdated` and `DebuggerStop` handlers when working with `LineBreakpoint`, `VariableBreakpoint`, and `CommandBreakpoint` objects
- added debugger SDK tests

## PR Context

Bring old unit tests that were written in .NET forward as Pester tests in PowerShell.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
