### PR TITLE
Add new tests for Get-ChildItem (FileSystemProvider)

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -570,10 +570,25 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
             $ci[1].Name | Should -MatchExactly $filenamePattern
             $ci[2].Name | Should -MatchExactly $filenamePattern
         }
+        It "Get-ChildItem -Name gets content of linked-to directory" {
+            # The test depends on the files created in previous test:
+            #$filenamePattern = "AlphaFile[12]\.txt"
+            #New-Item -ItemType SymbolicLink -Path $alphaLink -Value $alphaDir
+            $ci = Get-ChildItem $alphaLink -Name
+            $ci.Count | Should -Be 3
+            $ci[1] | Should -MatchExactly $filenamePattern
+            $ci[2] | Should -MatchExactly $filenamePattern
+        }
         It "Get-ChildItem does not recurse into symbolic links not explicitly given on the command line" {
             New-Item -ItemType SymbolicLink -Path $betaLink -Value $betaDir
             $ci = Get-ChildItem $alphaLink -Recurse
             $ci.Count | Should -BeExactly 7
+        }
+        It "Get-ChildItem -Name does not recurse into symbolic links not explicitly given on the command line" -Pending {
+            # The test depends on the files created in previous test:
+            #New-Item -ItemType SymbolicLink -Path $betaLink -Value $betaDir
+            $ci = Get-ChildItem $alphaLink -Recurse -Name
+            $ci.Count | Should -BeExactly 7 # returns 10 - unexpectly recurce in link-alpha\link-Beta. See https://github.com/PowerShell/PowerShell/issues/11614
         }
         It "Get-ChildItem will recurse into symlinks given -FollowSymlink, avoiding link loops" {
             New-Item -ItemType Directory -Path $gammaDir
@@ -581,6 +596,16 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
             New-Item -ItemType SymbolicLink -Path $uptwoLink -Value $alphaDir
             New-Item -ItemType SymbolicLink -Path $omegaLink -Value $omegaDir
             $ci = Get-ChildItem -Path $alphaDir -FollowSymlink -Recurse -WarningVariable w -WarningAction SilentlyContinue
+            $ci.Count | Should -BeExactly 13
+            $w.Count | Should -BeExactly 3
+        }
+        It "Get-ChildItem -Name will recurse into symlinks given -FollowSymlink, avoiding link loops" -Pending {
+            # The test depends on the files created in previous test:
+            # New-Item -ItemType Directory -Path $gammaDir
+            # New-Item -ItemType SymbolicLink -Path $uponeLink -Value $betaDir
+            # New-Item -ItemType SymbolicLink -Path $uptwoLink -Value $alphaDir
+            # New-Item -ItemType SymbolicLink -Path $omegaLink -Value $omegaDir
+            $ci = Get-ChildItem -Path $alphaDir -FollowSymlink -Recurse -WarningVariable w -WarningAction SilentlyContinue -Name # unexpectly dead cycle. See https://github.com/PowerShell/PowerShell/issues/11614
             $ci.Count | Should -BeExactly 13
             $w.Count | Should -BeExactly 3
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystemProviderExtended.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystemProviderExtended.Tests.ps1
@@ -5,6 +5,8 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
     BeforeAll {
         $restoreLocation = Get-Location
 
+        $DirSep = [io.path]::DirectorySeparatorChar
+
         $rootDir = Join-Path "TestDrive:" "TestDir"
         New-Item -Path $rootDir -ItemType Directory > $null
 
@@ -202,9 +204,9 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
             $result.Count | Should -Be 4
             $result | Should -BeOfType [string]
             $result | Where-Object { $_ -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2\filehidden2.asd" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2\subDir21" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir3\filehidden3.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2$($DirSep)filehidden2.asd" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2$($DirSep)subDir21" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir3$($DirSep)filehidden3.txt" } | Should -Not -BeNullOrEmpty
         }
 
         It "Get-ChildItem -Path -Recurse -Name -Force" {
@@ -212,9 +214,9 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
             $result.Count | Should -Be 13
             $result | Should -BeOfType [string]
             $result | Where-Object { $_ -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2\filehidden2.asd" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2\subDir21" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir3\filehidden3.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2$($DirSep)filehidden2.asd" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2$($DirSep)subDir21" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir3$($DirSep)filehidden3.txt" } | Should -Not -BeNullOrEmpty
         }
 
         It "Get-ChildItem -Path -Recurse -Name -Directory" {
@@ -244,8 +246,8 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
             $result.Count | Should -Be 3
             $result | Should -BeOfType [string]
             $result | Where-Object { $_ -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2\filehidden2.asd" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir3\filehidden3.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2$($DirSep)filehidden2.asd" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir3$($DirSep)filehidden3.txt" } | Should -Not -BeNullOrEmpty
         }
     }
 
@@ -341,7 +343,7 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
             $result.Count | Should -Be 2
             $result | Should -BeOfType [string]
             $result | Where-Object { $_ -eq "file1.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2\file2.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2$($DirSep)file2.txt" } | Should -Not -BeNullOrEmpty
         }
 
         It 'Get-ChildItem -Path -Filter "file*" -Recurse -Name' {
@@ -350,17 +352,17 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
             $result | Should -BeOfType [string]
             $result | Where-Object { $_ -eq "file1.txt" } | Should -Not -BeNullOrEmpty
             $result | Where-Object { $_ -eq "filereadonly1.asd" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2\file2.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2\filereadonly2.doc" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir3\file3.asd" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir3\filereadonly3.doc" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2$($DirSep)file2.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2$($DirSep)filereadonly2.doc" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir3$($DirSep)file3.asd" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir3$($DirSep)filereadonly3.doc" } | Should -Not -BeNullOrEmpty
         }
 
         It 'Get-ChildItem -Path -Filter "file????only3.*" -Recurse -Name' {
             $result = Get-ChildItem -Path $rootDir -Filter "file????only3.*" -Recurse -Name
             $result.Count | Should -Be 1
             $result | Should -BeOfType [string]
-            $result | Should -BeExactly "subDir3\filereadonly3.doc"
+            $result | Should -BeExactly "subDir3$($DirSep)filereadonly3.doc"
         }
 
         It 'Get-ChildItem -Path -Filter "file*" -Hidden -Recurse -Name' {
@@ -368,8 +370,8 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
             $result.Count | Should -Be 3
             $result | Should -BeOfType [string]
             $result | Where-Object { $_ -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2\filehidden2.asd" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir3\filehidden3.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2$($DirSep)filehidden2.asd" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir3$($DirSep)filehidden3.txt" } | Should -Not -BeNullOrEmpty
         }
 
         It 'Get-ChildItem -Path -Filter "file*" -Force -Recurse -Name' {
@@ -400,7 +402,7 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
             $result.Count | Should -Be 2
             $result | Should -BeOfType [string]
             $result | Where-Object { $_ -eq "file1.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2\file2.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2$($DirSep)file2.txt" } | Should -Not -BeNullOrEmpty
         }
 
         It 'Get-ChildItem -Path -Include "*.t?t" -Recurse -Name' {
@@ -408,7 +410,7 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
             $result.Count | Should -Be 2
             $result | Should -BeOfType [string]
             $result | Where-Object { $_ -eq "file1.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2\file2.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2$($DirSep)file2.txt" } | Should -Not -BeNullOrEmpty
         }
     }
 
@@ -435,9 +437,9 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
             $result.Count | Should -Be 4
             $result | Should -BeOfType [string]
             $result | Where-Object { $_ -eq "file1.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2\file2.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir3\filehidden3.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2\subDir21\file21.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2$($DirSep)file2.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir3$($DirSep)filehidden3.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2$($DirSep)subDir21$($DirSep)file21.txt" } | Should -Not -BeNullOrEmpty
         }
 
         It 'Get-ChildItem -Path -Include "*.t?t" -Recurse -Name -Force' {
@@ -445,9 +447,9 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
             $result.Count | Should -Be 4
             $result | Should -BeOfType [string]
             $result | Where-Object { $_ -eq "file1.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2\file2.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir3\filehidden3.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2\subDir21\file21.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2$($DirSep)file2.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir3$($DirSep)filehidden3.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2$($DirSep)subDir21$($DirSep)file21.txt" } | Should -Not -BeNullOrEmpty
         }
     }
 
@@ -496,8 +498,8 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
             $result = Get-ChildItem -Path $rootDir -Exclude "*.txt" -Recurse -Hidden -Name
             $result.Count | Should -Be 3
             $result | Where-Object { $_ -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2\filehidden2.asd" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2\subDir21" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2$($DirSep)filehidden2.asd" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2$($DirSep)subDir21" } | Should -Not -BeNullOrEmpty
         }
 
         It 'Get-ChildItem -Path -Exclude "*.txt" -Include "file*" -Recurse' {
@@ -529,7 +531,7 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
             $result | Should -BeOfType [string]
             $result | Where-Object { $_ -eq "subDir2" } | Should -Not -BeNullOrEmpty
             $result | Where-Object { $_ -eq "subDir3" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2\subDir21" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2$($DirSep)subDir21" } | Should -Not -BeNullOrEmpty
         }
 
         It 'Get-ChildItem -Path -Exclude "*.txt" -Recurse' {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystemProviderExtended.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystemProviderExtended.Tests.ps1
@@ -1,0 +1,580 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI" {
+    BeforeAll {
+        $restoreLocation = Get-Location
+
+        $rootDir = Join-Path "TestDrive:" "TestDir"
+        New-Item -Path $rootDir -ItemType Directory > $null
+
+        Set-Location $rootDir
+
+        New-Item -Path "file1.txt" -ItemType File > $null
+        (New-Item -Path "filehidden1.doc" -ItemType File).Attributes = "Hidden"
+        (New-Item -Path "filereadonly1.asd" -ItemType File).Attributes = "ReadOnly"
+
+        New-Item -Path "subDir2" -ItemType Directory > $null
+        Set-Location "subDir2"
+        New-Item -Path "file2.txt" -ItemType File > $null
+        (New-Item -Path "filehidden2.asd" -ItemType File).Attributes = "Hidden"
+        (New-Item -Path "filereadonly2.doc" -ItemType File).Attributes = "ReadOnly"
+        (New-Item -Path "subDir21" -ItemType Directory).Attributes = "Hidden"
+        Set-Location "subDir21"
+        New-Item -Path "file21.txt" -ItemType File > $null
+
+        Set-Location $rootDir
+        New-Item -Path "subDir3" -ItemType Directory > $null
+        Set-Location "subDir3"
+        New-Item -Path "file3.asd" -ItemType File > $null
+        (New-Item -Path "filehidden3.txt" -ItemType File).Attributes = "Hidden"
+        (New-Item -Path "filereadonly3.doc" -ItemType File).Attributes = "ReadOnly"
+
+        Set-Location $rootDir
+    }
+
+    AfterAll {
+        #restore the previous location
+        Set-Location -Path $restoreLocation
+    }
+
+    Context 'Validate Get-ChildItem -Path' {
+        It "Get-ChildItem -Path" {
+            $result = Get-ChildItem -Path $rootDir
+            $result.Count | Should -Be 4
+            $result[0] | Should -BeOfType System.IO.DirectoryInfo
+        }
+
+        It "Get-ChildItem -Path -Hidden" {
+            $result = Get-ChildItem -Path $rootDir -Hidden
+            $result.Count | Should -Be 1
+            $result | Should -BeOfType System.IO.FileInfo
+            $result.Name | Should -BeExactly "filehidden1.doc"
+        }
+
+        It "Get-ChildItem -Path -Attribute Hidden" {
+            $result = Get-ChildItem -Path $rootDir -Attributes Hidden
+            $result.Count | Should -Be 1
+            $result | Should -BeOfType System.IO.FileInfo
+            $result.Name | Should -BeExactly "filehidden1.doc"
+        }
+
+        It "Get-ChildItem -Path -Force" {
+            $result = Get-ChildItem -Path $rootDir -Force
+            $result.Count | Should -Be 5
+            $result | Where-Object Name -eq "filehidden1.doc" | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Validate Get-ChildItem -Path -Directory/-File' {
+        It "Get-ChildItem -Path -Directory" {
+            $result = Get-ChildItem -Path $rootDir -Directory
+            $result.Count | Should -Be 2
+        }
+
+        It "Get-ChildItem -Path -File" {
+            $result = Get-ChildItem -Path $rootDir -File
+            $result.Count | Should -Be 2
+        }
+
+        It "Get-ChildItem -Path -File -Hidden" {
+            $result = Get-ChildItem -Path $rootDir -File -Hidden
+            $result.Count | Should -Be 1
+            $result | Should -BeOfType System.IO.FileInfo
+            $result.Name | Should -BeExactly "filehidden1.doc"
+        }
+    }
+
+    Context 'Validate Get-ChildItem -Path -Name' {
+        It "Get-ChildItem -Path -Name" {
+            $result = Get-ChildItem -Path $rootDir -Name
+            $result.Count | Should -Be 4
+            $result[0] | Should -BeOfType [string]
+        }
+
+        It "Get-ChildItem -Path -Name -Hidden" {
+            $result = Get-ChildItem -Path $rootDir -Name -Hidden
+            $result.Count | Should -Be 1
+            $result | Should -BeOfType [string]
+            $result | Should -BeExactly "filehidden1.doc"
+        }
+
+        It "Get-ChildItem -Path -Name -Attributes Hidden" {
+            $result = Get-ChildItem -Path $rootDir -Name -Attributes Hidden
+            $result.Count | Should -Be 1
+            $result | Should -BeOfType [string]
+            $result | Should -BeExactly "filehidden1.doc"
+        }
+
+        It "Get-ChildItem -Path -Name -Force" {
+            $result = Get-ChildItem -Path $rootDir -Name -Force
+            $result.Count | Should -Be 5
+            $result | Should -BeOfType [string]
+            $result | Where-Object { $_ -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
+        }
+
+        It "Get-ChildItem -Path -Directory -Name" {
+            $result = Get-ChildItem -Path $rootDir -Directory -Name
+            $result.Count | Should -Be 2
+            $result[0] | Should -BeOfType [string]
+        }
+
+        It "Get-ChildItem -Path -File -Name" {
+            $result = Get-ChildItem -Path $rootDir -File -Name
+            $result.Count | Should -Be 2
+            $result[0] | Should -BeOfType [string]
+        }
+
+        It "Get-ChildItem -Path -File -Name -Hidden" {
+            $result = Get-ChildItem -Path $rootDir -File -Name -Hidden
+            $result.Count | Should -Be 1
+            $result | Should -BeOfType [string]
+            $result | Should -BeExactly "filehidden1.doc"
+        }
+    }
+
+    Context 'Validate Get-ChildItem -Path -Recurse' {
+        It "Get-ChildItem -Path -Recurse" {
+            $result = Get-ChildItem -Path $rootDir -Recurse
+            $result.Count | Should -Be 8
+        }
+
+        It "Get-ChildItem -Path -Recurse -Hidden" {
+            $result = Get-ChildItem -Path $rootDir -Recurse -Hidden
+            $result.Count | Should -Be 4
+            $result | Where-Object { $_.Name -eq "filehidden1.doc" -and $_.psobject.TypeNames[0] -eq "System.IO.FileInfo"} | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "filehidden2.asd" -and $_.psobject.TypeNames[0] -eq "System.IO.FileInfo" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "subDir21" -and $_.psobject.TypeNames[0] -eq "System.IO.DirectoryInfo" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "filehidden3.txt" -and $_.psobject.TypeNames[0] -eq "System.IO.FileInfo" } | Should -Not -BeNullOrEmpty
+        }
+
+        It "Get-ChildItem -Path -Recurse -Attributes Hidden" {
+            $result = Get-ChildItem -Path $rootDir -Recurse -Attributes Hidden
+            $result.Count | Should -Be 4
+            $result | Where-Object { $_.Name -eq "filehidden1.doc" -and $_.psobject.TypeNames[0] -eq "System.IO.FileInfo"} | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "filehidden2.asd" -and $_.psobject.TypeNames[0] -eq "System.IO.FileInfo" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "subDir21" -and $_.psobject.TypeNames[0] -eq "System.IO.DirectoryInfo" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "filehidden3.txt" -and $_.psobject.TypeNames[0] -eq "System.IO.FileInfo" } | Should -Not -BeNullOrEmpty
+        }
+
+        It "Get-ChildItem -Path -Recurse -Force" {
+            $result = Get-ChildItem -Path $rootDir -Recurse -Force
+            $result.Count | Should -Be 13
+            $result | Where-Object { $_.Name -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "filehidden2.asd" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "subDir21" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "filehidden3.txt" } | Should -Not -BeNullOrEmpty
+        }
+
+        It "Get-ChildItem -Path -Recurse -Directory" {
+            $result = Get-ChildItem -Path $rootDir -Recurse -Directory
+            $result.Count | Should -Be 2
+            $result | Should -BeOfType System.IO.DirectoryInfo
+            $result | Where-Object { $_.Name -eq "subDir2" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "subDir3" } | Should -Not -BeNullOrEmpty
+        }
+
+        It "Get-ChildItem -Path -Recurse -File" {
+            $result = Get-ChildItem -Path $rootDir -Recurse -File
+            $result.Count | Should -Be 6
+            $result | Should -BeOfType System.IO.FileInfo
+        }
+
+        It "Get-ChildItem -Path -Recurse -File -Hidden" {
+            $result = Get-ChildItem -Path $rootDir -Recurse -File -Hidden
+            $result.Count | Should -Be 3
+            $result | Should -BeOfType System.IO.FileInfo
+            $result | Where-Object { $_.Name -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "filehidden2.asd" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "filehidden3.txt" } | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Validate Get-ChildItem -Path -Recurse -Name' {
+        It "Get-ChildItem -Path -Recurse -Name" {
+            $result = Get-ChildItem -Path $rootDir -Recurse -Name
+            $result.Count | Should -Be 8
+            $result[0] | Should -BeOfType [string]
+        }
+
+        It "Get-ChildItem -Path -Recurse -Name -Hidden" {
+            $result = Get-ChildItem -Path $rootDir -Recurse -Name -Hidden
+            $result.Count | Should -Be 4
+            $result | Should -BeOfType [string]
+            $result | Where-Object { $_ -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2\filehidden2.asd" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2\subDir21" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir3\filehidden3.txt" } | Should -Not -BeNullOrEmpty
+        }
+
+        It "Get-ChildItem -Path -Recurse -Name -Force" {
+            $result = Get-ChildItem -Path $rootDir -Recurse -Name -Force
+            $result.Count | Should -Be 13
+            $result | Should -BeOfType [string]
+            $result | Where-Object { $_ -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2\filehidden2.asd" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2\subDir21" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir3\filehidden3.txt" } | Should -Not -BeNullOrEmpty
+        }
+
+        It "Get-ChildItem -Path -Recurse -Name -Directory" {
+            $result = Get-ChildItem -Path $rootDir -Recurse -Name -Directory
+            $result.Count | Should -Be 2
+            $result | Should -BeOfType [string]
+            $result | Where-Object { $_ -eq "subDir2" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir3" } | Should -Not -BeNullOrEmpty
+        }
+
+        It "Get-ChildItem -Path -Recurse -Name -Attributes Directory" {
+            $result = Get-ChildItem -Path $rootDir -Recurse -Name -Attributes Directory
+            $result.Count | Should -Be 2
+            $result | Should -BeOfType [string]
+            $result | Where-Object { $_ -eq "subDir2" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir3" } | Should -Not -BeNullOrEmpty
+        }
+
+        It "Get-ChildItem -Path -Recurse -Name -File" {
+            $result = Get-ChildItem -Path $rootDir -Recurse -Name -File
+            $result.Count | Should -Be 6
+            $result | Should -BeOfType [string]
+        }
+
+        It "Get-ChildItem -Path -Recurse -Name -File -Hidden" {
+            $result = Get-ChildItem -Path $rootDir -Recurse -Name -File -Hidden
+            $result.Count | Should -Be 3
+            $result | Should -BeOfType [string]
+            $result | Where-Object { $_ -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2\filehidden2.asd" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir3\filehidden3.txt" } | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Validate Get-ChildItem -Path -Filter' {
+        It 'Get-ChildItem -Path -Filter "*.txt"' {
+            $result = Get-ChildItem -Path $rootDir -Filter "*.txt"
+            $result.Count | Should -Be 1
+            $result[0] | Should -BeOfType System.IO.FileInfo
+            $result.Name | Should -BeExactly "file1.txt"
+        }
+
+        It 'Get-ChildItem -Path -Filter "file*"' {
+            $result = Get-ChildItem -Path $rootDir -Filter "file*"
+            $result.Count | Should -Be 2
+            $result | Should -BeOfType System.IO.FileInfo
+            $result | Where-Object { $_.Name -eq "file1.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "filereadonly1.asd" } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Get-ChildItem -Path -Filter "file?.txt"' {
+            $result = Get-ChildItem -Path $rootDir -Filter "file?.txt"
+            $result.Count | Should -Be 1
+            $result | Should -BeOfType System.IO.FileInfo
+            $result.Name | Should -BeExactly "file1.txt"
+        }
+
+        It 'Get-ChildItem -Path -Filter "file*" -Hidden' {
+            $result = Get-ChildItem -Path $rootDir -Filter "file*" -Hidden
+            $result.Count | Should -Be 1
+            $result | Should -BeOfType System.IO.FileInfo
+            $result.Name | Should -BeExactly "filehidden1.doc"
+        }
+
+        It 'Get-ChildItem -Path -Filter "file*" -Force' {
+            $result = Get-ChildItem -Path $rootDir -Filter "file*" -Force
+            $result.Count | Should -Be 3
+            $result | Should -BeOfType System.IO.FileInfo
+            $result | Where-Object { $_.Name -eq "file1.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "filereadonly1.asd" } | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Validate Get-ChildItem -Path -Filter -Recurse' {
+        It 'Get-ChildItem -Path -Filter "*.txt" -Recurse' {
+            $result = Get-ChildItem -Path $rootDir -Filter "*.txt" -Recurse
+            $result.Count | Should -Be 2
+            $result | Should -BeOfType System.IO.FileInfo
+            $result | Where-Object { $_.Name -eq "file1.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "file2.txt" } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Get-ChildItem -Path -Filter "file*" -Recurse' {
+            $result = Get-ChildItem -Path $rootDir -Filter "file*" -Recurse
+            $result.Count | Should -Be 6
+            $result | Should -BeOfType System.IO.FileInfo
+            $result | Where-Object { $_.Name -eq "file1.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "filereadonly1.asd" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "file2.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "filereadonly2.doc" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "file3.asd" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "filereadonly3.doc" } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Get-ChildItem -Path -Filter "file?.*" -Recurse' {
+            $result = Get-ChildItem -Path $rootDir -Filter "file?.*" -Recurse
+            $result.Count | Should -Be 3
+            $result | Should -BeOfType System.IO.FileInfo
+            $result | Where-Object { $_.Name -eq "file1.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "file2.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "file3.asd" } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Get-ChildItem -Path $rootDir -Filter "file*" -Hidden -Recurse' {
+            $result = Get-ChildItem -Path $rootDir -Filter "file*" -Hidden -Recurse
+            $result.Count | Should -Be 3
+            $result | Should -BeOfType System.IO.FileInfo
+            $result | Where-Object { $_.Name -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "filehidden2.asd" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "filehidden3.txt" } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Get-ChildItem -Path $rootDir -Filter "file*" -Force -Recurse' {
+            $result = Get-ChildItem -Path $rootDir -Filter "file*" -Force -Recurse
+            $result.Count | Should -Be 10
+            $result | Should -BeOfType System.IO.FileInfo
+        }
+    }
+
+    Context 'Validate Get-ChildItem -Path -Filter -Recurse -Name' {
+        It 'Get-ChildItem -Path -Filter "*.txt" -Recurse -Name' {
+            $result = Get-ChildItem -Path $rootDir -Filter "*.txt" -Recurse -Name
+            $result.Count | Should -Be 2
+            $result | Should -BeOfType [string]
+            $result | Where-Object { $_ -eq "file1.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2\file2.txt" } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Get-ChildItem -Path -Filter "file*" -Recurse -Name' {
+            $result = Get-ChildItem -Path $rootDir -Filter "file*" -Recurse -Name
+            $result.Count | Should -Be 6
+            $result | Should -BeOfType [string]
+            $result | Where-Object { $_ -eq "file1.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "filereadonly1.asd" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2\file2.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2\filereadonly2.doc" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir3\file3.asd" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir3\filereadonly3.doc" } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Get-ChildItem -Path -Filter "file????only3.*" -Recurse -Name' {
+            $result = Get-ChildItem -Path $rootDir -Filter "file????only3.*" -Recurse -Name
+            $result.Count | Should -Be 1
+            $result | Should -BeOfType [string]
+            $result | Should -BeExactly "subDir3\filereadonly3.doc"
+        }
+
+        It 'Get-ChildItem -Path -Filter "file*" -Hidden -Recurse -Name' {
+            $result = Get-ChildItem -Path $rootDir -Filter "file*" -Hidden -Recurse -Name
+            $result.Count | Should -Be 3
+            $result | Should -BeOfType [string]
+            $result | Where-Object { $_ -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2\filehidden2.asd" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir3\filehidden3.txt" } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Get-ChildItem -Path -Filter "file*" -Force -Recurse -Name' {
+            $result = Get-ChildItem -Path $rootDir -Filter "file*" -Force -Recurse -Name
+            $result.Count | Should -Be 10
+            $result | Should -BeOfType [string]
+        }
+    }
+
+    Context 'Validate Get-ChildItem -Path -Include' {
+        It 'Get-ChildItem -Path $-Include "*.txt"' -Pending:$true {    # Pending due to a bug
+            $result = Get-ChildItem -Path $rootDir -Include "*.txt"
+            $result.Count | Should -Be 1
+            $result | Should -BeOfType System.IO.FileInfo
+            $result.Name | Should -BeExactly "file1.txt"
+        }
+
+        It 'Get-ChildItem -Path -Include "*.txt" -Recurse' {
+            $result = Get-ChildItem -Path $rootDir -Include "*.txt" -Recurse
+            $result.Count | Should -Be 2
+            $result | Should -BeOfType System.IO.FileInfo
+            $result | Where-Object { $_.Name -eq "file1.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "file2.txt" } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Get-ChildItem -Path -Include "*.txt" -Recurse -Name' {
+            $result = Get-ChildItem -Path $rootDir -Include "*.txt" -Recurse -Name
+            $result.Count | Should -Be 2
+            $result | Should -BeOfType [string]
+            $result | Where-Object { $_ -eq "file1.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2\file2.txt" } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Get-ChildItem -Path -Include "*.t?t" -Recurse -Name' {
+            $result = Get-ChildItem -Path $rootDir -Include "*.t?t" -Recurse -Name
+            $result.Count | Should -Be 2
+            $result | Should -BeOfType [string]
+            $result | Where-Object { $_ -eq "file1.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2\file2.txt" } | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Validate Get-ChildItem -Path -Include' {
+        It 'Get-ChildItem -Path -Include "*.txt" -Force' -Pending:$true {    # Pending due to a bug
+            $result = Get-ChildItem -Path $rootDir -Include "*.txt" -Force
+            $result.Count | Should -Be 1
+            $result | Should -BeOfType System.IO.FileInfo
+            $result.Name | Should -BeExactly "file1.txt"
+        }
+
+        It 'Get-ChildItem -Path -Include "*.txt" -Recurse -Force' {
+            $result = Get-ChildItem -Path $rootDir -Include "*.txt" -Recurse -Force
+            $result.Count | Should -Be 4
+            $result | Should -BeOfType System.IO.FileInfo
+            $result | Where-Object { $_.Name -eq "file1.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "file2.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "file21.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "filehidden3.txt" } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Get-ChildItem -Path -Include "*.txt" -Recurse -Name -Force' {
+            $result = Get-ChildItem -Path $rootDir -Include "*.txt" -Recurse -Name -Force
+            $result.Count | Should -Be 4
+            $result | Should -BeOfType [string]
+            $result | Where-Object { $_ -eq "file1.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2\file2.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir3\filehidden3.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2\subDir21\file21.txt" } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Get-ChildItem -Path -Include "*.t?t" -Recurse -Name -Force' {
+            $result = Get-ChildItem -Path $rootDir -Include "*.t?t" -Recurse -Name -Force
+            $result.Count | Should -Be 4
+            $result | Should -BeOfType [string]
+            $result | Where-Object { $_ -eq "file1.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2\file2.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir3\filehidden3.txt" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2\subDir21\file21.txt" } | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Validate Get-ChildItem -Path -Exclude' {
+        It 'Get-ChildItem -Path $rootDir -Exclude "*.txt"' {
+            $result = Get-ChildItem -Path $rootDir -Exclude "*.txt"
+            $result.Count | Should -Be 3
+        }
+
+        It 'Get-ChildItem -Path $rootDir -Exclude "file*"' {
+            $result = Get-ChildItem -Path $rootDir -Exclude "file*"
+            $result.Count | Should -Be 2
+            $result | Should -BeOfType System.IO.DirectoryInfo
+            $result | Where-Object { $_.Name -eq "subDir2" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "subDir3" } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Get-ChildItem -Path -Exclude "*.txt" -Recurse' {
+            $result = Get-ChildItem -Path $rootDir -Exclude "*.txt" -Recurse
+            $result.Count | Should -Be 6
+            $result | Where-Object { $_.Name -like "*.txt" } | Should -BeNullOrEmpty
+        }
+
+        It 'Get-ChildItem -Path -Exclude "*.tx?" -Recurse' {
+            $result = Get-ChildItem -Path $rootDir -Exclude "*.tx?" -Recurse
+            $result.Count | Should -Be 6
+            $result | Where-Object { $_.Name -like "*.tx?" } | Should -BeNullOrEmpty
+        }
+
+        It 'Get-ChildItem -Path -Exclude "*.txt" -Recurse -Name' {
+            $result = Get-ChildItem -Path $rootDir -Exclude "*.txt" -Recurse -Name
+            $result | Should -BeOfType [string]
+            $result.Count | Should -Be 6
+            $result | Where-Object { $_.Name -like "*.txt" } | Should -BeNullOrEmpty
+        }
+
+        It 'Get-ChildItem -Path -Exclude "*.txt" -Recurse -Hidden' {
+            $result = Get-ChildItem -Path $rootDir -Exclude "*.txt" -Recurse -Hidden
+            $result.Count | Should -Be 3
+            $result | Where-Object { $_.Name -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "filehidden2.asd" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "subDir21" } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Get-ChildItem -Path -Exclude "*.txt" -Recurse -Hidden -Name' {
+            $result = Get-ChildItem -Path $rootDir -Exclude "*.txt" -Recurse -Hidden -Name
+            $result.Count | Should -Be 3
+            $result | Where-Object { $_ -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2\filehidden2.asd" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2\subDir21" } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Get-ChildItem -Path -Exclude "*.txt" -Include "file*" -Recurse' {
+            $result = Get-ChildItem -Path $rootDir -Exclude "*.txt" -Include "file*" -Recurse
+            $result.Count | Should -Be 4
+            $result | Where-Object { $_.Name -like "*.txt" } | Should -BeNullOrEmpty
+            $result | Where-Object { $_.Name -notlike "file*" } | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Validate Get-ChildItem -Path -Exclude -Force' {
+        It 'Get-ChildItem -Path -Exclude "*.txt" -Force' {
+            $result = Get-ChildItem -Path $rootDir -Exclude "*.txt" -Force
+            $result.Count | Should -Be 4
+        }
+
+        It 'Get-ChildItem -Path -Exclude "file*" -Recurse -Force' {
+            $result = Get-ChildItem -Path $rootDir -Exclude "file*" -Recurse -Force
+            $result.Count | Should -Be 3
+            $result | Should -BeOfType System.IO.DirectoryInfo
+            $result | Where-Object { $_.Name -eq "subDir2" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "subDir3" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_.Name -eq "subDir21" } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Get-ChildItem -Path -Exclude "file*" -Force -Recurse -Name' {
+            $result = Get-ChildItem -Path $rootDir -Exclude "file*" -Force -Recurse -Name
+            $result.Count | Should -Be 3
+            $result | Should -BeOfType [string]
+            $result | Where-Object { $_ -eq "subDir2" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir3" } | Should -Not -BeNullOrEmpty
+            $result | Where-Object { $_ -eq "subDir2\subDir21" } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Get-ChildItem -Path -Exclude "*.txt" -Recurse' {
+            $result = Get-ChildItem -Path $rootDir -Exclude "*.txt" -Recurse
+            $result.Count | Should -Be 6
+            $result | Where-Object { $_.Name -like "*.txt" } | Should -BeNullOrEmpty
+        }
+
+        It 'Get-ChildItem -Path -Exclude "*.txt" -Force -Include "file*" -Recurse' {
+            $result = Get-ChildItem -Path $rootDir -Exclude "*.txt" -Force -Include "file*" -Recurse
+            $result.Count | Should -Be 6
+            $result | Where-Object { $_.Name -like "*.txt" } | Should -BeNullOrEmpty
+            $result | Where-Object { $_.Name -notlike "file*" } | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Validate Get-ChildItem -Path -Exclude/-Include with some filters' {
+        It 'Get-ChildItem -Path -Exclude "*.txt","*.asd" -Force -Include "file*" -Recurse' {
+            $result = Get-ChildItem -Path $rootDir -Exclude "*.txt","*.asd" -Force -Include "file*" -Recurse
+            $result.Count | Should -Be 3
+            $result | Where-Object { $_.Name -like "*.txt" } | Should -BeNullOrEmpty
+            $result | Where-Object { $_.Name -like "*.asd" } | Should -BeNullOrEmpty
+            $result | Where-Object { $_.Name -notlike "file*" } | Should -BeNullOrEmpty
+        }
+
+        It 'Get-ChildItem -Path -Exclude "*.txt","*.asd" -Include "file*" -Recurse' {
+            $result = Get-ChildItem -Path $rootDir -Exclude "*.txt","*.asd" -Include "file*" -Recurse
+            $result.Count | Should -Be 2
+            $result | Where-Object { $_.Name -like "*.txt" } | Should -BeNullOrEmpty
+            $result | Where-Object { $_.Name -like "*.asd" } | Should -BeNullOrEmpty
+            $result | Where-Object { $_.Name -notlike "file*" } | Should -BeNullOrEmpty
+        }
+
+        It 'Get-ChildItem -Path -Exclude "*.txt" -Force -Include "*2.*","*3.*" -Recurse' {
+            $result = Get-ChildItem -Path $rootDir -Exclude "*.txt" -Force -Include "*2.*","*3.*" -Recurse
+            $result.Count | Should -Be 4
+            $result | Where-Object { $_.Name -like "*.txt" } | Should -BeNullOrEmpty
+            $result | Where-Object { $_.Name -notlike "*2.*" -and $_.Name -notlike "*3.*" } | Should -BeNullOrEmpty
+        }
+
+        It 'Get-ChildItem -Path -Exclude "*.txt" -Include "*2.*","*3.*" -Recurse' {
+            $result = Get-ChildItem -Path $rootDir -Exclude "*.txt" -Include "*2.*","*3.*" -Recurse
+            $result.Count | Should -Be 3
+            $result | Where-Object { $_.Name -like "*.txt" } | Should -BeNullOrEmpty
+            $result | Where-Object { $_.Name -notlike "*2.*" -and $_.Name -notlike "*3.*" } | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystemProviderExtended.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystemProviderExtended.Tests.ps1
@@ -192,6 +192,38 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
         }
     }
 
+    Context 'Validate Get-ChildItem -Path -Depth' {
+        It "Get-ChildItem -Path -Depth 0" {
+            $result = Get-ChildItem -Path $rootDir -Depth 0
+            $result.Count | Should -Be 4
+        }
+
+        It "Get-ChildItem -Path -Depth 0 -Force" {
+            $result = Get-ChildItem -Path $rootDir -Depth 0 -Force
+            $result.Count | Should -Be 5
+        }
+
+        It "Get-ChildItem -Path -Depth 1" {
+            $result = Get-ChildItem -Path $rootDir -Depth 1
+            $result.Count | Should -Be 8
+        }
+
+        It "Get-ChildItem -Path -Depth 1 -Force" {
+            $result = Get-ChildItem -Path $rootDir -Depth 1 -Force
+            $result.Count | Should -Be 12
+        }
+
+        It "Get-ChildItem -Path -Depth 2" {
+            $result = Get-ChildItem -Path $rootDir -Depth 2
+            $result.Count | Should -Be 8
+        }
+
+        It "Get-ChildItem -Path -Depth 2 -Force" {
+            $result = Get-ChildItem -Path $rootDir -Depth 2 -Force
+            $result.Count | Should -Be 13
+        }
+    }
+
     Context 'Validate Get-ChildItem -Path -Recurse -Name' {
         It "Get-ChildItem -Path -Recurse -Name" {
             $result = Get-ChildItem -Path $rootDir -Recurse -Name
@@ -248,6 +280,43 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
             $result | Where-Object { $_ -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
             $result | Where-Object { $_ -eq "subDir2$($DirSep)filehidden2.asd" } | Should -Not -BeNullOrEmpty
             $result | Where-Object { $_ -eq "subDir3$($DirSep)filehidden3.txt" } | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Validate Get-ChildItem -Path -Depth -Name' {
+        It "Get-ChildItem -Path -Depth 0 -Name" {
+            $result = Get-ChildItem -Path $rootDir -Depth 0 -Name
+            $result.Count | Should -Be 4
+            $result[0] | Should -BeOfType [string]
+        }
+
+        It "Get-ChildItem -Path -Depth 0 -Name -Force" {
+            $result = Get-ChildItem -Path $rootDir -Depth 0 -Name -Force
+            $result.Count | Should -Be 5
+        }
+
+        It "Get-ChildItem -Path -Depth 1 -Name" {
+            $result = Get-ChildItem -Path $rootDir -Depth 1 -Name
+            $result.Count | Should -Be 8
+            $result[0] | Should -BeOfType [string]
+        }
+
+        It "Get-ChildItem -Path -Depth 1 -Name -Force" {
+            $result = Get-ChildItem -Path $rootDir -Depth 1 -Name -Force
+            $result.Count | Should -Be 12
+            $result[0] | Should -BeOfType [string]
+        }
+
+        It "Get-ChildItem -Path -Depth 2 -Name" {
+            $result = Get-ChildItem -Path $rootDir -Depth 2 -Name
+            $result.Count | Should -Be 8
+            $result[0] | Should -BeOfType [string]
+        }
+
+        It "Get-ChildItem -Path -Depth 2 -Name -Force" {
+            $result = Get-ChildItem -Path $rootDir -Depth 2 -Name -Force
+            $result.Count | Should -Be 13
+            $result[0] | Should -BeOfType [string]
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystemProviderExtended.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystemProviderExtended.Tests.ps1
@@ -5,7 +5,7 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
     BeforeAll {
         $restoreLocation = Get-Location
 
-        $DirSep = [io.path]::DirectorySeparatorChar
+        $DirSep = [IO.Path]::DirectorySeparatorChar
 
         $rootDir = Join-Path "TestDrive:" "TestDir"
         New-Item -Path $rootDir -ItemType Directory > $null
@@ -64,7 +64,7 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
         It "Get-ChildItem -Path -Force" {
             $result = Get-ChildItem -Path $rootDir -Force
             $result.Count | Should -Be 5
-            $result | Where-Object Name -eq "filehidden1.doc" | Should -Not -BeNullOrEmpty
+            $result.Name | Should -Contain "filehidden1.doc"
         }
     }
 
@@ -91,46 +91,46 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
         It "Get-ChildItem -Path -Name" {
             $result = Get-ChildItem -Path $rootDir -Name
             $result.Count | Should -Be 4
-            $result[0] | Should -BeOfType [string]
+            $result[0] | Should -BeOfType System.String
         }
 
         It "Get-ChildItem -Path -Name -Hidden" {
             $result = Get-ChildItem -Path $rootDir -Name -Hidden
             $result.Count | Should -Be 1
-            $result | Should -BeOfType [string]
+            $result | Should -BeOfType System.String
             $result | Should -BeExactly "filehidden1.doc"
         }
 
         It "Get-ChildItem -Path -Name -Attributes Hidden" {
             $result = Get-ChildItem -Path $rootDir -Name -Attributes Hidden
             $result.Count | Should -Be 1
-            $result | Should -BeOfType [string]
+            $result | Should -BeOfType System.String
             $result | Should -BeExactly "filehidden1.doc"
         }
 
         It "Get-ChildItem -Path -Name -Force" {
             $result = Get-ChildItem -Path $rootDir -Name -Force
             $result.Count | Should -Be 5
-            $result | Should -BeOfType [string]
-            $result | Where-Object { $_ -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
+            $result | Should -BeOfType System.String
+            $result | Should -Contain "filehidden1.doc"
         }
 
         It "Get-ChildItem -Path -Directory -Name" {
             $result = Get-ChildItem -Path $rootDir -Directory -Name
             $result.Count | Should -Be 2
-            $result[0] | Should -BeOfType [string]
+            $result[0] | Should -BeOfType System.String
         }
 
         It "Get-ChildItem -Path -File -Name" {
             $result = Get-ChildItem -Path $rootDir -File -Name
             $result.Count | Should -Be 2
-            $result[0] | Should -BeOfType [string]
+            $result[0] | Should -BeOfType System.String
         }
 
         It "Get-ChildItem -Path -File -Name -Hidden" {
             $result = Get-ChildItem -Path $rootDir -File -Name -Hidden
             $result.Count | Should -Be 1
-            $result | Should -BeOfType [string]
+            $result | Should -BeOfType System.String
             $result | Should -BeExactly "filehidden1.doc"
         }
     }
@@ -144,36 +144,36 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
         It "Get-ChildItem -Path -Recurse -Hidden" {
             $result = Get-ChildItem -Path $rootDir -Recurse -Hidden
             $result.Count | Should -Be 4
-            $result | Where-Object { $_.Name -eq "filehidden1.doc" -and $_.psobject.TypeNames[0] -eq "System.IO.FileInfo"} | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "filehidden2.asd" -and $_.psobject.TypeNames[0] -eq "System.IO.FileInfo" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "subDir21" -and $_.psobject.TypeNames[0] -eq "System.IO.DirectoryInfo" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "filehidden3.txt" -and $_.psobject.TypeNames[0] -eq "System.IO.FileInfo" } | Should -Not -BeNullOrEmpty
+            $result.Where({ $_.Name -eq "filehidden1.doc"}) | Should -BeOfType System.IO.FileInfo
+            $result.Where({ $_.Name -eq "filehidden2.asd" }) | Should -BeOfType System.IO.FileInfo
+            $result.Where({ $_.Name -eq "subDir21" }) | Should -BeOfType System.IO.DirectoryInfo
+            $result.Where({ $_.Name -eq "filehidden3.txt" }) | Should -BeOfType System.IO.FileInfo
         }
 
         It "Get-ChildItem -Path -Recurse -Attributes Hidden" {
             $result = Get-ChildItem -Path $rootDir -Recurse -Attributes Hidden
             $result.Count | Should -Be 4
-            $result | Where-Object { $_.Name -eq "filehidden1.doc" -and $_.psobject.TypeNames[0] -eq "System.IO.FileInfo"} | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "filehidden2.asd" -and $_.psobject.TypeNames[0] -eq "System.IO.FileInfo" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "subDir21" -and $_.psobject.TypeNames[0] -eq "System.IO.DirectoryInfo" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "filehidden3.txt" -and $_.psobject.TypeNames[0] -eq "System.IO.FileInfo" } | Should -Not -BeNullOrEmpty
+            $result.Where({ $_.Name -eq "filehidden1.doc" }) | Should -BeOfType System.IO.FileInfo
+            $result.Where({ $_.Name -eq "filehidden2.asd" })| Should -BeOfType System.IO.FileInfo
+            $result.Where({ $_.Name -eq "subDir21" }) | Should -BeOfType System.IO.DirectoryInfo
+            $result.Where({ $_.Name -eq "filehidden3.txt" }) | Should -BeOfType System.IO.FileInfo
         }
 
         It "Get-ChildItem -Path -Recurse -Force" {
             $result = Get-ChildItem -Path $rootDir -Recurse -Force
             $result.Count | Should -Be 13
-            $result | Where-Object { $_.Name -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "filehidden2.asd" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "subDir21" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "filehidden3.txt" } | Should -Not -BeNullOrEmpty
+            $result.Where({ $_.Name -eq "filehidden1.doc" }) | Should -BeOfType System.IO.FileInfo
+            $result.Where({ $_.Name -eq "filehidden2.asd" }) | Should -BeOfType System.IO.FileInfo
+            $result.Where({ $_.Name -eq "subDir21" }) | Should -BeOfType System.IO.DirectoryInfo
+            $result.Where({ $_.Name -eq "filehidden3.txt" }) | Should -BeOfType System.IO.FileInfo
         }
 
         It "Get-ChildItem -Path -Recurse -Directory" {
             $result = Get-ChildItem -Path $rootDir -Recurse -Directory
             $result.Count | Should -Be 2
             $result | Should -BeOfType System.IO.DirectoryInfo
-            $result | Where-Object { $_.Name -eq "subDir2" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "subDir3" } | Should -Not -BeNullOrEmpty
+            $result.Where({ $_.Name -eq "subDir2" }) | Should -BeOfType System.IO.DirectoryInfo
+            $result.Where({ $_.Name -eq "subDir3" }) | Should -BeOfType System.IO.DirectoryInfo
         }
 
         It "Get-ChildItem -Path -Recurse -File" {
@@ -186,9 +186,9 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
             $result = Get-ChildItem -Path $rootDir -Recurse -File -Hidden
             $result.Count | Should -Be 3
             $result | Should -BeOfType System.IO.FileInfo
-            $result | Where-Object { $_.Name -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "filehidden2.asd" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "filehidden3.txt" } | Should -Not -BeNullOrEmpty
+            $result.Where({ $_.Name -eq "filehidden1.doc" }) | Should -BeOfType System.IO.FileInfo
+            $result.Where({ $_.Name -eq "filehidden2.asd" }) | Should -BeOfType System.IO.FileInfo
+            $result.Where({ $_.Name -eq "filehidden3.txt" }) | Should -BeOfType System.IO.FileInfo
         }
     }
 
@@ -228,58 +228,58 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
         It "Get-ChildItem -Path -Recurse -Name" {
             $result = Get-ChildItem -Path $rootDir -Recurse -Name
             $result.Count | Should -Be 8
-            $result[0] | Should -BeOfType [string]
+            $result[0] | Should -BeOfType System.String
         }
 
         It "Get-ChildItem -Path -Recurse -Name -Hidden" {
             $result = Get-ChildItem -Path $rootDir -Recurse -Name -Hidden
             $result.Count | Should -Be 4
-            $result | Should -BeOfType [string]
-            $result | Where-Object { $_ -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2$($DirSep)filehidden2.asd" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2$($DirSep)subDir21" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir3$($DirSep)filehidden3.txt" } | Should -Not -BeNullOrEmpty
+            $result | Should -BeOfType System.String
+            $result.Where({ $_ -eq "filehidden1.doc" }) | Should -BeOfType System.String
+            $result.Where({ $_ -eq "subDir2$($DirSep)filehidden2.asd" }) | Should -BeOfType System.String
+            $result.Where({ $_ -eq "subDir2$($DirSep)subDir21" }) | Should -BeOfType System.String
+            $result.Where({ $_ -eq "subDir3$($DirSep)filehidden3.txt" }) | Should -BeOfType System.String
         }
 
         It "Get-ChildItem -Path -Recurse -Name -Force" {
             $result = Get-ChildItem -Path $rootDir -Recurse -Name -Force
             $result.Count | Should -Be 13
-            $result | Should -BeOfType [string]
-            $result | Where-Object { $_ -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2$($DirSep)filehidden2.asd" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2$($DirSep)subDir21" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir3$($DirSep)filehidden3.txt" } | Should -Not -BeNullOrEmpty
+            $result | Should -BeOfType System.String
+            $result.Where({ $_ -eq "filehidden1.doc" }) | Should -BeOfType System.String
+            $result.Where({ $_ -eq "subDir2$($DirSep)filehidden2.asd" }) | Should -BeOfType System.String
+            $result.Where({ $_ -eq "subDir2$($DirSep)subDir21" }) | Should -BeOfType System.String
+            $result.Where({ $_ -eq "subDir3$($DirSep)filehidden3.txt" }) | Should -BeOfType System.String
         }
 
         It "Get-ChildItem -Path -Recurse -Name -Directory" {
             $result = Get-ChildItem -Path $rootDir -Recurse -Name -Directory
             $result.Count | Should -Be 2
-            $result | Should -BeOfType [string]
-            $result | Where-Object { $_ -eq "subDir2" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir3" } | Should -Not -BeNullOrEmpty
+            $result | Should -BeOfType System.String
+            $result.Where({ $_ -eq "subDir2" }) | Should -BeOfType System.String
+            $result.Where({ $_ -eq "subDir3" }) | Should -BeOfType System.String
         }
 
         It "Get-ChildItem -Path -Recurse -Name -Attributes Directory" {
             $result = Get-ChildItem -Path $rootDir -Recurse -Name -Attributes Directory
             $result.Count | Should -Be 2
-            $result | Should -BeOfType [string]
-            $result | Where-Object { $_ -eq "subDir2" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir3" } | Should -Not -BeNullOrEmpty
+            $result | Should -BeOfType System.String
+            $result.Where({ $_ -eq "subDir2" }) | Should -BeOfType System.String
+            $result.Where({ $_ -eq "subDir3" }) | Should -BeOfType System.String
         }
 
         It "Get-ChildItem -Path -Recurse -Name -File" {
             $result = Get-ChildItem -Path $rootDir -Recurse -Name -File
             $result.Count | Should -Be 6
-            $result | Should -BeOfType [string]
+            $result | Should -BeOfType System.String
         }
 
         It "Get-ChildItem -Path -Recurse -Name -File -Hidden" {
             $result = Get-ChildItem -Path $rootDir -Recurse -Name -File -Hidden
             $result.Count | Should -Be 3
-            $result | Should -BeOfType [string]
-            $result | Where-Object { $_ -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2$($DirSep)filehidden2.asd" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir3$($DirSep)filehidden3.txt" } | Should -Not -BeNullOrEmpty
+            $result | Should -BeOfType System.String
+            $result.Where({ $_ -eq "filehidden1.doc" }) | Should -Not -BeNullOrEmpty
+            $result.Where({ $_ -eq "subDir2$($DirSep)filehidden2.asd" }) | Should -BeOfType System.String
+            $result.Where({ $_ -eq "subDir3$($DirSep)filehidden3.txt" }) | Should -BeOfType System.String
         }
     }
 
@@ -287,7 +287,7 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
         It "Get-ChildItem -Path -Depth 0 -Name" {
             $result = Get-ChildItem -Path $rootDir -Depth 0 -Name
             $result.Count | Should -Be 4
-            $result[0] | Should -BeOfType [string]
+            $result[0] | Should -BeOfType System.String
         }
 
         It "Get-ChildItem -Path -Depth 0 -Name -Force" {
@@ -298,25 +298,25 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
         It "Get-ChildItem -Path -Depth 1 -Name" {
             $result = Get-ChildItem -Path $rootDir -Depth 1 -Name
             $result.Count | Should -Be 8
-            $result[0] | Should -BeOfType [string]
+            $result[0] | Should -BeOfType System.String
         }
 
         It "Get-ChildItem -Path -Depth 1 -Name -Force" {
             $result = Get-ChildItem -Path $rootDir -Depth 1 -Name -Force
             $result.Count | Should -Be 12
-            $result[0] | Should -BeOfType [string]
+            $result[0] | Should -BeOfType System.String
         }
 
         It "Get-ChildItem -Path -Depth 2 -Name" {
             $result = Get-ChildItem -Path $rootDir -Depth 2 -Name
             $result.Count | Should -Be 8
-            $result[0] | Should -BeOfType [string]
+            $result[0] | Should -BeOfType System.String
         }
 
         It "Get-ChildItem -Path -Depth 2 -Name -Force" {
             $result = Get-ChildItem -Path $rootDir -Depth 2 -Name -Force
             $result.Count | Should -Be 13
-            $result[0] | Should -BeOfType [string]
+            $result[0] | Should -BeOfType System.String
         }
     }
 
@@ -332,8 +332,8 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
             $result = Get-ChildItem -Path $rootDir -Filter "file*"
             $result.Count | Should -Be 2
             $result | Should -BeOfType System.IO.FileInfo
-            $result | Where-Object { $_.Name -eq "file1.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "filereadonly1.asd" } | Should -Not -BeNullOrEmpty
+            $result.Where({ $_.Name -eq "file1.txt" }) | Should -BeOfType System.IO.FileInfo
+            $result.Where({ $_.Name -eq "filereadonly1.asd" }) | Should -BeOfType System.IO.FileInfo
         }
 
         It 'Get-ChildItem -Path -Filter "file?.txt"' {
@@ -354,9 +354,9 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
             $result = Get-ChildItem -Path $rootDir -Filter "file*" -Force
             $result.Count | Should -Be 3
             $result | Should -BeOfType System.IO.FileInfo
-            $result | Where-Object { $_.Name -eq "file1.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "filereadonly1.asd" } | Should -Not -BeNullOrEmpty
+            $result.Where({ $_.Name -eq "file1.txt" }) | Should -BeOfType System.IO.FileInfo
+            $result.Where({ $_.Name -eq "filehidden1.doc" }) | Should -BeOfType System.IO.FileInfo
+            $result.Where({ $_.Name -eq "filereadonly1.asd" }) | Should -BeOfType System.IO.FileInfo
         }
     }
 
@@ -365,38 +365,38 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
             $result = Get-ChildItem -Path $rootDir -Filter "*.txt" -Recurse
             $result.Count | Should -Be 2
             $result | Should -BeOfType System.IO.FileInfo
-            $result | Where-Object { $_.Name -eq "file1.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "file2.txt" } | Should -Not -BeNullOrEmpty
+            $result.Where({ $_.Name -eq "file1.txt" }) | Should -BeOfType System.IO.FileInfo
+            $result.Where({ $_.Name -eq "file2.txt" }) | Should -BeOfType System.IO.FileInfo
         }
 
         It 'Get-ChildItem -Path -Filter "file*" -Recurse' {
             $result = Get-ChildItem -Path $rootDir -Filter "file*" -Recurse
             $result.Count | Should -Be 6
             $result | Should -BeOfType System.IO.FileInfo
-            $result | Where-Object { $_.Name -eq "file1.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "filereadonly1.asd" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "file2.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "filereadonly2.doc" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "file3.asd" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "filereadonly3.doc" } | Should -Not -BeNullOrEmpty
+            $result.Where({ $_.Name -eq "file1.txt" }) | Should -BeOfType System.IO.FileInfo
+            $result.Where({ $_.Name -eq "filereadonly1.asd" }) | Should -BeOfType System.IO.FileInfo
+            $result.Where({ $_.Name -eq "file2.txt" }) | Should -BeOfType System.IO.FileInfo
+            $result.Where({ $_.Name -eq "filereadonly2.doc" }) | Should -BeOfType System.IO.FileInfo
+            $result.Where({ $_.Name -eq "file3.asd" }) | Should -BeOfType System.IO.FileInfo
+            $result.Where({ $_.Name -eq "filereadonly3.doc" }) | Should -BeOfType System.IO.FileInfo
         }
 
         It 'Get-ChildItem -Path -Filter "file?.*" -Recurse' {
             $result = Get-ChildItem -Path $rootDir -Filter "file?.*" -Recurse
             $result.Count | Should -Be 3
             $result | Should -BeOfType System.IO.FileInfo
-            $result | Where-Object { $_.Name -eq "file1.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "file2.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "file3.asd" } | Should -Not -BeNullOrEmpty
+            $result.Where({ $_.Name -eq "file1.txt" }) | Should -BeOfType System.IO.FileInfo
+            $result.Where({ $_.Name -eq "file2.txt" }) | Should -BeOfType System.IO.FileInfo
+            $result.Where({ $_.Name -eq "file3.asd" }) | Should -BeOfType System.IO.FileInfo
         }
 
         It 'Get-ChildItem -Path $rootDir -Filter "file*" -Hidden -Recurse' {
             $result = Get-ChildItem -Path $rootDir -Filter "file*" -Hidden -Recurse
             $result.Count | Should -Be 3
             $result | Should -BeOfType System.IO.FileInfo
-            $result | Where-Object { $_.Name -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "filehidden2.asd" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "filehidden3.txt" } | Should -Not -BeNullOrEmpty
+            $result.Where({ $_.Name -eq "filehidden1.doc" }) | Should -BeOfType System.IO.FileInfo
+            $result.Where({ $_.Name -eq "filehidden2.asd" }) | Should -BeOfType System.IO.FileInfo
+            $result.Where({ $_.Name -eq "filehidden3.txt" }) | Should -BeOfType System.IO.FileInfo
         }
 
         It 'Get-ChildItem -Path $rootDir -Filter "file*" -Force -Recurse' {
@@ -410,43 +410,43 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
         It 'Get-ChildItem -Path -Filter "*.txt" -Recurse -Name' {
             $result = Get-ChildItem -Path $rootDir -Filter "*.txt" -Recurse -Name
             $result.Count | Should -Be 2
-            $result | Should -BeOfType [string]
-            $result | Where-Object { $_ -eq "file1.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2$($DirSep)file2.txt" } | Should -Not -BeNullOrEmpty
+            $result | Should -Not -BeNullOrEmpty
+            $result.Where({ $_ -eq "file1.txt" }) | Should -Not -BeNullOrEmpty
+            $result.Where({ $_ -eq "subDir2$($DirSep)file2.txt" }) | Should -Not -BeNullOrEmpty
         }
 
         It 'Get-ChildItem -Path -Filter "file*" -Recurse -Name' {
             $result = Get-ChildItem -Path $rootDir -Filter "file*" -Recurse -Name
             $result.Count | Should -Be 6
-            $result | Should -BeOfType [string]
-            $result | Where-Object { $_ -eq "file1.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "filereadonly1.asd" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2$($DirSep)file2.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2$($DirSep)filereadonly2.doc" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir3$($DirSep)file3.asd" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir3$($DirSep)filereadonly3.doc" } | Should -Not -BeNullOrEmpty
+            $result | Should -BeOfType System.String
+            $result.Where({ $_ -eq "file1.txt" }) | Should -Not -BeNullOrEmpty
+            $result.Where({ $_ -eq "filereadonly1.asd" }) | Should -Not -BeNullOrEmpty
+            $result.Where({ $_ -eq "subDir2$($DirSep)file2.txt" }) | Should -Not -BeNullOrEmpty
+            $result.Where({ $_ -eq "subDir2$($DirSep)filereadonly2.doc" }) | Should -Not -BeNullOrEmpty
+            $result.Where({ $_ -eq "subDir3$($DirSep)file3.asd" }) | Should -Not -BeNullOrEmpty
+            $result.Where({ $_ -eq "subDir3$($DirSep)filereadonly3.doc" }) | Should -Not -BeNullOrEmpty
         }
 
         It 'Get-ChildItem -Path -Filter "file????only3.*" -Recurse -Name' {
             $result = Get-ChildItem -Path $rootDir -Filter "file????only3.*" -Recurse -Name
             $result.Count | Should -Be 1
-            $result | Should -BeOfType [string]
+            $result | Should -BeOfType System.String
             $result | Should -BeExactly "subDir3$($DirSep)filereadonly3.doc"
         }
 
         It 'Get-ChildItem -Path -Filter "file*" -Hidden -Recurse -Name' {
             $result = Get-ChildItem -Path $rootDir -Filter "file*" -Hidden -Recurse -Name
             $result.Count | Should -Be 3
-            $result | Should -BeOfType [string]
-            $result | Where-Object { $_ -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2$($DirSep)filehidden2.asd" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir3$($DirSep)filehidden3.txt" } | Should -Not -BeNullOrEmpty
+            $result | Should -BeOfType System.String
+            $result.Where({ $_ -eq "filehidden1.doc" }) | Should -Not -BeNullOrEmpty
+            $result.Where({ $_ -eq "subDir2$($DirSep)filehidden2.asd" }) | Should -Not -BeNullOrEmpty
+            $result.Where({ $_ -eq "subDir3$($DirSep)filehidden3.txt" }) | Should -Not -BeNullOrEmpty
         }
 
         It 'Get-ChildItem -Path -Filter "file*" -Force -Recurse -Name' {
             $result = Get-ChildItem -Path $rootDir -Filter "file*" -Force -Recurse -Name
             $result.Count | Should -Be 10
-            $result | Should -BeOfType [string]
+            $result | Should -BeOfType System.String
         }
     }
 
@@ -462,24 +462,24 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
             $result = Get-ChildItem -Path $rootDir -Include "*.txt" -Recurse
             $result.Count | Should -Be 2
             $result | Should -BeOfType System.IO.FileInfo
-            $result | Where-Object { $_.Name -eq "file1.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "file2.txt" } | Should -Not -BeNullOrEmpty
+            $result.Where({ $_.Name -eq "file1.txt" }) | Should -BeOfType System.IO.FileInfo
+            $result.Where({ $_.Name -eq "file2.txt" }) | Should -BeOfType System.IO.FileInfo
         }
 
         It 'Get-ChildItem -Path -Include "*.txt" -Recurse -Name' {
             $result = Get-ChildItem -Path $rootDir -Include "*.txt" -Recurse -Name
             $result.Count | Should -Be 2
-            $result | Should -BeOfType [string]
-            $result | Where-Object { $_ -eq "file1.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2$($DirSep)file2.txt" } | Should -Not -BeNullOrEmpty
+            $result | Should -BeOfType System.String
+            $result.Where({ $_ -eq "file1.txt" }) | Should -BeOfType System.String
+            $result.Where({ $_ -eq "subDir2$($DirSep)file2.txt" }) | Should -BeOfType System.String
         }
 
         It 'Get-ChildItem -Path -Include "*.t?t" -Recurse -Name' {
             $result = Get-ChildItem -Path $rootDir -Include "*.t?t" -Recurse -Name
             $result.Count | Should -Be 2
-            $result | Should -BeOfType [string]
-            $result | Where-Object { $_ -eq "file1.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2$($DirSep)file2.txt" } | Should -Not -BeNullOrEmpty
+            $result | Should -BeOfType System.String
+            $result.Where({ $_ -eq "file1.txt" }) | Should -BeOfType System.String
+            $result.Where({ $_ -eq "subDir2$($DirSep)file2.txt" }) | Should -BeOfType System.String
         }
     }
 
@@ -495,30 +495,30 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
             $result = Get-ChildItem -Path $rootDir -Include "*.txt" -Recurse -Force
             $result.Count | Should -Be 4
             $result | Should -BeOfType System.IO.FileInfo
-            $result | Where-Object { $_.Name -eq "file1.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "file2.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "file21.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "filehidden3.txt" } | Should -Not -BeNullOrEmpty
+            $result.Where({ $_.Name -eq "file1.txt" }) | Should -BeOfType System.IO.FileInfo
+            $result.Where({ $_.Name -eq "file2.txt" }) | Should -BeOfType System.IO.FileInfo
+            $result.Where({ $_.Name -eq "file21.txt" }) | Should -BeOfType System.IO.FileInfo
+            $result.Where({ $_.Name -eq "filehidden3.txt" }) | Should -BeOfType System.IO.FileInfo
         }
 
         It 'Get-ChildItem -Path -Include "*.txt" -Recurse -Name -Force' {
             $result = Get-ChildItem -Path $rootDir -Include "*.txt" -Recurse -Name -Force
             $result.Count | Should -Be 4
-            $result | Should -BeOfType [string]
-            $result | Where-Object { $_ -eq "file1.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2$($DirSep)file2.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir3$($DirSep)filehidden3.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2$($DirSep)subDir21$($DirSep)file21.txt" } | Should -Not -BeNullOrEmpty
+            $result | Should -BeOfType System.String
+            $result.Where({ $_ -eq "file1.txt" }) | Should -Not -BeNullOrEmpty
+            $result.Where({ $_ -eq "subDir2$($DirSep)file2.txt" }) | Should -Not -BeNullOrEmpty
+            $result.Where({ $_ -eq "subDir3$($DirSep)filehidden3.txt" }) | Should -Not -BeNullOrEmpty
+            $result.Where({ $_ -eq "subDir2$($DirSep)subDir21$($DirSep)file21.txt" }) | Should -Not -BeNullOrEmpty
         }
 
         It 'Get-ChildItem -Path -Include "*.t?t" -Recurse -Name -Force' {
             $result = Get-ChildItem -Path $rootDir -Include "*.t?t" -Recurse -Name -Force
             $result.Count | Should -Be 4
-            $result | Should -BeOfType [string]
-            $result | Where-Object { $_ -eq "file1.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2$($DirSep)file2.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir3$($DirSep)filehidden3.txt" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2$($DirSep)subDir21$($DirSep)file21.txt" } | Should -Not -BeNullOrEmpty
+            $result | Should -BeOfType System.String
+            $result.Where({ $_ -eq "file1.txt" }) | Should -Not -BeNullOrEmpty
+            $result.Where({ $_ -eq "subDir2$($DirSep)file2.txt" }) | Should -Not -BeNullOrEmpty
+            $result.Where({ $_ -eq "subDir3$($DirSep)filehidden3.txt" } ) | Should -Not -BeNullOrEmpty
+            $result.Where({ $_ -eq "subDir2$($DirSep)subDir21$($DirSep)file21.txt" }) | Should -Not -BeNullOrEmpty
         }
     }
 
@@ -532,50 +532,52 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
             $result = Get-ChildItem -Path $rootDir -Exclude "file*"
             $result.Count | Should -Be 2
             $result | Should -BeOfType System.IO.DirectoryInfo
-            $result | Where-Object { $_.Name -eq "subDir2" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "subDir3" } | Should -Not -BeNullOrEmpty
+            $result.Where({ $_.Name -eq "subDir2" }) | Should -BeOfType System.IO.DirectoryInfo
+            $result.Where({ $_.Name -eq "subDir3" }) | Should -BeOfType System.IO.DirectoryInfo
         }
 
         It 'Get-ChildItem -Path -Exclude "*.txt" -Recurse' {
             $result = Get-ChildItem -Path $rootDir -Exclude "*.txt" -Recurse
             $result.Count | Should -Be 6
-            $result | Where-Object { $_.Name -like "*.txt" } | Should -BeNullOrEmpty
+            $result.Where({ $_.Name -like "*.txt" }) | Should -BeNullOrEmpty
         }
 
         It 'Get-ChildItem -Path -Exclude "*.tx?" -Recurse' {
             $result = Get-ChildItem -Path $rootDir -Exclude "*.tx?" -Recurse
             $result.Count | Should -Be 6
-            $result | Where-Object { $_.Name -like "*.tx?" } | Should -BeNullOrEmpty
+            $result.Where({ $_.Name -like "*.tx?" }) | Should -BeNullOrEmpty
         }
 
         It 'Get-ChildItem -Path -Exclude "*.txt" -Recurse -Name' {
             $result = Get-ChildItem -Path $rootDir -Exclude "*.txt" -Recurse -Name
-            $result | Should -BeOfType [string]
+            $result | Should -BeOfType System.String
             $result.Count | Should -Be 6
-            $result | Where-Object { $_.Name -like "*.txt" } | Should -BeNullOrEmpty
+            $result.Where({ $_ -like "*.txt" }) | Should -BeNullOrEmpty
         }
 
         It 'Get-ChildItem -Path -Exclude "*.txt" -Recurse -Hidden' {
             $result = Get-ChildItem -Path $rootDir -Exclude "*.txt" -Recurse -Hidden
             $result.Count | Should -Be 3
-            $result | Where-Object { $_.Name -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "filehidden2.asd" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "subDir21" } | Should -Not -BeNullOrEmpty
+            $result.Where({ $_.Name -like "*.txt" }) | Should -BeNullOrEmpty
+            $result.Where({ $_.Name -eq "filehidden1.doc" }) | Should -BeOfType System.IO.FileInfo
+            $result.Where({ $_.Name -eq "filehidden2.asd" }) | Should -BeOfType System.IO.FileInfo
+            $result.Where({ $_.Name -eq "subDir21" }) | Should -BeOfType System.IO.DirectoryInfo
         }
 
         It 'Get-ChildItem -Path -Exclude "*.txt" -Recurse -Hidden -Name' {
             $result = Get-ChildItem -Path $rootDir -Exclude "*.txt" -Recurse -Hidden -Name
             $result.Count | Should -Be 3
-            $result | Where-Object { $_ -eq "filehidden1.doc" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2$($DirSep)filehidden2.asd" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2$($DirSep)subDir21" } | Should -Not -BeNullOrEmpty
+            $result.Where({ $_.Name -like "*.txt" }) | Should -BeNullOrEmpty
+            $result.Where({ $_ -eq "filehidden1.doc" }) | Should -Not -BeNullOrEmpty
+            $result.Where({ $_ -eq "subDir2$($DirSep)filehidden2.asd" }) | Should -Not -BeNullOrEmpty
+            $result.Where({ $_ -eq "subDir2$($DirSep)subDir21" }) | Should -Not -BeNullOrEmpty
         }
 
         It 'Get-ChildItem -Path -Exclude "*.txt" -Include "file*" -Recurse' {
             $result = Get-ChildItem -Path $rootDir -Exclude "*.txt" -Include "file*" -Recurse
             $result.Count | Should -Be 4
-            $result | Where-Object { $_.Name -like "*.txt" } | Should -BeNullOrEmpty
-            $result | Where-Object { $_.Name -notlike "file*" } | Should -BeNullOrEmpty
+            $result.Where({ $_.Name -like "*.txt" }) | Should -BeNullOrEmpty
+            $result.Where({ $_.Name -like "file*" }) | Should -BeOfType System.IO.FileInfo
         }
     }
 
@@ -589,31 +591,31 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
             $result = Get-ChildItem -Path $rootDir -Exclude "file*" -Recurse -Force
             $result.Count | Should -Be 3
             $result | Should -BeOfType System.IO.DirectoryInfo
-            $result | Where-Object { $_.Name -eq "subDir2" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "subDir3" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_.Name -eq "subDir21" } | Should -Not -BeNullOrEmpty
+            $result.Where({ $_.Name -eq "subDir2" }) | Should -BeOfType System.IO.DirectoryInfo
+            $result.Where({ $_.Name -eq "subDir3" }) | Should -BeOfType System.IO.DirectoryInfo
+            $result.Where({ $_.Name -eq "subDir21" }) | Should -BeOfType System.IO.DirectoryInfo
         }
 
         It 'Get-ChildItem -Path -Exclude "file*" -Force -Recurse -Name' {
             $result = Get-ChildItem -Path $rootDir -Exclude "file*" -Force -Recurse -Name
             $result.Count | Should -Be 3
-            $result | Should -BeOfType [string]
-            $result | Where-Object { $_ -eq "subDir2" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir3" } | Should -Not -BeNullOrEmpty
-            $result | Where-Object { $_ -eq "subDir2$($DirSep)subDir21" } | Should -Not -BeNullOrEmpty
+            $result | Should -BeOfType System.String
+            $result.Where({ $_ -eq "subDir2" }) | Should -Not -BeNullOrEmpty
+            $result.Where({ $_ -eq "subDir3" }) | Should -Not -BeNullOrEmpty
+            $result.Where({ $_ -eq "subDir2$($DirSep)subDir21" }) | Should -Not -BeNullOrEmpty
         }
 
         It 'Get-ChildItem -Path -Exclude "*.txt" -Recurse' {
             $result = Get-ChildItem -Path $rootDir -Exclude "*.txt" -Recurse
             $result.Count | Should -Be 6
-            $result | Where-Object { $_.Name -like "*.txt" } | Should -BeNullOrEmpty
+            $result.Where({ $_.Name -like "*.txt" }) | Should -BeNullOrEmpty
         }
 
         It 'Get-ChildItem -Path -Exclude "*.txt" -Force -Include "file*" -Recurse' {
             $result = Get-ChildItem -Path $rootDir -Exclude "*.txt" -Force -Include "file*" -Recurse
             $result.Count | Should -Be 6
-            $result | Where-Object { $_.Name -like "*.txt" } | Should -BeNullOrEmpty
-            $result | Where-Object { $_.Name -notlike "file*" } | Should -BeNullOrEmpty
+            $result.Where({ $_.Name -like "*.txt" }) | Should -BeNullOrEmpty
+            $result.Where({ $_.Name -like "file*" }) | Should -BeOfType System.IO.FileInfo
         }
     }
 
@@ -621,31 +623,31 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
         It 'Get-ChildItem -Path -Exclude "*.txt","*.asd" -Force -Include "file*" -Recurse' {
             $result = Get-ChildItem -Path $rootDir -Exclude "*.txt","*.asd" -Force -Include "file*" -Recurse
             $result.Count | Should -Be 3
-            $result | Where-Object { $_.Name -like "*.txt" } | Should -BeNullOrEmpty
-            $result | Where-Object { $_.Name -like "*.asd" } | Should -BeNullOrEmpty
-            $result | Where-Object { $_.Name -notlike "file*" } | Should -BeNullOrEmpty
+            $result.Where({ $_.Name -like "*.txt" }) | Should -BeNullOrEmpty
+            $result.Where({ $_.Name -like "*.asd" }) | Should -BeNullOrEmpty
+            $result.Where({ $_.Name -like "file*" }) | Should -BeOfType System.IO.FileInfo
         }
 
         It 'Get-ChildItem -Path -Exclude "*.txt","*.asd" -Include "file*" -Recurse' {
             $result = Get-ChildItem -Path $rootDir -Exclude "*.txt","*.asd" -Include "file*" -Recurse
             $result.Count | Should -Be 2
-            $result | Where-Object { $_.Name -like "*.txt" } | Should -BeNullOrEmpty
-            $result | Where-Object { $_.Name -like "*.asd" } | Should -BeNullOrEmpty
-            $result | Where-Object { $_.Name -notlike "file*" } | Should -BeNullOrEmpty
+            $result.Where({ $_.Name -like "*.txt" }) | Should -BeNullOrEmpty
+            $result.Where({ $_.Name -like "*.asd" }) | Should -BeNullOrEmpty
+            $result.Where({ $_.Name -like "file*" }) | Should -BeOfType System.IO.FileInfo
         }
 
         It 'Get-ChildItem -Path -Exclude "*.txt" -Force -Include "*2.*","*3.*" -Recurse' {
             $result = Get-ChildItem -Path $rootDir -Exclude "*.txt" -Force -Include "*2.*","*3.*" -Recurse
             $result.Count | Should -Be 4
-            $result | Where-Object { $_.Name -like "*.txt" } | Should -BeNullOrEmpty
-            $result | Where-Object { $_.Name -notlike "*2.*" -and $_.Name -notlike "*3.*" } | Should -BeNullOrEmpty
+            $result.Where({ $_.Name -like "*.txt" }) | Should -BeNullOrEmpty
+            $result.Where({ $_.Name -like "*2.*" -or $_.Name -like "*3.*" }) | Should -BeOfType System.IO.FileInfo
         }
 
         It 'Get-ChildItem -Path -Exclude "*.txt" -Include "*2.*","*3.*" -Recurse' {
             $result = Get-ChildItem -Path $rootDir -Exclude "*.txt" -Include "*2.*","*3.*" -Recurse
             $result.Count | Should -Be 3
-            $result | Where-Object { $_.Name -like "*.txt" } | Should -BeNullOrEmpty
-            $result | Where-Object { $_.Name -notlike "*2.*" -and $_.Name -notlike "*3.*" } | Should -BeNullOrEmpty
+            $result.Where({ $_.Name -like "*.txt" }) | Should -BeNullOrEmpty
+            $result.Where({ $_.Name -like "*2.*" -or $_.Name -like "*3.*" }) | Should -BeOfType System.IO.FileInfo
         }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add new tests for better code coverage in SessionStateContainer.cs and FileSystemProvider.cs.

## PR Context

I prepare a code to address issue #9119 but we have not tests to cover the code paths at all. To avoid regressions we should merge the new tests before new code will be pulled.

Some bugs (#9126 and #3304) was discovered, the new tests was marked as pending.


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
