### PR TITLE
Update `PSPath` in `certificate_format_ps1.xml`

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/Certificate_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/Certificate_format_ps1xml.cs
@@ -89,10 +89,10 @@ namespace System.Management.Automation.Runspaces
             yield return new FormatViewDefinition("PathOnly",
                 ListControl.Create()
                     .StartEntry()
-                        .AddItemProperty(@"PSPathPath")
+                        .AddItemProperty(@"PSPath")
                     .EndEntry()
                     .StartEntry(entrySelectedByType: new[] { "Microsoft.PowerShell.Commands.X509StoreLocation" })
-                        .AddItemProperty(@"PSPathPath")
+                        .AddItemProperty(@"PSPath")
                     .EndEntry()
                     .StartEntry(entrySelectedByType: new[] { "System.Security.Cryptography.X509Certificates.X509Store" })
                         .AddItemProperty(@"PSPath")


### PR DESCRIPTION
# PR Summary

`PSPathPath` to `PSPath` in formatting xml

## PR Context

`PSPathPath` is an invalid item property name

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
- **User-facing changes**
    - [x] Not Applicable
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
