### PR TITLE
Generate guid for FormatViewDefinition InstanceId if not provided

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData.cs
@@ -697,6 +697,7 @@ namespace System.Management.Automation
 
             Name = name;
             Control = control;
+            InstanceId = Guid.NewGuid();
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-FormatData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-FormatData.Tests.ps1
@@ -153,4 +153,22 @@ Describe "Export-FormatData" -Tags "CI" {
             $runspace.Close()
         }
     }
+
+    It 'Should be able to export multiple views' {
+        $listControl = [System.Management.Automation.ListControl]::Create().StartEntry().AddItemProperty('test').AddItemProperty('test2').EndEntry().EndList()
+        $tableControl = [System.Management.Automation.TableControl]::Create().StartRowDefinition().AddPropertyColumn('test').AddPropertyColumn('test2').EndRowDefinition().EndTable()
+
+        $listView = [System.Management.Automation.FormatViewDefinition]::new('Default', $listControl)
+        $tableView = [System.Management.Automation.FormatViewDefinition]::new('Default', $tableControl)
+
+        $list = New-Object System.Collections.Generic.List[System.Management.Automation.FormatViewDefinition]
+        $list.Add($listView)
+        $list.Add($tableView)
+
+        $typeDef = [System.Management.Automation.ExtendedTypeDefinition]::new('TestTypeName', $list)
+        $filePath = Join-Path $TestDrive "test.format.ps1xml"
+        $typeDef | Export-FormatData -Path $filePath
+        [xml]$xml = Get-Content -Path $filePath
+        @($xml.Configuration.ViewDefinitions.View).Count | Should -Be 2
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

`InstanceId` for a `FormatViewDefinition` is the key to help differentiate views with the same name for the same type.  However, when using the constructor for `FormatViewDefinition` that doesn't take an InstanceId, it keeps the default guid value of all zeros.  During export time, the cmdlet builds a dictionary with the InstanceId as the key and with multiple views with same key, you only get the first one.  Fix is to generate a new guid for InstanceId if one is not provided.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/11825

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
