### PR TITLE
Re-add check for Invoke-Command job dispose.

### DIFF
--- a/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
@@ -1204,8 +1204,15 @@ namespace Microsoft.PowerShell.Commands
                         // be connected to later.
                         WriteJobResults(false);
 
-                        // finally dispose the job.
-                        _job.Dispose();
+                        // Dispose job object if it is not returned to the user.
+                        // The _asjob field can change dynamically and needs to be checked before the job 
+                        // object is disposed. For example, if remote sessions are disconnected abruptly
+                        // via WinRM, a disconnected job object is created to facilitate a reconnect.
+                        // If the job object is disposed here, then a session reconnect cannot happen.
+                        if (!_asjob)
+                        {
+                            _job.Dispose();
+                        }
 
                         // We no longer need to call ClearInvokeCommandOnRunspaces() here because
                         // this command might finish before the foreach block finishes. previously,
@@ -1251,8 +1258,15 @@ namespace Microsoft.PowerShell.Commands
                             // be connected to later.
                             WriteJobResults(false);
 
-                            // finally dispose the job.
-                            _job.Dispose();
+                            // Dispose job object if it is not returned to the user.
+                            // The _asjob field can change dynamically and needs to be checked before the job 
+                            // object is disposed. For example, if remote sessions are disconnected abruptly
+                            // via WinRM, a disconnected job object is created to facilitate a reconnect.
+                            // If the job object is disposed here, then a session reconnect cannot happen.
+                            if (!_asjob)
+                            {
+                                _job.Dispose();
+                            }
                         }
                     }
                 }

--- a/test/powershell/engine/Remoting/RemoteSession.Disconnect.Tests.ps1
+++ b/test/powershell/engine/Remoting/RemoteSession.Disconnect.Tests.ps1
@@ -1,0 +1,82 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+Import-Module HelpersCommon
+
+Describe "WinRM based remoting session abrupt disconnect" -Tags 'Feature','RequireAdminOnWindows' {
+
+    BeforeAll {
+        $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
+        if (! $IsWindows)
+        {
+            $PSDefaultParameterValues["it:skip"] = $true
+            return
+        }
+
+        $disconnectScript = @'
+            param (
+                [int] $RunspaceId
+            )
+
+            $rs = Get-Runspace -Id $RunspaceId
+
+            if (! $rs.RunspaceIsRemote)
+            {
+                throw "Runspace $RunspaceId is not a remote runspace."
+            }
+
+            # Wait up to one minute for Runspace to begin running script
+            $count = 0
+            while (($rs.RunspaceAvailability -ne "busy") -and (++$count -le 60)) {
+                Start-Sleep 1
+            }
+
+            if ($rs.RunspaceAvailability -ne "busy")
+            {
+                throw "Runspace $RunspaceId is not running any script after one minute."
+            }
+
+            # Disconnect running runspace
+            $rs.Disconnect()
+'@
+
+        $endPointName = "PowerShell.$(${PSVersionTable}.GitCommitId)"
+        $endPoint = (Get-PSSessionConfiguration -Name $endPointName -ErrorAction SilentlyContinue).Name
+        if ($endPoint -eq $null)
+        {
+            Enable-PSRemoting -SkipNetworkProfileCheck
+            $endPoint = (Get-PSSessionConfiguration -Name $endPointName).Name
+        }
+        $session = New-RemoteSession -ConfigurationName $endPoint
+
+        $ps = [powershell]::Create("NewRunspace")
+        $ps.AddScript($disconnectScript).AddParameter("RunspaceId", $session.Runspace.Id)
+    }
+
+    AfterAll {
+        $global:PSDefaultParameterValues = $originalDefaultParameterValues
+
+        if ($ps -ne $null) { $ps.Dispose() }
+        if ($session -ne $null) { Remove-PSSession -Session $session }
+        if ($global:job -ne $null) { Remove-Job -Job $global:job -Force }
+    }
+
+    It "Verifies that an abruptly disconnected Invoke-Command session produces a valid disconnected job needed for reconnect" {
+
+        # Start disconnect script running.
+        $ps.BeginInvoke()
+
+        # Run script synchronously on remote session, and let disconnect script disconnect the remote session.
+        $null = Invoke-Command -Session $session -ScriptBlock { 
+            1..60 | ForEach-Object { Start-Sleep 1; "Output $_" } 
+        } -ErrorAction SilentlyContinue
+
+        # Session should be disconnected.
+        $session.State | Should -BeExactly 'Disconnected'
+
+        # A disconnected job should have been created for reconnect.
+        $global:job = Get-Job | Where-Object { $_.ChildJobs[0].Runspace.Id -eq $session.Runspace.Id }
+        $global:job | Should -Not -BeNullOrEmpty
+        $global:job.State | Should -BeExactly 'Disconnected'
+    }
+}

--- a/test/powershell/engine/Remoting/RemoteSession.Disconnect.Tests.ps1
+++ b/test/powershell/engine/Remoting/RemoteSession.Disconnect.Tests.ps1
@@ -58,7 +58,7 @@ Describe "WinRM based remoting session abrupt disconnect" -Tags 'Feature','Requi
 
         if ($ps -ne $null) { $ps.Dispose() }
         if ($session -ne $null) { Remove-PSSession -Session $session }
-        if ($global:job -ne $null) { Remove-Job -Job $global:job -Force }
+        if ($script:job -ne $null) { Remove-Job -Job $script:job -Force }
     }
 
     It "Verifies that an abruptly disconnected Invoke-Command session produces a valid disconnected job needed for reconnect" {
@@ -67,16 +67,16 @@ Describe "WinRM based remoting session abrupt disconnect" -Tags 'Feature','Requi
         $ps.BeginInvoke()
 
         # Run script synchronously on remote session, and let disconnect script disconnect the remote session.
-        $null = Invoke-Command -Session $session -ScriptBlock { 
-            1..60 | ForEach-Object { Start-Sleep 1; "Output $_" } 
+        $null = Invoke-Command -Session $session -ScriptBlock {
+            1..60 | ForEach-Object { Start-Sleep 1; "Output $_" }
         } -ErrorAction SilentlyContinue
 
         # Session should be disconnected.
         $session.State | Should -BeExactly 'Disconnected'
 
         # A disconnected job should have been created for reconnect.
-        $global:job = Get-Job | Where-Object { $_.ChildJobs[0].Runspace.Id -eq $session.Runspace.Id }
-        $global:job | Should -Not -BeNullOrEmpty
-        $global:job.State | Should -BeExactly 'Disconnected'
+        $script:job = Get-Job | Where-Object { $_.ChildJobs[0].Runspace.Id -eq $session.Runspace.Id }
+        $script:job | Should -Not -BeNullOrEmpty
+        $script:job.State | Should -BeExactly 'Disconnected'
     }
 }


### PR DESCRIPTION
## PR Summary

This fixes session reconnect regression bug: #11150. 

## PR Context

Invoke-Command creates a disconnected job object to facilitate session re-connection, when WinRM abruptly disconnects the session due to network issues.  The EndProcessing() block was disposing the disconnected job object so that a session reconnect could not occur.

Fix is to add the checks back in the code which prevents EndProcessing() from disposing the disconnected job, and added comments explaining why the code checks are there.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
