### PR TITLE
Bring back `MainWindowTitle` in `PSHostProcessInfo`

### DIFF
--- a/src/System.Management.Automation/engine/remoting/commands/EnterPSHostProcessCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/EnterPSHostProcessCommand.cs
@@ -765,7 +765,6 @@ namespace Microsoft.PowerShell.Commands
             private set;
         }
 
-#if !CORECLR
         /// <summary>
         /// Main window title of the process.
         /// </summary>
@@ -774,7 +773,6 @@ namespace Microsoft.PowerShell.Commands
             get;
             private set;
         }
-#endif
 
         #endregion
 
@@ -794,7 +792,6 @@ namespace Microsoft.PowerShell.Commands
 
             if (string.IsNullOrEmpty(appDomainName)) { throw new PSArgumentNullException("appDomainName"); }
 
-#if !CORECLR
             MainWindowTitle = string.Empty;
             try
             {
@@ -803,7 +800,6 @@ namespace Microsoft.PowerShell.Commands
             }
             catch (ArgumentException) { }
             catch (InvalidOperationException) { }
-#endif
 
             this.ProcessName = processName;
             this.ProcessId = processId;

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-PSHostProcessInfo.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-PSHostProcessInfo.Tests.ps1
@@ -29,6 +29,11 @@ Describe "Get-PSHostProcessInfo tests" -Tag CI {
         (Get-PSHostProcessInfo).ProcessId | Should -Contain $PID
     }
 
+    It "Should return own self window title" {
+        $expected = (Get-Process -Id $PID).MainWindowTitle
+        (Get-PSHostProcessInfo -Id $PID).MainWindowTitle | Should -BeExactly $expected
+    }
+
     It "Should list info for other PowerShell hosted processes" {
         # Creation of the named pipe is async
         Wait-UntilTrue {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Process.MainWindowTitle is now in .Net Core so bring back MainWindowTitle in PSHostProcessInfo

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
