### PR TITLE
Avoid variable names that conflict with automatic variables part 2

### DIFF
--- a/test/powershell/engine/Module/TestModuleManifest.Tests.ps1
+++ b/test/powershell/engine/Module/TestModuleManifest.Tests.ps1
@@ -88,7 +88,7 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
 
         New-Item -ItemType File -Path testdrive:/module/$rootModuleValue > $null
         New-ModuleManifest -Path $testModulePath -RootModule $rootModuleValue
-        $fullyQualifiedErrorId = "$errorId,Microsoft.PowerShell.Commands.TestModuleManifestCommand"
+        [string]$fullyQualifiedErrorId = "$errorId,Microsoft.PowerShell.Commands.TestModuleManifestCommand"
         { Test-ModuleManifest -Path $testModulePath -ErrorAction Stop } | Should -Throw -ErrorId $fullyQualifiedErrorId
     }
 
@@ -114,7 +114,7 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
         New-Item -ItemType File -Path testdrive:/module/$rootModuleValue > $null
 
         New-ModuleManifest -Path $testModulePath -RootModule $rootModuleValue
-        $fullyQualifiedErrorId = "$errorId,Microsoft.PowerShell.Commands.TestModuleManifestCommand"
+        [string]$fullyQualifiedErrorId = "$errorId,Microsoft.PowerShell.Commands.TestModuleManifestCommand"
         { Test-ModuleManifest -Path $testModulePath -ErrorAction Stop } | Should -Throw -ErrorId $fullyQualifiedErrorId
     }
 
@@ -125,7 +125,7 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
         param($rootModuleValue, $errorId)
 
         New-ModuleManifest -Path $testModulePath -RootModule $rootModuleValue
-        $fullyQualifiedErrorId = "$errorId,Microsoft.PowerShell.Commands.TestModuleManifestCommand"
+        [string]$fullyQualifiedErrorId = "$errorId,Microsoft.PowerShell.Commands.TestModuleManifestCommand"
         { Test-ModuleManifest -Path $testModulePath -ErrorAction Stop } | Should -Throw -ErrorId $fullyQualifiedErrorId
     }
 

--- a/test/powershell/engine/Module/TestModuleManifest.Tests.ps1
+++ b/test/powershell/engine/Module/TestModuleManifest.Tests.ps1
@@ -50,7 +50,7 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
 
         $args = @{$parameter = "doesnotexist.psm1"}
         New-ModuleManifest -Path $testModulePath @args
-        [string]$fullyQualifiedErrorId = "$errorId,Microsoft.PowerShell.Commands.TestModuleManifestCommand"
+        $fullyQualifiedErrorId = "$errorId,Microsoft.PowerShell.Commands.TestModuleManifestCommand"
 
         { Test-ModuleManifest -Path $testModulePath -ErrorAction Stop } | Should -Throw -ErrorId $fullyQualifiedErrorId
     }
@@ -88,7 +88,7 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
 
         New-Item -ItemType File -Path testdrive:/module/$rootModuleValue > $null
         New-ModuleManifest -Path $testModulePath -RootModule $rootModuleValue
-        [string]$fullyQualifiedErrorId = "$errorId,Microsoft.PowerShell.Commands.TestModuleManifestCommand"
+        $fullyQualifiedErrorId = "$errorId,Microsoft.PowerShell.Commands.TestModuleManifestCommand"
         { Test-ModuleManifest -Path $testModulePath -ErrorAction Stop } | Should -Throw -ErrorId $fullyQualifiedErrorId
     }
 
@@ -114,7 +114,7 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
         New-Item -ItemType File -Path testdrive:/module/$rootModuleValue > $null
 
         New-ModuleManifest -Path $testModulePath -RootModule $rootModuleValue
-        [string]$fullyQualifiedErrorId = "$errorId,Microsoft.PowerShell.Commands.TestModuleManifestCommand"
+        $fullyQualifiedErrorId = "$errorId,Microsoft.PowerShell.Commands.TestModuleManifestCommand"
         { Test-ModuleManifest -Path $testModulePath -ErrorAction Stop } | Should -Throw -ErrorId $fullyQualifiedErrorId
     }
 
@@ -125,7 +125,7 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
         param($rootModuleValue, $errorId)
 
         New-ModuleManifest -Path $testModulePath -RootModule $rootModuleValue
-        [string]$fullyQualifiedErrorId = "$errorId,Microsoft.PowerShell.Commands.TestModuleManifestCommand"
+        $fullyQualifiedErrorId = "$errorId,Microsoft.PowerShell.Commands.TestModuleManifestCommand"
         { Test-ModuleManifest -Path $testModulePath -ErrorAction Stop } | Should -Throw -ErrorId $fullyQualifiedErrorId
     }
 

--- a/test/powershell/engine/Module/TestModuleManifest.Tests.ps1
+++ b/test/powershell/engine/Module/TestModuleManifest.Tests.ps1
@@ -32,27 +32,27 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
     }
 
     It "module manifest containing missing files returns error: <parameter>" -TestCases (
-        @{parameter = "RequiredAssemblies"; error = "Modules_InvalidRequiredAssembliesInModuleManifest"},
-        @{parameter = "NestedModules"; error = "Modules_InvalidNestedModuleinModuleManifest"},
-        @{parameter = "RequiredModules"; error = "Modules_InvalidRequiredModulesinModuleManifest"},
-        @{parameter = "FileList"; error = "Modules_InvalidFilePathinModuleManifest"},
-        @{parameter = "ModuleList"; error = "Modules_InvalidModuleListinModuleManifest"},
-        @{parameter = "TypesToProcess"; error = "Modules_InvalidManifest"},
-        @{parameter = "FormatsToProcess"; error = "Modules_InvalidManifest"},
-        @{parameter = "RootModule"; error = "Modules_InvalidRootModuleInModuleManifest"},
-        @{parameter = "ScriptsToProcess"; error = "Modules_InvalidManifest"}
+        @{parameter = "RequiredAssemblies"; errorId = "Modules_InvalidRequiredAssembliesInModuleManifest"},
+        @{parameter = "NestedModules"; errorId = "Modules_InvalidNestedModuleinModuleManifest"},
+        @{parameter = "RequiredModules"; errorId = "Modules_InvalidRequiredModulesinModuleManifest"},
+        @{parameter = "FileList"; errorId = "Modules_InvalidFilePathinModuleManifest"},
+        @{parameter = "ModuleList"; errorId = "Modules_InvalidModuleListinModuleManifest"},
+        @{parameter = "TypesToProcess"; errorId = "Modules_InvalidManifest"},
+        @{parameter = "FormatsToProcess"; errorId = "Modules_InvalidManifest"},
+        @{parameter = "RootModule"; errorId = "Modules_InvalidRootModuleInModuleManifest"},
+        @{parameter = "ScriptsToProcess"; errorId = "Modules_InvalidManifest"}
      ) {
 
-        param ($parameter, $error)
+        param ($parameter, $errorId)
 
         New-Item -ItemType Directory -Path testdrive:/module/foo > $null
         New-Item -ItemType File -Path testdrive:/module/foo/bar.psm1 > $null
 
         $args = @{$parameter = "doesnotexist.psm1"}
         New-ModuleManifest -Path $testModulePath @args
-        [string]$errorId = "$error,Microsoft.PowerShell.Commands.TestModuleManifestCommand"
+        [string]$fullyQualifiedErrorId = "$errorId,Microsoft.PowerShell.Commands.TestModuleManifestCommand"
 
-        { Test-ModuleManifest -Path $testModulePath -ErrorAction Stop } | Should -Throw -ErrorId $errorId
+        { Test-ModuleManifest -Path $testModulePath -ErrorAction Stop } | Should -Throw -ErrorId $fullyQualifiedErrorId
     }
 
     It "module manifest containing valid unprocessed rootmodule file type succeeds: <rootModuleValue>" -TestCases (
@@ -81,14 +81,15 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
     }
 
     It "module manifest containing valid processed empty rootmodule file type fails: <rootModuleValue>" -TestCases (
-        @{rootModuleValue = "foo.cdxml"; error = "System.Xml.XmlException"}  # fails when cmdlet tries to read it as XML
+        @{rootModuleValue = "foo.cdxml"; errorId = "System.Xml.XmlException"}  # fails when cmdlet tries to read it as XML
     ) {
 
-        param($rootModuleValue, $error)
+        param($rootModuleValue, $errorId)
 
         New-Item -ItemType File -Path testdrive:/module/$rootModuleValue > $null
         New-ModuleManifest -Path $testModulePath -RootModule $rootModuleValue
-        { Test-ModuleManifest -Path $testModulePath -ErrorAction Stop } | Should -Throw -ErrorId "$error,Microsoft.PowerShell.Commands.TestModuleManifestCommand"
+        $fullyQualifiedErrorId = "$errorId,Microsoft.PowerShell.Commands.TestModuleManifestCommand"
+        { Test-ModuleManifest -Path $testModulePath -ErrorAction Stop } | Should -Throw -ErrorId $fullyQualifiedErrorId
     }
 
     It "module manifest containing empty rootmodule succeeds: <rootModuleValue>" -TestCases (
@@ -105,25 +106,27 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
     }
 
     It "module manifest containing invalid rootmodule returns error: <rootModuleValue>" -TestCases (
-        @{rootModuleValue = "foo.psd1"; error = "Modules_InvalidManifest"}
+        @{rootModuleValue = "foo.psd1"; errorId = "Modules_InvalidManifest"}
     ) {
 
-        param($rootModuleValue, $error)
+        param($rootModuleValue, $errorId)
 
         New-Item -ItemType File -Path testdrive:/module/$rootModuleValue > $null
 
         New-ModuleManifest -Path $testModulePath -RootModule $rootModuleValue
-        { Test-ModuleManifest -Path $testModulePath -ErrorAction Stop } | Should -Throw -ErrorId "$error,Microsoft.PowerShell.Commands.TestModuleManifestCommand"
+        $fullyQualifiedErrorId = "$errorId,Microsoft.PowerShell.Commands.TestModuleManifestCommand"
+        { Test-ModuleManifest -Path $testModulePath -ErrorAction Stop } | Should -Throw -ErrorId $fullyQualifiedErrorId
     }
 
     It "module manifest containing non-existing rootmodule returns error: <rootModuleValue>" -TestCases (
-        @{rootModuleValue = "doesnotexist.psm1"; error = "Modules_InvalidRootModuleInModuleManifest"}
+        @{rootModuleValue = "doesnotexist.psm1"; errorId = "Modules_InvalidRootModuleInModuleManifest"}
     ) {
 
-        param($rootModuleValue, $error)
+        param($rootModuleValue, $errorId)
 
         New-ModuleManifest -Path $testModulePath -RootModule $rootModuleValue
-        { Test-ModuleManifest -Path $testModulePath -ErrorAction Stop } | Should -Throw -ErrorId "$error,Microsoft.PowerShell.Commands.TestModuleManifestCommand"
+        $fullyQualifiedErrorId = "$errorId,Microsoft.PowerShell.Commands.TestModuleManifestCommand"
+        { Test-ModuleManifest -Path $testModulePath -ErrorAction Stop } | Should -Throw -ErrorId $fullyQualifiedErrorId
     }
 
     It "module manifest containing nested module gets returned: <variation>" -TestCases (
@@ -262,4 +265,3 @@ Describe "Test-ModuleManifest Performance bug followup" -tags "CI" {
         }
     }
 }
-


### PR DESCRIPTION
# PR Summary

* Follow-up to #11392
* Fix 4 CodeFactor issues of type AvoidAssignmentToAutomaticVariable

## PR Context

Variable names such as $error cause a PSScriptAnalyzer rule violation of type AvoidAssignmentToAutomaticVariable.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
- **User-facing changes**
    - [x] Not Applicable
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
