### PR TITLE
Introduce a -matchall operator that finds *all* regex matches, to complement -match

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -5,7 +5,7 @@
 # On Windows paths is separated by semicolon
 $script:TestModulePathSeparator = [System.IO.Path]::PathSeparator
 
-$dotnetCLIChannel = 'release'
+$dotnetCLIChannel = 'preview' # TODO: Change this to 'release' once .Net Core 3.0 goes RTM
 $dotnetCLIRequiredVersion = $(Get-Content $PSScriptRoot/global.json | ConvertFrom-Json).Sdk.Version
 
 # Track if tags have been sync'ed
@@ -134,20 +134,11 @@ function Get-EnvironmentInformation
 
     if ($Environment.IsLinux) {
         $LinuxInfo = Get-Content /etc/os-release -Raw | ConvertFrom-StringData
-        $lsb_release = Get-Command lsb_release -Type Application -ErrorAction Ignore | Select-Object -First 1
-        if ($lsb_release) {
-            $LinuxID = & $lsb_release -is
-        }
-        else {
-            $LinuxID = ""
-        }
 
         $environment += @{'LinuxInfo' = $LinuxInfo}
         $environment += @{'IsDebian' = $LinuxInfo.ID -match 'debian' -or $LinuxInfo.ID -match 'kali'}
         $environment += @{'IsDebian9' = $Environment.IsDebian -and $LinuxInfo.VERSION_ID -match '9'}
-        $environment += @{'IsDebian10' = $Environment.IsDebian -and $LinuxInfo.VERSION_ID -match '10'}
-        $environment += @{'IsDebian11' = $Environment.IsDebian -and $LinuxInfo.PRETTY_NAME -match 'bullseye'}
-        $environment += @{'IsUbuntu' = $LinuxInfo.ID -match 'ubuntu' -or $LinuxID -match 'Ubuntu'}
+        $environment += @{'IsUbuntu' = $LinuxInfo.ID -match 'ubuntu'}
         $environment += @{'IsUbuntu16' = $Environment.IsUbuntu -and $LinuxInfo.VERSION_ID -match '16.04'}
         $environment += @{'IsUbuntu18' = $Environment.IsUbuntu -and $LinuxInfo.VERSION_ID -match '18.04'}
         $environment += @{'IsCentOS' = $LinuxInfo.ID -match 'centos' -and $LinuxInfo.VERSION_ID -match '7'}
@@ -208,30 +199,6 @@ function Test-IsPreview
     )
 
     return $Version -like '*-*'
-}
-
-<#
-    .Synopsis
-        Tests if a version is a Release Candidate
-    .EXAMPLE
-        Test-IsReleaseCandidate -version '6.1.0-sometthing' # returns false
-        Test-IsReleaseCandidate -version '6.1.0-rc.1' # returns true
-        Test-IsReleaseCandidate -version '6.1.0' # returns false
-#>
-function Test-IsReleaseCandidate
-{
-    param(
-        [parameter(Mandatory)]
-        [string]
-        $Version
-    )
-
-    if ($Version -like '*-rc.*')
-    {
-        return $true
-    }
-
-    return $false
 }
 
 function Start-PSBuild {
@@ -338,9 +305,12 @@ function Start-PSBuild {
     If ($dotnetCLIInstalledVersion -ne $dotnetCLIRequiredVersion) {
         Write-Warning @"
 The currently installed .NET Command Line Tools is not the required version.
+
 Installed version: $dotnetCLIInstalledVersion
 Required version: $dotnetCLIRequiredVersion
+
 Fix steps:
+
 1. Remove the installed version from:
     - on windows '`$env:LOCALAPPDATA\Microsoft\dotnet'
     - on macOS and linux '`$env:HOME/.dotnet'
@@ -498,18 +468,13 @@ Fix steps:
         $psVersion = git --git-dir="$PSSCriptRoot/.git" describe
     }
 
-    if ($Environment.IsRedHatFamily -or $Environment.IsDebian) {
-        # Symbolic links added here do NOT affect packaging as we do not build on Debian.
+    if ($Environment.IsRedHatFamily -or $Environment.IsDebian9) {
         # add two symbolic links to system shared libraries that libmi.so is dependent on to handle
         # platform specific changes. This is the only set of platforms needed for this currently
         # as Ubuntu has these specific library files in the platform and macOS builds for itself
         # against the correct versions.
 
-        if ($Environment.IsDebian10 -or $Environment.IsDebian11){
-            $sslTarget = "/usr/lib/x86_64-linux-gnu/libssl.so.1.1"
-            $cryptoTarget = "/usr/lib/x86_64-linux-gnu/libcrypto.so.1.1"
-        }
-        elseif ($Environment.IsDebian9){
+        if ($Environment.IsDebian9){
             # NOTE: Debian 8 doesn't need these symlinks
             $sslTarget = "/usr/lib/x86_64-linux-gnu/libssl.so.1.0.2"
             $cryptoTarget = "/usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.2"
@@ -543,7 +508,6 @@ Fix steps:
     # ARM is cross compiled, so we can't run pwsh to enumerate Experimental Features
     if (-not $SkipExperimentalFeatureGeneration -and
         (Test-IsPreview $psVersion) -and
-        -not (Test-IsReleaseCandidate $psVersion) -and
         -not $Runtime.Contains("arm") -and
         -not ($Runtime -like 'fxdependent*')) {
 
@@ -2013,6 +1977,7 @@ function Find-Dotnet() {
 
 <#
     This is one-time conversion. We use it for to turn GetEventResources.txt into GetEventResources.resx
+
     .EXAMPLE Convert-TxtResourceToXml -Path Microsoft.PowerShell.Commands.Diagnostics\resources
 #>
 function Convert-TxtResourceToXml
@@ -2066,9 +2031,9 @@ function script:Write-Log
         [ValidateNotNullOrEmpty()]
         [string] $message,
 
-        [switch] $isError
+        [switch] $error
     )
-    if ($isError)
+    if ($error)
     {
         Write-Host -Foreground Red $message
     }
@@ -2927,12 +2892,16 @@ $script:RESX_TEMPLATE = @'
 <root>
   <!--
     Microsoft ResX Schema
+
     Version 2.0
+
     The primary goals of this format is to allow a simple XML format
     that is mostly human readable. The generation and parsing of the
     various data types are done through the TypeConverter classes
     associated with the data types.
+
     Example:
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -2947,27 +2916,34 @@ $script:RESX_TEMPLATE = @'
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
+
     There are any number of "resheader" rows that contain simple
     name/value pairs.
+
     Each data row contains a name, and value. The row also contains a
     type or mimetype. Type corresponds to a .NET class that support
     text/value conversion through the TypeConverter architecture.
     Classes that don't support this are serialized and stored with the
     mimetype set.
+
     The mimetype is used for serialized objects, and tells the
     ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
+
     Note - application/x-microsoft.net.object.binary.base64 is the format
     that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
+
     mimetype: application/x-microsoft.net.object.binary.base64
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
+
     mimetype: application/x-microsoft.net.object.soap.base64
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
+
     mimetype: application/x-microsoft.net.object.bytearray.base64
     value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -1764,20 +1764,38 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Get or sets binary operator -Matchall.
+        /// Get or sets binary operator -Imatchall.
         /// </summary>
         [Parameter(Mandatory = true, ParameterSetName = "MatchSet")]
-        [Alias("MatchAll")]
-        public SwitchParameter MatchAll
+        [Alias("ImatchAll")]
+        public SwitchParameter ImatchAll
         {
             get
             {
-                return _binaryOperator == TokenKind.Matchall;
+                return _binaryOperator == TokenKind.Imatchall;
             }
 
             set
             {
-                _binaryOperator = TokenKind.Matchall;
+                _binaryOperator = TokenKind.Imatchall;
+            }
+        }
+
+         /// <summary>
+        /// Get or sets binary operator -Matchall.
+        /// </summary>
+        [Parameter(Mandatory = true, ParameterSetName = "MatchSet")]
+        [Alias("CmatchAll")]
+        public SwitchParameter CmatchAll
+        {
+            get
+            {
+                return _binaryOperator == TokenKind.Cmatchall;
+            }
+
+            set
+            {
+                _binaryOperator = TokenKind.Cmatchall;
             }
         }
 
@@ -2102,10 +2120,15 @@ namespace Microsoft.PowerShell.Commands
                     _operationDelegate =
                         (lval, rval) => ParserOps.LikeOperator(Context, PositionUtilities.EmptyExtent, lval, rval, _binaryOperator);
                     break;
-                case TokenKind.Matchall:
+                case TokenKind.Imatchall:
                     CheckLanguageMode();
                     _operationDelegate =
                         (lval, rval) => ParserOps.MatchAllOperator(Context, PositionUtilities.EmptyExtent, lval, (string) rval, ignoreCase: true);
+                    break;
+                case TokenKind.Cmatchall:
+                    CheckLanguageMode();
+                    _operationDelegate =
+                        (lval, rval) => ParserOps.MatchAllOperator(Context, PositionUtilities.EmptyExtent, lval, (string) rval, ignoreCase: false);
                     break;
                 case TokenKind.Imatch:
                     CheckLanguageMode();

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -1764,42 +1764,6 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Get or sets binary operator -Imatchall.
-        /// </summary>
-        [Parameter(Mandatory = true, ParameterSetName = "MatchSet")]
-        [Alias("ImatchAll")]
-        public SwitchParameter ImatchAll
-        {
-            get
-            {
-                return _binaryOperator == TokenKind.Imatchall;
-            }
-
-            set
-            {
-                _binaryOperator = TokenKind.Imatchall;
-            }
-        }
-
-         /// <summary>
-        /// Get or sets binary operator -Matchall.
-        /// </summary>
-        [Parameter(Mandatory = true, ParameterSetName = "MatchSet")]
-        [Alias("CmatchAll")]
-        public SwitchParameter CmatchAll
-        {
-            get
-            {
-                return _binaryOperator == TokenKind.Cmatchall;
-            }
-
-            set
-            {
-                _binaryOperator = TokenKind.Cmatchall;
-            }
-        }
-
-        /// <summary>
         /// Gets or sets binary operator -Contains.
         /// </summary>
         [Parameter(Mandatory = true, ParameterSetName = "ContainsSet")]

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -1764,6 +1764,24 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
+        /// Get or sets binary operator -Matchall.
+        /// </summary>
+        [Parameter(Mandatory = true, ParameterSetName = "MatchSet")]
+        [Alias("MatchAll")]
+        public SwitchParameter MatchAll
+        {
+            get
+            {
+                return _binaryOperator == TokenKind.Matchall;
+            }
+
+            set
+            {
+                _binaryOperator = TokenKind.Matchall;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets binary operator -Contains.
         /// </summary>
         [Parameter(Mandatory = true, ParameterSetName = "ContainsSet")]
@@ -2021,7 +2039,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 return;
             }
-
+            
             switch (_binaryOperator)
             {
                 case TokenKind.Ieq:
@@ -2083,6 +2101,11 @@ namespace Microsoft.PowerShell.Commands
                 case TokenKind.Cnotlike:
                     _operationDelegate =
                         (lval, rval) => ParserOps.LikeOperator(Context, PositionUtilities.EmptyExtent, lval, rval, _binaryOperator);
+                    break;
+                case TokenKind.Matchall:
+                    CheckLanguageMode();
+                    _operationDelegate =
+                        (lval, rval) => ParserOps.MatchAllOperator(Context, PositionUtilities.EmptyExtent, lval, (string) rval, ignoreCase: true);
                     break;
                 case TokenKind.Imatch:
                     CheckLanguageMode();

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -2021,7 +2021,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 return;
             }
-            
+
             switch (_binaryOperator)
             {
                 case TokenKind.Ieq:

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -1160,43 +1160,25 @@ namespace System.Management.Automation
         /// <param name="errorPosition">The position to use for error reporting.</param>
         /// <param name="lval">Left operand.</param>
         /// <param name="rval">Right operand.</param>
-        /// <param name="ignoreCase">Ignore case?</param>
+        /// <param name="ignoreCase">Ignore case.</param>
         /// <returns>The result of the operator.</returns>
         internal static object MatchAllOperator(ExecutionContext context, IScriptExtent errorPosition, object lval, string rval, bool ignoreCase)
         {
-            List<MatchCollection> matches = new List<MatchCollection>();
             IEnumerator list = LanguagePrimitives.GetEnumerator(lval);
             if (list == null)
             {
                 string lvalString = lval == null ? string.Empty : PSObject.ToStringParser(context, lval);
-                MatchCollection match;
-                if (ignoreCase)
-                {
-                    match = Regex.Matches(lvalString, rval, RegexOptions.IgnoreCase);
-                }
-                else
-                {
-                    match = Regex.Matches(lvalString, rval);
-                }
-               
-                return match;
+                RegexOptions options = ignoreCase ? RegexOptions.IgnoreCase : RegexOptions.None;
+                return Regex.Matches(lvalString, rval, options);
             }
-
+            
+            List<MatchCollection> matches = new List<MatchCollection>();
             while (list.MoveNext())
             {
                 object val = list.Current;
                 string lvalString = val == null ? string.Empty : PSObject.ToStringParser(context, val);
-                MatchCollection match;
-                if (ignoreCase)
-                {
-                    match = Regex.Matches(lvalString, rval, RegexOptions.IgnoreCase);
-                }
-                else
-                {
-                    match = Regex.Matches(lvalString, rval);
-                }
-               
-                matches.Add(match);
+                RegexOptions options = ignoreCase ? RegexOptions.IgnoreCase : RegexOptions.None;
+                matches.Add(Regex.Matches(lvalString, rval, options));
             }
             
             return matches.ToArray();

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -1164,7 +1164,6 @@ namespace System.Management.Automation
         /// <returns>The result of the operator.</returns>
         internal static object MatchAllOperator(ExecutionContext context, IScriptExtent errorPosition, object lval, string rval, bool ignoreCase)
         {
-            Regex r = new Regex(rval);
             List<MatchCollection> matches = new List<MatchCollection>();
             string[] text;
             if (lval is string)
@@ -1180,7 +1179,16 @@ namespace System.Management.Automation
 
             foreach(string s in text)
             {
-                MatchCollection match = Regex.Matches(s, rval);
+                MatchCollection match;
+                if (ignoreCase)
+                {
+                    match = Regex.Matches(s, rval, RegexOptions.IgnoreCase);
+                }
+                else
+                {
+                    match = Regex.Matches(s, rval);
+                }
+               
                 matches.Add(match);
                 
             }

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Linq;
 using System.Management.Automation.Internal;
 using System.Management.Automation.Internal.Host;
 using System.Management.Automation.Language;
@@ -1150,6 +1151,41 @@ namespace System.Management.Automation
             }
 
             return resultList.ToArray();
+        }
+
+        /// <summary>
+        /// Implementation of the PowerShell -matchall operator.
+        /// </summary>
+        /// <param name="context">The execution context to use.</param>
+        /// <param name="errorPosition">The position to use for error reporting.</param>
+        /// <param name="lval">Left operand.</param>
+        /// <param name="rval">Right operand.</param>
+        /// <param name="ignoreCase">Ignore case?</param>
+        /// <returns>The result of the operator.</returns>
+        internal static object MatchAllOperator(ExecutionContext context, IScriptExtent errorPosition, object lval, string rval, bool ignoreCase)
+        {
+            Regex r = new Regex(rval);
+            List<MatchCollection> matches = new List<MatchCollection>();
+            string[] text;
+            if (lval is string)
+            {
+                text = new string[]{(string)lval};
+            } 
+            else
+            {
+                text = ((IEnumerable)lval).Cast<object>()
+                                 .Select(x => x.ToString())
+                                 .ToArray();
+            }
+
+            foreach(string s in text)
+            {
+                MatchCollection match = Regex.Matches(s, rval);
+                matches.Add(match);
+                
+            }
+            
+            return matches.ToArray();
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -5799,7 +5799,7 @@ namespace System.Management.Automation.Language
                         Expression.Constant(binaryExpressionAst.ErrorPosition),
                         lhs.Cast(typeof(object)),
                         rhs.Cast(typeof(string)),
-                        ExpressionCache.Constant(false));
+                        ExpressionCache.Constant(true));
                 case TokenKind.Ireplace:
                     // TODO: replace this with faster code
                     return Expression.Call(

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -5792,7 +5792,6 @@ namespace System.Management.Automation.Language
                         ExpressionCache.Constant(true),
                         ExpressionCache.Constant(true));
                 case TokenKind.Imatchall:
-                    // TODO: replace this with faster code
                     return Expression.Call(
                         CachedReflectionInfo.ParserOps_MatchAllOperator,
                         s_executionContextParameter,
@@ -5873,7 +5872,6 @@ namespace System.Management.Automation.Language
                         ExpressionCache.Constant(false),
                         ExpressionCache.Constant(false));
                 case TokenKind.Cmatchall:
-                    // TODO: replace this with faster code
                     return Expression.Call(
                         CachedReflectionInfo.ParserOps_MatchAllOperator,
                         s_executionContextParameter,

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -5791,7 +5791,7 @@ namespace System.Management.Automation.Language
                         rhs.Cast(typeof(object)),
                         ExpressionCache.Constant(true),
                         ExpressionCache.Constant(true));
-                case TokenKind.Matchall:
+                case TokenKind.Imatchall:
                     // TODO: replace this with faster code
                     return Expression.Call(
                         CachedReflectionInfo.ParserOps_MatchAllOperator,
@@ -5871,6 +5871,15 @@ namespace System.Management.Automation.Language
                         lhs.Cast(typeof(object)),
                         rhs.Cast(typeof(object)),
                         ExpressionCache.Constant(false),
+                        ExpressionCache.Constant(false));
+                case TokenKind.Cmatchall:
+                    // TODO: replace this with faster code
+                    return Expression.Call(
+                        CachedReflectionInfo.ParserOps_MatchAllOperator,
+                        s_executionContextParameter,
+                        Expression.Constant(binaryExpressionAst.ErrorPosition),
+                        lhs.Cast(typeof(object)),
+                        rhs.Cast(typeof(string)),
                         ExpressionCache.Constant(false));
                 case TokenKind.Cnotmatch:
                     // TODO: replace this with faster code

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -332,6 +332,9 @@ namespace System.Management.Automation.Language
 
         internal static readonly MethodInfo ParserOps_MatchOperator =
             typeof(ParserOps).GetMethod(nameof(ParserOps.MatchOperator), StaticFlags);
+        
+        internal static readonly MethodInfo ParserOps_MatchAllOperator =
+            typeof(ParserOps).GetMethod(nameof(ParserOps.MatchAllOperator), StaticFlags);
 
         internal static readonly MethodInfo ParserOps_RangeOperator =
             typeof(ParserOps).GetMethod(nameof(ParserOps.RangeOperator), StaticFlags);
@@ -5788,6 +5791,15 @@ namespace System.Management.Automation.Language
                         rhs.Cast(typeof(object)),
                         ExpressionCache.Constant(true),
                         ExpressionCache.Constant(true));
+                case TokenKind.Matchall:
+                    // TODO: replace this with faster code
+                    return Expression.Call(
+                        CachedReflectionInfo.ParserOps_MatchAllOperator,
+                        s_executionContextParameter,
+                        Expression.Constant(binaryExpressionAst.ErrorPosition),
+                        lhs.Cast(typeof(object)),
+                        rhs.Cast(typeof(string)),
+                        ExpressionCache.Constant(false));
                 case TokenKind.Ireplace:
                     // TODO: replace this with faster code
                     return Expression.Call(

--- a/src/System.Management.Automation/engine/parser/token.cs
+++ b/src/System.Management.Automation/engine/parser/token.cs
@@ -427,9 +427,14 @@ namespace System.Management.Automation.Language
 
         /// <summary>The null conditional index access operator '?[]'.</summary>
         QuestionLBracket = 104,
+
         /// <summary>The case insensitive match operator '-imatchall' or '-matchall'.</summary>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
-        Matchall = 105,
+        Imatchall = 105,
+
+        /// <summary>The case insensitive match operator '-cmatchall'.</summary>
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
+        Cmatchall = 106,
 
         #endregion Operators
 
@@ -879,7 +884,7 @@ namespace System.Management.Automation.Language
             /*          QuestionDot */ TokenFlags.SpecialOperator | TokenFlags.DisallowedInRestrictedMode,
             /*     QuestionLBracket */ TokenFlags.None,
             /*           Imatchall  */ TokenFlags.BinaryOperator | TokenFlags.BinaryPrecedenceComparison | TokenFlags.DisallowedInRestrictedMode,
-            /*     Reserved slot 8  */ TokenFlags.None,
+            /*           CMatchall  */ TokenFlags.BinaryOperator | TokenFlags.BinaryPrecedenceComparison | TokenFlags.DisallowedInRestrictedMode,
             /*     Reserved slot 9  */ TokenFlags.None,
             /*     Reserved slot 10 */ TokenFlags.None,
             /*     Reserved slot 11 */ TokenFlags.None,

--- a/src/System.Management.Automation/engine/parser/token.cs
+++ b/src/System.Management.Automation/engine/parser/token.cs
@@ -427,6 +427,9 @@ namespace System.Management.Automation.Language
 
         /// <summary>The null conditional index access operator '?[]'.</summary>
         QuestionLBracket = 104,
+        /// <summary>The case insensitive match operator '-imatchall' or '-matchall'.</summary>
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
+        Matchall = 105,
 
         #endregion Operators
 
@@ -583,7 +586,7 @@ namespace System.Management.Automation.Language
         Hidden = 167,
 
         /// <summary>The 'base' keyword</summary>
-        Base = 168,
+        Base = 168
 
         #endregion Keywords
     }
@@ -875,7 +878,7 @@ namespace System.Management.Automation.Language
             /*     QuestionQuestion */ TokenFlags.BinaryOperator | TokenFlags.BinaryPrecedenceCoalesce,
             /*          QuestionDot */ TokenFlags.SpecialOperator | TokenFlags.DisallowedInRestrictedMode,
             /*     QuestionLBracket */ TokenFlags.None,
-            /*     Reserved slot 7  */ TokenFlags.None,
+            /*            matchall  */ TokenFlags.BinaryOperator | TokenFlags.BinaryPrecedenceComparison | TokenFlags.DisallowedInRestrictedMode,
             /*     Reserved slot 8  */ TokenFlags.None,
             /*     Reserved slot 9  */ TokenFlags.None,
             /*     Reserved slot 10 */ TokenFlags.None,
@@ -1073,7 +1076,7 @@ namespace System.Management.Automation.Language
             /*     QuestionQuestion */ "??",
             /*          QuestionDot */ "?.",
             /*     QuestionLBracket */ "?[",
-            /*    Reserved slot 7   */ string.Empty,
+            /*            matchall  */ "-matchall",
             /*    Reserved slot 8   */ string.Empty,
             /*    Reserved slot 9   */ string.Empty,
             /*    Reserved slot 10  */ string.Empty,
@@ -1163,7 +1166,7 @@ namespace System.Management.Automation.Language
             Diagnostics.Assert(GetTraits(TokenKind.Shr) == (TokenFlags.BinaryOperator | TokenFlags.BinaryPrecedenceComparison | TokenFlags.CanConstantFold),
                                "Table out of sync with enum - flags Shr");
             Diagnostics.Assert(s_tokenText[(int)TokenKind.Shr].Equals("-shr", StringComparison.OrdinalIgnoreCase),
-                               "Table out of sync with enum - text Shr");
+                               "Table out of sync with enum - text Shr " + s_tokenText[(int)TokenKind.Shr]);
         }
 #endif
 

--- a/src/System.Management.Automation/engine/parser/token.cs
+++ b/src/System.Management.Automation/engine/parser/token.cs
@@ -1171,7 +1171,7 @@ namespace System.Management.Automation.Language
             Diagnostics.Assert(GetTraits(TokenKind.Shr) == (TokenFlags.BinaryOperator | TokenFlags.BinaryPrecedenceComparison | TokenFlags.CanConstantFold),
                                "Table out of sync with enum - flags Shr");
             Diagnostics.Assert(s_tokenText[(int)TokenKind.Shr].Equals("-shr", StringComparison.OrdinalIgnoreCase),
-                               "Table out of sync with enum - text Shr " + s_tokenText[(int)TokenKind.Shr]);
+                               "Table out of sync with enum - text Shr ");
         }
 #endif
 

--- a/src/System.Management.Automation/engine/parser/token.cs
+++ b/src/System.Management.Automation/engine/parser/token.cs
@@ -1171,7 +1171,7 @@ namespace System.Management.Automation.Language
             Diagnostics.Assert(GetTraits(TokenKind.Shr) == (TokenFlags.BinaryOperator | TokenFlags.BinaryPrecedenceComparison | TokenFlags.CanConstantFold),
                                "Table out of sync with enum - flags Shr");
             Diagnostics.Assert(s_tokenText[(int)TokenKind.Shr].Equals("-shr", StringComparison.OrdinalIgnoreCase),
-                               "Table out of sync with enum - text Shr ");
+                               "Table out of sync with enum - text Shr");
         }
 #endif
 

--- a/src/System.Management.Automation/engine/parser/token.cs
+++ b/src/System.Management.Automation/engine/parser/token.cs
@@ -878,7 +878,7 @@ namespace System.Management.Automation.Language
             /*     QuestionQuestion */ TokenFlags.BinaryOperator | TokenFlags.BinaryPrecedenceCoalesce,
             /*          QuestionDot */ TokenFlags.SpecialOperator | TokenFlags.DisallowedInRestrictedMode,
             /*     QuestionLBracket */ TokenFlags.None,
-            /*            matchall  */ TokenFlags.BinaryOperator | TokenFlags.BinaryPrecedenceComparison | TokenFlags.DisallowedInRestrictedMode,
+            /*           Imatchall  */ TokenFlags.BinaryOperator | TokenFlags.BinaryPrecedenceComparison | TokenFlags.DisallowedInRestrictedMode,
             /*     Reserved slot 8  */ TokenFlags.None,
             /*     Reserved slot 9  */ TokenFlags.None,
             /*     Reserved slot 10 */ TokenFlags.None,

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -663,7 +663,8 @@ namespace System.Management.Automation.Language
         /*13*/  "isplit",               "csplit",               "isnot",                "is",                     /*13*/
         /*14*/  "as",                   "f",                    "and",                  "band",                   /*14*/
         /*15*/  "or",                   "bor",                  "xor",                  "bxor",                   /*15*/
-        /*16*/  "join",                 "shl",                  "shr",                  "matchall"                                        /*16*/
+        /*16*/  "join",                 "shl",                  "shr",                  "matchall",               /*16*/
+        /*17*/  "imatchall"
         };
 
         private static readonly TokenKind[] s_operatorTokenKind = new TokenKind[] {
@@ -682,7 +683,8 @@ namespace System.Management.Automation.Language
         /*13*/  TokenKind.Isplit,       TokenKind.Csplit,       TokenKind.IsNot,        TokenKind.Is,             /*13*/
         /*14*/  TokenKind.As,           TokenKind.Format,       TokenKind.And,          TokenKind.Band,           /*14*/
         /*15*/  TokenKind.Or,           TokenKind.Bor,          TokenKind.Xor,          TokenKind.Bxor,           /*15*/
-        /*16*/  TokenKind.Join,         TokenKind.Shl,          TokenKind.Shr,          TokenKind.Matchall,                                  /*16*/
+        /*16*/  TokenKind.Join,         TokenKind.Shl,          TokenKind.Shr,          TokenKind.Matchall,       /*16*/
+        /*17*/  TokenKind.Matchall
         };
 
         #endregion Tables for initialization

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -644,7 +644,7 @@ namespace System.Management.Automation.Language
         /*A*/    TokenKind.Configuration,   TokenKind.Public,   TokenKind.Private,  TokenKind.Static,             /*A*/
         /*B*/    TokenKind.Interface,       TokenKind.Enum,     TokenKind.Namespace,TokenKind.Module,             /*B*/
         /*C*/    TokenKind.Type,            TokenKind.Assembly, TokenKind.Command,  TokenKind.Hidden,             /*C*/
-        /*D*/    TokenKind.Base,                                                                                  /*D*/
+        /*D*/    TokenKind.Base,                                                                                           /*D*/
         };
 
         internal static readonly string[] _operatorText = new string[] {
@@ -663,7 +663,7 @@ namespace System.Management.Automation.Language
         /*13*/  "isplit",               "csplit",               "isnot",                "is",                     /*13*/
         /*14*/  "as",                   "f",                    "and",                  "band",                   /*14*/
         /*15*/  "or",                   "bor",                  "xor",                  "bxor",                   /*15*/
-        /*16*/  "join",                 "shl",                  "shr",                                            /*16*/
+        /*16*/  "join",                 "shl",                  "shr",                  "matchall"                                        /*16*/
         };
 
         private static readonly TokenKind[] s_operatorTokenKind = new TokenKind[] {
@@ -682,7 +682,7 @@ namespace System.Management.Automation.Language
         /*13*/  TokenKind.Isplit,       TokenKind.Csplit,       TokenKind.IsNot,        TokenKind.Is,             /*13*/
         /*14*/  TokenKind.As,           TokenKind.Format,       TokenKind.And,          TokenKind.Band,           /*14*/
         /*15*/  TokenKind.Or,           TokenKind.Bor,          TokenKind.Xor,          TokenKind.Bxor,           /*15*/
-        /*16*/  TokenKind.Join,         TokenKind.Shl,          TokenKind.Shr,                                    /*16*/
+        /*16*/  TokenKind.Join,         TokenKind.Shl,          TokenKind.Shr,          TokenKind.Matchall,                                  /*16*/
         };
 
         #endregion Tables for initialization

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -664,7 +664,7 @@ namespace System.Management.Automation.Language
         /*14*/  "as",                   "f",                    "and",                  "band",                   /*14*/
         /*15*/  "or",                   "bor",                  "xor",                  "bxor",                   /*15*/
         /*16*/  "join",                 "shl",                  "shr",                  "matchall",               /*16*/
-        /*17*/  "imatchall"
+        /*17*/  "imatchall",            "cmatchall"
         };
 
         private static readonly TokenKind[] s_operatorTokenKind = new TokenKind[] {
@@ -683,8 +683,8 @@ namespace System.Management.Automation.Language
         /*13*/  TokenKind.Isplit,       TokenKind.Csplit,       TokenKind.IsNot,        TokenKind.Is,             /*13*/
         /*14*/  TokenKind.As,           TokenKind.Format,       TokenKind.And,          TokenKind.Band,           /*14*/
         /*15*/  TokenKind.Or,           TokenKind.Bor,          TokenKind.Xor,          TokenKind.Bxor,           /*15*/
-        /*16*/  TokenKind.Join,         TokenKind.Shl,          TokenKind.Shr,          TokenKind.Matchall,       /*16*/
-        /*17*/  TokenKind.Matchall
+        /*16*/  TokenKind.Join,         TokenKind.Shl,          TokenKind.Shr,          TokenKind.Imatchall,       /*16*/
+        /*17*/  TokenKind.Imatchall,    TokenKind.Cmatchall
         };
 
         #endregion Tables for initialization

--- a/test/powershell/Language/Operators/MatchAllOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/MatchAllOperator.Tests.ps1
@@ -30,7 +30,7 @@ Describe "MatchAll/IMatchAll Operator" -Tags CI {
             $imatch = $string -imatchall $pattern
             $match.Count | Should -Be $string.Length
             $imatch.Count | Should -Be $string.Length
-            For ($i = 0; i -lt $string.Length; $i++)
+            For ($i = 0; $i -lt $string.Length; $i++)
             {
                 $match.Value[$i] | Should -Be $string[$i]
                 $match.Index[$i] | Should -Be $i

--- a/test/powershell/Language/Operators/MatchAllOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/MatchAllOperator.Tests.ps1
@@ -12,11 +12,11 @@ Describe "MatchAll/IMatchAll Operator" -Tags CI {
             param($string, $pattern)
             $match = $string -matchall $pattern
             $match.Count | Should -Be 1
-            $match.Value | Should -Be $string
+            $match.Value | Should -BeExactly $string
 
             $match = $string -imatchall $pattern
             $match.Count | Should -Be 1
-            $match.Value | Should -Be $string
+            $match.Value | Should -BeExactly $string
         }
 
         It "Should produce two matches from a pattern with regex syntax" -TestCases @(

--- a/test/powershell/Language/Operators/MatchAllOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/MatchAllOperator.Tests.ps1
@@ -45,47 +45,43 @@ Describe "MatchAll/IMatchAll Operator" -Tags CI {
 
     Context "Array LHS regular expression matching" {
         It "Should produce different matches from different strings in the array" -TestCases @(
-            @{ strings = 'foo', 'baa'; $pattern = 'o|a' },
-            @{ strings = 'foo', 'baa'; $pattern = 'o|A' },
-            @{ strings = 'foO', 'baa'; $pattern = 'o|a' }
+            @{ strings = 'foo', 'baa'; pattern = 'o|a' },
+            @{ strings = 'foo', 'baa'; pattern = 'o|A' },
+            @{ strings = 'foo', 'baa'; pattern = 'O|A' }
         ) {
             param($strings, $pattern)
             $match = $strings -matchall $pattern
             $imatch = $strings -imatchall $pattern
-            $match.Count | Should -Be 4
-            $imatch.Count | Should -Be 4
+            $match.Count | Should -Be 2
+            $imatch.Count | Should -Be 2
+            $match[0].Count | Should -Be 2
+            $imatch[0].Count | Should -Be 2
+            $match[1].Count | Should -Be 2
+            $imatch[1].Count | Should -Be 2
 
-            $match.Value[0] | Should -Be "o"
+            $match.Value[0] | Should -BeExactly "o"
             $match.Index[0] | Should -Be 1
-            $match.Length[0] | Should -Be 1
 
-            $match.Value[1] | Should -Be "o"
+            $match.Value[1] | Should -BeExactly "o"
             $match.Index[1] | Should -Be 2
-            $match.Length[1] | Should -Be 1
 
-            $match.Value[2] | Should -Be "a"
+            $match.Value[2] | Should -BeExactly "a"
             $match.Index[2] | Should -Be 1
-            $match.Length[2] | Should -Be 1
 
-            $match.Value[3] | Should -Be "a"
+            $match.Value[3] | Should -BeExactly "a"
             $match.Index[3] | Should -Be 2
-            $match.Length[3] | Should -Be 1
 
-            $imatch.Value[0] | Should -Be "o"
+            $imatch.Value[0] | Should -BeExactly "o"
             $imatch.Index[0] | Should -Be 1
-            $imatch.Length[0] | Should -Be 1
 
-            $imatch.Value[1] | Should -Be "o"
+            $imatch.Value[1] | Should -BeExactly "o"
             $imatch.Index[1] | Should -Be 2
-            $imatch.Length[1] | Should -Be 1
 
-            $imatch.Value[2] | Should -Be "a"
+            $imatch.Value[2] | Should -BeExactly "a"
             $imatch.Index[2] | Should -Be 1
-            $imatch.Length[2] | Should -Be 1
 
-            $imatch.Value[3] | Should -Be "a"
+            $imatch.Value[3] | Should -BeExactly "a"
             $imatch.Index[3] | Should -Be 2
-            $imatch.Length[3] | Should -Be 1
         }
     }
 }
@@ -98,13 +94,11 @@ Describe "CMatchAll operator" -Tags CI {
             $match = $string -cmatchall $pattern
             $match.Count | Should -Be 2
 
-            $match.Value[0] | Should -Be "o"
+            $match.Value[0] | Should -BeExactly "o"
             $match.Index[0] | Should -Be 1
-            $match.Length[0] | Should -Be 1
 
-            $match.Value[1] | Should -Be "o"
+            $match.Value[1] | Should -BeExactly "o"
             $match.Index[1] | Should -Be 2
-            $match.Length[1] | Should -Be 1
 
         }
 
@@ -121,23 +115,21 @@ Describe "CMatchAll operator" -Tags CI {
             $strings = 'foo', 'baa'
             $pattern = 'o|a'
             $match = $strings -cmatchall $pattern
-            $match.Count | Should -Be 4
+            $match.Count | Should -Be 2
+            $match[0].Count | Should -Be 2
+            $match[1].Count | Should -Be 2
 
-            $match.Value[0] | Should -Be "o"
+            $match.Value[0] | Should -BeExactly "o"
             $match.Index[0] | Should -Be 1
-            $match.Length[0] | Should -Be 1
 
-            $match.Value[1] | Should -Be "o"
+            $match.Value[1] | Should -BeExactly "o"
             $match.Index[1] | Should -Be 2
-            $match.Length[1] | Should -Be 1
 
-            $match.Value[2] | Should -Be "a"
+            $match.Value[2] | Should -BeExactly "a"
             $match.Index[2] | Should -Be 1
-            $match.Length[2] | Should -Be 1
 
-            $match.Value[3] | Should -Be "a"
+            $match.Value[3] | Should -BeExactly "a"
             $match.Index[3] | Should -Be 2
-            $match.Length[3] | Should -Be 1
         }
 
         It "One character the pattern is uppercase and all characters in the strings are lowercase" {
@@ -146,13 +138,11 @@ Describe "CMatchAll operator" -Tags CI {
             $match = $strings -cmatchall $pattern
             $match.Count | Should -Be 2
 
-            $match.Value[0] | Should -Be "o"
+            $match.Value[0] | Should -BeExactly "o"
             $match.Index[0] | Should -Be 1
-            $match.Length[0] | Should -Be 1
 
-            $match.Value[1] | Should -Be "o"
+            $match.Value[1] | Should -BeExactly "o"
             $match.Index[1] | Should -Be 2
-            $match.Length[1] | Should -Be 1
         }
     }
 }

--- a/test/powershell/Language/Operators/MatchAllOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/MatchAllOperator.Tests.ps1
@@ -45,15 +45,19 @@ Describe "MatchAll/IMatchAll Operator" -Tags CI {
 
     Context "Array LHS regular expression matching" {
         It "Should produce different matches from different strings in the array" -TestCases @(
-            @{ strings = 'foo', 'baa'; $pattern = 'o|a' },
-            @{ strings = 'foo', 'baa'; $pattern = 'o|A' },
-            @{ strings = 'foO', 'baa'; $pattern = 'o|a' }
+            @{ strings = 'foo', 'baa'; pattern = 'o|a' },
+            @{ strings = 'foo', 'baa'; pattern = 'o|A' },
+            @{ strings = 'foO', 'baa'; pattern = 'o|a' }
         ) {
             param($strings, $pattern)
             $match = $strings -matchall $pattern
             $imatch = $strings -imatchall $pattern
-            $match.Count | Should -Be 4
-            $imatch.Count | Should -Be 4
+            $match.Count | Should -Be 2
+            $imatch.Count | Should -Be 2
+            $match[0].Count | Should -Be 2
+            $imatch[0].Count | Should -Be 2
+            $match[1].Count | Should -Be 2
+            $imatch[1].Count | Should -Be 2
 
             $match.Value[0] | Should -Be "o"
             $match.Index[0] | Should -Be 1
@@ -111,7 +115,9 @@ Describe "CMatchAll operator" -Tags CI {
             $strings = 'foo', 'baa'
             $pattern = 'o|a'
             $match = $strings -cmatchall $pattern
-            $match.Count | Should -Be 4
+            $match.Count | Should -Be 2
+            $match[0].Count | Should -Be 2
+            $match[1].Count | Should -Be 2
 
             $match.Value[0] | Should -Be "o"
             $match.Index[0] | Should -Be 1

--- a/test/powershell/Language/Operators/MatchAllOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/MatchAllOperator.Tests.ps1
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-Describe "Scalar LHS MatchAll Operator" {
+Describe "Scalar LHS MatchAll Operator" -Tags CI {
     Context "Case insensitive regular expression matching" {
         It "Should produce one match from an exact string pattern" {
             $pattern = "foo"
@@ -83,7 +83,7 @@ Describe "Scalar LHS MatchAll Operator" {
     }
 }
 
-Describe "Array LHS MatchAll operator" {
+Describe "Array LHS MatchAll operator" -Tags CI {
     Context "Case insensitive regular expression matching" {
         It "Should produce different matches from different strings in the array" {
             $strings = 'foo', 'baa'

--- a/test/powershell/Language/Operators/MatchAllOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/MatchAllOperator.Tests.ps1
@@ -57,35 +57,27 @@ Describe "MatchAll/IMatchAll Operator" -Tags CI {
 
             $match.Value[0] | Should -Be "o"
             $match.Index[0] | Should -Be 1
-            $match.Length[0] | Should -Be 1
 
             $match.Value[1] | Should -Be "o"
             $match.Index[1] | Should -Be 2
-            $match.Length[1] | Should -Be 1
 
             $match.Value[2] | Should -Be "a"
             $match.Index[2] | Should -Be 1
-            $match.Length[2] | Should -Be 1
 
             $match.Value[3] | Should -Be "a"
             $match.Index[3] | Should -Be 2
-            $match.Length[3] | Should -Be 1
 
             $imatch.Value[0] | Should -Be "o"
             $imatch.Index[0] | Should -Be 1
-            $imatch.Length[0] | Should -Be 1
 
             $imatch.Value[1] | Should -Be "o"
             $imatch.Index[1] | Should -Be 2
-            $imatch.Length[1] | Should -Be 1
 
             $imatch.Value[2] | Should -Be "a"
             $imatch.Index[2] | Should -Be 1
-            $imatch.Length[2] | Should -Be 1
 
             $imatch.Value[3] | Should -Be "a"
             $imatch.Index[3] | Should -Be 2
-            $imatch.Length[3] | Should -Be 1
         }
     }
 }
@@ -100,11 +92,9 @@ Describe "CMatchAll operator" -Tags CI {
 
             $match.Value[0] | Should -Be "o"
             $match.Index[0] | Should -Be 1
-            $match.Length[0] | Should -Be 1
 
             $match.Value[1] | Should -Be "o"
             $match.Index[1] | Should -Be 2
-            $match.Length[1] | Should -Be 1
 
         }
 
@@ -125,19 +115,15 @@ Describe "CMatchAll operator" -Tags CI {
 
             $match.Value[0] | Should -Be "o"
             $match.Index[0] | Should -Be 1
-            $match.Length[0] | Should -Be 1
 
             $match.Value[1] | Should -Be "o"
             $match.Index[1] | Should -Be 2
-            $match.Length[1] | Should -Be 1
 
             $match.Value[2] | Should -Be "a"
             $match.Index[2] | Should -Be 1
-            $match.Length[2] | Should -Be 1
 
             $match.Value[3] | Should -Be "a"
             $match.Index[3] | Should -Be 2
-            $match.Length[3] | Should -Be 1
         }
 
         It "One character the pattern is uppercase and all characters in the strings are lowercase" {
@@ -148,11 +134,9 @@ Describe "CMatchAll operator" -Tags CI {
 
             $match.Value[0] | Should -Be "o"
             $match.Index[0] | Should -Be 1
-            $match.Length[0] | Should -Be 1
 
             $match.Value[1] | Should -Be "o"
             $match.Index[1] | Should -Be 2
-            $match.Length[1] | Should -Be 1
         }
     }
 }

--- a/test/powershell/Language/Operators/MatchAllOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/MatchAllOperator.Tests.ps1
@@ -61,27 +61,35 @@ Describe "MatchAll/IMatchAll Operator" -Tags CI {
 
             $match.Value[0] | Should -Be "o"
             $match.Index[0] | Should -Be 1
+            $match.Length[0] | Should -Be 1
 
             $match.Value[1] | Should -Be "o"
             $match.Index[1] | Should -Be 2
+            $match.Length[1] | Should -Be 1
 
             $match.Value[2] | Should -Be "a"
             $match.Index[2] | Should -Be 1
+            $match.Length[2] | Should -Be 1
 
             $match.Value[3] | Should -Be "a"
             $match.Index[3] | Should -Be 2
+            $match.Length[3] | Should -Be 1
 
             $imatch.Value[0] | Should -Be "o"
             $imatch.Index[0] | Should -Be 1
+            $imatch.Length[0] | Should -Be 1
 
             $imatch.Value[1] | Should -Be "o"
             $imatch.Index[1] | Should -Be 2
+            $imatch.Length[1] | Should -Be 1
 
             $imatch.Value[2] | Should -Be "a"
             $imatch.Index[2] | Should -Be 1
+            $imatch.Length[2] | Should -Be 1
 
             $imatch.Value[3] | Should -Be "a"
             $imatch.Index[3] | Should -Be 2
+            $imatch.Length[3] | Should -Be 1
         }
     }
 }
@@ -96,9 +104,11 @@ Describe "CMatchAll operator" -Tags CI {
 
             $match.Value[0] | Should -Be "o"
             $match.Index[0] | Should -Be 1
+            $match.Length[0] | Should -Be 1
 
             $match.Value[1] | Should -Be "o"
             $match.Index[1] | Should -Be 2
+            $match.Length[1] | Should -Be 1
 
         }
 
@@ -121,15 +131,19 @@ Describe "CMatchAll operator" -Tags CI {
 
             $match.Value[0] | Should -Be "o"
             $match.Index[0] | Should -Be 1
+            $match.Length[0] | Should -Be 1
 
             $match.Value[1] | Should -Be "o"
             $match.Index[1] | Should -Be 2
+            $match.Length[1] | Should -Be 1
 
             $match.Value[2] | Should -Be "a"
             $match.Index[2] | Should -Be 1
+            $match.Length[2] | Should -Be 1
 
             $match.Value[3] | Should -Be "a"
             $match.Index[3] | Should -Be 2
+            $match.Length[3] | Should -Be 1
         }
 
         It "One character the pattern is uppercase and all characters in the strings are lowercase" {
@@ -140,9 +154,11 @@ Describe "CMatchAll operator" -Tags CI {
 
             $match.Value[0] | Should -Be "o"
             $match.Index[0] | Should -Be 1
+            $match.Length[0] | Should -Be 1
 
             $match.Value[1] | Should -Be "o"
             $match.Index[1] | Should -Be 2
+            $match.Length[1] | Should -Be 1
         }
     }
 }

--- a/test/powershell/Language/Operators/MatchAllOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/MatchAllOperator.Tests.ps1
@@ -1,0 +1,130 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+Describe "Scalar LHS MatchAll Operator" {
+    Context "Case insensitive regular expression matching" {
+        It "Should produce one match from an exact string pattern" {
+            $pattern = "foo"
+            $string = "foo"
+            $match = $string -matchall $pattern
+            $match.Count | Should -Be 1
+            $match.Value | Should -Be "foo"
+        }
+
+        It "Should produce two matches from a substring that matches twice (different case)" {
+            $pattern = "O"
+            $string = "foO"
+            $match = $string -matchall $pattern
+            $match.Count | Should -Be 2
+
+            $match.Value[0] | Should -Be "o"
+            $match.Index[0] | Should -Be 1
+            $match.Length[0] | Should -Be 1
+
+            $match.Value[1] | Should -Be "o"
+            $match.Index[1] | Should -Be 2
+            $match.Length[1] | Should -Be 1
+        }
+
+        It "Should produce two matches from a pattern with regex syntax" {
+            $pattern = "(.)"
+            $string = "foo"
+            $match = $string -matchall $pattern
+            $match.Count | Should -Be 3
+
+            $match.Value[0] | Should -Be "f"
+            $match.Index[0] | Should -Be 0
+            $match.Length[0] | Should -Be 1
+
+            $match.Value[0] | Should -Be "o"
+            $match.Index[0] | Should -Be 1
+            $match.Length[0] | Should -Be 1
+
+            $match.Value[1] | Should -Be "o"
+            $match.Index[1] | Should -Be 2
+            $match.Length[1] | Should -Be 1
+        }
+    }
+
+    Context "Case sensitive regular expression matching" {
+        It "Should produce no matches from an exact string pattern with different case" {
+            $pattern = "FOo"
+            $string = "foo"
+            $match = $string -matchall $pattern
+            $match.Count | Should -Be 0
+        }
+
+        It "Should produce one match from an exact string pattern with the same casing" {
+            $pattern = "foo"
+            $string = "foo"
+            $match = $string -matchall $pattern
+            $match.Count | Should -Be 1
+            $match.Value | Should -Be "foo"
+        }
+
+        It "Should produce two matches from a pattern with regex syntax" {
+            $pattern = "(.)"
+            $string = "fOo"
+            $match = $string -matchall $pattern
+            $match.Count | Should -Be 3
+
+            $match.Value[0] | Should -Be "f"
+            $match.Index[0] | Should -Be 0
+            $match.Length[0] | Should -Be 1
+
+            $match.Value[0] | Should -Be "o"
+            $match.Index[0] | Should -Be 1
+            $match.Length[0] | Should -Be 1
+
+            $match.Value[1] | Should -Be "o"
+            $match.Index[1] | Should -Be 2
+            $match.Length[1] | Should -Be 1
+        }
+    }
+}
+
+Describe "Array LHS MatchAll operator" {
+    Context "Case insensitive regular expression matching" {
+        It "Should produce different matches from different strings in the array" {
+            $strings = 'foo', 'baa'
+            $pattern = 'o|a'
+            $match = $strings -matchall $pattern
+            $match.Count | Should -Be 4
+
+            $match.Value[0] | Should -Be "o"
+            $match.Index[0] | Should -Be 1
+            $match.Length[0] | Should -Be 1
+
+            $match.Value[1] | Should -Be "o"
+            $match.Index[1] | Should -Be 2
+            $match.Length[1] | Should -Be 1
+
+            $match.Value[2] | Should -Be "a"
+            $match.Index[2] | Should -Be 1
+            $match.Length[2] | Should -Be 1
+
+            $match.Value[3] | Should -Be "a"
+            $match.Index[3] | Should -Be 2
+            $match.Length[3] | Should -Be 1
+        }
+    }
+
+    Context "Case sensitive regular expression matching" {
+        It "Should exclude the matches with differnt casing" {
+            It "Should produce different matches from different strings in the array" {
+                $strings = 'foo', 'baa'
+                $pattern = 'o|A'
+                $match = $strings -matchall $pattern
+                $match.Count | Should -Be 2
+
+                $match.Value[0] | Should -Be "o"
+                $match.Index[0] | Should -Be 1
+                $match.Length[0] | Should -Be 1
+
+                $match.Value[1] | Should -Be "o"
+                $match.Index[1] | Should -Be 2
+                $match.Length[1] | Should -Be 1
+            }
+        }
+    }
+}

--- a/test/powershell/Language/Operators/MatchAllOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/MatchAllOperator.Tests.ps1
@@ -34,11 +34,9 @@ Describe "MatchAll/IMatchAll Operator" -Tags CI {
             {
                 $match.Value[$i] | Should -Be $string[$i]
                 $match.Index[$i] | Should -Be $i
-                $match.Length[$i] | Should -Be 1
 
                 $imatch.Value[$i] | Should -Be $string[$i]
                 $imatch.Index[$i] | Should -Be $i
-                $imatch.Length[$i] | Should -Be 1
             }
         }
     }

--- a/test/powershell/Language/Operators/MatchAllOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/MatchAllOperator.Tests.ps1
@@ -45,19 +45,15 @@ Describe "MatchAll/IMatchAll Operator" -Tags CI {
 
     Context "Array LHS regular expression matching" {
         It "Should produce different matches from different strings in the array" -TestCases @(
-            @{ strings = 'foo', 'baa'; pattern = 'o|a' },
-            @{ strings = 'foo', 'baa'; pattern = 'o|A' },
-            @{ strings = 'foO', 'baa'; pattern = 'o|a' }
+            @{ strings = 'foo', 'baa'; $pattern = 'o|a' },
+            @{ strings = 'foo', 'baa'; $pattern = 'o|A' },
+            @{ strings = 'foO', 'baa'; $pattern = 'o|a' }
         ) {
             param($strings, $pattern)
             $match = $strings -matchall $pattern
             $imatch = $strings -imatchall $pattern
-            $match.Count | Should -Be 2
-            $imatch.Count | Should -Be 2
-            $match[0].Count | Should -Be 2
-            $imatch[0].Count | Should -Be 2
-            $match[1].Count | Should -Be 2
-            $imatch[1].Count | Should -Be 2
+            $match.Count | Should -Be 4
+            $imatch.Count | Should -Be 4
 
             $match.Value[0] | Should -Be "o"
             $match.Index[0] | Should -Be 1
@@ -125,9 +121,7 @@ Describe "CMatchAll operator" -Tags CI {
             $strings = 'foo', 'baa'
             $pattern = 'o|a'
             $match = $strings -cmatchall $pattern
-            $match.Count | Should -Be 2
-            $match[0].Count | Should -Be 2
-            $match[1].Count | Should -Be 2
+            $match.Count | Should -Be 4
 
             $match.Value[0] | Should -Be "o"
             $match.Index[0] | Should -Be 1


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
As per https://github.com/PowerShell/PowerShell/issues/7867:
- A -matchall, -imatchall, and -cmatchall operators are introduced, as a PowerShell-friendly wrapper for the `[regex]::Matches()` method.

```
# Scalar LHS; returns a collection of 2 matches
'foo' -matchall 'o'
# Array LHS; returns 2 collections of 2 matches each
'foo', 'baa' -matchall 'o|a'
```

are now the equivalent of:

```
# Scalar LHS
[regex]::matches('foo', 'o')
# Array LHS
[regex]::matches('foo', 'o|a'), [regex]::matches('baa', 'o|a')
```

## PR Context

As per https://github.com/PowerShell/PowerShell/issues/7867

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
