### PR TITLE
[WIP] Fix using variable error for nested foreach parallel

### DIFF
--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -401,9 +401,9 @@ namespace Microsoft.PowerShell.Commands
 
             bool allowUsingExpression = this.Context.SessionState.LanguageMode != PSLanguageMode.NoLanguage;
             _usingValuesMap = ScriptBlockToPowerShellConverter.GetUsingValuesForEachParallel(
-                                Parallel,
-                                allowUsingExpression,
-                                this.Context);
+                                scriptBlock: Parallel,
+                                isTrustedInput: allowUsingExpression,
+                                context: this.Context);
 
             // Validate using values map, which is a map of '$using:' variables referenced in the script.
             // Script block variables are not allowed since their behavior is undefined outside the runspace

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -400,11 +400,10 @@ namespace Microsoft.PowerShell.Commands
             }
 
             bool allowUsingExpression = this.Context.SessionState.LanguageMode != PSLanguageMode.NoLanguage;
-            _usingValuesMap = ScriptBlockToPowerShellConverter.GetUsingValuesAsDictionary(
+            _usingValuesMap = ScriptBlockToPowerShellConverter.GetUsingValuesForEachParallel(
                                 Parallel,
                                 allowUsingExpression,
-                                this.Context,
-                                null);
+                                this.Context);
 
             // Validate using values map, which is a map of '$using:' variables referenced in the script.
             // Script block variables are not allowed since their behavior is undefined outside the runspace

--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -2433,7 +2433,7 @@ namespace Microsoft.PowerShell.Commands
                 throw new ArgumentNullException("localScriptBlock", "Caller needs to make sure the parameter value is not null");
             }
 
-            var allUsingExprs = UsingExpressionAstSearcher.FindAllUsingExpressionExceptForWorkflow(localScriptBlock.Ast);
+            var allUsingExprs = UsingExpressionAstSearcher.FindAllUsingExpressions(localScriptBlock.Ast);
             return allUsingExprs.Select(usingExpr => UsingExpressionAst.ExtractUsingVariable((UsingExpressionAst)usingExpr)).ToList();
         }
 

--- a/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
+++ b/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
@@ -346,10 +346,9 @@ namespace System.Management.Automation
                 for (int i = 0; i < usingAsts.Count; ++i)
                 {
                     usingAst = (UsingExpressionAst)usingAsts[i];
-                    object value = null;
                     if (IsInForeachParallelCallingScope(usingAst))
                     {
-                        value = Compiler.GetExpressionValue(usingAst.SubExpression, isTrustedInput, context);
+                        var value = Compiler.GetExpressionValue(usingAst.SubExpression, isTrustedInput, context);
                         string usingAstKey = PsUtils.GetUsingExpressionKey(usingAst);
                         usingValueMap.TryAdd(usingAstKey, value);
                     }

--- a/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
+++ b/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
@@ -319,6 +319,10 @@ namespace System.Management.Automation
         /// Get using values as dictionary for the Foreach-Object cmdlet, and limit the search
         /// to only the provided scriptblock and no nested scriptblocks.
         /// </summary>
+        /// <param name = "scriptBlock">Scriptblock to search</param>
+        /// <param name = "isTrustedInput">True when input is trusted</param>
+        /// <param name = "context">Execution context</param>
+        /// <returns>Dictionary of using variable map</returns>
         internal static Dictionary<string, object> GetUsingValuesForEachParallel(
             ScriptBlock scriptBlock,
             bool isTrustedInput,
@@ -416,8 +420,13 @@ namespace System.Management.Automation
                         var variableAst = usingAst.SubExpression as VariableExpressionAst;
                         if (variableAst == null)
                         {
-                            throw InterpreterError.NewInterpreterException(null, typeof(RuntimeException),
-                                usingAst.Extent, "CantGetUsingExpressionValueWithSpecifiedVariableDictionary", AutomationExceptions.CantGetUsingExpressionValueWithSpecifiedVariableDictionary, usingAst.Extent.Text);
+                            throw InterpreterError.NewInterpreterException(
+                                targetObject: null, 
+                                exceptionType: typeof(RuntimeException),
+                                errorPosition: usingAst.Extent, 
+                                resourceIdAndErrorId: "CantGetUsingExpressionValueWithSpecifiedVariableDictionary", 
+                                resourceString: AutomationExceptions.CantGetUsingExpressionValueWithSpecifiedVariableDictionary, 
+                                args: usingAst.Extent.Text);
                         }
 
                         string varName = variableAst.VariablePath.UserPath;
@@ -443,8 +452,13 @@ namespace System.Management.Automation
             {
                 if (rte.ErrorRecord.FullyQualifiedErrorId.Equals("VariableIsUndefined", StringComparison.Ordinal))
                 {
-                    throw InterpreterError.NewInterpreterException(null, typeof(RuntimeException),
-                        usingAst.Extent, "UsingVariableIsUndefined", AutomationExceptions.UsingVariableIsUndefined, rte.ErrorRecord.TargetObject);
+                    throw InterpreterError.NewInterpreterException(
+                        targetObject: null, 
+                        exceptionType: typeof(RuntimeException),
+                        errorPosition: usingAst.Extent, 
+                        resourceIdAndErrorId: "UsingVariableIsUndefined",
+                        resourceString: AutomationExceptions.UsingVariableIsUndefined, 
+                        args: rte.ErrorRecord.TargetObject);
                 }
                 else if (rte.ErrorRecord.FullyQualifiedErrorId.Equals("CantGetUsingExpressionValueWithSpecifiedVariableDictionary", StringComparison.Ordinal))
                 {

--- a/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
+++ b/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
@@ -320,7 +320,7 @@ namespace System.Management.Automation
         /// to only the provided scriptblock and no nested scriptblocks.
         /// </summary>
         /// <param name = "scriptBlock">Scriptblock to search.</param>
-        /// <param name = "isTrustedInput">True when input is trusted</param>
+        /// <param name = "isTrustedInput">True when input is trusted.</param>
         /// <param name = "context">Execution context</param>
         /// <returns>Dictionary of using variable map</returns>
         internal static Dictionary<string, object> GetUsingValuesForEachParallel(

--- a/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
+++ b/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
@@ -321,7 +321,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name = "scriptBlock">Scriptblock to search.</param>
         /// <param name = "isTrustedInput">True when input is trusted.</param>
-        /// <param name = "context">Execution context</param>
+        /// <param name = "context">Execution context.</param>
         /// <returns>Dictionary of using variable map</returns>
         internal static Dictionary<string, object> GetUsingValuesForEachParallel(
             ScriptBlock scriptBlock,

--- a/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
+++ b/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
@@ -319,7 +319,7 @@ namespace System.Management.Automation
         /// Get using values as dictionary for the Foreach-Object cmdlet, and limit the search
         /// to only the provided scriptblock and no nested scriptblocks.
         /// </summary>
-        /// <param name = "scriptBlock">Scriptblock to search</param>
+        /// <param name = "scriptBlock">Scriptblock to search.</param>
         /// <param name = "isTrustedInput">True when input is trusted</param>
         /// <param name = "context">Execution context</param>
         /// <returns>Dictionary of using variable map</returns>

--- a/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
+++ b/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
@@ -322,7 +322,7 @@ namespace System.Management.Automation
         /// <param name = "scriptBlock">Scriptblock to search.</param>
         /// <param name = "isTrustedInput">True when input is trusted.</param>
         /// <param name = "context">Execution context.</param>
-        /// <returns>Dictionary of using variable map</returns>
+        /// <returns>Dictionary of using variable map.</returns>
         internal static Dictionary<string, object> GetUsingValuesForEachParallel(
             ScriptBlock scriptBlock,
             bool isTrustedInput,

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
@@ -26,7 +26,7 @@ Describe 'ForEach-Object -Parallel Basic Tests' -Tags 'CI' {
         $result[1] | Should -BeExactly $varArray[1]
     }
 
-    It 'Verifies in scope using variables in nested foreach-object -parallel' {
+    It 'Verifies in scope using variables in nested calls' {
 
         $Test = "Test1"
         $results = 1..2 | ForEach-Object -Parallel {
@@ -47,9 +47,35 @@ Describe 'ForEach-Object -Parallel Basic Tests' -Tags 'CI' {
         $groups['Test3'].Count | Should -BeExactly 8
     }
 
-    It 'Verifies error for out of scope using variable in nested foreach-object -parallel' {
+    It 'Verifies in scope using variables with different names in nested calls' {
+        $Test1 = "TestA"
+        $results = 1..2 | ForEach-Object -parallel {
+          $using:Test1
+          $Test2 = "TestB"
+          1..2 | ForEach-Object -parallel {
+            $using:Test2
+          }
+        }
+        $results.Count | Should -BeExactly 6
+        $groups = $results | Group-Object -AsHashTable
+        $groups['TestA'].Count | Should -BeExactly 2
+        $groups['TestB'].Count | Should -BeExactly 4
+    }
 
-        $Test = "TestA"
+    It 'Verifies using variable in nested scriptblock' {
+
+        $test = 'testC'
+        $results = 1..2 | ForEach-Object -parallel {
+            & { $using:test }
+        }
+        $results.Count | Should -BeExactly 2
+        $groups = $results | Group-Object -AsHashTable
+        $groups['TestC'].Count | Should -BeExactly 2
+    }
+
+    It 'Verifies expected error for out of scope using variable in nested calls' {
+
+        $Test = "TestZ"
         1..1 | ForEach-Object -Parallel {
             $using:Test
             # Variable '$Test' is not defined in this scope.


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This fixes a bug in ForEach-Object -Parallel where a using variable in a nested ForEach-Object -Parallel throws an error even when the variable is defined in the correct scope (Issue #11817).

## PR Context

This error was occurring because, when ForEach-Object -Parallel was assembling the user variable map, it was searching all nested scriptblocks within the ForEach scriptblock, with the result of finding nested using variables where the variable had not yet been defined.  Since the nested scriptblock using variable had not been defined in the current scope, a mapping error was thrown.

Fix is to change the using variable map function to not search nested scriptblocks in the ForEach -Parallel case.  This way foreach -parallel using variable mapping is always performed only for the current scope.

Many thanks to @mklement0  for pointing out the fix.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: 5436
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
