### PR TITLE
Address UTF-8 Detection In Get-Content -Tail

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemContentStream.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemContentStream.cs
@@ -1466,7 +1466,6 @@ namespace Microsoft.PowerShell.Commands
                 IsSingleByteCharacterSet())
             {
                 // Unicode -- two bytes per character
-                // BigEndianUnicode -- two types per character
                 // UTF-32 -- four bytes per character
                 // ASCII -- one byte per character
                 // The BufferSize will be a multiple of 4, so we can just read toRead number of bytes

--- a/src/System.Management.Automation/namespaces/FileSystemContentStream.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemContentStream.cs
@@ -1434,7 +1434,7 @@ namespace Microsoft.PowerShell.Commands
             int toRead = lengthLeft > BuffSize ? BuffSize : (int)lengthLeft;
             _stream.Seek(-toRead, SeekOrigin.Current);
 
-            if (_currentEncoding.Equals(Encoding.UTF8))
+            if (_currentEncoding is UTF8Encoding)
             {
                 // It's UTF-8, we need to detect the starting byte of a character
                 do
@@ -1460,10 +1460,9 @@ namespace Microsoft.PowerShell.Commands
                 _byteCount += _stream.Read(_byteBuff, _byteCount, (int)(lengthLeft - _stream.Position));
                 _stream.Position = _currentPosition;
             }
-            else if (_currentEncoding.Equals(Encoding.Unicode) ||
-                _currentEncoding.Equals(Encoding.BigEndianUnicode) ||
-                _currentEncoding.Equals(Encoding.UTF32) ||
-                _currentEncoding.Equals(Encoding.ASCII) ||
+            else if (_currentEncoding is UnicodeEncoding ||
+                _currentEncoding is UTF32Encoding ||
+                _currentEncoding is ASCIIEncoding ||
                 IsSingleByteCharacterSet())
             {
                 // Unicode -- two bytes per character

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -95,9 +95,12 @@ Describe "Get-Content" -Tags "CI" {
 
     It 'Verifies -Tail with content that uses an explicit encoding' -TestCases @(
         @{EncodingName = 'String'},
+        @{EncodingName = 'OEM'},
         @{EncodingName = 'Unicode'},
         @{EncodingName = 'BigEndianUnicode'},
         @{EncodingName = 'UTF8'},
+        @{EncodingName = 'UTF8BOM'},
+        @{EncodingName = 'UTF8NoBOM'},
         @{EncodingName = 'UTF7'},
         @{EncodingName = 'UTF32'},
         @{EncodingName = 'Ascii'}

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -93,7 +93,7 @@ Describe "Get-Content" -Tags "CI" {
         { Get-Content -Path Variable:\PSHOME -Tail 1 -TotalCount 5 -ErrorAction Stop} | Should -Throw -ErrorId 'TailAndHeadCannotCoexist,Microsoft.PowerShell.Commands.GetContentCommand'
     }
 
-    It 'Verifies -Tail with content that uses an explicit encoding' -TestCases @(
+    It 'Verifies -Tail with content that uses an explicit/implicit encoding' -TestCases @(
         @{EncodingName = 'String'},
         @{EncodingName = 'OEM'},
         @{EncodingName = 'Unicode'},
@@ -107,24 +107,30 @@ Describe "Get-Content" -Tags "CI" {
         ){
         param($EncodingName)
 
-        $content = @"
-one
-two
-foo
-bar
-baz
-"@
-        $expected = 'foo'
-        $tailCount = 3
-
-        $testPath = Join-Path -Path $TestDrive -ChildPath 'TailWithEncoding.txt'
-        $content | Set-Content -Path $testPath -Encoding $encodingName
-        $expected = 'foo'
-
-        $actual = Get-Content -Path $testPath -Tail $tailCount -Encoding $encodingName
-        $actual | Should -BeOfType string
-        $actual.Length | Should -Be $tailCount
-        $actual[0] | Should -BeExactly $expected
+        $contentSets = 
+            @(@('a1','aa2','aaa3','aaaa4','aaaaa5'), # utf-8
+              @('€1','€€2','€€€3','€€€€4','€€€€€5'), # utf-16
+              @('𐍈1','𐍈𐍈2','𐍈𐍈𐍈3','𐍈𐍈𐍈𐍈4','𐍈𐍈𐍈𐍈𐍈5')) # utf-32
+        ForEach ($content in $contentSets)
+        {
+            $tailCount = 3
+            $testPath = Join-Path -Path $TestDrive -ChildPath 'TailWithEncoding.txt'
+            $content | Set-Content -Path $testPath -Encoding $EncodingName
+            
+            # read and verify using explicit encoding
+            $expected = (Get-Content -Path $testPath -Encoding $EncodingName)[-$tailCount]
+            $actual = Get-Content -Path $testPath -Tail $tailCount -Encoding $EncodingName
+            $actual | Should -BeOfType string
+            $actual.Length | Should -Be $tailCount
+            $actual[0] | Should -BeExactly $expected
+            
+            # read and verify using implicit encoding
+            $expected = (Get-Content -Path $testPath)[-$tailCount]
+            $actual = Get-Content -Path $testPath -Tail $tailCount
+            $actual | Should -BeOfType string
+            $actual.Length | Should -Be $tailCount
+            $actual[0] | Should -BeExactly $expected  
+        }
     }
 
     It "should Get-Content with a variety of -Tail and -ReadCount: <test>" -TestCases @(


### PR DESCRIPTION
# PR Summary

Fix #11830
Addresses a comparison failure that causes UTF-8 detection to fail which in turn causes Get-Content -Tail to resort to forward lookups given encoding type cannot be detected. Possible this misdetection is due to the incoming encoding object as being of type System.Text.UTF8Encoding where as the comparison uses the object Encoding.UTF8 which is derived from System.Text.UTF8Encoding+UTF8EncodingSealed.

## PR Context

Problem was discovered when investigating performance issues for Get-Content -Tail, in general.  The problem was narrowed to the fact that -Tail will read the entire file when using Get-Content on a UTF-8 file.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed:
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
