### PR TITLE
Add -AsUTC to the Get-Date cmdlet

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
@@ -217,6 +217,19 @@ namespace Microsoft.PowerShell.Commands
         [ArgumentCompletions("FileDate", "FileDateUniversal", "FileDateTime", "FileDateTimeUniversal")]
         public string Format { get; set; }
 
+        /// <summary>
+        /// Convert date to UTC before formatting
+        /// </summary>
+        [Parameter(ParameterSetName = "net")]
+        public SwitchParameter AsUTC
+        {
+            get { return _asUTC; }
+
+            set { _asUTC = value; }
+        }
+
+        private SwitchParameter _asUTC = false;
+
         #endregion
 
         #region methods
@@ -283,6 +296,10 @@ namespace Microsoft.PowerShell.Commands
                 offset = Millisecond - dateToUse.Millisecond;
                 dateToUse = dateToUse.AddMilliseconds(offset);
                 dateToUse = dateToUse.Subtract(TimeSpan.FromTicks(dateToUse.Ticks % 10000));
+            }
+
+            if (_asUTC) {
+                dateToUse = dateToUse.ToUniversalTime();
             }
 
             if (UFormat != null)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
@@ -218,7 +218,7 @@ namespace Microsoft.PowerShell.Commands
         public string Format { get; set; }
 
         /// <summary>
-        /// Convert date to UTC before formatting.
+        /// Gets or sets a value that converts date to UTC before formatting.
         /// </summary>
         [Parameter(ParameterSetName = "net")]
         public SwitchParameter AsUTC { get; set; }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
@@ -218,18 +218,10 @@ namespace Microsoft.PowerShell.Commands
         public string Format { get; set; }
 
         /// <summary>
-        /// Convert date to UTC before formatting
+        /// Convert date to UTC before formatting.
         /// </summary>
         [Parameter(ParameterSetName = "net")]
-        public SwitchParameter AsUTC
-        {
-            get { return _asUTC; }
-
-            set { _asUTC = value; }
-        }
-
-        private SwitchParameter _asUTC = false;
-
+        public SwitchParameter AsUTC { get; set; }
         #endregion
 
         #region methods
@@ -298,7 +290,8 @@ namespace Microsoft.PowerShell.Commands
                 dateToUse = dateToUse.Subtract(TimeSpan.FromTicks(dateToUse.Ticks % 10000));
             }
 
-            if (_asUTC) {
+            if (AsUTC)
+            {
                 dateToUse = dateToUse.ToUniversalTime();
             }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
@@ -25,8 +25,8 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
     }
 
     It "using -AsUTC produces the correct output" {
-        Get-date -Date:"2020-01-01T00:00:00" -Format:"MMM-dd-yy hh:mm" | Should -Be "Jan-01-20 12:00"
-        Get-date -Date:"2020-01-01T00:00:00" -Format:"MMM-dd-yy hh:mm" -AsUTC | Should -Be "Jan-01-20 08:00"
+        (Get-date -Date:"2020-01-01T00:00:00").Kind | Should -Be Unspecified
+        (Get-date -Date:"2020-01-01T00:00:00" -AsUTC).Kind | Should -Be Utc
     }
 
     It "using -uformat %s produces the correct output" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
@@ -24,6 +24,11 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
         Get-date -Date:"Jan 1, 2020"  -Format:"MMM-dd-yy" | Should -Be "Jan-01-20"
     }
 
+    It "using -AsUTC produces the correct output" {
+        Get-date -Date:"2020-01-01T00:00:00" -Format:"MMM-dd-yy hh:mm" | Should -Be "Jan-01-20 12:00"
+        Get-date -Date:"2020-01-01T00:00:00" -Format:"MMM-dd-yy hh:mm" -AsUTC | Should -Be "Jan-01-20 08:00"
+    }
+
     It "using -uformat %s produces the correct output" {
         $seconds = Get-date -Date:"Jan 1, 2020Z" -UFormat:"%s"
 


### PR DESCRIPTION
# PR Summary
Adds a `-AsUTC` flag to convert a date to UTC before formatting.

## PR Context

Requested in #11410

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
- **User-facing changes**
    - [X] Not Applicable
- **Testing - New and feature**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
