### PR TITLE
Make Test-Connection always use the default synchronization context for sending ping requests

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -819,10 +819,6 @@ namespace Microsoft.PowerShell.Commands
                 // The only cancellation we have implemented is on pipeline stops via StopProcessing().
                 throw new PipelineStoppedException();
             }
-            catch (Exception ex)
-            {
-                throw new PingException(ex.Message, ex);
-            }
             finally
             {
                 timer?.Stop();

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -62,10 +62,6 @@ namespace Microsoft.PowerShell.Commands
 
         private Ping? _sender;
 
-        private readonly ManualResetEventSlim _pingComplete = new ManualResetEventSlim();
-
-        private PingCompletedEventArgs? _pingCompleteArgs;
-
         #endregion
 
         #region Parameters
@@ -797,7 +793,6 @@ namespace Microsoft.PowerShell.Commands
                 if (disposing)
                 {
                     _sender?.Dispose();
-                    _pingComplete?.Dispose();
                 }
 
                 _disposed = true;
@@ -815,48 +810,25 @@ namespace Microsoft.PowerShell.Commands
             try
             {
                 _sender = new Ping();
-                _sender.PingCompleted += OnPingComplete;
 
                 timer?.Start();
-                _sender.SendAsync(targetAddress, timeout, buffer, pingOptions, this);
-                _pingComplete.Wait();
-                timer?.Stop();
-                _pingComplete.Reset();
-
-                if (_pingCompleteArgs == null)
-                {
-                    throw new PingException(string.Format(
-                        TestConnectionResources.NoPingResult,
-                        targetAddress,
-                        IPStatus.Unknown));
-                }
-
-                if (_pingCompleteArgs.Cancelled)
-                {
-                    // The only cancellation we have implemented is on pipeline stops via StopProcessing().
-                    throw new PipelineStoppedException();
-                }
-
-                if (_pingCompleteArgs.Error != null)
-                {
-                    throw new PingException(_pingCompleteArgs.Error.Message, _pingCompleteArgs.Error);
-                }
-
-                return _pingCompleteArgs.Reply;
+                return _sender.SendPingAsync(targetAddress, timeout, buffer, pingOptions).GetAwaiter().GetResult();
+            }
+            catch (PingException ex) when (ex.InnerException is TaskCanceledException)
+            {
+                // The only cancellation we have implemented is on pipeline stops via StopProcessing().
+                throw new PipelineStoppedException();
+            }
+            catch (Exception ex)
+            {
+                throw new PingException(ex.Message, ex);
             }
             finally
             {
+                timer?.Stop();
                 _sender?.Dispose();
                 _sender = null;
             }
-        }
-
-        // This event is triggered when the ping is completed, and passes along the eventargs so that we know
-        // if the ping was cancelled, or an exception was thrown.
-        private static void OnPingComplete(object sender, PingCompletedEventArgs e)
-        {
-            ((TestConnectionCommand)e.UserState)._pingCompleteArgs = e;
-            ((TestConnectionCommand)e.UserState)._pingComplete.Set();
         }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -812,6 +812,9 @@ namespace Microsoft.PowerShell.Commands
                 _sender = new Ping();
 
                 timer?.Start();
+                // 'SendPingAsync' always uses the default synchronization context (threadpool).
+                // This is what we want to avoid the deadlock resulted by async work being scheduled back to the
+                // pipeline thread due to a change of the current synchronization context of the pipeline thread.
                 return _sender.SendPingAsync(targetAddress, timeout, buffer, pingOptions).GetAwaiter().GetResult();
             }
             catch (PingException ex) when (ex.InnerException is TaskCanceledException)

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -303,7 +303,7 @@ Describe "Connection" -Tag "CI", "RequireAdminOnWindows" {
 Describe "Test-Connection should run in the default synchronization context (threadpool)" -Tag "CI" {
     It "Test-Connection works after constructing a WindowsForm object" -Skip:(!$IsWindows) {
         $pwsh = Join-Path $PSHOME "pwsh"
-        $pingResults = & $pwsh -noprofile {
+        $pingResults = & $pwsh -NoProfile {
             Add-Type -AssemblyName System.Windows.Forms
             $null = New-Object System.Windows.Forms.Form
             Test-Connection localhost

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -301,7 +301,7 @@ Describe "Connection" -Tag "CI", "RequireAdminOnWindows" {
 }
 
 Describe "Test-Connection should run in the default synchronization context (threadpool)" -Tag "CI" {
-    It "Test-Connection works after constructing a WindowsForm object" {
+    It "Test-Connection works after constructing a WindowsForm object" -Skip:(!$IsWindows) {
         $pwsh = Join-Path $PSHOME "pwsh"
         $pingResults = & $pwsh -noprofile {
             Add-Type -AssemblyName System.Windows.Forms

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -299,3 +299,24 @@ Describe "Connection" -Tag "CI", "RequireAdminOnWindows" {
         Test-Connection $UnreachableAddress -TcpPort 80 -TimeOut 1 | Should -BeFalse
     }
 }
+
+Describe "Test-Connection should run in the default synchronization context (threadpool)" -Tag "CI" {
+    It "Test-Connection works after constructing a WindowsForm object" {
+        $pwsh = Join-Path $PSHOME "pwsh"
+        $pingResults = & $pwsh -noprofile {
+            Add-Type -AssemblyName System.Windows.Forms
+            $null = New-Object System.Windows.Forms.Form
+            Test-Connection localhost
+        }
+
+        $pingResults.Length | Should -Be 4
+        $result = $pingResults | Select-Object -First 1
+
+        $result.Ping | Should -Be 1
+        $result.Source | Should -BeExactly ([System.Net.Dns]::GetHostName())
+        $result.Destination | Should -BeExactly localhost
+        $result.Latency | Should -BeOfType "long"
+        $result.Reply.Status | Should -BeExactly "Success"
+        $result.BufferSize | Should -Be 32
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #11418

When using `Ping.SendAsync` with a callback, the callback will always be invoked in the synchronization context of the pipeline thread. When the current synchronization context of the thread is null, the default context is used which is the threadpool.
In case the pipeline thread's synchronization context is set (for example, by constructing a WindowsForm object), the callback will be scheduled to run on the pipeline thread, which will result in a dead lock.
The fix is to use `Ping.SendPingAsync`.

## Note about `SendAsync` and `PingCompletedEventArgs`

Note that, when using `Ping.SendAsync`, `_pingCompleteArgs.Cancelled` is never set to `true` when the task is cancelled by `Ctrl+c`. Instead, `_pingCompleteArgs.Error` is set with a `PingException` whose `InnerException` is `TaskCanceledException`.
I think this is a bug in the `Ping.SendAsync` API, but didn't spend the time to dig into it.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
