### PR TITLE
Use ISOWeek for week numbers in Get-Date

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
@@ -474,28 +474,7 @@ namespace Microsoft.PowerShell.Commands
                             break;
 
                         case 'V':
-                            // .Net Core doesn't implement ISO 8601.
-                            // So we use workaround from https://blogs.msdn.microsoft.com/shawnste/2006/01/24/iso-8601-week-of-year-format-in-microsoft-net/
-                            // with corrections from comments
-
-                            // Culture doesn't matter since we specify start day of week
-                            var calender = CultureInfo.InvariantCulture.Calendar;
-                            var day = calender.GetDayOfWeek(dateTime);
-                            var normalizedDatetime = dateTime;
-
-                            switch (day)
-                            {
-                                case DayOfWeek.Monday:
-                                case DayOfWeek.Tuesday:
-                                case DayOfWeek.Wednesday:
-                                    normalizedDatetime = dateTime.AddDays(3);
-                                    break;
-                            }
-
-                            // FirstFourDayWeek and DayOfWeek.Monday is from ISO 8601
-                            sb.Append(StringUtil.Format("{0:00}", calender.GetWeekOfYear(normalizedDatetime,
-                                                                                        CalendarWeekRule.FirstFourDayWeek,
-                                                                                        DayOfWeek.Monday)));
+                            sb.Append(StringUtil.Format("{0:00}", ISOWeek.GetWeekOfYear(dateTime)));
                             break;
 
                         case 'W':

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
@@ -490,12 +490,6 @@ namespace Microsoft.PowerShell.Commands
                                 case DayOfWeek.Wednesday:
                                     normalizedDatetime = dateTime.AddDays(3);
                                     break;
-
-                                case DayOfWeek.Friday:
-                                case DayOfWeek.Saturday:
-                                case DayOfWeek.Sunday:
-                                    normalizedDatetime = dateTime.AddDays(-3);
-                                    break;
                             }
 
                             // FirstFourDayWeek and DayOfWeek.Monday is from ISO 8601

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
@@ -52,6 +52,11 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
 
     # The 'week of year' test cases is from https://en.wikipedia.org/wiki/ISO_week_date
     It "using -uformat 'V' produces the correct output" -TestCases @(
+        @{date="1998-01-02"; week = "01"},
+        @{date="1998-01-03"; week = "01"},
+        @{date="2003-01-03"; week = "01"},
+        @{date="2004-01-02"; week = "01"},
+        @{date="2004-01-03"; week = "01"},
         @{date="2005-01-01"; week = "53"},
         @{date="2005-01-02"; week = "53"},
         @{date="2005-12-31"; week = "52"},
@@ -67,11 +72,21 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
         @{date="2008-12-30"; week = "01"},
         @{date="2008-12-31"; week = "01"},
         @{date="2009-01-01"; week = "01"},
+        @{date="2009-01-02"; week = "01"},
+        @{date="2009-01-03"; week = "01"},
         @{date="2009-12-31"; week = "53"},
         @{date="2010-01-01"; week = "53"},
         @{date="2010-01-02"; week = "53"},
         @{date="2010-01-03"; week = "53"},
-        @{date="2010-01-04"; week = "01"}
+        @{date="2010-01-04"; week = "01"},
+        @{date="2014-01-03"; week = "01"},
+        @{date="2015-01-02"; week = "01"},
+        @{date="2015-01-03"; week = "01"},
+        @{date="2020-01-03"; week = "01"},
+        @{date="2025-01-03"; week = "01"},
+        @{date="2026-01-02"; week = "01"},
+        @{date="2026-01-03"; week = "01"},
+        @{date="2031-01-03"; week = "01"}
     ) {
         param($date, $week)
         Get-date -Date $date -uformat %V | Should -BeExactly $week


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

In https://github.com/PowerShell/PowerShell/pull/6542 we had to use a workaround to get a week of the year because .Net Core did not support the feature.

As result Get-Date -UFormat "%V" returns wrong week numbers around new year in some cases mentioned in issue #11534 .

Now we have ISOWeek API in .Net Core 3.1. The PR removes our workaround and utilizes new ISOWeek.GetWeekOfYear() method.

## PR Context

This PR fixes #11534 .

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
