### PR TITLE
Introduce PSVersionAttribute

### DIFF
--- a/src/System.Management.Automation/engine/Attributes.cs
+++ b/src/System.Management.Automation/engine/Attributes.cs
@@ -516,6 +516,55 @@ namespace System.Management.Automation
     }
 
     /// <summary>
+    /// PSVersionAttribute is used to specify the version of function or advanced function.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    [SuppressMessage("Microsoft.Design", "CA1019:DefineAccessorsForAttributeArguments")]
+    public sealed class PSVersionAttribute : CmdletMetadataAttribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PSVersionAttribute"/> class
+        /// with the specified major and minor numbers.
+        /// </summary>
+        /// <param name="major">The major version number.</param>
+        /// <param name="minor">The minor version number.</param>
+        public PSVersionAttribute(int major, int minor)
+        {
+            PSVersion = new Version(major, minor);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PSVersionAttribute"/> class
+        /// with the specified major, minor, and build numbers.
+        /// </summary>
+        /// <param name="major">The major version number.</param>
+        /// <param name="minor">The minor version number.</param>
+        /// <param name="build">The build version number.</param>
+        public PSVersionAttribute(int major, int minor, int build)
+        {
+            PSVersion = new Version(major, minor, build);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PSVersionAttribute"/> class
+        /// with the specified major, minor, build, and revision numbers.
+        /// </summary>
+        /// <param name="major">The major version number.</param>
+        /// <param name="minor">The minor version number.</param>
+        /// <param name="build">The build version number.</param>
+        /// <param name="revision">The revision version number.</param>
+        public PSVersionAttribute(int major, int minor, int build, int revision)
+        {
+            PSVersion = new Version(major, minor, build, revision);
+        }
+
+        /// <summary>
+        /// Gets the function version.
+        /// </summary>
+        public Version PSVersion { get; }
+    }
+
+    /// <summary>
     /// This attribute is used on a dynamic assembly to mark it as one that is used to implement
     /// a set of classes defined in a PowerShell script.
     /// </summary>

--- a/src/System.Management.Automation/engine/ExternalScriptInfo.cs
+++ b/src/System.Management.Automation/engine/ExternalScriptInfo.cs
@@ -182,6 +182,21 @@ namespace System.Management.Automation
         }
 
         /// <summary>
+        /// Gets the version of the script.
+        /// </summary>
+        /// <returns>
+        /// A module version if the script is in the module.
+        /// Othervise a version from PSVersionattribute if it presents in the script.
+        /// </returns>
+        public override Version Version
+        {
+            get
+            {
+                return base.Version ?? ScriptBlock.PSVersion;
+            }
+        }
+
+        /// <summary>
         /// Determine the visibility for this script...
         /// </summary>
         public override SessionStateEntryVisibility Visibility

--- a/src/System.Management.Automation/engine/FunctionInfo.cs
+++ b/src/System.Management.Automation/engine/FunctionInfo.cs
@@ -276,6 +276,21 @@ namespace System.Management.Automation
         }
 
         /// <summary>
+        /// Gets the version of the function.
+        /// </summary>
+        /// <returns>
+        /// A module version if the function is in the module.
+        /// Othervise a version from PSVersionattribute if it presents in the function.
+        /// </returns>
+        public override Version Version
+        {
+            get
+            {
+                return base.Version ?? ScriptBlock.PSVersion;
+            }
+        }
+
+        /// <summary>
         /// Gets the name of the default parameter set.
         /// Returns <c>null</c> if this function doesn't use cmdlet parameter binding or if the default parameter set wasn't specified.
         /// </summary>

--- a/src/System.Management.Automation/engine/lang/scriptblock.cs
+++ b/src/System.Management.Automation/engine/lang/scriptblock.cs
@@ -641,6 +641,22 @@ namespace System.Management.Automation
             }
         }
 
+        internal Version PSVersion
+        {
+            get
+            {
+                foreach (Attribute attribute in Attributes)
+                {
+                    if (attribute is PSVersionAttribute attr)
+                    {
+                        return attr.PSVersion;
+                    }
+                }
+
+                return new Version(-1, -1);
+            }
+        }
+
         /// <summary>
         /// This is a helper function to process script invocation result.
         /// </summary>

--- a/src/System.Management.Automation/engine/parser/TypeResolver.cs
+++ b/src/System.Management.Automation/engine/parser/TypeResolver.cs
@@ -769,6 +769,7 @@ namespace System.Management.Automation
                     { typeof(PSObject),                                    new[] { "psobject", "pscustomobject" } },
                     { typeof(PSPrimitiveDictionary),                       new[] { "psprimitivedictionary" } },
                     { typeof(PSReference),                                 new[] { "ref" } },
+                    { typeof(PSVersionAttribute),                          new[] { "PSVersion" } },
                     { typeof(PSTypeNameAttribute),                         new[] { "PSTypeNameAttribute" } },
                     { typeof(Regex),                                       new[] { "regex" } },
                     { typeof(DscPropertyAttribute),                        new[] { "DscProperty" } },

--- a/test/powershell/Language/Parser/TypeAccelerator.Tests.ps1
+++ b/test/powershell/Language/Parser/TypeAccelerator.Tests.ps1
@@ -187,6 +187,10 @@ Describe "Type accelerators" -Tags "CI" {
                     Type        = [System.Management.Automation.PSPrimitiveDictionary]
                 }
                 @{
+                    Accelerator = 'PSVersion'
+                    Type        = [System.Management.Automation.PSVersionAttribute]
+                }
+                @{
                     Accelerator = 'ref'
                     Type        = [System.Management.Automation.PSReference]
                 }
@@ -406,11 +410,11 @@ Describe "Type accelerators" -Tags "CI" {
 
             if ( !$IsWindows )
             {
-                $totalAccelerators = 99
+                $totalAccelerators = 100
             }
             else
             {
-                $totalAccelerators = 104
+                $totalAccelerators = 105
 
                 $extraFullPSAcceleratorTestCases = @(
                     @{

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Command.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Command.Tests.ps1
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+
 Describe "Get-Command Tests" -Tags "CI" {
     BeforeAll {
         function TestGetCommand-DynamicParametersDCR
@@ -28,7 +29,7 @@ Describe "Get-Command Tests" -Tags "CI" {
                      "return1" {
                         $attr = [System.Management.Automation.ParameterAttribute]::new()
                         $attr.Mandatory = $true
-				        $dynamicParameter = [System.Management.Automation.RuntimeDefinedParameter]::new("OneString",[string],$attr)
+                        $dynamicParameter = [System.Management.Automation.RuntimeDefinedParameter]::new("OneString",[string],$attr)
                         $dynamicParamDictionary.Add("OneString",$dynamicParameter)
                         break
                     }
@@ -268,5 +269,34 @@ Describe "Get-Command Tests" -Tags "CI" {
         $result = Get-Command -Name Add-Content, Get-Content | Get-Command
         $result.Count | Should -Be 2
         $result.Name | Should -Be "Add-Content","Get-Content"
+    }
+
+    It "ExternalScriptInfo contains metadata" {
+        $ScriptPath = "TestDrive:/GetCommandTestFile.ps1"
+        Set-Content -Path $ScriptPath -Value @"
+            [Outputtype([int])]
+            [PSVersion(1,2)]
+            param()
+
+            Process { "test" }
+"@
+
+        $info = Get-Command $ScriptPath
+        $info.OutputType[0].Name | Should -BeExactly "System.Int32"
+        $info.Version | Should -BeExactly "1.2"
+    }
+
+    It "FunctionInfo contains metadata" {
+        Function TestFunction {
+            [Outputtype([string])]
+            [PSVersion(2,4)]
+            param()
+
+            "test"
+        }
+
+        $info = Get-Command TestFunction
+        $info.OutputType[0].Name | Should -BeExactly "System.String"
+        $info.Version | Should -BeExactly "2.4"
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Address #11667

Added new PSVersionAttribute class.
Added Version property to FunctionInfo and ExternalScriptInfo classes.

## PR Context

```powershell
function TestFunction
{
   [cmdletbinding()]
   [OutputType([int])]
   [PSVersionAttribute(1,2)]
   Param ($Parameter1)

   "test"
}

(Get-Command TestFunction).Version
```
Output:
```powershell
Major  Minor  Build  Revision
-----  -----  -----  --------
1      2      -1     -1
```
## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
