### PR TITLE
Add custom 'Selected.*' type to PSCustomObject in Select-Object only once

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -607,7 +607,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 if (obj != AutomationNull.Value)
                 {
-                    SetPSCustomObject(obj);
+                    SetPSCustomObject(obj, addedNoteProperties.Count > 0);
                     WriteObject(obj);
                 }
 
@@ -648,16 +648,22 @@ namespace Microsoft.PowerShell.Commands
 
                 if (isObjUnique)
                 {
-                    SetPSCustomObject(obj);
+                    SetPSCustomObject(obj, addedNoteProperties.Count > 0);
                     _uniques.Add(new UniquePSObjectHelper(obj, addedNoteProperties.Count));
                 }
             }
         }
 
-        private void SetPSCustomObject(PSObject psObj)
+        private void SetPSCustomObject(PSObject psObj, bool newPSObject)
         {
             if (psObj.ImmediateBaseObject is PSCustomObject)
-                psObj.TypeNames.Insert(0, "Selected." + InputObject.BaseObject.GetType().ToString());
+            {
+                var typeName = "Selected." + InputObject.BaseObject.GetType().ToString();
+                if (newPSObject || !psObj.TypeNames.Contains(typeName))
+                {
+                    psObj.TypeNames.Insert(0, typeName);
+                }
+            }
         }
 
         private void ProcessObjectAndHandleErrors(PSObject pso)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -607,7 +607,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 if (obj != AutomationNull.Value)
                 {
-                    SetPSCustomObject(obj, addedNoteProperties.Count > 0);
+                    SetPSCustomObject(obj, newPSObject: addedNoteProperties.Count > 0);
                     WriteObject(obj);
                 }
 
@@ -648,7 +648,7 @@ namespace Microsoft.PowerShell.Commands
 
                 if (isObjUnique)
                 {
-                    SetPSCustomObject(obj, addedNoteProperties.Count > 0);
+                    SetPSCustomObject(obj, newPSObject: addedNoteProperties.Count > 0);
                     _uniques.Add(new UniquePSObjectHelper(obj, addedNoteProperties.Count));
                 }
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+
 . (Join-Path -Path $PSScriptRoot -ChildPath Test-Mocks.ps1)
 Add-TestDynamicType
 
@@ -348,5 +349,26 @@ Describe "Select-Object with Property = '*'" -Tags "CI" {
     It "Select-Object with ExpandProperty and Property don't skip processing ExcludeProperty" {
 		$p = Get-Process -Id $pid | Select-Object -Property Process* -ExcludeProperty ProcessorAffinity -ExpandProperty Modules
 		$p[0].psobject.Properties.Item("ProcessorAffinity") | Should -BeNullOrEmpty
+    }
+
+    It "Select-Object add 'Selected.*' type only once" {
+        $obj = [PSCustomObject]@{ Name = 1 }
+
+        $obj.psobject.TypeNames.Count | Should -Be 2
+        $obj.psobject.TypeNames | Should -Not -BeLike "Selected*"
+
+        $obj = $obj | Select-Object
+
+        $obj.psobject.TypeNames.Count | Should -Be 3
+        $obj.psobject.TypeNames[0] | Should -BeLike "Selected*"
+        $obj.psobject.TypeNames[1] | Should -Not -BeLike "Selected*"
+        $obj.psobject.TypeNames[2] | Should -Not -BeLike "Selected*"
+
+        $obj = $obj | Select-Object
+
+        $obj.psobject.TypeNames.Count | Should -Be 3
+        $obj.psobject.TypeNames[0] | Should -BeLike "Selected*"
+        $obj.psobject.TypeNames[1] | Should -Not -BeLike "Selected*"
+        $obj.psobject.TypeNames[2] | Should -Not -BeLike "Selected*"
     }
 }


### PR DESCRIPTION

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #11441

Before the fix Select-Object without parameters added custom 'Selected.*' type to PSCustomObject even if this type was already present in TypeNames that was a memory leak in the edge case.
The cause of the problem was that Select-Object without parameters did not create a new object but forwarded the original.
The fix is to add  custom 'Selected.*' type only if object is original and it has not already custom 'Selected.*' type.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
