### PR TITLE
Auto-sync current directory in WinCompat remote session

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -1978,6 +1978,22 @@ namespace Microsoft.PowerShell.Commands
                 string message = StringUtil.Format(Modules.WinCompatModuleWarning, moduleProxy.Name, WindowsPowerShellCompatRemotingSession.Name);
                 WriteWarning(message);
             }
+
+            // register LocationChanged handler so that $PWD in Windows PS process mirrors local $PWD changes
+            if (moduleProxyList.Count > 0)
+            {
+                // make sure that we add registration only once to a multicast delegate
+                SyncCurrentLocationDelegate ??= SyncCurrentLocationHandler;
+                var alreadyregistered = this.SessionState.InvokeCommand.LocationChangedAction?.GetInvocationList().Contains(SyncCurrentLocationDelegate);
+
+                if (!alreadyregistered ?? true)
+                {
+                    this.SessionState.InvokeCommand.LocationChangedAction += SyncCurrentLocationDelegate;
+
+                    // first sync has to be triggered manually
+                    SyncCurrentLocationHandler(this, new LocationChangedEventArgs(null, null, this.SessionState.Path.CurrentLocation));
+                }
+            }
 #endif
             return moduleProxyList;
         }

--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -1991,7 +1991,7 @@ namespace Microsoft.PowerShell.Commands
                     this.SessionState.InvokeCommand.LocationChangedAction += SyncCurrentLocationDelegate;
 
                     // first sync has to be triggered manually
-                    SyncCurrentLocationHandler(this, new LocationChangedEventArgs(null, null, this.SessionState.Path.CurrentLocation));
+                    SyncCurrentLocationHandler(sender: this, args: new LocationChangedEventArgs(sessionState: null, oldPath: null, newPath: this.SessionState.Path.CurrentLocation));
                 }
             }
 #endif

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -327,6 +327,26 @@ Describe "Import-Module from CompatiblePSEditions-checked paths" -Tag "CI" {
                 [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("TestWindowsPowerShellVersionString", $null)
             }
         }
+
+        It "Current location in Windows PS mirrors local current location" -TestCases $failCases -Skip:(-not $IsWindows) {
+            param($Editions, $ModuleName, $Result)
+            $location = Join-Path $TestDrive "Custom dir" (New-Guid).ToString()
+            $null = New-Item -Path $location -ItemType Directory
+            Push-Location -Path $location
+
+            # right after module import remote $PWD should be synchronized
+            Import-Module $ModuleName -UseWindowsPowerShell
+            $s = Get-PSSession -Name WinPSCompatSession
+            (Invoke-Command -Session $s {Get-Location}).Path | Should -BeExactly $PWD.Path
+
+            # after local $PWD changes remote $PWD should be synchronized
+            Set-Location -Path ..
+            (Invoke-Command -Session $s {Get-Location}).Path | Should -BeExactly $PWD.Path
+
+            # after WinCompat cleanup local $PWD changes should not cause errors
+            Remove-module $ModuleName -Force
+            Pop-Location
+        }
     }
 
     Context "Imports from absolute path" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -334,20 +334,20 @@ Describe "Import-Module from CompatiblePSEditions-checked paths" -Tag "CI" {
             $location = Join-Path $TestDrive "Custom dir" (New-Guid).ToString()
             $null = New-Item -Path $location -ItemType Directory
             Push-Location -Path $location
-
-            # right after module import remote $PWD should be synchronized
-            Import-Module $ModuleName -UseWindowsPowerShell
-            $s = Get-PSSession -Name WinPSCompatSession
-            (Invoke-Command -Session $s {Get-Location}).Path | Should -BeExactly $PWD.Path
-
-            # after local $PWD changes remote $PWD should be synchronized
-            Set-Location -Path ..
-            (Invoke-Command -Session $s {Get-Location}).Path | Should -BeExactly $PWD.Path
-
-            # after WinCompat cleanup local $PWD changes should not cause errors
-            Remove-module $ModuleName -Force
             try
             {
+                # right after module import remote $PWD should be synchronized
+                Import-Module $ModuleName -UseWindowsPowerShell
+                $s = Get-PSSession -Name WinPSCompatSession
+                (Invoke-Command -Session $s {Get-Location}).Path | Should -BeExactly $PWD.Path
+
+                # after local $PWD changes remote $PWD should be synchronized
+                Set-Location -Path ..
+                (Invoke-Command -Session $s {Get-Location}).Path | Should -BeExactly $PWD.Path
+
+                # after WinCompat cleanup local $PWD changes should not cause errors
+                Remove-module $ModuleName -Force
+
                 Pop-Location
             }
             finally

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -330,6 +330,7 @@ Describe "Import-Module from CompatiblePSEditions-checked paths" -Tag "CI" {
 
         It "Current location in Windows PS mirrors local current location" -TestCases $failCases -Skip:(-not $IsWindows) {
             param($Editions, $ModuleName, $Result)
+            $pwdBackup = $PWD
             $location = Join-Path $TestDrive "Custom dir" (New-Guid).ToString()
             $null = New-Item -Path $location -ItemType Directory
             Push-Location -Path $location
@@ -345,7 +346,14 @@ Describe "Import-Module from CompatiblePSEditions-checked paths" -Tag "CI" {
 
             # after WinCompat cleanup local $PWD changes should not cause errors
             Remove-module $ModuleName -Force
-            Pop-Location
+            try
+            {
+                Pop-Location
+            }
+            finally
+            {
+                Set-Location $pwdBackup
+            }
         }
     }
 


### PR DESCRIPTION
# PR Summary
WinCompat uses background Windows PS remote session which has its own current directory. It has to be synchronized with local PS Core current directory for cases when proxy cmdlets rely on current directory.
This PR enables auto-sync of current directory in WinCompat remote session.

This came up in #11411 .

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
