### PR TITLE
Fix race condition exception on recent change to OutOfProc transport

### DIFF
--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -636,6 +636,7 @@ namespace System.Management.Automation.Remoting.Client
                 }
                 catch (ObjectDisposedException)
                 {
+                    // Object already disposed.
                 }
                 _sessionMessageQueue.Dispose();
 
@@ -646,6 +647,7 @@ namespace System.Management.Automation.Remoting.Client
                 }
                 catch (ObjectDisposedException)
                 {
+                    // Object already disposed.
                 }
                 _commandMessageQueue.Dispose();
             }
@@ -785,7 +787,7 @@ namespace System.Management.Automation.Remoting.Client
             catch (InvalidOperationException)
             {
                 // This exception will be thrown by the BlockingCollection message queue objects
-                // after they have been closed (during session closed acknowledgement).
+                // after they have been closed.
             }
         }
 

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -638,6 +638,7 @@ namespace System.Management.Automation.Remoting.Client
                 {
                     // Object already disposed.
                 }
+
                 _sessionMessageQueue.Dispose();
 
                 // Stop command processing thread.
@@ -649,6 +650,7 @@ namespace System.Management.Automation.Remoting.Client
                 {
                     // Object already disposed.
                 }
+                
                 _commandMessageQueue.Dispose();
             }
         }

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -628,7 +628,25 @@ namespace System.Management.Automation.Remoting.Client
             {
                 _cmdTransportManagers.Clear();
                 _closeTimeOutTimer.Dispose();
+
+                // Stop session processing thread.
+                try
+                {
+                    _sessionMessageQueue.CompleteAdding();
+                }
+                catch (ObjectDisposedException)
+                {
+                }
                 _sessionMessageQueue.Dispose();
+
+                // Stop command processing thread.
+                try
+                {
+                    _commandMessageQueue.CompleteAdding();
+                }
+                catch (ObjectDisposedException)
+                {
+                }
                 _commandMessageQueue.Dispose();
             }
         }
@@ -682,10 +700,6 @@ namespace System.Management.Automation.Remoting.Client
         {
             // stop timer
             _closeTimeOutTimer.Change(Timeout.Infinite, Timeout.Infinite);
-
-            // Stop protocol message processing threads.
-            _sessionMessageQueue.CompleteAdding();
-            _commandMessageQueue.CompleteAdding();
 
             RaiseCloseCompleted();
             CleanupConnection();
@@ -753,17 +767,25 @@ namespace System.Management.Automation.Remoting.Client
 
         protected void HandleOutputDataReceived(string data)
         {
-            // Route protocol message based on whether it is a session or command message.
-            // Session messages have empty Guid values.
-            if (Guid.Equals(GetMessageGuid(data), Guid.Empty))
+            try
             {
-                // Session message
-                _sessionMessageQueue.Add(data);
+                // Route protocol message based on whether it is a session or command message.
+                // Session messages have empty Guid values.
+                if (Guid.Equals(GetMessageGuid(data), Guid.Empty))
+                {
+                    // Session message
+                    _sessionMessageQueue.Add(data);
+                }
+                else
+                {
+                    // Command message
+                    _commandMessageQueue.Add(data);
+                }
             }
-            else
+            catch (InvalidOperationException)
             {
-                // Command message
-                _commandMessageQueue.Add(data);
+                // This exception will be thrown by the BlockingCollection message queue objects
+                // after they have been closed (during session closed acknowledgement).
             }
         }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR fixes an exception thrown during a race condition in the OutOfProc transport base class, when a session is closed but command data is still being processed on the client.

## PR Context

A recent change to the OutOfProc transport base class, adds separate processing threads for command and session messages.  The processing threads are ended by setting the message BlockingCollection objects to complete.  But this is done at session close when there can still be command data messages to process, and this resulted in an `InvalidOperationException` error.

To fix this, two changes were made:
  1. Try/catch added to handle any late coming message events.
  2. Move the message queue object completion to Dispose() method, to ensure message processing is closed at the very end of the transport lifetime.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
