### PR TITLE
Use PositionMessage for the line context information for ConciseView

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1085,6 +1085,7 @@ namespace System.Management.Automation.Runspaces
                                             $verticalBar = '|'
                                             $posmsg += ""${accentColor}${headerWhitespace}Line ${verticalBar}${newline}""
 
+                                            $highlightLine = ''
                                             if ($useTargetObject) {
                                                 $line = $_.TargetObject.LineText.Trim()
                                                 $offsetLength = 0
@@ -1093,9 +1094,9 @@ namespace System.Management.Automation.Runspaces
                                             else {
                                                 $positionMessage = $myinv.PositionMessage.Split('+')
                                                 $line = $positionMessage[1]
-                                                $highlightLine = $positionMessage.Count - 1
-                                                $offsetLength = $positionMessage[$highlightLine].Trim().Length
-                                                $offsetInLine = $positionMessage[$highlightLine].IndexOf('~')
+                                                $highlightLine = $positionMessage[$positionMessage.Count - 1]
+                                                $offsetLength = $highlightLine.Trim().Length
+                                                $offsetInLine = $highlightLine.IndexOf('~')
                                             }
 
                                             if (-not $line.EndsWith(""`n"")) {
@@ -1110,7 +1111,10 @@ namespace System.Management.Automation.Runspaces
                                             $posmsg += ""${accentColor}${lineWhitespace}${ScriptLineNumber} ${verticalBar} ${resetcolor}${line}""
                                             $offsetWhitespace = ' ' * $offsetInLine
                                             $prefix = ""${accentColor}${headerWhitespace}     ${verticalBar} ${errorColor}""
-                                            $message = ""${prefix}${offsetWhitespace}^ ""
+                                            if ($highlightLine -ne '') {
+                                                $posMsg += ""${newline}${prefix}${highlightLine}${newline}""
+                                            }
+                                            $message = ""${prefix}""
                                         }
 
                                         if (! $err.ErrorDetails -or ! $err.ErrorDetails.Message) {

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1091,10 +1091,11 @@ namespace System.Management.Automation.Runspaces
                                                 $offsetInLine = 0
                                             }
                                             else {
-                                                $line = $myinv.Line
-                                                $highlightLine = $myinv.PositionMessage.Split('+').Count - 1
-                                                $offsetLength = $myinv.PositionMessage.split('+')[$highlightLine].Trim().Length
-                                                $offsetInLine = $myinv.OffsetInLine - 1
+                                                $positionMessage = $myinv.PositionMessage.Split('+')
+                                                $line = $positionMessage[1]
+                                                $highlightLine = $positionMessage.Count - 1
+                                                $offsetLength = $positionMessage[$highlightLine].Trim().Length
+                                                $offsetInLine = $positionMessage[$highlightLine].IndexOf('~')
                                             }
 
                                             if (-not $line.EndsWith(""`n"")) {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

If a script uses tabs instead of spaces, the calculation for the caret for error position is wrong.  This is because the InvocationInfo member treats tabs as a single character.  However, the pre-rendered PositionMessage member already takes care of the tabs and the correct index so the change is to rely on parsing that to get the information rather than the existing members.

Before and after shot:
![img](https://i.imgur.com/Jt0EiIc.png)

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/11394
Fix https://github.com/PowerShell/PowerShell/issues/10760

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
