### PR TITLE
Catch IOException in Get-FileHash

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
@@ -158,13 +158,12 @@ namespace Microsoft.PowerShell.Commands
                 }
                 catch (IOException ioException)
                 {
-                    ThrowTerminatingError(
-                        new ErrorRecord(
-                            ioException,
-                            "FileReadError",
-                            ErrorCategory.ReadError,
-                            path));
-                    return;
+                    var errorRecord = new ErrorRecord(
+                        ioException,
+                        "FileReadError",
+                        ErrorCategory.ReadError,
+                        path);
+                    WriteError(errorRecord);
                 }
                 finally
                 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
@@ -156,6 +156,16 @@ namespace Microsoft.PowerShell.Commands
                         path);
                     WriteError(errorRecord);
                 }
+                catch (IOException ioException)
+                {
+                    ThrowTerminatingError(
+                        new ErrorRecord(
+                            ioException,
+                            "FileReadError",
+                            ErrorCategory.ReadError,
+                            path));
+                    return;
+                }
                 finally
                 {
                     openfilestream?.Dispose();

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FileHash.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FileHash.Tests.ps1
@@ -30,7 +30,7 @@ Describe "Get-FileHash" -Tags "CI" {
         }
 
         It "Should write non-terminating error if a file is locked" -Skip:(-not $IsWindows) {
-            $result = "$env:SystemDrive\\pagefile.sys", "${pshome}\pwsh.dll" | Get-FileHash -ErrorVariable errorVariable
+            $result = "$env:SystemDrive\\swapfile.sys", "${pshome}\pwsh.dll" | Get-FileHash -ErrorVariable errorVariable
             $result.Count | Should -Be 1
             $errorVariable.FullyQualifiedErrorId | Should -BeExactly "FileReadError,Microsoft.PowerShell.Commands.GetFileHashCommand"
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FileHash.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FileHash.Tests.ps1
@@ -28,6 +28,12 @@ Describe "Get-FileHash" -Tags "CI" {
             $result.Count | Should -Be 1
             $errorVariable.FullyQualifiedErrorId | Should -BeExactly "UnauthorizedAccessError,Microsoft.PowerShell.Commands.GetFileHashCommand"
         }
+
+        It "Should write non-terminating error if a file is locked" -Skip:(-not $IsWindows) {
+            $result = "C:\pagefile.sys", "${pshome}\pwsh.dll" | Get-FileHash -ErrorVariable errorVariable
+            $result.Count | Should -Be 1
+            $errorVariable.FullyQualifiedErrorId | Should -BeExactly "FileReadError,Microsoft.PowerShell.Commands.GetFileHashCommand"
+        }
     }
 
     Context "Algorithm tests" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FileHash.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FileHash.Tests.ps1
@@ -30,7 +30,7 @@ Describe "Get-FileHash" -Tags "CI" {
         }
 
         It "Should write non-terminating error if a file is locked" -Skip:(-not $IsWindows) {
-            $result = "C:\pagefile.sys", "${pshome}\pwsh.dll" | Get-FileHash -ErrorVariable errorVariable
+            $result = "$env:SystemDrive\\pagefile.sys", "${pshome}\pwsh.dll" | Get-FileHash -ErrorVariable errorVariable
             $result.Count | Should -Be 1
             $errorVariable.FullyQualifiedErrorId | Should -BeExactly "FileReadError,Microsoft.PowerShell.Commands.GetFileHashCommand"
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FileHash.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FileHash.Tests.ps1
@@ -30,7 +30,8 @@ Describe "Get-FileHash" -Tags "CI" {
         }
 
         It "Should write non-terminating error if a file is locked" -Skip:(-not $IsWindows) {
-            $result = "$env:SystemDrive\\swapfile.sys", "${pshome}\pwsh.dll" | Get-FileHash -ErrorVariable errorVariable
+            $pagefilePath = (Get-CimInstance -ClassName Win32_PageFileusage).Name
+            $result = $pagefilePath, "${pshome}\pwsh.dll" | Get-FileHash -ErrorVariable errorVariable
             $result.Count | Should -Be 1
             $errorVariable.FullyQualifiedErrorId | Should -BeExactly "FileReadError,Microsoft.PowerShell.Commands.GetFileHashCommand"
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #11931
Catch all IO exceptions in Get-FileHash cmdlet to do not terminate pipeline.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
