### PR TITLE
Start-Process: Correct Unspecified WorkingDirectory Resolution

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -1896,7 +1896,7 @@ namespace Microsoft.PowerShell.Commands
             else
             {
                 // Working Directory not specified -> Assign Current Path.
-                startInfo.WorkingDirectory = PathUtils.ResolveFilePath(this.SessionState.Path.CurrentFileSystemLocation.Path, this, true);
+                startInfo.WorkingDirectory = PathUtils.ResolveFilePath(this.SessionState.Path.CurrentFileSystemLocation.Path, this, isLiteralPath: true);
             }
 
             if (this.ParameterSetName.Equals("Default"))

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -1896,7 +1896,7 @@ namespace Microsoft.PowerShell.Commands
             else
             {
                 // Working Directory not specified -> Assign Current Path.
-                startInfo.WorkingDirectory = ResolveFilePath(this.SessionState.Path.CurrentFileSystemLocation.Path);
+                startInfo.WorkingDirectory = PathUtils.ResolveFilePath(this.SessionState.Path.CurrentFileSystemLocation.Path, this, true);
             }
 
             if (this.ParameterSetName.Equals("Default"))

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
@@ -14,8 +14,8 @@ Describe "Start-Process" -Tag "Feature","RequireAdminOnWindows" {
         $pingCommand = (Get-Command -CommandType Application ping)[0].Definition
         $pingDirectory = Split-Path $pingCommand -Parent
         $tempFile = Join-Path -Path $TestDrive -ChildPath PSTest
-		$tempDirectory = Join-Path -Path $TestDrive -ChildPath 'PSPath[]'
-		New-Item $tempDirectory -ItemType Directory  -Force
+        $tempDirectory = Join-Path -Path $TestDrive -ChildPath 'PSPath[]'
+        New-Item $tempDirectory -ItemType Directory  -Force
         $assetsFile = Join-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath assets) -ChildPath SortTest.txt
         if ($IsWindows) {
             $pingParam = "-n 2 localhost"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
@@ -14,6 +14,8 @@ Describe "Start-Process" -Tag "Feature","RequireAdminOnWindows" {
         $pingCommand = (Get-Command -CommandType Application ping)[0].Definition
         $pingDirectory = Split-Path $pingCommand -Parent
         $tempFile = Join-Path -Path $TestDrive -ChildPath PSTest
+		$tempDirectory = Join-Path -Path $TestDrive -ChildPath 'PSPath[]'
+		New-Item $tempDirectory -ItemType Directory  -Force
         $assetsFile = Join-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath assets) -ChildPath SortTest.txt
         if ($IsWindows) {
             $pingParam = "-n 2 localhost"
@@ -67,6 +69,15 @@ Describe "Start-Process" -Tag "Feature","RequireAdminOnWindows" {
 	    $process.Length      | Should -Be 1
 	    $process.Id          | Should -BeGreaterThan 1
 	    # $process.ProcessName | Should -Be "ping"
+    }
+	
+    It "Should work correctly within an unspecified WorkingDirectory with wildcard-type characters" {
+        Push-Location -LiteralPath $tempDirectory
+	    $process = Start-Process ping -ArgumentList $pingParam -PassThru -RedirectStandardOutput "$TESTDRIVE/output" @extraArgs
+	    $process.Length      | Should -Be 1
+	    $process.Id          | Should -BeGreaterThan 1
+	    # $process.ProcessName | Should -Be "ping"
+        Pop-Location
     }
 
     It "Should handle stderr redirection without error" {


### PR DESCRIPTION
# PR Summary

Modified Start-Process such that an unspecified working directory is correctly treated as literal when being resolved.

Fix #11940

## PR Context

Problem was discovered when investigating an error that resulted from executing Start-Process in a directory that contained wildcard characters. 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: 
- **Testing - New and feature**
    - [] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
