### PR TITLE
Fix NRE in ConsiceView

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -885,7 +885,11 @@ namespace System.Management.Automation.Runspaces
                                         }
                                         # anything else, we use ToString()
                                         else {
-                                            $value = $prop.Value.ToString().Trim()
+                                            if ($prop.Value -ne $null) {
+                                                $value = $prop.Value.ToString().Trim()
+                                            } else {
+                                                $value = $prop.ToString().Trim()
+                                            }
 
                                             $isFirstLine = $true
                                             if ($value.Contains($newline)) {

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -883,29 +883,28 @@ namespace System.Management.Automation.Runspaces
                                                 }
                                             }
                                         }
-                                        # anything else, we use ToString()
+                                        # Anything else, we convert to string.
+                                        # ToString() can throw so we use LanguagePrimitives.TryConvertTo() to hide a convert error
                                         else {
-                                            if ($prop.Value -ne $null) {
-                                                $value = $prop.Value.ToString().Trim()
-                                            } else {
-                                                $value = $prop.ToString().Trim()
-                                            }
-
-                                            $isFirstLine = $true
-                                            if ($value.Contains($newline)) {
-                                                # the 3 is to account for ' : '
-                                                $valueIndent = ' ' * ($propLength + 3)
-                                                # need to trim any extra whitespace already in the text
-                                                foreach ($line in $value.Split($newline)) {
-                                                    if (!$isFirstLine) {
-                                                        $null = $output.Append(""${newline}${prefix}${valueIndent}"")
+                                            $value = $null
+                                            if ([System.Management.Automation.LanguagePrimitives]::TryConvertTo($a, [string], [ref]$value) -and $value -ne $null)
+                                            {
+                                                $isFirstLine = $true
+                                                if ($value.Contains($newline)) {
+                                                    # the 3 is to account for ' : '
+                                                    $valueIndent = ' ' * ($propLength + 3)
+                                                    # need to trim any extra whitespace already in the text
+                                                    foreach ($line in $value.Split($newline)) {
+                                                        if (!$isFirstLine) {
+                                                            $null = $output.Append(""${newline}${prefix}${valueIndent}"")
+                                                        }
+                                                        $null = $output.Append($line.Trim())
+                                                        $isFirstLine = $false
                                                     }
-                                                    $null = $output.Append($line.Trim())
-                                                    $isFirstLine = $false
                                                 }
-                                            }
-                                            else {
-                                                $null = $output.Append($value)
+                                                else {
+                                                    $null = $output.Append($value)
+                                                }
                                             }
                                         }
 

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -887,7 +887,7 @@ namespace System.Management.Automation.Runspaces
                                         # ToString() can throw so we use LanguagePrimitives.TryConvertTo() to hide a convert error
                                         else {
                                             $value = $null
-                                            if ([System.Management.Automation.LanguagePrimitives]::TryConvertTo($a, [string], [ref]$value) -and $value -ne $null)
+                                            if ([System.Management.Automation.LanguagePrimitives]::TryConvertTo($prop.Value, [string], [ref]$value) -and $value -ne $null)
                                             {
                                                 $isFirstLine = $true
                                                 if ($value.Contains($newline)) {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Use LanguagePrimitives.TryConvertTo() as last resort to string conversion.

## PR Context

Playing with AccountManagement module I catch an error where properties with disposed object reference present.
```powershell
PS C:\Windows\System32> $e.psobject.properties

GetterScript    : & { Set-StrictMode -Version 1; $this.Exception.InnerException.PSMessageDetails }
SetterScript    :
MemberType      : ScriptProperty
IsSettable      : False
IsGettable      : True
Value           :
TypeNameOfValue : System.Object
Name            : PSMessageDetails
IsInstance      : False

MemberType      : Property
Value           : System.Management.Automation.MethodInvocationException: Exception calling "ToString" with "0"
                  argument(s): "Can�t delete an already deleted object"
                   ---> System.InvalidOperationException: Can�t delete an already deleted object
                     at System.DirectoryServices.AccountManagement.Principal.CheckDisposedOrDeleted()
                     at System.DirectoryServices.AccountManagement.Principal.HandleGet[T](T& currentValue, String
                  name, LoadState& state)
                     at System.DirectoryServices.AccountManagement.Principal.get_Name()
                     at System.DirectoryServices.AccountManagement.Principal.ToString()
                     at CallSite.Target(Closure , CallSite , Object )
                     --- End of inner exception stack trace ---
                     at System.Management.Automation.ExceptionHandlingOps.ConvertToMethodInvocationException(Exception
                  exception, Type typeToThrow, String methodName, Int32 numArgs, MemberInfo memberInfo) in C:\Users\sie
                  \Documents\GitHub\iSazonov\PowerShell\src\System.Management.Automation\engine\runtime\Operations\Misc
                  Ops.cs:line 2062
                     at CallSite.Target(Closure , CallSite , Object )
                     at System.Dynamic.UpdateDelegates.UpdateAndExecute1[T0,TRet](CallSite site, T0 arg0)
                     at CallSite.Target(Closure , CallSite , Object )
                     at System.Management.Automation.Interpreter.DynamicInstruction`2.Run(InterpretedFrame frame) in C:
                  \Users\sie\Documents\GitHub\iSazonov\PowerShell\src\System.Management.Automation\engine\interpreter\D
                  ynamicInstructions.Generated.cs:line 141
                     at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame
                  frame) in C:\Users\sie\Documents\GitHub\iSazonov\PowerShell\src\System.Management.Automation\engine\i
                  nterpreter\ControlFlowInstructions.cs:line 357
IsSettable      : False
IsGettable      : True
TypeNameOfValue : System.Exception
Name            : Exception
IsInstance      : True

MemberType      : Property
Value           :
IsSettable      : False
IsGettable      : True
TypeNameOfValue : System.Object
Name            : TargetObject
IsInstance      : True

```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
