### PR TITLE
Add Get-Location Pester tests

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Location.Tests.ps1
@@ -56,7 +56,7 @@ Describe "Get-Location" -Tags "CI" {
     It "Should return a PathInfoStack with the correct values for parameter 'Stack'" {
         $stackAsArray = (Get-Location -Stack).ToArray()
 
-        $stackAsArray.Length | Should -BeExactly 1
+        $stackAsArray.Length -gt 0 | Should -BeTrue
 
         $stackAsArray[0] | Should -BeExactly $currentDirectory
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Location.Tests.ps1
@@ -5,6 +5,10 @@ Describe "Get-Location" -Tags "CI" {
         $currentDirectory=[System.IO.Directory]::GetCurrentDirectory()
     }
 
+    AfterAll {
+        Remove-Variable currentDirectory
+    }
+
     It "Should list the output of the current working directory" {
         (Get-Location).Path | Should -BeExactly $currentDirectory
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Location.Tests.ps1
@@ -1,81 +1,77 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 Describe "Get-Location" -Tags "CI" {
-    $currentDirectory=[System.IO.Directory]::GetCurrentDirectory()
+  $currentDirectory=[System.IO.Directory]::GetCurrentDirectory()
 
-    BeforeEach {
-        Push-Location $currentDirectory
+  BeforeEach {
+    Push-Location $currentDirectory
+  }
+
+  AfterEach {
+	Pop-location
+  }
+
+  It "Should list the output of the current working directory" {
+	(Get-Location).Path | Should -BeExactly $currentDirectory
+  }
+
+  It "Should throw an exception when missing an argument for parameter 'PSProvider'" {
+    { Get-Location -PSProvider } | Should -Throw -ErrorId "MissingArgument"
+  }
+
+  It "Should throw an exception when missing an argument for parameter 'PSDrive'" {
+    { Get-Location -PSDrive } | Should -Throw -ErrorId "MissingArgument"
+  }
+
+  It "Should throw an exception when missing an argument for parameter 'StackName'" {
+    { Get-Location -StackName } | Should -Throw -ErrorId "MissingArgument"
+  }
+
+  It "Should return a PathInfo object when no parameters are given" {
+    Get-Location | Should -BeOfType System.Management.Automation.PathInfo
+  }
+
+  It "Should return a PathInfo object given a valid argument for parameter 'PSDrive'" {
+    $tempPSDriveName = "GetLocationTempPSDrive"
+
+    $tempPSDrive = New-PSDrive -Name $tempPSDriveName -PSProvider "FileSystem" -Root $currentDirectory
+
+    try {
+      Get-Location -PSDrive $tempPSDriveName | Should -BeOfType System.Management.Automation.PathInfo
+    } finally {
+      $tempPSDrive | Remove-PSDrive
     }
+  }
 
-    AfterEach {
-	    Pop-location
-    }
+  It "Should return a PathInfo object given a valid argument for parameter 'PSProvider'" {
+    Get-Location -PSProvider alias | Should -BeOfType System.Management.Automation.PathInfo
+  }
 
-    It "Should list the output of the current working directory" {
-	    (Get-Location).Path | Should -BeExactly $currentDirectory
-    }
+  It "Should return a PathInfoStack object for parameter 'Stack'" {
+    Get-Location -Stack | Should -BeOfType System.Management.Automation.PathInfoStack
+  }
 
-    It "Should do exactly the same thing as its alias" {
-	    (pwd).Path | Should -BeExactly (Get-Location).Path
-    }
+  It "Should return a PathInfoStack with the correct values for parameter 'Stack'" {
+    $stackAsArray = (Get-Location -Stack).ToArray()
 
-    It "Should throw an exception when missing an argument for parameter 'PSProvider'" {
-         { Get-Location -PSProvider } | Should -Throw -ErrorId "MissingArgument"
-    }
+    $stackAsArray.Length | Should -BeGreaterThan 0
 
-    It "Should throw an exception when missing an argument for parameter 'PSDrive'" {
-        { Get-Location -PSDrive } | Should -Throw -ErrorId "MissingArgument"
-    }
+    $stackAsArray[0] | Should -BeExactly $currentDirectory
+  }
 
-    It "Should throw an exception when missing an argument for parameter 'StackName'" {
-        { Get-Location -StackName } | Should -Throw -ErrorId "MissingArgument"
-    }
+  It "Should return a PathInfoStack with the correct values for the argument for parameter 'StackName'" {
+    $tempDirectory = Join-Path -Path $TestDrive -ChildPath "getLocationTempDir"
 
-    It "Should return a PathInfo object when no parameters are given" {
-        Get-Location | Should -BeOfType System.Management.Automation.PathInfo
-    }
+    New-Item -Path ($tempDirectory) -ItemType "directory" > $null
 
-    It "Should return a PathInfo object given a valid argument for parameter 'PSDrive'" {
-        $tempPSDriveName = "GeLocationTempPSDrive"
+    Set-Location -Path $tempDirectory
 
-        $tempPSDrive = New-PSDrive -Name $tempPSDriveName -PSProvider "FileSystem" -Root $currentDirectory
+    Push-Location $currentDirectory -StackName "Stack1"
 
-        Get-Location -PSDrive $tempPSDriveName | Should -BeOfType System.Management.Automation.PathInfo
+    $stackAsArray = (Get-Location -StackName "Stack1").ToArray()
 
-        $tempPSDrive | Remove-PSDrive
-    }
+    $stackAsArray.Length | Should -BeExactly 1
 
-    It "Should return a PathInfo object given a valid argument for parameter 'PSProvider'" {
-        Get-Location -PSProvider alias | Should -BeOfType System.Management.Automation.PathInfo
-    }
-
-    It "Should return a PathInfoStack object for parameter 'Stack'" {
-        Get-Location -Stack | Should -BeOfType System.Management.Automation.PathInfoStack
-    }
-
-    It "Should return a PathInfoStack with the correct values for parameter 'Stack'" {
-        $stackAsArray = (Get-Location -Stack).ToArray()
-
-        $stackAsArray.Length | Should -BeGreaterThan 0
-
-        $stackAsArray[0] | Should -BeExactly $currentDirectory
-    }
-
-    It "Should return a PathInfoStack with the correct values for the argument for parameter 'StackName'" {
-        $tempDirectory = Join-Path -Path $currentDirectory -ChildPath "getLocationTempDir"
-
-        New-Item -Path ($tempDirectory) -ItemType "directory" > $null
-
-        Set-Location -Path $tempDirectory
-
-        Push-Location $currentDirectory -StackName "Stack1"
-
-        $stackAsArray = (Get-Location -StackName "Stack1").ToArray()
-
-        $stackAsArray.Length | Should -BeExactly 1
-
-        $stackAsArray[0].Path | Should -BeExactly $tempDirectory
-
-        Remove-Item -Path $tempDirectory
-    }
+    $stackAsArray[0].Path | Should -BeExactly $tempDirectory
+  }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Location.Tests.ps1
@@ -20,15 +20,15 @@ Describe "Get-Location" -Tags "CI" {
     }
 
     It "Should throw an exception when missing an argument for parameter 'PSProvider'" {
-        { Get-Location -PSProvider } | Should -Throw "Missing an argument for parameter 'PSProvider'."
+         { Get-Location -PSProvider } | Should -Throw -ErrorId "MissingArgument"
     }
 
     It "Should throw an exception when missing an argument for parameter 'PSDrive'" {
-        { Get-Location -PSDrive } | Should -Throw "Missing an argument for parameter 'PSDrive'."
+        { Get-Location -PSDrive } | Should -Throw -ErrorId "MissingArgument"
     }
 
     It "Should throw an exception when missing an argument for parameter 'StackName'" {
-        { Get-Location -StackName } | Should -Throw "Missing an argument for parameter 'StackName'."
+        { Get-Location -StackName } | Should -Throw -ErrorId "MissingArgument"
     }
 
     It "Should return a PathInfo object when no parameters are given" {
@@ -56,7 +56,7 @@ Describe "Get-Location" -Tags "CI" {
     It "Should return a PathInfoStack with the correct values for parameter 'Stack'" {
         $stackAsArray = (Get-Location -Stack).ToArray()
 
-        $stackAsArray.Length -gt 0 | Should -BeTrue
+        $stackAsArray.Length | Should -BeGreaterThan 0
 
         $stackAsArray[0] | Should -BeExactly $currentDirectory
     }
@@ -64,7 +64,7 @@ Describe "Get-Location" -Tags "CI" {
     It "Should return a PathInfoStack with the correct values for the argument for parameter 'StackName'" {
         $tempDirectory = Join-Path -Path $currentDirectory -ChildPath "getLocationTempDir"
 
-        New-Item -Path ($tempDirectory) -ItemType "directory"
+        New-Item -Path ($tempDirectory) -ItemType "directory" > $null
 
         Set-Location -Path $tempDirectory
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Location.Tests.ps1
@@ -2,20 +2,80 @@
 # Licensed under the MIT License.
 Describe "Get-Location" -Tags "CI" {
     $currentDirectory=[System.IO.Directory]::GetCurrentDirectory()
+
     BeforeEach {
-	Push-Location $currentDirectory
+        Push-Location $currentDirectory
     }
 
     AfterEach {
-	Pop-location
+	    Pop-location
     }
 
     It "Should list the output of the current working directory" {
-
-	(Get-Location).Path | Should -BeExactly $currentDirectory
+	    (Get-Location).Path | Should -BeExactly $currentDirectory
     }
 
     It "Should do exactly the same thing as its alias" {
-	(pwd).Path | Should -BeExactly (Get-Location).Path
+	    (pwd).Path | Should -BeExactly (Get-Location).Path
+    }
+
+    It "Should throw an exception when missing an argument for parameter 'PSProvider'" {
+        { Get-Location -PSProvider } | Should -Throw "Missing an argument for parameter 'PSProvider'."
+    }
+
+    It "Should throw an exception when missing an argument for parameter 'PSDrive'" {
+        { Get-Location -PSDrive } | Should -Throw "Missing an argument for parameter 'PSDrive'."
+    }
+
+    It "Should throw an exception when missing an argument for parameter 'StackName'" {
+        { Get-Location -StackName } | Should -Throw "Missing an argument for parameter 'StackName'."
+    }
+
+    It "Should return a PathInfo object when no parameters are given" {
+        Get-Location | Should -BeOfType System.Management.Automation.PathInfo
+    }
+
+    It "Should return a PathInfo object given a valid argument for parameter 'PSDrive'" {
+        $tempPSDriveName = "GeLocationTempPSDrive"
+
+        $tempPSDrive = New-PSDrive -Name $tempPSDriveName -PSProvider "FileSystem" -Root $currentDirectory
+
+        Get-Location -PSDrive $tempPSDriveName | Should -BeOfType System.Management.Automation.PathInfo
+
+        $tempPSDrive | Remove-PSDrive
+    }
+
+    It "Should return a PathInfo object given a valid argument for parameter 'PSProvider'" {
+        Get-Location -PSProvider alias | Should -BeOfType System.Management.Automation.PathInfo
+    }
+
+    It "Should return a PathInfoStack object for parameter 'Stack'" {
+        Get-Location -Stack | Should -BeOfType System.Management.Automation.PathInfoStack
+    }
+
+    It "Should return a PathInfoStack with the correct values for parameter 'Stack'" {
+        $stackAsArray = (Get-Location -Stack).ToArray()
+
+        $stackAsArray.Length | Should -BeExactly 1
+
+        $stackAsArray[0] | Should -BeExactly $currentDirectory
+    }
+
+    It "Should return a PathInfoStack with the correct values for the argument for parameter 'StackName'" {
+        $tempDirectory = Join-Path -Path $currentDirectory -ChildPath "getLocationTempDir"
+
+        New-Item -Path ($tempDirectory) -ItemType "directory"
+
+        Set-Location -Path $tempDirectory
+
+        Push-Location $currentDirectory -StackName "Stack1"
+
+        $stackAsArray = (Get-Location -StackName "Stack1").ToArray()
+
+        $stackAsArray.Length | Should -BeExactly 1
+
+        $stackAsArray[0].Path | Should -BeExactly $tempDirectory
+
+        Remove-Item -Path $tempDirectory
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Location.Tests.ps1
@@ -1,77 +1,77 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 Describe "Get-Location" -Tags "CI" {
-  $currentDirectory=[System.IO.Directory]::GetCurrentDirectory()
+    $currentDirectory=[System.IO.Directory]::GetCurrentDirectory()
 
-  BeforeEach {
-    Push-Location $currentDirectory
-  }
-
-  AfterEach {
-	Pop-location
-  }
-
-  It "Should list the output of the current working directory" {
-	(Get-Location).Path | Should -BeExactly $currentDirectory
-  }
-
-  It "Should throw an exception when missing an argument for parameter 'PSProvider'" {
-    { Get-Location -PSProvider } | Should -Throw -ErrorId "MissingArgument"
-  }
-
-  It "Should throw an exception when missing an argument for parameter 'PSDrive'" {
-    { Get-Location -PSDrive } | Should -Throw -ErrorId "MissingArgument"
-  }
-
-  It "Should throw an exception when missing an argument for parameter 'StackName'" {
-    { Get-Location -StackName } | Should -Throw -ErrorId "MissingArgument"
-  }
-
-  It "Should return a PathInfo object when no parameters are given" {
-    Get-Location | Should -BeOfType System.Management.Automation.PathInfo
-  }
-
-  It "Should return a PathInfo object given a valid argument for parameter 'PSDrive'" {
-    $tempPSDriveName = "GetLocationTempPSDrive"
-
-    $tempPSDrive = New-PSDrive -Name $tempPSDriveName -PSProvider "FileSystem" -Root $currentDirectory
-
-    try {
-      Get-Location -PSDrive $tempPSDriveName | Should -BeOfType System.Management.Automation.PathInfo
-    } finally {
-      $tempPSDrive | Remove-PSDrive
+    BeforeEach {
+        Push-Location $currentDirectory
     }
-  }
 
-  It "Should return a PathInfo object given a valid argument for parameter 'PSProvider'" {
-    Get-Location -PSProvider alias | Should -BeOfType System.Management.Automation.PathInfo
-  }
+    AfterEach {
+        Pop-location
+    }
 
-  It "Should return a PathInfoStack object for parameter 'Stack'" {
-    Get-Location -Stack | Should -BeOfType System.Management.Automation.PathInfoStack
-  }
+    It "Should list the output of the current working directory" {
+        (Get-Location).Path | Should -BeExactly $currentDirectory
+    }
 
-  It "Should return a PathInfoStack with the correct values for parameter 'Stack'" {
-    $stackAsArray = (Get-Location -Stack).ToArray()
+    It "Should throw an exception when missing an argument for parameter 'PSProvider'" {
+        { Get-Location -PSProvider } | Should -Throw -ErrorId "MissingArgument"
+    }
 
-    $stackAsArray.Length | Should -BeGreaterThan 0
+    It "Should throw an exception when missing an argument for parameter 'PSDrive'" {
+        { Get-Location -PSDrive } | Should -Throw -ErrorId "MissingArgument"
+    }
 
-    $stackAsArray[0] | Should -BeExactly $currentDirectory
-  }
+    It "Should throw an exception when missing an argument for parameter 'StackName'" {
+        { Get-Location -StackName } | Should -Throw -ErrorId "MissingArgument"
+    }
 
-  It "Should return a PathInfoStack with the correct values for the argument for parameter 'StackName'" {
-    $tempDirectory = Join-Path -Path $TestDrive -ChildPath "getLocationTempDir"
+    It "Should return a PathInfo object when no parameters are given" {
+        Get-Location | Should -BeOfType System.Management.Automation.PathInfo
+    }
 
-    New-Item -Path ($tempDirectory) -ItemType "directory" > $null
+    It "Should return a PathInfo object given a valid argument for parameter 'PSDrive'" {
+        $tempPSDriveName = "GetLocationTempPSDrive"
 
-    Set-Location -Path $tempDirectory
+        $tempPSDrive = New-PSDrive -Name $tempPSDriveName -PSProvider "FileSystem" -Root $currentDirectory
 
-    Push-Location $currentDirectory -StackName "Stack1"
+        try {
+            Get-Location -PSDrive $tempPSDriveName | Should -BeOfType System.Management.Automation.PathInfo
+        } finally {
+            $tempPSDrive | Remove-PSDrive
+        }
+    }
 
-    $stackAsArray = (Get-Location -StackName "Stack1").ToArray()
+    It "Should return a PathInfo object given a valid argument for parameter 'PSProvider'" {
+        Get-Location -PSProvider alias | Should -BeOfType System.Management.Automation.PathInfo
+    }
 
-    $stackAsArray.Length | Should -BeExactly 1
+    It "Should return a PathInfoStack object for parameter 'Stack'" {
+        Get-Location -Stack | Should -BeOfType System.Management.Automation.PathInfoStack
+    }
 
-    $stackAsArray[0].Path | Should -BeExactly $tempDirectory
-  }
+    It "Should return a PathInfoStack with the correct values for parameter 'Stack'" {
+        $stackAsArray = (Get-Location -Stack).ToArray()
+
+        $stackAsArray.Length | Should -BeGreaterThan 0
+
+        $stackAsArray[0] | Should -BeExactly $currentDirectory
+    }
+
+    It "Should return a PathInfoStack with the correct values for the argument for parameter 'StackName'" {
+        $tempDirectory = Join-Path -Path $TestDrive -ChildPath "getLocationTempDir"
+
+        New-Item -Path ($tempDirectory) -ItemType "directory" > $null
+
+        Set-Location -Path $tempDirectory
+
+        Push-Location $currentDirectory -StackName "Stack1"
+
+        $stackAsArray = (Get-Location -StackName "Stack1").ToArray()
+
+        $stackAsArray.Length | Should -BeExactly 1
+
+        $stackAsArray[0].Path | Should -BeExactly $tempDirectory
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Location.Tests.ps1
@@ -1,14 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 Describe "Get-Location" -Tags "CI" {
-    $currentDirectory=[System.IO.Directory]::GetCurrentDirectory()
-
     BeforeAll {
-        Push-Location $currentDirectory
-    }
-
-    AfterAll {
-        Pop-location
+        $currentDirectory=[System.IO.Directory]::GetCurrentDirectory()
     }
 
     It "Should list the output of the current working directory" {
@@ -52,11 +46,15 @@ Describe "Get-Location" -Tags "CI" {
     }
 
     It "Should return a PathInfoStack with the correct values for parameter 'Stack'" {
+        Push-Location $currentDirectory
+
         $stackAsArray = (Get-Location -Stack).ToArray()
 
         $stackAsArray.Length | Should -BeGreaterThan 0
 
         $stackAsArray[0] | Should -BeExactly $currentDirectory
+
+        Pop-location
     }
 
     It "Should return a PathInfoStack with the correct values for the argument for parameter 'StackName'" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Location.Tests.ps1
@@ -3,11 +3,11 @@
 Describe "Get-Location" -Tags "CI" {
     $currentDirectory=[System.IO.Directory]::GetCurrentDirectory()
 
-    BeforeEach {
+    BeforeAll {
         Push-Location $currentDirectory
     }
 
-    AfterEach {
+    AfterAll {
         Pop-location
     }
 


### PR DESCRIPTION
# PR Summary

Addresses the issue first raised in #2413 by adding tests to
increase coverage of the Get-Location cmdlet which is
supported by the file system provider.

## PR Context

#2413 was originally opened on October 3, 2016. Since then, the test coverage of Get-Location has remained low.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: 
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
