### PR TITLE
Fix how COM objects are enumerated

### DIFF
--- a/src/System.Management.Automation/engine/COM/ComUtil.cs
+++ b/src/System.Management.Automation/engine/COM/ComUtil.cs
@@ -411,41 +411,7 @@ namespace System.Management.Automation
             // The passed-in COM object could already be a IEnumVARIANT interface.
             // e.g. user call '_NewEnum()' on a COM collection interface.
             var enumVariant = comObject as COM.IEnumVARIANT;
-            if (enumVariant != null)
-            {
-                return new ComEnumerator(enumVariant);
-            }
-
-            // The passed-in COM object could be a collection.
-            var enumerable = comObject as IEnumerable;
-            var target = comObject as IDispatch;
-            if (enumerable != null && target != null)
-            {
-                try
-                {
-                    var comTypeInfo = ComTypeInfo.GetDispatchTypeInfo(comObject);
-                    if (comTypeInfo != null && comTypeInfo.NewEnumInvokeKind.HasValue)
-                    {
-                        // The COM object is a collection and also a IDispatch interface, so we try to get a
-                        // IEnumVARIANT interface out of it by invoking its '_NewEnum (DispId: -4)' function.
-                        var result = ComInvoker.Invoke(target, ComTypeInfo.DISPID_NEWENUM,
-                                                        args: Array.Empty<object>(), byRef: null,
-                                                        invokeKind: comTypeInfo.NewEnumInvokeKind.Value);
-                        enumVariant = result as COM.IEnumVARIANT;
-                        if (enumVariant != null)
-                        {
-                            return new ComEnumerator(enumVariant);
-                        }
-                    }
-                }
-                catch (Exception)
-                {
-                    // Ignore exceptions. In case of exception, no enumerator can be created
-                    // for the passed-in COM object, and we will return null eventually.
-                }
-            }
-
-            return null;
+            return enumVariant != null ? new ComEnumerator(enumVariant) : null;
         }
     }
 }

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -3291,17 +3291,29 @@ namespace System.Management.Automation
         internal static IEnumerator GetCOMEnumerator(object obj)
         {
             object targetValue = PSObject.Base(obj);
+            try
+            {
+                var enumerator = (targetValue as IEnumerable)?.GetEnumerator();
+                if (enumerator != null)
+                {
+                    return enumerator;
+                }
+            }
+            catch (Exception)
+            {
+            }
 
             // We use ComEnumerator to enumerate COM collections because the following code doesn't work in .NET Core
-            //   IEnumerable enumerable = targetValue as IEnumerable;
-            //   if (enumerable != null)
+            //   IEnumerator enumerator = targetValue as IEnumerator;
+            //   if (enumerator != null)
             //   {
-            //       var enumerator = enumerable.GetEnumerator();
+            //       enumerable.MoveNext();
             //       ...
             //   }
-            // The call to 'GetEnumerator()' throws exception because COM is not supported in .NET Core.
-            // See https://github.com/dotnet/corefx/issues/19731 for more information.
-            // When COM support is back to .NET Core, we need to change back to the original implementation.
+            // The call to 'MoveNext()' throws exception because COM is not fully supported in .NET Core.
+            // See https://github.com/dotnet/runtime/issues/21690 for more information.
+            // When COM support is fully back to .NET Core, we need to change back to directly use the type cast.
+
             return ComEnumerator.Create(targetValue) ?? NonEnumerableObjectEnumerator.Create(obj);
         }
 

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -3313,7 +3313,6 @@ namespace System.Management.Automation
             // The call to 'MoveNext()' throws exception because COM is not fully supported in .NET Core.
             // See https://github.com/dotnet/runtime/issues/21690 for more information.
             // When COM support is fully back to .NET Core, we need to change back to directly use the type cast.
-
             return ComEnumerator.Create(targetValue) ?? NonEnumerableObjectEnumerator.Create(obj);
         }
 

--- a/test/powershell/engine/COM/COM.Basic.Tests.ps1
+++ b/test/powershell/engine/COM/COM.Basic.Tests.ps1
@@ -49,6 +49,13 @@ try {
             $element | Should -Be $drives.Item($element.DriveLetter)
         }
 
+        It "Should be able to enumerate 'IADsMembers' object" {
+            $group = [ADSI]"WinNT://./Users,Group"
+            $members = $group.Invoke('Members')
+            $names = $members | ForEach-Object { $_.GetType().InvokeMember('Name', 'GetProperty', $null, $_, $null) }
+            $names | Should -Not -BeNullOrEmpty
+        }
+
         It "ToString() should return method paramter names" {
             $shell = New-Object -ComObject "Shell.Application"
             $fullSignature = $shell.AddToRecent.ToString()

--- a/test/powershell/engine/COM/COM.Basic.Tests.ps1
+++ b/test/powershell/engine/COM/COM.Basic.Tests.ps1
@@ -53,7 +53,10 @@ try {
             $group = [ADSI]"WinNT://./Users,Group"
             $members = $group.Invoke('Members')
             $names = $members | ForEach-Object { $_.GetType().InvokeMember('Name', 'GetProperty', $null, $_, $null) }
-            $names | Should -Not -BeNullOrEmpty
+
+            [System.Console]::WriteLine("$names")
+
+            $names | Should -Contain 'INTERACTIVE'
         }
 
         It "ToString() should return method paramter names" {

--- a/test/powershell/engine/COM/COM.Basic.Tests.ps1
+++ b/test/powershell/engine/COM/COM.Basic.Tests.ps1
@@ -53,9 +53,6 @@ try {
             $group = [ADSI]"WinNT://./Users,Group"
             $members = $group.Invoke('Members')
             $names = $members | ForEach-Object { $_.GetType().InvokeMember('Name', 'GetProperty', $null, $_, $null) }
-
-            [System.Console]::WriteLine("$names")
-
             $names | Should -Contain 'INTERACTIVE'
         }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #11782

The `ComEnumerator` was introduced back in early .NET Core 2.0 preview period of time (#4553), because `GetEnumerator()` didn't work on COM object even if the object can be cast to `IEnumerable` and .NET Core team said it was by design at the time (https://github.com/dotnet/runtime/issues/21690).
With .NET Core 3.1, `GetEnumerator()` works on the COM objects that can be cast to `IEnumerable` 🎉
So we can directly use the .NET Core support to get the enumerator for a COM object that implements `IEnumerable`.

However, for the COM object that can be cast to `IEnumerator`, exception is thrown when calling `MoveNext()` on it. 
So we still need the `ComEnumerator`, but much simplified to just cover the case that the COM object implements `COM.IEnumVARIANT` interface.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
