### PR TITLE
Restore the PowerShellStreamType enum with an ObsoleteAttribute

### DIFF
--- a/src/System.Management.Automation/engine/PowerShellStreamType.cs
+++ b/src/System.Management.Automation/engine/PowerShellStreamType.cs
@@ -13,7 +13,7 @@ namespace System.Management.Automation
     /// It is not used by any other PowerShell API, and is now obsolete
     /// and should not be used if possible.
     /// </remarks>
-    [Obsolete("Formerly used in PowerShell Workflow. Use an integer or System.Management.Automation.Language.RedirectionStream instead.")]
+    [Obsolete("This enum type was used only in PowerShell Workflow and is now obsolete.", error: true)]
     public enum PowerShellStreamType
     {
         /// <summary>

--- a/src/System.Management.Automation/engine/PowerShellStreamType.cs
+++ b/src/System.Management.Automation/engine/PowerShellStreamType.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace System.Management.Automation
+{
+    /// <summary>
+    /// Enumeration of the possible PowerShell stream types.
+    /// This enumeration is obsolete.
+    /// </summary>
+    /// <remarks>
+    /// This enumeration is a public type formerly used in PowerShell Workflow,
+    /// but kept due to its generic name and public accessibility.
+    /// It is not used by any other PowerShell API, and is now obsolete
+    /// and should not be used if possible.
+    /// </remarks>
+    [Obsolete("Formerly used in PowerShell Workflow. Use an integer or System.Management.Automation.Language.RedirectionStream instead.")]
+    public enum PowerShellStreamType
+    {
+        /// <summary>
+        /// PSObject.
+        /// </summary>
+        Input = 0,
+
+        /// <summary>
+        /// PSObject.
+        /// </summary>
+        Output = 1,
+
+        /// <summary>
+        /// ErrorRecord.
+        /// </summary>
+        Error = 2,
+
+        /// <summary>
+        /// WarningRecord.
+        /// </summary>
+        Warning = 3,
+
+        /// <summary>
+        /// VerboseRecord.
+        /// </summary>
+        Verbose = 4,
+
+        /// <summary>
+        /// DebugRecord.
+        /// </summary>
+        Debug = 5,
+
+        /// <summary>
+        /// ProgressRecord.
+        /// </summary>
+        Progress = 6,
+
+        /// <summary>
+        /// InformationRecord.
+        /// </summary>
+        Information = 7
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes https://github.com/PowerShell/PowerShell/issues/11619.

## PR Context

Returns the `PowerShellStreamType` enum to code, since it was public, generically named and removed. Adds an `ObsoleteAttribute` to prevent new usage.

