### PR TITLE
Fix package syncing to private Module Feed 

### DIFF
--- a/tools/releaseBuild/azureDevOps/AzArtifactFeed/PSGalleryToAzArtifacts.yml
+++ b/tools/releaseBuild/azureDevOps/AzArtifactFeed/PSGalleryToAzArtifacts.yml
@@ -7,19 +7,18 @@ resources:
 queue:
   name: Hosted VS2017
 steps:
-  - powershell: |
+  - pwsh: |
       Install-Module -Name PowerShellGet -MinimumVersion 2.0.1 -Force
-      Import-Module PowerShellGet -Force -Verbose
     displayName: Update PSGet and PackageManagement
     condition: succeededOrFailed()
 
-  - powershell: |
+  - pwsh: |
       Import-Module -Force "$(Build.SourcesDirectory)/tools/releaseBuild/azureDevOps/AzArtifactFeed/SyncGalleryToAzArtifacts.psm1"
       SyncGalleryToAzArtifacts -AzDevOpsFeedUserName $(AzDevOpsFeedUserName) -AzDevOpsPAT $(AzDevOpsFeedPAT) -Destination $(Build.ArtifactStagingDirectory)
     displayName: Download packages from PSGallery that need to be updated
     condition: succeededOrFailed()
 
-  - powershell: |
+  - pwsh: |
       Write-Verbose -Verbose "Packages to upload"
       if(Test-Path $(Build.ArtifactStagingDirectory)) { Get-ChildItem "$(Build.ArtifactStagingDirectory)/*.nupkg" | ForEach-Object { $_.FullName }}
     displayName: List packages to upload

--- a/tools/releaseBuild/azureDevOps/AzArtifactFeed/SyncGalleryToAzArtifacts.psm1
+++ b/tools/releaseBuild/azureDevOps/AzArtifactFeed/SyncGalleryToAzArtifacts.psm1
@@ -145,7 +145,7 @@ Function CompareVersions {
     } elseif ($lt.IsPresent) {
         return $DifferencePackage -eq $latest
     } else {
-        throw "Unknow paramater set"
+        throw "Unknow parameter set"
     }
 }
 

--- a/tools/releaseBuild/azureDevOps/AzArtifactFeed/SyncGalleryToAzArtifacts.psm1
+++ b/tools/releaseBuild/azureDevOps/AzArtifactFeed/SyncGalleryToAzArtifacts.psm1
@@ -92,6 +92,7 @@ function SyncGalleryToAzArtifacts {
 
     # Remove dependent packages downloaded by Save-Module if there are already present in AzArtifacts feed.
     try {
+        $null = New-Item -Path $Destination -ItemType Directory -Force
         Register-PackageSource -Name local -Location $Destination -ProviderName NuGet -Force
         $packageNamesToKeep = @()
         $savedPackages = Find-Package -Source local -AllVersions -AllowPreReleaseVersion
@@ -176,4 +177,4 @@ function NormalizeVersion {
     $sVer
 }
 
-Export-ModuleMember -Function 'SyncGalleryToAzArtifacts'
+Export-ModuleMember -Function 'SyncGalleryToAzArtifacts', 'SortPackage'

--- a/tools/releaseBuild/azureDevOps/AzArtifactFeed/SyncGalleryToAzArtifacts.psm1
+++ b/tools/releaseBuild/azureDevOps/AzArtifactFeed/SyncGalleryToAzArtifacts.psm1
@@ -66,10 +66,10 @@ function SyncGalleryToAzArtifacts {
         }
 
         # Check if Az package version is less that gallery version
-        if ($foundPackageOnAz.Version -lt $foundPackageOnGallery.Version) {
+        if (CompareVersions -lt -ReferencePackage $foundPackageOnAz -DifferencePackage $foundPackageOnGallery) {
             Write-Verbose -Verbose "Module needs to be updated $($package.Name) - $($foundPackageOnGallery.Version)"
             $modulesToUpdate += $foundPackageOnGallery
-        } elseif ($foundPackageOnGallery.Version -lt $foundPackageOnAz.Version) {
+        } elseif (CompareVersions -lt -ReferencePackage $foundPackageOnGallery -DifferencePackage $foundPackageOnAz) {
             Write-Warning "Newer version found on Az Artifacts - $($foundPackageOnAz.Name) - $($foundPackageOnAz.Version)"
         } else {
             Write-Verbose -Verbose "Module is in sync - $($package.Name)"
@@ -92,8 +92,7 @@ function SyncGalleryToAzArtifacts {
 
     # Remove dependent packages downloaded by Save-Module if there are already present in AzArtifacts feed.
     try {
-        $null = New-Item -Path $Destination -ItemType Directory -Force
-        Register-PackageSource -Name local -Location $Destination -ProviderName NuGet -Force
+        $null = Register-PackageSource -Name local -Location $Destination -ProviderName NuGet -Force
         $packageNamesToKeep = @()
         $savedPackages = Find-Package -Source local -AllVersions -AllowPreReleaseVersion
 
@@ -121,6 +120,34 @@ function SyncGalleryToAzArtifacts {
 
 }
 
+Function CompareVersions {
+    param (
+        [Microsoft.PackageManagement.Packaging.SoftwareIdentity]
+        $ReferencePackage,
+        [Microsoft.PackageManagement.Packaging.SoftwareIdentity]
+        $DifferencePackage,
+        [Parameter(Mandatory = $true, ParameterSetName='lt')]
+        [switch]
+        $lt,
+        [Parameter(Mandatory = $true, ParameterSetName='gt')]
+        [switch]
+        $gt
+    )
+
+    if ($ReferencePackage.Version -eq $DifferencePackage.Version) {
+        return $false
+    }
+
+    $latest = SortPackage -p @($ReferencePackage,$DifferencePackage) | Select-Object -First 1
+
+    if ($gt.IsPresent) {
+        return $ReferencePackage -eq $latest
+    } elseif ($lt.IsPresent) {
+        return $DifferencePackage -eq $latest
+    } else {
+        throw "Unknow paramater set"
+    }
+}
 
 
 Function SortPackage {

--- a/tools/releaseBuild/azureDevOps/AzArtifactFeed/SyncGalleryToAzArtifacts.psm1
+++ b/tools/releaseBuild/azureDevOps/AzArtifactFeed/SyncGalleryToAzArtifacts.psm1
@@ -145,7 +145,7 @@ Function CompareVersions {
     } elseif ($lt.IsPresent) {
         return $DifferencePackage -eq $latest
     } else {
-        throw "Unknow parameter set"
+        throw "Unknown parameter set"
     }
 }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix package syncing to private Module Feed 

Related to #11838

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
