### PR TITLE
Format-Hex - Fix Grouping Behaviour with Boolean values

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-hex/Format-Hex.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-hex/Format-Hex.cs
@@ -403,6 +403,7 @@ namespace Microsoft.PowerShell.Commands
                     if (_lastInputType != null && baseType != _lastInputType)
                     {
                         _groupInput = false;
+                        FlushInputBuffer();
                     }
 
                     _lastInputType = baseType;

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Hex.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Hex.Tests.ps1
@@ -64,6 +64,12 @@ public enum TestSByteEnum : sbyte {
 
         $testCases = @(
             @{
+                Name           = "Can process bool type 'fhx -InputObject `$true'"
+                InputObject    = $true
+                Count          = 1
+                ExpectedResult = "00000000   01 00 00 00"
+            }
+            @{
                 Name           = "Can process byte type 'fhx -InputObject [byte]5'"
                 InputObject    = [byte]5
                 Count          = 1
@@ -160,6 +166,12 @@ public enum TestSByteEnum : sbyte {
 
         $testCases = @(
             @{
+                Name           = "Can process bool type '`$true | fhx'"
+                InputObject    = $true
+                Count          = 1
+                ExpectedResult = "0000000000000000   01"
+            }
+            @{
                 Name           = "Can process byte type '[byte]5 | fhx'"
                 InputObject    = [byte]5
                 Count          = 1
@@ -228,6 +240,13 @@ public enum TestSByteEnum : sbyte {
                 ExpectedSecondResult = "0000000000000000   01 02 03 04 05 06                                ������"
             }
             @{
+                Name                 = "Can process jagged array type '[bool[]](`$true, `$false), [int[]](1, 2, 3, 4) | fhx'"
+                InputObject          = [bool[]]($true, $false), [int[]](1, 2, 3, 4)
+                Count                = 2
+                ExpectedResult       = "0000000000000000   01 00 00 00 00 00 00 00                          �"
+                ExpectedSecondResult = "0000000000000000   01 00 00 00 02 00 00 00 03 00 00 00 04 00 00 00  �   �   �   �"
+            }
+            @{
                 Name           = "Can process PS-native enum array '[TestEnum[]]('TestOne', 'TestTwo', 'TestThree', 'TestFour') | fhx'"
                 InputObject    = [TestEnum[]]('TestOne', 'TestTwo', 'TestThree', 'TestFour')
                 Count          = 1
@@ -289,6 +308,19 @@ public enum TestSByteEnum : sbyte {
                     "System.String"
                     "System.Int32"
                     "System.UInt16[]"
+                ).ForEach{ [regex]::Escape($_) } -join '|'
+            }
+            @{
+                InputScript     = { $true, $false, $true, 123, 100, 76, $true, $false }
+                Count           = 3
+                ExpectedResults = @(
+                    "0000000000000000   01 00 00 00 00 00 00 00 01 00 00 00              �       �"
+                    "0000000000000000   7B 00 00 00 64 00 00 00 4C 00 00 00              {   d   L"
+                    "0000000000000000   01 00 00 00 00 00 00 00                          �"
+                )
+                ExpectedLabels  = @(
+                    "System.Boolean"
+                    "System.Int32"
                 ).ForEach{ [regex]::Escape($_) } -join '|'
             }
         )
@@ -356,8 +388,7 @@ public enum TestSByteEnum : sbyte {
 
             if ($PathCase) {
                 $result = Format-Hex -Path $Path
-            }
-            else {
+            } else {
                 # LiteralPath
                 $result = Format-Hex -LiteralPath $Path
             }
@@ -380,8 +411,7 @@ public enum TestSByteEnum : sbyte {
                 $Result.Bytes[-1] | Should -Be 0x0A
                 $Result.Bytes[-2] | Should -Be 0x0D
                 $Result.Bytes.Length | Should -Be 14
-            }
-            else {
+            } else {
                 $Result.Bytes[-1] | Should -Be 0x0A
                 $Result.Bytes.Length | Should -Be 13
             }
@@ -507,8 +537,7 @@ public enum TestSByteEnum : sbyte {
 
             if ($PathCase) {
                 $output = Format-Hex -Path $InvalidPath, $inputFile1 -ErrorVariable errorThrown -ErrorAction SilentlyContinue
-            }
-            else {
+            } else {
                 # LiteralPath
                 $output = Format-Hex -LiteralPath $InvalidPath, $inputFile1 -ErrorVariable errorThrown -ErrorAction SilentlyContinue
             }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

We were not flushing the input buffer immediately when a different type is encountered. This caused some odd behaviour when piping in a mix of bools and ints. Fix is to immediately flush the input buffer when the incoming object is a different type than anything we have buffered.

This PR also contains a commit which cuts down the visual representation of booleans to 1 byte. `Marshal.SizeOf()` actually returns `4` for boolean values, since .NET pads Boolean values apparently to make them easier to compare with on modern processors which tend to be optimized for 32 or 64 bit values. See [this SO question](https://stackoverflow.com/questions/294905/why-is-a-boolean-4-bytes-in-net) for reference.

I modified some of the logic to skip checking the size if the input value is Boolean, and simply represent it with an `0x1` or `0x0` byte to keep the representation as effective as possible.

## PR Context

Resolves #11585 

/cc @SteveL-MSFT @iSazonov 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
