### PR TITLE
Migrate Test-Json to System.Text.Json API

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/TestJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/TestJsonCommand.cs
@@ -64,7 +64,7 @@ namespace Microsoft.PowerShell.Commands
         {
             if (e is TargetInvocationException && e.InnerException != null)
             {
-                ExceptionDispatchInfo.Capture(e.InnerException).Throw();
+                ExceptionDispatchInfo.Throw(e.InnerException);
             }
             else
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/TestJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/TestJsonCommand.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using System;
 using System.Globalization;
 using System.IO;
@@ -11,8 +13,6 @@ using System.Security;
 using System.Text.Json;
 
 using NJsonSchema;
-
-#nullable enable
 
 namespace Microsoft.PowerShell.Commands
 {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Test-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Test-Json.Tests.ps1
@@ -11,13 +11,13 @@ Describe "Test-Json" -Tags "CI" {
 
         $validSchemaJson = @"
             {
-            'description': 'A person',
-            'type': 'object',
-            'properties': {
-                'name': {'type': 'string'},
-                'hobbies': {
-                'type': 'array',
-                'items': {'type': 'string'}
+            "description": "A person",
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "hobbies": {
+                "type": "array",
+                "items": {"type": "string"}
                 }
                 }
             }
@@ -25,13 +25,13 @@ Describe "Test-Json" -Tags "CI" {
 
         $invalidSchemaJson = @"
             {
-            'description',
-            'type': 'object',
-            'properties': {
-                'name': {'type': 'string'},
-                'hobbies': {
-                'type': 'array',
-                'items': {'type': 'string'}
+            "description",
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "hobbies": {
+                "type": "array",
+                "items": {"type": "string"}
                 }
                 }
             }
@@ -39,29 +39,29 @@ Describe "Test-Json" -Tags "CI" {
 
         $validJson = @"
             {
-                'name': 'James',
-                'hobbies': ['.NET', 'Blogging', 'Reading', 'Xbox', 'LOLCATS']
+                "name": "James",
+                "hobbies": [".NET", "Blogging", "Reading", "Xbox", "LOLCATS"]
             }
 "@
 
         $invalidTypeInJson = @"
             {
-                'name': 123,
-                'hobbies': ['.NET', 'Blogging', 'Reading', 'Xbox', 'LOLCATS']
+                "name": 123,
+                "hobbies": [".NET", "Blogging", "Reading", "Xbox", "LOLCATS"]
             }
 "@
 
         $invalidTypeInJson2 = @"
             {
-                'name': 123,
-                'hobbies': [456, 'Blogging', 'Reading', 'Xbox', 'LOLCATS']
+                "name": 123,
+                "hobbies": [456, "Blogging", "Reading", "Xbox", "LOLCATS"]
             }
 "@
 
         $invalidNodeInJson = @"
             {
-                'name': 'James',
-                'hobbies': ['.NET', 'Blogging', 'Reading', 'Xbox', 'LOLCATS']
+                "name": "James",
+                "hobbies": [".NET", "Blogging", "Reading", "Xbox", "LOLCATS"]
                 errorNode
             }
 "@
@@ -151,5 +151,18 @@ Describe "Test-Json" -Tags "CI" {
         $errorVar.Count | Should -Be 2
         $errorVar[0].FullyQualifiedErrorId | Should -BeExactly "InvalidJsonAgainstSchema,Microsoft.PowerShell.Commands.TestJsonCommand"
         $errorVar[1].FullyQualifiedErrorId | Should -BeExactly "InvalidJsonAgainstSchema,Microsoft.PowerShell.Commands.TestJsonCommand"
+    }
+
+    It "Test-Json recognizes primitives: <name>" -TestCases @(
+        @{ name = 'number'; value = 1 }
+        @{ name = '"true"'; value = '"true"' }
+        @{ name = '"false"'; value = '"false"' }
+        @{ name = '"null"'; value = '"null"' }
+        @{ name = 'string'; value = '"abc"' }
+        @{ name = 'array'; value = '[ 1, 2 ]' }
+    ) {
+        param ($name, $value)
+
+        Test-Json -Json $value | Should -BeTrue
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Test-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Test-Json.Tests.ps1
@@ -156,8 +156,11 @@ Describe "Test-Json" -Tags "CI" {
     It "Test-Json recognizes primitives: <name>" -TestCases @(
         @{ name = 'number'; value = 1 }
         @{ name = '"true"'; value = '"true"' }
+        @{ name = 'true'; value = 'true' }
         @{ name = '"false"'; value = '"false"' }
+        @{ name = 'false'; value = 'false' }
         @{ name = '"null"'; value = '"null"' }
+        @{ name = 'null'; value = 'null' }
         @{ name = 'string'; value = '"abc"' }
         @{ name = 'array'; value = '[ 1, 2 ]' }
     ) {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Before the change we used Newtonsoft Json.NET `JObject.Parse()` method to validate Json. The method is not best choice to validate Json because it doesn't parse valid primitives.

As result we:
- migrate the cmdlet to new Core API - System.Text.Json. JsonDocument.Parse()
- change old tests to follow JSON standard (use double quotes as delimiters instead of single quotes)
- add new tests
- enable nullable reference types to follow best practice

Formally it is a breaking change because Newtonsoft Json.NET `JObject.Parse()` accepted single quote delimiters.

## PR Context

Fix #11384

Need review #5797

.Net docs https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
