### PR TITLE
Fix unnecessary trimming of line resulting in incorrect indexi…

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1100,18 +1100,18 @@ namespace System.Management.Automation.Runspaces
                                                 $offsetInLine = 0
                                             }
                                             else {
-                                                $positionMessage = $myinv.PositionMessage.Split('+')
-                                                $line = $positionMessage[1]
-                                                $highlightLine = $positionMessage[$positionMessage.Count - 1]
+                                                $positionMessage = $myinv.PositionMessage.Split($newline)
+                                                $line = $positionMessage[1].Substring(1) # skip the '+' at the start
+                                                $highlightLine = $positionMessage[$positionMessage.Count - 1].Substring(1)
                                                 $offsetLength = $highlightLine.Trim().Length
                                                 $offsetInLine = $highlightLine.IndexOf('~')
                                             }
 
-                                            if (-not $line.EndsWith(""`n"")) {
+                                            if (-not $line.EndsWith($newline)) {
                                                 $line += $newline
                                             }
 
-                                            # don't color the whole line red
+                                            # don't color the whole line
                                             if ($offsetLength -lt $line.Length - 1) {
                                                 $line = $line.Insert($offsetInLine + $offsetLength, $resetColor).Insert($offsetInLine, $accentColor)
                                             }
@@ -1120,16 +1120,15 @@ namespace System.Management.Automation.Runspaces
                                             $offsetWhitespace = ' ' * $offsetInLine
                                             $prefix = ""${accentColor}${headerWhitespace}     ${verticalBar} ${errorColor}""
                                             if ($highlightLine -ne '') {
-                                                $posMsg += ""${newline}${prefix}${highlightLine}${newline}""
+                                                $posMsg += ""${prefix}${highlightLine}${newline}""
                                             }
                                             $message = ""${prefix}""
                                         }
 
                                         if (! $err.ErrorDetails -or ! $err.ErrorDetails.Message) {
-                                            # we use `n instead of $newline here because that's what is in the message
-                                            if ($err.CategoryInfo.Category -eq 'ParserError' -and $err.Exception.Message.Contains(""~`n"")) {
+                                            if ($err.CategoryInfo.Category -eq 'ParserError' -and $err.Exception.Message.Contains(""~$newline"")) {
                                                 # need to parse out the relevant part of the pre-rendered positionmessage
-                                                $message += $err.Exception.Message.split(""~`n"")[1].split(""${newline}${newline}"")[0]
+                                                $message += $err.Exception.Message.split(""~$newline"")[1].split(""${newline}${newline}"")[0]
                                             }
                                             elseif ($err.Exception) {
                                                 $message += $err.Exception.Message
@@ -1229,7 +1228,7 @@ namespace System.Management.Automation.Runspaces
 
                                         if ($posmsg -ne '')
                                         {
-                                            $posmsg = ""`n"" + $posmsg
+                                            $posmsg = $newline + $posmsg
                                         }
 
                                         if ($err.PSMessageDetails) {
@@ -1253,24 +1252,24 @@ namespace System.Management.Automation.Runspaces
                                             $indentString = '+ CategoryInfo          : ' + $err.CategoryInfo
                                         }
 
-                                        $posmsg += ""`n"" + $indentString
+                                        $posmsg += $newline + $indentString
 
                                         $indentString = ""+ FullyQualifiedErrorId : "" + $err.FullyQualifiedErrorId
-                                        $posmsg += ""`n"" + $indentString
+                                        $posmsg += $newline + $indentString
 
                                         $originInfo = $err.OriginInfo
 
                                         if (($null -ne $originInfo) -and ($null -ne $originInfo.PSComputerName))
                                         {
                                             $indentString = ""+ PSComputerName        : "" + $originInfo.PSComputerName
-                                            $posmsg += ""`n"" + $indentString
+                                            $posmsg += $newline + $indentString
                                         }
 
                                         if ($ErrorView -eq 'CategoryView') {
                                             $err.CategoryInfo.GetMessage()
                                         }
                                         elseif (! $err.ErrorDetails -or ! $err.ErrorDetails.Message) {
-                                            $err.Exception.Message + $posmsg + ""`n""
+                                            $err.Exception.Message + $posmsg + $newline
                                         } else {
                                             $err.ErrorDetails.Message + $posmsg
                                         }

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -994,6 +994,7 @@ namespace System.Management.Automation.Runspaces
                                 ")
                         .AddScriptBlockExpressionBinding(@"
                                     Set-StrictMode -Off
+                                    $newline = [Environment]::Newline
 
                                     function Get-ConciseViewPositionMessage {
 
@@ -1049,7 +1050,6 @@ namespace System.Management.Automation.Runspaces
                                         $offsetWhitespace = ''
                                         $message = ''
                                         $prefix = ''
-                                        $newline = [Environment]::Newline
 
                                         if ($myinv -and $myinv.ScriptName -or $myinv.ScriptLineNumber -gt 1 -or $err.CategoryInfo.Category -eq 'ParserError') {
                                             $useTargetObject = $false

--- a/test/powershell/engine/Formatting/ErrorView.Tests.ps1
+++ b/test/powershell/engine/Formatting/ErrorView.Tests.ps1
@@ -42,10 +42,10 @@ Describe 'Tests for $ErrorView' -Tag CI {
 '@
 
             Set-Content -Path $testScriptPath -Value $testScript
-            $e = { & $testScriptPath } | Should -Throw -ErrorId 'UnexpectedToken' -PassThru
-            $e | Out-String | Should -BeLike "*${testScriptPath}:4*"
+            $e = { & $testScriptPath } | Should -Throw -ErrorId 'UnexpectedToken' -PassThru | Out-String
+            $e | Should -BeLike "*${testScriptPath}:4*"
             # validate line number is shown
-            $e | Out-String | Should -BeLike '* 4 *'
+            $e | Should -BeLike '* 4 *'
         }
 
         It "Remote errors show up correctly" {
@@ -69,12 +69,12 @@ Describe 'Tests for $ErrorView' -Tag CI {
             $testScript = '1 + 1 | Should -Be 3'
 
             Set-Content -Path $testScriptPath -Value $testScript
-            $e = { & $testScriptPath } | Should -Throw -ErrorId 'PesterAssertionFailed' -PassThru
-            $e | Out-String | Should -BeLike "*$testScriptPath*"
-            $e | Out-String | Should -Not -BeLike '*pester*'
+            $e = { & $testScriptPath } | Should -Throw -ErrorId 'PesterAssertionFailed' -PassThru | Out-String
+            $e | Should -BeLike "*$testScriptPath*"
+            $e | Should -Not -BeLike '*pester*'
         }
 
-        It "Long lines should be rendered correctly" {
+        It "Long lines should be rendered correctly with indentation" {
             $testscript = @'
                         $myerrors = [System.Collections.ArrayList]::new()
                         Copy-Item (New-Guid) (New-Guid) -ErrorVariable +myerrors -ErrorAction SilentlyContinue
@@ -82,10 +82,10 @@ Describe 'Tests for $ErrorView' -Tag CI {
 '@
 
             Set-Content -Path $testScriptPath -Value $testScript
-            $e = & $testScriptPath
-            $e | Out-String | Should -BeLike "*${testScriptPath}:2*"
+            $e = & $testScriptPath | Out-String
+            $e | Should -BeLike "*${testScriptPath}:2*"
             # validate line number is shown
-            $e | Out-String | Should -BeLike '* 2 *'
+            $e | Should -BeLike '* 2 *'
         }
     }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

After the switch to use `InvocationInfo.PositionMessage` instead of crafting equivalent, the use of `Trim()` caused a mismatch between the line of script with the error and the underlining line so the line of code to insert VT100 color can be out of bounds.  The whitespace at the beginning of the line causes this issue because `Trim()` makes the highlight line too short (previously the script line would also be trimmed).

Also fixed an issue where it was splitting `PositionMessage` by `+` to get the individual parts, but the message itself can contain a `+` so using newline instead.  This with the trim is what caused the index to be out of bounds as the line is now too short to insert the VT100 code to reset the color back.

In addition, switched all use of `` `n`` to `[Environment]::Newline`.

Finally, removed an extra newline in the rendering.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/11669

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
