### PR TITLE
Normalize line endings before comparing string in tests

### DIFF
--- a/test/powershell/Language/Scripting/Debugging/DebuggerCommand.Tests.ps1
+++ b/test/powershell/Language/Scripting/Debugging/DebuggerCommand.Tests.ps1
@@ -5,6 +5,15 @@ Describe 'Basic debugger command tests' -tag 'CI' {
 
     BeforeAll {
         Register-DebuggerHandler
+
+        function NormalizeLineEnd
+        {
+            param (
+                [string] $string
+            )
+
+            $string -replace "`r`n", "`n"
+        }
     }
 
     AfterAll {
@@ -76,6 +85,7 @@ Describe 'Basic debugger command tests' -tag 'CI' {
     7:                  }
     8:
 '@
+            $testScriptList = NormalizeLineEnd -string $testScriptList
 
             $results = @(Test-Debugger -ScriptBlock $testScript -CommandQueue 'l','list')
             $result = @{
@@ -99,7 +109,7 @@ Describe 'Basic debugger command tests' -tag 'CI' {
         }
 
         It 'Should show the entire script listing with the current position on line 5' {
-            $result['l'] | Should -BeExactly $testScriptList
+            (NormalizeLineEnd -string $result['l']) | Should -BeExactly $testScriptList
         }
     }
 
@@ -121,6 +131,8 @@ Describe 'Basic debugger command tests' -tag 'CI' {
     7:                  }
     8:
 '@
+
+            $testScriptList = NormalizeLineEnd -string $testScriptList
 
             $results = @(Test-Debugger -ScriptBlock $testScript -CommandQueue 'l 4','list 4')
             $result = @{
@@ -144,7 +156,7 @@ Describe 'Basic debugger command tests' -tag 'CI' {
         }
 
         It 'Should show a partial script listing starting on line 4 with the current position on line 5' {
-            $result['l 4'] | Should -BeExactly $testScriptList
+            (NormalizeLineEnd -string $result['l 4']) | Should -BeExactly $testScriptList
         }
     }
 
@@ -163,6 +175,8 @@ Describe 'Basic debugger command tests' -tag 'CI' {
     3:                      $bp = Set-PSBreakpoint -Command Get-Process
     4:*                     Get-Process -Id $PID > $null
 '@
+
+            $testScriptList = NormalizeLineEnd -string $testScriptList
 
             $results = @(Test-Debugger -ScriptBlock $testScript -CommandQueue 'l 3 2','list 3 2')
             $result = @{
@@ -186,7 +200,7 @@ Describe 'Basic debugger command tests' -tag 'CI' {
         }
 
         It 'Should show a partial script listing showing 3 lines starting on line 4 with the current position on line 5' {
-            $result['l 3 2'] | Should -BeExactly $testScriptList
+            (NormalizeLineEnd -string $result['l 3 2']) | Should -BeExactly $testScriptList
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-List.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-List.Tests.ps1
@@ -176,7 +176,10 @@ dbda : KM
 
 
 "@
+        $expected = $expected -replace "`r`n", "`n"
 
-        $obj | Format-List | Out-String | Should -BeExactly $expected
+        $actual = $obj | Format-List | Out-String
+        $actual = $actual -replace "`r`n", "`n"
+        $actual | Should -BeExactly $expected
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
@@ -829,6 +829,7 @@ A Name                                  B
 
 "@
 
-            $obj | Format-Table | Out-String | Should -BeExactly $expected
+            $actual = $obj | Format-Table | Out-String
+            ($actual.Replace("`r`n", "`n")) | Should -BeExactly ($expected.Replace("`r`n", "`n"))
         }
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix tests which fail on comparing string due to differences in line endings.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
