### PR TITLE
Replace use of throw GetExceptionForHR with ThrowExceptionForHR

### DIFF
--- a/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
+++ b/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
@@ -3088,7 +3088,7 @@ namespace Microsoft.PowerShell.Commands
             }
             else
             {
-                throw Marshal.GetExceptionForHR(Security.NativeMethods.NTE_NOT_SUPPORTED);
+                Marshal.ThrowExceptionForHR(Security.NativeMethods.NTE_NOT_SUPPORTED);
             }
         }
 

--- a/src/System.Management.Automation/engine/parser/FusionAssemblyIdentity.cs
+++ b/src/System.Management.Automation/engine/parser/FusionAssemblyIdentity.cs
@@ -133,17 +133,14 @@ namespace Microsoft.CodeAnalysis
 
             if (hr != ERROR_INSUFFICIENT_BUFFER)
             {
-                throw Marshal.GetExceptionForHR(hr);
+                Marshal.ThrowExceptionForHR(hr);
             }
 
             byte[] data = new byte[(int)characterCountIncludingTerminator * 2];
             fixed (byte* p = data)
             {
                 hr = nameObject.GetDisplayName(p, ref characterCountIncludingTerminator, displayFlags);
-                if (hr != 0)
-                {
-                    throw Marshal.GetExceptionForHR(hr);
-                }
+                Marshal.ThrowExceptionForHR(hr);
 
                 return Marshal.PtrToStringUni((IntPtr)p, (int)characterCountIncludingTerminator - 1);
             }
@@ -162,17 +159,14 @@ namespace Microsoft.CodeAnalysis
 
             if (hr != ERROR_INSUFFICIENT_BUFFER)
             {
-                throw Marshal.GetExceptionForHR(hr);
+                Marshal.ThrowExceptionForHR(hr);
             }
 
             byte[] data = new byte[(int)size];
             fixed (byte* p = data)
             {
                 hr = nameObject.GetProperty(propertyId, p, ref size);
-                if (hr != 0)
-                {
-                    throw Marshal.GetExceptionForHR(hr);
-                }
+                Marshal.ThrowExceptionForHR(hr);
             }
 
             return data;
@@ -210,10 +204,7 @@ namespace Microsoft.CodeAnalysis
             uint result;
             uint size = sizeof(uint);
             int hr = nameObject.GetProperty(propertyId, &result, ref size);
-            if (hr != 0)
-            {
-                throw Marshal.GetExceptionForHR(hr);
-            }
+            Marshal.ThrowExceptionForHR(hr);
 
             if (size == 0)
             {

--- a/src/System.Management.Automation/security/SecuritySupport.cs
+++ b/src/System.Management.Automation/security/SecuritySupport.cs
@@ -900,8 +900,7 @@ namespace System.Management.Automation.Internal
 
                 if (newfilter.Contains("=") || newfilter.Contains("&"))
                 {
-                    throw Marshal.GetExceptionForHR(
-                                    Security.NativeMethods.E_INVALID_DATA);
+                    Marshal.ThrowExceptionForHR(Security.NativeMethods.E_INVALID_DATA);
                 }
 
                 newfilter = name + "=" + newfilter;


### PR DESCRIPTION
# PR Summary

`System.Runtime.InteropServices.Marshall.GetExceptionForHR` may not return an exception. Instead of `throw GetExceptionForHR` we can use `ThrowExceptionForHR`.

## PR Context

Fix warnings `CS8597:Thrown value may be null.`

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
