### PR TITLE
Avoid caching ProviderInfo.FullName at init time

### DIFF
--- a/src/System.Management.Automation/engine/DataStoreAdapterProvider.cs
+++ b/src/System.Management.Automation/engine/DataStoreAdapterProvider.cs
@@ -50,35 +50,37 @@ namespace System.Management.Automation
         {
             get
             {
-                string GetFullName(string name, string psSnapInName, string moduleName)
-                {
-                    string result = name;
-                    if (!string.IsNullOrEmpty(psSnapInName))
-                    {
-                        result =
-                            string.Format(
-                                System.Globalization.CultureInfo.InvariantCulture,
-                                "{0}\\{1}",
-                                psSnapInName,
-                                name);
-                    }
-
-                    // After converting core snapins to load as modules, the providers will have Module property populated
-                    else if (!string.IsNullOrEmpty(moduleName))
-                    {
-                        result =
-                            string.Format(
-                                System.Globalization.CultureInfo.InvariantCulture,
-                                "{0}\\{1}",
-                                moduleName,
-                                name);
-                    }
-
-                    return result;
-                }
-
-                return _fullName ?? (_fullName = GetFullName(Name, PSSnapInName, ModuleName));
+                return _fullName ?? (_fullName = GetFullName());
             }
+        }
+
+        internal string GetFullName() => EvaluateFullName(Name, PSSnapInName, ModuleName);
+
+        private string EvaluateFullName(string name, string psSnapInName, string moduleName)
+        {
+            string result = name;
+            if (!string.IsNullOrEmpty(psSnapInName))
+            {
+                result =
+                    string.Format(
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        "{0}\\{1}",
+                        psSnapInName,
+                        name);
+            }
+
+            // After converting core snapins to load as modules, the providers will have Module property populated
+            else if (!string.IsNullOrEmpty(moduleName))
+            {
+                result =
+                    string.Format(
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        "{0}\\{1}",
+                        moduleName,
+                        name);
+            }
+
+            return result;
         }
 
         /// <summary>
@@ -411,10 +413,10 @@ namespace System.Management.Automation
 
             // Create the hidden drive. The name doesn't really
             // matter since we are not adding this drive to a scope.
-
+            // Use GetFullName() to avoid caching full name at init time.
             _hiddenDrive =
                 new PSDriveInfo(
-                    this.FullName,
+                    GetFullName(),
                     this,
                     string.Empty,
                     string.Empty,

--- a/src/System.Management.Automation/engine/DataStoreAdapterProvider.cs
+++ b/src/System.Management.Automation/engine/DataStoreAdapterProvider.cs
@@ -54,30 +54,28 @@ namespace System.Management.Automation
             }
         }
 
-        internal string GetFullName() => EvaluateFullName(Name, PSSnapInName, ModuleName);
-
-        private string EvaluateFullName(string name, string psSnapInName, string moduleName)
+        internal string GetFullName()
         {
-            string result = name;
-            if (!string.IsNullOrEmpty(psSnapInName))
+            string result = Name;
+            if (!string.IsNullOrEmpty(PSSnapInName))
             {
                 result =
                     string.Format(
                         System.Globalization.CultureInfo.InvariantCulture,
                         "{0}\\{1}",
-                        psSnapInName,
-                        name);
+                        PSSnapInName,
+                        Name);
             }
 
             // After converting core snapins to load as modules, the providers will have Module property populated
-            else if (!string.IsNullOrEmpty(moduleName))
+            else if (!string.IsNullOrEmpty(ModuleName))
             {
                 result =
                     string.Format(
                         System.Globalization.CultureInfo.InvariantCulture,
                         "{0}\\{1}",
-                        moduleName,
-                        name);
+                        ModuleName,
+                        Name);
             }
 
             return result;

--- a/src/System.Management.Automation/engine/SessionStateProviderAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateProviderAPIs.cs
@@ -1056,8 +1056,8 @@ namespace System.Management.Automation
                     }
 
                     // Only mount drives for the current provider
-
-                    if (!provider.NameEquals(newDrive.Provider.FullName))
+                    // Use GetFullName() to avoid caching full name at init time.
+                    if (!provider.NameEquals(newDrive.Provider.GetFullName()))
                     {
                         continue;
                     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Address #9840

In #8831 we added caching for ProviderInfo.FullName. It came a problem in scenario of loading nested module. PowerShell change nested module name to root module name after it is loaded the nested module. In the scenario ProviderInfo.FullName is cached with nested module name and not updated to root module name.
The fix is to do not cache ProviderInfo.FullName at init time. After modules are loaded and cached name is safely used.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
