### PR TITLE
Avoid variable names that conflict with automatic variables

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -2063,9 +2063,9 @@ function script:Write-Log
         [ValidateNotNullOrEmpty()]
         [string] $message,
 
-        [switch] $error
+        [switch] $errorId
     )
-    if ($error)
+    if ($errorId)
     {
         Write-Host -Foreground Red $message
     }

--- a/build.psm1
+++ b/build.psm1
@@ -2063,9 +2063,9 @@ function script:Write-Log
         [ValidateNotNullOrEmpty()]
         [string] $message,
 
-        [switch] $errorId
+        [switch] $isError
     )
-    if ($errorId)
+    if ($isError)
     {
         Write-Host -Foreground Red $message
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
@@ -772,7 +772,7 @@ ZoneId=$FileType
 
             function Test-RemoteSignedExecutionPolicy {
 
-                param($testScript, $expected, $error)
+                param ($testScript, $expected, $errorId)
 
                 $TestTypePrefix = "Test 'RemoteSigned' execution policy."
 
@@ -806,91 +806,91 @@ ZoneId=$FileType
                     $actualError = $result."exception"
 
                     $actualResult | Should -Be $expected
-                    $actualError | Should -Be $error
+                    $actualError | Should -Be $errorId
                 }
             }
             $message = "Hello"
-            $error = "System.Management.Automation.PSSecurityException"
+            $errorId = "System.Management.Automation.PSSecurityException"
             $testData = @(
                 @{
                     testScript = $LocalUnsignedScript
                     expected = $message
-                    error = $null
+                    errorId = $null
                 }
                 @{
                     testScript = $LocalSignatureCorruptedScript
                     expected = $message
-                    error = $null
+                    errorId = $null
                 }
                 @{
                     testScript = $LocalSignedScript
                     expected = "Hello"
-                    error = $null
+                    errorId = $null
                 }
                 @{
                     testScript = $MyComputerUnsignedScript
                     expected = $message
-                    error = $null
+                    errorId = $null
                 }
                 @{
                     testScript = $MyComputerSignatureCorruptedScript
                     expected = $message
-                    error = $null
+                    errorId = $null
                 }
                 @{
                     testScript = $myComputerSignedScript
                     expected = $message
-                    error = $null
+                    errorId = $null
                 }
                 @{
                     testScript = $TrustedUnsignedScript
                     expected = $message
-                    error = $null
+                    errorId = $null
                 }
                 @{
                     testScript = $TrustedSignatureCorruptedScript
                     expected = $message
-                    error = $null
+                    errorId = $null
                 }
                 @{
                     testScript = $TrustedSignedScript
                     expected = $message
-                    error = $null
+                    errorId = $null
                 }
                 @{
                     testScript = $IntranetUnsignedScript
                     expected = $message
-                    error = $null
+                    errorId = $null
                 }
                 @{
                     testScript = $IntranetSignatureCorruptedScript
                     expected = $message
-                    error = $null
+                    errorId = $null
                 }
                 @{
                     testScript = $IntranetSignedScript
                     expected = $message
-                    error = $null
+                    errorId = $null
                 }
                 @{
                     testScript = $InternetUnsignedScript
                     expected = $null
-                    error = $error
+                    errorId = $errorId
                 }
                 @{
                     testScript = $InternetSignatureCorruptedScript
                     expected = $null
-                    error = $error
+                    errorId = $errorId
                 }
                 @{
                     testScript = $UntrustedUnsignedScript
                     expected = $null
-                    error = $error
+                    errorId = $errorId
                 }
                 @{
                     testScript = $UntrustedSignatureCorruptedScript
                     expected = $null
-                    error = $error
+                    errorId = $errorId
                 }
             )
 
@@ -915,11 +915,11 @@ ZoneId=$FileType
 
             $TestTypePrefix = "Test 'AllSigned' execution policy."
 
-            $error = "UnauthorizedAccess,Microsoft.PowerShell.Commands.ImportModuleCommand"
+            $errorId = "UnauthorizedAccess,Microsoft.PowerShell.Commands.ImportModuleCommand"
             $testData = @(
                 @{
                     module = "Microsoft.PowerShell.Archive"
-                    error = $null
+                    errorId = $null
                 }
             )
 
@@ -927,21 +927,21 @@ ZoneId=$FileType
                 $testData += @(
                     @{
                         module = $PSHomeUntrustedModule
-                        error = $error
+                        errorId = $errorId
                     }
                     @{
                         module = $PSHomeUnsignedModule
-                        error = $error
+                        errorId = $errorId
                     }
                 )
             }
 
             It "$TestTypePrefix Importing <module> Module should throw '<error>'" -TestCases $testData  {
-                param([string]$module, [string]$error)
+                param ([string]$module, [string]$errorId)
                 $testScript = {Import-Module -Name $module -Force}
-                if($error)
+                if ($errorId)
                 {
-                    $testScript | Should -Throw -ErrorId $error
+                    $testScript | Should -Throw -ErrorId $errorId
                 }
                 else
                 {
@@ -949,33 +949,33 @@ ZoneId=$FileType
                 }
             }
 
-            $error = "UnauthorizedAccess"
+            $errorId = "UnauthorizedAccess"
             $pendingTestData = @(
                 # The following files are not signed correctly when generated, so we will skip for now
                 # filed https://github.com/PowerShell/PowerShell/issues/5559
                 @{
                     testScript = $MyComputerSignedScript
-                    error = $null
+                    errorId = $null
                 }
                 @{
                     testScript = $UntrustedSignedScript
-                    error = $null
+                    errorId = $null
                 }
                 @{
                     testScript = $TrustedSignedScript
-                    error = $null
+                    errorId = $null
                 }
                 @{
                     testScript = $LocalSignedScript
-                    error = $null
+                    errorId = $null
                 }
                 @{
                     testScript = $IntranetSignedScript
-                    error = $null
+                    errorId = $null
                 }
                 @{
                     testScript = $InternetSignedScript
-                    error = $null
+                    errorId = $null
                 }
             )
             It "$TestTypePrefix Running <testScript> Script should throw '<error>'" -TestCases $pendingTestData -Pending  {}
@@ -983,64 +983,64 @@ ZoneId=$FileType
             $testData = @(
                 @{
                     testScript = $InternetSignatureCorruptedScript
-                    error = $error
+                    errorId = $errorId
                 }
                 @{
                     testScript = $InternetUnsignedScript
-                    error = $error
+                    errorId = $errorId
                 }
                 @{
                     testScript = $IntranetSignatureCorruptedScript
-                    error = $error
+                    errorId = $errorId
                 }
                 @{
                     testScript = $IntranetSignatureCorruptedScript
-                    error = $error
+                    errorId = $errorId
                 }
                 @{
                     testScript = $IntranetUnsignedScript
-                    error = $error
+                    errorId = $errorId
                 }
                 @{
                     testScript = $LocalSignatureCorruptedScript
-                    error = $error
+                    errorId = $errorId
                 }
                 @{
                     testScript = $LocalUnsignedScript
-                    error = $error
+                    errorId = $errorId
                 }
                 @{
                     testScript = $TrustedSignatureCorruptedScript
-                    error = $error
+                    errorId = $errorId
                 }
                 @{
                     testScript = $TrustedUnsignedScript
-                    error = $error
+                    errorId = $errorId
                 }
                 @{
                     testScript = $UntrustedSignatureCorruptedScript
-                    error = $error
+                    errorId = $errorId
                 }
                 @{
                     testScript = $UntrustedUnsignedScript
-                    error = $error
+                    errorId = $errorId
                 }
                 @{
                     testScript = $MyComputerSignatureCorruptedScript
-                    error = $error
+                    errorId = $errorId
                 }
                 @{
                     testScript = $MyComputerUnsignedScript
-                    error = $error
+                    errorId = $errorId
                 }
 
             )
             It "$TestTypePrefix Running <testScript> Script should throw '<error>'" -TestCases $testData  {
-                param([string]$testScript, [string]$error)
+                param ([string]$testScript, [string]$errorId)
                 $testScript | Should -Exist
-                if($error)
+                if ($errorId)
                 {
-                    {& $testScript} | Should -Throw -ErrorId $error
+                    {& $testScript} | Should -Throw -ErrorId $errorId
                 }
                 else
                 {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Test-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Test-Json.Tests.ps1
@@ -83,15 +83,15 @@ Describe "Test-Json" -Tags "CI" {
     }
 
     It "Test-Json write an error on invalid (<name>) Json against a valid schema" -TestCases @(
-        @{ name = "type"; json = $invalidTypeInJson; error = "InvalidJsonAgainstSchema,Microsoft.PowerShell.Commands.TestJsonCommand" }
-        @{ name = "node"; json = $invalidNodeInJson; error = "InvalidJson,Microsoft.PowerShell.Commands.TestJsonCommand" }
+        @{ name = "type"; json = $invalidTypeInJson; errorId = "InvalidJsonAgainstSchema,Microsoft.PowerShell.Commands.TestJsonCommand" }
+        @{ name = "node"; json = $invalidNodeInJson; errorId = "InvalidJson,Microsoft.PowerShell.Commands.TestJsonCommand" }
         ) {
-            param($json, $error)
+            param ($json, $errorId)
 
             $errorVar = $null
             Test-Json -Json $json -Schema $validSchemaJson -ErrorVariable errorVar -ErrorAction SilentlyContinue
 
-            $errorVar.FullyQualifiedErrorId | Should -BeExactly $error
+            $errorVar.FullyQualifiedErrorId | Should -BeExactly $errorId
     }
 
     It "Test-Json return all errors when check invalid Json against a valid schema" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/alias.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/alias.tests.ps1
@@ -12,11 +12,11 @@ Describe "Alias tests" -Tags "CI" {
             [string] $testFile
             [string] $expectedError
 
-            TestData($name, $file, $error)
+            TestData($name, $file, $errorId)
             {
                 $this.testName = $name
                 $this.testFile = $file
-                $this.expectedError = $error
+                $this.expectedError = $errorId
             }
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/clixml.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/clixml.tests.ps1
@@ -23,11 +23,11 @@ Describe "CliXml test" -Tags "CI" {
             [string] $expectedError
             [string] $testFile
 
-            TestData($name, $file, $inputObj, $error)
+            TestData($name, $file, $inputObj, $errorId)
             {
                 $this.testName = $name
                 $this.inputObject = $inputObj
-                $this.expectedError = $error
+                $this.expectedError = $errorId
                 $this.testFile = $file
             }
         }

--- a/test/powershell/engine/Api/TypeInference.Tests.ps1
+++ b/test/powershell/engine/Api/TypeInference.Tests.ps1
@@ -226,7 +226,7 @@ Describe "Type inference Tests" -tags "CI" {
     }
 
     It "Infers type from using statement" {
-        $res = [AstTypeInference]::InferTypeOf( { $pid = 1; $using:pid }.Ast.EndBlock.Statements[1].PipelineElements[0].Expression)
+        $res = [AstTypeInference]::InferTypeOf( { $int = 1; $using:int }.Ast.EndBlock.Statements[1].PipelineElements[0].Expression)
         $res.Count | Should -Be 1
         $res.Name | Should -Be System.Int32
     }


### PR DESCRIPTION
# PR Summary

Avoid variable names that conflict with automatic variables.

## PR Context

Variable names such as $error and $pid cause a PSScriptAnalyzer rule violation of type AvoidAssignmentToAutomaticVariable

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
- **User-facing changes**
    - [x] Not Applicable
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
