### PR TITLE
Fix NRE in ActionPreference parameters

### DIFF
--- a/src/System.Management.Automation/engine/CommonCommandParameters.cs
+++ b/src/System.Management.Automation/engine/CommonCommandParameters.cs
@@ -78,6 +78,7 @@ namespace System.Management.Automation.Internal
         /// This parameter tells the command what to do when an error occurs.
         /// </remarks>
         [Parameter]
+        [ValidateNotNull]
         [Alias("ea")]
         public ActionPreference ErrorAction
         {
@@ -94,6 +95,7 @@ namespace System.Management.Automation.Internal
         /// occurs.
         /// </remarks>
         [Parameter]
+        [ValidateNotNull]
         [Alias("wa")]
         public ActionPreference WarningAction
         {
@@ -115,6 +117,7 @@ namespace System.Management.Automation.Internal
         /// was added to PowerShell, so "infa" was chosen instead.
         /// -->
         [Parameter]
+        [ValidateNotNull]
         [Alias("infa")]
         public ActionPreference InformationAction
         {

--- a/test/powershell/Language/Scripting/ActionPreference.Tests.ps1
+++ b/test/powershell/Language/Scripting/ActionPreference.Tests.ps1
@@ -186,6 +186,13 @@ Describe "Tests for (error, warning, etc) action preference" -Tags "CI" {
         { New-Item @params } | Should -Throw -ErrorId "NewItemIOError,Microsoft.PowerShell.Commands.NewItemCommand"
         Remove-Item "$testdrive\test.txt" -Force
     }
+
+    It "Parameter binding throws correctly (no NRE) if argument is null" {
+        $NullVariable = $null
+        { Test-Path .\noexistfile.ps1 -ErrorAction $NullVariable } | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.TestPathCommand"
+        { Test-Path .\noexistfile.ps1 -InformationAction $NullVariable } | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.TestPathCommand"
+        { Test-Path .\noexistfile.ps1 -WarningAction $NullVariable } | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.TestPathCommand"
+    }
 }
 
 Describe 'ActionPreference.Break tests' -tag 'CI' {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #11692

Add ValidateNotNull attribute to ErrorAction, WarningAction and InformationAction common parameters.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
