### PR TITLE
Update changelog generation script

### DIFF
--- a/CHANGELOG/6.2.md
+++ b/CHANGELOG/6.2.md
@@ -1,6 +1,6 @@
 # 6.2 Changelog
 
-## v6.2.4 - 01/27/2020
+## [6.2.4] - 2020-01-27
 
 ### General Cmdlet Updates and Fixes
 
@@ -794,6 +794,7 @@
 - Update `CONTRIBUTION.md` about adding an empty line after the copyright header (#7706) (Thanks @iSazonov!)
 - Update docs about .NET Core version `2.0` to be about version `2.x` (#7467) (Thanks @bergmeister!)
 
+[6.2.4]: https://github.com/PowerShell/PowerShell/compare/v6.2.3...v6.2.4
 [6.2.3]: https://github.com/PowerShell/PowerShell/compare/v6.2.2...v6.2.3
 [6.2.2]: https://github.com/PowerShell/PowerShell/compare/v6.2.1...v6.2.2
 [6.2.1]: https://github.com/PowerShell/PowerShell/compare/v6.2.0...v6.2.1

--- a/tools/releaseTools.psm1
+++ b/tools/releaseTools.psm1
@@ -137,10 +137,10 @@ function New-CommitNode
 function Get-ChangeLog
 {
     param(
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [string]$LastReleaseTag,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $false)]
         [string]$ThisReleaseTag,
 
         [Parameter(Mandatory)]
@@ -333,9 +333,18 @@ function Get-ChangeLog
 
     # Output the changelog
 
-    $thisRelease = $ThisReleaseTag.TrimStart('v')
+    $base = $LastReleaseTag
 
-    Write-Output "## [${thisRelease}] - $(Get-Date -Format yyyy-MM-dd)`n"
+    if ($PSBoundParameters.ContainsKey('ThisReleaseTag')) {
+        $head = $ThisReleaseTag
+        $version = $ThisReleaseTag.TrimStart('v')
+    }
+    else {
+        $head = $(git rev-parse HEAD)
+        $version = 'Unreleased'
+    }
+
+    Write-Output "## [${version}] - $(Get-Date -Format yyyy-MM-dd)`n"
 
     PrintChangeLog -clSection $clUntagged -sectionTitle 'UNTAGGED - Please classify'
     PrintChangeLog -clSection $clBreakingChange -sectionTitle 'Breaking Changes'
@@ -349,7 +358,7 @@ function Get-ChangeLog
     PrintChangeLog -clSection $clBuildPackage -sectionTitle 'Build and Packaging Improvements'
     PrintChangeLog -clSection $clDocs -sectionTitle 'Documentation and Help Content'
 
-    Write-Output "[${thisRelease}]: https://github.com/PowerShell/PowerShell/compare/${LastReleaseTag}...${ThisReleaseTag}`n"
+    Write-Output "[${version}]: https://github.com/PowerShell/PowerShell/compare/${base}...${head}`n"
 }
 
 function PrintChangeLog($clSection, $sectionTitle) {

--- a/tools/releaseTools.psm1
+++ b/tools/releaseTools.psm1
@@ -140,7 +140,7 @@ function Get-ChangeLog
         [Parameter(Mandatory = $true)]
         [string]$LastReleaseTag,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $true)]
         [string]$ThisReleaseTag,
 
         [Parameter(Mandatory)]
@@ -331,18 +331,9 @@ function Get-ChangeLog
         throw "Some PRs are tagged multiple times or have no tags."
     }
 
-    # Output the changelog
+    # Write output
 
-    $base = $LastReleaseTag
-
-    if ($PSBoundParameters.ContainsKey('ThisReleaseTag')) {
-        $head = $ThisReleaseTag
-        $version = $ThisReleaseTag.TrimStart('v')
-    }
-    else {
-        $head = $(git rev-parse HEAD)
-        $version = 'Unreleased'
-    }
+    $version = $ThisReleaseTag.TrimStart('v')
 
     Write-Output "## [${version}] - $(Get-Date -Format yyyy-MM-dd)`n"
 
@@ -358,7 +349,7 @@ function Get-ChangeLog
     PrintChangeLog -clSection $clBuildPackage -sectionTitle 'Build and Packaging Improvements'
     PrintChangeLog -clSection $clDocs -sectionTitle 'Documentation and Help Content'
 
-    Write-Output "[${version}]: https://github.com/PowerShell/PowerShell/compare/${base}...${head}`n"
+    Write-Output "[${version}]: https://github.com/PowerShell/PowerShell/compare/${$LastReleaseTag}...${ThisReleaseTag}`n"
 }
 
 function PrintChangeLog($clSection, $sectionTitle) {

--- a/tools/releaseTools.psm1
+++ b/tools/releaseTools.psm1
@@ -141,6 +141,9 @@ function Get-ChangeLog
         [string]$LastReleaseTag,
 
         [Parameter(Mandatory)]
+        [string]$ThisReleaseTag,
+
+        [Parameter(Mandatory)]
         [string]$Token,
 
         [Parameter()]
@@ -328,6 +331,12 @@ function Get-ChangeLog
         throw "Some PRs are tagged multiple times or have no tags."
     }
 
+    # Output the changelog
+
+    $thisRelease = $ThisReleaseTag.TrimStart('v')
+
+    Write-Output "## [${thisRelease}] - $(Get-Date -Format yyyy-MM-dd)`n"
+
     PrintChangeLog -clSection $clUntagged -sectionTitle 'UNTAGGED - Please classify'
     PrintChangeLog -clSection $clBreakingChange -sectionTitle 'Breaking Changes'
     PrintChangeLog -clSection $clEngine -sectionTitle 'Engine Updates and Fixes'
@@ -339,29 +348,6 @@ function Get-ChangeLog
     PrintChangeLog -clSection $clTest -sectionTitle 'Tests'
     PrintChangeLog -clSection $clBuildPackage -sectionTitle 'Build and Packaging Improvements'
     PrintChangeLog -clSection $clDocs -sectionTitle 'Documentation and Help Content'
-}
-
-function Get-ChangeLogEx
-{
-    param(
-        [Parameter(Mandatory)]
-        [string]$LastReleaseTag,
-
-        [Parameter(Mandatory)]
-        [string]$ThisReleaseTag,
-
-        [Parameter(Mandatory)]
-        [string]$Token,
-
-        [Parameter()]
-        [switch]$HasCherryPick
-    )
-
-    $thisRelease = $ThisReleaseTag.TrimStart('v')
-
-    Write-Output "## [${thisRelease}] - $(Get-Date -Format yyyy-MM-dd)`n"
-
-    Get-ChangeLog -LastReleaseTag:$LastReleaseTag -Token:$Token -HasCherryPick:$HasCherryPick
 
     Write-Output "[${thisRelease}]: https://github.com/PowerShell/PowerShell/compare/${LastReleaseTag}...${ThisReleaseTag}`n"
 }
@@ -621,4 +607,4 @@ function Update-PsVersionInCode
                 }
 }
 
-Export-ModuleMember -Function Get-ChangeLog, Get-ChangeLogEx, Get-NewOfficalPackage, Update-PsVersionInCode
+Export-ModuleMember -Function Get-ChangeLog, Get-NewOfficalPackage, Update-PsVersionInCode

--- a/tools/releaseTools.psm1
+++ b/tools/releaseTools.psm1
@@ -341,6 +341,31 @@ function Get-ChangeLog
     PrintChangeLog -clSection $clDocs -sectionTitle 'Documentation and Help Content'
 }
 
+function Get-ChangeLogEx
+{
+    param(
+        [Parameter(Mandatory)]
+        [string]$LastReleaseTag,
+
+        [Parameter(Mandatory)]
+        [string]$ThisReleaseTag,
+
+        [Parameter(Mandatory)]
+        [string]$Token,
+
+        [Parameter()]
+        [switch]$HasCherryPick
+    )
+
+    $thisRelease = $ThisReleaseTag.TrimStart('v')
+
+    Write-Output "## [${thisRelease}] - $(Get-Date -Format yyyy-MM-dd)`n"
+
+    Get-ChangeLog -LastReleaseTag:$LastReleaseTag -Token:$Token -HasCherryPick:$HasCherryPick
+
+    Write-Output "[${thisRelease}]: https://github.com/PowerShell/PowerShell/compare/${LastReleaseTag}...${ThisReleaseTag}`n"
+}
+
 function PrintChangeLog($clSection, $sectionTitle) {
     if ($clSection.Count -gt 0) {
         "### $sectionTitle`n"
@@ -596,4 +621,4 @@ function Update-PsVersionInCode
                 }
 }
 
-Export-ModuleMember -Function Get-ChangeLog, Get-NewOfficalPackage, Update-PsVersionInCode
+Export-ModuleMember -Function Get-ChangeLog, Get-ChangeLogEx, Get-NewOfficalPackage, Update-PsVersionInCode

--- a/tools/releaseTools.psm1
+++ b/tools/releaseTools.psm1
@@ -343,7 +343,7 @@ function Get-ChangeLog
 
 function PrintChangeLog($clSection, $sectionTitle) {
     if ($clSection.Count -gt 0) {
-        "### $sectionTitle"
+        "### $sectionTitle`n"
         $clSection | ForEach-Object -MemberName ChangeLogMessage
         ""
     }


### PR DESCRIPTION
# PR Summary

* Fix regression from #11652
* Fix [MD022](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md032---lists-should-be-surrounded-by-blank-lines) / [MD032](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md032---lists-should-be-surrounded-by-blank-lines) rule violations
* Modify `Get-ChangeLog` to generate the changelog according to the format from #11652.

## PR Context

Follow-up to #11652

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
