### PR TITLE
Fix test failing when UnixStat feature is disabled

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FormatData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FormatData.Tests.ps1
@@ -15,7 +15,9 @@ Describe "Get-FormatData" -Tags "CI" {
         $format.TypeNames | Should -HaveCount 2
         $format.TypeNames[0] | Should -BeExactly "System.IO.DirectoryInfo"
         $format.TypeNames[1] | Should -BeExactly "System.IO.FileInfo"
-        $format.FormatViewDefinition | Should -HaveCount ($IsWindows ? 4 : 5)
+
+        $isUnixStatEnabled = $EnabledExperimentalFeatures -contains 'PSUnixFileStat'
+        $format.FormatViewDefinition | Should -HaveCount ( $isUnixStatEnabled ? 5 : 4)
     }
 
     It "Should return nothing for format data requiring '-PowerShellVersion 5.1' and not provided" {

--- a/test/powershell/engine/ETS/TypeTable.Tests.ps1
+++ b/test/powershell/engine/ETS/TypeTable.Tests.ps1
@@ -18,7 +18,8 @@ Describe "Built-in type information tests" -Tag "CI" {
     }
 
     It "Should have correct number of built-in type items in type table" {
-        $types.Count | Should -BeExactly ($IsWindows ? 273 : 272)
+        $isUnixStatEnabled = $EnabledExperimentalFeatures -contains 'PSUnixFileStat'
+        $types.Count | Should -BeExactly ($isUnixStatEnabled ? 272 : 273)
     }
 
     It "Should have expected member info for 'System.Diagnostics.ProcessModule'" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes #11357 

## PR Context

We check if the experimental feature is enabled before determining the expected value.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
