### PR TITLE
Replace hardcode linefeed

### DIFF
--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -8059,7 +8059,7 @@ namespace System.Management.Automation.Language
         /// <returns></returns>
         public override string ToString()
         {
-            return PositionUtilities.VerboseMessage(Extent) + "\n" + Message;
+            return PositionUtilities.VerboseMessage(Extent) + Environment.NewLine + Message;
         }
 
         /// <summary>

--- a/test/powershell/Language/Parser/Parsing.Tests.ps1
+++ b/test/powershell/Language/Parser/Parsing.Tests.ps1
@@ -459,3 +459,20 @@ Describe "Ternary Operator parsing" -Tags CI {
         $expr.IfFalse | Should -BeOfType System.Management.Automation.Language.ConstantExpressionAst
     }
 }
+
+Describe "ParserError type tests" -Tag CI {
+    # This test was added because there use to be a hardcoded newline in the ToString() method of
+    # the ParseError class. This makes sure the proper newlines are used.
+    It "Should use consistant newline depending on OS" {
+        $expected = @'
+At line:1 char:5
++ $x =
++     ~
+You must provide a value expression following the '=' operator.
+'@
+
+        $ers = $null
+        [System.Management.Automation.Language.Parser]::ParseInput('$x =', [ref]$null, [ref]$ers) | Out-Null
+        $ers[0].ToString() | Should -BeExactly $expected
+    }
+}

--- a/test/powershell/Language/Parser/Parsing.Tests.ps1
+++ b/test/powershell/Language/Parser/Parsing.Tests.ps1
@@ -464,15 +464,18 @@ Describe "ParserError type tests" -Tag CI {
     # This test was added because there use to be a hardcoded newline in the ToString() method of
     # the ParseError class. This makes sure the proper newlines are used.
     It "Should use consistant newline depending on OS" {
-        $expected = @'
-At line:1 char:5
-+ $x =
-+     ~
-You must provide a value expression following the '=' operator.
-'@
-
         $ers = $null
         [System.Management.Automation.Language.Parser]::ParseInput('$x =', [ref]$null, [ref]$ers) | Out-Null
-        $ers[0].ToString() | Should -BeExactly $expected
+        $measureResult = $ers[0].ToString() -split [System.Environment]::NewLine | Measure-Object
+
+        # We expect the string to have 4 lines. That means that if we split by NewLine for that platform,
+        # We should have 4 as the count.
+        $measureResult.Count | Should -BeExactly 4
+
+        # Just checking the above is not enough. We should also make sure that on non-Windows, there are no
+        # `r`n
+        if (!$IsWindows) {
+            $measureResult = $ers[0].ToString() | Should -Not -Contain "`r`n"
+        }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

I've moved it over to using `Environment.NewLine`. I added a test to test this specific thing... but maybe in the future we can put that test in a "crossplat" test file that checks all of our `ToString`'s to make sure they honor the newline for the platform.

## PR Context

There was a hardcoded line feed in the `ToString` method of `ParseError`. this caused a [CI test failure in the Jupyter kernel](https://github.com/dotnet/interactive/pull/9) because on Windows, there would be all `\r\n` except for this single instance of `\n`.

Tooling could be impacted, but from my look around the tooling code, I don't think it would be.

This is a breaking change, albeit small... and worth it IMO.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
