### PR TITLE
Remove RequireLicenseAcceptance default value

### DIFF
--- a/src/System.Management.Automation/engine/Modules/NewModuleManifestCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/NewModuleManifestCommand.cs
@@ -477,7 +477,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets whether or not the module requires explicit user acceptance for install/update/save.
         /// </summary>
         [Parameter]
-        public SwitchParameter RequireLicenseAcceptance { get; set; } = true;
+        public SwitchParameter RequireLicenseAcceptance { get; set; }
 
         /// <summary>
         /// Gets or sets the external module dependencies.

--- a/test/powershell/engine/Module/NewModuleManifest.Tests.ps1
+++ b/test/powershell/engine/Module/NewModuleManifest.Tests.ps1
@@ -24,6 +24,7 @@ Describe "New-ModuleManifest basic tests" -tags "CI" {
         $module.Name | Should -BeExactly "test"
         $module.ModuleType | Should -BeExactly "Manifest"
         $module.Version | Should -BeExactly "0.0.1"
+        $module.PrivateData.PSData.RequireLicenseAcceptance | Should -BeNullOrEmpty
     }
 
     It "Verify manifest fields 2" {
@@ -58,7 +59,7 @@ Describe "New-ModuleManifest basic tests" -tags "CI" {
         $module.RequiredModules | Should -BeExactly 'PSReadline'
         $module.PrivateData.PSData.ExternalModuleDependencies | Should -BeExactly 'PSReadline'
         $module.PrivateData.PSData.Prerelease | Should -BeExactly 'prerelease'
-        $module.PrivateData.PSData.RequireLicenseAcceptance | Should -BeNullOrEmpty
+        $module.PrivateData.PSData.RequireLicenseAcceptance | Should -BeExactly $true
     }
 }
 

--- a/test/powershell/engine/Module/NewModuleManifest.Tests.ps1
+++ b/test/powershell/engine/Module/NewModuleManifest.Tests.ps1
@@ -58,7 +58,7 @@ Describe "New-ModuleManifest basic tests" -tags "CI" {
         $module.RequiredModules | Should -BeExactly 'PSReadline'
         $module.PrivateData.PSData.ExternalModuleDependencies | Should -BeExactly 'PSReadline'
         $module.PrivateData.PSData.Prerelease | Should -BeExactly 'prerelease'
-        $module.PrivateData.PSData.RequireLicenseAcceptance | Should -BeExactly $true
+        $module.PrivateData.PSData.RequireLicenseAcceptance | Should -BeNullOrEmpty
     }
 }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR is to fix #11491 by removing the default value for `RequireLicenseAcceptance` switch parameter on `New-ModuleManifest`.

## PR Context

When `RequireLicenseAcceptance` switch parameter was added, it had a default value of true. This caused new module manifests to have a unintended result. It also required users to use an awkward syntax to disable it (`-RequireLicenseAcceptance:$false`).

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/5275
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
