### PR TITLE
Set correct PSProvider full name

### DIFF
--- a/src/System.Management.Automation/engine/DataStoreAdapterProvider.cs
+++ b/src/System.Management.Automation/engine/DataStoreAdapterProvider.cs
@@ -77,9 +77,17 @@ namespace System.Management.Automation
                     return result;
                 }
 
-                return _fullName ?? (_fullName = GetFullName(Name, PSSnapInName, ModuleName));
+                if (_fullName != null && ModuleName.Equals(_cachedModuleName, StringComparison.Ordinal))
+                {
+                    return _fullName;
+                }
+
+                _cachedModuleName = ModuleName;
+                return (_fullName = GetFullName(Name, PSSnapInName, ModuleName));
             }
         }
+
+        private string _cachedModuleName = null;
 
         /// <summary>
         /// Gets the Snap-in in which the provider is implemented.

--- a/src/System.Management.Automation/engine/DataStoreAdapterProvider.cs
+++ b/src/System.Management.Automation/engine/DataStoreAdapterProvider.cs
@@ -83,7 +83,7 @@ namespace System.Management.Automation
                 }
 
                 _cachedModuleName = ModuleName;
-                return (_fullName = GetFullName(Name, PSSnapInName, ModuleName));
+                return _fullName = GetFullName(Name, PSSnapInName, ModuleName);
             }
         }
 

--- a/src/System.Management.Automation/engine/DataStoreAdapterProvider.cs
+++ b/src/System.Management.Automation/engine/DataStoreAdapterProvider.cs
@@ -37,6 +37,7 @@ namespace System.Management.Automation
         private SessionState _sessionState;
 
         private string _fullName;
+        private string _cachedModuleName;
 
         /// <summary>
         /// Gets the name of the provider.
@@ -86,8 +87,6 @@ namespace System.Management.Automation
                 return _fullName = GetFullName(Name, PSSnapInName, ModuleName);
             }
         }
-
-        private string _cachedModuleName = null;
 
         /// <summary>
         /// Gets the Snap-in in which the provider is implemented.

--- a/src/System.Management.Automation/engine/DataStoreAdapterProvider.cs
+++ b/src/System.Management.Automation/engine/DataStoreAdapterProvider.cs
@@ -46,7 +46,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets the full name of the provider including the module name if available.
         /// </summary>
-        public string FullName
+        internal string FullName
         {
             get
             {

--- a/src/System.Management.Automation/engine/DataStoreAdapterProvider.cs
+++ b/src/System.Management.Automation/engine/DataStoreAdapterProvider.cs
@@ -44,9 +44,9 @@ namespace System.Management.Automation
         public string Name { get; }
 
         /// <summary>
-        /// Gets the full name of the provider including the pssnapin name if available.
+        /// Gets the full name of the provider including the module name if available.
         /// </summary>
-        internal string FullName
+        public string FullName
         {
             get
             {

--- a/src/System.Management.Automation/engine/Modules/ImportProvider.Tests.ps1
+++ b/src/System.Management.Automation/engine/Modules/ImportProvider.Tests.ps1
@@ -1,0 +1,68 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+Describe "Import PowerShell provider" -Tags "CI" {
+    BeforeAll {
+        $testModulePath = Join-Path $TestDrive "ReproModule"
+        New-Item -Path $testModulePath -ItemType Directory > $null
+
+        New-ModuleManifest -Path "$testModulePath/ReproModule.psd1" -RootModule 'testmodule.dll'
+
+        $testBinaryModulePath = Join-Path $testModulePath "testmodule.dll"
+        $binaryModule = @'
+using System;
+using System.Collections.ObjectModel;
+using System.Management.Automation;
+using System.Management.Automation.Provider;
+
+namespace module {
+    [CmdletProvider(
+        "SamplePrv",
+        ProviderCapabilities.ShouldProcess)]
+    public class SampleProvider : ContainerCmdletProvider {
+        protected override bool IsValidPath(string path) {
+            return true;
+        }
+
+        protected override bool ItemExists(string path) {
+            return path == "test.txt";
+        }
+
+        protected override void GetItem(string path) {
+            Item resultItem;
+            if (path == "test.txt") {
+            resultItem = new Item { Name = "test.txt" };
+            } else {
+            throw new Exception("Item not found.");
+            }
+
+            WriteItemObject(resultItem, path, false);
+        }
+
+        protected override Collection<PSDriveInfo> InitializeDefaultDrives() {
+            var drive = new PSDriveInfo(
+            "defaultSampleDrive",
+            ProviderInfo,
+            "/",
+            "Sample default drive",
+            null);
+            var result = new Collection<PSDriveInfo> {drive};
+            return result;
+        }
+
+        private class Item {
+            public string Name { get; set; }
+        }
+    }
+}
+'@
+        Add-Type -OutputAssembly $testBinaryModulePath -TypeDefinition $binaryModule
+
+        $pwsh = "$PSHOME\pwsh"
+    }
+
+    It "Import a PowerShell provider with correct name" {
+        $result = & $pwsh -NoProfile -Command "Import-Module -Name $testModulePath; (Get-PSProvider ReproModule\SamplePrv).FullName"
+        $result | Should -BeExactly "ReproModule\SamplePrv"
+    }
+}

--- a/src/System.Management.Automation/engine/Modules/ImportProvider.Tests.ps1
+++ b/src/System.Management.Automation/engine/Modules/ImportProvider.Tests.ps1
@@ -62,7 +62,7 @@ namespace module {
     }
 
     It "Import a PowerShell provider with correct name" {
-        $result = & $pwsh -NoProfile -Command "Import-Module -Name $testModulePath; (Get-PSProvider ReproModule\SamplePrv).FullName"
-        $result | Should -BeExactly "ReproModule\SamplePrv"
+        $result = & $pwsh -NoProfile -Command "Import-Module -Name $testModulePath; Get-Item ReproModule\SamplePrv::test.txt"
+        $result.PSPath | Should -BeExactly "ReproModule\SamplePrv::test.txt"
     }
 }

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -3088,8 +3088,15 @@ namespace Microsoft.PowerShell.Commands
                 // In that case, the nested module will first be loaded with a different session state, and then when trying to load the RootModule via 'LoadModuleNamedInManifest',
                 // the same loaded nested module will be reused for the RootModule by 'LoadModuleNamedInManifest'.
 
-                // Change the module name to match the manifest name, not the original name
+                // Initially the original module name comes from RootModule manifest property but real name comes from the module (manifest) path.
+                // Change the module name to match the manifest name, not the original name.
+                // Then do the same for all providers loaded in the module since a provider caches full name based on the module name.
                 newManifestInfo.SetName(manifestInfo.Name);
+                IEnumerable<ProviderInfo> pis = ss.Provider.GetAll().Where((pi) => { return object.ReferenceEquals(pi.Module, newManifestInfo); });
+                foreach (ProviderInfo pi in pis)
+                {
+                    pi.SetModule(manifestInfo);
+                }
 
                 // Copy in any nested modules...
                 foreach (PSModuleInfo nm in manifestInfo.NestedModules)

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -3088,20 +3088,8 @@ namespace Microsoft.PowerShell.Commands
                 // In that case, the nested module will first be loaded with a different session state, and then when trying to load the RootModule via 'LoadModuleNamedInManifest',
                 // the same loaded nested module will be reused for the RootModule by 'LoadModuleNamedInManifest'.
 
-                // Initially the original module name comes from RootModule manifest property but real name comes from the module (manifest) path.
                 // Change the module name to match the manifest name, not the original name.
-                // Then do the same for all providers loaded in the module since a provider caches full name based on the module name.
                 newManifestInfo.SetName(manifestInfo.Name);
-                if (ss != null)
-                {
-                    foreach (ProviderInfo pi in ss.Provider.GetAll())
-                    {
-                        if (object.ReferenceEquals(pi.Module, newManifestInfo))
-                        {
-                            pi.SetModule(manifestInfo);
-                        }
-                    }
-                }
 
                 // Copy in any nested modules...
                 foreach (PSModuleInfo nm in manifestInfo.NestedModules)

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -3098,7 +3098,7 @@ namespace Microsoft.PowerShell.Commands
                     {
                         if (object.ReferenceEquals(pi.Module, newManifestInfo))
                         {
-                        pi.SetModule(manifestInfo);
+                            pi.SetModule(manifestInfo);
                         }
                     }
                 }

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -3092,10 +3092,15 @@ namespace Microsoft.PowerShell.Commands
                 // Change the module name to match the manifest name, not the original name.
                 // Then do the same for all providers loaded in the module since a provider caches full name based on the module name.
                 newManifestInfo.SetName(manifestInfo.Name);
-                IEnumerable<ProviderInfo> pis = ss.Provider.GetAll().Where((pi) => { return object.ReferenceEquals(pi.Module, newManifestInfo); });
-                foreach (ProviderInfo pi in pis)
+                if (ss != null)
                 {
-                    pi.SetModule(manifestInfo);
+                    foreach (ProviderInfo pi in ss.Provider.GetAll())
+                    {
+                        if (object.ReferenceEquals(pi.Module, newManifestInfo))
+                        {
+                        pi.SetModule(manifestInfo);
+                        }
+                    }
                 }
 
                 // Copy in any nested modules...


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Address #9840.

- Set correct PSProvider full name at module load time.
- Make PSProvider.FullName public

## PR Context

In #8831 we added caching for ProviderInfo.FullName. This created a side effect. 
PowerShell engine loads a module with name based on RootModule manifest property. Then it set explicitly correct module name based on the module (manifest) path. If the module contains a provider PowerShell engine loads and initializes the provider too. Full name of the provider is based on the module name and it is cached. So we should update the provider full name too that the fix explicitly does.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
