### PR TITLE
Run pwsh correctly in tests

### DIFF
--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -244,17 +244,17 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
 '@
             $testFilePath = Join-Path $TestDrive "test.ps1"
             Set-Content -Path $testFilePath -Value $testScript
-            $observed = echo hello | pwsh -noprofile $testFilePath e -
+            $observed = echo hello | & $powershell -noprofile $testFilePath e -
             $observed | Should -BeExactly "h-llo"
         }
 
         It "Empty command should fail" {
-            pwsh -noprofile -c ''
+            & $powershell -noprofile -c ''
             $LASTEXITCODE | Should -Be 64
         }
 
         It "Whitespace command should succeed" {
-            pwsh -noprofile -c ' ' | Should -BeNullOrEmpty
+            & $powershell -noprofile -c ' ' | Should -BeNullOrEmpty
             $LASTEXITCODE | Should -Be 0
         }
     }
@@ -655,7 +655,7 @@ namespace StackTest {
 
     Context "PATH environment variable" {
         It "`$PSHOME should be in front so that pwsh.exe starts current running PowerShell" {
-            pwsh -v | Should -Match $psversiontable.GitCommitId
+            & $powershell -v | Should -Match $psversiontable.GitCommitId
         }
 
         It "powershell starts if PATH is not set" -Skip:($IsWindows) {
@@ -731,7 +731,7 @@ namespace StackTest {
 "@ > $PROFILE
 
             try {
-                $out = pwsh -workingdirectory ~ -c '(Get-Location).Path'
+                $out = & $powershell -workingdirectory ~ -c '(Get-Location).Path'
                 $out | Should -HaveCount 2
                 $out[0] | Should -BeExactly (Get-Item ~).FullName
                 $out[1] | Should -BeExactly "$testdrive"
@@ -879,7 +879,7 @@ public enum ShowWindowCommands : int
         param ($WindowStyle)
 
         try {
-            $ps = Start-Process pwsh -ArgumentList "-WindowStyle $WindowStyle -noexit -interactive" -PassThru
+            $ps = Start-Process $powershell -ArgumentList "-WindowStyle $WindowStyle -noexit -interactive" -PassThru
             $startTime = Get-Date
             $showCmd = "Unknown"
             while (((Get-Date) - $startTime).TotalSeconds -lt 10 -and $showCmd -ne $WindowStyle) {
@@ -894,7 +894,7 @@ public enum ShowWindowCommands : int
     }
 
     It "Invalid -WindowStyle returns error" {
-        pwsh -WindowStyle invalid
+        & $powershell -WindowStyle invalid
         $LASTEXITCODE | Should -Be $ExitCodeBadCommandLineParameter
     }
 }

--- a/test/powershell/Host/ScreenReader.Tests.ps1
+++ b/test/powershell/Host/ScreenReader.Tests.ps1
@@ -44,7 +44,7 @@ Describe "Validate start of console host" -Tag CI {
     }
 
     It "PSReadLine should not be auto-loaded when screen reader status is active" -Skip:(-not $IsWindows) {
-        $output = pwsh -noprofile -noexit -c "Get-Module PSReadLine; exit"
+        $output = & "$PSHOME/pwsh" -noprofile -noexit -c "Get-Module PSReadLine; exit"
         $output.Length | Should -BeExactly 2
 
         ## The warning message about screen reader should be returned, but the PSReadLine module should not be loaded.

--- a/test/powershell/Host/Startup.Tests.ps1
+++ b/test/powershell/Host/Startup.Tests.ps1
@@ -99,7 +99,7 @@ Describe "Validate start of console host" -Tag CI {
             Remove-Item $profileDataFile -Force
         }
 
-        $loadedAssemblies = pwsh -noprofile -command '([System.AppDomain]::CurrentDomain.GetAssemblies()).manifestmodule | Where-Object { $_.Name -notlike ""<*>"" } | ForEach-Object { $_.Name }'
+        $loadedAssemblies = & "$PSHOME/pwsh" -noprofile -command '([System.AppDomain]::CurrentDomain.GetAssemblies()).manifestmodule | Where-Object { $_.Name -notlike ""<*>"" } | ForEach-Object { $_.Name }'
     }
 
     It "No new assemblies are loaded" {

--- a/test/powershell/Language/Parser/UsingAssembly.Tests.ps1
+++ b/test/powershell/Language/Parser/UsingAssembly.Tests.ps1
@@ -74,25 +74,25 @@ public class ABC {}
         }
 #>
         It "Assembly loaded at runtime" -pending {
-            $assemblies = pwsh -noprofile -command @"
+            $assemblies = & "$PSHOME/pwsh" -noprofile -command @"
     using assembly .\UsingAssemblyTest$guid.dll
     [Appdomain]::CurrentDomain.GetAssemblies().GetName().Name
 "@
             $assemblies -contains "UsingAssemblyTest$guid" | Should -BeTrue
 
-            $assemblies = pwsh -noprofile -command @"
+            $assemblies = & "$PSHOME/pwsh" -noprofile -command @"
     using assembly $PSScriptRoot\UsingAssemblyTest$guid.dll
     [Appdomain]::CurrentDomain.GetAssemblies().GetName().Name
 "@
             $assemblies -contains "UsingAssemblyTest$guid" | Should -BeTrue
 
-            $assemblies = pwsh -noprofile -command @"
+            $assemblies = & "$PSHOME/pwsh" -noprofile -command @"
     using assembly System.Drawing
     [Appdomain]::CurrentDomain.GetAssemblies().GetName().Name
 "@
             $assemblies -contains "System.Drawing" | Should -BeTrue
 
-            $assemblies = pwsh -noprofile -command @"
+            $assemblies = & "$PSHOME/pwsh" -noprofile -command @"
     using assembly 'System.Drawing, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
     [Appdomain]::CurrentDomain.GetAssemblies().GetName().Name
 "@

--- a/test/powershell/Language/Scripting/NativeExecution/NativeStreams.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeStreams.Tests.ps1
@@ -1,7 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 Describe "Native streams behavior with PowerShell" -Tags 'CI' {
-    $powershell = Join-Path -Path $PsHome -ChildPath "pwsh"
+    BeforeAll {
+        $powershell = Join-Path -Path $PsHome -ChildPath "pwsh"
+    }
 
     Context "Error stream" {
         # we are using powershell itself as an example of a native program.
@@ -57,7 +59,7 @@ Describe "Native streams behavior with PowerShell" -Tags 'CI' {
             while ($longtext.Length -lt [console]::WindowWidth) {
                 $longtext += $longtext
             }
-            pwsh -c "& { [Console]::Error.WriteLine('$longtext') }" 2>&1 > $testdrive\error.txt
+            & $powershell -c "& { [Console]::Error.WriteLine('$longtext') }" 2>&1 > $testdrive\error.txt
             $e = Get-Content -Path $testdrive\error.txt
             $e.Count | Should -Be 1
             $e | Should -BeExactly $longtext

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -274,7 +274,7 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
 
         It "'Get-Module -ListAvailable' should not load the module assembly" {
             ## $fullName should be null and thus the result should just be the module's name.
-            $result = pwsh -noprofile -c "`$env:PSModulePath = '$tempModulePath'; `$module = Get-Module -ListAvailable; `$fullName = [System.AppDomain]::CurrentDomain.GetAssemblies() | Where-Object Location -eq $assemblyPath | Foreach-Object FullName; `$module.Name + `$fullName"
+            $result = & "$PSHOME/pwsh" -noprofile -c "`$env:PSModulePath = '$tempModulePath'; `$module = Get-Module -ListAvailable; `$fullName = [System.AppDomain]::CurrentDomain.GetAssemblies() | Where-Object Location -eq $assemblyPath | Foreach-Object FullName; `$module.Name + `$fullName"
             $result | Should -BeExactly "MyModuelTest"
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -257,7 +257,7 @@ Describe "Import-Module for Binary Modules" -Tags 'CI' {
         Copy-Item $gacAssemblyPath -Destination $destPath -Force
 
         # Use a different pwsh so that we do not have the PSScheduledJob module already loaded.
-        $loadedAssemblyLocation = pwsh -noprofile -c "Import-Module $destPath -Force; [Microsoft.PowerShell.ScheduledJob.AddJobTriggerCommand].Assembly.Location"
+        $loadedAssemblyLocation = & "$PSHOME/pwsh" -noprofile -c "Import-Module $destPath -Force; [Microsoft.PowerShell.ScheduledJob.AddJobTriggerCommand].Assembly.Location"
         $loadedAssemblyLocation | Should -BeLike "$TestDrive*\Microsoft.PowerShell.ScheduledJob.dll"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
@@ -35,7 +35,7 @@ Describe "Get-Command Feature tests" -Tag Feature {
         }
 
         It "Can return multiple results relying on auto module loading" {
-            $results = pwsh -outputformat xml -command "`$env:PSModulePath += '$testPSModulePath'; Get-Command i-fzz -UseAbbreviationExpansion"
+            $results = & "$PSHOME/pwsh" -outputformat xml -command "`$env:PSModulePath += '$testPSModulePath'; Get-Command i-fzz -UseAbbreviationExpansion"
             $results | Should -HaveCount 2
             $results.Name | Should -Contain "Invoke-FooZedZed"
             $results.Name | Should -Contain "Import-FooZedZed"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Read-Host.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Read-Host.Tests.ps1
@@ -39,7 +39,7 @@ Describe "Read-Host Test" -tag "CI" {
     }
 
     It "Read-Host doesn't enter command prompt mode" {
-        $result = "!1" | pwsh -NoProfile -c "Read-host -Prompt 'foo'"
+        $result = "!1" | & "$PSHOME/pwsh" -NoProfile -c "Read-host -Prompt 'foo'"
         if ($IsWindows) {
             # Windows write to console directly so can't capture prompt in stdout
             $expected = @('!1','!1')

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
@@ -101,7 +101,7 @@ Describe "Write-Error Tests" -Tags "CI" {
         while ($longtext.Length -lt [console]::WindowWidth) {
             $longtext += $longtext
         }
-        $result = pwsh -noprofile -command "`$ErrorView = 'NormalView'; Write-Error -Message '$longtext'" 2>&1
+        $result = & "$PSHOME/pwsh" -noprofile -command "`$ErrorView = 'NormalView'; Write-Error -Message '$longtext'" 2>&1
         $result.Count | Should -BeExactly 3
         $result[0] | Should -Match $longtext
     }

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -149,7 +149,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
     }
 
     It "Transcription should be closed if the only runspace gets closed" {
-        pwsh -c "start-transcript $transcriptFilePath; Write-Host ''Before Dispose'';"
+        & "$PSHOME/pwsh" -c "start-transcript $transcriptFilePath; Write-Host ''Before Dispose'';"
 
         $transcriptFilePath | Should -Exist
         $transcriptFilePath | Should -FileContentMatch "Before Dispose"

--- a/test/powershell/engine/Api/BasicEngine.Tests.ps1
+++ b/test/powershell/engine/Api/BasicEngine.Tests.ps1
@@ -49,7 +49,7 @@ $null = $ps.AddScript(1).Invoke()
 exit
 '@
         $outputFile = New-Item -Path $TestDrive\output.txt -ItemType File
-        $process = Start-Process pwsh -ArgumentList $command -PassThru -RedirectStandardOutput $outputFile
+        $process = Start-Process "$PSHOME/pwsh" -ArgumentList $command -PassThru -RedirectStandardOutput $outputFile
         Wait-UntilTrue -sb { $process.HasExited } -TimeoutInMilliseconds 5000 -IntervalInMilliseconds 1000 | Should -BeTrue
         $hasExited = $process.HasExited
 

--- a/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
+++ b/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
@@ -523,8 +523,8 @@ Describe "Verify approved aliases list" -Tags "CI" {
             if ($isPreview) {
                 $emptyConfigPath = Join-Path -Path $TestDrive -ChildPath "test.config.json"
                 Set-Content -Path $emptyConfigPath -Value "" -Force -ErrorAction Stop
-                $currentAliasList = pwsh -NoProfile -OutputFormat XML -SettingsFile $emptyConfigPath -Command $getAliases -args ($moduleList | ConvertTo-Json)
-                $currentCmdletList = pwsh -NoProfile -OutputFormat XML -SettingsFile $emptyConfigPath -Command $getCommands -args ($moduleList | ConvertTo-Json)
+                $currentAliasList = & "$PSHOME/pwsh" -NoProfile -OutputFormat XML -SettingsFile $emptyConfigPath -Command $getAliases -args ($moduleList | ConvertTo-Json)
+                $currentCmdletList = & "$PSHOME/pwsh" -NoProfile -OutputFormat XML -SettingsFile $emptyConfigPath -Command $getCommands -args ($moduleList | ConvertTo-Json)
             }
             else {
                 $currentAliasList = & $getAliases $moduleList

--- a/test/powershell/engine/Basic/GroupPolicySettings.Tests.ps1
+++ b/test/powershell/engine/Basic/GroupPolicySettings.Tests.ps1
@@ -151,7 +151,7 @@ Describe 'Group policy settings tests' -Tag CI,RequireAdminOnWindows {
                 Set-ItemProperty -Path $KeyPath -Name EnableInvocationHeader -Value 1 -Force
 
                 $number = get-random
-                $null = pwsh -NoProfile -NonInteractive -c "$number"
+                $null = & "$PSHOME/pwsh" -NoProfile -NonInteractive -c "$number"
 
                 Remove-ItemProperty -Path $KeyPath -Name OutputDirectory -Force
                 Remove-ItemProperty -Path $KeyPath -Name EnableInvocationHeader -Force
@@ -228,7 +228,7 @@ Describe 'Group policy settings tests' -Tag CI,RequireAdminOnWindows {
                 Set-ItemProperty -Path $KeyPath -Name ConsoleSessionConfigurationName -Value $SessionName -Force
 
                 $LogPath = (New-TemporaryFile).FullName
-                pwsh -NoProfile -NonInteractive -c "1" *> $LogPath # this implicitly uses SessionConfiguration from the policy
+                & "$PSHOME/pwsh" -NoProfile -NonInteractive -c "1" *> $LogPath # this implicitly uses SessionConfiguration from the policy
 
                 # Log should have an error that has our configuration session name; e.g.:
                 # 'The shell cannot be started. A failure occurred during initialization:

--- a/test/powershell/engine/Basic/TypeResolution.Tests.ps1
+++ b/test/powershell/engine/Basic/TypeResolution.Tests.ps1
@@ -6,6 +6,6 @@ Describe "Resolve types in additional referenced assemblies" -Tag CI {
         @{ typename = "[System.DirectoryServices.AccountManagement.AdvancedFilters]"; name = "AdvancedFilters" }
     ){
         param ($typename, $name)
-        pwsh -noprofile -command "$typename.Name" | Should -BeExactly $name
+        & "$PSHOME/pwsh" -noprofile -command "$typename.Name" | Should -BeExactly $name
     }
 }

--- a/test/powershell/engine/ExperimentalFeature/EnableDisable-ExperimentalFeature.Tests.ps1
+++ b/test/powershell/engine/ExperimentalFeature/EnableDisable-ExperimentalFeature.Tests.ps1
@@ -6,6 +6,7 @@ Import-Module HelpersCommon
 Describe "Enable-ExperimentalFeature and Disable-ExperimentalFeature tests" -tags "Feature","RequireAdminOnWindows" {
 
     BeforeAll {
+        $pwsh = "$PSHOME/pwsh"
         $systemConfigPath = "$PSHOME/powershell.config.json"
         if ($IsWindows) {
             $userConfigPath = "~/Documents/powershell/powershell.config.json"
@@ -58,11 +59,11 @@ Describe "Enable-ExperimentalFeature and Disable-ExperimentalFeature tests" -tag
             return
         }
 
-        $feature = pwsh -noprofile -output xml -command Get-ExperimentalFeature ExpTest.FeatureOne
+        $feature = & $pwsh -noprofile -output xml -command Get-ExperimentalFeature ExpTest.FeatureOne
         $feature.Enabled | Should -BeFalse -Because "All Experimental Features disabled when no config file"
-        $feature = pwsh -noprofile -output xml -command Enable-ExperimentalFeature ExpTest.FeatureOne -Scope $scope -WarningAction SilentlyContinue
+        $feature = & $pwsh -noprofile -output xml -command Enable-ExperimentalFeature ExpTest.FeatureOne -Scope $scope -WarningAction SilentlyContinue
         $feature | Should -BeNullOrEmpty -Because "No object is output to pipeline on success"
-        $feature = pwsh -noprofile -output xml -command Get-ExperimentalFeature ExpTest.FeatureOne
+        $feature = & $pwsh -noprofile -output xml -command Get-ExperimentalFeature ExpTest.FeatureOne
         $feature.Enabled | Should -BeTrue -Because "The experimental feature is now enabled"
     }
 
@@ -77,11 +78,11 @@ Describe "Enable-ExperimentalFeature and Disable-ExperimentalFeature tests" -tag
         }
 
         '{"ExperimentalFeatures":["ExpTest.FeatureOne"]}' > $configPath
-        $feature = pwsh -noprofile -output xml -command Get-ExperimentalFeature ExpTest.FeatureOne
+        $feature = & $pwsh -noprofile -output xml -command Get-ExperimentalFeature ExpTest.FeatureOne
         $feature.Enabled | Should -BeTrue -Because "Test config should enable ExpTest.FeatureOne"
-        $feature = pwsh -noprofile -output xml -command Disable-ExperimentalFeature ExpTest.FeatureOne -Scope $scope -WarningAction SilentlyContinue
+        $feature = & $pwsh -noprofile -output xml -command Disable-ExperimentalFeature ExpTest.FeatureOne -Scope $scope -WarningAction SilentlyContinue
         $feature | Should -BeNullOrEmpty -Because "No object is output to pipeline on success"
-        $feature = pwsh -noprofile -output xml -command Get-ExperimentalFeature ExpTest.FeatureOne
+        $feature = & $pwsh -noprofile -output xml -command Get-ExperimentalFeature ExpTest.FeatureOne
         $feature.Enabled | Should -BeFalse -Because "The experimental feature is now disabled"
     }
 

--- a/test/powershell/engine/ExperimentalFeature/Get-ExperimentalFeature.Tests.ps1
+++ b/test/powershell/engine/ExperimentalFeature/Get-ExperimentalFeature.Tests.ps1
@@ -6,6 +6,7 @@ Import-Module HelpersCommon
 Describe "Get-ExperimentalFeature Tests" -tags "Feature","RequireAdminOnWindows" {
 
     BeforeAll {
+        $pwsh = "$PSHOME/pwsh"
         $systemConfigPath = "$PSHOME/powershell.config.json"
         if ($IsWindows) {
             $userConfigPath = "~/Documents/powershell/powershell.config.json"
@@ -55,7 +56,7 @@ Describe "Get-ExperimentalFeature Tests" -tags "Feature","RequireAdminOnWindows"
     Context "Feature disabled tests" {
 
         It "'Get-ExperimentalFeature' should return all available features from module path" {
-            $features = pwsh -noprofile -output xml -command Get-ExperimentalFeature "ExpTest*"
+            $features = & $pwsh -noprofile -output xml -command Get-ExperimentalFeature "ExpTest*"
             $features | Should -Not -BeNullOrEmpty
             $features[0].Name | Should -BeExactly "ExpTest.FeatureOne"
             $features[0].Enabled | Should -BeFalse
@@ -67,7 +68,7 @@ Describe "Get-ExperimentalFeature Tests" -tags "Feature","RequireAdminOnWindows"
         }
 
         It "'Get-ExperimentalFeature' pipeline input" {
-            $features = pwsh -noprofile -output xml -command { "ExpTest.FeatureOne", "ExpTest.FeatureTwo" | Get-ExperimentalFeature }
+            $features = & $pwsh -noprofile -output xml -command { "ExpTest.FeatureOne", "ExpTest.FeatureTwo" | Get-ExperimentalFeature }
             $features | Should -Not -BeNullOrEmpty
             $features[0].Name | Should -BeExactly "ExpTest.FeatureOne"
             $features[0].Enabled | Should -BeFalse
@@ -85,15 +86,15 @@ Describe "Get-ExperimentalFeature Tests" -tags "Feature","RequireAdminOnWindows"
         }
 
         It "'Get-ExperimentalFeature' should return enabled features 'ExpTest.FeatureOne'" {
-            pwsh -noprofile -command '$EnabledExperimentalFeatures.Count' | Should -Be 1
-            $feature = pwsh -noprofile -output xml -command Get-ExperimentalFeature "ExpTest.FeatureOne"
+            & $pwsh -noprofile -command '$EnabledExperimentalFeatures.Count' | Should -Be 1
+            $feature = & $pwsh -noprofile -output xml -command Get-ExperimentalFeature "ExpTest.FeatureOne"
             $feature | Should -Not -BeNullOrEmpty
             $feature.Enabled | Should -BeTrue
             $feature.Source | Should -BeExactly $testModuleManifestPath
         }
 
         It "'Get-ExperimentalFeature' should return all available features from module path" {
-            $features = pwsh -noprofile -output xml -command Get-ExperimentalFeature "ExpTest*"
+            $features = & $pwsh -noprofile -output xml -command Get-ExperimentalFeature "ExpTest*"
             $features | Should -Not -BeNullOrEmpty
             $features[0].Name | Should -BeExactly "ExpTest.FeatureOne"
             $features[0].Enabled | Should -BeTrue
@@ -105,7 +106,7 @@ Describe "Get-ExperimentalFeature Tests" -tags "Feature","RequireAdminOnWindows"
         }
 
         It "'Get-ExperimentalFeature' pipeline input" {
-            $features = pwsh -noprofile -output xml -command  { "ExpTest.FeatureOne", "ExpTest.FeatureTwo" | Get-ExperimentalFeature }
+            $features = & $pwsh -noprofile -output xml -command  { "ExpTest.FeatureOne", "ExpTest.FeatureTwo" | Get-ExperimentalFeature }
             $features | Should -Not -BeNullOrEmpty
             $features[0].Name | Should -BeExactly "ExpTest.FeatureOne"
             $features[0].Enabled | Should -BeTrue
@@ -122,9 +123,9 @@ Describe "Get-ExperimentalFeature Tests" -tags "Feature","RequireAdminOnWindows"
             '{"ExperimentalFeatures":["ExpTest.FeatureOne"]}' > $userConfigPath
             '{"ExperimentalFeatures":["ExpTest.FeatureTwo"]}' > $systemConfigPath
 
-            $feature = pwsh -noprofile -output xml -command Get-ExperimentalFeature ExpTest.FeatureOne
+            $feature = & $pwsh -noprofile -output xml -command Get-ExperimentalFeature ExpTest.FeatureOne
             $feature.Enabled | Should -BeTrue -Because "FeatureOne is enabled in user config"
-            $feature = pwsh -noprofile -output xml -command Get-ExperimentalFeature ExpTest.FeatureTwo
+            $feature = & $pwsh -noprofile -output xml -command Get-ExperimentalFeature ExpTest.FeatureTwo
             $feature.Enabled | Should -BeFalse -Because "System config is not read when user config exists"
         }
     }

--- a/test/powershell/engine/Formatting/ErrorView.Tests.ps1
+++ b/test/powershell/engine/Formatting/ErrorView.Tests.ps1
@@ -48,14 +48,14 @@ Describe 'Tests for $ErrorView' -Tag CI {
         }
 
         It "Activity shows up correctly for scriptblocks" {
-            $e = pwsh -noprofile -command 'Write-Error 'myError' -ErrorAction SilentlyContinue; $error[0] | Out-String'
+            $e = & "$PSHOME/pwsh" -noprofile -command 'Write-Error 'myError' -ErrorAction SilentlyContinue; $error[0] | Out-String'
             [string]::Join('', $e).Trim() | Should -BeLike "*Write-Error:*myError*" # wildcard due to VT100
         }
 
         It "Function shows up correctly" {
             function test-myerror { [cmdletbinding()] param() write-error 'myError' }
 
-            $e = pwsh -noprofile -command 'function test-myerror { [cmdletbinding()] param() write-error "myError" }; test-myerror -ErrorAction SilentlyContinue; $error[0] | Out-String'
+            $e = & "$PSHOME/pwsh" -noprofile -command 'function test-myerror { [cmdletbinding()] param() write-error "myError" }; test-myerror -ErrorAction SilentlyContinue; $error[0] | Out-String'
             [string]::Join('', $e).Trim() | Should -BeLike "*test-myerror:*myError*" # wildcard due to VT100
         }
 

--- a/test/powershell/engine/Job/Jobs.Tests.ps1
+++ b/test/powershell/engine/Job/Jobs.Tests.ps1
@@ -114,7 +114,7 @@ Describe 'Basic Job Tests' -Tags 'CI' {
 
         It "Create job with native command" {
             try {
-                $nativeJob = Start-job { pwsh -c 1+1 }
+                $nativeJob = Start-job { & "$PSHOME/pwsh" -c 1+1 }
                 $nativeJob | Wait-Job
                 $nativeJob.State | Should -BeExactly "Completed"
                 $nativeJob.HasMoreData | Should -BeTrue

--- a/test/powershell/engine/Module/ModulePath.Tests.ps1
+++ b/test/powershell/engine/Module/ModulePath.Tests.ps1
@@ -180,7 +180,7 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
         try {
             $userConfig = '{ "PSModulePath": "myUserPath" }'
             Set-Content -Path $userConfigPath -Value $userConfig -Force
-            $out = pwsh -noprofile -command 'powershell.exe -noprofile -command $env:PSModulePath'
+            $out = & $powershell -noprofile -command 'powershell.exe -noprofile -command $env:PSModulePath'
             $out | Should -Not -BeLike 'myUserPath;*'
         }
         finally {

--- a/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
+++ b/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
@@ -277,7 +277,7 @@ Describe "Parameter Binding Tests" -Tags "CI" {
             $test2File = Join-Path -Path $tempDir -ChildPath "test2.ps1"
 
             $expected = "[$tempDir]"
-            $psPath = "$PSHOME\pwsh"
+            $pwsh = "$PSHOME\pwsh"
 
             $null = New-Item -Path $tempDir -ItemType Directory -Force
             Set-Content -Path $test1File -Value $test1 -Force
@@ -297,10 +297,10 @@ Describe "Parameter Binding Tests" -Tags "CI" {
         }
 
         It "Test 'powershell -File' should evaluate '`$PSScriptRoot' for parameter default value" {
-            $result = & $psPath -NoProfile -File $test1File
+            $result = & $pwsh -NoProfile -File $test1File
             $result | Should -Be $expected
 
-            $result = & $psPath -NoProfile -File $test2File
+            $result = & $pwsh -NoProfile -File $test2File
             $result | Should -Be $expected
         }
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Use common pattern to run external pwsh in tests.
It makes test more readable.

## PR Context

Moved from #11420

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
