### PR TITLE
Update pester syntax to v4

### DIFF
--- a/test/docker/networktest/DockerRemoting.Tests.ps1
+++ b/test/docker/networktest/DockerRemoting.Tests.ps1
@@ -69,21 +69,21 @@ Describe "Basic remoting test with docker" -tags @("Scenario","Slow"){
 
     It "Full powershell can get correct remote powershell version" -pending:$pending {
         $result = docker exec $client powershell -c "`$ss = [security.securestring]::new(); '11aa!!AA'.ToCharArray() | ForEach-Object { `$ss.appendchar(`$_)}; `$c = [pscredential]::new('testuser',`$ss); `$ses=new-pssession $serverhostname -configurationname $powershellcoreConfiguration -auth basic -credential `$c; invoke-command -session `$ses { `$psversiontable.psversion.tostring() }"
-        $result | Should be $coreVersion
+        $result | Should -Be $coreVersion
     }
 
     It "Full powershell can get correct remote powershell full version" -pending:$pending {
         $result = docker exec $client powershell -c "`$ss = [security.securestring]::new(); '11aa!!AA'.ToCharArray() | ForEach-Object { `$ss.appendchar(`$_)}; `$c = [pscredential]::new('testuser',`$ss); `$ses=new-pssession $serverhostname -auth basic -credential `$c; invoke-command -session `$ses { `$psversiontable.psversion.tostring() }"
-        $result | Should be $fullVersion
+        $result | Should -Be $fullVersion
     }
 
     It "Core powershell can get correct remote powershell version" -pending:$pending {
         $result = docker exec $client "$powershellcorepath" -c "`$ss = [security.securestring]::new(); '11aa!!AA'.ToCharArray() | ForEach-Object { `$ss.appendchar(`$_)}; `$c = [pscredential]::new('testuser',`$ss); `$ses=new-pssession $serverhostname -configurationname $powershellcoreConfiguration -auth basic -credential `$c; invoke-command -session `$ses { `$psversiontable.psversion.tostring() }"
-        $result | Should be $coreVersion
+        $result | Should -Be $coreVersion
     }
 
     It "Core powershell can get correct remote powershell full version" -pending:$pending {
         $result = docker exec $client "$powershellcorepath" -c "`$ss = [security.securestring]::new(); '11aa!!AA'.ToCharArray() | ForEach-Object { `$ss.appendchar(`$_)}; `$c = [pscredential]::new('testuser',`$ss); `$ses=new-pssession $serverhostname -auth basic -credential `$c; invoke-command -session `$ses { `$psversiontable.psversion.tostring() }"
-        $result | Should be $fullVersion
+        $result | Should -Be $fullVersion
     }
 }

--- a/test/docker/networktest/DockerRemoting.Tests.ps1
+++ b/test/docker/networktest/DockerRemoting.Tests.ps1
@@ -69,21 +69,21 @@ Describe "Basic remoting test with docker" -tags @("Scenario","Slow"){
 
     It "Full powershell can get correct remote powershell version" -pending:$pending {
         $result = docker exec $client powershell -c "`$ss = [security.securestring]::new(); '11aa!!AA'.ToCharArray() | ForEach-Object { `$ss.appendchar(`$_)}; `$c = [pscredential]::new('testuser',`$ss); `$ses=new-pssession $serverhostname -configurationname $powershellcoreConfiguration -auth basic -credential `$c; invoke-command -session `$ses { `$psversiontable.psversion.tostring() }"
-        $result | should be $coreVersion
+        $result | Should be $coreVersion
     }
 
     It "Full powershell can get correct remote powershell full version" -pending:$pending {
         $result = docker exec $client powershell -c "`$ss = [security.securestring]::new(); '11aa!!AA'.ToCharArray() | ForEach-Object { `$ss.appendchar(`$_)}; `$c = [pscredential]::new('testuser',`$ss); `$ses=new-pssession $serverhostname -auth basic -credential `$c; invoke-command -session `$ses { `$psversiontable.psversion.tostring() }"
-        $result | should be $fullVersion
+        $result | Should be $fullVersion
     }
 
     It "Core powershell can get correct remote powershell version" -pending:$pending {
         $result = docker exec $client "$powershellcorepath" -c "`$ss = [security.securestring]::new(); '11aa!!AA'.ToCharArray() | ForEach-Object { `$ss.appendchar(`$_)}; `$c = [pscredential]::new('testuser',`$ss); `$ses=new-pssession $serverhostname -configurationname $powershellcoreConfiguration -auth basic -credential `$c; invoke-command -session `$ses { `$psversiontable.psversion.tostring() }"
-        $result | should be $coreVersion
+        $result | Should be $coreVersion
     }
 
     It "Core powershell can get correct remote powershell full version" -pending:$pending {
         $result = docker exec $client "$powershellcorepath" -c "`$ss = [security.securestring]::new(); '11aa!!AA'.ToCharArray() | ForEach-Object { `$ss.appendchar(`$_)}; `$c = [pscredential]::new('testuser',`$ss); `$ses=new-pssession $serverhostname -auth basic -credential `$c; invoke-command -session `$ses { `$psversiontable.psversion.tostring() }"
-        $result | should be $fullVersion
+        $result | Should be $fullVersion
     }
 }

--- a/test/nanoserver/nanoserver.tests.ps1
+++ b/test/nanoserver/nanoserver.tests.ps1
@@ -13,6 +13,6 @@ Describe "Verify PowerShell Runs" {
 
     it "Verify Version " {
         $version = docker run --rm -v "${rootPath}:${mount}" ${container} "${mount}\publish\pwsh" -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'
-        $version | Should -match '^7\.'
+        $version | Should -Match '^7\.'
     }
 }

--- a/test/powershell/Host/Logging.Tests.ps1
+++ b/test/powershell/Host/Logging.Tests.ps1
@@ -205,7 +205,7 @@ $pid
         $items | Should -Not -Be $null
         $items.Count | Should -BeGreaterThan 2
         $createdEvents = $items | where-object {$_.EventId -eq 'ScriptBlock_Compile_Detail:ExecuteCommand.Create.Verbose'}
-        $createdEvents.Count | should -BeGreaterOrEqual 3
+        $createdEvents.Count | Should -BeGreaterOrEqual 3
 
         # Verify we log that we are executing a file
         $createdEvents[0].Message | Should -Match ($scriptBlockCreatedRegExTemplate -f ".*/$testFileName")
@@ -234,7 +234,7 @@ $pid
         $items | Should -Not -Be $null
         $items.Count | Should -BeGreaterThan 2
         $createdEvents = $items | where-object {$_.EventId -eq 'ScriptBlock_Compile_Detail:ExecuteCommand.Create.Verbose'}
-        $createdEvents.Count | should -BeGreaterOrEqual 3
+        $createdEvents.Count | Should -BeGreaterOrEqual 3
 
         # Verify we log that we are executing a file
         $createdEvents[0].Message | Should -Match ($scriptBlockCreatedRegExTemplate -f ".*/$testFileName")
@@ -354,7 +354,7 @@ $pid
             $items | Should -Not -Be $null
             $items.Count | Should -BeGreaterThan 2
             $createdEvents = $items | where-object {$_.EventId -eq 'ScriptBlock_Compile_Detail:ExecuteCommand.Create.Verbose'}
-            $createdEvents.Count | should -BeGreaterOrEqual 3
+            $createdEvents.Count | Should -BeGreaterOrEqual 3
 
             # Verify we log that we are executing a file
             $createdEvents[0].Message | Should -Match ($scriptBlockCreatedRegExTemplate -f ".*/$testFileName")
@@ -392,7 +392,7 @@ $pid
             $items | Should -Not -Be $null
             $items.Count | Should -BeGreaterThan 2
             $createdEvents = $items | where-object {$_.EventId -eq 'ScriptBlock_Compile_Detail:ExecuteCommand.Create.Verbose'}
-            $createdEvents.Count | should -BeGreaterOrEqual 3
+            $createdEvents.Count | Should -BeGreaterOrEqual 3
 
             # Verify we log that we are executing a file
             $createdEvents[0].Message | Should -Match ($scriptBlockCreatedRegExTemplate -f ".*/$testFileName")

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -109,14 +109,14 @@ Describe "TabCompletion" -Tags CI {
         $res = TabExpansion2 -inputScript 'Get-ChildItem | Select-Object @{ ' -cursorColumn 'Get-ChildItem | Select-Object @{ '.Length
         $res.CompletionMatches | Should -HaveCount 2
         $completionText = $res.CompletionMatches.CompletionText | Sort-Object
-        $completionText -join ' '| Should -BeExactly 'Expression Name'
+        $completionText -join ' ' | Should -BeExactly 'Expression Name'
     }
 
     It 'Should complete Sort-Object hashtable' {
         $res = TabExpansion2 -inputScript 'Get-ChildItem | Sort-Object @{ ' -cursorColumn 'Get-ChildItem | Sort-Object @{ '.Length
         $res.CompletionMatches | Should -HaveCount 3
         $completionText = $res.CompletionMatches.CompletionText | Sort-Object
-        $completionText -join ' '| Should -BeExactly 'Ascending Descending Expression'
+        $completionText -join ' ' | Should -BeExactly 'Ascending Descending Expression'
     }
 
     It 'Should complete New-Object hashtable' {
@@ -375,7 +375,7 @@ Describe "TabCompletion" -Tags CI {
         $res = TabExpansion2 -inputScript 'Export-Counter -FileFormat ' -cursorColumn 'Export-Counter -FileFormat '.Length
         $res.CompletionMatches | Should -HaveCount 3
         $completionText = $res.CompletionMatches.CompletionText | Sort-Object
-        $completionText -join ' '| Should -BeExactly 'blg csv tsv'
+        $completionText -join ' ' | Should -BeExactly 'blg csv tsv'
     }
 
     Context "Script name completion" {

--- a/test/powershell/Installer/WindowsInstaller.Tests.ps1
+++ b/test/powershell/Installer/WindowsInstaller.Tests.ps1
@@ -15,7 +15,7 @@ Describe "Windows Installer" -Tags "Scenario" {
 
     It "WiX (Windows Installer XML) file contains pre-requisites link $preRequisitesLink" -skip:$skipTest {
         $wixProductFile = Join-Path -Path $PSScriptRoot -ChildPath "..\..\..\assets\Product.wxs"
-        (Get-Content $wixProductFile -Raw).Contains($preRequisitesLink) | Should Be $true
+        (Get-Content $wixProductFile -Raw).Contains($preRequisitesLink) | Should -Be $true
     }
 
     ## Running 'Invoke-WebRequest' with WMF download URLs has been failing intermittently,

--- a/test/powershell/Installer/WindowsInstaller.Tests.ps1
+++ b/test/powershell/Installer/WindowsInstaller.Tests.ps1
@@ -15,7 +15,7 @@ Describe "Windows Installer" -Tags "Scenario" {
 
     It "WiX (Windows Installer XML) file contains pre-requisites link $preRequisitesLink" -skip:$skipTest {
         $wixProductFile = Join-Path -Path $PSScriptRoot -ChildPath "..\..\..\assets\Product.wxs"
-        (Get-Content $wixProductFile -Raw).Contains($preRequisitesLink) | Should -Be $true
+        (Get-Content $wixProductFile -Raw).Contains($preRequisitesLink) | Should -BeTrue
     }
 
     ## Running 'Invoke-WebRequest' with WMF download URLs has been failing intermittently,

--- a/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
@@ -384,7 +384,7 @@ Describe 'Negative ClassAttributes Tests' -Tags "CI" {
 
     [System.Management.Automation.Cmdlet("Get", "Thing", SupportsShouldProcess = $true, SupportsPaging = $true)]class C2{}
     $t = [C2].GetCustomAttributes($false)
-    It "Should have one attribute (class C2)" { $t.Count | should -Be 1 }
+    It "Should have one attribute (class C2)" { $t.Count | Should -Be 1 }
     It "Should have instance of CmdletAttribute (class C2)" { $t[0] | Should -BeOfType System.Management.Automation.CmdletAttribute }
     [System.Management.Automation.CmdletAttribute]$c = $t[0]
     It "Verb should be Get (class C2)" {$c.VerbName | Should -BeExactly 'Get'}

--- a/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
+++ b/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
@@ -68,7 +68,7 @@ Describe 'Classes inheritance syntax' -Tags "CI" {
         $C1 = Invoke-Expression 'class ClassWithInterfaceProperty : InterfaceWithProperty { [int]$Integer } [ClassWithInterfaceProperty]::new()'
         $getter = $C1.GetType().GetMember('get_Integer')
         $getter.ReturnType.FullName | Should -Be System.Int32
-        $getter.Attributes -band [System.Reflection.MethodAttributes]::Virtual |Should -Be ([System.Reflection.MethodAttributes]::Virtual)
+        $getter.Attributes -band [System.Reflection.MethodAttributes]::Virtual | Should -Be ([System.Reflection.MethodAttributes]::Virtual)
     }
 
     It 'can implement inherited .NET interface properties' {
@@ -77,7 +77,7 @@ Describe 'Classes inheritance syntax' -Tags "CI" {
         $C1 = Invoke-Expression 'class ClassWithInheritedInterfaces : IChild { [int]$ParentInteger; [int]$ChildInteger } [ClassWithInheritedInterfaces]'
         $getter = $C1.GetMember('get_ParentInteger')
         $getter.ReturnType.FullName | Should -Be System.Int32
-        $getter.Attributes -band [System.Reflection.MethodAttributes]::Virtual |Should -Be ([System.Reflection.MethodAttributes]::Virtual)
+        $getter.Attributes -band [System.Reflection.MethodAttributes]::Virtual | Should -Be ([System.Reflection.MethodAttributes]::Virtual)
     }
 
     It 'allows use of defined later type as a property type' {

--- a/test/powershell/Language/Interop/DotNet/DotNetInterop.Tests.ps1
+++ b/test/powershell/Language/Interop/DotNet/DotNetInterop.Tests.ps1
@@ -277,7 +277,7 @@ namespace DotNetInterop
             { $testObj.PrintMySpan("abc", 12) } | Should -Throw -ErrorId "MethodArgumentConversionInvalidCastArgument"
 
             $path = [System.IO.Path]::GetTempPath()
-            [System.IO.Path]::IsPathRooted($path.ToCharArray()) | Should -Be $true
+            [System.IO.Path]::IsPathRooted($path.ToCharArray()) | Should -BeTrue
         }
 
         It "Support constructor calls with ByRef-like parameter as long as the argument can be casted to the ByRef-like type" {

--- a/test/powershell/Language/Parser/ParameterBinding.Tests.ps1
+++ b/test/powershell/Language/Parser/ParameterBinding.Tests.ps1
@@ -223,16 +223,16 @@ Describe "Custom type conversion in parameter binding" -Tags 'Feature' {
             Execute-Script -ps $ps -Script $importCSharpModule
 
             $languageMode = Execute-Script -ps $ps -Script $getLanguageMode
-            $languageMode | Should Be 'FullLanguage'
+            $languageMode | Should -Be 'FullLanguage'
 
             $result1 = Execute-Script -ps $ps -Script "Test-ScriptCmdlet -File fileToUse"
-            $result1 | Should Be "fileToUse"
+            $result1 | Should -Be "fileToUse"
 
             $result2 = Execute-Script -ps $ps -Script "Test-ScriptFunction -File fileToUse"
-            $result2 | Should Be "fileToUse"
+            $result2 | Should -Be "fileToUse"
 
             $result3 = Execute-Script -ps $ps -Script "Test-BinaryCmdlet -File fileToUse"
-            $result3 | Should Be "fileToUse"
+            $result3 | Should -Be "fileToUse"
 
             ## Conversion involves setting properties of an instance of the target type is allowed in FullLanguage mode
             $hashValue = @{ FileName = "filename"; Arguments = "args" }
@@ -240,21 +240,21 @@ Describe "Custom type conversion in parameter binding" -Tags 'Feature' {
 
             ## Test 'Test-ScriptCmdlet -StartInfo' with IDictionary and PSObject with properties
             $result4 = Execute-Script -ps $ps -Command "Test-ScriptCmdlet" -ParameterName "StartInfo" -Argument $hashValue
-            $result4 | Should Be "filename"
+            $result4 | Should -Be "filename"
             $result5 = Execute-Script -ps $ps -Command "Test-ScriptCmdlet" -ParameterName "StartInfo" -Argument $psobjValue
-            $result5 | Should Be "filename"
+            $result5 | Should -Be "filename"
 
             ## Test 'Test-ScriptFunction -StartInfo' with IDictionary and PSObject with properties
             $result6 = Execute-Script -ps $ps -Command "Test-ScriptFunction" -ParameterName "StartInfo" -Argument $hashValue
-            $result6 | Should Be "filename"
+            $result6 | Should -Be "filename"
             $result7 = Execute-Script -ps $ps -Command "Test-ScriptFunction" -ParameterName "StartInfo" -Argument $psobjValue
-            $result7 | Should Be "filename"
+            $result7 | Should -Be "filename"
 
             ## Test 'Test-BinaryCmdlet -StartInfo' with IDictionary and PSObject with properties
             $result8 = Execute-Script -ps $ps -Command "Test-BinaryCmdlet" -ParameterName "StartInfo" -Argument $hashValue
-            $result8 | Should Be "filename"
+            $result8 | Should -Be "filename"
             $result9 = Execute-Script -ps $ps -Command "Test-BinaryCmdlet" -ParameterName "StartInfo" -Argument $psobjValue
-            $result9 | Should Be "filename"
+            $result9 | Should -Be "filename"
         }
         finally {
             $ps.Dispose()
@@ -270,21 +270,21 @@ Describe "Custom type conversion in parameter binding" -Tags 'Feature' {
             Execute-Script -ps $ps -Script $importCSharpModule
 
             $languageMode = Execute-Script -ps $ps -Script $getLanguageMode
-            $languageMode | Should Be 'FullLanguage'
+            $languageMode | Should -Be 'FullLanguage'
 
             ## Change to ConstrainedLanguage mode
             Execute-Script -ps $ps -Script $changeToConstrainedLanguage
             $languageMode = Execute-Script -ps $ps -Script $getLanguageMode
-            $languageMode | Should Be 'ConstrainedLanguage'
+            $languageMode | Should -Be 'ConstrainedLanguage'
 
             $result1 = Execute-Script -ps $ps -Script "Test-ScriptCmdlet -File fileToUse"
-            $result1 | Should Be "fileToUse"
+            $result1 | Should -Be "fileToUse"
 
             $result2 = Execute-Script -ps $ps -Script "Test-ScriptFunction -File fileToUse"
-            $result2 | Should Be "fileToUse"
+            $result2 | Should -Be "fileToUse"
 
             $result3 = Execute-Script -ps $ps -Script "Test-BinaryCmdlet -File fileToUse"
-            $result3 | Should Be "fileToUse"
+            $result3 | Should -Be "fileToUse"
 
             ## If the conversion involves setting properties of an instance of the target type,
             ## then it's disallowed even for trusted cmdlets.
@@ -296,14 +296,14 @@ Describe "Custom type conversion in parameter binding" -Tags 'Feature' {
                 Execute-Script -ps $ps -Command "Test-ScriptCmdlet" -ParameterName "StartInfo" -Argument $hashValue
                 throw "Expected exception was not thrown!"
             } catch {
-                $_.FullyQualifiedErrorId | Should Be "ParameterBindingArgumentTransformationException,Execute-Script"
+                $_.FullyQualifiedErrorId | Should -Be "ParameterBindingArgumentTransformationException,Execute-Script"
             }
 
             try {
                 Execute-Script -ps $ps -Command "Test-ScriptCmdlet" -ParameterName "StartInfo" -Argument $psobjValue
                 throw "Expected exception was not thrown!"
             } catch {
-                $_.FullyQualifiedErrorId | Should Be "ParameterBindingArgumentTransformationException,Execute-Script"
+                $_.FullyQualifiedErrorId | Should -Be "ParameterBindingArgumentTransformationException,Execute-Script"
             }
 
             ## Test 'Test-ScriptFunction -StartInfo' with IDictionary and PSObject with properties
@@ -311,14 +311,14 @@ Describe "Custom type conversion in parameter binding" -Tags 'Feature' {
                 Execute-Script -ps $ps -Command "Test-ScriptFunction" -ParameterName "StartInfo" -Argument $hashValue
                 throw "Expected exception was not thrown!"
             } catch {
-                $_.FullyQualifiedErrorId | Should Be "ParameterBindingArgumentTransformationException,Execute-Script"
+                $_.FullyQualifiedErrorId | Should -Be "ParameterBindingArgumentTransformationException,Execute-Script"
             }
 
             try {
                 Execute-Script -ps $ps -Command "Test-ScriptFunction" -ParameterName "StartInfo" -Argument $psobjValue
                 throw "Expected exception was not thrown!"
             } catch {
-                $_.FullyQualifiedErrorId | Should Be "ParameterBindingArgumentTransformationException,Execute-Script"
+                $_.FullyQualifiedErrorId | Should -Be "ParameterBindingArgumentTransformationException,Execute-Script"
             }
 
             ## Test 'Test-BinaryCmdlet -StartInfo' with IDictionary and PSObject with properties
@@ -326,14 +326,14 @@ Describe "Custom type conversion in parameter binding" -Tags 'Feature' {
                 Execute-Script -ps $ps -Command "Test-BinaryCmdlet" -ParameterName "StartInfo" -Argument $hashValue
                 throw "Expected exception was not thrown!"
             } catch {
-                $_.FullyQualifiedErrorId | Should Be "ParameterBindingException,Execute-Script"
+                $_.FullyQualifiedErrorId | Should -Be "ParameterBindingException,Execute-Script"
             }
 
             try {
                 Execute-Script -ps $ps -Command "Test-BinaryCmdlet" -ParameterName "StartInfo" -Argument $psobjValue
                 throw "Expected exception was not thrown!"
             } catch {
-                $_.FullyQualifiedErrorId | Should Be "ParameterBindingException,Execute-Script"
+                $_.FullyQualifiedErrorId | Should -Be "ParameterBindingException,Execute-Script"
             }
         }
         finally {
@@ -346,30 +346,30 @@ Describe "Custom type conversion in parameter binding" -Tags 'Feature' {
         $ps = [powershell]::Create()
         try {
             $languageMode = Execute-Script -ps $ps -Script $getLanguageMode
-            $languageMode | Should Be 'FullLanguage'
+            $languageMode | Should -Be 'FullLanguage'
 
             ## Change to ConstrainedLanguage mode
             Execute-Script -ps $ps -Script $changeToConstrainedLanguage
             $languageMode = Execute-Script -ps $ps -Script $getLanguageMode
-            $languageMode | Should Be 'ConstrainedLanguage'
+            $languageMode | Should -Be 'ConstrainedLanguage'
 
             ## Import the modules in ConstrainedLanguage mode
             Execute-Script -ps $ps -Script $importScriptModule
             Execute-Script -ps $ps -Script $importCSharpModule
 
             $result1 = Execute-Script -ps $ps -Script "Test-ScriptCmdlet -File fileToUse"
-            $result1 | Should Be $null
-            $ps.Streams.Error.Count | Should Be 1
-            $ps.Streams.Error[0].FullyQualifiedErrorId | Should Be "ParameterArgumentTransformationError,Test-ScriptCmdlet"
+            $result1 | Should -Be $null
+            $ps.Streams.Error.Count | Should -Be 1
+            $ps.Streams.Error[0].FullyQualifiedErrorId | Should -Be "ParameterArgumentTransformationError,Test-ScriptCmdlet"
 
             $result2 = Execute-Script -ps $ps -Script "Test-ScriptFunction -File fileToUse"
-            $result2 | Should Be $null
-            $ps.Streams.Error.Count | Should Be 1
-            $ps.Streams.Error[0].FullyQualifiedErrorId | Should Be "ParameterArgumentTransformationError,Test-ScriptFunction"
+            $result2 | Should -Be $null
+            $ps.Streams.Error.Count | Should -Be 1
+            $ps.Streams.Error[0].FullyQualifiedErrorId | Should -Be "ParameterArgumentTransformationError,Test-ScriptFunction"
 
             ## Binary cmdlets are always marked as trusted because only trusted assemblies can be loaded on DeviceGuard machine.
             $result3 = Execute-Script -ps $ps -Script "Test-BinaryCmdlet -File fileToUse"
-            $result3 | Should Be "fileToUse"
+            $result3 | Should -Be "fileToUse"
 
             ## Conversion that involves setting properties of an instance of the target type is disallowed.
             $hashValue = @{ FileName = "filename"; Arguments = "args" }
@@ -380,14 +380,14 @@ Describe "Custom type conversion in parameter binding" -Tags 'Feature' {
                 Execute-Script -ps $ps -Command "Test-ScriptCmdlet" -ParameterName "StartInfo" -Argument $hashValue
                 throw "Expected exception was not thrown!"
             } catch {
-                $_.FullyQualifiedErrorId | Should Be "ParameterBindingArgumentTransformationException,Execute-Script"
+                $_.FullyQualifiedErrorId | Should -Be "ParameterBindingArgumentTransformationException,Execute-Script"
             }
 
             try {
                 Execute-Script -ps $ps -Command "Test-ScriptCmdlet" -ParameterName "StartInfo" -Argument $psobjValue
                 throw "Expected exception was not thrown!"
             } catch {
-                $_.FullyQualifiedErrorId | Should Be "ParameterBindingArgumentTransformationException,Execute-Script"
+                $_.FullyQualifiedErrorId | Should -Be "ParameterBindingArgumentTransformationException,Execute-Script"
             }
 
             ## Test 'Test-ScriptFunction -StartInfo' with IDictionary and PSObject with properties
@@ -395,14 +395,14 @@ Describe "Custom type conversion in parameter binding" -Tags 'Feature' {
                 Execute-Script -ps $ps -Command "Test-ScriptFunction" -ParameterName "StartInfo" -Argument $hashValue
                 throw "Expected exception was not thrown!"
             } catch {
-                $_.FullyQualifiedErrorId | Should Be "ParameterBindingArgumentTransformationException,Execute-Script"
+                $_.FullyQualifiedErrorId | Should -Be "ParameterBindingArgumentTransformationException,Execute-Script"
             }
 
             try {
                 Execute-Script -ps $ps -Command "Test-ScriptFunction" -ParameterName "StartInfo" -Argument $psobjValue
                 throw "Expected exception was not thrown!"
             } catch {
-                $_.FullyQualifiedErrorId | Should Be "ParameterBindingArgumentTransformationException,Execute-Script"
+                $_.FullyQualifiedErrorId | Should -Be "ParameterBindingArgumentTransformationException,Execute-Script"
             }
 
             ## Test 'Test-BinaryCmdlet -StartInfo' with IDictionary and PSObject with properties
@@ -410,14 +410,14 @@ Describe "Custom type conversion in parameter binding" -Tags 'Feature' {
                 Execute-Script -ps $ps -Command "Test-BinaryCmdlet" -ParameterName "StartInfo" -Argument $hashValue
                 throw "Expected exception was not thrown!"
             } catch {
-                $_.FullyQualifiedErrorId | Should Be "ParameterBindingException,Execute-Script"
+                $_.FullyQualifiedErrorId | Should -Be "ParameterBindingException,Execute-Script"
             }
 
             try {
                 Execute-Script -ps $ps -Command "Test-BinaryCmdlet" -ParameterName "StartInfo" -Argument $psobjValue
                 throw "Expected exception was not thrown!"
             } catch {
-                $_.FullyQualifiedErrorId | Should Be "ParameterBindingException,Execute-Script"
+                $_.FullyQualifiedErrorId | Should -Be "ParameterBindingException,Execute-Script"
             }
         }
         finally {

--- a/test/powershell/Language/Parser/UsingNamespace.Tests.ps1
+++ b/test/powershell/Language/Parser/UsingNamespace.Tests.ps1
@@ -44,17 +44,17 @@ Describe "Using Namespace" -Tags "CI" {
     It "Type literals w/ using namespace" {
         [Thread].FullName | Should -Be System.Threading.Thread
         [Int32].FullName | Should -Be System.Int32
-        #[ElapsedEventHandler].FullName | Should Be System.Timers.ElapsedEventHandler
+        #[ElapsedEventHandler].FullName | Should -Be System.Timers.ElapsedEventHandler
 
         [C1].GetProperty("Thread").PropertyType.FullName | Should -Be System.Threading.Thread
         [C1].GetProperty("Int").PropertyType.FullName | Should -Be System.Int32
-        # [C1].GetProperty("EventHandler").PropertyType.FullName | Should Be System.Timers.ElapsedEventHandler
+        # [C1].GetProperty("EventHandler").PropertyType.FullName | Should -Be System.Timers.ElapsedEventHandler
     }
 
     It "Covert string to Type w/ using namespace" {
         ("Thread" -as [Type]).FullName | Should -Be System.Threading.Thread
         ("Int32" -as [Type]).FullName | Should -Be System.Int32
-        # ("ElapsedEventHandler" -as [Type]).FullName | Should Be System.Timers.ElapsedEventHandler
+        # ("ElapsedEventHandler" -as [Type]).FullName | Should -Be System.Timers.ElapsedEventHandler
 
         New-Object Int32 | Should -Be 0
         New-Object CompilerGeneratedAttribute | Should -Be System.Runtime.CompilerServices.CompilerGeneratedAttribute
@@ -83,11 +83,11 @@ Describe "Using Namespace" -Tags "CI" {
 
         [C1].GetProperty("Thread").GetCustomAttributesData()[0].AttributeType.FullName | Should -Be System.Runtime.CompilerServices.CompilerGeneratedAttribute
         [C1].GetProperty("Int").GetCustomAttributesData()[0].AttributeType.FullName | Should -Be System.Runtime.CompilerServices.CompilerGeneratedAttribute
-        # [C1].GetProperty("EventHandler").GetCustomAttributesData()[0].AttributeType.FullName | Should Be System.Runtime.CompilerServices.CompilerGeneratedAttribute
+        # [C1].GetProperty("EventHandler").GetCustomAttributesData()[0].AttributeType.FullName | Should -Be System.Runtime.CompilerServices.CompilerGeneratedAttribute
 
         [C2].GetProperty("Thread").GetCustomAttributesData()[0].AttributeType.FullName | Should -Be System.Runtime.CompilerServices.CompilerGeneratedAttribute
         [C2].GetProperty("Int").GetCustomAttributesData()[0].AttributeType.FullName | Should -Be System.Runtime.CompilerServices.CompilerGeneratedAttribute
-        # [C2].GetProperty("EventHandler").GetCustomAttributesData()[0].AttributeType.FullName | Should Be System.Runtime.CompilerServices.CompilerGeneratedAttribute
+        # [C2].GetProperty("EventHandler").GetCustomAttributesData()[0].AttributeType.FullName | Should -Be System.Runtime.CompilerServices.CompilerGeneratedAttribute
 
         [C1].GetCustomAttributesData()[0].AttributeType.FullName | Should -Be System.Runtime.CompilerServices.CompilerGeneratedAttribute
         [C2].GetCustomAttributesData()[0].AttributeType.FullName | Should -Be System.Runtime.CompilerServices.CompilerGeneratedAttribute

--- a/test/powershell/Language/Scripting/CheckRestrictedlanguage.Tests.ps1
+++ b/test/powershell/Language/Scripting/CheckRestrictedlanguage.Tests.ps1
@@ -30,7 +30,7 @@ Describe "Test restricted language check method on scriptblocks" -Tags "CI" {
 
         It 'Check union of default + one allowed variables' {
 
-            { { 2 + $a }.CheckRestrictedLanguage($null, (list a), $false) }| Should -Not -Throw  # succeed
+            { { 2 + $a }.CheckRestrictedLanguage($null, (list a), $false) } | Should -Not -Throw  # succeed
         }
 
         It 'Check union of default + two allowed variables' {
@@ -40,7 +40,7 @@ Describe "Test restricted language check method on scriptblocks" -Tags "CI" {
 
         It 'Check union of default + allowed variables' {
 
-            { { $PSCulture, $PSUICulture, $true, $false, $null,  $a, $b}.CheckRestrictedLanguage($null, (list a b), $false) }| Should -Not -Throw
+            { { $PSCulture, $PSUICulture, $true, $false, $null,  $a, $b}.CheckRestrictedLanguage($null, (list a b), $false) } | Should -Not -Throw
         }
 
         It 'Check union of default + one disallowed variables' {
@@ -70,6 +70,6 @@ Describe "Test restricted language check method on scriptblocks" -Tags "CI" {
             { { get-process | where name -Match $pattern | foreach $prop }.CheckRestrictedLanguage(
                 (list get-process where foreach),
                 (list prop pattern)
-                , $false) }| Should -Not -Throw
+                , $false) } | Should -Not -Throw
         }
 }

--- a/test/powershell/Language/Scripting/CommonParameters.Tests.ps1
+++ b/test/powershell/Language/Scripting/CommonParameters.Tests.ps1
@@ -141,7 +141,7 @@ Describe "Common parameters support for script cmdlets" -Tags "CI" {
             # Exception: "Command execution stopped because the preference variable "ErrorActionPreference" or common parameter is set to Stop: error foo"
 
             # BUG in runspace api.
-            #$ps.error.count | Should Be 1
+            #$ps.error.count | Should -Be 1
 
             $ps.InvocationStateInfo.State | Should -BeExactly 'Failed'
         }

--- a/test/powershell/Language/Scripting/DeserializedTypeConversion.Tests.ps1
+++ b/test/powershell/Language/Scripting/DeserializedTypeConversion.Tests.ps1
@@ -94,7 +94,7 @@ Describe "Tests conversion of deserialized types to original type using object p
         }
 
         It 'Type casts should succeed.' {
-            { $tc1 = [test1]$dst1 }| Should -Not -Throw
+            { $tc1 = [test1]$dst1 } | Should -Not -Throw
         }
 
         It 'Parameter bindings should succeed.' {

--- a/test/powershell/Language/Scripting/NativeExecution/NativeUnixGlobbing.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeUnixGlobbing.Tests.ps1
@@ -52,7 +52,7 @@ Describe 'Native UNIX globbing tests' -tags "CI" {
     It 'Should not normalize absolute paths' {
         $matches = /bin/echo /etc/*
         # Matched path should start with '/etc/' not '../..'
-        $matches.substring(0,5) | Should Be '/etc/'
+        $matches.substring(0,5) | Should -Be '/etc/'
     }
 	It 'Globbing should not happen with quoted expressions' {
 	    $v = "$TESTDRIVE/abc*"

--- a/test/powershell/Language/Scripting/ParameterBinding.Tests.ps1
+++ b/test/powershell/Language/Scripting/ParameterBinding.Tests.ps1
@@ -400,7 +400,7 @@ Describe "Tests for parameter binding" -Tags "CI" {
                 $p
             }
 
-            { get-foog } | Should -Not -throw
+            { get-foog } | Should -Not -Throw
         }
 
         It "Validation attributes should not run on default values when CmdletBinding is set" {
@@ -411,7 +411,7 @@ Describe "Tests for parameter binding" -Tags "CI" {
                 $p
             }
 
-            { get-fooh } | Should -Not -throw
+            { get-fooh } | Should -Not -Throw
         }
 
         It "ValidateScript can use custom ErrorMessage" {

--- a/test/powershell/Language/Scripting/ParameterBinding.Tests.ps1
+++ b/test/powershell/Language/Scripting/ParameterBinding.Tests.ps1
@@ -379,7 +379,7 @@ Describe "Tests for parameter binding" -Tags "CI" {
                 $p
             }
 
-            get-fooe| Should -Be 55
+            get-fooe | Should -Be 55
         }
 
         It "Validation attributes should not run on default values when CmdletBinding is set on the parameter" {
@@ -390,7 +390,7 @@ Describe "Tests for parameter binding" -Tags "CI" {
                 $p
             }
 
-            get-foof| Should -Be 55
+            get-foof | Should -Be 55
         }
 
         It "Validation attributes should not run on default values" {

--- a/test/powershell/Language/Scripting/SuppressAnsiEscapeSequence.Tests.ps1
+++ b/test/powershell/Language/Scripting/SuppressAnsiEscapeSequence.Tests.ps1
@@ -17,7 +17,7 @@ Describe '$env:__SuppressAnsiEscapeSequences tests' -Tag CI {
         }
 
         It 'Select-String emits VT' {
-            "select this string" | Select-String 'this' | Out-String |Should -BeLikeExactly "*`e*"
+            "select this string" | Select-String 'this' | Out-String | Should -BeLikeExactly "*`e*"
         }
 
         It 'ConciseView emits VT' {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -919,8 +919,8 @@ Describe "Import-Module nested module behaviour with Edition checking" -Tag "Fea
                 if ((-not $SkipEditionCheck) -and (-not ($MarkedEdition -contains "Core")))
                 {
                     # this goes through WinCompat code
-                    { Import-Module $moduleBase -ErrorAction Stop } | Should Not Throw
-                    Get-Module -Name $moduleName | Should Not BeNullOrEmpty
+                    { Import-Module $moduleBase -ErrorAction Stop } | Should -Not Throw
+                    Get-Module -Name $moduleName | Should -Not BeNullOrEmpty
                     return
                 }
 
@@ -967,8 +967,8 @@ Describe "Import-Module nested module behaviour with Edition checking" -Tag "Fea
             if ((-not $SkipEditionCheck) -and (-not ($MarkedEdition -contains "Core")))
             {
                 # this goes through WinCompat code
-                { Import-Module $moduleName -ErrorAction Stop } | Should Not Throw
-                Get-Module -Name $moduleName | Should Not BeNullOrEmpty
+                { Import-Module $moduleName -ErrorAction Stop } | Should -Not Throw
+                Get-Module -Name $moduleName | Should -Not BeNullOrEmpty
                 return
             }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -919,7 +919,7 @@ Describe "Import-Module nested module behaviour with Edition checking" -Tag "Fea
                 if ((-not $SkipEditionCheck) -and (-not ($MarkedEdition -contains "Core")))
                 {
                     # this goes through WinCompat code
-                    { Import-Module $moduleBase -ErrorAction Stop } | Should -Not Throw
+                    { Import-Module $moduleBase -ErrorAction Stop } | Should -Not -Throw
                     Get-Module -Name $moduleName | Should -Not BeNullOrEmpty
                     return
                 }
@@ -967,7 +967,7 @@ Describe "Import-Module nested module behaviour with Edition checking" -Tag "Fea
             if ((-not $SkipEditionCheck) -and (-not ($MarkedEdition -contains "Core")))
             {
                 # this goes through WinCompat code
-                { Import-Module $moduleName -ErrorAction Stop } | Should -Not Throw
+                { Import-Module $moduleName -ErrorAction Stop } | Should -Not -Throw
                 Get-Module -Name $moduleName | Should -Not BeNullOrEmpty
                 return
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -920,7 +920,7 @@ Describe "Import-Module nested module behaviour with Edition checking" -Tag "Fea
                 {
                     # this goes through WinCompat code
                     { Import-Module $moduleBase -ErrorAction Stop } | Should -Not -Throw
-                    Get-Module -Name $moduleName | Should -Not BeNullOrEmpty
+                    Get-Module -Name $moduleName | Should -Not -BeNullOrEmpty
                     return
                 }
 
@@ -968,7 +968,7 @@ Describe "Import-Module nested module behaviour with Edition checking" -Tag "Fea
             {
                 # this goes through WinCompat code
                 { Import-Module $moduleName -ErrorAction Stop } | Should -Not -Throw
-                Get-Module -Name $moduleName | Should -Not BeNullOrEmpty
+                Get-Module -Name $moduleName | Should -Not -BeNullOrEmpty
                 return
             }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
@@ -359,7 +359,7 @@ Describe "Feature tests for Import-Counter cmdlet" -Tags "Feature" {
             foreach ($err in $errVar)
             {
                 $err.CategoryInfo.Category | Should -BeExactly "InvalidResult"
-                $err.FullyQualifiedErrorId | SHould -BeExactly "CounterApiError,Microsoft.PowerShell.Commands.ImportCounterCommand"
+                $err.FullyQualifiedErrorId | Should -BeExactly "CounterApiError,Microsoft.PowerShell.Commands.ImportCounterCommand"
             }
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
@@ -49,11 +49,11 @@ try {
         It "Test command presence" {
             $result = Get-Command -Module Microsoft.PowerShell.LocalAccounts | ForEach-Object Name
 
-            $result -contains "New-LocalGroup" | Should -Be $true
-            $result -contains "Set-LocalGroup" | Should -Be $true
-            $result -contains "Get-LocalGroup" | Should -Be $true
-            $result -contains "Rename-LocalGroup" | Should -Be $true
-            $result -contains "Remove-LocalGroup" | Should -Be $true
+            $result -contains "New-LocalGroup" | Should -BeTrue
+            $result -contains "Set-LocalGroup" | Should -BeTrue
+            $result -contains "Get-LocalGroup" | Should -BeTrue
+            $result -contains "Rename-LocalGroup" | Should -BeTrue
+            $result -contains "Remove-LocalGroup" | Should -BeTrue
         }
     }
 
@@ -185,7 +185,7 @@ try {
             }
 
             if ($failedCharacters.Count -gt 0) { Write-Host "characters causing test fail: $failedCharacters" }
-            $failedCharacters.Count -eq 0 | Should -Be true
+            $failedCharacters.Count -eq 0 | Should -BeTrue
         }
 
         It "Error on names containing only spaces" {
@@ -270,7 +270,7 @@ try {
         It "Can Get-LocalGroup of all groups"  {
             $result = Get-LocalGroup
 
-            $result.Count -gt 2 | Should -Be true
+            $result.Count -gt 2 | Should -BeTrue
         }
 
         It "Can Get-LocalGroup of a specific group by SID" {
@@ -291,17 +291,17 @@ try {
         It "Can Get-LocalGroup by wildcard" {
             $result = Get-LocalGroup TestGroupGet*
 
-            $result.Count -eq 2 | Should -Be true
-            $result.Name -contains "TestGroupGet1" | Should -Be true
-            $result.Name -contains "TestGroupGet2" | Should -Be true
+            $result.Count -eq 2 | Should -BeTrue
+            $result.Name -contains "TestGroupGet1" | Should -BeTrue
+            $result.Name -contains "TestGroupGet2" | Should -BeTrue
         }
 
         It "Can Get-LocalGroup gets by array of names" {
             $result = Get-LocalGroup @("TestGroupGet1", "TestGroupGet2")
 
-            $result.Count -eq 2 | Should -Be true
-            $result.Name -contains "TestGroupGet1" | Should -Be true
-            $result.Name -contains "TestGroupGet2" | Should -Be true
+            $result.Count -eq 2 | Should -BeTrue
+            $result.Name -contains "TestGroupGet1" | Should -BeTrue
+            $result.Name -contains "TestGroupGet2" | Should -BeTrue
         }
 
         It "Can Get-LocalGroups by array of SIDs" {
@@ -309,18 +309,18 @@ try {
             $sid2 = (Get-LocalGroup TestGroupGet2).SID
             $result = Get-LocalGroup -SID @($sid1, $sid2)
 
-            $result.Count -eq 2 | Should -Be true
-            $result.Name -contains "TestGroupGet1" | Should -Be true
-            $result.Name -contains "TestGroupGet2" | Should -Be true
+            $result.Count -eq 2 | Should -BeTrue
+            $result.Name -contains "TestGroupGet1" | Should -BeTrue
+            $result.Name -contains "TestGroupGet2" | Should -BeTrue
         }
 
         It "Can Get-LocalGroups by pipe of an array of Group objects" {
             $testGroups = Get-LocalGroup TestGroupGet*
             $result = @($testGroups, $testGroups) | Get-LocalGroup
 
-            $result.Count -eq 4 | Should -Be true
-            $result.Name -contains "TestGroupGet1" | Should -Be true
-            $result.Name -contains "TestGroupGet2" | Should -Be true
+            $result.Count -eq 4 | Should -BeTrue
+            $result.Name -contains "TestGroupGet1" | Should -BeTrue
+            $result.Name -contains "TestGroupGet2" | Should -BeTrue
         }
 
         It "Can respond to -ErrorAction Stop" {
@@ -335,13 +335,13 @@ try {
             if ($null -eq $result)
             {
                 # Force failing the test because an unexpected outcome occurred
-                $false | Should -Be $true
+                $false | Should -BeTrue
             }
             else
             {
-                $result[0] -eq 1 | Should -Be true
-                $result[1] -match "GroupNotFound" | Should -Be true
-                $result[2] -match "TestGroupGet1" | Should -Be true
+                $result[0] -eq 1 | Should -BeTrue
+                $result[1] -match "GroupNotFound" | Should -BeTrue
+                $result[2] -match "TestGroupGet1" | Should -BeTrue
             }
         }
 
@@ -365,7 +365,7 @@ try {
             $localGroupName = 'TestGroupGetNameThatDoesntExist'
             $result = (Get-LocalGroup $localGroupName*).Count
 
-            $result -eq 0 | Should -Be true
+            $result -eq 0 | Should -BeTrue
         }
     }
 
@@ -627,7 +627,7 @@ try {
 
             #Assert
             if ($failedCharacters.Count -gt 0) { Write-Host "characters causing test fail: $failedCharacters" }
-            $failedCharacters.Count -eq 0 | Should -Be true
+            $failedCharacters.Count -eq 0 | Should -BeTrue
         }
 
         It "Error on names containing only spaces" {
@@ -705,7 +705,7 @@ try {
 
         It "Can Remove-LocalGroup by name" {
             $initialCount = (Get-LocalGroup).Count
-            $initialCount -gt 1 | Should -Be true
+            $initialCount -gt 1 | Should -BeTrue
 
             $removeResult = Remove-LocalGroup TestGroupRemove1 2>&1
             $removeResult | Should BeNullOrEmpty
@@ -716,7 +716,7 @@ try {
             VerifyFailingTest $sb "GroupNotFound,Microsoft.PowerShell.Commands.GetLocalGroupCommand"
 
             $finalCount = (Get-LocalGroup).Count
-            $initialCount -eq $finalCount + 1 | Should -Be true
+            $initialCount -eq $finalCount + 1 | Should -BeTrue
         }
     }
 
@@ -732,7 +732,7 @@ try {
                         [scriptblock]$removalAction
                     )
                     $initialCount = (Get-LocalGroup).Count
-                    $initialCount -gt 1 | Should -Be true
+                    $initialCount -gt 1 | Should -BeTrue
 
                     & $removalAction
 
@@ -742,7 +742,7 @@ try {
                     VerifyFailingTest $sb "GroupNotFound,Microsoft.PowerShell.Commands.GetLocalGroupCommand"
 
                     $finalCount = (Get-LocalGroup).Count
-                    $initialCount -eq $finalCount + 1 | Should -Be true
+                    $initialCount -eq $finalCount + 1 | Should -BeTrue
                 }
 
                 function VerifyArrayRemoval {
@@ -750,7 +750,7 @@ try {
                         [scriptblock]$removalAction
                     )
                     $initialCount = (Get-LocalGroup).Count
-                    $initialCount -gt 1 | Should -Be $true
+                    $initialCount -gt 1 | Should -BeTrue
 
                     & $removalAction
 
@@ -765,7 +765,7 @@ try {
                     VerifyFailingTest $sb "GroupNotFound,Microsoft.PowerShell.Commands.GetLocalGroupCommand"
 
                     $finalCount = (Get-LocalGroup).Count
-                    $initialCount -eq $finalCount + 2 | Should -Be $true
+                    $initialCount -eq $finalCount + 2 | Should -BeTrue
                 }
             }
         }
@@ -852,7 +852,7 @@ try {
             New-LocalUser TestUserRemove1 -NoPassword | Out-Null
             Add-LocalGroupMember TestGroupRemove1 -Member TestUserRemove1 | Out-Null
             $initialCount = (Get-LocalGroup).Count
-            $initialCount -gt 1 | Should -Be true
+            $initialCount -gt 1 | Should -BeTrue
 
             $removeResult = Remove-LocalGroup TestGroupRemove1 2>&1
             $removeResult | Should BeNullOrEmpty
@@ -866,12 +866,12 @@ try {
             VerifyFailingTest $sb "GroupNotFound,Microsoft.PowerShell.Commands.GetLocalGroupCommand"
 
             $finalCount = (Get-LocalGroup).Count
-            $initialCount -eq $finalCount + 1 | Should -Be true
+            $initialCount -eq $finalCount + 1 | Should -BeTrue
         }
 
         It "Errors on Remove-LocalGroup by invalid name" {
             $initialCount = (Get-LocalGroup).Count
-            $initialCount -gt 1 | Should -Be true
+            $initialCount -gt 1 | Should -BeTrue
 
             $sb = {
                 Remove-LocalGroup TestGroupRemove1NameThatDoesntExist
@@ -879,12 +879,12 @@ try {
             VerifyFailingTest $sb "GroupNotFound,Microsoft.PowerShell.Commands.RemoveLocalGroupCommand"
 
             $finalCount = (Get-LocalGroup).Count
-            $initialCount -eq $finalCount | Should -Be true
+            $initialCount -eq $finalCount | Should -BeTrue
         }
 
         It "Errors on Remove-LocalGroup by invalid SID" {
             $initialCount = (Get-LocalGroup).Count
-            $initialCount -gt 1 | Should -Be true
+            $initialCount -gt 1 | Should -BeTrue
 
             $sb = {
                 Remove-LocalGroup -SID $group1SID
@@ -893,7 +893,7 @@ try {
             VerifyFailingTest $sb "GroupNotFound,Microsoft.PowerShell.Commands.RemoveLocalGroupCommand"
 
             $finalCount = (Get-LocalGroup).Count
-            $initialCount -eq $finalCount + 1 | Should -Be $true
+            $initialCount -eq $finalCount + 1 | Should -BeTrue
         }
 
         It "Can respond to -ErrorAction Stop" {

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
@@ -86,7 +86,7 @@ try {
 
             $result.Name | Should -BeExactly TestGroupAddRemove
             $result.Description | Should -BeExactly "Test Group New 1 Description"
-            $result.SID | Should -Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -Be Group
         }
 
@@ -103,7 +103,7 @@ try {
             try {
                 $result = New-LocalGroup -Name $sidName
 
-                $result | Should -Not BeNullOrEmpty
+                $result | Should -Not -BeNullOrEmpty
                 $result.Name | Should -BeExactly $sidName
                 $result.SID | Should -Not -BeExactly $sidName
                 $result.ObjectClass | Should -Be Group
@@ -127,7 +127,7 @@ try {
 
                 $result.Name | Should -BeExactly $nameMax
                 $result.Description | Should -BeExactly $desc
-                $result.SID | Should -Not BeNullOrEmpty
+                $result.SID | Should -Not -BeNullOrEmpty
                 $result.ObjectClass | Should -Be Group
             }
             finally {
@@ -277,7 +277,7 @@ try {
             $result = Get-LocalGroup TestGroupGet1
             $resultBySID = Get-LocalGroup -SID $result.SID
 
-            $resultBySID.SID | Should -Not BeNullOrEmpty
+            $resultBySID.SID | Should -Not -BeNullOrEmpty
             $resultBySID.Name | Should -Be TestGroupGet1
         }
 
@@ -501,7 +501,7 @@ try {
         }
 
         It "Can Rename-LocalGroup using a valid group name" {
-            $group1SID | Should -Not BeNullOrEmpty
+            $group1SID | Should -Not -BeNullOrEmpty
             Rename-LocalGroup TestGroupRename1 TestGroupRename1x
             $result = Get-LocalGroup -SID $group1SID
 
@@ -538,7 +538,7 @@ try {
         }
 
         It "Can Rename-LocalGroup using a valid group SID" {
-            $group1SID | Should -Not BeNullOrEmpty
+            $group1SID | Should -Not -BeNullOrEmpty
             Rename-LocalGroup -SID $group1SID TestGroupRename1x
             $result = Get-LocalGroup -SID $group1SID
 
@@ -546,7 +546,7 @@ try {
         }
 
         It "Can Rename-LocalGroup using a valid group -InputObject" {
-            $group1SID | Should -Not BeNullOrEmpty
+            $group1SID | Should -Not -BeNullOrEmpty
             $group = Get-LocalGroup TestGroupRename1
             Rename-LocalGroup -InputObject $group -NewName TestGroupRename1x
             $result = Get-LocalGroup -SID $group1SID
@@ -555,7 +555,7 @@ try {
         }
 
         It "Can Rename-LocalGroup using a valid group sent using pipeline" {
-            $group1SID | Should -Not BeNullOrEmpty
+            $group1SID | Should -Not -BeNullOrEmpty
             Get-LocalGroup TestGroupRename1 | Rename-LocalGroup -NewName TestGroupRename1x
             $result = Get-LocalGroup -SID $group1SID
 
@@ -708,7 +708,7 @@ try {
             $initialCount -gt 1 | Should -BeTrue
 
             $removeResult = Remove-LocalGroup TestGroupRemove1 2>&1
-            $removeResult | Should BeNullOrEmpty
+            $removeResult | Should -BeNullOrEmpty
 
             $sb = {
                 Get-LocalGroup -SID $group1SID
@@ -788,7 +788,7 @@ try {
         It "Can Remove-LocalGroup by SID" {
             $sb = {
                 $removeResult = Remove-LocalGroup -SID $group1SID 2>&1
-                $removeResult | Should BeNullOrEmpty
+                $removeResult | Should -BeNullOrEmpty
             }
             VerifyBasicRemoval $sb
         }
@@ -797,7 +797,7 @@ try {
             $sb = {
                 $group = Get-LocalGroup TestGroupRemove1
                 $removeResult = Remove-LocalGroup -InputObject $group 2>&1
-                $removeResult | Should BeNullOrEmpty
+                $removeResult | Should -BeNullOrEmpty
             }
             VerifyBasicRemoval $sb
         }
@@ -805,7 +805,7 @@ try {
         It "Can Remove-LocalGroup using pipeline" {
             $sb = {
                 $removeResult = Get-LocalGroup TestGroupRemove1 | Remove-LocalGroup 2>&1
-                $removeResult | Should BeNullOrEmpty
+                $removeResult | Should -BeNullOrEmpty
             }
             VerifyBasicRemoval $sb
         }
@@ -813,7 +813,7 @@ try {
         It "Can Remove-LocalGroup by array of names" {
             $sb = {
                 $removeResult = Remove-LocalGroup @("TestGroupRemove1","TestGroupRemove2") 2>&1
-                $removeResult | Should BeNullOrEmpty
+                $removeResult | Should -BeNullOrEmpty
             }
             VerifyArrayRemoval $sb
         }
@@ -821,7 +821,7 @@ try {
         It "Can Remove-LocalGroup by array of SIDs" {
             $sb = {
                 $removeResult = Remove-LocalGroup -SID @($group1SID, $group2SID) 2>&1
-                $removeResult | Should BeNullOrEmpty
+                $removeResult | Should -BeNullOrEmpty
             }
             VerifyArrayRemoval $sb
         }
@@ -830,7 +830,7 @@ try {
             $sb = {
                 $groups = Get-LocalGroup -Name @("TestGroupRemove1","TestGroupRemove2")
                 $removeResult = Remove-LocalGroup -InputObject $groups 2>&1
-                $removeResult | Should BeNullOrEmpty
+                $removeResult | Should -BeNullOrEmpty
             }
             VerifyArrayRemoval $sb
         }
@@ -838,7 +838,7 @@ try {
         It "Can Remove-LocalGroup by array using pipeline" {
             $sb = {
                 $removeResult = Get-LocalGroup -Name @("TestGroupRemove1","TestGroupRemove2") | Remove-LocalGroup 2>&1
-                $removeResult | Should BeNullOrEmpty
+                $removeResult | Should -BeNullOrEmpty
             }
             VerifyArrayRemoval $sb
         }
@@ -855,7 +855,7 @@ try {
             $initialCount -gt 1 | Should -BeTrue
 
             $removeResult = Remove-LocalGroup TestGroupRemove1 2>&1
-            $removeResult | Should BeNullOrEmpty
+            $removeResult | Should -BeNullOrEmpty
 
             #clean-up
             Remove-LocalUser TestUserRemove1 | Out-Null

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
@@ -31,7 +31,7 @@ function VerifyFailingTest
         throw "Expected FullyQualifiedErrorId: $expectedFqeid"
     }
     catch {
-        $_.FullyQualifiedErrorId | Should Be $expectedFqeid
+        $_.FullyQualifiedErrorId | Should -Be $expectedFqeid
     }
     finally {
         $script:ErrorActionPreference = $backupEAP
@@ -49,11 +49,11 @@ try {
         It "Test command presence" {
             $result = Get-Command -Module Microsoft.PowerShell.LocalAccounts | ForEach-Object Name
 
-            $result -contains "New-LocalGroup" | Should Be $true
-            $result -contains "Set-LocalGroup" | Should Be $true
-            $result -contains "Get-LocalGroup" | Should Be $true
-            $result -contains "Rename-LocalGroup" | Should Be $true
-            $result -contains "Remove-LocalGroup" | Should Be $true
+            $result -contains "New-LocalGroup" | Should -Be $true
+            $result -contains "Set-LocalGroup" | Should -Be $true
+            $result -contains "Get-LocalGroup" | Should -Be $true
+            $result -contains "Rename-LocalGroup" | Should -Be $true
+            $result -contains "Remove-LocalGroup" | Should -Be $true
         }
     }
 
@@ -69,7 +69,7 @@ try {
             $result = New-LocalGroup -Name TestGroupAddRemove
 
             $result.Name | Should BeExactly TestGroupAddRemove
-            $result.ObjectClass | Should Be Group
+            $result.ObjectClass | Should -Be Group
         }
     }
 
@@ -87,7 +87,7 @@ try {
             $result.Name | Should BeExactly TestGroupAddRemove
             $result.Description | Should BeExactly "Test Group New 1 Description"
             $result.SID | Should -Not BeNullOrEmpty
-            $result.ObjectClass | Should Be Group
+            $result.ObjectClass | Should -Be Group
         }
 
         It "Errors on New-LocalGroup with name collision" {
@@ -106,7 +106,7 @@ try {
                 $result | Should -Not BeNullOrEmpty
                 $result.Name | Should BeExactly $sidName
                 $result.SID | Should -Not BeExactly $sidName
-                $result.ObjectClass | Should Be Group
+                $result.ObjectClass | Should -Be Group
             }
             finally {
                 RemoveTestGroups -basename $sidName
@@ -128,7 +128,7 @@ try {
                 $result.Name | Should BeExactly $nameMax
                 $result.Description | Should BeExactly $desc
                 $result.SID | Should -Not BeNullOrEmpty
-                $result.ObjectClass | Should Be Group
+                $result.ObjectClass | Should -Be Group
             }
             finally {
                 RemoveTestGroups -basename $nameMax
@@ -144,7 +144,7 @@ try {
                 throw "An error was expected"
             }
             catch {
-                $_.FullyQualifiedErrorId | Should Be "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.NewLocalGroupCommand"
+                $_.FullyQualifiedErrorId | Should -Be "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.NewLocalGroupCommand"
             }
             finally {
                 #clean up erroneous creation
@@ -185,7 +185,7 @@ try {
             }
 
             if ($failedCharacters.Count -gt 0) { Write-Host "characters causing test fail: $failedCharacters" }
-            $failedCharacters.Count -eq 0 | Should Be true
+            $failedCharacters.Count -eq 0 | Should -Be true
         }
 
         It "Error on names containing only spaces" {
@@ -245,9 +245,9 @@ try {
         It "Can Get-LocalGroup by specific group name" {
             $result = Get-LocalGroup TestGroupGet1
 
-            $result.Name | Should Be "TestGroupGet1"
-            $result.Description | Should Be "Test Group Get 1 Description"
-            $result.ObjectClass | Should Be "Group"
+            $result.Name | Should -Be "TestGroupGet1"
+            $result.Description | Should -Be "Test Group Get 1 Description"
+            $result.ObjectClass | Should -Be "Group"
         }
     }
 
@@ -270,7 +270,7 @@ try {
         It "Can Get-LocalGroup of all groups"  {
             $result = Get-LocalGroup
 
-            $result.Count -gt 2 | Should Be true
+            $result.Count -gt 2 | Should -Be true
         }
 
         It "Can Get-LocalGroup of a specific group by SID" {
@@ -278,30 +278,30 @@ try {
             $resultBySID = Get-LocalGroup -SID $result.SID
 
             $resultBySID.SID | Should -Not BeNullOrEmpty
-            $resultBySID.Name | Should Be TestGroupGet1
+            $resultBySID.Name | Should -Be TestGroupGet1
         }
 
         It "Can Get-LocalGroup of a well-known group by SID string" {
             $sid = New-Object System.Security.Principal.SecurityIdentifier -ArgumentList BG
             $guestGroup = Get-LocalGroup -SID BG
 
-            $guestGroup.SID | Should Be $sid.Value
+            $guestGroup.SID | Should -Be $sid.Value
         }
 
         It "Can Get-LocalGroup by wildcard" {
             $result = Get-LocalGroup TestGroupGet*
 
-            $result.Count -eq 2 | Should Be true
-            $result.Name -contains "TestGroupGet1" | Should Be true
-            $result.Name -contains "TestGroupGet2" | Should Be true
+            $result.Count -eq 2 | Should -Be true
+            $result.Name -contains "TestGroupGet1" | Should -Be true
+            $result.Name -contains "TestGroupGet2" | Should -Be true
         }
 
         It "Can Get-LocalGroup gets by array of names" {
             $result = Get-LocalGroup @("TestGroupGet1", "TestGroupGet2")
 
-            $result.Count -eq 2 | Should Be true
-            $result.Name -contains "TestGroupGet1" | Should Be true
-            $result.Name -contains "TestGroupGet2" | Should Be true
+            $result.Count -eq 2 | Should -Be true
+            $result.Name -contains "TestGroupGet1" | Should -Be true
+            $result.Name -contains "TestGroupGet2" | Should -Be true
         }
 
         It "Can Get-LocalGroups by array of SIDs" {
@@ -309,18 +309,18 @@ try {
             $sid2 = (Get-LocalGroup TestGroupGet2).SID
             $result = Get-LocalGroup -SID @($sid1, $sid2)
 
-            $result.Count -eq 2 | Should Be true
-            $result.Name -contains "TestGroupGet1" | Should Be true
-            $result.Name -contains "TestGroupGet2" | Should Be true
+            $result.Count -eq 2 | Should -Be true
+            $result.Name -contains "TestGroupGet1" | Should -Be true
+            $result.Name -contains "TestGroupGet2" | Should -Be true
         }
 
         It "Can Get-LocalGroups by pipe of an array of Group objects" {
             $testGroups = Get-LocalGroup TestGroupGet*
             $result = @($testGroups, $testGroups) | Get-LocalGroup
 
-            $result.Count -eq 4 | Should Be true
-            $result.Name -contains "TestGroupGet1" | Should Be true
-            $result.Name -contains "TestGroupGet2" | Should Be true
+            $result.Count -eq 4 | Should -Be true
+            $result.Name -contains "TestGroupGet1" | Should -Be true
+            $result.Name -contains "TestGroupGet2" | Should -Be true
         }
 
         It "Can respond to -ErrorAction Stop" {
@@ -335,13 +335,13 @@ try {
             if ($null -eq $result)
             {
                 # Force failing the test because an unexpected outcome occurred
-                $false | Should Be $true
+                $false | Should -Be $true
             }
             else
             {
-                $result[0] -eq 1 | Should Be true
-                $result[1] -match "GroupNotFound" | Should Be true
-                $result[2] -match "TestGroupGet1" | Should Be true
+                $result[0] -eq 1 | Should -Be true
+                $result[1] -match "GroupNotFound" | Should -Be true
+                $result[2] -match "TestGroupGet1" | Should -Be true
             }
         }
 
@@ -365,7 +365,7 @@ try {
             $localGroupName = 'TestGroupGetNameThatDoesntExist'
             $result = (Get-LocalGroup $localGroupName*).Count
 
-            $result -eq 0 | Should Be true
+            $result -eq 0 | Should -Be true
         }
     }
 
@@ -627,7 +627,7 @@ try {
 
             #Assert
             if ($failedCharacters.Count -gt 0) { Write-Host "characters causing test fail: $failedCharacters" }
-            $failedCharacters.Count -eq 0 | Should Be true
+            $failedCharacters.Count -eq 0 | Should -Be true
         }
 
         It "Error on names containing only spaces" {
@@ -705,7 +705,7 @@ try {
 
         It "Can Remove-LocalGroup by name" {
             $initialCount = (Get-LocalGroup).Count
-            $initialCount -gt 1 | Should Be true
+            $initialCount -gt 1 | Should -Be true
 
             $removeResult = Remove-LocalGroup TestGroupRemove1 2>&1
             $removeResult | Should BeNullOrEmpty
@@ -716,7 +716,7 @@ try {
             VerifyFailingTest $sb "GroupNotFound,Microsoft.PowerShell.Commands.GetLocalGroupCommand"
 
             $finalCount = (Get-LocalGroup).Count
-            $initialCount -eq $finalCount + 1 | Should Be true
+            $initialCount -eq $finalCount + 1 | Should -Be true
         }
     }
 
@@ -732,7 +732,7 @@ try {
                         [scriptblock]$removalAction
                     )
                     $initialCount = (Get-LocalGroup).Count
-                    $initialCount -gt 1 | Should Be true
+                    $initialCount -gt 1 | Should -Be true
 
                     & $removalAction
 
@@ -742,7 +742,7 @@ try {
                     VerifyFailingTest $sb "GroupNotFound,Microsoft.PowerShell.Commands.GetLocalGroupCommand"
 
                     $finalCount = (Get-LocalGroup).Count
-                    $initialCount -eq $finalCount + 1 | Should Be true
+                    $initialCount -eq $finalCount + 1 | Should -Be true
                 }
 
                 function VerifyArrayRemoval {
@@ -750,7 +750,7 @@ try {
                         [scriptblock]$removalAction
                     )
                     $initialCount = (Get-LocalGroup).Count
-                    $initialCount -gt 1 | Should Be $true
+                    $initialCount -gt 1 | Should -Be $true
 
                     & $removalAction
 
@@ -765,7 +765,7 @@ try {
                     VerifyFailingTest $sb "GroupNotFound,Microsoft.PowerShell.Commands.GetLocalGroupCommand"
 
                     $finalCount = (Get-LocalGroup).Count
-                    $initialCount -eq $finalCount + 2 | Should Be $true
+                    $initialCount -eq $finalCount + 2 | Should -Be $true
                 }
             }
         }
@@ -852,7 +852,7 @@ try {
             New-LocalUser TestUserRemove1 -NoPassword | Out-Null
             Add-LocalGroupMember TestGroupRemove1 -Member TestUserRemove1 | Out-Null
             $initialCount = (Get-LocalGroup).Count
-            $initialCount -gt 1 | Should Be true
+            $initialCount -gt 1 | Should -Be true
 
             $removeResult = Remove-LocalGroup TestGroupRemove1 2>&1
             $removeResult | Should BeNullOrEmpty
@@ -866,12 +866,12 @@ try {
             VerifyFailingTest $sb "GroupNotFound,Microsoft.PowerShell.Commands.GetLocalGroupCommand"
 
             $finalCount = (Get-LocalGroup).Count
-            $initialCount -eq $finalCount + 1 | Should Be true
+            $initialCount -eq $finalCount + 1 | Should -Be true
         }
 
         It "Errors on Remove-LocalGroup by invalid name" {
             $initialCount = (Get-LocalGroup).Count
-            $initialCount -gt 1 | Should Be true
+            $initialCount -gt 1 | Should -Be true
 
             $sb = {
                 Remove-LocalGroup TestGroupRemove1NameThatDoesntExist
@@ -879,12 +879,12 @@ try {
             VerifyFailingTest $sb "GroupNotFound,Microsoft.PowerShell.Commands.RemoveLocalGroupCommand"
 
             $finalCount = (Get-LocalGroup).Count
-            $initialCount -eq $finalCount | Should Be true
+            $initialCount -eq $finalCount | Should -Be true
         }
 
         It "Errors on Remove-LocalGroup by invalid SID" {
             $initialCount = (Get-LocalGroup).Count
-            $initialCount -gt 1 | Should Be true
+            $initialCount -gt 1 | Should -Be true
 
             $sb = {
                 Remove-LocalGroup -SID $group1SID
@@ -893,7 +893,7 @@ try {
             VerifyFailingTest $sb "GroupNotFound,Microsoft.PowerShell.Commands.RemoveLocalGroupCommand"
 
             $finalCount = (Get-LocalGroup).Count
-            $initialCount -eq $finalCount + 1 | Should Be $true
+            $initialCount -eq $finalCount + 1 | Should -Be $true
         }
 
         It "Can respond to -ErrorAction Stop" {
@@ -908,8 +908,8 @@ try {
             }
 
             # Confirm that the expected errors were caught
-            $errCount | Should Be 2
-            $fqeid | Should Be "GroupNotFound,Microsoft.PowerShell.Commands.RemoveLocalGroupCommand"
+            $errCount | Should -Be 2
+            $fqeid | Should -Be "GroupNotFound,Microsoft.PowerShell.Commands.RemoveLocalGroupCommand"
 
             # confirm that the first group was removed
             $sb = {

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
@@ -68,7 +68,7 @@ try {
         It "Creates New-LocalGroup using only name" {
             $result = New-LocalGroup -Name TestGroupAddRemove
 
-            $result.Name | Should BeExactly TestGroupAddRemove
+            $result.Name | Should -BeExactly TestGroupAddRemove
             $result.ObjectClass | Should -Be Group
         }
     }
@@ -84,8 +84,8 @@ try {
         It "Creates New-LocalGroup with name and description" {
             $result = New-LocalGroup -Name TestGroupAddRemove -Description "Test Group New 1 Description"
 
-            $result.Name | Should BeExactly TestGroupAddRemove
-            $result.Description | Should BeExactly "Test Group New 1 Description"
+            $result.Name | Should -BeExactly TestGroupAddRemove
+            $result.Description | Should -BeExactly "Test Group New 1 Description"
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be Group
         }
@@ -104,8 +104,8 @@ try {
                 $result = New-LocalGroup -Name $sidName
 
                 $result | Should -Not BeNullOrEmpty
-                $result.Name | Should BeExactly $sidName
-                $result.SID | Should -Not BeExactly $sidName
+                $result.Name | Should -BeExactly $sidName
+                $result.SID | Should -Not -BeExactly $sidName
                 $result.ObjectClass | Should -Be Group
             }
             finally {
@@ -125,8 +125,8 @@ try {
             try {
                 $result = New-LocalGroup -Name $nameMax -Description $desc
 
-                $result.Name | Should BeExactly $nameMax
-                $result.Description | Should BeExactly $desc
+                $result.Name | Should -BeExactly $nameMax
+                $result.Description | Should -BeExactly $desc
                 $result.SID | Should -Not BeNullOrEmpty
                 $result.ObjectClass | Should -Be Group
             }
@@ -156,7 +156,7 @@ try {
             $descMax = "Test Group Add Description that is longer than 48 characters"
             $result = New-LocalGroup -Name TestGroupAddRemove -Description $descMax
 
-            $result.Description | Should BeExactly $descMax
+            $result.Description | Should -BeExactly $descMax
         }
 
         It "Errors on Invalid characters" {
@@ -394,7 +394,7 @@ try {
             Set-LocalGroup -Name TestGroupSet1 -Description "Test Group Set 1 new description"
             $result = Get-LocalGroup -Name TestGroupSet1
 
-            $result.Description | Should BeExactly "Test Group Set 1 new description"
+            $result.Description | Should -BeExactly "Test Group Set 1 new description"
         }
     }
 
@@ -423,7 +423,7 @@ try {
             Set-LocalGroup -SID $group1SID -Description "Test Group Set 1 newer description"
             $result = Get-LocalGroup -Name TestGroupSet1
 
-            $result.Description | Should BeExactly "Test Group Set 1 newer description"
+            $result.Description | Should -BeExactly "Test Group Set 1 newer description"
         }
 
         It "Can Set-LocalGroup using -InputObject" {
@@ -431,14 +431,14 @@ try {
             Set-LocalGroup -InputObject $group -Description "Test Group Set 1 newer still description"
             $result = Get-LocalGroup TestGroupSet1
 
-            $result.Description | Should BeExactly "Test Group Set 1 newer still description"
+            $result.Description | Should -BeExactly "Test Group Set 1 newer still description"
         }
 
         It "Can Set-LocalGroup using pipeline" {
             Get-LocalGroup TestGroupSet1 | Set-LocalGroup -Description "Test Group Set 1 newer still description"
             $result = Get-LocalGroup TestGroupSet1
 
-            $result.Description | Should BeExactly "Test Group Set 1 newer still description"
+            $result.Description | Should -BeExactly "Test Group Set 1 newer still description"
         }
 
         It "Errors on Set-LocalGroup without specifying a Group" {
@@ -468,7 +468,7 @@ try {
             Set-LocalGroup -Name TestGroupSet1 -Description $desc
             $result = Get-LocalGroup -Name TestGroupSet1
 
-            $result.Description | Should BeExactly $desc
+            $result.Description | Should -BeExactly $desc
         }
     }
 
@@ -505,7 +505,7 @@ try {
             Rename-LocalGroup TestGroupRename1 TestGroupRename1x
             $result = Get-LocalGroup -SID $group1SID
 
-            $result.Name | Should BeExactly TestGroupRename1x
+            $result.Name | Should -BeExactly TestGroupRename1x
         }
     }
 
@@ -542,7 +542,7 @@ try {
             Rename-LocalGroup -SID $group1SID TestGroupRename1x
             $result = Get-LocalGroup -SID $group1SID
 
-            $result.Name | Should BeExactly TestGroupRename1x
+            $result.Name | Should -BeExactly TestGroupRename1x
         }
 
         It "Can Rename-LocalGroup using a valid group -InputObject" {
@@ -551,7 +551,7 @@ try {
             Rename-LocalGroup -InputObject $group -NewName TestGroupRename1x
             $result = Get-LocalGroup -SID $group1SID
 
-            $result.Name | Should BeExactly TestGroupRename1x
+            $result.Name | Should -BeExactly TestGroupRename1x
         }
 
         It "Can Rename-LocalGroup using a valid group sent using pipeline" {
@@ -559,7 +559,7 @@ try {
             Get-LocalGroup TestGroupRename1 | Rename-LocalGroup -NewName TestGroupRename1x
             $result = Get-LocalGroup -SID $group1SID
 
-            $result.Name | Should BeExactly TestGroupRename1x
+            $result.Name | Should -BeExactly TestGroupRename1x
         }
 
         It "Errors on Rename-LocalGroup without specifying a Group" {
@@ -595,8 +595,8 @@ try {
             $group1Name = (Get-LocalGroup -SID $group1SID).Name
             $group2Name = (Get-LocalGroup -SID $group2SID).Name
 
-            $group1Name | Should BeExactly TestGroupRename1
-            $group2Name | Should BeExactly $newName
+            $group1Name | Should -BeExactly TestGroupRename1
+            $group2Name | Should -BeExactly $newName
         }
 
         It "Errors on Invalid characters" {
@@ -668,7 +668,7 @@ try {
             Rename-LocalGroup TestGroupRename1 $newName
             $result = Get-LocalGroup -SID $group1SID
 
-            $result.Name | Should BeExactly $newName
+            $result.Name | Should -BeExactly $newName
         }
 
         It "Errors on Rename-LocalGroup using a valid group name over max length 256" {
@@ -678,7 +678,7 @@ try {
             }
             VerifyFailingTest $sb "InvalidName,Microsoft.PowerShell.Commands.RenameLocalGroupCommand"
 
-            (Get-LocalGroup -SID $group1SID).Name | Should BeExactly TestGroupRename1
+            (Get-LocalGroup -SID $group1SID).Name | Should -BeExactly TestGroupRename1
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
@@ -86,7 +86,7 @@ try {
 
             $result.Name | Should BeExactly TestGroupAddRemove
             $result.Description | Should BeExactly "Test Group New 1 Description"
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should Be Group
         }
 
@@ -103,9 +103,9 @@ try {
             try {
                 $result = New-LocalGroup -Name $sidName
 
-                $result | Should Not BeNullOrEmpty
+                $result | Should -Not BeNullOrEmpty
                 $result.Name | Should BeExactly $sidName
-                $result.SID | Should Not BeExactly $sidName
+                $result.SID | Should -Not BeExactly $sidName
                 $result.ObjectClass | Should Be Group
             }
             finally {
@@ -127,7 +127,7 @@ try {
 
                 $result.Name | Should BeExactly $nameMax
                 $result.Description | Should BeExactly $desc
-                $result.SID | Should Not BeNullOrEmpty
+                $result.SID | Should -Not BeNullOrEmpty
                 $result.ObjectClass | Should Be Group
             }
             finally {
@@ -277,7 +277,7 @@ try {
             $result = Get-LocalGroup TestGroupGet1
             $resultBySID = Get-LocalGroup -SID $result.SID
 
-            $resultBySID.SID | Should Not BeNullOrEmpty
+            $resultBySID.SID | Should -Not BeNullOrEmpty
             $resultBySID.Name | Should Be TestGroupGet1
         }
 
@@ -501,7 +501,7 @@ try {
         }
 
         It "Can Rename-LocalGroup using a valid group name" {
-            $group1SID | Should Not BeNullOrEmpty
+            $group1SID | Should -Not BeNullOrEmpty
             Rename-LocalGroup TestGroupRename1 TestGroupRename1x
             $result = Get-LocalGroup -SID $group1SID
 
@@ -538,7 +538,7 @@ try {
         }
 
         It "Can Rename-LocalGroup using a valid group SID" {
-            $group1SID | Should Not BeNullOrEmpty
+            $group1SID | Should -Not BeNullOrEmpty
             Rename-LocalGroup -SID $group1SID TestGroupRename1x
             $result = Get-LocalGroup -SID $group1SID
 
@@ -546,7 +546,7 @@ try {
         }
 
         It "Can Rename-LocalGroup using a valid group -InputObject" {
-            $group1SID | Should Not BeNullOrEmpty
+            $group1SID | Should -Not BeNullOrEmpty
             $group = Get-LocalGroup TestGroupRename1
             Rename-LocalGroup -InputObject $group -NewName TestGroupRename1x
             $result = Get-LocalGroup -SID $group1SID
@@ -555,7 +555,7 @@ try {
         }
 
         It "Can Rename-LocalGroup using a valid group sent using pipeline" {
-            $group1SID | Should Not BeNullOrEmpty
+            $group1SID | Should -Not BeNullOrEmpty
             Get-LocalGroup TestGroupRename1 | Rename-LocalGroup -NewName TestGroupRename1x
             $result = Get-LocalGroup -SID $group1SID
 

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
@@ -205,7 +205,7 @@ try {
 
             $result = Get-LocalGroupMember TestGroup1
             $result.Name -match ($OptDomainPrefix + "TestUser1") | Should -BeTrue
-            $result.Name -match ($OptDomainPrefix + "TestUser2") | Should -Be $false
+            $result.Name -match ($OptDomainPrefix + "TestUser2") | Should -BeFalse
         }
 
         It "Errors on adding user to group by name twice" {

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
@@ -48,7 +48,7 @@ function VerifyFailingTest
         throw "Expected error: $expectedFqeid"
     }
     catch {
-        $_.FullyQualifiedErrorId | Should Be $expectedFqeid
+        $_.FullyQualifiedErrorId | Should -Be $expectedFqeid
     }
     finally {
         $script:ErrorActionPreference = $backupEAP
@@ -66,9 +66,9 @@ try {
         It "Test command presence" {
             $result = Get-Command -Module Microsoft.PowerShell.LocalAccounts | ForEach-Object Name
 
-            $result -contains "Add-LocalGroupMember" | Should Be $true
-            $result -contains "Get-LocalGroupMember" | Should Be $true
-            $result -contains "Remove-LocalGroupMember" | Should Be $true
+            $result -contains "Add-LocalGroupMember" | Should -Be $true
+            $result -contains "Get-LocalGroupMember" | Should -Be $true
+            $result -contains "Remove-LocalGroupMember" | Should -Be $true
         }
     }
 
@@ -92,8 +92,8 @@ try {
             Add-LocalGroupMember TestGroup1 -Member TestUser1
             $result = Get-LocalGroupMember TestGroup1
 
-            $result.Name.EndsWith("TestUser1") | Should Be $true
-            $result.SID | Should Be $user1sid
+            $result.Name.EndsWith("TestUser1") | Should -Be $true
+            $result.SID | Should -Be $user1sid
         }
     }
 
@@ -123,8 +123,8 @@ try {
             Add-LocalGroupMember -SID $group1sid -Member TestUser1
             $result = Get-LocalGroupMember TestGroup1
 
-            $result.Name.EndsWith("TestUser1") | Should Be $true
-            $result.SID | Should Be $user1sid
+            $result.Name.EndsWith("TestUser1") | Should -Be $true
+            $result.SID | Should -Be $user1sid
         }
 
         It "Can add user to group using group object" {
@@ -132,16 +132,16 @@ try {
             Add-LocalGroupMember -Group $groupObject -Member TestUser1
             $result = Get-LocalGroupMember TestGroup1
 
-            $result.Name.EndsWith("TestUser1") | Should Be $true
-            $result.SID | Should Be $user1sid
+            $result.Name.EndsWith("TestUser1") | Should -Be $true
+            $result.SID | Should -Be $user1sid
         }
 
         It "Can add user to group using pipeline" {
             Get-LocalUser TestUser1 | Add-LocalGroupMember -Name TestGroup1
             $result = Get-LocalGroupMember TestGroup1
 
-            $result.Name.EndsWith("TestUser1") | Should Be $true
-            $result.SID | Should Be $user1sid
+            $result.Name.EndsWith("TestUser1") | Should -Be $true
+            $result.SID | Should -Be $user1sid
         }
 
         It "Errors on missing group parameter value missing" {
@@ -169,32 +169,32 @@ try {
             Add-LocalGroupMember TestGroup1 -Member @("TestUser1", "TestUser2")
             $result = Get-LocalGroupMember TestGroup1
 
-            $result[0].Name -match ($OptDomainPrefix + "TestUser1") | Should Be $true
-            $result[1].Name -match ($OptDomainPrefix + "TestUser2") | Should Be $true
+            $result[0].Name -match ($OptDomainPrefix + "TestUser1") | Should -Be $true
+            $result[1].Name -match ($OptDomainPrefix + "TestUser2") | Should -Be $true
         }
 
         It "Can add array of user SIDs to group" {
             Add-LocalGroupMember TestGroup1 -Member @($user1sid, $user2sid)
             $result = Get-LocalGroupMember TestGroup1
 
-            $result[0].Name -match ($OptDomainPrefix + "TestUser1") | Should Be $true
-            $result[1].Name -match ($OptDomainPrefix + "TestUser2") | Should Be $true
+            $result[0].Name -match ($OptDomainPrefix + "TestUser1") | Should -Be $true
+            $result[1].Name -match ($OptDomainPrefix + "TestUser2") | Should -Be $true
         }
 
         It "Can add array of users names or SIDs to group" {
             Add-LocalGroupMember TestGroup1 -Member @($user1sid, "TestUser2")
             $result = Get-LocalGroupMember TestGroup1
 
-            $result[0].Name -match ($OptDomainPrefix + "TestUser1") | Should Be $true
-            $result[1].Name -match ($OptDomainPrefix + "TestUser2") | Should Be $true
+            $result[0].Name -match ($OptDomainPrefix + "TestUser1") | Should -Be $true
+            $result[1].Name -match ($OptDomainPrefix + "TestUser2") | Should -Be $true
         }
 
         It "Can add array of user names using pipeline" {
             @("TestUser1", "TestUser2") | Add-LocalGroupMember TestGroup1
             $result = Get-LocalGroupMember TestGroup1
 
-            $result[0].Name -match ($OptDomainPrefix + "TestUser1") | Should Be $true
-            $result[1].Name -match ($OptDomainPrefix + "TestUser2") | Should Be $true
+            $result[0].Name -match ($OptDomainPrefix + "TestUser1") | Should -Be $true
+            $result[1].Name -match ($OptDomainPrefix + "TestUser2") | Should -Be $true
         }
 
         It "Can add array of existent and nonexistent users names to group" {
@@ -204,8 +204,8 @@ try {
             VerifyFailingTest $sb "PrincipalNotFound,Microsoft.PowerShell.Commands.AddLocalGroupMemberCommand"
 
             $result = Get-LocalGroupMember TestGroup1
-            $result.Name -match ($OptDomainPrefix + "TestUser1") | Should Be $true
-            $result.Name -match ($OptDomainPrefix + "TestUser2") | Should Be $false
+            $result.Name -match ($OptDomainPrefix + "TestUser1") | Should -Be $true
+            $result.Name -match ($OptDomainPrefix + "TestUser2") | Should -Be $false
         }
 
         It "Errors on adding user to group by name twice" {
@@ -216,8 +216,8 @@ try {
             VerifyFailingTest $sb "MemberExists,Microsoft.PowerShell.Commands.AddLocalGroupMemberCommand"
 
             $result = Get-LocalGroupMember TestGroup1
-            $result.Name.EndsWith("TestUser1") | Should Be $true
-            $result.SID | Should Be $user1sid
+            $result.Name.EndsWith("TestUser1") | Should -Be $true
+            $result.SID | Should -Be $user1sid
         }
 
         It "Errors on adding nonexistent user to group" {
@@ -241,7 +241,7 @@ try {
             VerifyFailingTest $sb "PrincipalNotFound,Microsoft.PowerShell.Commands.AddLocalGroupMemberCommand"
 
             $result = Get-LocalGroupMember TestGroup1
-            $result.Name -match ($OptDomainPrefix + "TestUser1") | Should Be $true
+            $result.Name -match ($OptDomainPrefix + "TestUser1") | Should -Be $true
         }
     }
 
@@ -267,13 +267,13 @@ try {
         It "Can get a local group member by name" {
             $result = Get-LocalGroupMember TestGroupGet1
 
-            $result.Name.EndsWith("TestUserGet1") | Should Be $true
-            $result.SID | Should Be $user1sid
+            $result.Name.EndsWith("TestUserGet1") | Should -Be $true
+            $result.SID | Should -Be $user1sid
             if (IsWin10OrHigher)
             {
-                $result.PrincipalSource | Should Be Local
+                $result.PrincipalSource | Should -Be Local
             }
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -Be User
         }
     }
 
@@ -308,85 +308,85 @@ try {
         It "Can get all group members by name" {
             $result = Get-LocalGroupMember TestGroupGet1
 
-            $result[0].Name.EndsWith("TestUserGet1") | Should Be $true
-            $result[0].SID | Should Be $user1sid
+            $result[0].Name.EndsWith("TestUserGet1") | Should -Be $true
+            $result[0].SID | Should -Be $user1sid
             if (IsWin10OrHigher)
             {
-                $result[0].PrincipalSource | Should Be Local
+                $result[0].PrincipalSource | Should -Be Local
             }
-            $result[0].ObjectClass | Should Be User
-            $result[1].Name.EndsWith("TestUserGet2") | Should Be $true
-            $result[1].SID | Should Be $user2sid
+            $result[0].ObjectClass | Should -Be User
+            $result[1].Name.EndsWith("TestUserGet2") | Should -Be $true
+            $result[1].SID | Should -Be $user2sid
             if (IsWin10OrHigher)
             {
-                $result[1].PrincipalSource | Should Be Local
+                $result[1].PrincipalSource | Should -Be Local
             }
-            $result[1].ObjectClass | Should Be User
+            $result[1].ObjectClass | Should -Be User
         }
 
         It "Can get all group members by SID" {
             $result = Get-LocalGroupMember -SID $group1sid
 
-            $result[0].Name.EndsWith("TestUserGet1") | Should Be $true
-            $result[0].SID | Should Be $user1sid
+            $result[0].Name.EndsWith("TestUserGet1") | Should -Be $true
+            $result[0].SID | Should -Be $user1sid
             if (IsWin10OrHigher)
             {
-                $result[0].PrincipalSource | Should Be Local
+                $result[0].PrincipalSource | Should -Be Local
             }
-            $result[0].ObjectClass | Should Be User
-            $result[1].Name.EndsWith("TestUserGet2") | Should Be $true
-            $result[1].SID | Should Be $user2sid
+            $result[0].ObjectClass | Should -Be User
+            $result[1].Name.EndsWith("TestUserGet2") | Should -Be $true
+            $result[1].SID | Should -Be $user2sid
             if (IsWin10OrHigher)
             {
-                $result[1].PrincipalSource | Should Be Local
+                $result[1].PrincipalSource | Should -Be Local
             }
-            $result[1].ObjectClass | Should Be User
+            $result[1].ObjectClass | Should -Be User
         }
 
         It "Can get all group members by Group object" {
             $group = Get-LocalGroup TestGroupGet1
             $result = Get-LocalGroupMember -Group $group
 
-            $result[0].Name.EndsWith("TestUserGet1") | Should Be $true
-            $result[0].SID | Should Be $user1sid
+            $result[0].Name.EndsWith("TestUserGet1") | Should -Be $true
+            $result[0].SID | Should -Be $user1sid
             if (IsWin10OrHigher)
             {
-                $result[0].PrincipalSource | Should Be Local
+                $result[0].PrincipalSource | Should -Be Local
             }
-            $result[0].ObjectClass | Should Be User
-            $result[1].Name.EndsWith("TestUserGet2") | Should Be $true
-            $result[1].SID | Should Be $user2sid
+            $result[0].ObjectClass | Should -Be User
+            $result[1].Name.EndsWith("TestUserGet2") | Should -Be $true
+            $result[1].SID | Should -Be $user2sid
             if (IsWin10OrHigher)
             {
-                $result[1].PrincipalSource | Should Be Local
+                $result[1].PrincipalSource | Should -Be Local
             }
-            $result[1].ObjectClass | Should Be User
+            $result[1].ObjectClass | Should -Be User
         }
 
         It "Can get all group members by pipeline" {
             $result = Get-LocalGroup TestGroupGet1 | Get-LocalGroupMember
 
-            $result[0].Name.EndsWith("TestUserGet1") | Should Be $true
-            $result[0].SID | Should Be $user1sid
+            $result[0].Name.EndsWith("TestUserGet1") | Should -Be $true
+            $result[0].SID | Should -Be $user1sid
             if (IsWin10OrHigher)
             {
-                $result[0].PrincipalSource | Should Be Local
+                $result[0].PrincipalSource | Should -Be Local
             }
-            $result[0].ObjectClass | Should Be User
-            $result[1].Name.EndsWith("TestUserGet2") | Should Be $true
-            $result[1].SID | Should Be $user2sid
+            $result[0].ObjectClass | Should -Be User
+            $result[1].Name.EndsWith("TestUserGet2") | Should -Be $true
+            $result[1].SID | Should -Be $user2sid
             if (IsWin10OrHigher)
             {
-                $result[1].PrincipalSource | Should Be Local
+                $result[1].PrincipalSource | Should -Be Local
             }
-            $result[1].ObjectClass | Should Be User
+            $result[1].ObjectClass | Should -Be User
         }
 
         It "Can get group members by wildcard" {
             $result = Get-LocalGroupMember TestGroupGet1 -Member TestUserGet*
-            $result.Count -eq 2 | Should Be $true
-            $result[0].Name -match ($OptDomainPrefix+"TestUserGet1") | Should Be $true
-            $result[1].Name -match ($OptDomainPrefix + "TestUserGet2") | Should Be $true
+            $result.Count -eq 2 | Should -Be $true
+            $result[0].Name -match ($OptDomainPrefix+"TestUserGet1") | Should -Be $true
+            $result[1].Name -match ($OptDomainPrefix + "TestUserGet2") | Should -Be $true
         }
 
         It "Errors on group name being nonexistent" {
@@ -399,13 +399,13 @@ try {
         It "Can get specific group member by name" {
             $result = Get-LocalGroupMember TestGroupGet1 -Member TestUserGet1
 
-            $result.Name.EndsWith("TestUserGet1") | Should Be $true
-            $result.SID | Should Be $user1sid
+            $result.Name.EndsWith("TestUserGet1") | Should -Be $true
+            $result.SID | Should -Be $user1sid
             if (IsWin10OrHigher)
             {
-                $result.PrincipalSource | Should Be Local
+                $result.PrincipalSource | Should -Be Local
             }
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -Be User
         }
 
         #TODO: 10.A valid user attempts to get membership from a group to which they don't have access
@@ -434,7 +434,7 @@ try {
             Remove-LocalGroupMember TestGroupRemove1 -Member TestUserRemove1
             $result = Get-LocalGroupMember TestGroupRemove1
 
-            $result | Should Be $null
+            $result | Should -Be $null
         }
     }
 
@@ -466,14 +466,14 @@ try {
             Remove-LocalGroupMember TestGroupRemove1 -Member TestUserRemove2
             $result = Get-LocalGroupMember TestGroupRemove1
 
-            $result.Name.EndsWith("TestUserRemove1") | Should Be $true
+            $result.Name.EndsWith("TestUserRemove1") | Should -Be $true
         }
 
         It "Can remove a group member by SID" {
             Remove-LocalGroupMember -SID $group1sid -Member TestUserRemove2
             $result = Get-LocalGroupMember TestGroupRemove1
 
-            $result.Name.EndsWith("TestUserRemove1") | Should Be $true
+            $result.Name.EndsWith("TestUserRemove1") | Should -Be $true
         }
 
         It "Can remove a group member by Group object" {
@@ -481,14 +481,14 @@ try {
             Remove-LocalGroupMember -Group $group -Member TestUserRemove2
             $result = Get-LocalGroupMember TestGroupRemove1
 
-            $result.Name.EndsWith("TestUserRemove1") | Should Be $true
+            $result.Name.EndsWith("TestUserRemove1") | Should -Be $true
         }
 
         It "Can remove a group member by pipeline" {
             Get-LocalUser TestUserRemove2 | Remove-LocalGroupMember -Name TestGroupRemove1
             $result = Get-LocalGroupMember TestGroupRemove1
 
-            $result.Name.EndsWith("TestUserRemove1") | Should Be $true
+            $result.Name.EndsWith("TestUserRemove1") | Should -Be $true
         }
 
         It "Errors on group argument missing" {
@@ -524,21 +524,21 @@ try {
             Remove-LocalGroupMember TestGroupRemove1 -Member @("TestUserRemove1", "TestUserRemove2")
             $result = Get-LocalGroupMember TestGroupRemove1
 
-            $result | Should Be $null
+            $result | Should -Be $null
         }
 
         It "Can remove array of user SIDs from group" {
             Remove-LocalGroupMember TestGroupRemove1 -Member @($user1sid, $user2sid)
             $result = Get-LocalGroupMember TestGroupRemove1
 
-            $result | Should Be $null
+            $result | Should -Be $null
         }
 
         It "Can remove array of users names or SIDs from group" {
             Remove-LocalGroupMember TestGroupRemove1 -Member @($user1sid, "TestUserRemove2")
             $result = Get-LocalGroupMember TestGroupRemove1
 
-            $result | Should Be $null
+            $result | Should -Be $null
         }
 
         It "Can remove array of user names using pipeline" {
@@ -547,7 +547,7 @@ try {
             @($name1, $name2) | Remove-LocalGroupMember TestGroupRemove1
             $result = Get-LocalGroupMember TestGroupRemove1
 
-            $result | Should Be $null
+            $result | Should -Be $null
         }
 
         It "Errors on remove nonexistent user from group" {
@@ -573,7 +573,7 @@ try {
             VerifyFailingTest $sb "PrincipalNotFound,Microsoft.PowerShell.Commands.RemoveLocalGroupMemberCommand"
 
             $result = Get-LocalGroupMember TestGroupRemove2
-            $result | Should Be $null
+            $result | Should -Be $null
         }
 
         It "Errors on remove user from nonexistent group" {
@@ -590,7 +590,7 @@ try {
             VerifyFailingTest $sb "PrincipalNotFound,Microsoft.PowerShell.Commands.RemoveLocalGroupMemberCommand"
 
             $result = Get-LocalGroupMember TestGroupRemove1 2>&1
-            $result.Name -match ($OptDomainPrefix + "TestUserRemove2") | Should Be $true
+            $result.Name -match ($OptDomainPrefix + "TestUserRemove2") | Should -Be $true
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
@@ -66,9 +66,9 @@ try {
         It "Test command presence" {
             $result = Get-Command -Module Microsoft.PowerShell.LocalAccounts | ForEach-Object Name
 
-            $result -contains "Add-LocalGroupMember" | Should -Be $true
-            $result -contains "Get-LocalGroupMember" | Should -Be $true
-            $result -contains "Remove-LocalGroupMember" | Should -Be $true
+            $result -contains "Add-LocalGroupMember" | Should -BeTrue
+            $result -contains "Get-LocalGroupMember" | Should -BeTrue
+            $result -contains "Remove-LocalGroupMember" | Should -BeTrue
         }
     }
 
@@ -92,7 +92,7 @@ try {
             Add-LocalGroupMember TestGroup1 -Member TestUser1
             $result = Get-LocalGroupMember TestGroup1
 
-            $result.Name.EndsWith("TestUser1") | Should -Be $true
+            $result.Name.EndsWith("TestUser1") | Should -BeTrue
             $result.SID | Should -Be $user1sid
         }
     }
@@ -123,7 +123,7 @@ try {
             Add-LocalGroupMember -SID $group1sid -Member TestUser1
             $result = Get-LocalGroupMember TestGroup1
 
-            $result.Name.EndsWith("TestUser1") | Should -Be $true
+            $result.Name.EndsWith("TestUser1") | Should -BeTrue
             $result.SID | Should -Be $user1sid
         }
 
@@ -132,7 +132,7 @@ try {
             Add-LocalGroupMember -Group $groupObject -Member TestUser1
             $result = Get-LocalGroupMember TestGroup1
 
-            $result.Name.EndsWith("TestUser1") | Should -Be $true
+            $result.Name.EndsWith("TestUser1") | Should -BeTrue
             $result.SID | Should -Be $user1sid
         }
 
@@ -140,7 +140,7 @@ try {
             Get-LocalUser TestUser1 | Add-LocalGroupMember -Name TestGroup1
             $result = Get-LocalGroupMember TestGroup1
 
-            $result.Name.EndsWith("TestUser1") | Should -Be $true
+            $result.Name.EndsWith("TestUser1") | Should -BeTrue
             $result.SID | Should -Be $user1sid
         }
 
@@ -169,32 +169,32 @@ try {
             Add-LocalGroupMember TestGroup1 -Member @("TestUser1", "TestUser2")
             $result = Get-LocalGroupMember TestGroup1
 
-            $result[0].Name -match ($OptDomainPrefix + "TestUser1") | Should -Be $true
-            $result[1].Name -match ($OptDomainPrefix + "TestUser2") | Should -Be $true
+            $result[0].Name -match ($OptDomainPrefix + "TestUser1") | Should -BeTrue
+            $result[1].Name -match ($OptDomainPrefix + "TestUser2") | Should -BeTrue
         }
 
         It "Can add array of user SIDs to group" {
             Add-LocalGroupMember TestGroup1 -Member @($user1sid, $user2sid)
             $result = Get-LocalGroupMember TestGroup1
 
-            $result[0].Name -match ($OptDomainPrefix + "TestUser1") | Should -Be $true
-            $result[1].Name -match ($OptDomainPrefix + "TestUser2") | Should -Be $true
+            $result[0].Name -match ($OptDomainPrefix + "TestUser1") | Should -BeTrue
+            $result[1].Name -match ($OptDomainPrefix + "TestUser2") | Should -BeTrue
         }
 
         It "Can add array of users names or SIDs to group" {
             Add-LocalGroupMember TestGroup1 -Member @($user1sid, "TestUser2")
             $result = Get-LocalGroupMember TestGroup1
 
-            $result[0].Name -match ($OptDomainPrefix + "TestUser1") | Should -Be $true
-            $result[1].Name -match ($OptDomainPrefix + "TestUser2") | Should -Be $true
+            $result[0].Name -match ($OptDomainPrefix + "TestUser1") | Should -BeTrue
+            $result[1].Name -match ($OptDomainPrefix + "TestUser2") | Should -BeTrue
         }
 
         It "Can add array of user names using pipeline" {
             @("TestUser1", "TestUser2") | Add-LocalGroupMember TestGroup1
             $result = Get-LocalGroupMember TestGroup1
 
-            $result[0].Name -match ($OptDomainPrefix + "TestUser1") | Should -Be $true
-            $result[1].Name -match ($OptDomainPrefix + "TestUser2") | Should -Be $true
+            $result[0].Name -match ($OptDomainPrefix + "TestUser1") | Should -BeTrue
+            $result[1].Name -match ($OptDomainPrefix + "TestUser2") | Should -BeTrue
         }
 
         It "Can add array of existent and nonexistent users names to group" {
@@ -204,7 +204,7 @@ try {
             VerifyFailingTest $sb "PrincipalNotFound,Microsoft.PowerShell.Commands.AddLocalGroupMemberCommand"
 
             $result = Get-LocalGroupMember TestGroup1
-            $result.Name -match ($OptDomainPrefix + "TestUser1") | Should -Be $true
+            $result.Name -match ($OptDomainPrefix + "TestUser1") | Should -BeTrue
             $result.Name -match ($OptDomainPrefix + "TestUser2") | Should -Be $false
         }
 
@@ -216,7 +216,7 @@ try {
             VerifyFailingTest $sb "MemberExists,Microsoft.PowerShell.Commands.AddLocalGroupMemberCommand"
 
             $result = Get-LocalGroupMember TestGroup1
-            $result.Name.EndsWith("TestUser1") | Should -Be $true
+            $result.Name.EndsWith("TestUser1") | Should -BeTrue
             $result.SID | Should -Be $user1sid
         }
 
@@ -241,7 +241,7 @@ try {
             VerifyFailingTest $sb "PrincipalNotFound,Microsoft.PowerShell.Commands.AddLocalGroupMemberCommand"
 
             $result = Get-LocalGroupMember TestGroup1
-            $result.Name -match ($OptDomainPrefix + "TestUser1") | Should -Be $true
+            $result.Name -match ($OptDomainPrefix + "TestUser1") | Should -BeTrue
         }
     }
 
@@ -267,7 +267,7 @@ try {
         It "Can get a local group member by name" {
             $result = Get-LocalGroupMember TestGroupGet1
 
-            $result.Name.EndsWith("TestUserGet1") | Should -Be $true
+            $result.Name.EndsWith("TestUserGet1") | Should -BeTrue
             $result.SID | Should -Be $user1sid
             if (IsWin10OrHigher)
             {
@@ -308,14 +308,14 @@ try {
         It "Can get all group members by name" {
             $result = Get-LocalGroupMember TestGroupGet1
 
-            $result[0].Name.EndsWith("TestUserGet1") | Should -Be $true
+            $result[0].Name.EndsWith("TestUserGet1") | Should -BeTrue
             $result[0].SID | Should -Be $user1sid
             if (IsWin10OrHigher)
             {
                 $result[0].PrincipalSource | Should -Be Local
             }
             $result[0].ObjectClass | Should -Be User
-            $result[1].Name.EndsWith("TestUserGet2") | Should -Be $true
+            $result[1].Name.EndsWith("TestUserGet2") | Should -BeTrue
             $result[1].SID | Should -Be $user2sid
             if (IsWin10OrHigher)
             {
@@ -327,14 +327,14 @@ try {
         It "Can get all group members by SID" {
             $result = Get-LocalGroupMember -SID $group1sid
 
-            $result[0].Name.EndsWith("TestUserGet1") | Should -Be $true
+            $result[0].Name.EndsWith("TestUserGet1") | Should -BeTrue
             $result[0].SID | Should -Be $user1sid
             if (IsWin10OrHigher)
             {
                 $result[0].PrincipalSource | Should -Be Local
             }
             $result[0].ObjectClass | Should -Be User
-            $result[1].Name.EndsWith("TestUserGet2") | Should -Be $true
+            $result[1].Name.EndsWith("TestUserGet2") | Should -BeTrue
             $result[1].SID | Should -Be $user2sid
             if (IsWin10OrHigher)
             {
@@ -347,14 +347,14 @@ try {
             $group = Get-LocalGroup TestGroupGet1
             $result = Get-LocalGroupMember -Group $group
 
-            $result[0].Name.EndsWith("TestUserGet1") | Should -Be $true
+            $result[0].Name.EndsWith("TestUserGet1") | Should -BeTrue
             $result[0].SID | Should -Be $user1sid
             if (IsWin10OrHigher)
             {
                 $result[0].PrincipalSource | Should -Be Local
             }
             $result[0].ObjectClass | Should -Be User
-            $result[1].Name.EndsWith("TestUserGet2") | Should -Be $true
+            $result[1].Name.EndsWith("TestUserGet2") | Should -BeTrue
             $result[1].SID | Should -Be $user2sid
             if (IsWin10OrHigher)
             {
@@ -366,14 +366,14 @@ try {
         It "Can get all group members by pipeline" {
             $result = Get-LocalGroup TestGroupGet1 | Get-LocalGroupMember
 
-            $result[0].Name.EndsWith("TestUserGet1") | Should -Be $true
+            $result[0].Name.EndsWith("TestUserGet1") | Should -BeTrue
             $result[0].SID | Should -Be $user1sid
             if (IsWin10OrHigher)
             {
                 $result[0].PrincipalSource | Should -Be Local
             }
             $result[0].ObjectClass | Should -Be User
-            $result[1].Name.EndsWith("TestUserGet2") | Should -Be $true
+            $result[1].Name.EndsWith("TestUserGet2") | Should -BeTrue
             $result[1].SID | Should -Be $user2sid
             if (IsWin10OrHigher)
             {
@@ -384,9 +384,9 @@ try {
 
         It "Can get group members by wildcard" {
             $result = Get-LocalGroupMember TestGroupGet1 -Member TestUserGet*
-            $result.Count -eq 2 | Should -Be $true
-            $result[0].Name -match ($OptDomainPrefix+"TestUserGet1") | Should -Be $true
-            $result[1].Name -match ($OptDomainPrefix + "TestUserGet2") | Should -Be $true
+            $result.Count -eq 2 | Should -BeTrue
+            $result[0].Name -match ($OptDomainPrefix+"TestUserGet1") | Should -BeTrue
+            $result[1].Name -match ($OptDomainPrefix + "TestUserGet2") | Should -BeTrue
         }
 
         It "Errors on group name being nonexistent" {
@@ -399,7 +399,7 @@ try {
         It "Can get specific group member by name" {
             $result = Get-LocalGroupMember TestGroupGet1 -Member TestUserGet1
 
-            $result.Name.EndsWith("TestUserGet1") | Should -Be $true
+            $result.Name.EndsWith("TestUserGet1") | Should -BeTrue
             $result.SID | Should -Be $user1sid
             if (IsWin10OrHigher)
             {
@@ -466,14 +466,14 @@ try {
             Remove-LocalGroupMember TestGroupRemove1 -Member TestUserRemove2
             $result = Get-LocalGroupMember TestGroupRemove1
 
-            $result.Name.EndsWith("TestUserRemove1") | Should -Be $true
+            $result.Name.EndsWith("TestUserRemove1") | Should -BeTrue
         }
 
         It "Can remove a group member by SID" {
             Remove-LocalGroupMember -SID $group1sid -Member TestUserRemove2
             $result = Get-LocalGroupMember TestGroupRemove1
 
-            $result.Name.EndsWith("TestUserRemove1") | Should -Be $true
+            $result.Name.EndsWith("TestUserRemove1") | Should -BeTrue
         }
 
         It "Can remove a group member by Group object" {
@@ -481,14 +481,14 @@ try {
             Remove-LocalGroupMember -Group $group -Member TestUserRemove2
             $result = Get-LocalGroupMember TestGroupRemove1
 
-            $result.Name.EndsWith("TestUserRemove1") | Should -Be $true
+            $result.Name.EndsWith("TestUserRemove1") | Should -BeTrue
         }
 
         It "Can remove a group member by pipeline" {
             Get-LocalUser TestUserRemove2 | Remove-LocalGroupMember -Name TestGroupRemove1
             $result = Get-LocalGroupMember TestGroupRemove1
 
-            $result.Name.EndsWith("TestUserRemove1") | Should -Be $true
+            $result.Name.EndsWith("TestUserRemove1") | Should -BeTrue
         }
 
         It "Errors on group argument missing" {
@@ -590,7 +590,7 @@ try {
             VerifyFailingTest $sb "PrincipalNotFound,Microsoft.PowerShell.Commands.RemoveLocalGroupMemberCommand"
 
             $result = Get-LocalGroupMember TestGroupRemove1 2>&1
-            $result.Name -match ($OptDomainPrefix + "TestUserRemove2") | Should -Be $true
+            $result.Name -match ($OptDomainPrefix + "TestUserRemove2") | Should -BeTrue
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
@@ -97,7 +97,7 @@ try {
         It "Can create New-LocalUser with only name" {
             $result = New-LocalUser TestUserNew1 -NoPassword
 
-            $result.Name | Should BeExactly TestUserNew1
+            $result.Name | Should -BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
@@ -118,7 +118,7 @@ try {
             $userName = "S-1-5-32-545"
             $result = New-LocalUser $userName -NoPassword
 
-            $result.Name | Should BeExactly $userName
+            $result.Name | Should -BeExactly $userName
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
@@ -212,7 +212,7 @@ try {
             $expiration = $dateInFuture
             $result = New-LocalUser TestUserNew1 -NoPassword -AccountExpires $expiration
 
-            $result.Name | Should BeExactly TestUserNew1
+            $result.Name | Should -BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
@@ -224,7 +224,7 @@ try {
             $expiration = $dateInPast
             $result = New-LocalUser TestUserNew1 -NoPassword -AccountExpires $expiration
 
-            $result.Name | Should BeExactly TestUserNew1
+            $result.Name | Should -BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
@@ -243,7 +243,7 @@ try {
         It "Can set AccountNeverExpires to create a user with null for AccountExpires date" {
             $result = New-LocalUser TestUserNew1 -NoPassword -AccountNeverExpires
 
-            $result.Name | Should BeExactly TestUserNew1
+            $result.Name | Should -BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
@@ -261,8 +261,8 @@ try {
         It "Can set empty string for Description" {
             $result = New-LocalUser TestUserNew1 -NoPassword -Description ""
 
-            $result.Name | Should BeExactly TestUserNew1
-            $result.Description | Should BeExactly ""
+            $result.Name | Should -BeExactly TestUserNew1
+            $result.Description | Should -BeExactly ""
             $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
@@ -271,8 +271,8 @@ try {
         It "Can set with description at max 48" {
             $result = New-LocalUser TestUserNew1 -NoPassword -Description ("A"*48)
 
-            $result.Name | Should BeExactly TestUserNew1
-            $result.Description | Should BeExactly ("A"*48)
+            $result.Name | Should -BeExactly TestUserNew1
+            $result.Description | Should -BeExactly ("A"*48)
             $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
@@ -281,13 +281,13 @@ try {
         It "Can set with description over max 48" {
             $result = New-LocalUser TestUserNew1 -NoPassword -Description ("A"*257)
 
-            $result.Name | Should BeExactly TestUserNew1
+            $result.Name | Should -BeExactly TestUserNew1
         }
 
         It "Enabled is true by default" {
             $result = New-LocalUser TestUserNew1 -NoPassword
 
-            $result.Name | Should BeExactly TestUserNew1
+            $result.Name | Should -BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
@@ -297,7 +297,7 @@ try {
         It "Can set enabled to false" {
             $result = New-LocalUser TestUserNew1 -NoPassword -Disabled
 
-            $result.Name | Should BeExactly TestUserNew1
+            $result.Name | Should -BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should -Be $false
             $result.SID | Should -Not BeNullOrEmpty
@@ -307,7 +307,7 @@ try {
         It "Can set empty string for FullName" {
             $result = New-LocalUser TestUserNew1 -NoPassword -FullName ""
 
-            $result.Name | Should BeExactly TestUserNew1
+            $result.Name | Should -BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
@@ -318,12 +318,12 @@ try {
         It "Can set string for FullName at 256 characters" {
             $result = New-LocalUser TestUserNew1 -NoPassword -FullName ("A"*256)
 
-            $result.Name | Should BeExactly TestUserNew1
+            $result.Name | Should -BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
-            $result.FullName | Should BeExactly ("A"*256)
+            $result.FullName | Should -BeExactly ("A"*256)
         }
 
         It "Errors when Password is an empty string" {
@@ -336,7 +336,7 @@ try {
         It "Can set Password value at max 256" {
             $result = New-LocalUser TestUserNew1 -Password (ConvertTo-SecureString ("135@"+"A"*252) -AsPlainText -Force)
 
-            $result.Name | Should BeExactly TestUserNew1
+            $result.Name | Should -BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
@@ -364,7 +364,7 @@ try {
         It "Can set UserMayNotChangePassword" {
             $result = New-LocalUser TestUserNew1 -NoPassword -UserMayNotChangePassword
 
-            $result.Name | Should BeExactly TestUserNew1
+            $result.Name | Should -BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
@@ -376,7 +376,7 @@ try {
             #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
             $result = New-LocalUser TestUserNew1 -Password (ConvertTo-SecureString "p@ssw0rd" -Asplaintext -Force) -PasswordNeverExpires
 
-            $result.Name | Should BeExactly TestUserNew1
+            $result.Name | Should -BeExactly TestUserNew1
             $result.PasswordExpires | Should BeNullOrEmpty
         }
 
@@ -390,7 +390,7 @@ try {
         It "UserMayChangePassword is true by default" {
             $result = New-LocalUser TestUserNew1 -NoPassword
 
-            $result.Name | Should BeExactly TestUserNew1
+            $result.Name | Should -BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
@@ -556,11 +556,11 @@ try {
 
             $result = New-LocalUser TestUserGet3 -NoPassword -AccountExpires $AccountExpires -Description $Description -Disabled -FullName $FullName -UserMayNotChangePassword
 
-            $result.Name | Should BeExactly $Name
+            $result.Name | Should -BeExactly $Name
             $result.AccountExpires | Should -Be ([DateTime]$AccountExpires)
-            $result.Description | Should BeExactly $Description
+            $result.Description | Should -BeExactly $Description
             $result.Enabled | Should -Be $false
-            $result.FullName | Should BeExactly $FullName
+            $result.FullName | Should -BeExactly $FullName
             $result.ObjectClass -eq "User" | Should -Be true
             $result.UserMayChangePassword | Should -Be $false
             $result.SID | Should -Not BeNullOrEmpty
@@ -594,7 +594,7 @@ try {
             Set-LocalUser -Name TestUserSet1 -Description "Test User Set 1 new description"
             $result = Get-LocalUser -Name TestUserSet1
 
-            $result.Description | Should BeExactly "Test User Set 1 new description"
+            $result.Description | Should -BeExactly "Test User Set 1 new description"
         }
     }
 
@@ -624,7 +624,7 @@ try {
             Set-LocalUser -SID $user1SID -Description "Test User Set 1 new description"
             $result = Get-LocalUser -Name TestUserSet1
 
-            $result.Description | Should BeExactly "Test User Set 1 new description"
+            $result.Description | Should -BeExactly "Test User Set 1 new description"
         }
 
         It "Can set user description by -InputObject" {
@@ -632,14 +632,14 @@ try {
             Set-LocalUser -InputObject $user -Description "Test User Set 1 new description"
             $result = Get-LocalUser -Name TestUserSet1
 
-            $result.Description | Should BeExactly "Test User Set 1 new description"
+            $result.Description | Should -BeExactly "Test User Set 1 new description"
         }
 
         It "Can set user description by pipeline" {
             Get-LocalUser -Name TestUserSet1 | Set-LocalUser -Description "Test User Set 1 new description"
             $result = Get-LocalUser -Name TestUserSet1
 
-            $result.Description | Should BeExactly "Test User Set 1 new description"
+            $result.Description | Should -BeExactly "Test User Set 1 new description"
         }
 
         It "Errors on nonexistent user name" {
@@ -661,8 +661,8 @@ try {
             Set-LocalUser -Name TestUserSet1 -AccountExpires $expiration
             $result = Get-LocalUser -Name TestUserSet1
 
-            $result.Name | Should BeExactly TestUserSet1
-            $result.Description | Should BeExactly "Test User Set 1 Description"
+            $result.Name | Should -BeExactly TestUserSet1
+            $result.Description | Should -BeExactly "Test User Set 1 Description"
             $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
@@ -674,8 +674,8 @@ try {
             Set-LocalUser -Name TestUserSet1 -AccountExpires $expiration
             $result = Get-LocalUser -Name TestUserSet1
 
-            $result.Name | Should BeExactly TestUserSet1
-            $result.Description | Should BeExactly "Test User Set 1 Description"
+            $result.Name | Should -BeExactly TestUserSet1
+            $result.Description | Should -BeExactly "Test User Set 1 Description"
             $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
@@ -695,7 +695,7 @@ try {
             Set-LocalUser -Name TestUserSet1 -AccountNeverExpires
             $result = Get-LocalUser -Name TestUserSet1
 
-            $result.Name | Should BeExactly TestUserSet1
+            $result.Name | Should -BeExactly TestUserSet1
             $result.AccountExpires | Should BeNullOrEmpty
         }
 
@@ -710,22 +710,22 @@ try {
             Set-LocalUser -Name TestUserSet1 -Description ""
             $result = Get-LocalUser -Name TestUserSet1
 
-            $result.Description | Should BeExactly ""
+            $result.Description | Should -BeExactly ""
         }
 
         It "Can set empty string for Description" {
             Set-LocalUser -Name TestUserSet1 -Description ""
             $result = Get-LocalUser -Name TestUserSet1
 
-            $result.Description | Should BeExactly ""
+            $result.Description | Should -BeExactly ""
         }
 
         It "Can set string for Description at max 48" {
             Set-LocalUser TestUserSet1 -Description ("A"*48)
             $result = Get-LocalUser TestUserSet1
 
-            $result.Name | Should BeExactly TestUserSet1
-            $result.Description | Should BeExactly ("A"*48)
+            $result.Name | Should -BeExactly TestUserSet1
+            $result.Description | Should -BeExactly ("A"*48)
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
         }
@@ -734,15 +734,15 @@ try {
             Set-LocalUser -Name TestUserSet1 -FullName ""
             $result = Get-LocalUser -Name TestUserSet1
 
-            $result.FullName | Should BeExactly ""
+            $result.FullName | Should -BeExactly ""
         }
 
         It "Can set string for FullName at 256" {
             Set-LocalUser TestUserSet1 -FullName ("A"*256)
             $result = Get-LocalUser TestUserSet1
 
-            $result.Name | Should BeExactly TestUserSet1
-            $result.FullName | Should BeExactly ("A"*256)
+            $result.Name | Should -BeExactly TestUserSet1
+            $result.FullName | Should -BeExactly ("A"*256)
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
         }
@@ -765,7 +765,7 @@ try {
             Set-LocalUser -Name TestUserSet1 -Password (ConvertTo-SecureString ("123@"+"A"*252) -asplaintext -Force)
             $result = Get-LocalUser -Name TestUserSet1
 
-            $result.Name | Should BeExactly TestUserSet1
+            $result.Name | Should -BeExactly TestUserSet1
             $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
@@ -784,7 +784,7 @@ try {
             $user | Set-LocalUser -PasswordNeverExpires:$true
             $result = Get-LocalUser TestUserSet2
 
-            $result.Name | Should BeExactly TestUserSet2
+            $result.Name | Should -BeExactly TestUserSet2
             $result.PasswordExpires | Should BeNullOrEmpty
         }
 
@@ -794,7 +794,7 @@ try {
             $user | Set-LocalUser -PasswordNeverExpires:$false
             $result = Get-LocalUser TestUserSet2
 
-            $result.Name | Should BeExactly TestUserSet2
+            $result.Name | Should -BeExactly TestUserSet2
             $result.PasswordExpires | Should -Not BeNullOrEmpty
         }
 
@@ -802,7 +802,7 @@ try {
             Set-LocalUser TestUserSet1 -UserMayChangePassword $true
             $result = Get-LocalUser -Name TestUserSet1
 
-            $result.Name | Should BeExactly TestUserSet1
+            $result.Name | Should -BeExactly TestUserSet1
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
             $result.UserMayChangePassword | Should -Be $true
@@ -812,7 +812,7 @@ try {
             Set-LocalUser TestUserSet1 -UserMayChangePassword $false
             $result = Get-LocalUser -Name TestUserSet1
 
-            $result.Name | Should BeExactly TestUserSet1
+            $result.Name | Should -BeExactly TestUserSet1
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
             $result.UserMayChangePassword | Should -Be $false
@@ -845,7 +845,7 @@ try {
             Rename-LocalUser -Name TestUserRename1 -NewName TestUserRename2
             $result = Get-LocalUser -SID $user1SID
 
-            $result.Name | Should BeExactly TestUserRename2
+            $result.Name | Should -BeExactly TestUserRename2
         }
     }
 
@@ -875,7 +875,7 @@ try {
             Rename-LocalUser -SID $user1SID -NewName TestUserRename2
             $result = Get-LocalUser -SID $user1SID
 
-            $result.Name | Should BeExactly TestUserRename2
+            $result.Name | Should -BeExactly TestUserRename2
         }
 
         It "Can rename using -InputObject" {
@@ -883,16 +883,16 @@ try {
             Rename-LocalUser -InputObject $user -NewName TestUserRename2
             $result = Get-LocalUser -SID $user1SID
 
-            $result.Name | Should BeExactly TestUserRename2
-            $result.SID | Should BeExactly $user1SID
+            $result.Name | Should -BeExactly TestUserRename2
+            $result.SID | Should -BeExactly $user1SID
         }
 
         It "Can rename using pipeline" {
             Get-LocalUser -SID $user1SID | Rename-LocalUser -NewName TestUserRename2
             $result = Get-LocalUser -SID $user1SID
 
-            $result.Name | Should BeExactly TestUserRename2
-            $result.SID | Should BeExactly $user1SID
+            $result.Name | Should -BeExactly TestUserRename2
+            $result.SID | Should -BeExactly $user1SID
         }
 
         It "Errors on no name or SID specified" {
@@ -989,7 +989,7 @@ try {
             Rename-LocalUser -Name TestUserRename1 -NewName TestUserRename2
             $result = Get-LocalUser -SID $user1SID
 
-            $result.Name | Should BeExactly TestUserRename2
+            $result.Name | Should -BeExactly TestUserRename2
         }
 
         It "Errors when NewName over max 20" {

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
@@ -98,9 +98,9 @@ try {
             $result = New-LocalUser TestUserNew1 -NoPassword
 
             $result.Name | Should -BeExactly TestUserNew1
-            $result.Description | Should BeNullOrEmpty
+            $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should -BeTrue
-            $result.SID | Should -Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -Be User
         }
     }
@@ -119,9 +119,9 @@ try {
             $result = New-LocalUser $userName -NoPassword
 
             $result.Name | Should -BeExactly $userName
-            $result.Description | Should BeNullOrEmpty
+            $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should -BeTrue
-            $result.SID | Should -Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -Be User
         }
 
@@ -213,9 +213,9 @@ try {
             $result = New-LocalUser TestUserNew1 -NoPassword -AccountExpires $expiration
 
             $result.Name | Should -BeExactly TestUserNew1
-            $result.Description | Should BeNullOrEmpty
+            $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should -BeTrue
-            $result.SID | Should -Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -Be User
             $result.AccountExpires | Should -Be ([DateTime]$expiration)
         }
@@ -225,9 +225,9 @@ try {
             $result = New-LocalUser TestUserNew1 -NoPassword -AccountExpires $expiration
 
             $result.Name | Should -BeExactly TestUserNew1
-            $result.Description | Should BeNullOrEmpty
+            $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should -BeTrue
-            $result.SID | Should -Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -Be User
             $result.AccountExpires | Should -Be ([DateTime]$expiration)
         }
@@ -244,11 +244,11 @@ try {
             $result = New-LocalUser TestUserNew1 -NoPassword -AccountNeverExpires
 
             $result.Name | Should -BeExactly TestUserNew1
-            $result.Description | Should BeNullOrEmpty
+            $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should -BeTrue
-            $result.SID | Should -Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -Be User
-            $result.AccountExpires | Should BeNullOrEmpty
+            $result.AccountExpires | Should -BeNullOrEmpty
         }
 
          It "Errors on both AccountExpires and AccountNeverExpires being set" {
@@ -264,7 +264,7 @@ try {
             $result.Name | Should -BeExactly TestUserNew1
             $result.Description | Should -BeExactly ""
             $result.Enabled | Should -BeTrue
-            $result.SID | Should -Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -Be User
         }
 
@@ -274,7 +274,7 @@ try {
             $result.Name | Should -BeExactly TestUserNew1
             $result.Description | Should -BeExactly ("A"*48)
             $result.Enabled | Should -BeTrue
-            $result.SID | Should -Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -Be User
         }
 
@@ -288,9 +288,9 @@ try {
             $result = New-LocalUser TestUserNew1 -NoPassword
 
             $result.Name | Should -BeExactly TestUserNew1
-            $result.Description | Should BeNullOrEmpty
+            $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should -BeTrue
-            $result.SID | Should -Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -Be User
         }
 
@@ -298,9 +298,9 @@ try {
             $result = New-LocalUser TestUserNew1 -NoPassword -Disabled
 
             $result.Name | Should -BeExactly TestUserNew1
-            $result.Description | Should BeNullOrEmpty
+            $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should -BeFalse
-            $result.SID | Should -Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -Be User
         }
 
@@ -308,20 +308,20 @@ try {
             $result = New-LocalUser TestUserNew1 -NoPassword -FullName ""
 
             $result.Name | Should -BeExactly TestUserNew1
-            $result.Description | Should BeNullOrEmpty
+            $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should -BeTrue
-            $result.SID | Should -Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -Be User
-            $result.FullName | Should BeNullOrEmpty
+            $result.FullName | Should -BeNullOrEmpty
         }
 
         It "Can set string for FullName at 256 characters" {
             $result = New-LocalUser TestUserNew1 -NoPassword -FullName ("A"*256)
 
             $result.Name | Should -BeExactly TestUserNew1
-            $result.Description | Should BeNullOrEmpty
+            $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should -BeTrue
-            $result.SID | Should -Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -Be User
             $result.FullName | Should -BeExactly ("A"*256)
         }
@@ -337,9 +337,9 @@ try {
             $result = New-LocalUser TestUserNew1 -Password (ConvertTo-SecureString ("135@"+"A"*252) -AsPlainText -Force)
 
             $result.Name | Should -BeExactly TestUserNew1
-            $result.Description | Should BeNullOrEmpty
+            $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should -BeTrue
-            $result.SID | Should -Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -Be User
         }
 
@@ -365,9 +365,9 @@ try {
             $result = New-LocalUser TestUserNew1 -NoPassword -UserMayNotChangePassword
 
             $result.Name | Should -BeExactly TestUserNew1
-            $result.Description | Should BeNullOrEmpty
+            $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should -BeTrue
-            $result.SID | Should -Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -Be User
             $result.UserMayChangePassword | Should -BeFalse
         }
@@ -377,7 +377,7 @@ try {
             $result = New-LocalUser TestUserNew1 -Password (ConvertTo-SecureString "p@ssw0rd" -Asplaintext -Force) -PasswordNeverExpires
 
             $result.Name | Should -BeExactly TestUserNew1
-            $result.PasswordExpires | Should BeNullOrEmpty
+            $result.PasswordExpires | Should -BeNullOrEmpty
         }
 
         It "Errors on both NoPassword and PasswordNeverExpires being set" {
@@ -391,9 +391,9 @@ try {
             $result = New-LocalUser TestUserNew1 -NoPassword
 
             $result.Name | Should -BeExactly TestUserNew1
-            $result.Description | Should BeNullOrEmpty
+            $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should -BeTrue
-            $result.SID | Should -Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -Be User
             $result.UserMayChangePassword | Should -BeTrue
         }
@@ -448,7 +448,7 @@ try {
             $result = Get-LocalUser TestUserGet1
             $resultBySID = Get-LocalUser -SID $result.SID
 
-            $resultBySID.SID | Should -Not BeNullOrEmpty
+            $resultBySID.SID | Should -Not -BeNullOrEmpty
             $resultBySID.Name | Should -Be TestUserGet1
         }
 
@@ -563,7 +563,7 @@ try {
             $result.FullName | Should -BeExactly $FullName
             $result.ObjectClass -eq "User" | Should -BeTrue
             $result.UserMayChangePassword | Should -BeFalse
-            $result.SID | Should -Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -Be User
         }
     }
@@ -664,7 +664,7 @@ try {
             $result.Name | Should -BeExactly TestUserSet1
             $result.Description | Should -BeExactly "Test User Set 1 Description"
             $result.Enabled | Should -BeTrue
-            $result.SID | Should -Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -Be User
             $result.AccountExpires | Should -Be ([DateTime]$expiration)
         }
@@ -677,7 +677,7 @@ try {
             $result.Name | Should -BeExactly TestUserSet1
             $result.Description | Should -BeExactly "Test User Set 1 Description"
             $result.Enabled | Should -BeTrue
-            $result.SID | Should -Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -Be User
             $result.AccountExpires | Should -Be ([DateTime]$expiration)
         }
@@ -696,7 +696,7 @@ try {
             $result = Get-LocalUser -Name TestUserSet1
 
             $result.Name | Should -BeExactly TestUserSet1
-            $result.AccountExpires | Should BeNullOrEmpty
+            $result.AccountExpires | Should -BeNullOrEmpty
         }
 
         It "Errors on both AccountExpires and AccountNeverExpires being set" {
@@ -726,7 +726,7 @@ try {
 
             $result.Name | Should -BeExactly TestUserSet1
             $result.Description | Should -BeExactly ("A"*48)
-            $result.SID | Should -Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -Be User
         }
 
@@ -743,7 +743,7 @@ try {
 
             $result.Name | Should -BeExactly TestUserSet1
             $result.FullName | Should -BeExactly ("A"*256)
-            $result.SID | Should -Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -Be User
         }
 
@@ -767,7 +767,7 @@ try {
 
             $result.Name | Should -BeExactly TestUserSet1
             $result.Enabled | Should -BeTrue
-            $result.SID | Should -Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -Be User
         }
 
@@ -785,7 +785,7 @@ try {
             $result = Get-LocalUser TestUserSet2
 
             $result.Name | Should -BeExactly TestUserSet2
-            $result.PasswordExpires | Should BeNullOrEmpty
+            $result.PasswordExpires | Should -BeNullOrEmpty
         }
 
         It 'Can use PasswordNeverExpires:$false to activate a PasswordExpires date' {
@@ -795,7 +795,7 @@ try {
             $result = Get-LocalUser TestUserSet2
 
             $result.Name | Should -BeExactly TestUserSet2
-            $result.PasswordExpires | Should -Not BeNullOrEmpty
+            $result.PasswordExpires | Should -Not -BeNullOrEmpty
         }
 
         It "Can set UserMayChangePassword to true" {
@@ -803,7 +803,7 @@ try {
             $result = Get-LocalUser -Name TestUserSet1
 
             $result.Name | Should -BeExactly TestUserSet1
-            $result.SID | Should -Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -Be User
             $result.UserMayChangePassword | Should -BeTrue
         }
@@ -813,7 +813,7 @@ try {
             $result = Get-LocalUser -Name TestUserSet1
 
             $result.Name | Should -BeExactly TestUserSet1
-            $result.SID | Should -Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -Be User
             $result.UserMayChangePassword | Should -BeFalse
         }
@@ -1027,7 +1027,7 @@ try {
             $initialCount -gt 1 | Should -BeTrue
 
             $removeResult = Remove-LocalUser TestUserRemove1 2>&1
-            $removeResult | Should BeNullOrEmpty
+            $removeResult | Should -BeNullOrEmpty
 
             $sb = {
                 Get-LocalUser -SID $user1SID
@@ -1105,10 +1105,10 @@ try {
         }
 
         It "Can remove by SID" {
-            $user1SID | Should -Not BeNullOrEmpty
+            $user1SID | Should -Not -BeNullOrEmpty
             $sb = {
                 $result = Remove-LocalUser -SID $user1SID 2>&1
-                $result | Should BeNullOrEmpty
+                $result | Should -BeNullOrEmpty
             }
             VerifyBasicRemoval $sb
         }
@@ -1117,7 +1117,7 @@ try {
             $sb = {
                 $user = Get-LocalUser -SID $user1SID
                 $result = Remove-LocalUser -InputObject $user 2>&1
-                $result | Should BeNullOrEmpty
+                $result | Should -BeNullOrEmpty
             }
             VerifyBasicRemoval $sb
         }
@@ -1125,7 +1125,7 @@ try {
         It "Can remove using pipeline" {
             $sb = {
                 $result = Get-LocalUser -SID $user1SID | Remove-LocalUser 2>&1
-                $result | Should BeNullOrEmpty
+                $result | Should -BeNullOrEmpty
             }
             VerifyBasicRemoval $sb
         }
@@ -1140,7 +1140,7 @@ try {
         It "Can remove by array of names" {
             $sb = {
                 $result = Remove-LocalUser @("TestUserRemove1", "TestUserRemove2") 2>&1
-                $result | Should BeNullOrEmpty
+                $result | Should -BeNullOrEmpty
             }
             VerifyArrayRemoval $sb
         }
@@ -1148,7 +1148,7 @@ try {
         It "Can remove by array of SIDs" {
             $sb = {
                 $result = Remove-LocalUser -SID @($user1SID, $user2SID) 2>&1
-                $result | Should BeNullOrEmpty
+                $result | Should -BeNullOrEmpty
             }
             VerifyArrayRemoval $sb
         }
@@ -1157,7 +1157,7 @@ try {
             $sb = {
                 $users = Get-LocalUser @("TestUserRemove1", "TestUserRemove2")
                 $results = Remove-LocalUser -InputObject $users 2>&1
-                $result | Should BeNullOrEmpty
+                $result | Should -BeNullOrEmpty
             }
             VerifyArrayRemoval $sb
         }
@@ -1165,7 +1165,7 @@ try {
         It "Can remove by array using pipeline" {
             $sb = {
                 $result = Get-LocalUser @("TestUserRemove1", "TestUserRemove2") | Remove-LocalUser 2>&1
-                $result | Should BeNullOrEmpty
+                $result | Should -BeNullOrEmpty
             }
             VerifyArrayRemoval $sb
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
@@ -100,7 +100,7 @@ try {
             $result.Name | Should BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
         }
     }
@@ -121,7 +121,7 @@ try {
             $result.Name | Should BeExactly $userName
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
         }
 
@@ -215,7 +215,7 @@ try {
             $result.Name | Should BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
             $result.AccountExpires | Should Be ([DateTime]$expiration)
         }
@@ -227,7 +227,7 @@ try {
             $result.Name | Should BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
             $result.AccountExpires | Should Be ([DateTime]$expiration)
         }
@@ -246,7 +246,7 @@ try {
             $result.Name | Should BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
             $result.AccountExpires | Should BeNullOrEmpty
         }
@@ -264,7 +264,7 @@ try {
             $result.Name | Should BeExactly TestUserNew1
             $result.Description | Should BeExactly ""
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
         }
 
@@ -274,7 +274,7 @@ try {
             $result.Name | Should BeExactly TestUserNew1
             $result.Description | Should BeExactly ("A"*48)
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
         }
 
@@ -290,7 +290,7 @@ try {
             $result.Name | Should BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
         }
 
@@ -300,7 +300,7 @@ try {
             $result.Name | Should BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should Be $false
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
         }
 
@@ -310,7 +310,7 @@ try {
             $result.Name | Should BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
             $result.FullName | Should BeNullOrEmpty
         }
@@ -321,7 +321,7 @@ try {
             $result.Name | Should BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
             $result.FullName | Should BeExactly ("A"*256)
         }
@@ -339,7 +339,7 @@ try {
             $result.Name | Should BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
         }
 
@@ -367,7 +367,7 @@ try {
             $result.Name | Should BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
             $result.UserMayChangePassword | Should Be $false
         }
@@ -393,7 +393,7 @@ try {
             $result.Name | Should BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
             $result.UserMayChangePassword | Should Be $true
         }
@@ -448,7 +448,7 @@ try {
             $result = Get-LocalUser TestUserGet1
             $resultBySID = Get-LocalUser -SID $result.SID
 
-            $resultBySID.SID | Should Not BeNullOrEmpty
+            $resultBySID.SID | Should -Not BeNullOrEmpty
             $resultBySID.Name | Should Be TestUserGet1
         }
 
@@ -563,7 +563,7 @@ try {
             $result.FullName | Should BeExactly $FullName
             $result.ObjectClass -eq "User" | Should be true
             $result.UserMayChangePassword | Should Be $false
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
         }
     }
@@ -664,7 +664,7 @@ try {
             $result.Name | Should BeExactly TestUserSet1
             $result.Description | Should BeExactly "Test User Set 1 Description"
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
             $result.AccountExpires | Should Be ([DateTime]$expiration)
         }
@@ -677,7 +677,7 @@ try {
             $result.Name | Should BeExactly TestUserSet1
             $result.Description | Should BeExactly "Test User Set 1 Description"
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
             $result.AccountExpires | Should Be ([DateTime]$expiration)
         }
@@ -726,7 +726,7 @@ try {
 
             $result.Name | Should BeExactly TestUserSet1
             $result.Description | Should BeExactly ("A"*48)
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
         }
 
@@ -743,7 +743,7 @@ try {
 
             $result.Name | Should BeExactly TestUserSet1
             $result.FullName | Should BeExactly ("A"*256)
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
         }
 
@@ -767,7 +767,7 @@ try {
 
             $result.Name | Should BeExactly TestUserSet1
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
         }
 
@@ -795,7 +795,7 @@ try {
             $result = Get-LocalUser TestUserSet2
 
             $result.Name | Should BeExactly TestUserSet2
-            $result.PasswordExpires | Should Not BeNullOrEmpty
+            $result.PasswordExpires | Should -Not BeNullOrEmpty
         }
 
         It "Can set UserMayChangePassword to true" {
@@ -803,7 +803,7 @@ try {
             $result = Get-LocalUser -Name TestUserSet1
 
             $result.Name | Should BeExactly TestUserSet1
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
             $result.UserMayChangePassword | Should Be $true
         }
@@ -813,7 +813,7 @@ try {
             $result = Get-LocalUser -Name TestUserSet1
 
             $result.Name | Should BeExactly TestUserSet1
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
             $result.UserMayChangePassword | Should Be $false
         }
@@ -1105,7 +1105,7 @@ try {
         }
 
         It "Can remove by SID" {
-            $user1SID | Should Not BeNullOrEmpty
+            $user1SID | Should -Not BeNullOrEmpty
             $sb = {
                 $result = Remove-LocalUser -SID $user1SID 2>&1
                 $result | Should BeNullOrEmpty

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
@@ -299,7 +299,7 @@ try {
 
             $result.Name | Should -BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
-            $result.Enabled | Should -Be $false
+            $result.Enabled | Should -BeFalse
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
         }
@@ -369,7 +369,7 @@ try {
             $result.Enabled | Should -BeTrue
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
-            $result.UserMayChangePassword | Should -Be $false
+            $result.UserMayChangePassword | Should -BeFalse
         }
 
         It "Can set PasswordNeverExpires to create a user with null for PasswordExpires date" {
@@ -559,10 +559,10 @@ try {
             $result.Name | Should -BeExactly $Name
             $result.AccountExpires | Should -Be ([DateTime]$AccountExpires)
             $result.Description | Should -BeExactly $Description
-            $result.Enabled | Should -Be $false
+            $result.Enabled | Should -BeFalse
             $result.FullName | Should -BeExactly $FullName
             $result.ObjectClass -eq "User" | Should -BeTrue
-            $result.UserMayChangePassword | Should -Be $false
+            $result.UserMayChangePassword | Should -BeFalse
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
         }
@@ -815,7 +815,7 @@ try {
             $result.Name | Should -BeExactly TestUserSet1
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
-            $result.UserMayChangePassword | Should -Be $false
+            $result.UserMayChangePassword | Should -BeFalse
         }
     }
 
@@ -1410,7 +1410,7 @@ try {
             Disable-LocalUser TestUserEnabled1
             $result = Get-LocalUser TestUserEnabled1
 
-            $result.Enabled | Should -Be $false
+            $result.Enabled | Should -BeFalse
         }
     }
 
@@ -1450,7 +1450,7 @@ try {
             Disable-LocalUser -SID $enabledUser1SID
             $result = Get-LocalUser -SID $enabledUser1SID
 
-            $result.Enabled | Should -Be $false
+            $result.Enabled | Should -BeFalse
         }
 
         It "Can disable an enabled user using -InputObject" {
@@ -1458,43 +1458,43 @@ try {
             Disable-LocalUser -InputObject $user
             $result = Get-LocalUser TestUserEnabled1
 
-            $result.Enabled | Should -Be $false
+            $result.Enabled | Should -BeFalse
         }
 
         It "Can disable an enabled user using pipeline" {
             Get-LocalUser TestUserEnabled1 | Disable-LocalUser
             $result = Get-LocalUser TestUserEnabled1
 
-            $result.Enabled | Should -Be $false
+            $result.Enabled | Should -BeFalse
         }
 
         It "Can disable an enabled user by array of names" {
             Disable-LocalUser @("TestUserEnabled1", "TestUserEnabled2")
 
-            (Get-LocalUser "TestUserEnabled1").Enabled | Should -Be $false
-            (Get-LocalUser "TestUserEnabled2").Enabled | Should -Be $false
+            (Get-LocalUser "TestUserEnabled1").Enabled | Should -BeFalse
+            (Get-LocalUser "TestUserEnabled2").Enabled | Should -BeFalse
         }
 
         It "Can disable an enabled user by array of SIDs" {
             Disable-LocalUser -SID @($enabledUser1SID, $enabledUser2SID)
 
-            (Get-LocalUser -SID $enabledUser1SID).Enabled | Should -Be $false
-            (Get-LocalUser -SID $enabledUser2SID).Enabled | Should -Be $false
+            (Get-LocalUser -SID $enabledUser1SID).Enabled | Should -BeFalse
+            (Get-LocalUser -SID $enabledUser2SID).Enabled | Should -BeFalse
         }
 
         It "Can disable an enabled user by array sent using pipeline" {
             $users = @((Get-LocalUser "TestUserEnabled1"), (Get-LocalUser "TestUserEnabled2"))
             Disable-LocalUser -InputObject $users
 
-            (Get-LocalUser "TestUserEnabled1").Enabled | Should -Be $false
-            (Get-LocalUser "TestUserEnabled2").Enabled | Should -Be $false
+            (Get-LocalUser "TestUserEnabled1").Enabled | Should -BeFalse
+            (Get-LocalUser "TestUserEnabled2").Enabled | Should -BeFalse
         }
 
         It "Can disable an enabled user by array sent using pipeline" {
             @((Get-LocalUser "TestUserEnabled1"), (Get-LocalUser "TestUserEnabled2")) | Disable-LocalUser
 
-            (Get-LocalUser "TestUserEnabled1").Enabled | Should -Be $false
-            (Get-LocalUser "TestUserEnabled2").Enabled | Should -Be $false
+            (Get-LocalUser "TestUserEnabled1").Enabled | Should -BeFalse
+            (Get-LocalUser "TestUserEnabled2").Enabled | Should -BeFalse
         }
 
         It "Errors on no name or SID specified" {
@@ -1507,19 +1507,19 @@ try {
         It "Can disable an already disabled user by name" {
             Disable-LocalUser TestUserDisabled1
 
-            (Get-LocalUser TestUserDisabled1).Enabled | Should -Be $false
+            (Get-LocalUser TestUserDisabled1).Enabled | Should -BeFalse
         }
 
         It "Can disable an already disabled user by SID" {
             Disable-LocalUser -SID $disabledUser1SID
 
-            (Get-LocalUser -SID $disabledUser1SID).Enabled | Should -Be $false
+            (Get-LocalUser -SID $disabledUser1SID).Enabled | Should -BeFalse
         }
 
         It "Can disable an already disabled user using the pipeline" {
             Get-LocalUser TestUserDisabled1 | Disable-LocalUser
 
-            (Get-LocalUser TestUserDisabled1).Enabled | Should -Be $false
+            (Get-LocalUser TestUserDisabled1).Enabled | Should -BeFalse
         }
 
         It "Errors on disabling an invalid user by name" {
@@ -1548,7 +1548,7 @@ try {
             $outError[0].ErrorRecord.FullyQualifiedErrorId | Should -Be "UserNotFound,Microsoft.PowerShell.Commands.DisableLocalUserCommand"
 
             $getResult = Get-LocalUser TestUserEnabled1 2>&1
-            $getResult.Enabled | Should -Be $false
+            $getResult.Enabled | Should -BeFalse
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
@@ -53,13 +53,13 @@ try {
         It "Test command presence" {
             $result = Get-Command -Module Microsoft.PowerShell.LocalAccounts | ForEach-Object Name
 
-            $result -contains "New-LocalUser" | Should -Be $true
-            $result -contains "Set-LocalUser" | Should -Be $true
-            $result -contains "Get-LocalUser" | Should -Be $true
-            $result -contains "Rename-LocalUser" | Should -Be $true
-            $result -contains "Remove-LocalUser" | Should -Be $true
-            $result -contains "Enable-LocalUser" | Should -Be $true
-            $result -contains "Disable-LocalUser" | Should -Be $true
+            $result -contains "New-LocalUser" | Should -BeTrue
+            $result -contains "Set-LocalUser" | Should -BeTrue
+            $result -contains "Get-LocalUser" | Should -BeTrue
+            $result -contains "Rename-LocalUser" | Should -BeTrue
+            $result -contains "Remove-LocalUser" | Should -BeTrue
+            $result -contains "Enable-LocalUser" | Should -BeTrue
+            $result -contains "Disable-LocalUser" | Should -BeTrue
         }
     }
 
@@ -68,21 +68,21 @@ try {
         It "Test command presence" {
             $result = get-alias | ForEach-Object { if ($_.Source -eq "Microsoft.PowerShell.LocalAccounts") {$_}}
 
-            $result.Name -contains "algm" | Should -Be $true
-            $result.Name -contains "dlu" | Should -Be $true
-            $result.Name -contains "elu" | Should -Be $true
-            $result.Name -contains "glg" | Should -Be $true
-            $result.Name -contains "glgm" | Should -Be $true
-            $result.Name -contains "glu" | Should -Be $true
-            $result.Name -contains "nlg" | Should -Be $true
-            $result.Name -contains "nlu" | Should -Be $true
-            $result.Name -contains "rlg" | Should -Be $true
-            $result.Name -contains "rlgm" | Should -Be $true
-            $result.Name -contains "rlu" | Should -Be $true
-            $result.Name -contains "rnlg" | Should -Be $true
-            $result.Name -contains "rnlu" | Should -Be $true
-            $result.Name -contains "slg" | Should -Be $true
-            $result.Name -contains "slu" | Should -Be $true
+            $result.Name -contains "algm" | Should -BeTrue
+            $result.Name -contains "dlu" | Should -BeTrue
+            $result.Name -contains "elu" | Should -BeTrue
+            $result.Name -contains "glg" | Should -BeTrue
+            $result.Name -contains "glgm" | Should -BeTrue
+            $result.Name -contains "glu" | Should -BeTrue
+            $result.Name -contains "nlg" | Should -BeTrue
+            $result.Name -contains "nlu" | Should -BeTrue
+            $result.Name -contains "rlg" | Should -BeTrue
+            $result.Name -contains "rlgm" | Should -BeTrue
+            $result.Name -contains "rlu" | Should -BeTrue
+            $result.Name -contains "rnlg" | Should -BeTrue
+            $result.Name -contains "rnlu" | Should -BeTrue
+            $result.Name -contains "slg" | Should -BeTrue
+            $result.Name -contains "slu" | Should -BeTrue
         }
     }
 
@@ -99,7 +99,7 @@ try {
 
             $result.Name | Should -BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
-            $result.Enabled | Should -Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
         }
@@ -120,7 +120,7 @@ try {
 
             $result.Name | Should -BeExactly $userName
             $result.Description | Should BeNullOrEmpty
-            $result.Enabled | Should -Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
         }
@@ -161,7 +161,7 @@ try {
 
             #Assert
             if ($failedCharacters.Count -gt 0) { Write-Host "characters causing test fail: $failedCharacters" }
-            $failedCharacters.Count -eq 0 | Should -Be $true
+            $failedCharacters.Count -eq 0 | Should -BeTrue
         }
 
         It "Errors on names containing only spaces or periods" {
@@ -214,7 +214,7 @@ try {
 
             $result.Name | Should -BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
-            $result.Enabled | Should -Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
             $result.AccountExpires | Should -Be ([DateTime]$expiration)
@@ -226,7 +226,7 @@ try {
 
             $result.Name | Should -BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
-            $result.Enabled | Should -Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
             $result.AccountExpires | Should -Be ([DateTime]$expiration)
@@ -245,7 +245,7 @@ try {
 
             $result.Name | Should -BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
-            $result.Enabled | Should -Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
             $result.AccountExpires | Should BeNullOrEmpty
@@ -263,7 +263,7 @@ try {
 
             $result.Name | Should -BeExactly TestUserNew1
             $result.Description | Should -BeExactly ""
-            $result.Enabled | Should -Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
         }
@@ -273,7 +273,7 @@ try {
 
             $result.Name | Should -BeExactly TestUserNew1
             $result.Description | Should -BeExactly ("A"*48)
-            $result.Enabled | Should -Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
         }
@@ -289,7 +289,7 @@ try {
 
             $result.Name | Should -BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
-            $result.Enabled | Should -Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
         }
@@ -309,7 +309,7 @@ try {
 
             $result.Name | Should -BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
-            $result.Enabled | Should -Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
             $result.FullName | Should BeNullOrEmpty
@@ -320,7 +320,7 @@ try {
 
             $result.Name | Should -BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
-            $result.Enabled | Should -Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
             $result.FullName | Should -BeExactly ("A"*256)
@@ -338,7 +338,7 @@ try {
 
             $result.Name | Should -BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
-            $result.Enabled | Should -Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
         }
@@ -366,7 +366,7 @@ try {
 
             $result.Name | Should -BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
-            $result.Enabled | Should -Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
             $result.UserMayChangePassword | Should -Be $false
@@ -392,10 +392,10 @@ try {
 
             $result.Name | Should -BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
-            $result.Enabled | Should -Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
-            $result.UserMayChangePassword | Should -Be $true
+            $result.UserMayChangePassword | Should -BeTrue
         }
     }
 
@@ -441,7 +441,7 @@ try {
         It "Get-LocalUser gets all users"  {
             $result = Get-LocalUser
 
-            $result.Count -gt 2 | Should -Be $true
+            $result.Count -gt 2 | Should -BeTrue
         }
 
         It "Can get a specific user by SID" {
@@ -462,17 +462,17 @@ try {
         It "Can get users by wildcard" {
             $result = Get-LocalUser TestUserGet*
 
-            $result.Count -eq 2 | Should -Be $true
-            $result.Name -contains "TestUserGet1" | Should -Be $true
-            $result.Name -contains "TestUserGet2" | Should -Be $true
+            $result.Count -eq 2 | Should -BeTrue
+            $result.Name -contains "TestUserGet1" | Should -BeTrue
+            $result.Name -contains "TestUserGet2" | Should -BeTrue
         }
 
         It "Can get a user by array of names" {
             $result = Get-LocalUser @("TestUserGet1", "TestUserGet2")
 
-            $result.Count -eq 2 | Should -Be $true
-            $result.Name -contains "TestUserGet1" | Should -Be $true
-            $result.Name -contains "TestUserGet2" | Should -Be $true
+            $result.Count -eq 2 | Should -BeTrue
+            $result.Name -contains "TestUserGet1" | Should -BeTrue
+            $result.Name -contains "TestUserGet2" | Should -BeTrue
         }
 
         It "Can get a user by array of SIDs" {
@@ -480,9 +480,9 @@ try {
             $sid2 = (Get-LocalUser TestUserGet2).SID
             $result = Get-LocalUser -SID @($sid1, $sid2)
 
-            $result.Count -eq 2 | Should -Be $true
-            $result.Name -contains "TestUserGet1" | Should -Be $true
-            $result.Name -contains "TestUserGet2" | Should -Be $true
+            $result.Count -eq 2 | Should -BeTrue
+            $result.Name -contains "TestUserGet1" | Should -BeTrue
+            $result.Name -contains "TestUserGet2" | Should -BeTrue
         }
 
         It "Can respond to -ErrorAction Stop" {
@@ -492,9 +492,9 @@ try {
             Catch {
                 # Ignore the execption
             }
-            $outErr.Count -eq 1 | Should -Be $true
-            $outErr[0].ErrorRecord.CategoryInfo.Reason -match "UserNotFound" | Should -Be $true
-            $outOut.Name -match "TestUserGet1" | Should -Be $true
+            $outErr.Count -eq 1 | Should -BeTrue
+            $outErr[0].ErrorRecord.CategoryInfo.Reason -match "UserNotFound" | Should -BeTrue
+            $outOut.Name -match "TestUserGet1" | Should -BeTrue
         }
 
         It "Error on Name not being supplied an argument" {
@@ -561,7 +561,7 @@ try {
             $result.Description | Should -BeExactly $Description
             $result.Enabled | Should -Be $false
             $result.FullName | Should -BeExactly $FullName
-            $result.ObjectClass -eq "User" | Should -Be true
+            $result.ObjectClass -eq "User" | Should -BeTrue
             $result.UserMayChangePassword | Should -Be $false
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
@@ -663,7 +663,7 @@ try {
 
             $result.Name | Should -BeExactly TestUserSet1
             $result.Description | Should -BeExactly "Test User Set 1 Description"
-            $result.Enabled | Should -Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
             $result.AccountExpires | Should -Be ([DateTime]$expiration)
@@ -676,7 +676,7 @@ try {
 
             $result.Name | Should -BeExactly TestUserSet1
             $result.Description | Should -BeExactly "Test User Set 1 Description"
-            $result.Enabled | Should -Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
             $result.AccountExpires | Should -Be ([DateTime]$expiration)
@@ -766,7 +766,7 @@ try {
             $result = Get-LocalUser -Name TestUserSet1
 
             $result.Name | Should -BeExactly TestUserSet1
-            $result.Enabled | Should -Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
         }
@@ -805,7 +805,7 @@ try {
             $result.Name | Should -BeExactly TestUserSet1
             $result.SID | Should -Not BeNullOrEmpty
             $result.ObjectClass | Should -Be User
-            $result.UserMayChangePassword | Should -Be $true
+            $result.UserMayChangePassword | Should -BeTrue
         }
 
         It "Can set UserMayChangePassword to false" {
@@ -958,7 +958,7 @@ try {
 
             #Assert
             if ($failedCharacters.Count -gt 0) { Write-Host "characters causing test fail: $failedCharacters" }
-            $failedCharacters.Count -eq 0 | Should -Be $true
+            $failedCharacters.Count -eq 0 | Should -BeTrue
         }
 
         It "Errors on names containing only spaces or periods" {
@@ -1024,7 +1024,7 @@ try {
 
         It "Can Remove-LocalUser with only name" {
             $initialCount = (Get-LocalUser).Count
-            $initialCount -gt 1 | Should -Be $true
+            $initialCount -gt 1 | Should -BeTrue
 
             $removeResult = Remove-LocalUser TestUserRemove1 2>&1
             $removeResult | Should BeNullOrEmpty
@@ -1035,7 +1035,7 @@ try {
             VerifyFailingTest $sb "UserNotFound,Microsoft.PowerShell.Commands.GetLocalUserCommand"
 
             $finalCount = (Get-LocalUser).Count
-            $initialCount -eq $finalCount + 1 | Should -Be $true
+            $initialCount -eq $finalCount + 1 | Should -BeTrue
         }
     }
 
@@ -1051,7 +1051,7 @@ try {
                         [scriptblock]$removalAction
                     )
                     $initialCount = (Get-LocalUser).Count
-                    $initialCount -gt 1 | Should -Be true
+                    $initialCount -gt 1 | Should -BeTrue
 
                     & $removalAction
 
@@ -1061,7 +1061,7 @@ try {
                     VerifyFailingTest $sb "UserNotFound,Microsoft.PowerShell.Commands.GetLocalUserCommand"
 
                     $finalCount = (Get-LocalUser).Count
-                    $initialCount -eq $finalCount + 1 | Should -Be true
+                    $initialCount -eq $finalCount + 1 | Should -BeTrue
                 }
 
                 function VerifyArrayRemoval {
@@ -1069,7 +1069,7 @@ try {
                         [scriptblock]$removalAction
                     )
                     $initialCount = (Get-LocalUser).Count
-                    $initialCount -gt 1 | Should -Be true
+                    $initialCount -gt 1 | Should -BeTrue
 
                     & $removalAction
 
@@ -1084,7 +1084,7 @@ try {
                     VerifyFailingTest $sb "UserNotFound,Microsoft.PowerShell.Commands.GetLocalUserCommand"
 
                     $finalCount = (Get-LocalUser).Count
-                    $initialCount -eq $finalCount + 2 | Should -Be $true
+                    $initialCount -eq $finalCount + 2 | Should -BeTrue
                 }
             }
         }
@@ -1172,7 +1172,7 @@ try {
 
         It "Errors on remove by invalid name" {
             $initialCount =  (Get-LocalUser).Count
-            $initialCount -gt 1 | Should -Be $true
+            $initialCount -gt 1 | Should -BeTrue
 
             $sb = {
                 Remove-LocalUser TestUserRemove1NameThatDoesntExist
@@ -1180,14 +1180,14 @@ try {
             VerifyFailingTest $sb "UserNotFound,Microsoft.PowerShell.Commands.RemoveLocalUserCommand"
 
             $finalCount = (Get-LocalUser).Count
-            $initialCount -eq $finalCount | Should -Be $true
+            $initialCount -eq $finalCount | Should -BeTrue
         }
 
         It "Errors on remove by invalid SID" {
             Remove-LocalUser -SID $user1SID
             # This test verifies that it cannot be removed a second time
             $initialCount =  (Get-LocalUser).Count
-            $initialCount -gt 1 | Should -Be $true
+            $initialCount -gt 1 | Should -BeTrue
 
             $sb = {
                 Remove-LocalUser -SID $user1SID
@@ -1195,7 +1195,7 @@ try {
             VerifyFailingTest $sb "UserNotFound,Microsoft.PowerShell.Commands.RemoveLocalUserCommand"
 
             $finalCount = (Get-LocalUser).Count
-            $initialCount -eq $finalCount | Should -Be $true
+            $initialCount -eq $finalCount | Should -BeTrue
         }
 
         It "Can respond to -ErrorAction Stop" {
@@ -1209,7 +1209,7 @@ try {
             $outError[0].ErrorRecord.FullyQualifiedErrorId | Should -Be "UserNotFound,Microsoft.PowerShell.Commands.RemoveLocalUserCommand"
 
             $getResult = Get-LocalUser TestUserGet1 2>&1
-            $getResult.FullyQualifiedErrorId -match "UserNotFound" | Should -Be $true
+            $getResult.FullyQualifiedErrorId -match "UserNotFound" | Should -BeTrue
         }
     }
 
@@ -1239,7 +1239,7 @@ try {
             Enable-LocalUser TestUserDisabled1
             $result = Get-LocalUser TestUserDisabled1
 
-            $result.Enabled | Should -Be $true
+            $result.Enabled | Should -BeTrue
         }
     }
 
@@ -1279,7 +1279,7 @@ try {
             Enable-LocalUser -SID $disabledUser1SID
             $result = Get-LocalUser -SID $disabledUser1SID
 
-            $result.Enabled | Should -Be $true
+            $result.Enabled | Should -BeTrue
         }
 
         It "Can enable a disabled user using -InputObject" {
@@ -1287,43 +1287,43 @@ try {
             Enable-LocalUser -InputObject $user
             $result = Get-LocalUser TestUserDisabled1
 
-            $result.Enabled | Should -Be $true
+            $result.Enabled | Should -BeTrue
         }
 
         It "Can enable a disabled user using pipeline" {
             Get-LocalUser TestUserDisabled1 | Enable-LocalUser
             $result = Get-LocalUser TestUserDisabled1
 
-            $result.Enabled | Should -Be $true
+            $result.Enabled | Should -BeTrue
         }
 
         It "Can enable a disabled user by array of names" {
             Enable-LocalUser @("TestUserDisabled1", "TestUserDisabled2")
 
-            (Get-LocalUser "TestUserDisabled1").Enabled | Should -Be $true
-            (Get-LocalUser "TestUserDisabled2").Enabled | Should -Be $true
+            (Get-LocalUser "TestUserDisabled1").Enabled | Should -BeTrue
+            (Get-LocalUser "TestUserDisabled2").Enabled | Should -BeTrue
         }
 
         It "Can enable a disabled user by array of SIDs" {
             Enable-LocalUser -SID @($disabledUser1SID, $disabledUser2SID)
 
-            (Get-LocalUser -SID $disabledUser1SID).Enabled | Should -Be $true
-            (Get-LocalUser -SID $disabledUser2SID).Enabled | Should -Be $true
+            (Get-LocalUser -SID $disabledUser1SID).Enabled | Should -BeTrue
+            (Get-LocalUser -SID $disabledUser2SID).Enabled | Should -BeTrue
         }
 
         It "Can enable a disabled user by array sent using -InputObject" {
             $users = @((Get-LocalUser "TestUserDisabled1"), (Get-LocalUser "TestUserDisabled2"))
             Enable-LocalUser -InputObject $users
 
-            (Get-LocalUser "TestUserDisabled1").Enabled | Should -Be $true
-            (Get-LocalUser "TestUserDisabled2").Enabled | Should -Be $true
+            (Get-LocalUser "TestUserDisabled1").Enabled | Should -BeTrue
+            (Get-LocalUser "TestUserDisabled2").Enabled | Should -BeTrue
         }
 
         It "Can enable a disabled user by array sent using pipeline" {
             @((Get-LocalUser "TestUserDisabled1"), (Get-LocalUser "TestUserDisabled2")) | Enable-LocalUser
 
-            (Get-LocalUser "TestUserDisabled1").Enabled | Should -Be $true
-            (Get-LocalUser "TestUserDisabled2").Enabled | Should -Be $true
+            (Get-LocalUser "TestUserDisabled1").Enabled | Should -BeTrue
+            (Get-LocalUser "TestUserDisabled2").Enabled | Should -BeTrue
         }
 
         It "Errors on no name or SID specified" {
@@ -1337,21 +1337,21 @@ try {
             Enable-LocalUser TestUserEnabled1
             $result = Get-LocalUser TestUserEnabled1
 
-            $result.Enabled | Should -Be $true
+            $result.Enabled | Should -BeTrue
         }
 
         It "Can enable an already enabled user by SID" {
             Enable-LocalUser -SID $enabledUser1SID
             $result = Get-LocalUser -SID $enabledUser1SID
 
-            $result.Enabled | Should -Be $true
+            $result.Enabled | Should -BeTrue
         }
 
         It "Can enable an already enabled user using the pipeline" {
             Get-LocalUser TestUserEnabled1 | Enable-LocalUser
             $result = Get-LocalUser TestUserEnabled1
 
-            $result.Enabled | Should -Be $true
+            $result.Enabled | Should -BeTrue
         }
 
         It "Errors on enabling an invalid user by name" {
@@ -1380,7 +1380,7 @@ try {
             $outError[0].ErrorRecord.FullyQualifiedErrorId | Should -Be "UserNotFound,Microsoft.PowerShell.Commands.EnableLocalUserCommand"
 
             $getResult = Get-LocalUser TestUserDisabled1 2>&1
-            $getResult.Enabled | Should -Be $true
+            $getResult.Enabled | Should -BeTrue
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
@@ -35,7 +35,7 @@ function VerifyFailingTest
         throw "Expected error: $expectedFqeid"
     }
     catch {
-        $_.FullyQualifiedErrorId | Should Be $expectedFqeid
+        $_.FullyQualifiedErrorId | Should -Be $expectedFqeid
     }
     finally {
         $script:ErrorActionPreference = $backupEAP
@@ -53,13 +53,13 @@ try {
         It "Test command presence" {
             $result = Get-Command -Module Microsoft.PowerShell.LocalAccounts | ForEach-Object Name
 
-            $result -contains "New-LocalUser" | Should Be $true
-            $result -contains "Set-LocalUser" | Should Be $true
-            $result -contains "Get-LocalUser" | Should Be $true
-            $result -contains "Rename-LocalUser" | Should Be $true
-            $result -contains "Remove-LocalUser" | Should Be $true
-            $result -contains "Enable-LocalUser" | Should Be $true
-            $result -contains "Disable-LocalUser" | Should Be $true
+            $result -contains "New-LocalUser" | Should -Be $true
+            $result -contains "Set-LocalUser" | Should -Be $true
+            $result -contains "Get-LocalUser" | Should -Be $true
+            $result -contains "Rename-LocalUser" | Should -Be $true
+            $result -contains "Remove-LocalUser" | Should -Be $true
+            $result -contains "Enable-LocalUser" | Should -Be $true
+            $result -contains "Disable-LocalUser" | Should -Be $true
         }
     }
 
@@ -68,21 +68,21 @@ try {
         It "Test command presence" {
             $result = get-alias | ForEach-Object { if ($_.Source -eq "Microsoft.PowerShell.LocalAccounts") {$_}}
 
-            $result.Name -contains "algm" | Should Be $true
-            $result.Name -contains "dlu" | Should Be $true
-            $result.Name -contains "elu" | Should Be $true
-            $result.Name -contains "glg" | Should Be $true
-            $result.Name -contains "glgm" | Should Be $true
-            $result.Name -contains "glu" | Should Be $true
-            $result.Name -contains "nlg" | Should Be $true
-            $result.Name -contains "nlu" | Should Be $true
-            $result.Name -contains "rlg" | Should Be $true
-            $result.Name -contains "rlgm" | Should Be $true
-            $result.Name -contains "rlu" | Should Be $true
-            $result.Name -contains "rnlg" | Should Be $true
-            $result.Name -contains "rnlu" | Should Be $true
-            $result.Name -contains "slg" | Should Be $true
-            $result.Name -contains "slu" | Should Be $true
+            $result.Name -contains "algm" | Should -Be $true
+            $result.Name -contains "dlu" | Should -Be $true
+            $result.Name -contains "elu" | Should -Be $true
+            $result.Name -contains "glg" | Should -Be $true
+            $result.Name -contains "glgm" | Should -Be $true
+            $result.Name -contains "glu" | Should -Be $true
+            $result.Name -contains "nlg" | Should -Be $true
+            $result.Name -contains "nlu" | Should -Be $true
+            $result.Name -contains "rlg" | Should -Be $true
+            $result.Name -contains "rlgm" | Should -Be $true
+            $result.Name -contains "rlu" | Should -Be $true
+            $result.Name -contains "rnlg" | Should -Be $true
+            $result.Name -contains "rnlu" | Should -Be $true
+            $result.Name -contains "slg" | Should -Be $true
+            $result.Name -contains "slu" | Should -Be $true
         }
     }
 
@@ -99,9 +99,9 @@ try {
 
             $result.Name | Should BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -Be User
         }
     }
 
@@ -120,9 +120,9 @@ try {
 
             $result.Name | Should BeExactly $userName
             $result.Description | Should BeNullOrEmpty
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -Be User
         }
 
         It "Errors on Name argument of empty string or null" {
@@ -161,7 +161,7 @@ try {
 
             #Assert
             if ($failedCharacters.Count -gt 0) { Write-Host "characters causing test fail: $failedCharacters" }
-            $failedCharacters.Count -eq 0 | Should Be $true
+            $failedCharacters.Count -eq 0 | Should -Be $true
         }
 
         It "Errors on names containing only spaces or periods" {
@@ -214,10 +214,10 @@ try {
 
             $result.Name | Should BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
-            $result.ObjectClass | Should Be User
-            $result.AccountExpires | Should Be ([DateTime]$expiration)
+            $result.ObjectClass | Should -Be User
+            $result.AccountExpires | Should -Be ([DateTime]$expiration)
         }
 
         It "Can set AccountExpires to the past" {
@@ -226,10 +226,10 @@ try {
 
             $result.Name | Should BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
-            $result.ObjectClass | Should Be User
-            $result.AccountExpires | Should Be ([DateTime]$expiration)
+            $result.ObjectClass | Should -Be User
+            $result.AccountExpires | Should -Be ([DateTime]$expiration)
         }
 
         It "Errors on AccountExpires being set to invalid date" {
@@ -245,9 +245,9 @@ try {
 
             $result.Name | Should BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -Be User
             $result.AccountExpires | Should BeNullOrEmpty
         }
 
@@ -263,9 +263,9 @@ try {
 
             $result.Name | Should BeExactly TestUserNew1
             $result.Description | Should BeExactly ""
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -Be User
         }
 
         It "Can set with description at max 48" {
@@ -273,9 +273,9 @@ try {
 
             $result.Name | Should BeExactly TestUserNew1
             $result.Description | Should BeExactly ("A"*48)
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -Be User
         }
 
         It "Can set with description over max 48" {
@@ -289,9 +289,9 @@ try {
 
             $result.Name | Should BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -Be User
         }
 
         It "Can set enabled to false" {
@@ -299,9 +299,9 @@ try {
 
             $result.Name | Should BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
-            $result.Enabled | Should Be $false
+            $result.Enabled | Should -Be $false
             $result.SID | Should -Not BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -Be User
         }
 
         It "Can set empty string for FullName" {
@@ -309,9 +309,9 @@ try {
 
             $result.Name | Should BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -Be User
             $result.FullName | Should BeNullOrEmpty
         }
 
@@ -320,9 +320,9 @@ try {
 
             $result.Name | Should BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -Be User
             $result.FullName | Should BeExactly ("A"*256)
         }
 
@@ -338,9 +338,9 @@ try {
 
             $result.Name | Should BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -Be User
         }
 
         It "Errors when Password over max 257" {
@@ -366,10 +366,10 @@ try {
 
             $result.Name | Should BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
-            $result.ObjectClass | Should Be User
-            $result.UserMayChangePassword | Should Be $false
+            $result.ObjectClass | Should -Be User
+            $result.UserMayChangePassword | Should -Be $false
         }
 
         It "Can set PasswordNeverExpires to create a user with null for PasswordExpires date" {
@@ -392,10 +392,10 @@ try {
 
             $result.Name | Should BeExactly TestUserNew1
             $result.Description | Should BeNullOrEmpty
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
-            $result.ObjectClass | Should Be User
-            $result.UserMayChangePassword | Should Be $true
+            $result.ObjectClass | Should -Be User
+            $result.UserMayChangePassword | Should -Be $true
         }
     }
 
@@ -417,9 +417,9 @@ try {
         It "Can Get-LocalUser by only name" {
             $result = Get-LocalUser TestUserGet1
 
-            $result.Name | Should Be "TestUserGet1"
-            $result.Description | Should Be "Test User Get 1 Description"
-            $result.ObjectClass | Should Be "User"
+            $result.Name | Should -Be "TestUserGet1"
+            $result.Description | Should -Be "Test User Get 1 Description"
+            $result.ObjectClass | Should -Be "User"
         }
     }
 
@@ -441,7 +441,7 @@ try {
         It "Get-LocalUser gets all users"  {
             $result = Get-LocalUser
 
-            $result.Count -gt 2 | Should Be $true
+            $result.Count -gt 2 | Should -Be $true
         }
 
         It "Can get a specific user by SID" {
@@ -449,30 +449,30 @@ try {
             $resultBySID = Get-LocalUser -SID $result.SID
 
             $resultBySID.SID | Should -Not BeNullOrEmpty
-            $resultBySID.Name | Should Be TestUserGet1
+            $resultBySID.Name | Should -Be TestUserGet1
         }
 
         It "Can get a well-known user by SID string" {
             $sid = New-Object System.Security.Principal.SecurityIdentifier -ArgumentList LG
             $guestUser = Get-LocalUser -SID LG
 
-            $guestUser.SID | Should Be $sid.Value
+            $guestUser.SID | Should -Be $sid.Value
         }
 
         It "Can get users by wildcard" {
             $result = Get-LocalUser TestUserGet*
 
-            $result.Count -eq 2 | Should Be $true
-            $result.Name -contains "TestUserGet1" | Should Be $true
-            $result.Name -contains "TestUserGet2" | Should Be $true
+            $result.Count -eq 2 | Should -Be $true
+            $result.Name -contains "TestUserGet1" | Should -Be $true
+            $result.Name -contains "TestUserGet2" | Should -Be $true
         }
 
         It "Can get a user by array of names" {
             $result = Get-LocalUser @("TestUserGet1", "TestUserGet2")
 
-            $result.Count -eq 2 | Should Be $true
-            $result.Name -contains "TestUserGet1" | Should Be $true
-            $result.Name -contains "TestUserGet2" | Should Be $true
+            $result.Count -eq 2 | Should -Be $true
+            $result.Name -contains "TestUserGet1" | Should -Be $true
+            $result.Name -contains "TestUserGet2" | Should -Be $true
         }
 
         It "Can get a user by array of SIDs" {
@@ -480,9 +480,9 @@ try {
             $sid2 = (Get-LocalUser TestUserGet2).SID
             $result = Get-LocalUser -SID @($sid1, $sid2)
 
-            $result.Count -eq 2 | Should Be $true
-            $result.Name -contains "TestUserGet1" | Should Be $true
-            $result.Name -contains "TestUserGet2" | Should Be $true
+            $result.Count -eq 2 | Should -Be $true
+            $result.Name -contains "TestUserGet1" | Should -Be $true
+            $result.Name -contains "TestUserGet2" | Should -Be $true
         }
 
         It "Can respond to -ErrorAction Stop" {
@@ -492,9 +492,9 @@ try {
             Catch {
                 # Ignore the execption
             }
-            $outErr.Count -eq 1 | Should Be $true
-            $outErr[0].ErrorRecord.CategoryInfo.Reason -match "UserNotFound" | Should Be $true
-            $outOut.Name -match "TestUserGet1" | Should Be $true
+            $outErr.Count -eq 1 | Should -Be $true
+            $outErr[0].ErrorRecord.CategoryInfo.Reason -match "UserNotFound" | Should -Be $true
+            $outOut.Name -match "TestUserGet1" | Should -Be $true
         }
 
         It "Error on Name not being supplied an argument" {
@@ -539,7 +539,7 @@ try {
             $localUserName = 'TestUserGetNameThatDoesntExist'
             $result = Get-LocalGroup $localUserName*
 
-            $result | Should Be $null
+            $result | Should -Be $null
         }
 
         It "Returns the correct property values of a user" {
@@ -557,14 +557,14 @@ try {
             $result = New-LocalUser TestUserGet3 -NoPassword -AccountExpires $AccountExpires -Description $Description -Disabled -FullName $FullName -UserMayNotChangePassword
 
             $result.Name | Should BeExactly $Name
-            $result.AccountExpires | Should Be ([DateTime]$AccountExpires)
+            $result.AccountExpires | Should -Be ([DateTime]$AccountExpires)
             $result.Description | Should BeExactly $Description
-            $result.Enabled | Should Be $false
+            $result.Enabled | Should -Be $false
             $result.FullName | Should BeExactly $FullName
-            $result.ObjectClass -eq "User" | Should be true
-            $result.UserMayChangePassword | Should Be $false
+            $result.ObjectClass -eq "User" | Should -Be true
+            $result.UserMayChangePassword | Should -Be $false
             $result.SID | Should -Not BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -Be User
         }
     }
 
@@ -663,10 +663,10 @@ try {
 
             $result.Name | Should BeExactly TestUserSet1
             $result.Description | Should BeExactly "Test User Set 1 Description"
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
-            $result.ObjectClass | Should Be User
-            $result.AccountExpires | Should Be ([DateTime]$expiration)
+            $result.ObjectClass | Should -Be User
+            $result.AccountExpires | Should -Be ([DateTime]$expiration)
         }
 
         It "Can set AccountExpires to the past" {
@@ -676,10 +676,10 @@ try {
 
             $result.Name | Should BeExactly TestUserSet1
             $result.Description | Should BeExactly "Test User Set 1 Description"
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
-            $result.ObjectClass | Should Be User
-            $result.AccountExpires | Should Be ([DateTime]$expiration)
+            $result.ObjectClass | Should -Be User
+            $result.AccountExpires | Should -Be ([DateTime]$expiration)
         }
 
         It "Errors on AccountExpires being set to invalid date" {
@@ -727,7 +727,7 @@ try {
             $result.Name | Should BeExactly TestUserSet1
             $result.Description | Should BeExactly ("A"*48)
             $result.SID | Should -Not BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -Be User
         }
 
         It "Can set empty string for FullName" {
@@ -744,7 +744,7 @@ try {
             $result.Name | Should BeExactly TestUserSet1
             $result.FullName | Should BeExactly ("A"*256)
             $result.SID | Should -Not BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -Be User
         }
 
         It "Errors when Password is an empty string" {
@@ -766,9 +766,9 @@ try {
             $result = Get-LocalUser -Name TestUserSet1
 
             $result.Name | Should BeExactly TestUserSet1
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -Be $true
             $result.SID | Should -Not BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -Be User
         }
 
         It "Errors when Password over max 257" {
@@ -804,8 +804,8 @@ try {
 
             $result.Name | Should BeExactly TestUserSet1
             $result.SID | Should -Not BeNullOrEmpty
-            $result.ObjectClass | Should Be User
-            $result.UserMayChangePassword | Should Be $true
+            $result.ObjectClass | Should -Be User
+            $result.UserMayChangePassword | Should -Be $true
         }
 
         It "Can set UserMayChangePassword to false" {
@@ -814,8 +814,8 @@ try {
 
             $result.Name | Should BeExactly TestUserSet1
             $result.SID | Should -Not BeNullOrEmpty
-            $result.ObjectClass | Should Be User
-            $result.UserMayChangePassword | Should Be $false
+            $result.ObjectClass | Should -Be User
+            $result.UserMayChangePassword | Should -Be $false
         }
     }
 
@@ -958,7 +958,7 @@ try {
 
             #Assert
             if ($failedCharacters.Count -gt 0) { Write-Host "characters causing test fail: $failedCharacters" }
-            $failedCharacters.Count -eq 0 | Should Be $true
+            $failedCharacters.Count -eq 0 | Should -Be $true
         }
 
         It "Errors on names containing only spaces or periods" {
@@ -1024,7 +1024,7 @@ try {
 
         It "Can Remove-LocalUser with only name" {
             $initialCount = (Get-LocalUser).Count
-            $initialCount -gt 1 | Should Be $true
+            $initialCount -gt 1 | Should -Be $true
 
             $removeResult = Remove-LocalUser TestUserRemove1 2>&1
             $removeResult | Should BeNullOrEmpty
@@ -1035,7 +1035,7 @@ try {
             VerifyFailingTest $sb "UserNotFound,Microsoft.PowerShell.Commands.GetLocalUserCommand"
 
             $finalCount = (Get-LocalUser).Count
-            $initialCount -eq $finalCount + 1 | Should Be $true
+            $initialCount -eq $finalCount + 1 | Should -Be $true
         }
     }
 
@@ -1051,7 +1051,7 @@ try {
                         [scriptblock]$removalAction
                     )
                     $initialCount = (Get-LocalUser).Count
-                    $initialCount -gt 1 | Should Be true
+                    $initialCount -gt 1 | Should -Be true
 
                     & $removalAction
 
@@ -1061,7 +1061,7 @@ try {
                     VerifyFailingTest $sb "UserNotFound,Microsoft.PowerShell.Commands.GetLocalUserCommand"
 
                     $finalCount = (Get-LocalUser).Count
-                    $initialCount -eq $finalCount + 1 | Should Be true
+                    $initialCount -eq $finalCount + 1 | Should -Be true
                 }
 
                 function VerifyArrayRemoval {
@@ -1069,7 +1069,7 @@ try {
                         [scriptblock]$removalAction
                     )
                     $initialCount = (Get-LocalUser).Count
-                    $initialCount -gt 1 | Should Be true
+                    $initialCount -gt 1 | Should -Be true
 
                     & $removalAction
 
@@ -1084,7 +1084,7 @@ try {
                     VerifyFailingTest $sb "UserNotFound,Microsoft.PowerShell.Commands.GetLocalUserCommand"
 
                     $finalCount = (Get-LocalUser).Count
-                    $initialCount -eq $finalCount + 2 | Should Be $true
+                    $initialCount -eq $finalCount + 2 | Should -Be $true
                 }
             }
         }
@@ -1172,7 +1172,7 @@ try {
 
         It "Errors on remove by invalid name" {
             $initialCount =  (Get-LocalUser).Count
-            $initialCount -gt 1 | Should Be $true
+            $initialCount -gt 1 | Should -Be $true
 
             $sb = {
                 Remove-LocalUser TestUserRemove1NameThatDoesntExist
@@ -1180,14 +1180,14 @@ try {
             VerifyFailingTest $sb "UserNotFound,Microsoft.PowerShell.Commands.RemoveLocalUserCommand"
 
             $finalCount = (Get-LocalUser).Count
-            $initialCount -eq $finalCount | Should Be $true
+            $initialCount -eq $finalCount | Should -Be $true
         }
 
         It "Errors on remove by invalid SID" {
             Remove-LocalUser -SID $user1SID
             # This test verifies that it cannot be removed a second time
             $initialCount =  (Get-LocalUser).Count
-            $initialCount -gt 1 | Should Be $true
+            $initialCount -gt 1 | Should -Be $true
 
             $sb = {
                 Remove-LocalUser -SID $user1SID
@@ -1195,7 +1195,7 @@ try {
             VerifyFailingTest $sb "UserNotFound,Microsoft.PowerShell.Commands.RemoveLocalUserCommand"
 
             $finalCount = (Get-LocalUser).Count
-            $initialCount -eq $finalCount | Should Be $true
+            $initialCount -eq $finalCount | Should -Be $true
         }
 
         It "Can respond to -ErrorAction Stop" {
@@ -1205,11 +1205,11 @@ try {
             catch {
                 # Nothing to do here
             }
-            $outError.Count | Should Be 2
-            $outError[0].ErrorRecord.FullyQualifiedErrorId | Should Be "UserNotFound,Microsoft.PowerShell.Commands.RemoveLocalUserCommand"
+            $outError.Count | Should -Be 2
+            $outError[0].ErrorRecord.FullyQualifiedErrorId | Should -Be "UserNotFound,Microsoft.PowerShell.Commands.RemoveLocalUserCommand"
 
             $getResult = Get-LocalUser TestUserGet1 2>&1
-            $getResult.FullyQualifiedErrorId -match "UserNotFound" | Should Be $true
+            $getResult.FullyQualifiedErrorId -match "UserNotFound" | Should -Be $true
         }
     }
 
@@ -1239,7 +1239,7 @@ try {
             Enable-LocalUser TestUserDisabled1
             $result = Get-LocalUser TestUserDisabled1
 
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -Be $true
         }
     }
 
@@ -1279,7 +1279,7 @@ try {
             Enable-LocalUser -SID $disabledUser1SID
             $result = Get-LocalUser -SID $disabledUser1SID
 
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -Be $true
         }
 
         It "Can enable a disabled user using -InputObject" {
@@ -1287,43 +1287,43 @@ try {
             Enable-LocalUser -InputObject $user
             $result = Get-LocalUser TestUserDisabled1
 
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -Be $true
         }
 
         It "Can enable a disabled user using pipeline" {
             Get-LocalUser TestUserDisabled1 | Enable-LocalUser
             $result = Get-LocalUser TestUserDisabled1
 
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -Be $true
         }
 
         It "Can enable a disabled user by array of names" {
             Enable-LocalUser @("TestUserDisabled1", "TestUserDisabled2")
 
-            (Get-LocalUser "TestUserDisabled1").Enabled | Should Be $true
-            (Get-LocalUser "TestUserDisabled2").Enabled | Should Be $true
+            (Get-LocalUser "TestUserDisabled1").Enabled | Should -Be $true
+            (Get-LocalUser "TestUserDisabled2").Enabled | Should -Be $true
         }
 
         It "Can enable a disabled user by array of SIDs" {
             Enable-LocalUser -SID @($disabledUser1SID, $disabledUser2SID)
 
-            (Get-LocalUser -SID $disabledUser1SID).Enabled | Should Be $true
-            (Get-LocalUser -SID $disabledUser2SID).Enabled | Should Be $true
+            (Get-LocalUser -SID $disabledUser1SID).Enabled | Should -Be $true
+            (Get-LocalUser -SID $disabledUser2SID).Enabled | Should -Be $true
         }
 
         It "Can enable a disabled user by array sent using -InputObject" {
             $users = @((Get-LocalUser "TestUserDisabled1"), (Get-LocalUser "TestUserDisabled2"))
             Enable-LocalUser -InputObject $users
 
-            (Get-LocalUser "TestUserDisabled1").Enabled | Should Be $true
-            (Get-LocalUser "TestUserDisabled2").Enabled | Should Be $true
+            (Get-LocalUser "TestUserDisabled1").Enabled | Should -Be $true
+            (Get-LocalUser "TestUserDisabled2").Enabled | Should -Be $true
         }
 
         It "Can enable a disabled user by array sent using pipeline" {
             @((Get-LocalUser "TestUserDisabled1"), (Get-LocalUser "TestUserDisabled2")) | Enable-LocalUser
 
-            (Get-LocalUser "TestUserDisabled1").Enabled | Should Be $true
-            (Get-LocalUser "TestUserDisabled2").Enabled | Should Be $true
+            (Get-LocalUser "TestUserDisabled1").Enabled | Should -Be $true
+            (Get-LocalUser "TestUserDisabled2").Enabled | Should -Be $true
         }
 
         It "Errors on no name or SID specified" {
@@ -1337,21 +1337,21 @@ try {
             Enable-LocalUser TestUserEnabled1
             $result = Get-LocalUser TestUserEnabled1
 
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -Be $true
         }
 
         It "Can enable an already enabled user by SID" {
             Enable-LocalUser -SID $enabledUser1SID
             $result = Get-LocalUser -SID $enabledUser1SID
 
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -Be $true
         }
 
         It "Can enable an already enabled user using the pipeline" {
             Get-LocalUser TestUserEnabled1 | Enable-LocalUser
             $result = Get-LocalUser TestUserEnabled1
 
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -Be $true
         }
 
         It "Errors on enabling an invalid user by name" {
@@ -1376,11 +1376,11 @@ try {
             Catch {
                 # do nothing
             }
-            $outError.Count | Should Be 2
-            $outError[0].ErrorRecord.FullyQualifiedErrorId | Should Be "UserNotFound,Microsoft.PowerShell.Commands.EnableLocalUserCommand"
+            $outError.Count | Should -Be 2
+            $outError[0].ErrorRecord.FullyQualifiedErrorId | Should -Be "UserNotFound,Microsoft.PowerShell.Commands.EnableLocalUserCommand"
 
             $getResult = Get-LocalUser TestUserDisabled1 2>&1
-            $getResult.Enabled | Should Be $true
+            $getResult.Enabled | Should -Be $true
         }
     }
 
@@ -1410,7 +1410,7 @@ try {
             Disable-LocalUser TestUserEnabled1
             $result = Get-LocalUser TestUserEnabled1
 
-            $result.Enabled | Should Be $false
+            $result.Enabled | Should -Be $false
         }
     }
 
@@ -1450,7 +1450,7 @@ try {
             Disable-LocalUser -SID $enabledUser1SID
             $result = Get-LocalUser -SID $enabledUser1SID
 
-            $result.Enabled | Should Be $false
+            $result.Enabled | Should -Be $false
         }
 
         It "Can disable an enabled user using -InputObject" {
@@ -1458,43 +1458,43 @@ try {
             Disable-LocalUser -InputObject $user
             $result = Get-LocalUser TestUserEnabled1
 
-            $result.Enabled | Should Be $false
+            $result.Enabled | Should -Be $false
         }
 
         It "Can disable an enabled user using pipeline" {
             Get-LocalUser TestUserEnabled1 | Disable-LocalUser
             $result = Get-LocalUser TestUserEnabled1
 
-            $result.Enabled | Should Be $false
+            $result.Enabled | Should -Be $false
         }
 
         It "Can disable an enabled user by array of names" {
             Disable-LocalUser @("TestUserEnabled1", "TestUserEnabled2")
 
-            (Get-LocalUser "TestUserEnabled1").Enabled | Should Be $false
-            (Get-LocalUser "TestUserEnabled2").Enabled | Should Be $false
+            (Get-LocalUser "TestUserEnabled1").Enabled | Should -Be $false
+            (Get-LocalUser "TestUserEnabled2").Enabled | Should -Be $false
         }
 
         It "Can disable an enabled user by array of SIDs" {
             Disable-LocalUser -SID @($enabledUser1SID, $enabledUser2SID)
 
-            (Get-LocalUser -SID $enabledUser1SID).Enabled | Should Be $false
-            (Get-LocalUser -SID $enabledUser2SID).Enabled | Should Be $false
+            (Get-LocalUser -SID $enabledUser1SID).Enabled | Should -Be $false
+            (Get-LocalUser -SID $enabledUser2SID).Enabled | Should -Be $false
         }
 
         It "Can disable an enabled user by array sent using pipeline" {
             $users = @((Get-LocalUser "TestUserEnabled1"), (Get-LocalUser "TestUserEnabled2"))
             Disable-LocalUser -InputObject $users
 
-            (Get-LocalUser "TestUserEnabled1").Enabled | Should Be $false
-            (Get-LocalUser "TestUserEnabled2").Enabled | Should Be $false
+            (Get-LocalUser "TestUserEnabled1").Enabled | Should -Be $false
+            (Get-LocalUser "TestUserEnabled2").Enabled | Should -Be $false
         }
 
         It "Can disable an enabled user by array sent using pipeline" {
             @((Get-LocalUser "TestUserEnabled1"), (Get-LocalUser "TestUserEnabled2")) | Disable-LocalUser
 
-            (Get-LocalUser "TestUserEnabled1").Enabled | Should Be $false
-            (Get-LocalUser "TestUserEnabled2").Enabled | Should Be $false
+            (Get-LocalUser "TestUserEnabled1").Enabled | Should -Be $false
+            (Get-LocalUser "TestUserEnabled2").Enabled | Should -Be $false
         }
 
         It "Errors on no name or SID specified" {
@@ -1507,19 +1507,19 @@ try {
         It "Can disable an already disabled user by name" {
             Disable-LocalUser TestUserDisabled1
 
-            (Get-LocalUser TestUserDisabled1).Enabled | Should Be $false
+            (Get-LocalUser TestUserDisabled1).Enabled | Should -Be $false
         }
 
         It "Can disable an already disabled user by SID" {
             Disable-LocalUser -SID $disabledUser1SID
 
-            (Get-LocalUser -SID $disabledUser1SID).Enabled | Should Be $false
+            (Get-LocalUser -SID $disabledUser1SID).Enabled | Should -Be $false
         }
 
         It "Can disable an already disabled user using the pipeline" {
             Get-LocalUser TestUserDisabled1 | Disable-LocalUser
 
-            (Get-LocalUser TestUserDisabled1).Enabled | Should Be $false
+            (Get-LocalUser TestUserDisabled1).Enabled | Should -Be $false
         }
 
         It "Errors on disabling an invalid user by name" {
@@ -1544,11 +1544,11 @@ try {
             Catch {
                 # Do nothing here
             }
-            $outError.Count | Should Be 2
-            $outError[0].ErrorRecord.FullyQualifiedErrorId | Should Be "UserNotFound,Microsoft.PowerShell.Commands.DisableLocalUserCommand"
+            $outError.Count | Should -Be 2
+            $outError[0].ErrorRecord.FullyQualifiedErrorId | Should -Be "UserNotFound,Microsoft.PowerShell.Commands.DisableLocalUserCommand"
 
             $getResult = Get-LocalUser TestUserEnabled1 2>&1
-            $getResult.Enabled | Should Be $false
+            $getResult.Enabled | Should -Be $false
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Copy.Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Copy.Item.Tests.ps1
@@ -498,7 +498,7 @@ Describe "Validate Copy-Item Remotely" -Tags "CI" {
             try
             {
                 $s1 = New-PSSession -ComputerName . -ErrorAction SilentlyContinue
-                $s1 | Should Not BeNullOrEmpty
+                $s1 | Should -Not BeNullOrEmpty
                 $filePath = CreateTestFile
                 $destinationFolderPath = GetDestinationFolderPath
                 { Copy-Item -Path $filePath -Destination $destinationFolderPath -FromSession $s -ToSession $s1 -ErrorAction Stop } | Should -Throw -ErrorId "InvalidInput,Microsoft.PowerShell.Commands.CopyItemCommand"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Copy.Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Copy.Item.Tests.ps1
@@ -498,7 +498,7 @@ Describe "Validate Copy-Item Remotely" -Tags "CI" {
             try
             {
                 $s1 = New-PSSession -ComputerName . -ErrorAction SilentlyContinue
-                $s1 | Should -Not BeNullOrEmpty
+                $s1 | Should -Not -BeNullOrEmpty
                 $filePath = CreateTestFile
                 $destinationFolderPath = GetDestinationFolderPath
                 { Copy-Item -Path $filePath -Destination $destinationFolderPath -FromSession $s -ToSession $s1 -ErrorAction Stop } | Should -Throw -ErrorId "InvalidInput,Microsoft.PowerShell.Commands.CopyItemCommand"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -171,7 +171,7 @@ Describe "Get-ChildItem" -Tags "CI" {
         It "Should give .sys file if the fullpath is specified with hidden and force parameter" -Pending {
             # Don't remove!!! It is special test for hidden and opened file with exclusive lock.
             $file = Get-ChildItem -path "$env:SystemDrive\\pagefile.sys" -Hidden
-            $file | Should not be $null
+            $file | Should -Not be $null
             $file.Count | Should be 1
             $file.Name | Should be "pagefile.sys"
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -142,10 +142,10 @@ Describe "Get-ChildItem" -Tags "CI" {
         }
 
         It "Should return items recursively when using 'Include' or 'Exclude' parameters with -LiteralPath" {
-            (Get-ChildItem -LiteralPath $TestDrive -Recurse -Exclude *).Count | Should Be 0
-            (Get-ChildItem -LiteralPath $TestDrive -Recurse -Include *.dll).Count | Should Be (Get-ChildItem $TestDrive -Recurse -Include *.dll).Count
-            (Get-ChildItem -LiteralPath $TestDrive -Depth 1 -Include $item_G).Count | Should Be 1
-            (Get-ChildItem -LiteralPath $TestDrive -Depth 1 -Exclude $item_a).Count | Should Be 5
+            (Get-ChildItem -LiteralPath $TestDrive -Recurse -Exclude *).Count | Should -Be 0
+            (Get-ChildItem -LiteralPath $TestDrive -Recurse -Include *.dll).Count | Should -Be (Get-ChildItem $TestDrive -Recurse -Include *.dll).Count
+            (Get-ChildItem -LiteralPath $TestDrive -Depth 1 -Include $item_G).Count | Should -Be 1
+            (Get-ChildItem -LiteralPath $TestDrive -Depth 1 -Exclude $item_a).Count | Should -Be 5
         }
 
         It "get-childitem path wildcard - <title>" -TestCases $PathWildCardTestCases {
@@ -171,9 +171,9 @@ Describe "Get-ChildItem" -Tags "CI" {
         It "Should give .sys file if the fullpath is specified with hidden and force parameter" -Pending {
             # Don't remove!!! It is special test for hidden and opened file with exclusive lock.
             $file = Get-ChildItem -path "$env:SystemDrive\\pagefile.sys" -Hidden
-            $file | Should -Not be $null
-            $file.Count | Should be 1
-            $file.Name | Should be "pagefile.sys"
+            $file | Should -Not -Be $null
+            $file.Count | Should -Be 1
+            $file.Name | Should -Be "pagefile.sys"
         }
 
         It "-Filter *. finds extension-less files" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-HotFix.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-HotFix.Tests.ps1
@@ -60,7 +60,7 @@ Describe "Get-HotFix Tests" -Tag CI {
     }
 
     It "Get-Hotfix can accept ComputerName via pipeline" {
-        { [PSCustomObject]@{ComputerName = 'UnavailableComputer'} | Get-HotFix } |Should -Throw -ErrorID 'Microsoft.PowerShell.Commands.GetHotFixCommand'
+        { [PSCustomObject]@{ComputerName = 'UnavailableComputer'} | Get-HotFix } | Should -Throw -ErrorID 'Microsoft.PowerShell.Commands.GetHotFixCommand'
         [PSCustomObject]@{ComputerName = 'localhost'} | Get-HotFix | Should -Not -BeNullOrEmpty
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
@@ -26,13 +26,13 @@ try
 
         It "Should restart the local computer" {
             Set-TesthookResult -testhookName $restartTesthookResultName -value $defaultResultValue
-            Restart-Computer -ErrorAction Stop| Should -BeNullOrEmpty
+            Restart-Computer -ErrorAction Stop | Should -BeNullOrEmpty
         }
 
         It "Should support -computer parameter" {
             Set-TesthookResult -testhookName $restartTesthookResultName -value $defaultResultValue
             $computerNames = "localhost","${env:COMPUTERNAME}"
-            Restart-Computer -Computer $computerNames -ErrorAction Stop| Should -BeNullOrEmpty
+            Restart-Computer -Computer $computerNames -ErrorAction Stop | Should -BeNullOrEmpty
         }
 
         It "Should support WsmanAuthentication types" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Content.Tests.ps1
@@ -22,7 +22,7 @@ Describe "Set-Content cmdlet tests" -Tags "CI" {
         It "should create a file if it does not exist" {
             Set-Content -Path $filePath1 -Value "$file1"
             $result = Get-Content -Path $filePath1
-            $result| Should -Be "$file1"
+            $result | Should -Be "$file1"
         }
     }
     Context "Set-Content/Get-Content should set/get the content of an exisiting file" {
@@ -32,7 +32,7 @@ Describe "Set-Content cmdlet tests" -Tags "CI" {
         It "should set-Content of testdrive\$file1" {
             Set-Content -Path $filePath1 -Value "ExpectedContent"
             $result = Get-Content -Path $filePath1
-            $result| Should -Be "ExpectedContent"
+            $result | Should -Be "ExpectedContent"
         }
         It "should return expected string from testdrive\$file1" {
             $result = Get-Content -Path $filePath1
@@ -41,7 +41,7 @@ Describe "Set-Content cmdlet tests" -Tags "CI" {
         It "should Set-Content to testdrive\dynamicfile.txt with dynamic parameters" {
             Set-Content -Path $testdrive\dynamicfile.txt -Value "ExpectedContent"
             $result = Get-Content -Path $testdrive\dynamicfile.txt
-            $result| Should -BeExactly "ExpectedContent"
+            $result | Should -BeExactly "ExpectedContent"
         }
         It "should return expected string from testdrive\dynamicfile.txt" {
             $result = Get-Content -Path $testdrive\dynamicfile.txt
@@ -49,10 +49,10 @@ Describe "Set-Content cmdlet tests" -Tags "CI" {
         }
         It "should remove existing content from testdrive\$file1 when the -Value is `$null" {
             $AsItWas=Get-Content $filePath1
-            $AsItWas |Should -BeExactly "ExpectedContent"
+            $AsItWas | Should -BeExactly "ExpectedContent"
             Set-Content -Path $filePath1 -Value $null -ErrorAction Stop
             $AsItIs=Get-Content $filePath1
-            $AsItIs| Should -Not -Be $AsItWas
+            $AsItIs | Should -Not -Be $AsItWas
         }
         It "should throw 'ParameterArgumentValidationErrorNullNotAllowed' when -Path is `$null" {
             { Set-Content -Path $null -Value "ShouldNotWorkBecausePathIsNull" -ErrorAction Stop } | Should -Throw -ErrorId "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.SetContentCommand"
@@ -91,7 +91,7 @@ Describe "Set-Content should work for PSDrive with UNC path as root" -Tags @('CI
             New-PSDrive -Name Foo -Root \\localhost\testshare -PSProvider FileSystem
             Set-Content -Path Foo:\$file1 -Value "$file1"
             $result = Get-Content -Path Foo:\$file1
-            $result| Should -BeExactly "$file1"
+            $result | Should -BeExactly "$file1"
         }
         finally
         {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
@@ -171,7 +171,7 @@ Describe "Set-Location" -Tags "CI" {
             foreach ($i in 1..$maximumLocationHistory) {
                 Set-Location -
             }
-            (Get-Location).Path | Should Be $initialLocation
+            (Get-Location).Path | Should -Be $initialLocation
             { Set-Location - } | Should -Throw -ErrorId 'System.InvalidOperationException,Microsoft.PowerShell.Commands.SetLocationCommand'
             # Go forwards up to the maximum
             foreach ($i in 1..($maximumLocationHistory)) {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
@@ -31,7 +31,7 @@ Describe "Start-Process" -Tag "Feature","RequireAdminOnWindows" {
 
 	    $process.Length      | Should -Be 1
 	    $process.Id          | Should -BeGreaterThan 1
-	    # $process.ProcessName | Should Be "ping"
+	    # $process.ProcessName | Should -Be "ping"
     }
 
     It "Should work correctly when used with full path name" {
@@ -39,7 +39,7 @@ Describe "Start-Process" -Tag "Feature","RequireAdminOnWindows" {
 
 	    $process.Length      | Should -Be 1
 	    $process.Id          | Should -BeGreaterThan 1
-	    # $process.ProcessName | Should Be "ping"
+	    # $process.ProcessName | Should -Be "ping"
     }
 
     It "Should invoke correct path when used with FilePath argument" {
@@ -47,7 +47,7 @@ Describe "Start-Process" -Tag "Feature","RequireAdminOnWindows" {
 
 	    $process.Length      | Should -Be 1
 	    $process.Id          | Should -BeGreaterThan 1
-	    # $process.ProcessName | Should Be "ping"
+	    # $process.ProcessName | Should -Be "ping"
     }
 
     It "Should invoke correct path when used with Path alias argument" {
@@ -66,7 +66,7 @@ Describe "Start-Process" -Tag "Feature","RequireAdminOnWindows" {
 
 	    $process.Length      | Should -Be 1
 	    $process.Id          | Should -BeGreaterThan 1
-	    # $process.ProcessName | Should Be "ping"
+	    # $process.ProcessName | Should -Be "ping"
     }
 
     It "Should handle stderr redirection without error" {
@@ -74,7 +74,7 @@ Describe "Start-Process" -Tag "Feature","RequireAdminOnWindows" {
 
 	    $process.Length      | Should -Be 1
 	    $process.Id          | Should -BeGreaterThan 1
-	    # $process.ProcessName | Should Be "ping"
+	    # $process.ProcessName | Should -Be "ping"
     }
 
     It "Should handle stdout redirection without error" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Stop-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Stop-Computer.Tests.ps1
@@ -27,13 +27,13 @@ try
 
         It "Should stop the local computer" {
             Set-TesthookResult -testhookName $stopTesthookResultName -Value $defaultResultValue
-            Stop-Computer -ErrorAction Stop| Should -BeNullOrEmpty
+            Stop-Computer -ErrorAction Stop | Should -BeNullOrEmpty
         }
 
         It "Should support -Computer parameter" {
             Set-TesthookResult -testhookName $stopTesthookResultName -Value $defaultResultValue
             $computerNames = "localhost","${env:COMPUTERNAME}"
-            Stop-Computer -Computer $computerNames -ErrorAction Stop| Should -BeNullOrEmpty
+            Stop-Computer -Computer $computerNames -ErrorAction Stop | Should -BeNullOrEmpty
         }
 
         It "Should support WsmanAuthentication types" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
@@ -48,7 +48,7 @@ Describe "Certificate Provider tests" -Tags "CI" {
             param([string] $path)
             $expectedResolvedPath = Resolve-Path -LiteralPath $path
             $result = Get-Item -LiteralPath $path
-            $result | Should not be null
+            $result | Should -Not be null
             $result | ForEach-Object {
                 $resolvedPath = Resolve-Path $_.PSPath
                 $resolvedPath.Provider | Should -Be $expectedResolvedPath.Provider
@@ -111,7 +111,7 @@ Describe "Certificate Provider tests" -Tags "Feature" {
             $expectedThumbprint = (Get-GoodCertificateObject).Thumbprint
             $leafPath = Join-Path -Path $path -ChildPath $expectedThumbprint
             $cert = (Get-item -LiteralPath $leafPath)
-            $cert | Should not be null
+            $cert | Should -Not be null
             $cert.Thumbprint | Should -Be $expectedThumbprint
         }
         it "Should be able to get DnsNameList of certifate by path: <path>" -TestCases $currentUserMyLocations {
@@ -121,8 +121,8 @@ Describe "Certificate Provider tests" -Tags "Feature" {
             $expectedEncodedName = (Get-GoodCertificateObject).DnsNameList[0].Punycode
             $leafPath = Join-Path -Path $path -ChildPath $expectedThumbprint
             $cert = (Get-item -LiteralPath $leafPath)
-            $cert | Should not be null
-            $cert.DnsNameList | Should not be null
+            $cert | Should -Not be null
+            $cert.DnsNameList | Should -Not be null
             $cert.DnsNameList.Count | Should -Be 1
             $cert.DnsNameList[0].Unicode | Should -Be $expectedName
             $cert.DnsNameList[0].Punycode | Should -Be $expectedEncodedName
@@ -133,8 +133,8 @@ Describe "Certificate Provider tests" -Tags "Feature" {
             $expectedOid = (Get-GoodCertificateObject).EnhancedKeyUsageList[0].ObjectId
             $leafPath = Join-Path -Path $path -ChildPath $expectedThumbprint
             $cert = (Get-item -LiteralPath $leafPath)
-            $cert | Should not be null
-            $cert.EnhancedKeyUsageList | Should not be null
+            $cert | Should -Not be null
+            $cert.EnhancedKeyUsageList | Should -Not be null
             $cert.EnhancedKeyUsageList.Count | Should -Be 1
             $cert.EnhancedKeyUsageList[0].ObjectId.Length | Should -Not -Be 0
             $cert.EnhancedKeyUsageList[0].ObjectId | Should -Be $expectedOid
@@ -142,8 +142,8 @@ Describe "Certificate Provider tests" -Tags "Feature" {
         it "Should filter to codesign certificates" {
             $allCerts = get-item cert:\CurrentUser\My\*
             $codeSignCerts = get-item cert:\CurrentUser\My\* -CodeSigningCert
-            $codeSignCerts | Should not be null
-            $allCerts | Should not be null
+            $codeSignCerts | Should -Not be null
+            $allCerts | Should -Not be null
             $nonCodeSignCertCount = $allCerts.Count - $codeSignCerts.Count
             $nonCodeSignCertCount | Should -Not -Be 0
         }
@@ -151,8 +151,8 @@ Describe "Certificate Provider tests" -Tags "Feature" {
             $allCerts = get-item cert:\CurrentUser\My\*
             $testThumbprint = (Get-GoodCertificateObject).Thumbprint
             $allCertsExceptOne = (Get-Item "cert:\currentuser\my\*" -Exclude $testThumbprint)
-            $allCerts | Should not be null
-            $allCertsExceptOne | Should not be null
+            $allCerts | Should -Not be null
+            $allCertsExceptOne | Should -Not be null
             $countDifference = $allCerts.Count - $allCertsExceptOne.Count
             $countDifference | Should -Be 1
         }
@@ -161,8 +161,8 @@ Describe "Certificate Provider tests" -Tags "Feature" {
         it "Should filter to codesign certificates" {
             $allCerts = get-ChildItem cert:\CurrentUser\My
             $codeSignCerts = get-ChildItem cert:\CurrentUser\My -CodeSigningCert
-            $codeSignCerts | Should not be null
-            $allCerts | Should not be null
+            $codeSignCerts | Should -Not be null
+            $allCerts | Should -Not be null
             $nonCodeSignCertCount = $allCerts.Count - $codeSignCerts.Count
             $nonCodeSignCertCount | Should -Not -Be 0
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
@@ -48,7 +48,7 @@ Describe "Certificate Provider tests" -Tags "CI" {
             param([string] $path)
             $expectedResolvedPath = Resolve-Path -LiteralPath $path
             $result = Get-Item -LiteralPath $path
-            $result | should not be null
+            $result | Should not be null
             $result | ForEach-Object {
                 $resolvedPath = Resolve-Path $_.PSPath
                 $resolvedPath.Provider | Should -Be $expectedResolvedPath.Provider
@@ -111,7 +111,7 @@ Describe "Certificate Provider tests" -Tags "Feature" {
             $expectedThumbprint = (Get-GoodCertificateObject).Thumbprint
             $leafPath = Join-Path -Path $path -ChildPath $expectedThumbprint
             $cert = (Get-item -LiteralPath $leafPath)
-            $cert | should not be null
+            $cert | Should not be null
             $cert.Thumbprint | Should -Be $expectedThumbprint
         }
         it "Should be able to get DnsNameList of certifate by path: <path>" -TestCases $currentUserMyLocations {
@@ -121,8 +121,8 @@ Describe "Certificate Provider tests" -Tags "Feature" {
             $expectedEncodedName = (Get-GoodCertificateObject).DnsNameList[0].Punycode
             $leafPath = Join-Path -Path $path -ChildPath $expectedThumbprint
             $cert = (Get-item -LiteralPath $leafPath)
-            $cert | should not be null
-            $cert.DnsNameList | should not be null
+            $cert | Should not be null
+            $cert.DnsNameList | Should not be null
             $cert.DnsNameList.Count | Should -Be 1
             $cert.DnsNameList[0].Unicode | Should -Be $expectedName
             $cert.DnsNameList[0].Punycode | Should -Be $expectedEncodedName
@@ -133,8 +133,8 @@ Describe "Certificate Provider tests" -Tags "Feature" {
             $expectedOid = (Get-GoodCertificateObject).EnhancedKeyUsageList[0].ObjectId
             $leafPath = Join-Path -Path $path -ChildPath $expectedThumbprint
             $cert = (Get-item -LiteralPath $leafPath)
-            $cert | should not be null
-            $cert.EnhancedKeyUsageList | should not be null
+            $cert | Should not be null
+            $cert.EnhancedKeyUsageList | Should not be null
             $cert.EnhancedKeyUsageList.Count | Should -Be 1
             $cert.EnhancedKeyUsageList[0].ObjectId.Length | Should -Not -Be 0
             $cert.EnhancedKeyUsageList[0].ObjectId | Should -Be $expectedOid
@@ -142,8 +142,8 @@ Describe "Certificate Provider tests" -Tags "Feature" {
         it "Should filter to codesign certificates" {
             $allCerts = get-item cert:\CurrentUser\My\*
             $codeSignCerts = get-item cert:\CurrentUser\My\* -CodeSigningCert
-            $codeSignCerts | should not be null
-            $allCerts | should not be null
+            $codeSignCerts | Should not be null
+            $allCerts | Should not be null
             $nonCodeSignCertCount = $allCerts.Count - $codeSignCerts.Count
             $nonCodeSignCertCount | Should -Not -Be 0
         }
@@ -151,8 +151,8 @@ Describe "Certificate Provider tests" -Tags "Feature" {
             $allCerts = get-item cert:\CurrentUser\My\*
             $testThumbprint = (Get-GoodCertificateObject).Thumbprint
             $allCertsExceptOne = (Get-Item "cert:\currentuser\my\*" -Exclude $testThumbprint)
-            $allCerts | should not be null
-            $allCertsExceptOne | should not be null
+            $allCerts | Should not be null
+            $allCertsExceptOne | Should not be null
             $countDifference = $allCerts.Count - $allCertsExceptOne.Count
             $countDifference | Should -Be 1
         }
@@ -161,8 +161,8 @@ Describe "Certificate Provider tests" -Tags "Feature" {
         it "Should filter to codesign certificates" {
             $allCerts = get-ChildItem cert:\CurrentUser\My
             $codeSignCerts = get-ChildItem cert:\CurrentUser\My -CodeSigningCert
-            $codeSignCerts | should not be null
-            $allCerts | should not be null
+            $codeSignCerts | Should not be null
+            $allCerts | Should not be null
             $nonCodeSignCertCount = $allCerts.Count - $codeSignCerts.Count
             $nonCodeSignCertCount | Should -Not -Be 0
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
@@ -48,7 +48,7 @@ Describe "Certificate Provider tests" -Tags "CI" {
             param([string] $path)
             $expectedResolvedPath = Resolve-Path -LiteralPath $path
             $result = Get-Item -LiteralPath $path
-            $result | Should -Not be null
+            $result | Should -Not -Be null
             $result | ForEach-Object {
                 $resolvedPath = Resolve-Path $_.PSPath
                 $resolvedPath.Provider | Should -Be $expectedResolvedPath.Provider
@@ -111,7 +111,7 @@ Describe "Certificate Provider tests" -Tags "Feature" {
             $expectedThumbprint = (Get-GoodCertificateObject).Thumbprint
             $leafPath = Join-Path -Path $path -ChildPath $expectedThumbprint
             $cert = (Get-item -LiteralPath $leafPath)
-            $cert | Should -Not be null
+            $cert | Should -Not -Be null
             $cert.Thumbprint | Should -Be $expectedThumbprint
         }
         it "Should be able to get DnsNameList of certifate by path: <path>" -TestCases $currentUserMyLocations {
@@ -121,8 +121,8 @@ Describe "Certificate Provider tests" -Tags "Feature" {
             $expectedEncodedName = (Get-GoodCertificateObject).DnsNameList[0].Punycode
             $leafPath = Join-Path -Path $path -ChildPath $expectedThumbprint
             $cert = (Get-item -LiteralPath $leafPath)
-            $cert | Should -Not be null
-            $cert.DnsNameList | Should -Not be null
+            $cert | Should -Not -Be null
+            $cert.DnsNameList | Should -Not -Be null
             $cert.DnsNameList.Count | Should -Be 1
             $cert.DnsNameList[0].Unicode | Should -Be $expectedName
             $cert.DnsNameList[0].Punycode | Should -Be $expectedEncodedName
@@ -133,8 +133,8 @@ Describe "Certificate Provider tests" -Tags "Feature" {
             $expectedOid = (Get-GoodCertificateObject).EnhancedKeyUsageList[0].ObjectId
             $leafPath = Join-Path -Path $path -ChildPath $expectedThumbprint
             $cert = (Get-item -LiteralPath $leafPath)
-            $cert | Should -Not be null
-            $cert.EnhancedKeyUsageList | Should -Not be null
+            $cert | Should -Not -Be null
+            $cert.EnhancedKeyUsageList | Should -Not -Be null
             $cert.EnhancedKeyUsageList.Count | Should -Be 1
             $cert.EnhancedKeyUsageList[0].ObjectId.Length | Should -Not -Be 0
             $cert.EnhancedKeyUsageList[0].ObjectId | Should -Be $expectedOid
@@ -142,8 +142,8 @@ Describe "Certificate Provider tests" -Tags "Feature" {
         it "Should filter to codesign certificates" {
             $allCerts = get-item cert:\CurrentUser\My\*
             $codeSignCerts = get-item cert:\CurrentUser\My\* -CodeSigningCert
-            $codeSignCerts | Should -Not be null
-            $allCerts | Should -Not be null
+            $codeSignCerts | Should -Not -Be null
+            $allCerts | Should -Not -Be null
             $nonCodeSignCertCount = $allCerts.Count - $codeSignCerts.Count
             $nonCodeSignCertCount | Should -Not -Be 0
         }
@@ -151,8 +151,8 @@ Describe "Certificate Provider tests" -Tags "Feature" {
             $allCerts = get-item cert:\CurrentUser\My\*
             $testThumbprint = (Get-GoodCertificateObject).Thumbprint
             $allCertsExceptOne = (Get-Item "cert:\currentuser\my\*" -Exclude $testThumbprint)
-            $allCerts | Should -Not be null
-            $allCertsExceptOne | Should -Not be null
+            $allCerts | Should -Not -Be null
+            $allCertsExceptOne | Should -Not -Be null
             $countDifference = $allCerts.Count - $allCertsExceptOne.Count
             $countDifference | Should -Be 1
         }
@@ -161,8 +161,8 @@ Describe "Certificate Provider tests" -Tags "Feature" {
         it "Should filter to codesign certificates" {
             $allCerts = get-ChildItem cert:\CurrentUser\My
             $codeSignCerts = get-ChildItem cert:\CurrentUser\My -CodeSigningCert
-            $codeSignCerts | Should -Not be null
-            $allCerts | Should -Not be null
+            $codeSignCerts | Should -Not -Be null
+            $allCerts | Should -Not -Be null
             $nonCodeSignCertCount = $allCerts.Count - $codeSignCerts.Count
             $nonCodeSignCertCount | Should -Not -Be 0
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageDebugger.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageDebugger.Tests.ps1
@@ -116,7 +116,7 @@ try
                 if ($ps -ne $null) { $ps.Dispose() }
             }
 
-            $expectedError.FullyQualifiedErrorId | Should Be 'NotSupported,Microsoft.PowerShell.Commands.SetPSBreakpointCommand'
+            $expectedError.FullyQualifiedErrorId | Should -Be 'NotSupported,Microsoft.PowerShell.Commands.SetPSBreakpointCommand'
         }
 
         It "Verifies that Wait-Debugger is disabled on locked down system" {
@@ -145,7 +145,7 @@ try
             }
 
             # Debugger should not have been active in lockdown mode
-            $debuggerTester.DebuggerStopHitCount | Should Be 0
+            $debuggerTester.DebuggerStopHitCount | Should -Be 0
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
@@ -532,10 +532,10 @@ ZoneId=$FileType
 
         Context "Prereq: Validate that 'Microsoft.PowerShell.Archive' is signed" {
             It "'Microsoft.PowerShell.Archive' should have a signature" {
-                $script:archiveAllCert | Should not be null
+                $script:archiveAllCert | Should -Not be null
             }
             It "'Microsoft.PowerShell.Archive' should have a valid signature" {
-                $script:archiveCert | Should not be null
+                $script:archiveCert | Should -Not be null
             }
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
@@ -532,10 +532,10 @@ ZoneId=$FileType
 
         Context "Prereq: Validate that 'Microsoft.PowerShell.Archive' is signed" {
             It "'Microsoft.PowerShell.Archive' should have a signature" {
-                $script:archiveAllCert | should not be null
+                $script:archiveAllCert | Should not be null
             }
             It "'Microsoft.PowerShell.Archive' should have a valid signature" {
-                $script:archiveCert | should not be null
+                $script:archiveCert | Should not be null
             }
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
@@ -532,10 +532,10 @@ ZoneId=$FileType
 
         Context "Prereq: Validate that 'Microsoft.PowerShell.Archive' is signed" {
             It "'Microsoft.PowerShell.Archive' should have a signature" {
-                $script:archiveAllCert | Should -Not be null
+                $script:archiveAllCert | Should -Not -Be null
             }
             It "'Microsoft.PowerShell.Archive' should have a valid signature" {
-                $script:archiveCert | Should -Not be null
+                $script:archiveCert | Should -Not -Be null
             }
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Type.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Type.Tests.ps1
@@ -110,8 +110,8 @@ public class SMAAttributeTest$guid : PSCmdlet
         $type2 = Invoke-Expression -Command $type2
 
         # We can compile, load and use new code.
-        $type1::Add1(1, 2) | Should Be 3
-        $type2::Add2(3, 4) | Should Be 7
+        $type1::Add1(1, 2) | Should -Be 3
+        $type2::Add2(3, 4) | Should -Be 7
 
         # Return the same assembly if source code has not been changed.
         # Also check that '-LiteralPath' works.

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Type.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Type.Tests.ps1
@@ -101,8 +101,8 @@ public class SMAAttributeTest$guid : PSCmdlet
         param($type1, $type2, $file1, $file2, $sourceLanguage)
 
         # The types shouldn't exist before compile the test code.
-        $type1 -as [type] | Should BeNullOrEmpty
-        $type2 -as [type] | Should BeNullOrEmpty
+        $type1 -as [type] | Should -BeNullOrEmpty
+        $type2 -as [type] | Should -BeNullOrEmpty
 
         $returnedTypes = Add-Type -Path $file1,$file2 -PassThru
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Type.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Type.Tests.ps1
@@ -85,7 +85,7 @@ public class SMAAttributeTest$guid : PSCmdlet
 
     It "Can load TPA assembly System.Runtime.Serialization.Primitives.dll" {
         $returnedTypes = Add-Type -AssemblyName 'System.Runtime.Serialization.Primitives' -PassThru
-        $returnedTypes.Count | Should BeGreaterThan 0
+        $returnedTypes.Count | Should -BeGreaterThan 0
         ($returnedTypes[0].Assembly.FullName -Split ",")[0]  | Should -BeExactly 'System.Runtime.Serialization.Primitives'
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Type.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Type.Tests.ps1
@@ -58,7 +58,7 @@ Describe "Add-Type" -Tags "CI" {
         # Also we check that '-Language CSharp' is by default.
         # In subsequent launches from the same session
         # the test will be passed without real compile - it will return an assembly previously compiled.
-        { Add-Type -TypeDefinition "public static class CSharpfooType { }" } | Should -Not Throw
+        { Add-Type -TypeDefinition "public static class CSharpfooType { }" } | Should -Not -Throw
         [CSharpfooType].Name | Should -BeExactly "CSharpfooType"
     }
 
@@ -186,7 +186,7 @@ public class AttributeTest$guid : PSCmdlet
         $types[0].Name | Should -BeExactly "AttributeTest$guid"
         $outFile2 | Should -Exist
 
-        { Invoke-Expression -Command $cmdlet } | Should Throw
+        { Invoke-Expression -Command $cmdlet } | Should -Throw
 
         $testModule = Import-Module -Name $outFile -PassThru
         & $cmdlet | Should -BeExactly $guid

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Type.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Type.Tests.ps1
@@ -59,7 +59,7 @@ Describe "Add-Type" -Tags "CI" {
         # In subsequent launches from the same session
         # the test will be passed without real compile - it will return an assembly previously compiled.
         { Add-Type -TypeDefinition "public static class CSharpfooType { }" } | Should -Not Throw
-        [CSharpfooType].Name | Should BeExactly "CSharpfooType"
+        [CSharpfooType].Name | Should -BeExactly "CSharpfooType"
     }
 
     It "Can use System.Management.Automation.CmdletAttribute" {
@@ -78,7 +78,7 @@ public class SMAAttributeTest$guid : PSCmdlet
         $cls = Add-Type -TypeDefinition $code -PassThru | Select-Object -First 1
         $testModule = Import-Module $cls.Assembly -PassThru
 
-        Invoke-Expression -Command "Get-Thing$guid" | Should BeExactly $guid
+        Invoke-Expression -Command "Get-Thing$guid" | Should -BeExactly $guid
 
         Remove-Module $testModule -ErrorAction SilentlyContinue -Force
     }
@@ -86,7 +86,7 @@ public class SMAAttributeTest$guid : PSCmdlet
     It "Can load TPA assembly System.Runtime.Serialization.Primitives.dll" {
         $returnedTypes = Add-Type -AssemblyName 'System.Runtime.Serialization.Primitives' -PassThru
         $returnedTypes.Count | Should BeGreaterThan 0
-        ($returnedTypes[0].Assembly.FullName -Split ",")[0]  | Should BeExactly 'System.Runtime.Serialization.Primitives'
+        ($returnedTypes[0].Assembly.FullName -Split ",")[0]  | Should -BeExactly 'System.Runtime.Serialization.Primitives'
     }
 
     It "Can compile <sourceLanguage> files" -TestCases @(
@@ -116,7 +116,7 @@ public class SMAAttributeTest$guid : PSCmdlet
         # Return the same assembly if source code has not been changed.
         # Also check that '-LiteralPath' works.
         $returnedTypes2 = Add-Type -LiteralPath $file1,$file2 -PassThru
-        $returnedTypes[0].Assembly.FullName | Should BeExactly $returnedTypes2[0].Assembly.FullName
+        $returnedTypes[0].Assembly.FullName | Should -BeExactly $returnedTypes2[0].Assembly.FullName
     }
 
     It "Can compile <sourceLanguage> with MemberDefinition" -TestCases @(
@@ -140,15 +140,15 @@ public class SMAAttributeTest$guid : PSCmdlet
         { Add-Type -MemberDefinition $sourceCode -Name $sourceType -Namespace $sourceNS -Language $sourceLanguage -ErrorAction SilentlyContinue } | Should -Throw -ErrorId "COMPILER_ERRORS,Microsoft.PowerShell.Commands.AddTypeCommand"
 
         $returnedTypes = Add-Type -MemberDefinition $sourceCode -Name $sourceType -UsingNamespace $sourceUsingNS -Namespace $sourceNS -Language $sourceLanguage -PassThru
-        ([type]$sourceRunType)::TestString() | Should BeExactly $expectedResult
+        ([type]$sourceRunType)::TestString() | Should -BeExactly $expectedResult
 
         # Return the same assembly if source code has not been changed.
         $returnedTypes2 = Add-Type -MemberDefinition $sourceCode -Name $sourceType -UsingNamespace $sourceUsingNS -Namespace $sourceNS -Language $sourceLanguage -PassThru
-        $returnedTypes[0].Assembly.FullName | Should BeExactly $returnedTypes2[0].Assembly.FullName
+        $returnedTypes[0].Assembly.FullName | Should -BeExactly $returnedTypes2[0].Assembly.FullName
 
         # With default namespace.
         Add-Type -MemberDefinition $sourceCode -Name $sourceType -UsingNamespace $sourceUsingNS -Language $sourceLanguage
-        ([type]$sourceDefaultNSRunType)::TestString() | Should BeExactly $expectedResult
+        ([type]$sourceDefaultNSRunType)::TestString() | Should -BeExactly $expectedResult
     }
 
     It "Can compile without loading" {
@@ -189,7 +189,7 @@ public class AttributeTest$guid : PSCmdlet
         { Invoke-Expression -Command $cmdlet } | Should Throw
 
         $testModule = Import-Module -Name $outFile -PassThru
-        & $cmdlet | Should BeExactly $guid
+        & $cmdlet | Should -BeExactly $guid
 
         Remove-Module $testModule -Force
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Type.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Type.Tests.ps1
@@ -58,7 +58,7 @@ Describe "Add-Type" -Tags "CI" {
         # Also we check that '-Language CSharp' is by default.
         # In subsequent launches from the same session
         # the test will be passed without real compile - it will return an assembly previously compiled.
-        { Add-Type -TypeDefinition "public static class CSharpfooType { }" } | Should Not Throw
+        { Add-Type -TypeDefinition "public static class CSharpfooType { }" } | Should -Not Throw
         [CSharpfooType].Name | Should BeExactly "CSharpfooType"
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Clear-Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Clear-Variable.Tests.ps1
@@ -5,10 +5,10 @@ Describe "Clear-Variable DRT Unit Tests" -Tags "CI" {
 		Set-Variable foo bar
 		Clear-Variable -Name foo
 		$var1=Get-Variable -Name foo
-		$var1.Name|Should -BeExactly "foo"
-		$var1.Value|Should -BeNullOrEmpty
-		$var1.Options|Should -BeExactly "None"
-		$var1.Description|Should -BeNullOrEmpty
+		$var1.Name | Should -BeExactly "foo"
+		$var1.Value | Should -BeNullOrEmpty
+		$var1.Options | Should -BeExactly "None"
+		$var1.Description | Should -BeNullOrEmpty
 	}
 
 	It "Clear-Variable ReadOnly variable Name should throw exception and force Clear-Variable should works"{
@@ -19,10 +19,10 @@ Describe "Clear-Variable DRT Unit Tests" -Tags "CI" {
 
 		Clear-Variable -Name foo -Force
 		$var1=Get-Variable -Name foo
-		$var1.Name|Should -BeExactly "foo"
-		$var1.Value|Should -BeNullOrEmpty
-		$var1.Options|Should -BeExactly "ReadOnly"
-		$var1.Description| Should -BeNullOrEmpty
+		$var1.Name | Should -BeExactly "foo"
+		$var1.Value | Should -BeNullOrEmpty
+		$var1.Options | Should -BeExactly "ReadOnly"
+		$var1.Description | Should -BeNullOrEmpty
 	}
 
 	It "Clear-Variable normal variable Name with local scope should works"{
@@ -33,17 +33,17 @@ Describe "Clear-Variable DRT Unit Tests" -Tags "CI" {
 			Clear-Variable -Name foo -Scope "local"
 
 			$var1=Get-Variable -Name foo -Scope "local"
-			$var1.Name|Should -BeExactly "foo"
-			$var1.Value|Should -BeNullOrEmpty
-			$var1.Options|Should -BeExactly "None"
-			$var1.Description|Should -BeNullOrEmpty
+			$var1.Name | Should -BeExactly "foo"
+			$var1.Value | Should -BeNullOrEmpty
+			$var1.Options | Should -BeExactly "None"
+			$var1.Description | Should -BeNullOrEmpty
 		}
 
 		$var1=Get-Variable -Name foo
-		$var1.Name|Should -BeExactly "foo"
-		$var1.Value|Should -BeExactly "bar"
-		$var1.Options|Should -BeExactly "None"
-		$var1.Description|Should -BeNullOrEmpty
+		$var1.Name | Should -BeExactly "foo"
+		$var1.Value | Should -BeExactly "bar"
+		$var1.Options | Should -BeExactly "None"
+		$var1.Description | Should -BeNullOrEmpty
 	}
 
 	It "Clear-Variable Private variable Name should works and Get-Variable with local scope should throw exception"{
@@ -55,10 +55,10 @@ Describe "Clear-Variable DRT Unit Tests" -Tags "CI" {
 		}
 
 		$var1=Get-Variable -Name foo
-		$var1.Name|Should -BeExactly "foo"
-		$var1.Value|Should -BeExactly "bar"
-		$var1.Options|Should -BeExactly "Private"
-		$var1.Description|Should -BeNullOrEmpty
+		$var1.Name | Should -BeExactly "foo"
+		$var1.Value | Should -BeExactly "bar"
+		$var1.Options | Should -BeExactly "Private"
+		$var1.Description | Should -BeNullOrEmpty
 	}
 
 	It "Clear-Variable normal variable Name with local scope should works in different scope"{
@@ -68,23 +68,23 @@ Describe "Clear-Variable DRT Unit Tests" -Tags "CI" {
 			Clear-Variable -Name foo -Scope "local"
 
 			$var1=Get-Variable -Name foo -Scope "local"
-			$var1.Name|Should -BeExactly "foo"
-			$var1.Value|Should -BeNullOrEmpty
-			$var1.Options|Should -BeExactly "None"
-			$var1.Description|Should -BeNullOrEmpty
+			$var1.Name | Should -BeExactly "foo"
+			$var1.Value | Should -BeNullOrEmpty
+			$var1.Options | Should -BeExactly "None"
+			$var1.Description | Should -BeNullOrEmpty
 		}
 
 		$var1=Get-Variable -Name foo
-		$var1.Name|Should -BeExactly "foo"
-		$var1.Value|Should -BeExactly "bar"
-		$var1.Options|Should -BeExactly "None"
-		$var1.Description|Should -BeNullOrEmpty
+		$var1.Name | Should -BeExactly "foo"
+		$var1.Value | Should -BeExactly "bar"
+		$var1.Options | Should -BeExactly "None"
+		$var1.Description | Should -BeNullOrEmpty
 
 		$var1=Get-Variable -Name foo -Scope "local"
-		$var1.Name|Should -BeExactly "foo"
-		$var1.Value|Should -BeExactly "bar"
-		$var1.Options|Should -BeExactly "None"
-		$var1.Description|Should -BeNullOrEmpty
+		$var1.Name | Should -BeExactly "foo"
+		$var1.Value | Should -BeExactly "bar"
+		$var1.Options | Should -BeExactly "None"
+		$var1.Description | Should -BeNullOrEmpty
 	}
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Alias.Tests.ps1
@@ -55,46 +55,46 @@ Describe "Export-Alias DRT Unit Tests" -Tags "CI" {
 
 	It "Export-Alias for Default"{
 		Export-Alias $fulltestpath abcd01 -passthru
-		$fulltestpath| Should -FileContentMatchExactly '"abcd01","efgh01","","None"'
+		$fulltestpath | Should -FileContentMatchExactly '"abcd01","efgh01","","None"'
     }
 
 	It "Export-Alias As CSV"{
 		Export-Alias $fulltestpath abcd01 -As CSV -passthru
-		$fulltestpath| Should -FileContentMatchExactly '"abcd01","efgh01","","None"'
+		$fulltestpath | Should -FileContentMatchExactly '"abcd01","efgh01","","None"'
     }
 
 	It "Export-Alias As CSV With Description"{
 		Export-Alias $fulltestpath abcd01 -As CSV -description "My Aliases" -passthru
-		$fulltestpath| Should -FileContentMatchExactly '"abcd01","efgh01","","None"'
-		$fulltestpath| Should -FileContentMatchExactly "My Aliases"
+		$fulltestpath | Should -FileContentMatchExactly '"abcd01","efgh01","","None"'
+		$fulltestpath | Should -FileContentMatchExactly "My Aliases"
     }
 
 	It "Export-Alias As CSV With Multiline Description"{
 		Export-Alias $fulltestpath abcd01 -As CSV -description "My Aliases\nYour Aliases\nEveryones Aliases" -passthru
-		$fulltestpath| Should -FileContentMatchExactly '"abcd01","efgh01","","None"'
-		$fulltestpath| Should -FileContentMatchExactly "My Aliases"
-		$fulltestpath| Should -FileContentMatchExactly "Your Aliases"
-		$fulltestpath| Should -FileContentMatchExactly "Everyones Aliases"
+		$fulltestpath | Should -FileContentMatchExactly '"abcd01","efgh01","","None"'
+		$fulltestpath | Should -FileContentMatchExactly "My Aliases"
+		$fulltestpath | Should -FileContentMatchExactly "Your Aliases"
+		$fulltestpath | Should -FileContentMatchExactly "Everyones Aliases"
     }
 
 	It "Export-Alias As Script"{
 		Export-Alias $fulltestpath abcd01 -As Script -passthru
-		$fulltestpath| Should -FileContentMatchExactly 'set-alias -Name:"abcd01" -Value:"efgh01" -Description:"" -Option:"None"'
+		$fulltestpath | Should -FileContentMatchExactly 'set-alias -Name:"abcd01" -Value:"efgh01" -Description:"" -Option:"None"'
     }
 
 	It "Export-Alias As Script With Multiline Description"{
 		Export-Alias $fulltestpath abcd01 -As Script -description "My Aliases\nYour Aliases\nEveryones Aliases" -passthru
-		$fulltestpath| Should -FileContentMatchExactly 'set-alias -Name:"abcd01" -Value:"efgh01" -Description:"" -Option:"None"'
-		$fulltestpath| Should -FileContentMatchExactly "My Aliases"
-		$fulltestpath| Should -FileContentMatchExactly "Your Aliases"
-		$fulltestpath| Should -FileContentMatchExactly "Everyones Aliases"
+		$fulltestpath | Should -FileContentMatchExactly 'set-alias -Name:"abcd01" -Value:"efgh01" -Description:"" -Option:"None"'
+		$fulltestpath | Should -FileContentMatchExactly "My Aliases"
+		$fulltestpath | Should -FileContentMatchExactly "Your Aliases"
+		$fulltestpath | Should -FileContentMatchExactly "Everyones Aliases"
     }
 
 	It "Export-Alias for Force Test"{
 		Export-Alias $fulltestpath abcd01
 		Export-Alias $fulltestpath abcd02 -force
-		$fulltestpath| Should -Not -FileContentMatchExactly '"abcd01","efgh01","","None"'
-		$fulltestpath| Should -FileContentMatchExactly '"abcd02","efgh02","","None"'
+		$fulltestpath | Should -Not -FileContentMatchExactly '"abcd01","efgh01","","None"'
+		$fulltestpath | Should -FileContentMatchExactly '"abcd02","efgh02","","None"'
     }
 
 	It "Export-Alias for Force ReadOnly Test" -Skip:(Test-IsRoot) {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
@@ -11,81 +11,81 @@ Describe "Get-Alias DRT Unit Tests" -Tags "CI" {
     It "Get-Alias Named Single Valid"{
             Set-Alias -Name ABCD -Value "foo"
             $result=Get-Alias -Name ABCD
-            $result.Name| Should -BeExactly "ABCD"
-            $result.Definition| Should -BeExactly "foo"
-            $result.Description| Should -BeNullOrEmpty
-            $result.Options| Should -BeExactly "None"
+            $result.Name | Should -BeExactly "ABCD"
+            $result.Definition | Should -BeExactly "foo"
+            $result.Description | Should -BeNullOrEmpty
+            $result.Options | Should -BeExactly "None"
     }
     It "Get-Alias Positional Single Valid"{
             Set-Alias -Name ABCD -Value "foo"
             $result=Get-Alias ABCD
-            $result.Name| Should -BeExactly "ABCD"
-            $result.Definition| Should -BeExactly "foo"
-            $result.Description| Should -BeNullOrEmpty
-            $result.Options| Should -BeExactly "None"
+            $result.Name | Should -BeExactly "ABCD"
+            $result.Definition | Should -BeExactly "foo"
+            $result.Description | Should -BeNullOrEmpty
+            $result.Options | Should -BeExactly "None"
     }
     It "Get-Alias Named Multiple Valid"{
             Set-Alias -Name ABCD -Value "foo"
             Set-Alias -Name AEFG -Value "bar"
             $result=Get-Alias -Name ABCD,AEFG
-            $result[0].Name| Should -BeExactly "ABCD"
-            $result[0].Definition| Should -BeExactly "foo"
-            $result[0].Description| Should -BeNullOrEmpty
-            $result[0].Options| Should -BeExactly "None"
-            $result[1].Name| Should -BeExactly "AEFG"
-            $result[1].Definition| Should -BeExactly "bar"
-            $result[1].Description| Should -BeNullOrEmpty
-            $result[1].Options| Should -BeExactly "None"
+            $result[0].Name | Should -BeExactly "ABCD"
+            $result[0].Definition | Should -BeExactly "foo"
+            $result[0].Description | Should -BeNullOrEmpty
+            $result[0].Options | Should -BeExactly "None"
+            $result[1].Name | Should -BeExactly "AEFG"
+            $result[1].Definition | Should -BeExactly "bar"
+            $result[1].Description | Should -BeNullOrEmpty
+            $result[1].Options | Should -BeExactly "None"
     }
     It "Get-Alias Named Wildcard Valid"{
             Set-Alias -Name ABCD -Value "foo"
             Set-Alias -Name ABCG -Value "bar"
             $result=Get-Alias -Name ABC*
-            $result[0].Name| Should -BeExactly "ABCD"
-            $result[0].Definition| Should -BeExactly "foo"
-            $result[0].Description| Should -BeNullOrEmpty
-            $result[0].Options| Should -BeExactly "None"
-            $result[1].Name| Should -BeExactly "ABCG"
-            $result[1].Definition| Should -BeExactly "bar"
-            $result[1].Description| Should -BeNullOrEmpty
-            $result[1].Options| Should -BeExactly "None"
+            $result[0].Name | Should -BeExactly "ABCD"
+            $result[0].Definition | Should -BeExactly "foo"
+            $result[0].Description | Should -BeNullOrEmpty
+            $result[0].Options | Should -BeExactly "None"
+            $result[1].Name | Should -BeExactly "ABCG"
+            $result[1].Definition | Should -BeExactly "bar"
+            $result[1].Description | Should -BeNullOrEmpty
+            $result[1].Options | Should -BeExactly "None"
     }
     It "Get-Alias Positional Wildcard Valid"{
             Set-Alias -Name ABCD -Value "foo"
             Set-Alias -Name ABCG -Value "bar"
             $result=Get-Alias ABC*
-            $result[0].Name| Should -BeExactly "ABCD"
-            $result[0].Definition| Should -BeExactly "foo"
-            $result[0].Description| Should -BeNullOrEmpty
-            $result[0].Options| Should -BeExactly "None"
-            $result[1].Name| Should -BeExactly "ABCG"
-            $result[1].Definition| Should -BeExactly "bar"
-            $result[1].Description| Should -BeNullOrEmpty
-            $result[1].Options| Should -BeExactly "None"
+            $result[0].Name | Should -BeExactly "ABCD"
+            $result[0].Definition | Should -BeExactly "foo"
+            $result[0].Description | Should -BeNullOrEmpty
+            $result[0].Options | Should -BeExactly "None"
+            $result[1].Name | Should -BeExactly "ABCG"
+            $result[1].Definition | Should -BeExactly "bar"
+            $result[1].Description | Should -BeNullOrEmpty
+            $result[1].Options | Should -BeExactly "None"
     }
     It "Get-Alias Named Wildcard And Exclude Valid"{
             Set-Alias -Name ABCD -Value "foo"
             Set-Alias -Name ABCG -Value "bar"
             $result=Get-Alias -Name ABC* -Exclude "*BCG"
-            $result[0].Name| Should -BeExactly "ABCD"
-            $result[0].Definition| Should -BeExactly "foo"
-            $result[0].Description| Should -BeNullOrEmpty
-            $result[0].Options| Should -BeExactly "None"
+            $result[0].Name | Should -BeExactly "ABCD"
+            $result[0].Definition | Should -BeExactly "foo"
+            $result[0].Description | Should -BeNullOrEmpty
+            $result[0].Options | Should -BeExactly "None"
     }
     It "Get-Alias Scope Valid"{
             Set-Alias -Name ABCD -Value "foo"
             $result=Get-Alias -Name ABCD
-            $result.Name| Should -BeExactly "ABCD"
-            $result.Definition| Should -BeExactly "foo"
-            $result.Description| Should -BeNullOrEmpty
-            $result.Options| Should -BeExactly "None"
+            $result.Name | Should -BeExactly "ABCD"
+            $result.Definition | Should -BeExactly "foo"
+            $result.Description | Should -BeNullOrEmpty
+            $result.Options | Should -BeExactly "None"
 
             Set-Alias -Name ABCD -Value "localfoo" -scope local
             $result=Get-Alias -Name ABCD -scope local
-            $result.Name| Should -BeExactly "ABCD"
-            $result.Definition| Should -BeExactly "localfoo"
-            $result.Description| Should -BeNullOrEmpty
-            $result.Options| Should -BeExactly "None"
+            $result.Name | Should -BeExactly "ABCD"
+            $result.Definition | Should -BeExactly "localfoo"
+            $result.Description | Should -BeNullOrEmpty
+            $result.Options | Should -BeExactly "None"
 
             Set-Alias -Name ABCD -Value "globalfoo" -scope global
             Set-Alias -Name ABCD -Value "scriptfoo" -scope "script"
@@ -93,40 +93,40 @@ Describe "Get-Alias DRT Unit Tests" -Tags "CI" {
             Set-Alias -Name ABCD -Value "foo1" -scope "1"
 
             $result=Get-Alias -Name ABCD
-            $result.Name| Should -BeExactly "ABCD"
-            $result.Definition| Should -BeExactly "foo0"
-            $result.Description| Should -BeNullOrEmpty
-            $result.Options| Should -BeExactly "None"
+            $result.Name | Should -BeExactly "ABCD"
+            $result.Definition | Should -BeExactly "foo0"
+            $result.Description | Should -BeNullOrEmpty
+            $result.Options | Should -BeExactly "None"
 
             $result=Get-Alias -Name ABCD -scope local
-            $result.Name| Should -BeExactly "ABCD"
-            $result.Definition| Should -BeExactly "foo0"
-            $result.Description| Should -BeNullOrEmpty
-            $result.Options| Should -BeExactly "None"
+            $result.Name | Should -BeExactly "ABCD"
+            $result.Definition | Should -BeExactly "foo0"
+            $result.Description | Should -BeNullOrEmpty
+            $result.Options | Should -BeExactly "None"
 
             $result=Get-Alias -Name ABCD -scope global
-            $result.Name| Should -BeExactly "ABCD"
-            $result.Definition| Should -BeExactly "globalfoo"
-            $result.Description| Should -BeNullOrEmpty
-            $result.Options| Should -BeExactly "None"
+            $result.Name | Should -BeExactly "ABCD"
+            $result.Definition | Should -BeExactly "globalfoo"
+            $result.Description | Should -BeNullOrEmpty
+            $result.Options | Should -BeExactly "None"
 
             $result=Get-Alias -Name ABCD -scope "script"
-            $result.Name| Should -BeExactly "ABCD"
-            $result.Definition| Should -BeExactly "scriptfoo"
-            $result.Description| Should -BeNullOrEmpty
-            $result.Options| Should -BeExactly "None"
+            $result.Name | Should -BeExactly "ABCD"
+            $result.Definition | Should -BeExactly "scriptfoo"
+            $result.Description | Should -BeNullOrEmpty
+            $result.Options | Should -BeExactly "None"
 
             $result=Get-Alias -Name ABCD -scope "0"
-            $result.Name| Should -BeExactly "ABCD"
-            $result.Definition| Should -BeExactly "foo0"
-            $result.Description| Should -BeNullOrEmpty
-            $result.Options| Should -BeExactly "None"
+            $result.Name | Should -BeExactly "ABCD"
+            $result.Definition | Should -BeExactly "foo0"
+            $result.Description | Should -BeNullOrEmpty
+            $result.Options | Should -BeExactly "None"
 
             $result=Get-Alias -Name ABCD -scope "1"
-            $result.Name| Should -BeExactly "ABCD"
-            $result.Definition| Should -BeExactly "foo1"
-            $result.Description| Should -BeNullOrEmpty
-            $result.Options| Should -BeExactly "None"
+            $result.Name | Should -BeExactly "ABCD"
+            $result.Definition | Should -BeExactly "foo1"
+            $result.Description | Should -BeNullOrEmpty
+            $result.Options | Should -BeExactly "None"
     }
     It "Get-Alias Expose Bug 1065828, BugId:905235"{
             { Get-Alias -Name "ABCD" -Scope "100" } | Should -Throw -ErrorId "ArgumentOutOfRange,Microsoft.PowerShell.Commands.GetAliasCommand"
@@ -134,16 +134,16 @@ Describe "Get-Alias DRT Unit Tests" -Tags "CI" {
     It "Get-Alias Zero Scope Valid"{
             Set-Alias -Name ABCD -Value "foo"
             $result=Get-Alias -Name ABCD
-            $result.Name| Should -BeExactly "ABCD"
-            $result.Definition| Should -BeExactly "foo"
-            $result.Description| Should -BeNullOrEmpty
-            $result.Options| Should -BeExactly "None"
+            $result.Name | Should -BeExactly "ABCD"
+            $result.Definition | Should -BeExactly "foo"
+            $result.Description | Should -BeNullOrEmpty
+            $result.Options | Should -BeExactly "None"
 
             $result=Get-Alias -Name ABCD -scope "0"
-            $result.Name| Should -BeExactly "ABCD"
-            $result.Definition| Should -BeExactly "foo"
-            $result.Description| Should -BeNullOrEmpty
-            $result.Options| Should -BeExactly "None"
+            $result.Name | Should -BeExactly "ABCD"
+            $result.Definition | Should -BeExactly "foo"
+            $result.Description | Should -BeNullOrEmpty
+            $result.Options | Should -BeExactly "None"
     }
 
     It "Test get-alias with Definition parameter" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
@@ -7,7 +7,7 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
         $result = Get-Date -Date $date -Year 1973 -Month 2 -Day 22 -Hour 15 -Minute 40 -Second 10 -Millisecond 200
         $result | Should -BeOfType Datetime
         $result.Year | Should -Be 1973
-        $result.Month| Should -Be 2
+        $result.Month | Should -Be 2
         $result.Day | Should -Be 22
         $result.Hour | Should -Be 15
         $result.Minute | Should -Be 40

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Variable.Tests.ps1
@@ -10,17 +10,17 @@ Describe "Get-Variable DRT Unit Tests" -Tags "CI" {
 	It "Get-Variable of existing variable Name with include and bogus exclude should work"{
 		Set-Variable newVar testing
 		$var1=get-variable -Name newVar -Include newVar -Exclude bogus
-		$var1.Name|Should -BeExactly "newVar"
-		$var1.Value|Should -BeExactly "testing"
+		$var1.Name | Should -BeExactly "newVar"
+		$var1.Value | Should -BeExactly "testing"
 	}
 
 	It "Get-Variable of existing variable Name with Description and Option should work"{
 		Set-Variable newVar testing -Option ReadOnly -Description "testing description"
 		$var1=get-variable -Name newVar
-		$var1.Name|Should -BeExactly "newVar"
-		$var1.Value|Should -BeExactly "testing"
-		$var1.Options|Should -BeExactly "ReadOnly"
-		$var1.Description|Should -BeExactly "testing description"
+		$var1.Name | Should -BeExactly "newVar"
+		$var1.Value | Should -BeExactly "testing"
+		$var1.Options | Should -BeExactly "ReadOnly"
+		$var1.Description | Should -BeExactly "testing description"
 	}
 
 	It "Get-Variable of existing variable Globbing Name should work"{
@@ -29,12 +29,12 @@ Describe "Get-Variable DRT Unit Tests" -Tags "CI" {
 		Set-Variable aVarfoo wow
 		$var1=get-variable -Name *aVar* -Scope local
 		$var1.Count | Should -Be 3
-		$var1[0].Name|Should -BeExactly "abcaVar"
-		$var1[0].Value|Should -BeExactly "testing"
-		$var1[1].Name|Should -BeExactly "aVarfoo"
-		$var1[1].Value|Should -BeExactly "wow"
-		$var1[2].Name|Should -BeExactly "bcdaVar"
-		$var1[2].Value|Should -BeExactly "another test"
+		$var1[0].Name | Should -BeExactly "abcaVar"
+		$var1[0].Value | Should -BeExactly "testing"
+		$var1[1].Name | Should -BeExactly "aVarfoo"
+		$var1[1].Value | Should -BeExactly "wow"
+		$var1[2].Name | Should -BeExactly "bcdaVar"
+		$var1[2].Value | Should -BeExactly "another test"
 	}
 
 	It "Get-Variable of existing private variable Name should throw ItemNotFoundException"{

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Expression.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Expression.Tests.ps1
@@ -20,6 +20,6 @@ Describe "Invoke-Expression" -Tags "CI" {
 Describe "Invoke-Expression DRT Unit Tests" -Tags "CI" {
 	It "Invoke-Expression should work"{
 		$result=invoke-expression -Command 2+2
-		$result|Should -Be 4
+		$result | Should -Be 4
 	}
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
@@ -303,7 +303,7 @@ Describe "Invoke-Item tests on Windows" -Tags "CI","RequireAdminOnWindows" {
                 Start-Sleep -Milliseconds 100
                 if (([Datetime]::Now - $startTime) -ge [timespan]"00:00:05") { throw "Timeout exception" }
             }
-        } | Should -Not -throw
+        } | Should -Not -Throw
     }
 
     It "Should start a file without error on Windows full SKUs" -Skip:(-not $isFullWin) {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Measure-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Measure-Object.Tests.ps1
@@ -38,7 +38,7 @@ Describe "Measure-Object" -Tags "CI" {
     It "Should calculate Standard Deviation with -Sum" {
         $actual = ($testObject | Measure-Object -Sum -StandardDeviation)
         # We check this way since .StandardDeviation returns a double value
-        $actual.Sum | Should Be 8
+        $actual.Sum | Should -Be 8
         # 1.52752523165195 was calculated outside powershell using formula from
         # http://mathworld.wolfram.com/StandardDeviation.html
         [Math]::abs($actual.StandardDeviation - 1.52752523165195) | Should -BeLessThan .00000000000001
@@ -56,8 +56,8 @@ Describe "Measure-Object" -Tags "CI" {
     It "Should calculate Standard Deviation with -Sum -Average" {
         $actual = ($testObject2 | Measure-Object -Sum -Average -StandardDeviation)
         # We check this way since .StandardDeviation returns a double value
-        $actual.Sum | Should Be 5050
-        $actual.Average | Should Be 50.5
+        $actual.Sum | Should -Be 5050
+        $actual.Average | Should -Be 50.5
         # 29.011491975882 was calculated outside powershell using formula from
         # http://mathworld.wolfram.com/StandardDeviation.html
         [Math]::abs($actual.StandardDeviation - 29.011491975882) | Should -BeLessThan .0000000000001

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Alias.Tests.ps1
@@ -11,28 +11,28 @@ Describe "New-Alias DRT Unit Tests" -Tags "CI" {
 	It "New-Alias NamePositional And Value Valid" {
 			New-Alias ABCD -Value "MyCommand" -Scope "0"
 			$result=Get-Alias -Name ABCD -Scope "0"
-			$result.Name| Should -BeExactly "ABCD"
-			$result.Definition| Should -BeExactly "MyCommand"
-			$result.Description| Should -BeNullOrEmpty
-			$result.Options| Should -BeExactly "None"
+			$result.Name | Should -BeExactly "ABCD"
+			$result.Definition | Should -BeExactly "MyCommand"
+			$result.Description | Should -BeNullOrEmpty
+			$result.Options | Should -BeExactly "None"
 	}
 
 	It "New-Alias NamePositional And ValuePositional Valid" {
 			New-Alias ABCD "MyCommand" -Scope "0"
 			$result=Get-Alias -Name ABCD -Scope "0"
-			$result.Name| Should -BeExactly "ABCD"
-			$result.Definition| Should -BeExactly "MyCommand"
-			$result.Description| Should -BeNullOrEmpty
-			$result.Options| Should -BeExactly "None"
+			$result.Name | Should -BeExactly "ABCD"
+			$result.Definition | Should -BeExactly "MyCommand"
+			$result.Description | Should -BeNullOrEmpty
+			$result.Options | Should -BeExactly "None"
 	}
 
 	It "New-Alias Description Valid" {
 			New-Alias -Name ABCD -Value "MyCommand" -Description "test description" -Scope "0"
 			$result=Get-Alias -Name ABCD -Scope "0"
-			$result.Name| Should -BeExactly "ABCD"
-			$result.Definition| Should -BeExactly "MyCommand"
-			$result.Description| Should -BeExactly "test description"
-			$result.Options| Should -BeExactly "None"
+			$result.Name | Should -BeExactly "ABCD"
+			$result.Definition | Should -BeExactly "MyCommand"
+			$result.Description | Should -BeExactly "test description"
+			$result.Options | Should -BeExactly "None"
 	}
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Variable.Tests.ps1
@@ -5,19 +5,19 @@ Describe "New-Variable DRT Unit Tests" -Tags "CI" {
 	It "New-Variable variable with description should works"{
 		New-Variable foo bar -description "my description"
 		$var1=Get-Variable -Name foo
-		$var1.Name|Should -BeExactly "foo"
-		$var1.Value|Should -BeExactly "bar"
-		$var1.Options|Should -BeExactly "None"
-		$var1.Description|Should -BeExactly "my description"
+		$var1.Name | Should -BeExactly "foo"
+		$var1.Value | Should -BeExactly "bar"
+		$var1.Options | Should -BeExactly "None"
+		$var1.Description | Should -BeExactly "my description"
 	}
 
 	It "New-Variable variable with option should works"{
 		New-Variable foo bar -option Constant
 		$var1=Get-Variable -Name foo
-		$var1.Name|Should -BeExactly "foo"
-		$var1.Value|Should -BeExactly "bar"
-		$var1.Options|Should -BeExactly "Constant"
-		$var1.Description|Should -BeNullOrEmpty
+		$var1.Name | Should -BeExactly "foo"
+		$var1.Value | Should -BeExactly "bar"
+		$var1.Options | Should -BeExactly "Constant"
+		$var1.Description | Should -BeNullOrEmpty
 	}
 
 	It "New-Variable variable twice should throw Exception"{
@@ -29,10 +29,10 @@ Describe "New-Variable DRT Unit Tests" -Tags "CI" {
 
 		New-Variable foo bar -Force -PassThru
 		$var1=Get-Variable -Name foo
-		$var1.Name|Should -BeExactly "foo"
-		$var1.Value|Should -BeExactly "bar"
-		$var1.Options|Should -BeExactly "None"
-		$var1.Description|Should -BeNullOrEmpty
+		$var1.Name | Should -BeExactly "foo"
+		$var1.Value | Should -BeExactly "bar"
+		$var1.Options | Should -BeExactly "None"
+		$var1.Description | Should -BeNullOrEmpty
 	}
 
 	It "New-Variable ReadOnly variable twice should throw Exception"{
@@ -44,10 +44,10 @@ Describe "New-Variable DRT Unit Tests" -Tags "CI" {
 
 		New-Variable foo bar -Force -PassThru
 		$var1=Get-Variable -Name foo
-		$var1.Name|Should -BeExactly "foo"
-		$var1.Value|Should -BeExactly "bar"
-		$var1.Options|Should -BeExactly "None"
-		$var1.Description|Should -BeNullOrEmpty
+		$var1.Name | Should -BeExactly "foo"
+		$var1.Value | Should -BeExactly "bar"
+		$var1.Options | Should -BeExactly "None"
+		$var1.Description | Should -BeNullOrEmpty
 	}
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
@@ -13,8 +13,8 @@ Describe "Out-File DRT Unit Tests" -Tags "CI" {
         $tempFile = Join-Path -Path $TestDrive -ChildPath "outfileAppendTest.txt"
         { 'This is first line.' | out-file $tempFile } | Should -Not -Throw
         { 'This is second line.' | out-file -append $tempFile } | Should -Not -Throw
-        $tempFile |Should -FileContentMatch "first"
-        $tempFile |Should -FileContentMatch "second"
+        $tempFile | Should -FileContentMatch "first"
+        $tempFile | Should -FileContentMatch "second"
         Remove-Item $tempFile -Force
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-String.Tests.ps1
@@ -37,7 +37,7 @@ Describe "Out-String" -Tags "CI" {
 	$streamoutputlength = $($testInput | Out-String -Stream).Length
 	$nonstreamoutputlength = $($testInput | Out-String).Length
 
-	$nonstreamoutputlength| Should -BeGreaterThan $streamoutputlength
+	$nonstreamoutputlength | Should -BeGreaterThan $streamoutputlength
     }
 
     It "Should send a single object through a pipeline when the stream switch is used" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Read-Host.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Read-Host.Tests.ps1
@@ -47,6 +47,6 @@ Describe "Read-Host Test" -tag "CI" {
         else {
             $expected = @('foo: !1','!1')
         }
-        $result | should -BeExactly $expected
+        $result | Should -BeExactly $expected
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Remove-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Remove-Alias.Tests.ps1
@@ -39,7 +39,7 @@ Describe "Remove-Alias" -Tags "CI" {
 
     It "Remove-Alias should throw if alias does not exist"{
         {
-            Get-Alias -Name $testAliasName -ErrorAction SilentlyContinue | Should -BeNullorEmpty
+            Get-Alias -Name $testAliasName -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
             Remove-Alias -Name $testAliasName -ErrorAction Stop
         } | Should -Throw -ErrorId 'ItemNotFoundException,Microsoft.PowerShell.Commands.RemoveAliasCommand'
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -45,7 +45,7 @@ Describe "Select-String" -Tags "CI" {
             $secondMatch = $testinputtwo | Select-String -Pattern "hello" -ca
 
             $equal = @(Compare-Object $firstMatch $secondMatch).Length -eq 0
-            $equal | Should -Be True
+            $equal | Should -BeTrue
         }
 
         it "Should only return the case sensitive match when the casesensitive switch is used" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -171,7 +171,7 @@ Describe "Select-String" -Tags "CI" {
         It "Should return all strings where 'second' is found in testfile1 if there is only one lines that has a match" {
             $expected = $testInputFile + ":2:This is the second line"
 
-            Select-String $testInputFile  -Pattern "second"| Should -BeExactly $expected
+            Select-String $testInputFile  -Pattern "second" | Should -BeExactly $expected
         }
 
         It "Should return all strings where 'in' is found in testfile1 pattern switch is not required" {
@@ -202,7 +202,7 @@ Describe "Select-String" -Tags "CI" {
         }
 
         It "Should return the number of matches for 'is' in textfile1 " {
-            (Select-String is $testInputFile -CaseSensitive).count| Should -Be 4
+            (Select-String is $testInputFile -CaseSensitive).count | Should -Be 4
         }
 
         It "Should return the third line in testfile1 when a relative path is used" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Alias.Tests.ps1
@@ -9,64 +9,64 @@ Describe "Set-Alias DRT Unit Tests" -Tags "CI" {
 	It "Set-Alias ReadOnly Force"{
 			Set-Alias -Name ABCD -Value "foo" -Option ReadOnly -Force:$true
 			$result=Get-Alias -Name ABCD
-			$result.Name| Should -BeExactly "ABCD"
-			$result.Definition| Should -BeExactly "foo"
-			$result.Description| Should -BeNullOrEmpty
-			$result.Options| Should -BeExactly "ReadOnly"
+			$result.Name | Should -BeExactly "ABCD"
+			$result.Definition | Should -BeExactly "foo"
+			$result.Description | Should -BeNullOrEmpty
+			$result.Options | Should -BeExactly "ReadOnly"
 
 			Set-Alias -Name ABCD -Value "foo" -Force:$true
 			$result=Get-Alias -Name ABCD
-			$result.Name| Should -BeExactly "ABCD"
-			$result.Definition| Should -BeExactly "foo"
-			$result.Description| Should -BeNullOrEmpty
-			$result.Options| Should -BeExactly "None"
+			$result.Name | Should -BeExactly "ABCD"
+			$result.Definition | Should -BeExactly "foo"
+			$result.Description | Should -BeNullOrEmpty
+			$result.Options | Should -BeExactly "None"
 	}
 
 	It "Set-Alias Name And Value Valid"{
 			Set-Alias -Name ABCD -Value "MyCommand"
 			$result=Get-Alias -Name ABCD
-			$result.Name| Should -BeExactly "ABCD"
-			$result.Definition| Should -BeExactly "MyCommand"
-			$result.Description| Should -BeNullOrEmpty
-			$result.Options| Should -BeExactly "None"
+			$result.Name | Should -BeExactly "ABCD"
+			$result.Definition | Should -BeExactly "MyCommand"
+			$result.Description | Should -BeNullOrEmpty
+			$result.Options | Should -BeExactly "None"
 	}
 	It "Set-Alias Name And Value Positional Valid"{
 			Set-Alias -Name ABCD "foo"
 			$result=Get-Alias ABCD
-			$result.Name| Should -BeExactly "ABCD"
-			$result.Definition| Should -BeExactly "foo"
-			$result.Description| Should -BeNullOrEmpty
-			$result.Options| Should -BeExactly "None"
+			$result.Name | Should -BeExactly "ABCD"
+			$result.Definition | Should -BeExactly "foo"
+			$result.Description | Should -BeNullOrEmpty
+			$result.Options | Should -BeExactly "None"
 	}
 	It "Set-Alias Description Valid"{
 			Set-Alias -Name ABCD -Value "MyCommand" -Description "test description"
 			$result=Get-Alias -Name ABCD
-			$result.Name| Should -BeExactly "ABCD"
-			$result.Definition| Should -BeExactly "MyCommand"
-			$result.Description| Should -BeExactly "test description"
-			$result.Options| Should -BeExactly "None"
+			$result.Name | Should -BeExactly "ABCD"
+			$result.Definition | Should -BeExactly "MyCommand"
+			$result.Description | Should -BeExactly "test description"
+			$result.Options | Should -BeExactly "None"
 	}
 	It "Set-Alias Scope Valid"{
 			Set-Alias -Name ABCD -Value "localfoo" -scope local -Force:$true
 			Set-Alias -Name ABCD -Value "foo1" -scope "1" -Force:$true
 
 			$result=Get-Alias -Name ABCD
-			$result.Name| Should -BeExactly "ABCD"
-			$result.Definition| Should -BeExactly "localfoo"
-			$result.Description| Should -BeNullOrEmpty
-			$result.Options| Should -BeExactly "None"
+			$result.Name | Should -BeExactly "ABCD"
+			$result.Definition | Should -BeExactly "localfoo"
+			$result.Description | Should -BeNullOrEmpty
+			$result.Options | Should -BeExactly "None"
 
 			$result=Get-Alias -Name ABCD -scope local
-			$result.Name| Should -BeExactly "ABCD"
-			$result.Definition| Should -BeExactly "localfoo"
-			$result.Description| Should -BeNullOrEmpty
-			$result.Options| Should -BeExactly "None"
+			$result.Name | Should -BeExactly "ABCD"
+			$result.Definition | Should -BeExactly "localfoo"
+			$result.Description | Should -BeNullOrEmpty
+			$result.Options | Should -BeExactly "None"
 
 			$result=Get-Alias -Name ABCD -scope "1"
-			$result.Name| Should -BeExactly "ABCD"
-			$result.Definition| Should -BeExactly "foo1"
-			$result.Description| Should -BeNullOrEmpty
-			$result.Options| Should -BeExactly "None"
+			$result.Name | Should -BeExactly "ABCD"
+			$result.Definition | Should -BeExactly "foo1"
+			$result.Description | Should -BeNullOrEmpty
+			$result.Options | Should -BeExactly "None"
 	}
 	It "Set-Alias Expose Bug 1062958, BugId:905449"{
 			{ Set-Alias -Name "ABCD" -Value "foo" -Scope "-1" } | Should -Throw -ErrorId "ArgumentOutOfRange,Microsoft.PowerShell.Commands.SetAliasCommand"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Variable.Tests.ps1
@@ -5,19 +5,19 @@ Describe "Set-Variable DRT Unit Tests" -Tags "CI" {
 	It "Set-Variable normal variable Name should works"{
 		Set-Variable foo bar
 		$var1=Get-Variable -Name foo
-		$var1.Name|Should -BeExactly "foo"
-		$var1.Value|Should -BeExactly "bar"
-		$var1.Options|Should -BeExactly "None"
-		$var1.Description|Should -BeNullOrEmpty
+		$var1.Name | Should -BeExactly "foo"
+		$var1.Value | Should -BeExactly "bar"
+		$var1.Options | Should -BeExactly "None"
+		$var1.Description | Should -BeNullOrEmpty
 	}
 
 	It "Set-Variable normal variable Name with position should works"{
 		Set-Variable -Name foo bar
 		$var1=Get-Variable -Name foo
-		$var1.Name|Should -BeExactly "foo"
-		$var1.Value|Should -BeExactly "bar"
-		$var1.Options|Should -BeExactly "None"
-		$var1.Description|Should -BeNullOrEmpty
+		$var1.Name | Should -BeExactly "foo"
+		$var1.Value | Should -BeExactly "bar"
+		$var1.Options | Should -BeExactly "None"
+		$var1.Description | Should -BeNullOrEmpty
 	}
 
 	It "Set-Variable normal variable Name with scope should works"{
@@ -25,24 +25,24 @@ Describe "Set-Variable DRT Unit Tests" -Tags "CI" {
 
 		Set-Variable -Name foo -Value bar -Scope "1"
 		$var1=Get-Variable -Name foo -scope "1"
-		$var1.Name|Should -BeExactly "foo"
-		$var1.Value|Should -BeExactly "bar"
-		$var1.Options|Should -BeExactly "None"
-		$var1.Description|Should -BeNullOrEmpty
+		$var1.Name | Should -BeExactly "foo"
+		$var1.Value | Should -BeExactly "bar"
+		$var1.Options | Should -BeExactly "None"
+		$var1.Description | Should -BeNullOrEmpty
 
 		Set-Variable -Name foo -Value newValue -Scope "local"
 		$var1=Get-Variable -Name foo -scope "local"
-		$var1.Name|Should -BeExactly "foo"
-		$var1.Value|Should -BeExactly "newValue"
-		$var1.Options|Should -BeExactly "None"
-		$var1.Description|Should -BeNullOrEmpty
+		$var1.Name | Should -BeExactly "foo"
+		$var1.Value | Should -BeExactly "newValue"
+		$var1.Options | Should -BeExactly "None"
+		$var1.Description | Should -BeNullOrEmpty
 
 		Set-Variable -Name foo -Value newValue2 -Scope "script"
 		$var1=Get-Variable -Name foo -scope "script"
-		$var1.Name|Should -BeExactly "foo"
-		$var1.Value|Should -BeExactly "newValue2"
-		$var1.Options|Should -BeExactly "None"
-		$var1.Description|Should -BeNullOrEmpty
+		$var1.Name | Should -BeExactly "foo"
+		$var1.Value | Should -BeExactly "newValue2"
+		$var1.Options | Should -BeExactly "None"
+		$var1.Description | Should -BeNullOrEmpty
 	}
 
 	It "Set-Variable normal variable Name with position should works"{
@@ -53,40 +53,40 @@ Describe "Set-Variable DRT Unit Tests" -Tags "CI" {
 		Set-Variable -Name "*aV*" -Value "overwrite" -Include "*Var*" -Exclude "bcd*"
 
 		$var1=Get-Variable -Name "*aVar*" -Scope "local"
-		$var1[0].Name|Should -BeExactly "abcaVar"
-		$var1[0].Value|Should -BeExactly "overwrite"
-		$var1[0].Options|Should -BeExactly "None"
-		$var1[0].Description|Should -BeNullOrEmpty
+		$var1[0].Name | Should -BeExactly "abcaVar"
+		$var1[0].Value | Should -BeExactly "overwrite"
+		$var1[0].Options | Should -BeExactly "None"
+		$var1[0].Description | Should -BeNullOrEmpty
 
-		$var1[1].Name|Should -BeExactly "aVarfoo"
-		$var1[1].Value|Should -BeExactly "overwrite"
-		$var1[1].Options|Should -BeExactly "None"
-		$var1[1].Description|Should -BeNullOrEmpty
+		$var1[1].Name | Should -BeExactly "aVarfoo"
+		$var1[1].Value | Should -BeExactly "overwrite"
+		$var1[1].Options | Should -BeExactly "None"
+		$var1[1].Description | Should -BeNullOrEmpty
 
-		$var1[2].Name|Should -BeExactly "bcdaVar"
-		$var1[2].Value|Should -BeExactly "anotherVal"
-		$var1[2].Options|Should -BeExactly "None"
-		$var1[2].Description|Should -BeNullOrEmpty
+		$var1[2].Name | Should -BeExactly "bcdaVar"
+		$var1[2].Value | Should -BeExactly "anotherVal"
+		$var1[2].Options | Should -BeExactly "None"
+		$var1[2].Description | Should -BeNullOrEmpty
 	}
 
 	It "Set-Variable normal variable Name with Description and Value should works"{
 		Set-Variable foo bar
 		Set-Variable -Name foo $null -Description "new description" -PassThru:$true -Scope "local"
 		$var1=Get-Variable -Name foo -Scope "local"
-		$var1.Name|Should -BeExactly "foo"
-		$var1.Value|Should -BeNullOrEmpty
-		$var1.Options|Should -BeExactly "None"
-		$var1.Description|Should -BeExactly "new description"
+		$var1.Name | Should -BeExactly "foo"
+		$var1.Value | Should -BeNullOrEmpty
+		$var1.Options | Should -BeExactly "None"
+		$var1.Description | Should -BeExactly "new description"
 	}
 
 	It "Set-Variable normal variable Name with just Description should works"{
 		Set-Variable foo bar
 		Set-Variable -Name foo -Description "new description" -PassThru:$true -Scope "local"
 		$var1=Get-Variable -Name foo -Scope "local"
-		$var1.Name|Should -BeExactly "foo"
-		$var1.Value|Should -BeExactly "bar"
-		$var1.Options|Should -BeExactly "None"
-		$var1.Description|Should -BeExactly "new description"
+		$var1.Name | Should -BeExactly "foo"
+		$var1.Value | Should -BeExactly "bar"
+		$var1.Options | Should -BeExactly "None"
+		$var1.Description | Should -BeExactly "new description"
 	}
 
 	It "Set-Variable overwrite Constant Option should throw SessionStateUnauthorizedAccessException"{
@@ -97,17 +97,17 @@ Describe "Set-Variable DRT Unit Tests" -Tags "CI" {
 	It "Set-Variable of existing Private variable without force should throw Exception"{
 		Set-Variable abcaVar bar -Description "new description" -Option Private
 		$var1=Get-Variable -Name abcaVar
-		$var1.Name|Should -BeExactly "abcaVar"
-		$var1.Value|Should -BeExactly "bar"
-		$var1.Options|Should -BeExactly "Private"
-		$var1.Description|Should -BeExactly "new description"
+		$var1.Name | Should -BeExactly "abcaVar"
+		$var1.Value | Should -BeExactly "bar"
+		$var1.Options | Should -BeExactly "Private"
+		$var1.Description | Should -BeExactly "new description"
 
 		Set-Variable abcaVar other -Description "new description"
 		$var1=Get-Variable -Name abcaVar
-		$var1.Name|Should -BeExactly "abcaVar"
-		$var1.Value|Should -BeExactly "other"
-		$var1.Options|Should -BeExactly "Private"
-		$var1.Description|Should -BeExactly "new description"
+		$var1.Name | Should -BeExactly "abcaVar"
+		$var1.Value | Should -BeExactly "other"
+		$var1.Options | Should -BeExactly "Private"
+		$var1.Description | Should -BeExactly "new description"
 	}
 
 	It "Set-Variable with Exclude, then Get-Variable it should throw ItemNotFoundException"{
@@ -118,30 +118,30 @@ Describe "Set-Variable DRT Unit Tests" -Tags "CI" {
 	It "Set-Variable of existing ReadOnly variable without force should throw Exception"{
 		Set-Variable abcaVar bar -Description "new description" -Option ReadOnly
 		$var1=Get-Variable -Name abcaVar
-		$var1.Name|Should -BeExactly "abcaVar"
-		$var1.Value|Should -BeExactly "bar"
-		$var1.Options|Should -BeExactly "ReadOnly"
-		$var1.Description|Should -BeExactly "new description"
+		$var1.Name | Should -BeExactly "abcaVar"
+		$var1.Value | Should -BeExactly "bar"
+		$var1.Options | Should -BeExactly "ReadOnly"
+		$var1.Description | Should -BeExactly "new description"
 		{ Set-Variable abcaVar -Option None -Scope 1 -ErrorAction Stop } | Should -Throw -ErrorId "VariableNotWritable,Microsoft.PowerShell.Commands.SetVariableCommand"
 	}
 
 	It "Set-Variable of ReadOnly variable with private scope should work"{
 		Set-Variable foo bar -Description "new description" -Option ReadOnly -scope "private"
 		$var1=Get-Variable -Name foo
-		$var1.Name|Should -BeExactly "foo"
-		$var1.Value|Should -BeExactly "bar"
-		$var1.Options|Should -BeExactly "ReadOnly, Private"
-		$var1.Description|Should -BeExactly "new description"
+		$var1.Name | Should -BeExactly "foo"
+		$var1.Value | Should -BeExactly "bar"
+		$var1.Options | Should -BeExactly "ReadOnly, Private"
+		$var1.Description | Should -BeExactly "new description"
 	}
 
 	It "Set-Variable pipeline with Get-Variable should work"{
 		$footest1="bar"
 		${Get-Variable footest1 -valueonly|Set-Variable bootest1 -passthru}
 		$var1=Get-Variable -Name footest1
-		$var1.Name|Should -BeExactly "footest1"
-		$var1.Value|Should -BeExactly "bar"
-		$var1.Options|Should -BeExactly "None"
-		$var1.Description|Should -BeNullOrEmpty
+		$var1.Name | Should -BeExactly "footest1"
+		$var1.Value | Should -BeExactly "bar"
+		$var1.Options | Should -BeExactly "None"
+		$var1.Description | Should -BeNullOrEmpty
 	}
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Update-FormatData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Update-FormatData.Tests.ps1
@@ -9,7 +9,7 @@ Describe "Update-FormatData" -Tags "CI" {
     Context "Validate Update-FormatData update correctly" {
 
         It "Should not throw upon reloading previous formatting file" {
-            { Update-FormatData } | Should -Not -throw
+            { Update-FormatData } | Should -Not -Throw
         }
 
         It "Should validly load formatting data" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -1913,7 +1913,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
                 $response.Images | out-null
             }
 
-            $script:content | should -Not -BeNullOrEmpty
+            $script:content | Should -Not -BeNullOrEmpty
 
             # pathological regex
             $regex = [RegEx]::new('<img\s+[^>]*>')
@@ -1944,7 +1944,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
             # Pathological regex
             $regex = [RegEx]::new('<meta\s[.\n]*[^><]*charset\s*=\s*["''\n]?(?<charset>[A-Za-z].[^\s"''\n<>]*)[\s"''\n>]')
 
-            $script:content | should -Not -BeNullOrEmpty
+            $script:content | Should -Not -BeNullOrEmpty
 
             [TimeSpan] $pathologicalTimeSpan = Measure-Command {
                 $regex.Match($content)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -3339,7 +3339,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
             $response = Invoke-RestMethod -uri $resumeUri -OutFile $outFile -ResponseHeadersVariable 'Headers' -Resume
 
             $outFileHash = Get-FileHash -Algorithm SHA256 -Path $outFile
-            $outFileHash.Hash | Should BeExactly $referenceFileHash.Hash
+            $outFileHash.Hash | Should -BeExactly $referenceFileHash.Hash
             Get-Item $outFile | Select-Object -ExpandProperty Length | Should -Be $referenceFileSize
             $Headers.'X-WebListener-Has-Range'[0] | Should -BeExactly 'true'
             $Headers.'X-WebListener-Request-Range'[0] | Should -BeExactly "bytes=$bytes-"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
@@ -93,7 +93,7 @@ Describe "Write-Error Tests" -Tags "CI" {
         $theError = "Error: Too many input values."
         write-error -message $theError -category InvalidArgument -ErrorAction SilentlyContinue
 
-        [string]$error[0]| Should -Be $theError
+        [string]$error[0] | Should -Be $theError
     }
 
     It "ErrorRecord should not be truncated or have inserted newlines when redirected from another process" {

--- a/test/powershell/Modules/Microsoft.WSMan.Management/CredSSP.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.WSMan.Management/CredSSP.Tests.ps1
@@ -105,6 +105,6 @@ Describe "CredSSP cmdlet error cases tests" -Tags 'Feature' {
         param ($cmdline, $cmd)
 
         $scriptBlock = [scriptblock]::Create($cmdline)
-        $scriptBlock | should -Throw -ErrorId "System.InvalidOperationException,Microsoft.WSMan.Management.$cmd"
+        $scriptBlock | Should -Throw -ErrorId "System.InvalidOperationException,Microsoft.WSMan.Management.$cmd"
     }
 }

--- a/test/powershell/Modules/Microsoft.WSMan.Management/CredSSP.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.WSMan.Management/CredSSP.Tests.ps1
@@ -49,7 +49,7 @@ Describe "CredSSP cmdlet tests" -Tags 'Feature','RequireAdminOnWindows' {
     ) {
         param ($params)
         $c = Enable-WSManCredSSP @params -Force
-        $c.CredSSP | Should -Be $true
+        $c.CredSSP | Should -BeTrue
 
         $c = Get-WSManCredSSP
         if ($params.Role -eq "Client")
@@ -87,7 +87,7 @@ Describe "CredSSP cmdlet tests" -Tags 'Feature','RequireAdminOnWindows' {
         $credssp.DelegateComputer = "foo", "bar"
         $credssp.DelegateComputer -join ',' | Should -Be "foo,bar"
         $credssp.Force = $true
-        $credssp.Force | Should -Be $true
+        $credssp.Force | Should -BeTrue
 
         $credssp = [Microsoft.WSMan.Management.DisableWSManCredSSPCommand]::new()
         $credssp.Role = "Server"

--- a/test/powershell/Modules/PSDesiredStateConfiguration/PSDesiredStateConfiguration.Tests.ps1
+++ b/test/powershell/Modules/PSDesiredStateConfiguration/PSDesiredStateConfiguration.Tests.ps1
@@ -487,7 +487,7 @@ Describe "Test PSDesiredStateConfiguration" -tags CI {
                     #this will fail too, but that is nat what we are testing...
                 }
 
-                $warnings.Count | Should -Be 1 -because "There should be 1 warning on macOS and Linux"
+                $warnings.Count | Should -Be 1 -Because "There should be 1 warning on macOS and Linux"
                 $warnings[0] | Should -Match 'embedded resources.*not support'
             }
 

--- a/test/powershell/Modules/PSDesiredStateConfiguration/PSDesiredStateConfiguration.Tests.ps1
+++ b/test/powershell/Modules/PSDesiredStateConfiguration/PSDesiredStateConfiguration.Tests.ps1
@@ -533,7 +533,7 @@ Describe "Test PSDesiredStateConfiguration" -tags CI {
                 $result.InstallationPolicy | Should -BeOfType [string]
                 $result.Guid | Should -BeOfType [Guid]
                 $result.Ensure | Should -Be 'Present'
-                $result.Name | Should -be 'PsDscResources'
+                $result.Name | Should -Be 'PsDscResources'
                 $result.Description | Should -BeLike 'This*DSC*'
                 $result.InstalledVersion | Should -BeOfType [Version]
                 $result.ModuleBase | Should -BeLike '*PSDscResources*'

--- a/test/powershell/Modules/PSDesiredStateConfiguration/PSDesiredStateConfiguration.Tests.ps1
+++ b/test/powershell/Modules/PSDesiredStateConfiguration/PSDesiredStateConfiguration.Tests.ps1
@@ -535,9 +535,9 @@ Describe "Test PSDesiredStateConfiguration" -tags CI {
                 $result.Ensure | Should -Be 'Present'
                 $result.Name | Should -be 'PsDscResources'
                 $result.Description | Should -BeLike 'This*DSC*'
-                $result.InstalledVersion | should -BeOfType [Version]
+                $result.InstalledVersion | Should -BeOfType [Version]
                 $result.ModuleBase | Should -BeLike '*PSDscResources*'
-                $result.Repository | should -BeOfType [string]
+                $result.Repository | Should -BeOfType [string]
                 $result.ModuleType | Should -Be 'Manifest'
             }
         }

--- a/test/powershell/Modules/ThreadJob/ThreadJob.Tests.ps1
+++ b/test/powershell/Modules/ThreadJob/ThreadJob.Tests.ps1
@@ -227,7 +227,7 @@ Describe 'Basic ThreadJob Tests' -Tags 'CI' {
     It 'ThreadJob and Verbose stream output' {
 
         $job = Start-ThreadJob -ScriptBlock { $VerbosePreference = 'Continue'; Write-Verbose "VerboseOut" } | Wait-Job
-        $job.Verbose | Should Match "VerboseOut"
+        $job.Verbose | Should -Match "VerboseOut"
     }
 
     It 'ThreadJob and Verbose stream output' {

--- a/test/powershell/engine/Api/TaskBasedAsyncPowerShellAPI.Tests.ps1
+++ b/test/powershell/engine/Api/TaskBasedAsyncPowerShellAPI.Tests.ps1
@@ -49,7 +49,7 @@ Describe 'Task-based PowerShell async APIs' -Tags 'Feature' {
             try {
                 $r = InvokeAsyncHelper -PowerShell $ps -Wait
                 $r.Status | Should -Be ([System.Threading.Tasks.TaskStatus]::RanToCompletion)
-                $r.IsCompletedSuccessfully | Should -Be $true
+                $r.IsCompletedSuccessfully | Should -BeTrue
             } finally {
                 $ps.Dispose()
             }
@@ -72,8 +72,8 @@ try {
                 }
                 # This test is designed to gracefully fail with an error when invoked asynchronously.
                 { $sb.Invoke() } | Should -Throw -ErrorId 'AggregateException'
-                $r.IsFaulted | Should -Be $true
-                $r.Exception.InnerException -is [System.Management.Automation.ParameterBindingException] | Should -Be $true
+                $r.IsFaulted | Should -BeTrue
+                $r.Exception.InnerException -is [System.Management.Automation.ParameterBindingException] | Should -BeTrue
                 $r.Exception.InnerException.CommandInvocation.InvocationName | Should -BeExactly 'Get-Process'
                 $r.Exception.InnerException.ParameterName | Should -BeExactly 'Invalid'
                 $r.Exception.InnerException.ErrorId | Should -BeExactly 'NamedParameterNotFound'
@@ -149,9 +149,9 @@ try {
                 $r2 = $ps2.AddScript("@(2,4,6,8,10,12,14,16,18,20)${sbStub}").InvokeAsync()
                 [System.Threading.Tasks.Task]::WaitAll(@($r1, $r2))
                 $r1.Status | Should -Be ([System.Threading.Tasks.TaskStatus]::RanToCompletion)
-                $r1.IsCompletedSuccessfully | Should -Be $true
+                $r1.IsCompletedSuccessfully | Should -BeTrue
                 $r2.Status | Should -Be ([System.Threading.Tasks.TaskStatus]::RanToCompletion)
-                $r2.IsCompletedSuccessfully | Should -Be $true
+                $r2.IsCompletedSuccessfully | Should -BeTrue
                 $results = @($r1.Result.foreach('Value')) + @($r2.Result.foreach('Value'))
                 Compare-Object -ReferenceObject @(1..20) -DifferenceObject $results -SyncWindow 20 | Should -Be $null
             } finally {
@@ -183,9 +183,9 @@ try {
                 $r2 = $ps2.AddScript($script).InvokeAsync($d2)
                 [System.Threading.Tasks.Task]::WaitAll(@($r1, $r2))
                 $r1.Status | Should -Be ([System.Threading.Tasks.TaskStatus]::RanToCompletion)
-                $r1.IsCompletedSuccessfully | Should -Be $true
+                $r1.IsCompletedSuccessfully | Should -BeTrue
                 $r2.Status | Should -Be ([System.Threading.Tasks.TaskStatus]::RanToCompletion)
-                $r2.IsCompletedSuccessfully | Should -Be $true
+                $r2.IsCompletedSuccessfully | Should -BeTrue
                 $allResults = @($r1.Result) + @($r2.Result)
                 Compare-Object -ReferenceObject @(1..20) -DifferenceObject $allResults.Value -SyncWindow 20 | Should -Be $null
             } finally {
@@ -204,9 +204,9 @@ try {
                 [System.Threading.Tasks.Task]::WaitAll(@($r1, $r2))
                 $o.Complete()
                 $r1.Status | Should -Be ([System.Threading.Tasks.TaskStatus]::RanToCompletion)
-                $r1.IsCompletedSuccessfully | Should -Be $true
+                $r1.IsCompletedSuccessfully | Should -BeTrue
                 $r2.Status | Should -Be ([System.Threading.Tasks.TaskStatus]::RanToCompletion)
-                $r2.IsCompletedSuccessfully | Should -Be $true
+                $r2.IsCompletedSuccessfully | Should -BeTrue
                 Compare-Object -ReferenceObject @(1..20) -DifferenceObject $o.Value -SyncWindow 20 | Should -Be $null
             } finally {
                 $ps1.Dispose()
@@ -227,10 +227,10 @@ try {
                 [System.Threading.Tasks.Task]::WaitAll(@($sr))
                 $ps.Streams.Error | Should -HaveCount 0 -Because ($ps.Streams.Error | Out-String)
                 $ps.Commands.Commands.commandtext | Should -Be "Start-Sleep -Seconds 60"
-                $sr.IsCompletedSuccessfully | Should -Be $true
-                $ir.IsFaulted | Should -Be $true -Because ($ir | Format-List -Force * | Out-String)
-                $ir.Exception -is [System.AggregateException] | Should -Be $true
-                $ir.Exception.InnerException -is [System.Management.Automation.PipelineStoppedException] | Should -Be $true
+                $sr.IsCompletedSuccessfully | Should -BeTrue
+                $ir.IsFaulted | Should -BeTrue -Because ($ir | Format-List -Force * | Out-String)
+                $ir.Exception -is [System.AggregateException] | Should -BeTrue
+                $ir.Exception.InnerException -is [System.Management.Automation.PipelineStoppedException] | Should -BeTrue
                 $ps.InvocationStateInfo.State | Should -Be ([System.Management.Automation.PSInvocationState]::Stopped)
             } finally {
                 $ps.Dispose()

--- a/test/powershell/engine/Api/TypeInference.Tests.ps1
+++ b/test/powershell/engine/Api/TypeInference.Tests.ps1
@@ -468,7 +468,7 @@ Describe "Type inference Tests" -tags "CI" {
                 }}.Ast)
         $res.Count | Should -Be 1
         $res[0].GetType().Name | Should -Be "PSSyntheticTypeName"
-        $res.Members.Count  | Should Be 2
+        $res.Members.Count  | Should -Be 2
         $res[0].Name | Should -Be "MyType#A:B"
         $res[0].Members[0].Name | Should -Be "A"
         $res[0].Members[0].PSTypeName | Should -Be "System.Int32"

--- a/test/powershell/engine/Basic/Encoding.Tests.ps1
+++ b/test/powershell/engine/Basic/Encoding.Tests.ps1
@@ -49,21 +49,21 @@ Describe "File encoding tests" -Tag CI {
             param ( $Command, $parameters, $Expected, $Operator)
             & $command @parameters
             $bytes = Get-FileBytes $outputFile
-            $bytes -join "-" | should ${Operator} ($Expected -join "-")
+            $bytes -join "-" | Should ${Operator} ($Expected -join "-")
         }
 
         It "Export-CSV creates file with UTF-8 encoding without BOM" {
             [pscustomobject]@{ Key = $testStr } | Export-Csv $outputFile
             $bytes = Get-FileBytes $outputFile
-            $bytes[0,1,2] -join "-" | should -Not -Be ($utf8Preamble -join "-")
-            $bytes -join "-" | should -Match ($utf8bytes -join "-")
+            $bytes[0,1,2] -join "-" | Should -Not -Be ($utf8Preamble -join "-")
+            $bytes -join "-" | Should -Match ($utf8bytes -join "-")
         }
 
         It "Export-CliXml creates file with UTF-8 encoding without BOM" {
             [pscustomobject]@{ Key = $testStr } | Export-Clixml $outputFile
             $bytes = Get-FileBytes $outputFile
-            $bytes[0,1,2] -join "-" | should -Not -Be ($utf8Preamble -join "-")
-            $bytes -join "-" | should -Match ($utf8bytes -join "-")
+            $bytes[0,1,2] -join "-" | Should -Not -Be ($utf8Preamble -join "-")
+            $bytes -join "-" | Should -Match ($utf8bytes -join "-")
         }
 
         It "Appends correctly on non-Windows systems" -Skip:$IsWindows {
@@ -71,7 +71,7 @@ Describe "File encoding tests" -Tag CI {
             ${testStr} >> $outputFile
             $bytes = Get-FileBytes $outputFile
             $Expected = $( $ExpectedWithNewline; $ExpectedWithNewline )
-            $bytes -join "-" | should -Be ($Expected -join "-")
+            $bytes -join "-" | Should -Be ($Expected -join "-")
         }
     }
 

--- a/test/powershell/engine/Basic/GroupPolicySettings.Tests.ps1
+++ b/test/powershell/engine/Basic/GroupPolicySettings.Tests.ps1
@@ -159,8 +159,8 @@ Describe 'Group policy settings tests' -Tag CI,RequireAdminOnWindows {
                 $LogPath = (gci -Path $OutputDirectory -Filter "PowerShell_transcript*.txt" -Recurse).FullName
                 $Log = Get-Content $LogPath -Raw
 
-                $Log.Contains("$number") | should be $True # verifies that Transcription policy works
-                $Log.Contains("Command start time:") | should be $True # verifies that EnableInvocationHeader works
+                $Log.Contains("$number") | Should be $True # verifies that Transcription policy works
+                $Log.Contains("Command start time:") | Should be $True # verifies that EnableInvocationHeader works
 
                 Remove-Item -Path $OutputDirectory -Recurse -Force
             }
@@ -235,7 +235,7 @@ Describe 'Group policy settings tests' -Tag CI,RequireAdminOnWindows {
                 # Cannot create or open the configuration session 116337267.'
 
                 $Log = Get-Content $LogPath -Raw
-                $Log.Contains("$SessionName") | should be $True
+                $Log.Contains("$SessionName") | Should be $True
                 Remove-Item -Path $LogPath -Force
             }
 

--- a/test/powershell/engine/Basic/GroupPolicySettings.Tests.ps1
+++ b/test/powershell/engine/Basic/GroupPolicySettings.Tests.ps1
@@ -67,7 +67,7 @@ Describe 'Group policy settings tests' -Tag CI,RequireAdminOnWindows {
 
                 Remove-Module $ModuleToLog -ErrorAction SilentlyContinue
                 Import-Module $ModuleToLog
-                (Get-Module $ModuleToLog).LogPipelineExecutionDetails | Should -Be $False # without GP logging for the module should be OFF
+                (Get-Module $ModuleToLog).LogPipelineExecutionDetails | Should -BeFalse # without GP logging for the module should be OFF
 
                 # enable GP
                 [string]$RareCommand = Get-Random

--- a/test/powershell/engine/Basic/GroupPolicySettings.Tests.ps1
+++ b/test/powershell/engine/Basic/GroupPolicySettings.Tests.ps1
@@ -120,9 +120,9 @@ Describe 'Group policy settings tests' -Tag CI,RequireAdminOnWindows {
                 $sbString = $script:CreatingScriptblockEvent.Message.Substring($sbStringStart, $sbStringEnd - $sbStringStart)
 
                 $StartedScriptBlockInvocationEvent = Get-WinEvent -FilterHashtable @{ ProviderName="PowerShellCore"; Id = 4105 } -MaxEvents 5 | ? {$_.Message.Contains($sbString)}
-                $StartedScriptBlockInvocationEvent | Should -Not BeNullOrEmpty
+                $StartedScriptBlockInvocationEvent | Should -Not -BeNullOrEmpty
                 $CompletedScriptBlockInvocationEvent = Get-WinEvent -FilterHashtable @{ ProviderName="PowerShellCore"; Id = 4106 } -MaxEvents 5 | ? {$_.Message.Contains($sbString)}
-                $CompletedScriptBlockInvocationEvent | Should -Not BeNullOrEmpty
+                $CompletedScriptBlockInvocationEvent | Should -Not -BeNullOrEmpty
             }
 
             $KeyPath = Join-Path $KeyRoot 'ScriptBlockLogging'

--- a/test/powershell/engine/Basic/GroupPolicySettings.Tests.ps1
+++ b/test/powershell/engine/Basic/GroupPolicySettings.Tests.ps1
@@ -120,9 +120,9 @@ Describe 'Group policy settings tests' -Tag CI,RequireAdminOnWindows {
                 $sbString = $script:CreatingScriptblockEvent.Message.Substring($sbStringStart, $sbStringEnd - $sbStringStart)
 
                 $StartedScriptBlockInvocationEvent = Get-WinEvent -FilterHashtable @{ ProviderName="PowerShellCore"; Id = 4105 } -MaxEvents 5 | ? {$_.Message.Contains($sbString)}
-                $StartedScriptBlockInvocationEvent | Should Not BeNullOrEmpty
+                $StartedScriptBlockInvocationEvent | Should -Not BeNullOrEmpty
                 $CompletedScriptBlockInvocationEvent = Get-WinEvent -FilterHashtable @{ ProviderName="PowerShellCore"; Id = 4106 } -MaxEvents 5 | ? {$_.Message.Contains($sbString)}
-                $CompletedScriptBlockInvocationEvent | Should Not BeNullOrEmpty
+                $CompletedScriptBlockInvocationEvent | Should -Not BeNullOrEmpty
             }
 
             $KeyPath = Join-Path $KeyRoot 'ScriptBlockLogging'

--- a/test/powershell/engine/Basic/GroupPolicySettings.Tests.ps1
+++ b/test/powershell/engine/Basic/GroupPolicySettings.Tests.ps1
@@ -76,7 +76,7 @@ Describe 'Group policy settings tests' -Tag CI,RequireAdminOnWindows {
 
                 Remove-Module $ModuleToLog -ErrorAction SilentlyContinue
                 Import-Module $ModuleToLog # this will read and start using GP setting
-                (Get-Module $ModuleToLog).LogPipelineExecutionDetails | Should -Be $True # with GP logging for the module should be ON
+                (Get-Module $ModuleToLog).LogPipelineExecutionDetails | Should -BeTrue # with GP logging for the module should be ON
 
                 Get-Alias $RareCommand -ErrorAction SilentlyContinue | Out-Null
 
@@ -159,8 +159,8 @@ Describe 'Group policy settings tests' -Tag CI,RequireAdminOnWindows {
                 $LogPath = (gci -Path $OutputDirectory -Filter "PowerShell_transcript*.txt" -Recurse).FullName
                 $Log = Get-Content $LogPath -Raw
 
-                $Log.Contains("$number") | Should -Be $True # verifies that Transcription policy works
-                $Log.Contains("Command start time:") | Should -Be $True # verifies that EnableInvocationHeader works
+                $Log.Contains("$number") | Should -BeTrue # verifies that Transcription policy works
+                $Log.Contains("Command start time:") | Should -BeTrue # verifies that EnableInvocationHeader works
 
                 Remove-Item -Path $OutputDirectory -Recurse -Force
             }
@@ -235,7 +235,7 @@ Describe 'Group policy settings tests' -Tag CI,RequireAdminOnWindows {
                 # Cannot create or open the configuration session 116337267.'
 
                 $Log = Get-Content $LogPath -Raw
-                $Log.Contains("$SessionName") | Should -Be $True
+                $Log.Contains("$SessionName") | Should -BeTrue
                 Remove-Item -Path $LogPath -Force
             }
 

--- a/test/powershell/engine/Basic/GroupPolicySettings.Tests.ps1
+++ b/test/powershell/engine/Basic/GroupPolicySettings.Tests.ps1
@@ -159,8 +159,8 @@ Describe 'Group policy settings tests' -Tag CI,RequireAdminOnWindows {
                 $LogPath = (gci -Path $OutputDirectory -Filter "PowerShell_transcript*.txt" -Recurse).FullName
                 $Log = Get-Content $LogPath -Raw
 
-                $Log.Contains("$number") | Should be $True # verifies that Transcription policy works
-                $Log.Contains("Command start time:") | Should be $True # verifies that EnableInvocationHeader works
+                $Log.Contains("$number") | Should -Be $True # verifies that Transcription policy works
+                $Log.Contains("Command start time:") | Should -Be $True # verifies that EnableInvocationHeader works
 
                 Remove-Item -Path $OutputDirectory -Recurse -Force
             }
@@ -235,7 +235,7 @@ Describe 'Group policy settings tests' -Tag CI,RequireAdminOnWindows {
                 # Cannot create or open the configuration session 116337267.'
 
                 $Log = Get-Content $LogPath -Raw
-                $Log.Contains("$SessionName") | Should be $True
+                $Log.Contains("$SessionName") | Should -Be $True
                 Remove-Item -Path $LogPath -Force
             }
 

--- a/test/powershell/engine/Cdxml/Cdxml.Tests.ps1
+++ b/test/powershell/engine/Cdxml/Cdxml.Tests.ps1
@@ -102,7 +102,7 @@ Describe "Cdxml cmdlets are supported" -Tag CI,RequireAdminOnWindows {
     Context "Module level tests" {
         It "The CimTest module should have been loaded" @ItSkipOrPending {
             $result = Get-Module CimTest
-            $result.ModuleBase | should -Be ${script:ModuleDir}
+            $result.ModuleBase | Should -Be ${script:ModuleDir}
         }
 
         It "The CimTest module should have the proper cmdlets" @ItSkipOrPending {
@@ -115,19 +115,19 @@ Describe "Cdxml cmdlets are supported" -Tag CI,RequireAdminOnWindows {
     Context "Get-CimTest cmdlet" {
         It "The Get-CimTest cmdlet should return 4 objects" @ItSkipOrPending {
             $result = Get-CimTest
-            $result.Count | should -Be 4
-            ($result.id |sort-object) -join ","  | should -Be "1,2,3,4"
+            $result.Count | Should -Be 4
+            ($result.id |sort-object) -join ","  | Should -Be "1,2,3,4"
         }
 
         It "The Get-CimTest cmdlet should retrieve an object via id" @ItSkipOrPending {
             $result = Get-CimTest -id 1
-            @($result).Count | should -Be 1
+            @($result).Count | Should -Be 1
             $result.field1 | Should -Be "instance 1"
         }
 
         It "The Get-CimTest cmdlet should retrieve an object by piped id" @ItSkipOrPending {
             $result = 1,2,4 | foreach-object { [pscustomobject]@{ id = $_ } } | Get-CimTest
-            @($result).Count | should -Be 3
+            @($result).Count | Should -Be 3
             ( $result.id | sort-object ) -join "," | Should -Be "1,2,4"
         }
 
@@ -150,7 +150,7 @@ Describe "Cdxml cmdlets are supported" -Tag CI,RequireAdminOnWindows {
                 # the time can be adjusted
                 $null = Wait-Job -Job $job -timeout 10
                 $result = $job | Receive-Job
-                $result.Count | should -Be 4
+                $result.Count | Should -Be 4
                 ( $result.id | sort-object ) -join "," | Should -Be "1,2,3,4"
             }
             finally {
@@ -180,15 +180,15 @@ Describe "Cdxml cmdlets are supported" -Tag CI,RequireAdminOnWindows {
         It "The Remote-CimTest cmdlet should remove objects by id" @ItSkipOrPending {
             Remove-CimTest -id 1
             $result = Get-CimTest
-            $result.Count | should -Be 3
-            ($result.id |sort-object) -join ","  | should -Be "2,3,4"
+            $result.Count | Should -Be 3
+            ($result.id |sort-object) -join ","  | Should -Be "2,3,4"
         }
 
         It "The Remove-CimTest cmdlet should remove piped objects" @ItSkipOrPending {
             Get-CimTest -id 2 | Remove-CimTest
             $result  = Get-CimTest
-            @($result).Count | should -Be 3
-            ($result.id |sort-object) -join ","  | should -Be "1,3,4"
+            @($result).Count | Should -Be 3
+            ($result.id |sort-object) -join ","  | Should -Be "1,3,4"
         }
 
         It "The Remove-CimTest cmdlet should work as a job" @ItSkipOrPending {
@@ -200,8 +200,8 @@ Describe "Cdxml cmdlets are supported" -Tag CI,RequireAdminOnWindows {
                 # the time can be adjusted
                 $null = Wait-Job -Job $job -Timeout 10
                 $result  = Get-CimTest
-                @($result).Count | should -Be 3
-                ($result.id |sort-object) -join ","  | should -Be "1,2,4"
+                @($result).Count | Should -Be 3
+                ($result.id |sort-object) -join ","  | Should -Be "1,2,4"
             }
             finally {
                 if ( $job ) {
@@ -220,7 +220,7 @@ Describe "Cdxml cmdlets are supported" -Tag CI,RequireAdminOnWindows {
             }
             New-CimTest @instanceArgs
             $result = Get-CimInstance -namespace root/default -class PSCore_Test1 | Where-Object {$_.id -eq "telephone"}
-            $result.field2 | should -Be 0
+            $result.field2 | Should -Be 0
             $result.field1 | Should -Be $instanceArgs.field1
         }
 
@@ -261,12 +261,12 @@ Describe "Cdxml cmdlets are supported" -Tag CI,RequireAdminOnWindows {
             }
             New-CimTest @instanceArgs
             $result = Get-CimTest -id $instanceArgs.id
-            $result.field2 | should -Be $instanceArgs.field2
+            $result.field2 | Should -Be $instanceArgs.field2
             $result.field1 | Should -Be $instanceArgs.field1
             Set-CimTest @newValues
             $result = Get-CimTest -id $newValues.id
             $result.field1 | Should -Be $newValues.field1
-            $result.field2 | should -Be $newValues.field2
+            $result.field2 | Should -Be $newValues.field2
         }
 
         It "Should set properties on an instance via pipeline" @ItSkipOrPending {
@@ -277,14 +277,14 @@ Describe "Cdxml cmdlets are supported" -Tag CI,RequireAdminOnWindows {
             }
             New-CimTest @instanceArgs
             $result = Get-CimTest -id $instanceArgs.id
-            $result.field2 | should -Be $instanceArgs.field2
+            $result.field2 | Should -Be $instanceArgs.field2
             $result.field1 | Should -Be $instanceArgs.field1
             $result.field1 = "yet another value"
             $result.field2 = 33
             $result | Set-CimTest
             $result = Get-CimTest -id $instanceArgs.id
             $result.field1 | Should -Be "yet another value"
-            $result.field2 | should -Be 33
+            $result.field2 | Should -Be 33
         }
     }
 

--- a/test/powershell/engine/ExperimentalFeature/ExperimentalFeature.Basic.Tests.ps1
+++ b/test/powershell/engine/ExperimentalFeature/ExperimentalFeature.Basic.Tests.ps1
@@ -78,25 +78,25 @@ Describe "Experimental Feature Basic Tests - Feature-Disabled" -tags "CI" {
         $command.ParameterSets.Count | Should -Be 2
 
         $command.Parameters["UserName"].ParameterSets.Count | Should -Be 1
-        $command.Parameters["UserName"].ParameterSets.ContainsKey("ComputerSet") | Should -Be $true
+        $command.Parameters["UserName"].ParameterSets.ContainsKey("ComputerSet") | Should -BeTrue
 
         $command.Parameters["ComputerName"].ParameterSets.Count | Should -Be 1
-        $command.Parameters["ComputerName"].ParameterSets.ContainsKey("ComputerSet") | Should -Be $true
+        $command.Parameters["ComputerName"].ParameterSets.ContainsKey("ComputerSet") | Should -BeTrue
 
         $command.Parameters["ConfigurationName"].ParameterSets.Count | Should -Be 1
-        $command.Parameters["ConfigurationName"].ParameterSets.ContainsKey("ComputerSet") | Should -Be $true
+        $command.Parameters["ConfigurationName"].ParameterSets.ContainsKey("ComputerSet") | Should -BeTrue
 
         $command.Parameters["VMName"].ParameterSets.Count | Should -Be 1
-        $command.Parameters["VMName"].ParameterSets.ContainsKey("VMSet") | Should -Be $true
+        $command.Parameters["VMName"].ParameterSets.ContainsKey("VMSet") | Should -BeTrue
 
         $command.Parameters["Port"].ParameterSets.Count | Should -Be 1
-        $command.Parameters["Port"].ParameterSets.ContainsKey("VMSet") | Should -Be $true
+        $command.Parameters["Port"].ParameterSets.ContainsKey("VMSet") | Should -BeTrue
 
         $command.Parameters["ThrottleLimit"].ParameterSets.Count | Should -Be 1
-        $command.Parameters["ThrottleLimit"].ParameterSets.ContainsKey("__AllParameterSets") | Should -Be $true
+        $command.Parameters["ThrottleLimit"].ParameterSets.ContainsKey("__AllParameterSets") | Should -BeTrue
 
         $command.Parameters["Command"].ParameterSets.Count | Should -Be 1
-        $command.Parameters["Command"].ParameterSets.ContainsKey("__AllParameterSets") | Should -Be $true
+        $command.Parameters["Command"].ParameterSets.ContainsKey("__AllParameterSets") | Should -BeTrue
 
         ## Common parameters + '-UserName', '-ComputerName', '-ConfigurationName', '-ThrottleLimit' and '-Command'
         $command.ParameterSets[0].Name | Should -BeExactly "ComputerSet"
@@ -135,17 +135,17 @@ Describe "Experimental Feature Basic Tests - Feature-Disabled" -tags "CI" {
         $command.ParameterSets.Count | Should -Be 2
 
         $command.Parameters["ByUrl"].ParameterSets.Count | Should -Be 1
-        $command.Parameters["ByUrl"].ParameterSets.ContainsKey("UrlSet") | Should -Be $true
+        $command.Parameters["ByUrl"].ParameterSets.ContainsKey("UrlSet") | Should -BeTrue
 
         $command.Parameters["ByRadio"].ParameterSets.Count | Should -Be 1
-        $command.Parameters["ByRadio"].ParameterSets.ContainsKey("RadioSet") | Should -Be $true
+        $command.Parameters["ByRadio"].ParameterSets.ContainsKey("RadioSet") | Should -BeTrue
 
         $command.Parameters["Configuration"].ParameterSets.Count | Should -Be 2
-        $command.Parameters["Configuration"].ParameterSets.ContainsKey("UrlSet") | Should -Be $true
-        $command.Parameters["Configuration"].ParameterSets.ContainsKey("RadioSet") | Should -Be $true
+        $command.Parameters["Configuration"].ParameterSets.ContainsKey("UrlSet") | Should -BeTrue
+        $command.Parameters["Configuration"].ParameterSets.ContainsKey("RadioSet") | Should -BeTrue
 
         $command.Parameters["FileName"].ParameterSets.Count | Should -Be 1
-        $command.Parameters["FileName"].ParameterSets.ContainsKey("__AllParameterSets") | Should -Be $true
+        $command.Parameters["FileName"].ParameterSets.ContainsKey("__AllParameterSets") | Should -BeTrue
 
         $command.Parameters.ContainsKey("Destination") | Should -Be $false
     }
@@ -207,7 +207,7 @@ Describe "Experimental Feature Basic Tests - Feature-Enabled" -Tag "CI" {
 
     It "Experimental feature 'ExpTest.FeatureOne' should be enabled" {
         $EnabledExperimentalFeatures.Count | Should -Be 1
-        $EnabledExperimentalFeatures -contains "ExpTest.FeatureOne" | Should -Be $true
+        $EnabledExperimentalFeatures -contains "ExpTest.FeatureOne" | Should -BeTrue
     }
 
     It "Replace existing command <Name> - version two should be shown" -TestCases @(
@@ -258,33 +258,33 @@ Describe "Experimental Feature Basic Tests - Feature-Enabled" -Tag "CI" {
         $command.ParameterSets.Count | Should -Be 3
 
         $command.Parameters["UserName"].ParameterSets.Count | Should -Be 1
-        $command.Parameters["UserName"].ParameterSets.ContainsKey("ComputerSet") | Should -Be $true
+        $command.Parameters["UserName"].ParameterSets.ContainsKey("ComputerSet") | Should -BeTrue
 
         $command.Parameters["ComputerName"].ParameterSets.Count | Should -Be 1
-        $command.Parameters["ComputerName"].ParameterSets.ContainsKey("ComputerSet") | Should -Be $true
+        $command.Parameters["ComputerName"].ParameterSets.ContainsKey("ComputerSet") | Should -BeTrue
 
         $command.Parameters["VMName"].ParameterSets.Count | Should -Be 1
-        $command.Parameters["VMName"].ParameterSets.ContainsKey("VMSet") | Should -Be $true
+        $command.Parameters["VMName"].ParameterSets.ContainsKey("VMSet") | Should -BeTrue
 
         $command.Parameters["Token"].ParameterSets.Count | Should -Be 1
-        $command.Parameters["Token"].ParameterSets.ContainsKey("WebSocketSet") | Should -Be $true
+        $command.Parameters["Token"].ParameterSets.ContainsKey("WebSocketSet") | Should -BeTrue
 
         $command.Parameters["WebSocketUrl"].ParameterSets.Count | Should -Be 1
-        $command.Parameters["WebSocketUrl"].ParameterSets.ContainsKey("WebSocketSet") | Should -Be $true
+        $command.Parameters["WebSocketUrl"].ParameterSets.ContainsKey("WebSocketSet") | Should -BeTrue
 
         $command.Parameters["ConfigurationName"].ParameterSets.Count | Should -Be 2
-        $command.Parameters["ConfigurationName"].ParameterSets.ContainsKey("ComputerSet") | Should -Be $true
-        $command.Parameters["ConfigurationName"].ParameterSets.ContainsKey("WebSocketSet") | Should -Be $true
+        $command.Parameters["ConfigurationName"].ParameterSets.ContainsKey("ComputerSet") | Should -BeTrue
+        $command.Parameters["ConfigurationName"].ParameterSets.ContainsKey("WebSocketSet") | Should -BeTrue
 
         $command.Parameters["Port"].ParameterSets.Count | Should -Be 2
-        $command.Parameters["Port"].ParameterSets.ContainsKey("VMSet") | Should -Be $true
-        $command.Parameters["Port"].ParameterSets.ContainsKey("WebSocketSet") | Should -Be $true
+        $command.Parameters["Port"].ParameterSets.ContainsKey("VMSet") | Should -BeTrue
+        $command.Parameters["Port"].ParameterSets.ContainsKey("WebSocketSet") | Should -BeTrue
 
         $command.Parameters["ThrottleLimit"].ParameterSets.Count | Should -Be 1
-        $command.Parameters["ThrottleLimit"].ParameterSets.ContainsKey("__AllParameterSets") | Should -Be $true
+        $command.Parameters["ThrottleLimit"].ParameterSets.ContainsKey("__AllParameterSets") | Should -BeTrue
 
         $command.Parameters["Command"].ParameterSets.Count | Should -Be 1
-        $command.Parameters["Command"].ParameterSets.ContainsKey("__AllParameterSets") | Should -Be $true
+        $command.Parameters["Command"].ParameterSets.ContainsKey("__AllParameterSets") | Should -BeTrue
 
         ## Common parameters + '-UserName', '-ComputerName', '-ConfigurationName', '-ThrottleLimit' and '-Command'
         $command.ParameterSets[0].Name | Should -BeExactly "ComputerSet"
@@ -333,16 +333,16 @@ Describe "Experimental Feature Basic Tests - Feature-Enabled" -Tag "CI" {
         $command.ParameterSets.Count | Should -Be 2
 
         $command.Parameters["ByUrl"].ParameterSets.Count | Should -Be 1
-        $command.Parameters["ByUrl"].ParameterSets.ContainsKey("UrlSet") | Should -Be $true
+        $command.Parameters["ByUrl"].ParameterSets.ContainsKey("UrlSet") | Should -BeTrue
 
         $command.Parameters["ByRadio"].ParameterSets.Count | Should -Be 1
-        $command.Parameters["ByRadio"].ParameterSets.ContainsKey("RadioSet") | Should -Be $true
+        $command.Parameters["ByRadio"].ParameterSets.ContainsKey("RadioSet") | Should -BeTrue
 
         $command.Parameters["Destination"].ParameterSets.Count | Should -Be 1
-        $command.Parameters["Destination"].ParameterSets.ContainsKey("__AllParameterSets") | Should -Be $true
+        $command.Parameters["Destination"].ParameterSets.ContainsKey("__AllParameterSets") | Should -BeTrue
 
         $command.Parameters["FileName"].ParameterSets.Count | Should -Be 1
-        $command.Parameters["FileName"].ParameterSets.ContainsKey("__AllParameterSets") | Should -Be $true
+        $command.Parameters["FileName"].ParameterSets.ContainsKey("__AllParameterSets") | Should -BeTrue
 
         $command.Parameters.ContainsKey("Configuration") | Should -Be $false
     }
@@ -434,10 +434,10 @@ PrivateData = @{
         Import-Module $moduleFile -ErrorVariable featureNameError -ErrorAction SilentlyContinue
         $featureNameError | Should -Not -BeNullOrEmpty
         $featureNameError[0].FullyQualifiedErrorId | Should -Be "Modules_InvalidExperimentalFeatureName,Microsoft.PowerShell.Commands.ImportModuleCommand"
-        $featureNameError[0].Exception.Message.Contains(".Feature1") | Should -Be $true
-        $featureNameError[0].Exception.Message.Contains("Feature2.") | Should -Be $true
-        $featureNameError[0].Exception.Message.Contains("Feature3") | Should -Be $true
-        $featureNameError[0].Exception.Message.Contains("Module.Feature4") | Should -Be $true
+        $featureNameError[0].Exception.Message.Contains(".Feature1") | Should -BeTrue
+        $featureNameError[0].Exception.Message.Contains("Feature2.") | Should -BeTrue
+        $featureNameError[0].Exception.Message.Contains("Feature3") | Should -BeTrue
+        $featureNameError[0].Exception.Message.Contains("Module.Feature4") | Should -BeTrue
         $featureNameError[0].Exception.Message.Contains("InvalidFeatureName.Feature5") | Should -Be $false
     }
 }

--- a/test/powershell/engine/ExperimentalFeature/ExperimentalFeature.Basic.Tests.ps1
+++ b/test/powershell/engine/ExperimentalFeature/ExperimentalFeature.Basic.Tests.ps1
@@ -120,7 +120,7 @@ Describe "Experimental Feature Basic Tests - Feature-Disabled" -tags "CI" {
         ## Common parameters + '-SessionName'
         $command.Parameters.Count | Should -Be ($CommonParameterCount + 1)
         $command.Parameters["SessionName"].ParameterType.FullName | Should -BeExactly "System.String"
-        $command.Parameters.ContainsKey("ComputerName") | Should -Be $false
+        $command.Parameters.ContainsKey("ComputerName") | Should -BeFalse
     }
 
     It "Use 'Experimental' attribute directly on parameters - '<Name>'" -TestCases @(
@@ -147,7 +147,7 @@ Describe "Experimental Feature Basic Tests - Feature-Disabled" -tags "CI" {
         $command.Parameters["FileName"].ParameterSets.Count | Should -Be 1
         $command.Parameters["FileName"].ParameterSets.ContainsKey("__AllParameterSets") | Should -BeTrue
 
-        $command.Parameters.ContainsKey("Destination") | Should -Be $false
+        $command.Parameters.ContainsKey("Destination") | Should -BeFalse
     }
 
     It "Dynamic parameters - <CommandType>-<Name>" -TestCases @(
@@ -170,7 +170,7 @@ Describe "Experimental Feature Basic Tests - Feature-Disabled" -tags "CI" {
         $command.Parameters["ConfigName"].Attributes[0] | Should -BeOfType [parameter]
         $command.Parameters["ConfigName"].Attributes[1] | Should -BeOfType [ValidateNotNullOrEmpty]
 
-        $command.Parameters.ContainsKey("ConfigFile") | Should -Be $false
+        $command.Parameters.ContainsKey("ConfigFile") | Should -BeFalse
     }
 }
 
@@ -318,7 +318,7 @@ Describe "Experimental Feature Basic Tests - Feature-Enabled" -Tag "CI" {
         ## Common parameters + '-ComputerName'
         $command.Parameters.Count | Should -Be ($CommonParameterCount + 1)
         $command.Parameters["ComputerName"].ParameterType.FullName | Should -BeExactly "System.String"
-        $command.Parameters.ContainsKey("SessionName") | Should -Be $false
+        $command.Parameters.ContainsKey("SessionName") | Should -BeFalse
     }
 
     It "Use 'Experimental' attribute directly on parameters - '<Name>'" -TestCases @(
@@ -344,7 +344,7 @@ Describe "Experimental Feature Basic Tests - Feature-Enabled" -Tag "CI" {
         $command.Parameters["FileName"].ParameterSets.Count | Should -Be 1
         $command.Parameters["FileName"].ParameterSets.ContainsKey("__AllParameterSets") | Should -BeTrue
 
-        $command.Parameters.ContainsKey("Configuration") | Should -Be $false
+        $command.Parameters.ContainsKey("Configuration") | Should -BeFalse
     }
 
     It "Dynamic parameters - <CommandType>-<Name>" -TestCases @(
@@ -368,7 +368,7 @@ Describe "Experimental Feature Basic Tests - Feature-Enabled" -Tag "CI" {
         $command.Parameters["ConfigFile"].Attributes[0] | Should -BeOfType [parameter]
         $command.Parameters["ConfigFile"].Attributes[1] | Should -BeOfType [ValidateNotNullOrEmpty]
 
-        $command.Parameters.ContainsKey("ConfigName") | Should -Be $false
+        $command.Parameters.ContainsKey("ConfigName") | Should -BeFalse
     }
 }
 
@@ -438,6 +438,6 @@ PrivateData = @{
         $featureNameError[0].Exception.Message.Contains("Feature2.") | Should -BeTrue
         $featureNameError[0].Exception.Message.Contains("Feature3") | Should -BeTrue
         $featureNameError[0].Exception.Message.Contains("Module.Feature4") | Should -BeTrue
-        $featureNameError[0].Exception.Message.Contains("InvalidFeatureName.Feature5") | Should -Be $false
+        $featureNameError[0].Exception.Message.Contains("InvalidFeatureName.Feature5") | Should -BeFalse
     }
 }

--- a/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
@@ -71,7 +71,7 @@ Describe 'Get-Help -Online opens the default web browser and navigates to the cm
             {
                 if (-not (Test-Path 'HKCR:\'))
                 {
-                    New-PSDrive -PSProvider registry -Root HKEY_CLASSES_ROOT -Name HKCR | Should NotBeNullOrEmpty
+                    New-PSDrive -PSProvider registry -Root HKEY_CLASSES_ROOT -Name HKCR | Should -Not -BeNullOrEmpty
                 }
                 $browserExe = ((Get-ItemProperty "HKCR:\$progId\shell\open\command")."(default)" -replace '"', '') -split " "
                 if ($browserExe.count -ge 1)

--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -273,7 +273,7 @@ Describe "About help files can be found in AllUsers scope" -Tags @('Feature', 'R
 
     It "Get-Help for about_Variable should return only one help object" -Skip:(!(Test-CanWriteToPsHome)) {
         $help = Get-Help about_Variables
-        $help.count | Should Be 1
+        $help.count | Should -Be 1
     }
 }
 

--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -92,8 +92,8 @@ Describe "Validate that get-help works for CurrentUserScope" -Tags @('CI') {
         It "Validate -Description and -Examples sections in help content. Run 'Get-help -name <cmdletName>" -TestCases $testCases {
             param($cmdletName)
             $help = get-help -name $cmdletName
-            $help.Description | Out-String | Should Match $cmdletName
-            $help.Examples | Out-String | Should Match $cmdletName
+            $help.Description | Out-String | Should -Match $cmdletName
+            $help.Examples | Out-String | Should -Match $cmdletName
         }
     }
 }
@@ -136,8 +136,8 @@ Describe "Validate that get-help works for AllUsers Scope" -Tags @('Feature', 'R
         It "Validate -Description and -Examples sections in help content. Run 'Get-help -name <cmdletName>" -TestCases $testCases -Skip:(!(Test-CanWriteToPsHome)) {
             param($cmdletName)
             $help = get-help -name $cmdletName
-            $help.Description | Out-String | Should Match $cmdletName
-            $help.Examples | Out-String | Should Match $cmdletName
+            $help.Description | Out-String | Should -Match $cmdletName
+            $help.Examples | Out-String | Should -Match $cmdletName
         }
     }
 }

--- a/test/powershell/engine/ParameterBinding/BooleanParameterDCR.Tests.ps1
+++ b/test/powershell/engine/ParameterBinding/BooleanParameterDCR.Tests.ps1
@@ -27,7 +27,7 @@ Describe "BooleanParameterDCR Tests" -tags "CI" {
             param ( $inputTest, $expected )
             [bool]$switchTestParam = $inputTest
             $result = ParserTestSwitchCmdlet -switchParam:$switchTestParam
-            $result | should -Be $expected
+            $result | Should -Be $expected
     }
 
     $tests = @(
@@ -39,16 +39,16 @@ Describe "BooleanParameterDCR Tests" -tags "CI" {
             param ( $inputTest, $expected )
             [bool]$switchTestParam = $inputTest
             $result = ParserTestSwitchCmdlet -switchParam:$switchTestParam
-            $result | should -Be $expected
+            $result | Should -Be $expected
     }
 
     It "Test that a nullable boolean is accepted for a boolean parameter." {
         [System.Nullable[System.Int32]] $nullBoolVar = $false
         $result = ParserTestBoolCmdlet2 $nullBoolVar
-        $result | should -BeFalse
+        $result | Should -BeFalse
         $result = ParserTestBoolCmdlet2 -First:$nullBoolVar
-        $result | should -BeFalse
+        $result | Should -BeFalse
         $result = ParserTestBoolCmdlet2 -First $nullBoolVar
-        $result | should -BeFalse
+        $result | Should -BeFalse
     }
 }

--- a/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
+++ b/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
@@ -131,7 +131,7 @@ Describe "Parameter Binding Tests" -Tags "CI" {
             Should -Throw -ErrorId "ParameterArgumentTransformationError,test-singleintparameter" -PassThru
         $e.CategoryInfo | Should -Match "ParameterBindingArgumentTransformationException"
         $e.Exception.Message | Should -Match "Input string was not in a correct format"
-        $e.Exception.Message | should -Match "Parameter1"
+        $e.Exception.Message | Should -Match "Parameter1"
     }
 
     It "Verify that WhatIf is available when SupportShouldProcess is true" {
@@ -241,8 +241,8 @@ Describe "Parameter Binding Tests" -Tags "CI" {
 
         $e = { test-nameconflicts6 -Parameter2 1 } | Should -Throw -ErrorId "ParameterNameConflictsWithAlias" -PassThru
         $e.CategoryInfo | Should -Match "MetadataException"
-        $e.Exception.Message | should -Match "Parameter1"
-        $e.Exception.Message | should -Match "Parameter2"
+        $e.Exception.Message | Should -Match "Parameter1"
+        $e.Exception.Message | Should -Match "Parameter2"
     }
 
     It "PipelineVariable shouldn't cause a NullRef exception when 'DynamicParam' block is present" {

--- a/test/powershell/engine/Remoting/ImplicitRemotingBatching.Tests.ps1
+++ b/test/powershell/engine/Remoting/ImplicitRemotingBatching.Tests.ps1
@@ -163,6 +163,6 @@ Describe "TestImplicitRemotingBatching hook should correctly batch simple remote
         $psInvoke.Commands.AddScript('param ($cmdLine, $runspace) [System.Management.Automation.Internal.InternalTestHooks]::TestImplicitRemotingBatching($cmdLine, $runspace)').AddArgument($CommandLine).AddArgument($localRunspace)
 
         $result = $psInvoke.Invoke()
-        $result | Should Be $ExpectedOutput
+        $result | Should -Be $ExpectedOutput
     }
 }

--- a/test/powershell/engine/Remoting/SessionOption.Tests.ps1
+++ b/test/powershell/engine/Remoting/SessionOption.Tests.ps1
@@ -10,20 +10,20 @@ try {
         }
         It "The SessionOption type can be created" {
             $result = [Microsoft.WSMan.Management.SessionOption]::new()
-            $result | should -BeOfType "Microsoft.WSMan.Management.SessionOption"
+            $result | Should -BeOfType "Microsoft.WSMan.Management.SessionOption"
         }
         It "The SessionOption type has the proper properties when created with the default constructor" {
             $result = [Microsoft.WSMan.Management.SessionOption]::new()
-            $result.SkipCACheck         | should -BeFalse
-            $result.SkipCNCheck         | should -BeFalse
-            $result.SkipRevocationCheck | should -BeFalse
-            $result.UseEncryption       | should -BeTrue
-            $result.UseUtf16            | should -BeFalse
-            $result.ProxyAuthentication | should -Be 0
-            $result.SPNPort             | should -Be 0
-            $result.OperationTimeout    | should -Be 0
-            $result.ProxyCredential     | should -BeNullOrEmpty
-            $result.ProxyAccessType     | should -Be ProxyIEConfig
+            $result.SkipCACheck         | Should -BeFalse
+            $result.SkipCNCheck         | Should -BeFalse
+            $result.SkipRevocationCheck | Should -BeFalse
+            $result.UseEncryption       | Should -BeTrue
+            $result.UseUtf16            | Should -BeFalse
+            $result.ProxyAuthentication | Should -Be 0
+            $result.SPNPort             | Should -Be 0
+            $result.OperationTimeout    | Should -Be 0
+            $result.ProxyCredential     | Should -BeNullOrEmpty
+            $result.ProxyAccessType     | Should -Be ProxyIEConfig
         }
         It "The values of SessionOption may be set" {
             $result = [Microsoft.WSMan.Management.SessionOption]::new()
@@ -38,16 +38,16 @@ try {
             $result.ProxyAccessType = "ProxyAutoDetect"
             $result.ProxyCredential = [System.Net.NetworkCredential]::new("user","pass")
 
-            $result.SkipCACheck         | should -BeTrue
-            $result.SkipCNCheck         | should -BeTrue
-            $result.SkipRevocationCheck | should -BeTrue
-            $result.UseEncryption       | should -BeFalse
-            $result.UseUtf16            | should -BeTrue
-            $result.ProxyAuthentication | should -Be "Negotiate"
-            $result.SPNPort             | should -Be 10
-            $result.OperationTimeout    | should -Be 10
-            $result.ProxyCredential     | should -Not -BeNullOrEmpty
-            $result.ProxyAccessType     | should -Be "ProxyAutoDetect"
+            $result.SkipCACheck         | Should -BeTrue
+            $result.SkipCNCheck         | Should -BeTrue
+            $result.SkipRevocationCheck | Should -BeTrue
+            $result.UseEncryption       | Should -BeFalse
+            $result.UseUtf16            | Should -BeTrue
+            $result.ProxyAuthentication | Should -Be "Negotiate"
+            $result.SPNPort             | Should -Be 10
+            $result.OperationTimeout    | Should -Be 10
+            $result.ProxyCredential     | Should -Not -BeNullOrEmpty
+            $result.ProxyAccessType     | Should -Be "ProxyAutoDetect"
         }
     }
 }

--- a/test/powershell/engine/Security/UntrustedDataMode.Tests.ps1
+++ b/test/powershell/engine/Security/UntrustedDataMode.Tests.ps1
@@ -120,19 +120,19 @@ Describe "UntrustedDataMode tests for variable assignments" -Tags 'CI' {
 
     It "verify the initial state of the test module 'UntrustedDataModeTest'" {
         $result = Execute-Script -Script "Test-WithScriptVar"
-        $result | Should Be 15
+        $result | Should -Be 15
 
         $result = Execute-Script -Script "Test-WithGlobalVar"
-        $result | Should Be "Hello"
+        $result | Should -Be "Hello"
 
         $result = Execute-Script -Script "Get-ScriptVar"
-        $result | Should Be 15
+        $result | Should -Be 15
 
         $result = Execute-Script -Script "Get-GlobalVar"
-        $result | Should Be "Hello"
+        $result | Should -Be "Hello"
 
         $result = Execute-Script -Script '$ExecutionContext.SessionState.LanguageMode'
-        $result | Should Be "ConstrainedLanguage"
+        $result | Should -Be "ConstrainedLanguage"
     }
 
     Context "Set global variable value in top-level session state" {
@@ -286,7 +286,7 @@ Describe "UntrustedDataMode tests for variable assignments" -Tags 'CI' {
             Execute-Script -Script $SetupScript > $null
             $result = Execute-Script -Script $testScript
 
-            $result -join ";" | Should Be $ExpectedOutput
+            $result -join ";" | Should -Be $ExpectedOutput
         }
 
         It "Enable 'data global:var' test if the syntax is supported" {
@@ -298,7 +298,7 @@ Describe "UntrustedDataMode tests for variable assignments" -Tags 'CI' {
                 ## Syntax 'data global:var { }' is not supported at the time writting the tests here
                 ## If this test fail, then maybe this syntax is supported now, and in that case, please
                 ## enable the test 'Data Section - "data global:var"' in $testCases above
-                $_.FullyQualifiedErrorId | Should Be "ParseException"
+                $_.FullyQualifiedErrorId | Should -Be "ParseException"
             }
         }
     }
@@ -318,7 +318,7 @@ Describe "UntrustedDataMode tests for variable assignments" -Tags 'CI' {
             Execute-Script -Script "Import-LocalizedData -BindingVariable globalVar -BaseDirectory $TestDrive -FileName local.psd1"
             $result = Execute-Script -Script $testScript
 
-            $result -join ";" | Should Be "Localized-Data;ParameterArgumentValidationError,Test-Untrusted"
+            $result -join ";" | Should -Be "Localized-Data;ParameterArgumentValidationError,Test-Untrusted"
         }
     }
 
@@ -354,7 +354,7 @@ Describe "UntrustedDataMode tests for variable assignments" -Tags 'CI' {
                 Execute-Script -Script "Import-Module $VarModule"
                 $result = Execute-Script -Script $testScript
 
-                $result -join ";" | Should Be "global-from-module;ParameterArgumentValidationError,Test-Untrusted;Trusted-Script;Trusted-Script"
+                $result -join ";" | Should -Be "global-from-module;ParameterArgumentValidationError,Test-Untrusted;Trusted-Script;Trusted-Script"
             } finally {
                 Execute-Script -Script "Remove-Module Var -Force"
             }
@@ -370,7 +370,7 @@ Describe "UntrustedDataMode tests for variable assignments" -Tags 'CI' {
             Execute-Script -Script '$globalVar = @{ Argument = "global-splatting" }'
             $result = Execute-Script -Script $testScript
 
-            $result -join ";" | Should Be "System.Collections.Hashtable;ParameterArgumentValidationError,Test-Untrusted"
+            $result -join ";" | Should -Be "System.Collections.Hashtable;ParameterArgumentValidationError,Test-Untrusted"
         }
     }
 
@@ -387,7 +387,7 @@ Describe "UntrustedDataMode tests for variable assignments" -Tags 'CI' {
                 $_.FullyQualifiedErrorId
             }
 '@
-            $result | Should Be "CannotDefineNewType,Microsoft.PowerShell.Commands.AddTypeCommand"
+            $result | Should -Be "CannotDefineNewType,Microsoft.PowerShell.Commands.AddTypeCommand"
         }
 
         It "test 'ValidateTrustedDataAttribute' NOT take effect in non-FullLanguage [Invoke-Expression]" {
@@ -396,7 +396,7 @@ Describe "UntrustedDataMode tests for variable assignments" -Tags 'CI' {
             $globalVar = "Get-Process -id $PID"
             Invoke-Expression -Command $globalVar | ForEach-Object Id
 '@
-            $result | Should Be $PID
+            $result | Should -Be $PID
         }
 
         It "test 'ValidateTrustedDataAttribute' NOT take effect in non-FullLanguage [New-Object]" {
@@ -424,7 +424,7 @@ Describe "UntrustedDataMode tests for variable assignments" -Tags 'CI' {
             Import-Module -Name $globalVar -ErrorAction SilentlyContinue -ErrorVariable ev; $ev
 '@
             $result | Should -Not BeNullOrEmpty
-            $result.FullyQualifiedErrorId | Should Be "Modules_ModuleNotFound,Microsoft.PowerShell.Commands.ImportModuleCommand"
+            $result.FullyQualifiedErrorId | Should -Be "Modules_ModuleNotFound,Microsoft.PowerShell.Commands.ImportModuleCommand"
         }
 
         It "test 'ValidateTrustedDataAttribute' NOT take effect in non-FullLanguage [Start-Job]" {
@@ -438,7 +438,7 @@ Describe "UntrustedDataMode tests for variable assignments" -Tags 'CI' {
                 $_.FullyQualifiedErrorId
             }
 '@
-            $result | Should Be "CannotStartJobInconsistentLanguageMode,Microsoft.PowerShell.Commands.StartJobCommand"
+            $result | Should -Be "CannotStartJobInconsistentLanguageMode,Microsoft.PowerShell.Commands.StartJobCommand"
         }
     }
 
@@ -455,7 +455,7 @@ Describe "UntrustedDataMode tests for variable assignments" -Tags 'CI' {
                 $_.FullyQualifiedErrorId
             }
 '@
-            $result | Should Be "ParameterArgumentValidationError,Test-Untrusted"
+            $result | Should -Be "ParameterArgumentValidationError,Test-Untrusted"
         }
 
         It "test 'ValidateTrustedDataAttribute' take effect when calling from 'Constrained' to 'Full' [Simple function]" {
@@ -469,7 +469,7 @@ Describe "UntrustedDataMode tests for variable assignments" -Tags 'CI' {
                 $_.FullyQualifiedErrorId
             }
 '@
-            $result | Should Be "ParameterArgumentValidationError,Test-SimpleUntrusted"
+            $result | Should -Be "ParameterArgumentValidationError,Test-SimpleUntrusted"
         }
 
         It "test 'ValidateTrustedDataAttribute' with param type conversion [string -> string[]]" {
@@ -483,7 +483,7 @@ Describe "UntrustedDataMode tests for variable assignments" -Tags 'CI' {
                 $_.FullyQualifiedErrorId
             }
 '@
-            $result | Should Be "ParameterArgumentValidationError,Test-OtherParameterType"
+            $result | Should -Be "ParameterArgumentValidationError,Test-OtherParameterType"
         }
 
         It "test 'ValidateTrustedDataAttribute' with value type param [DateTime]" {
@@ -497,7 +497,7 @@ Describe "UntrustedDataMode tests for variable assignments" -Tags 'CI' {
                 $_.FullyQualifiedErrorId
             }
 '@
-            $result | Should Be "ParameterArgumentValidationError,Test-OtherParameterType"
+            $result | Should -Be "ParameterArgumentValidationError,Test-OtherParameterType"
         }
 
         It "test 'ValidateTrustedDataAttribute' with param type conversion [string -> FileInfo]" {
@@ -511,7 +511,7 @@ Describe "UntrustedDataMode tests for variable assignments" -Tags 'CI' {
                 $_.FullyQualifiedErrorId
             }
 '@
-            $result | Should Be "ParameterArgumentValidationError,Test-OtherParameterType"
+            $result | Should -Be "ParameterArgumentValidationError,Test-OtherParameterType"
         }
 
         It "test type property conversion to [ProcessStartInfo] should fail during Lang-Mode transition" {
@@ -524,7 +524,7 @@ Describe "UntrustedDataMode tests for variable assignments" -Tags 'CI' {
                 $_.FullyQualifiedErrorId
             }
 '@
-            $result | Should Be "ParameterArgumentTransformationError,Test-OtherParameterType"
+            $result | Should -Be "ParameterArgumentTransformationError,Test-OtherParameterType"
         }
     }
 
@@ -554,7 +554,7 @@ Describe "UntrustedDataMode tests for variable assignments" -Tags 'CI' {
             ## Run this in the global scope, so value of $globalVar will be marked as untrusted
             $testScript = $ScriptTemplate -f $Argument
             $result = Execute-Script -Script $testScript
-            $result | Should Be $ExpectedErrorId
+            $result | Should -Be $ExpectedErrorId
         }
     }
 }

--- a/test/powershell/engine/Security/UntrustedDataMode.Tests.ps1
+++ b/test/powershell/engine/Security/UntrustedDataMode.Tests.ps1
@@ -405,7 +405,7 @@ Describe "UntrustedDataMode tests for variable assignments" -Tags 'CI' {
             $globalVar = "uri"
             New-Object -TypeName $globalVar -ArgumentList 'https://www.bing.com'
 '@
-            $result | Should -Not BeNullOrEmpty
+            $result | Should -Not -BeNullOrEmpty
         }
 
         It "test 'ValidateTrustedDataAttribute' NOT take effect in non-FullLanguage [Foreach-Object]" {
@@ -414,7 +414,7 @@ Describe "UntrustedDataMode tests for variable assignments" -Tags 'CI' {
             $globalVar = "Year"
             Get-Date | Foreach-Object -MemberName $globalVar
 '@
-            $result | Should -Not BeNullOrEmpty
+            $result | Should -Not -BeNullOrEmpty
         }
 
         It "test 'ValidateTrustedDataAttribute' NOT take effect in non-FullLanguage [Import-Module]" {
@@ -423,7 +423,7 @@ Describe "UntrustedDataMode tests for variable assignments" -Tags 'CI' {
             $globalVar = "NonExistModule"
             Import-Module -Name $globalVar -ErrorAction SilentlyContinue -ErrorVariable ev; $ev
 '@
-            $result | Should -Not BeNullOrEmpty
+            $result | Should -Not -BeNullOrEmpty
             $result.FullyQualifiedErrorId | Should -Be "Modules_ModuleNotFound,Microsoft.PowerShell.Commands.ImportModuleCommand"
         }
 

--- a/test/powershell/engine/Security/UntrustedDataMode.Tests.ps1
+++ b/test/powershell/engine/Security/UntrustedDataMode.Tests.ps1
@@ -405,7 +405,7 @@ Describe "UntrustedDataMode tests for variable assignments" -Tags 'CI' {
             $globalVar = "uri"
             New-Object -TypeName $globalVar -ArgumentList 'https://www.bing.com'
 '@
-            $result | Should Not BeNullOrEmpty
+            $result | Should -Not BeNullOrEmpty
         }
 
         It "test 'ValidateTrustedDataAttribute' NOT take effect in non-FullLanguage [Foreach-Object]" {
@@ -414,7 +414,7 @@ Describe "UntrustedDataMode tests for variable assignments" -Tags 'CI' {
             $globalVar = "Year"
             Get-Date | Foreach-Object -MemberName $globalVar
 '@
-            $result | Should Not BeNullOrEmpty
+            $result | Should -Not BeNullOrEmpty
         }
 
         It "test 'ValidateTrustedDataAttribute' NOT take effect in non-FullLanguage [Import-Module]" {
@@ -423,7 +423,7 @@ Describe "UntrustedDataMode tests for variable assignments" -Tags 'CI' {
             $globalVar = "NonExistModule"
             Import-Module -Name $globalVar -ErrorAction SilentlyContinue -ErrorVariable ev; $ev
 '@
-            $result | Should Not BeNullOrEmpty
+            $result | Should -Not BeNullOrEmpty
             $result.FullyQualifiedErrorId | Should Be "Modules_ModuleNotFound,Microsoft.PowerShell.Commands.ImportModuleCommand"
         }
 

--- a/test/tools/Modules/HelpersLanguage/HelpersLanguage.psm1
+++ b/test/tools/Modules/HelpersLanguage/HelpersLanguage.psm1
@@ -71,7 +71,7 @@ function ShouldBeParseError
 
     Context "Parse error expected: <<$src>>" {
         # Test case error if this fails
-        $expectedErrors.Count | Should Be $expectedOffsets.Count
+        $expectedErrors.Count | Should -Be $expectedOffsets.Count
 
         if ($SkipAndCheckRuntimeError)
         {
@@ -86,7 +86,7 @@ function ShouldBeParseError
             $errors = Get-ParseResults -Src $src
         }
 
-        It "Error count" { $errors.Count | Should Be $expectedErrors.Count }
+        It "Error count" { $errors.Count | Should -Be $expectedErrors.Count }
         for ($i = 0; $i -lt $errors.Count; ++$i)
         {
             $err = $errors[$i]
@@ -99,10 +99,10 @@ function ShouldBeParseError
             {
                 $errorId = $err.ErrorId
             }
-            It "Error Id (iteration:$i)" { $errorId | Should Be $expectedErrors[$i] }
+            It "Error Id (iteration:$i)" { $errorId | Should -Be $expectedErrors[$i] }
             $acutalPostion = $err.Extent.StartScriptPosition.Offset
             if ( $CheckColumnNumber ) { $acutalPostion = $err.Extent.StartScriptPosition.ColumnNumber }
-            It "Error position (iteration:$i)" -Pending:$SkipAndCheckRuntimeError { $acutalPostion | Should Be $expectedOffsets[$i] }
+            It "Error position (iteration:$i)" -Pending:$SkipAndCheckRuntimeError { $acutalPostion | Should -Be $expectedOffsets[$i] }
        }
     }
 }
@@ -127,11 +127,11 @@ function Test-ErrorStmt
         $asts = @(Flatten-Ast $ast.EndBlock.Statements[0])
 
         It 'Type is ErrorStatementAst' { $asts[0] | Should BeOfType System.Management.Automation.Language.ErrorStatementAst }
-        It "`$asts.count" { $asts.Count | Should Be ($a.Count + 1) }
-        It "`$asts[0].Extent.Text" { $asts[0].Extent.Text | Should Be $errorStmtExtent }
+        It "`$asts.count" { $asts.Count | Should -Be ($a.Count + 1) }
+        It "`$asts[0].Extent.Text" { $asts[0].Extent.Text | Should -Be $errorStmtExtent }
         for ($i = 0; $i -lt $a.Count; ++$i)
         {
-            It "`$asts[$($i + 1)].Extent.Text" {  $asts[$i + 1].Extent.Text | Should Be $a[$i] }
+            It "`$asts[$($i + 1)].Extent.Text" {  $asts[$i + 1].Extent.Text | Should -Be $a[$i] }
         }
     }
 }
@@ -143,10 +143,10 @@ function Test-Ast
     $ast = Get-ParseResults $src -Ast
     $asts = @(Flatten-Ast $ast)
     Context "Ast Validation: <<$src>>" {
-        It "`$asts.count" { $asts.Count | Should Be $a.Count }
+        It "`$asts.count" { $asts.Count | Should -Be $a.Count }
         for ($i = 0; $i -lt $a.Count; ++$i)
         {
-            It "`$asts[$i].Extent.Text" { $asts[$i].Extent.Text | Should Be $a[$i] }
+            It "`$asts[$i].Extent.Text" { $asts[$i].Extent.Text | Should -Be $a[$i] }
         }
     }
 }
@@ -160,14 +160,14 @@ function Test-Ast
         $ast = $ast.EndBlock.Statements[0]
         Context "Ast Validation: <<$src>>" {
             $ast | Should BeOfType System.Management.Automation.Language.ErrorStatementAst
-            $ast.Flags.ContainsKey($flagName) | Should be $true
+            $ast.Flags.ContainsKey($flagName) | Should -Be $true
 
             $asts = @(Flatten-Ast $ast.Flags[$flagName].Item2)
 
-            $asts.Count | Should Be $a.Count
+            $asts.Count | Should -Be $a.Count
             for ($i = 0; $i -lt $a.Count; ++$i)
             {
-                $asts[$i].Extent.Text | Should Be $a[$i]
+                $asts[$i].Extent.Text | Should -Be $a[$i]
             }
         }
     }

--- a/test/tools/Modules/HelpersLanguage/HelpersLanguage.psm1
+++ b/test/tools/Modules/HelpersLanguage/HelpersLanguage.psm1
@@ -160,7 +160,7 @@ function Test-Ast
         $ast = $ast.EndBlock.Statements[0]
         Context "Ast Validation: <<$src>>" {
             $ast | Should BeOfType System.Management.Automation.Language.ErrorStatementAst
-            $ast.Flags.ContainsKey($flagName) | Should -Be $true
+            $ast.Flags.ContainsKey($flagName) | Should -BeTrue
 
             $asts = @(Flatten-Ast $ast.Flags[$flagName].Item2)
 

--- a/tools/failingTests/fail.tests.ps1
+++ b/tools/failingTests/fail.tests.ps1
@@ -2,6 +2,6 @@
 # Licensed under the MIT License.
 Describe "Failing test used to test CI Scripts" -Tags 'CI' {
     It "Should fail" {
-        1 | Should be 2
+        1 | Should -Be 2
     }
 }

--- a/tools/failingTests/fail.tests.ps1
+++ b/tools/failingTests/fail.tests.ps1
@@ -2,6 +2,6 @@
 # Licensed under the MIT License.
 Describe "Failing test used to test CI Scripts" -Tags 'CI' {
     It "Should fail" {
-        1 | should be 2
+        1 | Should be 2
     }
 }


### PR DESCRIPTION
# PR Summary

* Update Pester tests to dashed v4 syntax
* Capitalise 'Should' and parameters

## PR Context

Pester documentation for 4.x recommends using Should -Be instead of Should Be syntax.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
- **User-facing changes**
    - [x] Not Applicable
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.