### PR TITLE
Add retry to Enter-PSHostProcess test

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Enter-PSHostProcess.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Enter-PSHostProcess.Tests.ps1
@@ -133,7 +133,22 @@ Describe "Enter-PSHostProcess tests" -Tag Feature {
                 $rs.Open()
                 $ps = [powershell]::Create()
                 $ps.Runspace = $rs
-                $ps.AddScript('$pid').Invoke() | Should -Be $pwshId
+                $ps.AddScript('$pid')
+
+                [int]$retry = 0
+                $result = $null
+                while ($retry -lt 5 -and $result -eq $null) {
+                    try {
+                        $result = $ps.Invoke()
+                    }
+                    catch [System.Management.Automation.Runspaces.InvalidRunspaceStateException] {
+                        Write-Verbose -Verbose $_.Exception.InnerException.Message
+                        $retry++
+                        Start-Sleep -Milliseconds 100
+                    }
+                }
+
+                $result | Should -Be $pwshId
             } finally {
                 $rs.Dispose()
                 $ps.Dispose()

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Enter-PSHostProcess.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Enter-PSHostProcess.Tests.ps1
@@ -137,18 +137,19 @@ Describe "Enter-PSHostProcess tests" -Tag Feature {
 
                 [int]$retry = 0
                 $result = $null
+                $errorMsg = "Exception: "
                 while ($retry -lt 5 -and $result -eq $null) {
                     try {
                         $result = $ps.Invoke()
                     }
                     catch [System.Management.Automation.Runspaces.InvalidRunspaceStateException] {
-                        Write-Verbose -Verbose $_.Exception.InnerException.Message
+                        $errorMsg += $_.Exception.InnerException.Message + "; "
                         $retry++
                         Start-Sleep -Milliseconds 100
                     }
                 }
 
-                $result | Should -Be $pwshId
+                $result | Should -Be $pwshId -Because $errorMsg
             } finally {
                 $rs.Dispose()
                 $ps.Dispose()


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Been seeing this test fail in CI on occasion.  Have it retry 5 times and also write out a verbose message if the runspace state is not valid to see why it fails.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
