### PR TITLE
Use dedicated threads to read the redirected output and error streams from the child process for out-of-proc jobs

### DIFF
--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -1187,9 +1187,12 @@ namespace System.Management.Automation.Remoting.Client
                 }
                 catch (Exception e)
                 {
-                    string errorMsg = e.Message ?? string.Empty;
-                    _tracer.WriteMessage("OutOfProcessClientSessionTransportManager", "ProcessOutputThread", Guid.Empty,
-                        "Transport manager output reader thread ended with error: {0}", errorMsg);
+                    _tracer.WriteMessage(
+                        "OutOfProcessClientSessionTransportManager",
+                        "ProcessOutputThread",
+                        Guid.Empty,
+                        "Transport manager output reader thread ended with error: {0}",
+                        e.Message ?? string.Empty);
                 }
             }
             else
@@ -1217,9 +1220,12 @@ namespace System.Management.Automation.Remoting.Client
                 }
                 catch (Exception e)
                 {
-                    string errorMsg = e.Message ?? string.Empty;
-                    _tracer.WriteMessage("OutOfProcessClientSessionTransportManager", "ProcessErrorThread", Guid.Empty,
-                        "Transport manager error reader thread ended with error: {0}", errorMsg);
+                    _tracer.WriteMessage(
+                        "OutOfProcessClientSessionTransportManager",
+                        "ProcessErrorThread",
+                        Guid.Empty,
+                        "Transport manager error reader thread ended with error: {0}",
+                        e.Message ?? string.Empty);
                 }
             }
             else

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -1098,7 +1098,6 @@ namespace System.Management.Automation.Remoting.Client
                 {
                     _processCreated = false;
                 }
-                // _processInstance.Start();
             }
 
             PSEtwLog.LogAnalyticInformational(PSEventId.WSManCreateShell, PSOpcode.Connect,
@@ -1278,8 +1277,6 @@ namespace System.Management.Automation.Remoting.Client
 
                     if (_processCreated)
                     {
-                        _serverProcess.CancelOutputRead();
-                        _serverProcess.CancelErrorRead();
                         _serverProcess.Kill();
                     }
                 }

--- a/test/powershell/engine/Job/Jobs.Tests.ps1
+++ b/test/powershell/engine/Job/Jobs.Tests.ps1
@@ -344,14 +344,12 @@ Describe 'Basic Job Tests' -Tags 'Feature' {
             $job = Start-Job { $pid }
             $processId = Receive-Job $job -Wait
 
-            # The job is done, wait for the cleanup to finish.
-            Wait-UntilTrue {
-                $null -eq (Get-Process -Id $processId -ErrorAction Ignore)
-            } -IntervalInMilliseconds 300 | Should -BeTrue
-
-            # Double check that we cannot find the process.
-            { Get-Process -Id $processId -ErrorAction Stop } | Should -Throw `
-                -ErrorId 'NoProcessFoundForGivenId,Microsoft.PowerShell.Commands.GetProcessCommand'
+            try {
+                $process = Get-Process -Id $processId -ErrorAction Stop
+                Wait-UntilTrue { $process.HasExited } -IntervalInMilliseconds 300 | Should -BeTrue
+            } catch {
+                $_.FullyQualifiedErrorId | Should -BeExactly 'NoProcessFoundForGivenId,Microsoft.PowerShell.Commands.GetProcessCommand'
+            }
 
             Remove-Job $job -Force
         }
@@ -365,13 +363,13 @@ Describe 'Basic Job Tests' -Tags 'Feature' {
 
             # Stop the job and wait for the cleanup to finish.
             Stop-Job $job
-            Wait-UntilTrue {
-                $null -eq (Get-Process -Id $processId -ErrorAction Ignore)
-            } -IntervalInMilliseconds 300 | Should -BeTrue
 
-            # Double check that we cannot find the process.
-            { Get-Process -Id $processId -ErrorAction Stop } | Should -Throw `
-                -ErrorId 'NoProcessFoundForGivenId,Microsoft.PowerShell.Commands.GetProcessCommand'
+            try {
+                $process = Get-Process -Id $processId -ErrorAction Stop
+                Wait-UntilTrue { $process.HasExited } -IntervalInMilliseconds 300 | Should -BeTrue
+            } catch {
+                $_.FullyQualifiedErrorId | Should -BeExactly 'NoProcessFoundForGivenId,Microsoft.PowerShell.Commands.GetProcessCommand'
+            }
 
             Remove-Job $job -Force
         }
@@ -385,13 +383,13 @@ Describe 'Basic Job Tests' -Tags 'Feature' {
 
             # Remove the job and wait for the cleanup to finish.
             Remove-Job $job -Force
-            Wait-UntilTrue {
-                $null -eq (Get-Process -Id $processId -ErrorAction Ignore)
-            } -IntervalInMilliseconds 300 | Should -BeTrue
 
-            # Double check that we cannot find the process.
-            { Get-Process -Id $processId -ErrorAction Stop } | Should -Throw `
-                -ErrorId 'NoProcessFoundForGivenId,Microsoft.PowerShell.Commands.GetProcessCommand'
+            try {
+                $process = Get-Process -Id $processId -ErrorAction Stop
+                Wait-UntilTrue { $process.HasExited } -IntervalInMilliseconds 300 | Should -BeTrue
+            } catch {
+                $_.FullyQualifiedErrorId | Should -BeExactly 'NoProcessFoundForGivenId,Microsoft.PowerShell.Commands.GetProcessCommand'
+            }
         }
     }
 }


### PR DESCRIPTION
# PR Summary

Fix #11659
Use dedicated threads to read the redirected output and error streams from the child process for out-of-proc jobs.

## PR Context

Currently, when `Start-Job` starts a child PowerShell process, it depends on the `Process` events `OutputDataReceived` and `ErrorDataReceived` to handle messages from the output and error streams.
Internally, the `Process` implementation uses 2 thread-pool threads to read messages from those 2 streams. Even though the implementation calls `stream.ReadAsync` on those 2 streams, the actual read operation is synchronous because the underlying Win32 API `CreatePipe()` only allows the pipe handle to be created in `"synchronous"` mode.

This results in 2 thread-pool threads being held up indefinitely for each out-of-proc job created. When more out-of-proc jobs are created at the same time, it quickly depletes the thread pool, and causing thread starvation for other tasks that depend on thread-pool threads until the thread pool manager realize it's time to increase the pool.

**Thread-pool threads should be used for transient tasks that finish quickly, not for long-running tasks. In this case, reading from pipe in a blocking manner is obviously a long-running tasks and should be done with dedicated threads.**

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
