### PR TITLE
Refactor delegate types to lambda expressions

### DIFF
--- a/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/Innerlist.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/Innerlist.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Management.UI.Internal
         {
             Dispatcher.BeginInvoke(
                 DispatcherPriority.Background,
-                (DispatcherOperationCallback)((object arg) =>
+                (DispatcherOperationCallback)((arg) =>
                 {
                     if (this.IsLoaded)
                     {

--- a/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/Innerlist.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/Innerlist.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Management.UI.Internal
         {
             Dispatcher.BeginInvoke(
                 DispatcherPriority.Background,
-                (DispatcherOperationCallback)delegate(object arg)
+                (DispatcherOperationCallback)((object arg) =>
                 {
                     if (this.IsLoaded)
                     {
@@ -154,7 +154,7 @@ namespace Microsoft.Management.UI.Internal
                     }
 
                     return null;
-                },
+                }),
                 item);
         }
 

--- a/src/Microsoft.Management.UI.Internal/commandHelpers/HelpWindowHelper.cs
+++ b/src/Microsoft.Management.UI.Internal/commandHelpers/HelpWindowHelper.cs
@@ -30,13 +30,13 @@ namespace Microsoft.PowerShell.Commands.Internal
             {
                 ownerWindow.Dispatcher.Invoke(
                     new SendOrPostCallback(
-                        delegate(object ignored)
+                        (object ignored) =>
                         {
                             HelpWindow helpWindow = new HelpWindow(helpObj);
                             helpWindow.Owner = ownerWindow;
                             helpWindow.Show();
 
-                            helpWindow.Closed += new EventHandler(delegate(object sender, EventArgs e) { ownerWindow.Focus(); });
+                            helpWindow.Closed += new EventHandler((object sender, EventArgs e) => { ownerWindow.Focus(); });
                         }),
                         string.Empty);
                 return;

--- a/src/Microsoft.Management.UI.Internal/commandHelpers/HelpWindowHelper.cs
+++ b/src/Microsoft.Management.UI.Internal/commandHelpers/HelpWindowHelper.cs
@@ -30,13 +30,13 @@ namespace Microsoft.PowerShell.Commands.Internal
             {
                 ownerWindow.Dispatcher.Invoke(
                     new SendOrPostCallback(
-                        (object ignored) =>
+                        (_) =>
                         {
                             HelpWindow helpWindow = new HelpWindow(helpObj);
                             helpWindow.Owner = ownerWindow;
                             helpWindow.Show();
 
-                            helpWindow.Closed += new EventHandler((object sender, EventArgs e) => { ownerWindow.Focus(); });
+                            helpWindow.Closed += new EventHandler((sender, e) => ownerWindow.Focus());
                         }),
                         string.Empty);
                 return;

--- a/src/Microsoft.Management.UI.Internal/commandHelpers/OutGridView.cs
+++ b/src/Microsoft.Management.UI.Internal/commandHelpers/OutGridView.cs
@@ -409,7 +409,7 @@ namespace Microsoft.Management.UI.Internal
             this.managementList.Dispatcher.Invoke(
                 System.Windows.Threading.DispatcherPriority.Normal,
                 new Action(
-                    delegate()
+                    () =>
                     {
                         // Pick the length of the shortest incoming arrays. Normally all incoming arrays should be of the same length.
                         int length = propertyNames.Length;
@@ -461,19 +461,19 @@ namespace Microsoft.Management.UI.Internal
                             // Set focus on ListView
                             this.managementList.List.SelectedIndex = 0;
                             this.managementList.List.Focus();
-                       }
-                       catch (Exception e)
-                       {
-                           // Store the exception in a local variable that will be checked later.
-                           if (e.InnerException != null)
-                           {
-                               this.exception = e.InnerException;
-                           }
-                           else
-                           {
-                            this.exception = e;
-                           }
-                       }
+                        }
+                        catch (Exception e)
+                        {
+                            // Store the exception in a local variable that will be checked later.
+                            if (e.InnerException != null)
+                            {
+                                this.exception = e.InnerException;
+                            }
+                            else
+                            {
+                                this.exception = e;
+                            }
+                        }
                     }));
         }
 
@@ -492,7 +492,7 @@ namespace Microsoft.Management.UI.Internal
             this.managementList.Dispatcher.BeginInvoke(
                 System.Windows.Threading.DispatcherPriority.Normal,
                 new Action(
-                    delegate()
+                    () =>
                     {
                         try
                         {

--- a/src/Microsoft.Management.UI.Internal/commandHelpers/ShowCommandHelper.cs
+++ b/src/Microsoft.Management.UI.Internal/commandHelpers/ShowCommandHelper.cs
@@ -645,7 +645,7 @@ Function PSGetSerializedShowCommandInfo
             }
 
             ModuleViewModel moduleToSelect = returnValue.Modules.Find(
-                new Predicate<ModuleViewModel>((ModuleViewModel module) =>
+                new Predicate<ModuleViewModel>((module) =>
                 {
                     return module.Name.Equals(selectedModuleNeedingImportModule, StringComparison.OrdinalIgnoreCase) ? true : false;
                 }));
@@ -658,7 +658,7 @@ Function PSGetSerializedShowCommandInfo
             returnValue.SelectedModule = moduleToSelect;
 
             CommandViewModel commandToSelect = moduleToSelect.Commands.Find(
-                new Predicate<CommandViewModel>((CommandViewModel command) =>
+                new Predicate<CommandViewModel>((command) =>
                 {
                     return command.ModuleName.Equals(parentModuleNeedingImportModule, StringComparison.OrdinalIgnoreCase) &&
                         command.Name.Equals(commandNeedingImportModule, StringComparison.OrdinalIgnoreCase) ? true : false;
@@ -876,8 +876,8 @@ Function PSGetSerializedShowCommandInfo
         {
             window.Dispatcher.Invoke(
                 new SendOrPostCallback(
-                    (object ignored) => window.Activate()),
-                    string.Empty);
+                    (_) => window.Activate()),
+                string.Empty);
         }
 
         /// <summary>
@@ -936,7 +936,7 @@ Function PSGetSerializedShowCommandInfo
 
             this.hostWindow.Dispatcher.Invoke(
                 new SendOrPostCallback(
-                    (object ignored) =>
+                    (_) =>
                     {
                         Window childWindow = (Window)this.methodThatReturnsDialog.Invoke(null);
                         childWindow.Owner = this.hostWindow;
@@ -1031,7 +1031,7 @@ Function PSGetSerializedShowCommandInfo
             {
                 this.window.Dispatcher.Invoke(
                     new SendOrPostCallback(
-                        (object ignored) =>
+                        (_) =>
                         {
                             string message = ShowCommandHelper.GetImportModuleFailedMessage(
                                 this.commandNeedingImportModule,

--- a/src/Microsoft.Management.UI.Internal/commandHelpers/ShowCommandHelper.cs
+++ b/src/Microsoft.Management.UI.Internal/commandHelpers/ShowCommandHelper.cs
@@ -645,7 +645,7 @@ Function PSGetSerializedShowCommandInfo
             }
 
             ModuleViewModel moduleToSelect = returnValue.Modules.Find(
-                new Predicate<ModuleViewModel>(delegate(ModuleViewModel module)
+                new Predicate<ModuleViewModel>((ModuleViewModel module) =>
                 {
                     return module.Name.Equals(selectedModuleNeedingImportModule, StringComparison.OrdinalIgnoreCase) ? true : false;
                 }));
@@ -658,7 +658,7 @@ Function PSGetSerializedShowCommandInfo
             returnValue.SelectedModule = moduleToSelect;
 
             CommandViewModel commandToSelect = moduleToSelect.Commands.Find(
-                new Predicate<CommandViewModel>(delegate(CommandViewModel command)
+                new Predicate<CommandViewModel>((CommandViewModel command) =>
                 {
                     return command.ModuleName.Equals(parentModuleNeedingImportModule, StringComparison.OrdinalIgnoreCase) &&
                         command.Name.Equals(commandNeedingImportModule, StringComparison.OrdinalIgnoreCase) ? true : false;
@@ -876,10 +876,7 @@ Function PSGetSerializedShowCommandInfo
         {
             window.Dispatcher.Invoke(
                 new SendOrPostCallback(
-                    delegate(object ignored)
-                    {
-                        window.Activate();
-                    }),
+                    (object ignored) => window.Activate()),
                     string.Empty);
         }
 
@@ -896,7 +893,7 @@ Function PSGetSerializedShowCommandInfo
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called using reflection")]
         private void ShowAllModulesWindow(PSCmdlet cmdlet, Dictionary<string, ShowCommandModuleInfo> importedModules, IEnumerable<ShowCommandCommandInfo> commands, bool noCommonParameter, double windowWidth, double windowHeight, bool passThrough)
         {
-            this.methodThatReturnsDialog = new DispatcherOperationCallback(delegate(object ignored)
+            this.methodThatReturnsDialog = new DispatcherOperationCallback((object ignored) =>
             {
                 ShowAllModulesWindow allModulesWindow = new ShowAllModulesWindow();
                 this.allModulesViewModel = new AllModulesViewModel(importedModules, commands, noCommonParameter);
@@ -939,7 +936,7 @@ Function PSGetSerializedShowCommandInfo
 
             this.hostWindow.Dispatcher.Invoke(
                 new SendOrPostCallback(
-                    delegate(object ignored)
+                    (object ignored) =>
                     {
                         Window childWindow = (Window)this.methodThatReturnsDialog.Invoke(null);
                         childWindow.Owner = this.hostWindow;
@@ -967,7 +964,7 @@ Function PSGetSerializedShowCommandInfo
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called using reflection")]
         private void ShowCommandWindow(PSCmdlet cmdlet, object commandViewModelObj, double windowWidth, double windowHeight, bool passThrough)
         {
-            this.methodThatReturnsDialog = new DispatcherOperationCallback(delegate(object ignored)
+            this.methodThatReturnsDialog = new DispatcherOperationCallback((object ignored) =>
             {
                 this.commandViewModel = (CommandViewModel)commandViewModelObj;
                 ShowCommandWindow showCommandWindow = new ShowCommandWindow();
@@ -1034,7 +1031,7 @@ Function PSGetSerializedShowCommandInfo
             {
                 this.window.Dispatcher.Invoke(
                     new SendOrPostCallback(
-                        delegate(object ignored)
+                        (object ignored) =>
                         {
                             string message = ShowCommandHelper.GetImportModuleFailedMessage(
                                 this.commandNeedingImportModule,


### PR DESCRIPTION
# PR Summary

Fix CodeFactor issues from #11681 (space after delegate keyword):
* Refactor to use lambda expressions.
* Remove redundant type specifications (to fix codacy issues).
* Fix general style issues.

## PR Context
* #11681

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
