### PR TITLE
Make module formatting not generate error with strict mode

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1632,7 +1632,7 @@ namespace System.Management.Automation.Runspaces
                 .EndTable());
         }
 
-        private const string GetPreReleaseStringScriptBlock = @"
+        private const string PreReleaseStringScriptBlock = @"
                             if ($_.PrivateData -and 
                                 $_.PrivateData.ContainsKey('PSData') -and 
                                 $_.PrivateData.PSData.ContainsKey('PreRelease'))
@@ -1654,7 +1654,7 @@ namespace System.Management.Automation.Runspaces
                     .StartRowDefinition()
                         .AddPropertyColumn("ModuleType")
                         .AddPropertyColumn("Version")
-                        .AddScriptBlockColumn(GetPreReleaseStringScriptBlock)
+                        .AddScriptBlockColumn(PreReleaseStringScriptBlock)
                         .AddPropertyColumn("Name")
                         .AddScriptBlockColumn(@"
                             $result = [System.Collections.ArrayList]::new()
@@ -1687,7 +1687,7 @@ namespace System.Management.Automation.Runspaces
                     .StartRowDefinition()
                         .AddPropertyColumn("ModuleType")
                         .AddPropertyColumn("Version")
-                        .AddScriptBlockColumn(GetPreReleaseStringScriptBlock)
+                        .AddScriptBlockColumn(PreReleaseStringScriptBlock)
                         .AddPropertyColumn("Name")
                         .AddScriptBlockColumn("$_.ExportedCommands.Keys")
                     .EndRowDefinition()
@@ -1707,7 +1707,7 @@ namespace System.Management.Automation.Runspaces
                         .AddItemProperty(@"ModuleType")
                         .AddItemProperty(@"Version")
                         .AddItemScriptBlock(
-                            GetPreReleaseStringScriptBlock,
+                            PreReleaseStringScriptBlock,
                             label: "PreRelease")
                         .AddItemProperty(@"NestedModules")
                         .AddItemScriptBlock(@"$_.ExportedFunctions.Keys", label: "ExportedFunctions")

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1632,6 +1632,14 @@ namespace System.Management.Automation.Runspaces
                 .EndTable());
         }
 
+        private const string GetPreReleaseStringScriptBlock = @"
+                            if ($_.PrivateData -and 
+                                $_.PrivateData.ContainsKey('PSData') -and 
+                                $_.PrivateData.PSData.ContainsKey('PreRelease'))
+                            {
+                                    $_.PrivateData.PSData.PreRelease
+                            }";
+
         private static IEnumerable<FormatViewDefinition> ViewsOf_ModuleInfoGrouping(CustomControl[] sharedControls)
         {
             yield return new FormatViewDefinition("Module",
@@ -1646,11 +1654,7 @@ namespace System.Management.Automation.Runspaces
                     .StartRowDefinition()
                         .AddPropertyColumn("ModuleType")
                         .AddPropertyColumn("Version")
-                        .AddScriptBlockColumn(@"
-                            if ($_.PrivateData -and $_.PrivateData.PSData)
-                            {
-                                    $_.PrivateData.PSData.PreRelease
-                            }")
+                        .AddScriptBlockColumn(GetPreReleaseStringScriptBlock)
                         .AddPropertyColumn("Name")
                         .AddScriptBlockColumn(@"
                             $result = [System.Collections.ArrayList]::new()
@@ -1683,11 +1687,7 @@ namespace System.Management.Automation.Runspaces
                     .StartRowDefinition()
                         .AddPropertyColumn("ModuleType")
                         .AddPropertyColumn("Version")
-                        .AddScriptBlockColumn(@"
-                            if ($_.PrivateData -and $_.PrivateData.PSData)
-                            {
-                                    $_.PrivateData.PSData.PreRelease
-                            }")
+                        .AddScriptBlockColumn(GetPreReleaseStringScriptBlock)
                         .AddPropertyColumn("Name")
                         .AddScriptBlockColumn("$_.ExportedCommands.Keys")
                     .EndRowDefinition()
@@ -1707,11 +1707,7 @@ namespace System.Management.Automation.Runspaces
                         .AddItemProperty(@"ModuleType")
                         .AddItemProperty(@"Version")
                         .AddItemScriptBlock(
-                            @"
-                            if ($_.PrivateData -and $_.PrivateData.PSData)
-                            {
-                                    $_.PrivateData.PSData.PreRelease
-                            }",
+                            GetPreReleaseStringScriptBlock,
                             label: "PreRelease")
                         .AddItemProperty(@"NestedModules")
                         .AddItemScriptBlock(@"$_.ExportedFunctions.Keys", label: "ExportedFunctions")


### PR DESCRIPTION
Fixes #11909

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Minor tweak to module formatting script to avoid errors when strict mode is on.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
