### PR TITLE
Comment out the NullConditionalOperator tests for now to avoid parsing errors when the feature is disabled

### DIFF
--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -33,6 +33,9 @@ Describe "TabCompletion" -Tags CI {
         $res.CompletionMatches[0].CompletionText | Should -BeExactly 'ToString('
     }
 
+<# Disable null-conditional operator tests to not cause parsing errors when the NullConditionalOperator feature is disabled
+   Tracked by #11354 in GitHub
+
     It 'Should complete dotnet method with null conditional operator' {
         $res = TabExpansion2 -inputScript '(1)?.ToSt' -cursorColumn '(1)?.ToSt'.Length
         $res.CompletionMatches[0].CompletionText | Should -BeExactly 'ToString('
@@ -42,6 +45,7 @@ Describe "TabCompletion" -Tags CI {
         $res = TabExpansion2 -inputScript '(1)?.' -cursorColumn '(1)?.'.Length
         $res.CompletionMatches[0].CompletionText | Should -BeExactly 'CompareTo('
     }
+#>
 
     It 'Should complete Magic foreach' {
         $res = TabExpansion2 -inputScript '(1..10).Fo' -cursorColumn '(1..10).Fo'.Length

--- a/test/powershell/Language/Operators/NullConditional.Tests.ps1
+++ b/test/powershell/Language/Operators/NullConditional.Tests.ps1
@@ -250,6 +250,9 @@ Describe 'NullCoalesceOperations' -Tags 'CI' {
     }
 }
 
+<# Disable null-conditional operators tests to not cause parsing errors when the NullConditionalOperator feature is disabled
+   Tracked by #11354 in GitHub
+
 Describe 'NullConditionalMemberAccess' -Tag 'CI' {
 
     BeforeAll {
@@ -379,3 +382,4 @@ Describe 'NullConditionalMemberAccess' -Tag 'CI' {
         }
     }
 }
+#>

--- a/test/powershell/Language/Parser/Parsing.Tests.ps1
+++ b/test/powershell/Language/Parser/Parsing.Tests.ps1
@@ -278,6 +278,9 @@ Describe 'null coalescing statement parsing' -Tag "CI" {
     ShouldBeParseError '$hello ??? $what' ExpectedValueExpression,MissingColonInTernaryExpression 9,17
 }
 
+<# Disable null-conditional operator tests to not cause parsing errors when the NullConditionalOperator feature is disabled
+   Tracked by #11354 in GitHub
+
 Describe 'null conditional member access statement parsing' -Tag 'CI' {
     BeforeAll {
         $skipTest = -not $EnabledExperimentalFeatures.Contains('PSNullConditionalOperators')
@@ -308,6 +311,7 @@ Describe 'null conditional member access statement parsing' -Tag 'CI' {
     ShouldBeParseError '${x}?[             ]' MissingArrayIndexExpression 6
     ShouldBeParseError '${x}?[0] = 1' InvalidLeftHandSide 0
 }
+#>
 
 Describe 'splatting parsing' -Tags "CI" {
     ShouldBeParseError '@a' SplattingNotPermitted 0


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Comment out the NullConditionalOperator tests for now to avoid parsing errors when the feature is disabled.
The test needs to be rewritten, and the work is tracked by #11354

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
