### PR TITLE
Remove hop restrictions for interactive sessions

### DIFF
--- a/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
@@ -246,25 +246,6 @@ namespace Microsoft.PowerShell.Commands
                 return;
             }
 
-            // Check if current host is remote host.  Enter-PSSession on remote host is not
-            // currently supported.
-            if (!IsParameterSetForVM() &&
-                !IsParameterSetForContainer() &&
-                !IsParameterSetForVMContainerSession() &&
-                this.Context != null &&
-                this.Context.EngineHostInterface != null &&
-                this.Context.EngineHostInterface.ExternalHost != null &&
-                this.Context.EngineHostInterface.ExternalHost is System.Management.Automation.Remoting.ServerRemoteHost)
-            {
-                WriteError(
-                    new ErrorRecord(
-                        new ArgumentException(GetMessage(RemotingErrorIdStrings.RemoteHostDoesNotSupportPushRunspace)),
-                        PSRemotingErrorId.RemoteHostDoesNotSupportPushRunspace.ToString(),
-                        ErrorCategory.InvalidArgument,
-                        null));
-                return;
-            }
-
             // for the console host and Graphical PowerShell host
             // we want to skip pushing into the the runspace if
             // the host is in a nested prompt

--- a/src/System.Management.Automation/engine/remoting/common/remotingexceptions.cs
+++ b/src/System.Management.Automation/engine/remoting/common/remotingexceptions.cs
@@ -209,7 +209,6 @@ namespace System.Management.Automation.Remoting
         RemoteRunspaceHasMultipleMatchesForSpecifiedName = 955,
         RemoteRunspaceDoesNotSupportPushRunspace = 956,
         HostInNestedPrompt = 957,
-        RemoteHostDoesNotSupportPushRunspace = 958,
         InvalidVMId = 959,
         InvalidVMNameNoVM = 960,
         InvalidVMNameMultipleVM = 961,

--- a/src/System.Management.Automation/engine/remoting/server/ServerRemoteHost.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRemoteHost.cs
@@ -151,17 +151,6 @@ namespace System.Management.Automation.Remoting
         /// </summary>
         internal HostInfo HostInfo { get; }
 
-        /// <summary>
-        /// Allows a push runspace on this remote server host instance, regardless of
-        /// transport being used.
-        /// </summary>
-        internal virtual bool AllowPushRunspace
-        {
-            get { return (_serverDriverRemoteHost != null) ? _serverDriverRemoteHost.AllowPushRunspace : false; }
-
-            set { if (_serverDriverRemoteHost != null) { _serverDriverRemoteHost.AllowPushRunspace = value; } }
-        }
-
         #endregion
 
         #region Method Overrides
@@ -328,18 +317,6 @@ namespace System.Management.Automation.Remoting
         /// <param name="runspace">RemoteRunspace.</param>
         public override void PushRunspace(Runspace runspace)
         {
-            // Double session hop is currently allowed only for WSMan (non-OutOfProc) sessions, where
-            // the second session is either through a named pipe or hyperV socket connection.
-            if (!AllowPushRunspace &&
-                ((_transportManager is OutOfProcessServerSessionTransportManager) ||
-                 !(runspace.ConnectionInfo is NamedPipeConnectionInfo ||
-                   runspace.ConnectionInfo is VMConnectionInfo ||
-                   runspace.ConnectionInfo is ContainerConnectionInfo))
-               )
-            {
-                throw new PSNotSupportedException();
-            }
-
             if (_debugger == null)
             {
                 throw new PSInvalidOperationException(RemotingErrorIdStrings.ServerDriverRemoteHostNoDebuggerToPush);
@@ -415,16 +392,6 @@ namespace System.Management.Automation.Remoting
         internal Runspace PushedRunspace
         {
             get { return _pushedRunspace; }
-        }
-
-        /// <summary>
-        /// Allows a push runspace on this remote server host instance, regardless of
-        /// transport being used.
-        /// </summary>
-        internal override bool AllowPushRunspace
-        {
-            get;
-            set;
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
@@ -457,10 +457,7 @@ namespace System.Management.Automation
                 {
                     // Let exceptions propagate.
                     RemoteRunspace remoteRunspace = HostUtilities.CreateConfiguredRunspace(_configurationName, _remoteHost);
-
-                    _remoteHost.AllowPushRunspace = true;
                     _remoteHost.PropagatePop = true;
-
                     _remoteHost.PushRunspace(remoteRunspace);
                 }
             }

--- a/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
+++ b/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
@@ -1339,9 +1339,6 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
   <data name="EnableNetworkAccessWarning" xml:space="preserve">
     <value>PSSession {0} was created using the EnableNetworkAccess parameter and can only be reconnected from the local computer.</value>
   </data>
-  <data name="RemoteHostDoesNotSupportPushRunspace" xml:space="preserve">
-    <value>You are currently in a PowerShell PSSession and cannot use the Enter-PSSession cmdlet to enter another PSSession.</value>
-  </data>
   <data name="CannotStartJobInconsistentLanguageMode" xml:space="preserve">
     <value>Cannot start job. The language mode for this session is incompatible with the system-wide language mode.</value>
   </data>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This addresses Issue #2453 
This PR allows Enter-PSHostProcess to work from within an SSH remote interactive session.


## PR Context

Interactive session second hop support was added a while ago, but current behavior is to restrict a second hop to work only from a WinRM remote session.  This is an unnecessary restriction and this PR allows both `Enter-PSSession` and `Enter-PSHostProcess` to work from within any interactive remote session.

Example:
```powershell
PS> Enter-PSSession -HostName localhost
[localhost]: PS> Enter-PSHostProcess 8380
[localhost]: [Process:8380]: PS> $pid
8380
Exit-PSHostProcess
[localhost]: PS> Exit-PSSession
PS> 
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/5468
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
