### PR TITLE
Include url in the markdown-links test error message

### DIFF
--- a/test/common/markdown/markdown-link.tests.ps1
+++ b/test/common/markdown/markdown-link.tests.ps1
@@ -114,7 +114,7 @@ Describe "Verify Markdown Links" {
                             catch
                             {
                                 if ( $allowedFailures -notcontains $_.Exception.Response.StatusCode )  {
-                                    $PSCmdlet.ThrowTerminatingError($PSItem)
+                                    throw "Failed to complete request to `"$url`". $($_.Exception.Message)"
                                 }
                             }
                         }

--- a/test/common/markdown/markdown-link.tests.ps1
+++ b/test/common/markdown/markdown-link.tests.ps1
@@ -114,7 +114,7 @@ Describe "Verify Markdown Links" {
                             catch
                             {
                                 if ( $allowedFailures -notcontains $_.Exception.Response.StatusCode )  {
-                                    $PSCmdlet.ThrowTerminatingError("Failed to complete request to `"$url`". $($_.Exception.Message)")
+                                    throw "Failed to complete request to `"$url`". $($_.Exception.Message)"
                                 }
                             }
                         }

--- a/test/common/markdown/markdown-link.tests.ps1
+++ b/test/common/markdown/markdown-link.tests.ps1
@@ -111,7 +111,7 @@ Describe "Verify Markdown Links" {
                             {
                                 $null = Invoke-WebRequest -uri $url -RetryIntervalSec 10 -MaximumRetryCount 6
                             }
-                            catch
+                            catch [System.Net.WebException]
                             {
                                 if ( $allowedFailures -notcontains $_.Exception.Response.StatusCode )  {
                                     throw "Failed to complete request to `"$url`". $($_.Exception.Message)"

--- a/test/common/markdown/markdown-link.tests.ps1
+++ b/test/common/markdown/markdown-link.tests.ps1
@@ -114,7 +114,14 @@ Describe "Verify Markdown Links" {
                             catch
                             {
                                 if ( $allowedFailures -notcontains $_.Exception.Response.StatusCode )  {
-                                    throw "Failed to complete request to `"$url`". $($_.Exception.Message)"
+                                    $PSCmdlet.ThrowTerminatingError(
+                                        [System.Management.Automation.ErrorRecord]::new(
+                                            "Failed to complete request to `"$url`". $($PSItem.Exception.Message)",
+                                            $PSItem.FullyQualifiedErrorId,
+                                            $PSItem.CategoryInfo.Category,
+                                            $null
+                                        )
+                                    )
                                 }
                             }
                         }

--- a/test/common/markdown/markdown-link.tests.ps1
+++ b/test/common/markdown/markdown-link.tests.ps1
@@ -114,14 +114,7 @@ Describe "Verify Markdown Links" {
                             catch
                             {
                                 if ( $allowedFailures -notcontains $_.Exception.Response.StatusCode )  {
-                                    $PSCmdlet.ThrowTerminatingError(
-                                        [System.Management.Automation.ErrorRecord]::new(
-                                            "Failed to complete request to `"$url`". $($PSItem.Exception.Message)",
-                                            $PSItem.FullyQualifiedErrorId,
-                                            $PSItem.CategoryInfo.Category,
-                                            $null
-                                        )
-                                    )
+                                    throw "Failed to complete request to `"$url`". $($_.Exception.Message)"
                                 }
                             }
                         }

--- a/test/common/markdown/markdown-link.tests.ps1
+++ b/test/common/markdown/markdown-link.tests.ps1
@@ -114,7 +114,7 @@ Describe "Verify Markdown Links" {
                             catch
                             {
                                 if ( $allowedFailures -notcontains $_.Exception.Response.StatusCode )  {
-                                    throw "Failed to complete request to `"$url`". $($_.Exception.Message)"
+                                    $PSCmdlet.ThrowTerminatingError("Failed to complete request to `"$url`". $($_.Exception.Message)")
                                 }
                             }
                         }

--- a/test/common/markdown/markdown-link.tests.ps1
+++ b/test/common/markdown/markdown-link.tests.ps1
@@ -111,7 +111,7 @@ Describe "Verify Markdown Links" {
                             {
                                 $null = Invoke-WebRequest -uri $url -RetryIntervalSec 10 -MaximumRetryCount 6
                             }
-                            catch [System.Net.WebException]
+                            catch [Microsoft.PowerShell.Commands.HttpResponseException]
                             {
                                 if ( $allowedFailures -notcontains $_.Exception.Response.StatusCode )  {
                                     throw "Failed to complete request to `"$url`". $($_.Exception.Message)"

--- a/test/common/markdown/markdown-link.tests.ps1
+++ b/test/common/markdown/markdown-link.tests.ps1
@@ -114,7 +114,7 @@ Describe "Verify Markdown Links" {
                             catch
                             {
                                 if ( $allowedFailures -notcontains $_.Exception.Response.StatusCode )  {
-                                    throw "retry of URL failed with error: $($_.Exception.Message)"
+                                    throw "Failed to complete request to `"$url`". $($_.Exception.Message)"
                                 }
                             }
                         }

--- a/test/common/markdown/markdown-link.tests.ps1
+++ b/test/common/markdown/markdown-link.tests.ps1
@@ -114,7 +114,7 @@ Describe "Verify Markdown Links" {
                             catch
                             {
                                 if ( $allowedFailures -notcontains $_.Exception.Response.StatusCode )  {
-                                    throw "Failed to complete request to `"$url`". $($_.Exception.Message)"
+                                    $PSCmdlet.ThrowTerminatingError($PSItem)
                                 }
                             }
                         }


### PR DESCRIPTION
# PR Summary

Include the failed url in the markdown-links test error message

## PR Context

Including url aids diagnosis in Azure DevOps.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
- **User-facing changes**
    - [x] Not Applicable
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.