### PR TITLE
Check state and report reason if it's not "opened"

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Enter-PSHostProcess.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Enter-PSHostProcess.Tests.ps1
@@ -133,7 +133,7 @@ Describe "Enter-PSHostProcess tests" -Tag Feature {
                 $rs = [runspacefactory]::CreateRunspace($npInfo)
                 $rs.Open()
                 $rs.RunspaceStateInfo.State |
-                    Should -Be [System.Management.Automation.Runspaces.RunspaceState]::Opened -Because $rs.RunspaceStateInfo.Reason
+                    Should -Be ([System.Management.Automation.Runspaces.RunspaceState]::Opened) -Because $rs.RunspaceStateInfo.Reason
 
                 $ps = [powershell]::Create()
                 $ps.Runspace = $rs

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Enter-PSHostProcess.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Enter-PSHostProcess.Tests.ps1
@@ -132,7 +132,8 @@ Describe "Enter-PSHostProcess tests" -Tag Feature {
                 $npInfo = [System.Management.Automation.Runspaces.NamedPipeConnectionInfo]::new($pwshId)
                 $rs = [runspacefactory]::CreateRunspace($npInfo)
                 $rs.Open()
-                Wait-UntilTrue { $rs.RunspaceStateInfo.State -eq [System.Management.Automation.Runspaces.RunspaceState]::Opened } | Should -BeTrue
+                $rs.RunspaceStateInfo.State |
+                    Should -Be [System.Management.Automation.Runspaces.RunspaceState]::Opened -Because $rs.RunspaceStateInfo.Reason
 
                 $ps = [powershell]::Create()
                 $ps.Runspace = $rs

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Enter-PSHostProcess.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Enter-PSHostProcess.Tests.ps1
@@ -155,8 +155,8 @@ Describe "Enter-PSHostProcess tests" -Tag Feature {
 
                 $result | Should -Be $pwshId -Because $errorMsg
             } finally {
-                $rs.Dispose()
-                $ps.Dispose()
+                ${rs}?.Dispose()
+                ${ps}?.Dispose()
             }
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Enter-PSHostProcess.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Enter-PSHostProcess.Tests.ps1
@@ -132,6 +132,8 @@ Describe "Enter-PSHostProcess tests" -Tag Feature {
                 $npInfo = [System.Management.Automation.Runspaces.NamedPipeConnectionInfo]::new($pwshId)
                 $rs = [runspacefactory]::CreateRunspace($npInfo)
                 $rs.Open()
+                Wait-UntilTrue { $rs.RunspaceStateInfo.State -eq [System.Management.Automation.Runspaces.RunspaceState]::Opened } | Should -BeTrue
+
                 $ps = [powershell]::Create()
                 $ps.Runspace = $rs
                 $ps.AddScript('$pid')

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Enter-PSHostProcess.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Enter-PSHostProcess.Tests.ps1
@@ -167,8 +167,14 @@ Describe "Enter-PSHostProcess tests" -Tag Feature {
 
                 $result | Should -Be $pwshId -Because $errorMsg
             } finally {
-                ${rs}?.Dispose()
-                ${ps}?.Dispose()
+                # Clean up disposables
+                if ($rs) {
+                    $rs.Dispose()
+                }
+
+                if ($ps) {
+                    $ps.Dispose()
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Occasionally, the `"Can enter using NamedPipeConnectionInfo"` test fails. This will allow us to collect more information about the failure.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
