### PR TITLE
Fix String Parameter Binding for Biginteger numeric literals

### DIFF
--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -14,6 +14,7 @@ using System.Linq.Expressions;
 using System.Management.Automation.Internal;
 using System.Management.Automation.Language;
 using System.Management.Automation.Runspaces;
+using System.Numerics;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
@@ -3307,6 +3308,11 @@ namespace System.Management.Automation
                     return sgl.ToString(SinglePrecision, numberFormat);
                 }
 
+                if (valueToConvert is BigInteger b)
+                {
+                    return b.ToString(numberFormat);
+                }
+
                 return (string)Convert.ChangeType(valueToConvert, resultType, CultureInfo.InvariantCulture.NumberFormat);
             }
             catch (Exception e)
@@ -4380,7 +4386,8 @@ namespace System.Management.Automation
             typeof(Int16), typeof(Int32), typeof(Int64),
             typeof(UInt16), typeof(UInt32), typeof(UInt64),
             typeof(sbyte), typeof(byte),
-            typeof(Single), typeof(double), typeof(decimal)
+            typeof(Single), typeof(double), typeof(decimal),
+            typeof(System.Numerics.BigInteger)
         };
 
         private static Type[] s_integerTypes = new Type[] {
@@ -4415,6 +4422,7 @@ namespace System.Management.Automation
                     CacheConversion<object>(typeofNull, type, LanguagePrimitives.ConvertNullToNumeric, ConversionRank.NullToValue);
                 }
 
+                CacheConversion<string>(typeof(BigInteger), typeofString, ConvertNumericToString, ConversionRank.NumericString);
                 CacheConversion<bool>(typeof(Int16), typeofBool, ConvertInt16ToBool, ConversionRank.Language);
                 CacheConversion<bool>(typeof(Int32), typeofBool, ConvertInt32ToBool, ConversionRank.Language);
                 CacheConversion<bool>(typeof(Int64), typeofBool, ConvertInt64ToBool, ConversionRank.Language);

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -4387,7 +4387,7 @@ namespace System.Management.Automation
             typeof(UInt16), typeof(UInt32), typeof(UInt64),
             typeof(sbyte), typeof(byte),
             typeof(Single), typeof(double), typeof(decimal),
-            typeof(System.Numerics.BigInteger)
+            typeof(BigInteger)
         };
 
         private static Type[] s_integerTypes = new Type[] {
@@ -4422,7 +4422,6 @@ namespace System.Management.Automation
                     CacheConversion<object>(typeofNull, type, LanguagePrimitives.ConvertNullToNumeric, ConversionRank.NullToValue);
                 }
 
-                CacheConversion<string>(typeof(BigInteger), typeofString, ConvertNumericToString, ConversionRank.NumericString);
                 CacheConversion<bool>(typeof(Int16), typeofBool, ConvertInt16ToBool, ConversionRank.Language);
                 CacheConversion<bool>(typeof(Int32), typeofBool, ConvertInt32ToBool, ConversionRank.Language);
                 CacheConversion<bool>(typeof(Int64), typeofBool, ConvertInt64ToBool, ConversionRank.Language);

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -4171,7 +4171,9 @@ namespace System.Management.Automation.Language
         private Expression GetCommandArgumentExpression(CommandElementAst element)
         {
             var constElement = element as ConstantExpressionAst;
-            if (constElement != null && LanguagePrimitives.IsNumeric(LanguagePrimitives.GetTypeCode(constElement.StaticType)))
+            if (constElement != null
+                && (LanguagePrimitives.IsNumeric(LanguagePrimitives.GetTypeCode(constElement.StaticType))
+                || constElement.StaticType == typeof(System.Numerics.BigInteger)))
             {
                 var commandArgumentText = constElement.Extent.Text;
                 if (!commandArgumentText.Equals(constElement.Value.ToString(), StringComparison.Ordinal))

--- a/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
+++ b/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
@@ -643,7 +643,9 @@ namespace System.Management.Automation
                     {
                         var constantExprAst = ast as ConstantExpressionAst;
                         object argument;
-                        if (constantExprAst != null && LanguagePrimitives.IsNumeric(LanguagePrimitives.GetTypeCode(constantExprAst.StaticType)))
+                        if (constantExprAst != null
+                            && (LanguagePrimitives.IsNumeric(LanguagePrimitives.GetTypeCode(constantExprAst.StaticType))
+                            || constantExprAst.StaticType == typeof(System.Numerics.BigInteger)))
                         {
                             var commandArgumentText = constantExprAst.Extent.Text;
                             argument = constantExprAst.Value;

--- a/test/powershell/Language/Parser/ParameterBinding.Tests.ps1
+++ b/test/powershell/Language/Parser/ParameterBinding.Tests.ps1
@@ -425,3 +425,44 @@ Describe "Custom type conversion in parameter binding" -Tags 'Feature' {
         }
     }
 }
+
+Describe 'Roundtrippable Conversions for Bare-string Numeric Literals passed to [string] Parameters' -Tags CI {
+
+    BeforeAll {
+        $TestValues = @(
+            @{ Argument = "34uy" }
+            @{ Argument = "48y" }
+            @{ Argument = "8s" }
+            @{ Argument = "49us" }
+            @{ Argument = "26" }
+            @{ Argument = "28u" }
+            @{ Argument = "24l" }
+            @{ Argument = "32ul" }
+            @{ Argument = "20d" }
+            @{ Argument = "6n" }
+        )
+
+        function Test-SimpleStringValue([string] $Value) { $Value }
+        function Test-AdvancedStringValue {
+            [CmdletBinding()]
+            param(
+                [string]
+                $Value
+            )
+
+            $Value
+        }
+    }
+
+    It 'should correctly convert <Argument> back to string in simple functions' -TestCases $TestValues {
+        param($Argument)
+
+        Invoke-Expression "Test-SimpleStringValue -Value $Argument" | Should -BeExactly $Argument
+    }
+
+    It 'should correctly convert <Argument> back to string in advanced functions' -TestCases $TestValues {
+        param($Argument)
+
+        Invoke-Expression "Test-AdvancedStringValue -Value $Argument" | Should -BeExactly $Argument
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

When passing a bigint literal, e.g., `7n`, as a bare string to a parameter of type [string], the parameter binder was incorrectly using the direct ToString() conversion (unlike other numeric literals), which
store the original TokenText in order to properly retrieve the original string that was entered at the command line.

Fix is to ensure that we're capturing and storing the TokenText value when the value is of type BigInteger (since this type's TypeCode is simply `object` and is not read as being a numeric type by those APIs).

I also needed to add BigInteger to the array of numeric types stored in LanguagePrimitives in order for the conversion methods to recognise that BigInteger literals need to be converted to string more carefully.

Quick test case (interactive only):

```powershell
function Test-StringValue([string]$Value) { $value }

Test-StringValue -Value 11n

# `11n` should be returned, but you will see `11` returned before these changes
```

## PR Context

This PR resolves #11626 

/cc @SteveL-MSFT
I know y'all are probably up to your necks with the v7 release -- I'm hoping this can pass under the wire for that; would definitely like to have it fixed for the upcoming release. 🙂 

I'm not 100% sure the included tests are the _best_ way to test this, but they certainly seem to do the job.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
