### PR TITLE
Update the map between console color to VT sequences

### DIFF
--- a/src/System.Management.Automation/utils/VTUtils.cs
+++ b/src/System.Management.Automation/utils/VTUtils.cs
@@ -22,24 +22,24 @@ namespace System.Management.Automation
             Inverse
         }
 
-        private static readonly Dictionary<ConsoleColor, string> ConsoleColors = new Dictionary<ConsoleColor, string>
+        private static readonly Dictionary<ConsoleColor, string> ForegroundColorMap = new Dictionary<ConsoleColor, string>
         {
-            { ConsoleColor.Black, "\x1b[2;30m" },
-            { ConsoleColor.Gray, "\x1b[2;37m" },
-            { ConsoleColor.Red, "\x1b[1;31m" },
-            { ConsoleColor.Green, "\x1b[1;32m" },
-            { ConsoleColor.Yellow, "\x1b[1;33m" },
-            { ConsoleColor.Blue, "\x1b[1;34m" },
-            { ConsoleColor.Magenta, "\x1b[1;35m" },
-            { ConsoleColor.Cyan, "\x1b[1;36m" },
-            { ConsoleColor.White, "\x1b[1;37m" },
-            { ConsoleColor.DarkRed, "\x1b[2;31m" },
-            { ConsoleColor.DarkGreen, "\x1b[2;32m" },
-            { ConsoleColor.DarkYellow, "\x1b[2;33m" },
-            { ConsoleColor.DarkBlue, "\x1b[2;34m" },
-            { ConsoleColor.DarkMagenta, "\x1b[2;35m" },
-            { ConsoleColor.DarkCyan, "\x1b[2;36m" },
-            { ConsoleColor.DarkGray, "\x1b[1;30m" },
+            { ConsoleColor.Black, "\x1b[30m" },
+            { ConsoleColor.Gray, "\x1b[37m" },
+            { ConsoleColor.Red, "\x1b[91m" },
+            { ConsoleColor.Green, "\x1b[92m" },
+            { ConsoleColor.Yellow, "\x1b[93m" },
+            { ConsoleColor.Blue, "\x1b[94m" },
+            { ConsoleColor.Magenta, "\x1b[95m" },
+            { ConsoleColor.Cyan, "\x1b[96m" },
+            { ConsoleColor.White, "\x1b[97m" },
+            { ConsoleColor.DarkRed, "\x1b[31m" },
+            { ConsoleColor.DarkGreen, "\x1b[32m" },
+            { ConsoleColor.DarkYellow, "\x1b[33m" },
+            { ConsoleColor.DarkBlue, "\x1b[34m" },
+            { ConsoleColor.DarkMagenta, "\x1b[35m" },
+            { ConsoleColor.DarkCyan, "\x1b[36m" },
+            { ConsoleColor.DarkGray, "\x1b[90m" },
         };
 
         private static readonly Dictionary<VT, string> VTCodes = new Dictionary<VT, string>
@@ -60,7 +60,7 @@ namespace System.Management.Automation
         public static string GetEscapeSequence(ConsoleColor color)
         {
             string value = string.Empty;
-            ConsoleColors.TryGetValue(color, out value);
+            ForegroundColorMap.TryGetValue(color, out value);
             return value;
         }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Update the map between console color to VT sequences.
The `ConsoleColor` to `VT Escape Sequences` mapping in `VTUtils.cs` is not accurate, and thus is updated according to https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences#text-formatting

https://github.com/PowerShell/PowerShell/blob/895d4b3f3ebb51193d68095d2a95549b0b92c5fc/src/System.Management.Automation/utils/VTUtils.cs#L25-L43

The update is needed as "Bright foreground color" (e.g. bright red `\x1b[91m`) is rendered differently from `bold` color (e.g. `\x1b[1;31m`) in some front-end client, such as the Jupyter Notebook client.
See the 3rd and 4th output below as an example:
![image](https://user-images.githubusercontent.com/127450/74873553-475dc380-5314-11ea-8a56-bf384abf8f99.png)


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
