### PR TITLE
Move to version 3 of AzFileCopy

### DIFF
--- a/tools/releaseBuild/azureDevOps/WindowsBuild.yml
+++ b/tools/releaseBuild/azureDevOps/WindowsBuild.yml
@@ -332,7 +332,7 @@ jobs:
     continueOnError: true
     condition: and(succeeded(), eq(variables['Build.Reason'], 'Manual'))
 
-  - task: AzureFileCopy@1
+  - task: AzureFileCopy@3
     displayName: 'upload signed msi to Azure - x64'
     inputs:
       SourcePath: '$(Build.StagingDirectory)\signedPackages\PowerShell-$(Version)-win-x64.msi'
@@ -352,7 +352,7 @@ jobs:
     displayName: '[create script] upload signed msi - x86'
     continueOnError: true
 
-  - task: AzureFileCopy@1
+  - task: AzureFileCopy@3
     displayName: 'upload signed msi to Azure - x86'
     inputs:
       SourcePath: '$(Build.StagingDirectory)\signedPackages\PowerShell-$(Version)-win-x86.msi'
@@ -372,7 +372,7 @@ jobs:
     displayName: '[Create script] upload signed zip - x64'
     continueOnError: true
 
-  - task: AzureFileCopy@1
+  - task: AzureFileCopy@3
     displayName: 'upload signed zip to Azure - x64'
     inputs:
       SourcePath: '$(System.ArtifactsDirectory)\signed\PowerShell-$(Version)-win-x64.zip'
@@ -392,7 +392,7 @@ jobs:
     displayName: '[create script] upload signed zip - x86'
     continueOnError: true
 
-  - task: AzureFileCopy@1
+  - task: AzureFileCopy@3
     displayName: 'upload signed zip to Azure - x86'
     inputs:
       SourcePath: '$(System.ArtifactsDirectory)\signed\PowerShell-$(Version)-win-x86.zip'
@@ -412,7 +412,7 @@ jobs:
     displayName: '[create script] upload signed zip - arm'
     continueOnError: true
 
-  - task: AzureFileCopy@1
+  - task: AzureFileCopy@3
     displayName: 'upload signed zip to Azure - arm'
     inputs:
       SourcePath: '$(System.ArtifactsDirectory)\signed\PowerShell-$(Version)-win-arm32.zip'
@@ -432,7 +432,7 @@ jobs:
     displayName: '[create script] upload signed zip - arm64'
     continueOnError: true
 
-  - task: AzureFileCopy@1
+  - task: AzureFileCopy@3
     displayName: 'upload signed zip to Azure - arm64'
     inputs:
       SourcePath: '$(System.ArtifactsDirectory)\signed\PowerShell-$(Version)-win-arm64.zip'
@@ -452,7 +452,7 @@ jobs:
     displayName: '[create script] upload signed zip - fxdependent'
     continueOnError: true
 
-  - task: AzureFileCopy@1
+  - task: AzureFileCopy@3
     displayName: 'upload signed zip to Azure - fxdependent'
     inputs:
       SourcePath: '$(System.ArtifactsDirectory)\signed\PowerShell-$(Version)-win-fxdependent.zip'

--- a/tools/releaseBuild/azureDevOps/templates/json.yml
+++ b/tools/releaseBuild/azureDevOps/templates/json.yml
@@ -20,7 +20,7 @@ jobs:
       ReleaseTagVar: $(ReleaseTagVar)
       CreateJson: yes
 
-  - task: AzureFileCopy@1
+  - task: AzureFileCopy@3
     displayName: 'upload daily-build-info JSON file to Azure - ${{ parameters.architecture }}'
     inputs:
       SourcePath: '$(BuildInfoPath)'

--- a/tools/releaseBuild/azureDevOps/templates/linux.yml
+++ b/tools/releaseBuild/azureDevOps/templates/linux.yml
@@ -106,7 +106,7 @@ jobs:
       binVersionOverride: $(SigningVersionOverride)
     condition: and(and(succeeded(), eq(variables['SHOULD_SIGN'], 'true')),eq(variables['buildName'], 'RPM'))
 
-  - task: AzureFileCopy@1
+  - task: AzureFileCopy@3
     displayName: 'Upload to Azure - DEB and tar.gz'
     inputs:
       SourcePath: '$(System.ArtifactsDirectory)\finished\release'
@@ -119,7 +119,7 @@ jobs:
     parameters:
       artifactPath: $(System.ArtifactsDirectory)\finished\release
 
-  - task: AzureFileCopy@1
+  - task: AzureFileCopy@3
     displayName: 'Upload to Azure - RPM - Unsigned'
     inputs:
       SourcePath: '$(System.ArtifactsDirectory)\rpm\release'
@@ -129,7 +129,7 @@ jobs:
       ContainerName: '$(AzureVersion)'
     condition: and(and(succeeded(), ne(variables['SHOULD_SIGN'], 'true')),eq(variables['buildName'], 'RPM'))
 
-  - task: AzureFileCopy@1
+  - task: AzureFileCopy@3
     displayName: 'Upload to Azure - RPM - Signed'
     inputs:
       SourcePath: '$(Build.StagingDirectory)\signedPackages'

--- a/tools/releaseBuild/azureDevOps/templates/mac-package-signing.yml
+++ b/tools/releaseBuild/azureDevOps/templates/mac-package-signing.yml
@@ -87,7 +87,7 @@ jobs:
     displayName: 'Create unsigned folder to upload'
     condition: and(succeeded(), ne(variables['SHOULD_SIGN'], 'true'))
 
-  - task: AzureFileCopy@1
+  - task: AzureFileCopy@3
     displayName: 'AzureBlob File Copy - unsigned'
     inputs:
       SourcePath: '$(Build.StagingDirectory)\macos-unsigned'
@@ -97,7 +97,7 @@ jobs:
       ContainerName: '$(AzureVersion)'
     condition: and(succeeded(), ne(variables['SHOULD_SIGN'], 'true'))
 
-  - task: AzureFileCopy@1
+  - task: AzureFileCopy@3
     displayName: 'AzureBlob File Copy - signed'
     inputs:
       SourcePath: '$(System.ArtifactsDirectory)\azureMacOs'

--- a/tools/releaseBuild/azureDevOps/templates/nuget.yml
+++ b/tools/releaseBuild/azureDevOps/templates/nuget.yml
@@ -162,7 +162,7 @@ jobs:
       Get-ChildItem "$(System.ArtifactsDirectory)\signed\globaltool" -Recurse
     displayName: Move global tool packages to subfolder and capture
 
-  - task: AzureFileCopy@1
+  - task: AzureFileCopy@3
     displayName: 'Upload NuGet packages to Azure'
     inputs:
       SourcePath: '$(System.ArtifactsDirectory)\signed\'
@@ -172,7 +172,7 @@ jobs:
       ContainerName: '$(AzureVersion)-nuget'
     condition: and(succeeded(), eq(variables['SHOULD_SIGN'], 'true'))
 
-  - task: AzureFileCopy@1
+  - task: AzureFileCopy@3
     displayName: 'Upload global tool packages to Azure'
     inputs:
       sourcePath: '$(System.ArtifactsDirectory)\signed\globaltool'

--- a/tools/releaseBuild/azureDevOps/templates/upload.yml
+++ b/tools/releaseBuild/azureDevOps/templates/upload.yml
@@ -11,7 +11,7 @@ steps:
     artifactFilter: PowerShell-${{ parameters.version }}-win-${{ parameters.architecture }}.msi
     condition: and(succeeded(), eq('${{ parameters.msi }}', 'yes'))
 
-- task: AzureFileCopy@1
+- task: AzureFileCopy@3
   displayName: 'upload signed msi to Azure - ${{ parameters.architecture }}'
   inputs:
     SourcePath: '$(Build.StagingDirectory)\signedPackages\PowerShell-${{ parameters.version }}-win-${{ parameters.architecture }}.msi'
@@ -26,7 +26,7 @@ steps:
     artifactPath: $(System.ArtifactsDirectory)\signed
     artifactFilter: PowerShell-${{ parameters.version }}-win-${{ parameters.architecture }}.zip
 
-- task: AzureFileCopy@1
+- task: AzureFileCopy@3
   displayName: 'upload signed zip to Azure - ${{ parameters.architecture }}'
   inputs:
     SourcePath: '$(System.ArtifactsDirectory)\signed\PowerShell-${{ parameters.version }}-win-${{ parameters.architecture }}.zip'
@@ -42,7 +42,7 @@ steps:
     artifactFilter: PowerShell-${{ parameters.version }}-win-${{ parameters.architecture }}.msix
     condition: and(succeeded(), eq('${{ parameters.msix }}', 'yes'))
 
-- task: AzureFileCopy@1
+- task: AzureFileCopy@3
   displayName: 'upload signed msix to Azure - ${{ parameters.architecture }}'
   inputs:
     SourcePath: '$(Build.StagingDirectory)\signedPackages\PowerShell-${{ parameters.version }}-win-${{ parameters.architecture }}.msix'


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Move to version 3 of AzFileCopy

## PR Context

We are getting random file corruption during these phases.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
