### PR TITLE
Fix `Invoke-Command` missing error on session termination.

### DIFF
--- a/src/System.Management.Automation/engine/remoting/client/Job.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job.cs
@@ -3382,11 +3382,11 @@ namespace System.Management.Automation
                                 fullyQualifiedErrorId, ErrorCategory.OpenError,
                                 null, null, null, null, null, errorDetails, null);
             }
-            // Pipeline stopped state is an error condition if the associated exception is not 'PipelineStoppedException'.
             else if ((pipeline.PipelineStateInfo.State == PipelineState.Failed) ||
                      ((pipeline.PipelineStateInfo.State == PipelineState.Stopped) &&
                       (pipeline.PipelineStateInfo.Reason != null && !(pipeline.PipelineStateInfo.Reason is PipelineStoppedException))))
             {
+                // Pipeline stopped state is also an error condition if the associated exception is not 'PipelineStoppedException'.
                 object targetObject = runspace.ConnectionInfo.ComputerName;
                 failureException = pipeline.PipelineStateInfo.Reason;
                 if (failureException != null)

--- a/src/System.Management.Automation/engine/remoting/client/Job.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job.cs
@@ -3397,6 +3397,15 @@ namespace System.Management.Automation
                     if (rException != null)
                     {
                         errorRecord = rException.ErrorRecord;
+
+                        // A RemoteException will hide a PipelineStoppedException, which should be ignored.
+                        if (errorRecord != null &&
+                            errorRecord.FullyQualifiedErrorId.Equals("PipelineStopped", StringComparison.OrdinalIgnoreCase))
+                        {
+                            // PipelineStoppedException should not be reported as error.
+                            failureException = null;
+                            return;
+                        }
                     }
                     else
                     {

--- a/src/System.Management.Automation/engine/remoting/client/Job.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job.cs
@@ -3382,7 +3382,10 @@ namespace System.Management.Automation
                                 fullyQualifiedErrorId, ErrorCategory.OpenError,
                                 null, null, null, null, null, errorDetails, null);
             }
-            else if (pipeline.PipelineStateInfo.State == PipelineState.Failed)
+            // Pipeline stopped state is an error condition if the associated exception is not 'PipelineStoppedException'.
+            else if ((pipeline.PipelineStateInfo.State == PipelineState.Failed) ||
+                     ((pipeline.PipelineStateInfo.State == PipelineState.Stopped) &&
+                      (pipeline.PipelineStateInfo.Reason != null && !(pipeline.PipelineStateInfo.Reason is PipelineStoppedException))))
             {
                 object targetObject = runspace.ConnectionInfo.ComputerName;
                 failureException = pipeline.PipelineStateInfo.Reason;

--- a/test/powershell/engine/Job/Jobs.Tests.ps1
+++ b/test/powershell/engine/Job/Jobs.Tests.ps1
@@ -311,6 +311,9 @@ Describe 'Basic Job Tests' -Tags 'Feature' {
                 @{ property = 'InstanceId'}
                 @{ property = 'State'}
             )
+        }
+
+        BeforeEach {
             # 20 seconds is chosen to be large, so that the job is in running state when Stop-Job is called.
             $jobToStop = Start-Job -ScriptBlock {
                 1..80 | ForEach-Object {
@@ -321,7 +324,11 @@ Describe 'Basic Job Tests' -Tags 'Feature' {
             # Wait until the job is actually running and executing the script
             do {
                 $data = Receive-Job -Job $jobToStop
-            } while ($data.Count -eq 0)
+            } while (($data.Count -eq 0) -and ($jobToStop.State -eq 'Running'))
+        }
+
+        AfterEach {
+            Remove-Job $jobToStop -Force -ErrorAction SilentlyContinue
         }
 
         It 'Can Stop-Job with <property>' -TestCases $stopJobTestCases {
@@ -329,10 +336,6 @@ Describe 'Basic Job Tests' -Tags 'Feature' {
             $splat = @{ $property = $jobToStop.$property }
             Stop-Job @splat
             ValidateJobInfo -job $jobToStop -state 'Stopped' -hasMoreData $false
-        }
-
-        AfterAll {
-            Remove-Job $jobToStop -Force -ErrorAction SilentlyContinue
         }
     }
 }

--- a/test/powershell/engine/Job/Jobs.Tests.ps1
+++ b/test/powershell/engine/Job/Jobs.Tests.ps1
@@ -311,8 +311,17 @@ Describe 'Basic Job Tests' -Tags 'Feature' {
                 @{ property = 'InstanceId'}
                 @{ property = 'State'}
             )
-            # '-Seconds 100' is chosen to be substantially large, so that the job is in running state when Stop-Job is called.
-            $jobToStop = Start-Job -ScriptBlock { Start-Sleep -Seconds 100 } -Name 'JobToStop'
+            # 20 seconds is chosen to be large, so that the job is in running state when Stop-Job is called.
+            $jobToStop = Start-Job -ScriptBlock {
+                1..80 | ForEach-Object {
+                    Write-Output $_
+                    Start-Sleep -Milliseconds 250
+                }
+            } -Name 'JobToStop'
+            # Wait until the job is actually running and executing the script
+            do {
+                $data = Receive-Job -Job $jobToStop
+            } while ($data.Count -eq 0)
         }
 
         It 'Can Stop-Job with <property>' -TestCases $stopJobTestCases {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This change fixes a problem in Invoke-Command against a remote session and that session is abruptly terminated, but no error is reported.

## PR Context

In certain conditions, an abrupt session termination results in an Invoke-Command pipeline state going to 'Stopped' with an exception.  Currently this is ignored in job processing because a user initiated stop is not an error.  But a stopped state due to an error that is not 'PipelineStoppedException' (such as a remote transport exception) should not be ignored, but instead be treated as an error so that Invoke-Command will report it.

The fix is to update job error processing to correctly handle this error state.

Repro steps
-------------
```powershell
$session = New-PSSession -cn vm1
Invoke-Command -Session $session -ScriptBlock { 1..1000 | % { sleep 1; "Output $_" } }

# Turn off virtual machine vm1

# Result
# No error is reported by Invoke-Command

# Expected
OpenError: [vm1] Processing data from remote server vm1 failed with the following error message: The request for the Windows Remote Shell with ShellId 8E31C82A-7B31-41F0-B882-E60EF7634D33 failed because the shell was not found on the server. Possible causes are: the specified ShellId is incorrect or the shell no longer exists on the server. Provide the correct ShellId or create a new shell and retry the operation. For more information, see the about_Remote_Troubleshooting Help topic.
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
