### PR TITLE
Make `-OutFile` param in web cmdlets to work like -LiteralPath

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -763,7 +763,7 @@ namespace Microsoft.PowerShell.Commands
 
         private string QualifyFilePath(string path)
         {
-            string resolvedFilePath = PathUtils.ResolveFilePath(path, this, false);
+            string resolvedFilePath = PathUtils.ResolveFilePath(filePath: path, command: this, isLiteralPath: true);
             return resolvedFilePath;
         }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
@@ -187,10 +187,10 @@
     <value>Path '{0}' is not a file system path. Please specify the path to a file in the file system.</value>
   </data>
   <data name="OutFileMissing" xml:space="preserve">
-    <value>The cmdlet cannot run because the following parameter is missing: Path (or LiteralPath). Provide a valid Path (or LiteralPath) parameter value when using the {0} parameter, then retry.</value>
+    <value>The cmdlet cannot run because the following parameter is missing: OutFile. Provide a valid OutFile parameter value when using the {0} parameter, then retry.</value>
   </data>
   <data name="OutFileWritingSkipped" xml:space="preserve">
-    <value>The file will not be re-downloaded because the remote file is the same size as the output file: {0}</value>
+    <value>The file will not be re-downloaded because the remote file is the same size as the OutFile: {0}</value>
   </data>
   <data name="ProxyCredentialConflict" xml:space="preserve">
     <value>The cmdlet cannot run because the following conflicting parameters are specified: ProxyCredential and ProxyUseDefaultCredentials. Specify either ProxyCredential or ProxyUseDefaultCredentials, then retry.</value>
@@ -260,8 +260,5 @@
   </data>
   <data name="RetryVerboseMsg" xml:space="preserve">
     <value>Retrying after interval of {0} seconds. Status code for previous attempt: {1}</value>
-  </data>
-  <data name="CannotSpecifyPathAndLiteralPath" xml:space="preserve">
-    <value>You must specify either the -Path or -LiteralPath parameter, but not both.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
@@ -187,10 +187,10 @@
     <value>Path '{0}' is not a file system path. Please specify the path to a file in the file system.</value>
   </data>
   <data name="OutFileMissing" xml:space="preserve">
-    <value>The cmdlet cannot run because the following parameter is missing: OutFile. Provide a valid OutFile parameter value when using the {0} parameter, then retry.</value>
+    <value>The cmdlet cannot run because the following parameter is missing: Path (or LiteralPath). Provide a valid Path (or LiteralPath) parameter value when using the {0} parameter, then retry.</value>
   </data>
   <data name="OutFileWritingSkipped" xml:space="preserve">
-    <value>The file will not be re-downloaded because the remote file is the same size as the OutFile: {0}</value>
+    <value>The file will not be re-downloaded because the remote file is the same size as the output file: {0}</value>
   </data>
   <data name="ProxyCredentialConflict" xml:space="preserve">
     <value>The cmdlet cannot run because the following conflicting parameters are specified: ProxyCredential and ProxyUseDefaultCredentials. Specify either ProxyCredential or ProxyUseDefaultCredentials, then retry.</value>
@@ -260,5 +260,8 @@
   </data>
   <data name="RetryVerboseMsg" xml:space="preserve">
     <value>Retrying after interval of {0} seconds. Status code for previous attempt: {1}</value>
+  </data>
+  <data name="CannotSpecifyPathAndLiteralPath" xml:space="preserve">
+    <value>You must specify either the -Path or -LiteralPath parameter, but not both.</value>
   </data>
 </root>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -49,7 +49,7 @@ function ExecuteRequestWithOutFile {
         } else {
             Invoke-RestMethod -Uri $uri -OutFile $filePath
         }
-        $result.Output = Get-Content $filePath -Raw -ErrorAction SilentlyContinue
+        $result.Output = Get-Content -LiteralPath $filePath -Raw -ErrorAction SilentlyContinue
     } catch {
         $result.Error = $_
     } finally {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -814,25 +814,25 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
         $result.error | Should -Not -BeNullOrEmpty
     }
 
-    Context "Path and LigeralPath parameters work" {
+    Context "Path and LiteralPath parameters work" {
         BeforeAll {
             $uri = Get-WebListenerUrl -Test 'Get'
             $testOutfile1 = Join-Path $TestDrive "[outfile1].txt"
             $testOutfile2 = Join-Path $TestDrive "[outfile2].txt"
         }
 
-        It "Cannot use both Path and LigeralPath parameters" {
+        It "Cannot use both Path and LiteralPath parameters" {
             { Invoke-WebRequest -uri $uri -Path $testOutFile1 -LiteralPath $testOutFile1 -ErrorAction Stop } | Should -Throw -ErrorId "CannotSpecifyPAthAndLiteralPath,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
             { Invoke-RestMethod -uri $uri -Path $testOutFile1 -LiteralPath $testOutFile1 -ErrorAction Stop } | Should -Throw -ErrorId "CannotSpecifyPAthAndLiteralPath,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
         }
 
-        It "Path and LigeralPath parameters work in Invoke-WebRequest" {
+        It "Path and LiteralPath parameters work in Invoke-WebRequest" {
             { Invoke-WebRequest -uri $uri -Path $testOutFile1 -ErrorAction Stop } | Should -Throw -ErrorId "FileOpenFailure,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
             Invoke-WebRequest -uri $uri -LiteralPath $testOutFile1 -ErrorAction Stop
             Test-Path -LiteralPath $testOutFile1 | Should -BeTrue
         }
 
-        It "Path and LigeralPath parameters work in Invoke-RestMethod" {
+        It "Path and LiteralPath parameters work in Invoke-RestMethod" {
             { Invoke-RestMethod -uri $uri -Path $testOutFile1 -ErrorAction Stop } | Should -Throw -ErrorId "FileOpenFailure,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
             Invoke-RestMethod -uri $uri -LiteralPath $testOutFile2 -ErrorAction Stop
             Test-Path -LiteralPath $testOutFile2 | Should -BeTrue

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -27,7 +27,7 @@ function ExecuteWebCommand {
     return $result
 }
 
-# This function calls either Invoke-WebRequest or Invoke-RestMethod using the OutFile parameter
+# This function calls either Invoke-WebRequest or Invoke-RestMethod using the Path parameter
 # Then, the file content is read and return in a $result object.
 #
 function ExecuteRequestWithOutFile {
@@ -44,9 +44,9 @@ function ExecuteRequestWithOutFile {
     $filePath = Join-Path $TestDrive ((Get-Random).ToString() + ".txt")
     try {
         if ($cmdletName -eq "Invoke-WebRequest") {
-            Invoke-WebRequest -Uri $uri -OutFile $filePath
+            Invoke-WebRequest -Uri $uri -Path $filePath
         } else {
-            Invoke-RestMethod -Uri $uri -OutFile $filePath
+            Invoke-RestMethod -Uri $uri -Path $filePath
         }
         $result.Output = Get-Content $filePath -Raw -ErrorAction SilentlyContinue
     } catch {
@@ -641,7 +641,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
         }
     }
 
-    It "Validate Invoke-WebRequest -OutFile" {
+    It "Validate Invoke-WebRequest -Path" {
         $uri = Get-WebListenerUrl -Test 'Get'
         $result = ExecuteRequestWithOutFile -cmdletName "Invoke-WebRequest" -uri $uri
         $jsonContent = $result.Output | ConvertFrom-Json
@@ -812,6 +812,31 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
         $result = ExecuteWebCommand -Command $command
         $result.output | Should -BeNullOrEmpty
         $result.error | Should -Not -BeNullOrEmpty
+    }
+
+    Context "Path and LigeralPath parameters work" {
+        BeforeAll {
+            $uri = Get-WebListenerUrl -Test 'Get'
+            $testOutfile1 = Join-Path $TestDrive "[outfile1].txt"
+            $testOutfile2 = Join-Path $TestDrive "[outfile2].txt"
+        }
+
+        It "Cannot use both Path and LigeralPath parameters" {
+            { Invoke-WebRequest -uri $uri -Path $testOutFile1 -LiteralPath $testOutFile1 -ErrorAction Stop } | Should -Throw -ErrorId "CannotSpecifyPAthAndLiteralPath,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
+            { Invoke-RestMethod -uri $uri -Path $testOutFile1 -LiteralPath $testOutFile1 -ErrorAction Stop } | Should -Throw -ErrorId "CannotSpecifyPAthAndLiteralPath,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
+        }
+
+        It "Path and LigeralPath parameters work in Invoke-WebRequest" {
+            { Invoke-WebRequest -uri $uri -Path $testOutFile1 -ErrorAction Stop } | Should -Throw -ErrorId "FileOpenFailure,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
+            Invoke-WebRequest -uri $uri -LiteralPath $testOutFile1 -ErrorAction Stop
+            Test-Path -LiteralPath $testOutFile1 | Should -BeTrue
+        }
+
+        It "Path and LigeralPath parameters work in Invoke-RestMethod" {
+            { Invoke-RestMethod -uri $uri -Path $testOutFile1 -ErrorAction Stop } | Should -Throw -ErrorId "FileOpenFailure,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
+            Invoke-RestMethod -uri $uri -LiteralPath $testOutFile2 -ErrorAction Stop
+            Test-Path -LiteralPath $testOutFile2 | Should -BeTrue
+        }
     }
 
     Context "Redirect" {
@@ -1754,7 +1779,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
             # Download the entire file to reference in tests
             $referenceFile = Join-Path $TestDrive "reference.txt"
             $resumeUri = Get-WebListenerUrl -Test 'Resume'
-            Invoke-WebRequest -uri $resumeUri -OutFile $referenceFile -ErrorAction Stop
+            Invoke-WebRequest -uri $resumeUri -Path $referenceFile -ErrorAction Stop
             $referenceFileHash = Get-FileHash -Algorithm SHA256 -Path $referenceFile
             $referenceFileSize = Get-Item $referenceFile | Select-Object -ExpandProperty Length
         }
@@ -1763,13 +1788,13 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
             Remove-Item -Force -ErrorAction 'SilentlyContinue' -Path $outFile
         }
 
-        It "Invoke-WebRequest -Resume requires -OutFile" {
+        It "Invoke-WebRequest -Resume requires -Path" {
             { Invoke-WebRequest -Resume -Uri $resumeUri -ErrorAction Stop } |
                 Should -Throw -ErrorId 'WebCmdletOutFileMissingException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand'
         }
 
         It "Invoke-WebRequest -Resume Downloads the whole file when the file does not exist" {
-            $response = Invoke-WebRequest -uri $resumeUri -OutFile $outFile -Resume -PassThru
+            $response = Invoke-WebRequest -uri $resumeUri -Path $outFile -Resume -PassThru
 
             $outFileHash = Get-FileHash -Algorithm SHA256 -Path $outFile
             $outFileHash.Hash | Should -BeExactly $referenceFileHash.Hash
@@ -1786,7 +1811,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
             1..$largerFileSize | ForEach-Object { [Byte]$_ } | Set-Content -AsByteStream $outFile
             $largerFileSize = Get-Item $outFile | Select-Object -ExpandProperty Length
 
-            $response = Invoke-WebRequest -uri $resumeUri -OutFile $outFile -Resume -PassThru
+            $response = Invoke-WebRequest -uri $resumeUri -Path $outFile -Resume -PassThru
 
             $outFileHash = Get-FileHash -Algorithm SHA256 -Path $outFile
             $outFileHash.Hash | Should -BeExactly $referenceFileHash.Hash
@@ -1804,7 +1829,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
             $largerFileSize = Get-Item $outFile | Select-Object -ExpandProperty Length
 
             $uri = Get-WebListenerUrl -Test 'Resume' -TestValue 'NoResume'
-            $response = Invoke-WebRequest -Uri $uri -OutFile $outFile -Resume -PassThru
+            $response = Invoke-WebRequest -Uri $uri -Path $outFile -Resume -PassThru
 
             $outFileHash = Get-FileHash -Algorithm SHA256 -Path $outFile
             $outFileHash.Hash | Should -BeExactly $referenceFileHash.Hash
@@ -1824,10 +1849,10 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
             param($bytes, $statuscode)
             # Simulate partial download
             $uri = Get-WebListenerUrl -Test 'Resume' -TestValue "Bytes/$bytes"
-            $null = Invoke-WebRequest -uri $uri -OutFile $outFile
+            $null = Invoke-WebRequest -uri $uri -Path $outFile
             Get-Item $outFile | Select-Object -ExpandProperty Length | Should -Be $bytes
 
-            $response = Invoke-WebRequest -uri $resumeUri -OutFile $outFile -Resume -PassThru
+            $response = Invoke-WebRequest -uri $resumeUri -Path $outFile -Resume -PassThru
 
             $outFileHash = Get-FileHash -Algorithm SHA256 -Path $outFile
             $outFileHash.Hash | Should -BeExactly $referenceFileHash.Hash
@@ -1841,10 +1866,10 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
         It "Invoke-WebRequest -Resume assumes the file was successfully completed when the local and remote file are the same size." {
             # Download the entire file
             $uri = Get-WebListenerUrl -Test 'Resume' -TestValue 'NoResume'
-            $null = Invoke-WebRequest -uri $uri -OutFile $outFile
+            $null = Invoke-WebRequest -uri $uri -Path $outFile
             $fileSize = Get-Item $outFile | Select-Object -ExpandProperty Length
 
-            $response = Invoke-WebRequest -uri $resumeUri -OutFile $outFile -Resume -PassThru
+            $response = Invoke-WebRequest -uri $resumeUri -Path $outFile -Resume -PassThru
 
             $outFileHash = Get-FileHash -Algorithm SHA256 -Path $outFile
             $outFileHash.Hash | Should -BeExactly $referenceFileHash.Hash
@@ -2209,7 +2234,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
         }
     }
 
-    It "Validate Invoke-RestMethod -OutFile" {
+    It "Validate Invoke-RestMethod -Path" {
         $uri = Get-WebListenerUrl -Test 'Get'
         $result = ExecuteRequestWithOutFile -cmdletName "Invoke-RestMethod" -uri $uri
         $jsonContent = $result.Output | ConvertFrom-Json
@@ -3278,7 +3303,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
             # Download the entire file to reference in tests
             $referenceFile = Join-Path $TestDrive "reference.txt"
             $resumeUri = Get-WebListenerUrl -Test 'Resume'
-            Invoke-RestMethod -uri $resumeUri -OutFile $referenceFile -ErrorAction Stop
+            Invoke-RestMethod -uri $resumeUri -Path $referenceFile -ErrorAction Stop
             $referenceFileHash = Get-FileHash -Algorithm SHA256 -Path $referenceFile
             $referenceFileSize = Get-Item $referenceFile | Select-Object -ExpandProperty Length
         }
@@ -3287,7 +3312,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
             Remove-Item -Force -ErrorAction 'SilentlyContinue' -Path $outFile
         }
 
-        It "Invoke-RestMethod -Resume requires -OutFile" {
+        It "Invoke-RestMethod -Resume requires -Path" {
             { Invoke-RestMethod -Resume -Uri $resumeUri -ErrorAction Stop } |
                 Should -Throw -ErrorId 'WebCmdletOutFileMissingException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand'
         }
@@ -3296,7 +3321,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
             # ensure the file does not exist
             Remove-Item -Force -ErrorAction 'SilentlyContinue' -Path $outFile
 
-            Invoke-RestMethod -uri $resumeUri -OutFile $outFile -ResponseHeadersVariable 'Headers' -Resume
+            Invoke-RestMethod -uri $resumeUri -Path $outFile -ResponseHeadersVariable 'Headers' -Resume
 
             $outFileHash = Get-FileHash -Algorithm SHA256 -Path $outFile
             $outFileHash.Hash | Should -BeExactly $referenceFileHash.Hash
@@ -3312,7 +3337,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
             1..$largerFileSize | ForEach-Object { [Byte]$_ } | Set-Content -AsByteStream $outFile
             $largerFileSize = Get-Item $outFile | Select-Object -ExpandProperty Length
 
-            $response = Invoke-RestMethod -uri $resumeUri -OutFile $outFile -ResponseHeadersVariable 'Headers' -Resume
+            $response = Invoke-RestMethod -uri $resumeUri -Path $outFile -ResponseHeadersVariable 'Headers' -Resume
 
             $outFileHash = Get-FileHash -Algorithm SHA256 -Path $outFile
             $outFileHash.Hash | Should -BeExactly $referenceFileHash.Hash
@@ -3329,7 +3354,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
             $largerFileSize = Get-Item $outFile | Select-Object -ExpandProperty Length
 
             $uri = Get-WebListenerUrl -Test 'Resume' -TestValue 'NoResume'
-            $response = Invoke-RestMethod -uri $uri -OutFile $outFile -ResponseHeadersVariable 'Headers' -Resume
+            $response = Invoke-RestMethod -uri $uri -Path $outFile -ResponseHeadersVariable 'Headers' -Resume
 
             $outFileHash = Get-FileHash -Algorithm SHA256 -Path $outFile
             $outFileHash.Hash | Should -BeExactly $referenceFileHash.Hash
@@ -3349,10 +3374,10 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
             param($bytes)
             # Simulate partial download
             $uri = Get-WebListenerUrl -Test 'Resume' -TestValue "Bytes/$bytes"
-            $null = Invoke-RestMethod -uri $uri -OutFile $outFile
+            $null = Invoke-RestMethod -uri $uri -Path $outFile
             Get-Item $outFile | Select-Object -ExpandProperty Length | Should -Be $bytes
 
-            $response = Invoke-RestMethod -uri $resumeUri -OutFile $outFile -ResponseHeadersVariable 'Headers' -Resume
+            $response = Invoke-RestMethod -uri $resumeUri -Path $outFile -ResponseHeadersVariable 'Headers' -Resume
 
             $outFileHash = Get-FileHash -Algorithm SHA256 -Path $outFile
             $outFileHash.Hash | Should -BeExactly $referenceFileHash.Hash
@@ -3365,10 +3390,10 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
         It "Invoke-RestMethod -Resume assumes the file was successfully completed when the local and remote file are the same size." {
             # Download the entire file
             $uri = Get-WebListenerUrl -Test 'Resume' -TestValue 'NoResume'
-            $null = Invoke-RestMethod -uri $uri -OutFile $outFile
+            $null = Invoke-RestMethod -uri $uri -Path $outFile
             $fileSize = Get-Item $outFile | Select-Object -ExpandProperty Length
 
-            $response = Invoke-RestMethod -uri $resumeUri -OutFile $outFile -ResponseHeadersVariable 'Headers' -Resume
+            $response = Invoke-RestMethod -uri $resumeUri -Path $outFile -ResponseHeadersVariable 'Headers' -Resume
 
             $outFileHash = Get-FileHash -Algorithm SHA256 -Path $outFile
             $outFileHash.Hash | Should -BeExactly $referenceFileHash.Hash

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -814,25 +814,25 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
         $result.error | Should -Not -BeNullOrEmpty
     }
 
-    Context "Path and LiteralPath parameters work" {
+    Context "Path and LigeralPath parameters work" {
         BeforeAll {
             $uri = Get-WebListenerUrl -Test 'Get'
             $testOutfile1 = Join-Path $TestDrive "[outfile1].txt"
             $testOutfile2 = Join-Path $TestDrive "[outfile2].txt"
         }
 
-        It "Cannot use both Path and LiteralPath parameters" {
+        It "Cannot use both Path and LigeralPath parameters" {
             { Invoke-WebRequest -uri $uri -Path $testOutFile1 -LiteralPath $testOutFile1 -ErrorAction Stop } | Should -Throw -ErrorId "CannotSpecifyPAthAndLiteralPath,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
             { Invoke-RestMethod -uri $uri -Path $testOutFile1 -LiteralPath $testOutFile1 -ErrorAction Stop } | Should -Throw -ErrorId "CannotSpecifyPAthAndLiteralPath,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
         }
 
-        It "Path and LiteralPath parameters work in Invoke-WebRequest" {
+        It "Path and LigeralPath parameters work in Invoke-WebRequest" {
             { Invoke-WebRequest -uri $uri -Path $testOutFile1 -ErrorAction Stop } | Should -Throw -ErrorId "FileOpenFailure,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
             Invoke-WebRequest -uri $uri -LiteralPath $testOutFile1 -ErrorAction Stop
             Test-Path -LiteralPath $testOutFile1 | Should -BeTrue
         }
 
-        It "Path and LiteralPath parameters work in Invoke-RestMethod" {
+        It "Path and LigeralPath parameters work in Invoke-RestMethod" {
             { Invoke-RestMethod -uri $uri -Path $testOutFile1 -ErrorAction Stop } | Should -Throw -ErrorId "FileOpenFailure,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
             Invoke-RestMethod -uri $uri -LiteralPath $testOutFile2 -ErrorAction Stop
             Test-Path -LiteralPath $testOutFile2 | Should -BeTrue

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -41,7 +41,8 @@ function ExecuteRequestWithOutFile {
     )
 
     $result = [PSObject]@{Output = $null; Error = $null}
-    $filePath = Join-Path $TestDrive ((Get-Random).ToString() + ".txt")
+    # We use '[outfile1]' in the file name to check that OutFile parameter is literal path
+    $filePath = Join-Path $TestDrive ((Get-Random).ToString() + "[outfile1].txt")
     try {
         if ($cmdletName -eq "Invoke-WebRequest") {
             Invoke-WebRequest -Uri $uri -OutFile $filePath


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Now OutFile parameter in Invoke-WebRequest and Invoke-RestMethod works like LiteralPath and does not process wildcards.


## PR Context

Fix #3174 - approved by PowerShell Committee.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/5653
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
