### PR TITLE
Handle cases where `CustomEvent` was not initially sent

### DIFF
--- a/src/System.Management.Automation/utils/Telemetry.cs
+++ b/src/System.Management.Automation/utils/Telemetry.cs
@@ -87,6 +87,9 @@ namespace Microsoft.PowerShell.Telemetry
         // the session identifier
         private static string s_sessionId { get; set; }
 
+        // private semaphore to determine whether we sent the startup telemetry event
+        private static bool s_startupEventSent { get; set; }
+
         /// Use a hashset for quick lookups.
         /// We send telemetry only a known set of modules.
         /// If it's not in the list (initialized in the static constructor), then we report anonymous.
@@ -583,6 +586,13 @@ namespace Microsoft.PowerShell.Telemetry
                 return;
             }
 
+            // If we didn't send a startup event, it means we didn't use the console host
+            // so mark this as "hosted" to designate it as non-console host.
+            if (!s_startupEventSent)
+            {
+                SendPSCoreStartupTelemetry("hosted");
+            }
+
             string metricName = metricId.ToString();
             try
             {
@@ -666,6 +676,7 @@ namespace Microsoft.PowerShell.Telemetry
             try
             {
                 s_telemetryClient.TrackEvent("ConsoleHostStartup", properties, null);
+                s_startupEventSent = true;
             }
             catch
             {

--- a/test/powershell/engine/Basic/Telemetry.Tests.ps1
+++ b/test/powershell/engine/Basic/Telemetry.Tests.ps1
@@ -5,21 +5,7 @@
 # these tests aren't going to check that telemetry is being sent
 # only that we're not treating the telemetry.uuid file correctly
 
-Describe "CustomEvent resend check" {
-    It "Should resend startup event if the semaphore says we haven't sent telemetry" {
-        # base line should be true
-        $telemetryType = [Microsoft.PowerShell.Telemetry.ApplicationInsightsTelemetry]
-        $bindingFlags = [System.Reflection.BindingFlags]"NonPublic,Static"
-        $telemetrySent = ${telemetryType}.GetMember("get_s_startupEventSent", $bindingFlags).Invoke($null, $null)
-        $telemetrySent | Should -Be $true
-        # force a resend of the startup telemetry
-        ${telemetryType}.GetMember("set_s_startupEventSent", $bindingFlags).Invoke($null, @($false))
-        $null = Get-Date
-        # now check it again, it should be true now that something has executed
-        $telemetrySent = ${telemetryType}.GetMember("get_s_startupEventSent", $bindingFlags).Invoke($null, $null)
-        $telemetrySent | Should -Be $true
-    }
-}
+
 
 Describe "Telemetry for shell startup" -Tag CI {
     BeforeAll {
@@ -143,6 +129,21 @@ Describe "Telemetry for shell startup" -Tag CI {
         $env:POWERSHELL_TELEMETRY_OPTOUT = $value
         $result = & $PWSH -NoProfile -Command '[Microsoft.PowerShell.Telemetry.ApplicationInsightsTelemetry]::CanSendTelemetry'
         $result | Should -Be $expectedValue
+    }
+
+    It "Should resend startup event if the semaphore says we haven't sent telemetry" {
+
+        $result = & $PWSH -c {
+            $telemetryType = [Microsoft.PowerShell.Telemetry.ApplicationInsightsTelemetry]
+            $bindingFlags = [System.Reflection.BindingFlags]"NonPublic,Static"
+            ${telemetryType}.GetMember("get_s_startupEventSent", $bindingFlags).Invoke($null, $null)
+            # force a resend of the startup telemetry
+            $null = ${telemetryType}.GetMember("set_s_startupEventSent", $bindingFlags).Invoke($null, @($false))
+            $null = Get-Date | Out-String
+            # now check it again, it should be true now that something has executed
+            ${telemetryType}.GetMember("get_s_startupEventSent", $bindingFlags).Invoke($null, $null)
+            }
+        $result | Should -Be $true,$true
     }
 
 }


### PR DESCRIPTION
Since the CustomEvent is sent only on startup, we need a way to send
the startup event in those cases where PowerShell is being hosted
(not the console). This will check to see if we have already sent the
custom event for startup and send if it hasn't. This will enable us
to track some of the hosted scenarios like Jupyter.

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
