### PR TITLE
Support expanding ~ in $env:PATH when doing command discovery

### DIFF
--- a/src/System.Management.Automation/engine/CommandDiscovery.cs
+++ b/src/System.Management.Automation/engine/CommandDiscovery.cs
@@ -888,7 +888,7 @@ namespace System.Management.Automation
             It attempts to load modules from a fixed ModulesWithJobSourceAdapters list that currently has only `PSScheduledJob` module that is not PS-Core compatible.
             Because this function does not check the result of a (currently failing) `PSScheduledJob` module autoload, it provides no value.
             After discussion it was decided to comment out this code as it may be useful if ModulesWithJobSourceAdapters list changes in the future.
-                        
+
             if (!context.IsModuleWithJobSourceAdapterLoaded)
             {
                 PSModuleAutoLoadingPreference moduleAutoLoadingPreference = GetCommandDiscoveryPreference(context, SpecialVariables.PSModuleAutoLoadingPreferenceVarPath, "PSModuleAutoLoadingPreference");
@@ -1328,6 +1328,15 @@ namespace System.Management.Automation
                     foreach (string directory in tokenizedPath)
                     {
                         string tempDir = directory.TrimStart();
+                        if (tempDir.EqualsOrdinalIgnoreCase("~"))
+                        {
+                            tempDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                        }
+                        else if (tempDir.StartsWith("~" + Path.DirectorySeparatorChar))
+                        {
+                            tempDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) + Path.DirectorySeparatorChar + tempDir.Substring(2);
+                        }
+
                         _cachedPath.Add(tempDir);
                         result.Add(tempDir);
                     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Environment-Variables.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Environment-Variables.Tests.ps1
@@ -42,5 +42,44 @@ Describe "Environment-Variables" -Tags "CI" {
 	$ENV:TESTENVIRONMENTVARIABLE | Should -Not -BeNullOrEmpty
 	$ENV:TESTENVIRONMENTVARIABLE | Should -Be $expected
 
-    }
+	}
+
+	Context "~ in PATH" {
+        AfterEach {
+            $env:PATH = $oldPath
+        }
+
+		BeforeAll {
+            $oldPath = $env:PATH
+			$pwsh = (Get-Command pwsh | Select-Object -First 1).Source
+			if ($IsWindows) {
+				$pwsh2 = "pwsh2.exe"
+			}
+			else {
+				$pwsh2 = "pwsh2"
+			}
+
+            Copy-Item -Path $pwsh -Destination "~/$pwsh2"
+            $testPath = Join-Path -Path "~" -ChildPath (New-Guid)
+            New-Item -Path $testPath -ItemType Directory
+            Copy-Item -Path $pwsh -Destination "$testPath/$pwsh2"
+		}
+
+		AfterAll {
+            Remove-Item -Path "~/pwsh2" -Force
+            Remove-Item -Path $testPath -Recurse -Force
+		}
+
+		It "Should be able to resolve ~ in PATH" {
+            $env:PATH = "~" + [System.IO.Path]::PathSeparator + $env:PATH
+            $out = Get-Command pwsh2
+            $out.Source | Should -BeExactly (Join-Path -Path ([System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::UserProfile)) -ChildPath $pwsh2)
+		}
+
+		It "Should be able to resolve ~/folder in PATH" {
+            $env:PATH = $testPath + [System.IO.Path]::PathSeparator + $env:PATH
+            $out = Get-Command pwsh2
+			$out.Source | Should -BeExactly (Join-Path -Path (Resolve-Path $testPath) -ChildPath $pwsh2)
+		}
+	}
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Environment-Variables.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Environment-Variables.Tests.ps1
@@ -54,7 +54,7 @@ Describe "Environment-Variables" -Tags "CI" {
 
             Copy-Item -Path $pwsh -Destination "~/$pwsh2"
             $testPath = Join-Path -Path "~" -ChildPath (New-Guid)
-            New-Item -Path $testPath -ItemType Directory
+            New-Item -Path $testPath -ItemType Directory > $null
             Copy-Item -Path $pwsh -Destination "$testPath/$pwsh2"
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Environment-Variables.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Environment-Variables.Tests.ps1
@@ -3,83 +3,76 @@
 Describe "Environment-Variables" -Tags "CI" {
 
     It "Should have environment variables" {
-	Get-Item ENV: | Should -Not -BeNullOrEmpty
+        Get-Item ENV: | Should -Not -BeNullOrEmpty
     }
 
     It "Should have a nonempty PATH" {
-	$ENV:PATH | Should -Not -BeNullOrEmpty
+        $ENV:PATH | Should -Not -BeNullOrEmpty
     }
 
     It "Should contain /bin in the PATH" {
-	if ($IsWindows)
-	{
-	    $ENV:PATH | Should -Match "C:"
-	}
-	else
-	{
-	    $ENV:PATH | Should -Match "/bin"
-	}
+        if ($IsWindows) {
+            $ENV:PATH | Should -Match "C:"
+        } else {
+            $ENV:PATH | Should -Match "/bin"
+        }
     }
 
     It "Should have the correct HOME" {
-	if ($IsWindows)
-	{
-	    # \Windows\System32 is found as $env:HOMEPATH for temporary profiles
-	    $expected = "\Users", "\Windows"
-	    Split-Path $ENV:HOMEPATH -Parent | Should -BeIn $expected
-	}
-	else
-	{
-	    $expected = /bin/bash -c "cd ~ && pwd"
-	    $ENV:HOME | Should -Be $expected
-	}
+        if ($IsWindows) {
+            # \Windows\System32 is found as $env:HOMEPATH for temporary profiles
+            $expected = "\Users", "\Windows"
+            Split-Path $ENV:HOMEPATH -Parent | Should -BeIn $expected
+        } else {
+            $expected = /bin/bash -c "cd ~ && pwd"
+            $ENV:HOME | Should -Be $expected
+        }
     }
 
     It "Should be able to set the environment variables" {
-	$expected = "this is a test environment variable"
-	{ $ENV:TESTENVIRONMENTVARIABLE = $expected  } | Should -Not -Throw
+        $expected = "this is a test environment variable"
+        { $ENV:TESTENVIRONMENTVARIABLE = $expected } | Should -Not -Throw
 
-	$ENV:TESTENVIRONMENTVARIABLE | Should -Not -BeNullOrEmpty
-	$ENV:TESTENVIRONMENTVARIABLE | Should -Be $expected
+        $ENV:TESTENVIRONMENTVARIABLE | Should -Not -BeNullOrEmpty
+        $ENV:TESTENVIRONMENTVARIABLE | Should -Be $expected
 
-	}
+    }
 
-	Context "~ in PATH" {
+    Context "~ in PATH" {
         AfterEach {
             $env:PATH = $oldPath
         }
 
-		BeforeAll {
+        BeforeAll {
             $oldPath = $env:PATH
-			$pwsh = (Get-Command pwsh | Select-Object -First 1).Source
-			if ($IsWindows) {
-				$pwsh2 = "pwsh2.exe"
-			}
-			else {
-				$pwsh2 = "pwsh2"
-			}
+            $pwsh = (Get-Command pwsh | Select-Object -First 1).Source
+            if ($IsWindows) {
+                $pwsh2 = "pwsh2.exe"
+            } else {
+                $pwsh2 = "pwsh2"
+            }
 
             Copy-Item -Path $pwsh -Destination "~/$pwsh2"
             $testPath = Join-Path -Path "~" -ChildPath (New-Guid)
             New-Item -Path $testPath -ItemType Directory
             Copy-Item -Path $pwsh -Destination "$testPath/$pwsh2"
-		}
+        }
 
-		AfterAll {
+        AfterAll {
             Remove-Item -Path "~/pwsh2" -Force
             Remove-Item -Path $testPath -Recurse -Force
-		}
+        }
 
-		It "Should be able to resolve ~ in PATH" {
+        It "Should be able to resolve ~ in PATH" {
             $env:PATH = "~" + [System.IO.Path]::PathSeparator + $env:PATH
             $out = Get-Command pwsh2
             $out.Source | Should -BeExactly (Join-Path -Path ([System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::UserProfile)) -ChildPath $pwsh2)
-		}
+        }
 
-		It "Should be able to resolve ~/folder in PATH" {
+        It "Should be able to resolve ~/folder in PATH" {
             $env:PATH = $testPath + [System.IO.Path]::PathSeparator + $env:PATH
             $out = Get-Command pwsh2
-			$out.Source | Should -BeExactly (Join-Path -Path (Resolve-Path $testPath) -ChildPath $pwsh2)
-		}
-	}
+            $out.Source | Should -BeExactly (Join-Path -Path (Resolve-Path $testPath) -ChildPath $pwsh2)
+        }
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The `~` meaning user home path is a commonly used convention.  Bash (and compatible shells) expands this automatically (along with other derivatives not covered in this PR).  Dotnet global tools sets $env:PATH with a path to the tools starting with `~`.  In PowerShell, that is treated as a literal so the tools aren't found.  Fix is in command discovery, when processing $env:PATH, handle the case where a sub-path starts with `~/` or just contains `~` and expand it to be the user home path.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/11531

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
