### PR TITLE
Allow shorter signed hex literals with appropriate type suffixes

### DIFF
--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -1460,17 +1460,28 @@ namespace System.Management.Automation.Language
 
             switch (c)
             {
-                case '0': return '\0';
-                case 'a': return '\a';
-                case 'b': return '\b';
-                case 'e': return '\u001b';
-                case 'f': return '\f';
-                case 'n': return '\n';
-                case 'r': return '\r';
-                case 't': return '\t';
-                case 'u': return ScanUnicodeEscape(out surrogateCharacter);
-                case 'v': return '\v';
-                default: return c;
+                case '0':
+                    return '\0';
+                case 'a':
+                    return '\a';
+                case 'b':
+                    return '\b';
+                case 'e':
+                    return '\u001b';
+                case 'f':
+                    return '\f';
+                case 'n':
+                    return '\n';
+                case 'r':
+                    return '\r';
+                case 't':
+                    return '\t';
+                case 'u':
+                    return ScanUnicodeEscape(out surrogateCharacter);
+                case 'v':
+                    return '\v';
+                default:
+                    return c;
             }
         }
 
@@ -3557,8 +3568,9 @@ namespace System.Management.Automation.Language
             {
                 try
                 {
-                    NumberStyles style = NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint |
-                                         NumberStyles.AllowExponent;
+                    NumberStyles style = NumberStyles.AllowLeadingSign
+                        | NumberStyles.AllowDecimalPoint
+                        | NumberStyles.AllowExponent;
 
                     if (real)
                     {
@@ -3685,9 +3697,40 @@ namespace System.Management.Automation.Language
                             }
 
                             // If we're expecting a sign bit, remove the leading 0 added in ScanNumberHelper
-                            if (!suffix.HasFlag(NumberSuffixFlags.Unsigned) && ((strNum.Length - 1) & 7) == 0)
+                            if (!suffix.HasFlag(NumberSuffixFlags.Unsigned))
                             {
-                                strNum = strNum.Slice(1);
+                                var expectedLength = suffix switch
+                                {
+                                    NumberSuffixFlags.SignedByte => 2,
+                                    NumberSuffixFlags.Short => 4,
+                                    NumberSuffixFlags.Long => 16,
+                                    // No suffix flag can mean int or long depending on input string length
+                                    _ => strNum.Length < 16 ? 8 : 16
+                                };
+
+                                if (strNum.Length == expectedLength)
+                                {
+                                    strNum = strNum.Slice(1);
+                                }
+                            }
+
+
+                            // If we're expecting a sign bit, remove the leading 0 added in ScanNumberHelper
+                            if (!suffix.HasFlag(NumberSuffixFlags.Unsigned))
+                            {
+                                var expectedLength = suffix switch
+                                {
+                                    NumberSuffixFlags.SignedByte => 2,
+                                    NumberSuffixFlags.Short => 4,
+                                    NumberSuffixFlags.Long => 16,
+                                    // No suffix flag can mean int or long depending on input string length
+                                    _ => strNum.Length < 16 ? 8 : 16
+                                };
+
+                                if (strNum.Length == expectedLength)
+                                {
+                                    strNum = strNum.Slice(1);
+                                }
                             }
 
                             style = NumberStyles.AllowHexSpecifier;
@@ -4988,7 +5031,8 @@ namespace System.Management.Automation.Language
                         _currentIndex = _tokenStart;
                         c = GetChar();
 
-                        if (strNum == null) { return ScanGenericToken(c); }
+                        if (strNum == null)
+                        { return ScanGenericToken(c); }
                     }
 
                     return NewToken(TokenKind.Exclaim);

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -5013,7 +5013,9 @@ namespace System.Management.Automation.Language
                         c = GetChar();
 
                         if (strNum == null)
-                        { return ScanGenericToken(c); }
+                        {
+                            return ScanGenericToken(c);
+                        }
                     }
 
                     return NewToken(TokenKind.Exclaim);

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -3727,7 +3727,8 @@ namespace System.Management.Automation.Language
                                     _ => strNum.Length < 16 ? 8 : 16
                                 };
 
-                                if (strNum.Length == expectedLength)
+                                // Add one to account for the added 0 from ScanNumberHelper
+                                if (strNum.Length == expectedLength + 1)
                                 {
                                     strNum = strNum.Slice(1);
                                 }

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -3708,26 +3708,6 @@ namespace System.Management.Automation.Language
                                     _ => strNum.Length < 16 ? 8 : 16
                                 };
 
-                                if (strNum.Length == expectedLength)
-                                {
-                                    strNum = strNum.Slice(1);
-                                }
-                            }
-
-
-                            // If we're expecting a sign bit, remove the leading 0 added in ScanNumberHelper
-                            if (!suffix.HasFlag(NumberSuffixFlags.Unsigned))
-                            {
-                                var expectedLength = suffix switch
-                                {
-                                    NumberSuffixFlags.SignedByte => 2,
-                                    NumberSuffixFlags.Short => 4,
-                                    NumberSuffixFlags.Long => 16,
-                                    // No suffix flag can mean int or long depending on input string length
-                                    _ => strNum.Length < 16 ? 8 : 16
-                                };
-
-                                // Add one to account for the added 0 from ScanNumberHelper
                                 if (strNum.Length == expectedLength + 1)
                                 {
                                     strNum = strNum.Slice(1);

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -703,7 +703,7 @@ foo``u{2195}abc
         if ( $IsLinux -or $IsMacOS ) {
             # because we execute on *nix based on executable bit, and the file name doesn't matter
             # so we can use the same filename as for windows, just make sure it's executable with chmod
-            "#!/bin/sh`necho ""Hello World""" | out-file -encoding ASCII $shellfile
+            "#!/bin/sh`necho ""Hello World""" | Out-File -encoding ASCII $shellfile
             /bin/chmod +x $shellfile
         }
         else {
@@ -931,6 +931,7 @@ foo``u{2195}abc
             @{ Script = "0x0y"; ExpectedValue = "0"; ExpectedType = [sbyte] }
             @{ Script = "0x41y"; ExpectedValue = "65"; ExpectedType = [sbyte] }
             @{ Script = "-0x41y"; ExpectedValue = "-65"; ExpectedType = [sbyte] }
+            @{ Script = "0xFFy"; ExpectedValue = "-1"; ExpectedType = [sbyte] }
             #Binary
             @{ Script = "0b0y"; ExpectedValue = "0"; ExpectedType = [sbyte] }
             @{ Script = "0b10y"; ExpectedValue = "2"; ExpectedType = [sbyte] }
@@ -957,6 +958,7 @@ foo``u{2195}abc
             @{ Script = "0x0s"; ExpectedValue = "0"; ExpectedType = [short] }
             @{ Script = "0x41s"; ExpectedValue = "65"; ExpectedType = [short] }
             @{ Script = "-0x41s"; ExpectedValue = "-65"; ExpectedType = [short] }
+            @{ Script = "0xFFFFs"; ExpectedValue = "-1"; ExpectedType = [short] }
             #Binary
             @{ Script = "0b0s"; ExpectedValue = "0"; ExpectedType = [short] }
             @{ Script = "0b10s"; ExpectedValue = "2"; ExpectedType = [short] }
@@ -985,6 +987,7 @@ foo``u{2195}abc
             @{ Script = "0x0l"; ExpectedValue = "0"; ExpectedType = [long] }
             @{ Script = "0x41l"; ExpectedValue = "65"; ExpectedType = [long] }
             @{ Script = "-0x41l"; ExpectedValue = "-65"; ExpectedType = [long] }
+            @{ Script = "0xFFFFFFFFFFFFFFFFl"; ExpectedValue = "-1"; ExpectedType = [long] }
             #Binary
             @{ Script = "0b0l"; ExpectedValue = "0"; ExpectedType = [long] }
             @{ Script = "0b10l"; ExpectedValue = "2"; ExpectedType = [long] }
@@ -1078,6 +1081,7 @@ foo``u{2195}abc
             #Hexadecimal
             @{ Script = "0x0uy"; ExpectedValue = "0"; ExpectedType = [byte] }
             @{ Script = "0x41uy"; ExpectedValue = "65"; ExpectedType = [byte] }
+            @{ Script = "0xFFuy"; ExpectedValue = [byte]::MaxValue; ExpectedType = [byte] }
             #Binary
             @{ Script = "0b0uy"; ExpectedValue = "0"; ExpectedType = [byte] }
             @{ Script = "0b10uy"; ExpectedValue = "2"; ExpectedType = [byte] }
@@ -1098,6 +1102,8 @@ foo``u{2195}abc
             #Hexadecimal
             @{ Script = "0x0us"; ExpectedValue = "0"; ExpectedType = [ushort] }
             @{ Script = "0x41us"; ExpectedValue = "65"; ExpectedType = [ushort] }
+            @{ Script = "0x41us"; ExpectedValue = "65"; ExpectedType = [ushort] }
+            @{ Script = "0xFFFFus"; ExpectedValue = [ushort]::MaxValue; ExpectedType = [ushort] }
             #Binary
             @{ Script = "0b0us"; ExpectedValue = "0"; ExpectedType = [ushort] }
             @{ Script = "0b10us"; ExpectedValue = "2"; ExpectedType = [ushort] }
@@ -1119,6 +1125,7 @@ foo``u{2195}abc
             #Hexadecimal
             @{ Script = "0x0ul"; ExpectedValue = "0"; ExpectedType = [ulong] }
             @{ Script = "0x41ul"; ExpectedValue = "65"; ExpectedType = [ulong] }
+            @{ Script = "0xFFFFFFFFFFFFFFFFul"; ExpectedValue = [ulong]::MaxValue; ExpectedType = [ulong] }
             #Binary
             @{ Script = "0b0ul"; ExpectedValue = "0"; ExpectedType = [ulong] }
             @{ Script = "0b10ul"; ExpectedValue = "2"; ExpectedType = [ulong] }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This change allows shorter hex literals to be treated as signed, if the specified type suffix is a signed type with correct hex lengths. For example, `0xFFFFs` now parses correctly to -1 instead of erroring. Default behaviour without a specific suffix and/or with explicit unsigned suffixes remains as it was. 

## PR Context

Resolves #11823. See the issue for further context and discussion.

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
