### PR TITLE
Update the NuGet package generation to include 'cimcmdlet.dll' and most of the built-in modules

### DIFF
--- a/test/hosting/test_HostingBasic.cs
+++ b/test/hosting/test_HostingBasic.cs
@@ -204,8 +204,8 @@ namespace PowerShell.Hosting.SDK.Tests
 
             ps.Commands.Clear();
             var results_2 = ps.AddScript("Join-Path $PSHOME 'Modules' 'Microsoft.PowerShell.Utility' 'Microsoft.PowerShell.Utility.psd1'").Invoke<string>();
-            var moduleBase = results_2[0];
-            Assert.Equal(moduleBase, module.Path, ignoreCase: true);
+            var moduleManifestPath = results_2[0];
+            Assert.Equal(moduleManifestPath, module.Path, ignoreCase: true);
         }
     }
 }

--- a/test/hosting/test_HostingBasic.cs
+++ b/test/hosting/test_HostingBasic.cs
@@ -182,5 +182,25 @@ namespace PowerShell.Hosting.SDK.Tests
             int ret = ConsoleShell.Start("Hello", string.Empty, new string[] { "-noprofile", "-c", "exit 42" });
             Assert.Equal(42, ret);
         }
+
+        [Fact]
+        public static void TestBuiltInModules()
+        {
+            var iss = System.Management.Automation.Runspaces.InitialSessionState.CreateDefault2();
+            if (System.Management.Automation.Platform.IsWindows)
+            {
+                iss.ExecutionPolicy = Microsoft.PowerShell.ExecutionPolicy.RemoteSigned;
+            }
+
+            using var runspace = System.Management.Automation.Runspaces.RunspaceFactory.CreateRunspace(iss);
+            runspace.Open();
+
+            using var ps = System.Management.Automation.PowerShell.Create(runspace);
+            var results = ps.AddScript("Write-Output Hello > $null; Get-Module").Invoke();
+            Assert.Single(results);
+
+            dynamic module = results[0];
+            Assert.Equal("Microsoft.PowerShell.Utility", module.Name);
+        }
     }
 }

--- a/test/hosting/test_HostingBasic.cs
+++ b/test/hosting/test_HostingBasic.cs
@@ -196,11 +196,16 @@ namespace PowerShell.Hosting.SDK.Tests
             runspace.Open();
 
             using var ps = System.Management.Automation.PowerShell.Create(runspace);
-            var results = ps.AddScript("Write-Output Hello > $null; Get-Module").Invoke();
-            Assert.Single(results);
+            var results_1 = ps.AddScript("Write-Output Hello > $null; Get-Module").Invoke<System.Management.Automation.PSModuleInfo>();
+            Assert.Single(results_1);
 
-            dynamic module = results[0];
+            var module = results_1[0];
             Assert.Equal("Microsoft.PowerShell.Utility", module.Name);
+
+            ps.Commands.Clear();
+            var results_2 = ps.AddScript("Join-Path $PSHOME 'Modules' 'Microsoft.PowerShell.Utility' 'Microsoft.PowerShell.Utility.psd1'").Invoke<string>();
+            var moduleBase = results_2[0];
+            Assert.Equal(moduleBase, module.Path, ignoreCase: true);
         }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #11783 

- Generate and include `Microsoft.Management.Infrastructure.CimCmdlets` NuGet package
- Include all built-in module folders in `Microsoft.PowerShell.SDK` NuGet package except for the `PSDesiredConfiguration` module.
   - `PSDesiredConfiguration` module is not included because it has files in nested folders, which cause the file path length to be more than 180 in the dotnet-interactive global tool, so it will require the long path support to work. I'm not sure if this would be a problem, and thus don't have it included.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
