### PR TITLE
Added Support For Big Endian UTF-32

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/UtilityCommon.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/UtilityCommon.cs
@@ -44,6 +44,11 @@ namespace Microsoft.PowerShell.Commands
         BigEndianUnicode,
 
         /// <summary>
+        /// Big Endian UTF32 encoding.
+        /// </summary>
+        BigEndianUTF32,
+        
+        /// <summary>
         /// UTF8 encoding.
         /// </summary>
         Utf8,

--- a/src/System.Management.Automation/utils/EncodingUtils.cs
+++ b/src/System.Management.Automation/utils/EncodingUtils.cs
@@ -16,6 +16,7 @@ namespace System.Management.Automation
         internal const string String = "string";
         internal const string Unicode = "unicode";
         internal const string BigEndianUnicode = "bigendianunicode";
+        internal const string BigEndianUtf32 = "bigendianutf32";
         internal const string Ascii = "ascii";
         internal const string Utf8 = "utf8";
         internal const string Utf8NoBom = "utf8NoBOM";
@@ -25,13 +26,14 @@ namespace System.Management.Automation
         internal const string Default = "default";
         internal const string OEM = "oem";
         internal static readonly string[] TabCompletionResults = {
-                Ascii, BigEndianUnicode, OEM, Unicode, Utf7, Utf8, Utf8Bom, Utf8NoBom, Utf32
+                Ascii, BigEndianUnicode, BigEndianUtf32, OEM, Unicode, Utf7, Utf8, Utf8Bom, Utf8NoBom, Utf32
             };
 
         internal static Dictionary<string, Encoding> encodingMap = new Dictionary<string, Encoding>(StringComparer.OrdinalIgnoreCase)
         {
             { Ascii, System.Text.Encoding.ASCII },
             { BigEndianUnicode, System.Text.Encoding.BigEndianUnicode },
+            { BigEndianUtf32, new UTF32Encoding(bigEndian: true, byteOrderMark: true) },
             { Default, ClrFacade.GetDefaultEncoding() },
             { OEM, ClrFacade.GetOEMEncoding() },
             { Unicode, System.Text.Encoding.Unicode },
@@ -116,6 +118,7 @@ namespace System.Management.Automation
         public ArgumentEncodingCompletionsAttribute() : base(
             EncodingConversion.Ascii,
             EncodingConversion.BigEndianUnicode,
+            EncodingConversion.BigEndianUtf32,
             EncodingConversion.OEM,
             EncodingConversion.Unicode,
             EncodingConversion.Utf7,

--- a/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
+++ b/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
@@ -46,26 +46,22 @@ Describe "Redirection operator now supports encoding changes" -Tags "CI" {
     }
 
     $availableEncodings = 
-        @([System.Text.Encoding]::ASCII,
-          [System.Text.Encoding]::BigEndianUnicode,
-          (New-Object System.Text.UTF32Encoding($true,$true)),
-          [System.Text.Encoding]::Unicode,
-          [System.Text.Encoding]::UTF7,
-          [System.Text.Encoding]::UTF8,
-          [System.Text.Encoding]::UTF32);
+        @([System.Text.Encoding]::ASCII
+          [System.Text.Encoding]::BigEndianUnicode
+          [System.Text.UTF32Encoding]::new($true,$true)
+          [System.Text.Encoding]::Unicode
+          [System.Text.Encoding]::UTF7
+          [System.Text.Encoding]::UTF8
+          [System.Text.Encoding]::UTF32)
               
     foreach($encoding in $availableEncodings) {
 
-        # some of the encodings accepted by Out-File aren't real,
-        # and Out-File has its own translation, so we'll
-        # not do that logic here, but simply ignore those encodings
-        # as they eventually are translated to "real" encoding
         $encodingName = $encoding.EncodingName
         $msg = "Overriding encoding for Out-File is respected for $encodingName"
         $BOM = $encoding.GetPreamble()
         $TXT = $encoding.GetBytes($asciiString)
         $CR  = $encoding.GetBytes($asciiCR)
-        $expectedBytes = .{ $BOM; $TXT; $CR }
+        $expectedBytes = @( $BOM; $TXT; $CR )
         $PSDefaultParameterValues["Out-File:Encoding"] = $encoding
         $asciiString > TESTDRIVE:/file.txt
         $observedBytes = Get-Content -AsByteStream TESTDRIVE:/file.txt

--- a/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
+++ b/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
@@ -45,42 +45,36 @@ Describe "Redirection operator now supports encoding changes" -Tags "CI" {
         }
     }
 
-    # $availableEncodings = "unknown","string","unicode","bigendianunicode","utf8","utf7", "utf32","ascii","default","oem"
-    $availableEncodings = (Get-Command Out-File).Parameters["Encoding"].Attributes.ValidValues
-
+    $availableEncodings = 
+        @([System.Text.Encoding]::ASCII,
+          [System.Text.Encoding]::BigEndianUnicode,
+          (New-Object System.Text.UTF32Encoding($true,$true)),
+          [System.Text.Encoding]::Unicode,
+          [System.Text.Encoding]::UTF7,
+          [System.Text.Encoding]::UTF8,
+          [System.Text.Encoding]::UTF32);
+              
     foreach($encoding in $availableEncodings) {
-        $skipTest = $false
-        if ($encoding -eq "default") {
-            # [System.Text.Encoding]::Default is exposed by 'System.Private.CoreLib.dll' at
-            # runtime via reflection. However,it isn't exposed in the reference contract of
-            # 'System.Text.Encoding', and therefore we cannot use 'Encoding.Default' in our
-            # code. So we need to skip this encoding in the test.
-            $skipTest = $true
-        }
 
         # some of the encodings accepted by Out-File aren't real,
         # and Out-File has its own translation, so we'll
         # not do that logic here, but simply ignore those encodings
         # as they eventually are translated to "real" encoding
-        $enc = [System.Text.Encoding]::$encoding
-        if ( $enc )
-        {
-            $msg = "Overriding encoding for Out-File is respected for $encoding"
-            $BOM = $enc.GetPreamble()
-            $TXT = $enc.GetBytes($asciiString)
-            $CR  = $enc.GetBytes($asciiCR)
-            $expectedBytes = .{ $BOM; $TXT; $CR }
-            $PSDefaultParameterValues["Out-File:Encoding"] = "$encoding"
-            $asciiString > TESTDRIVE:/file.txt
-            $observedBytes = Get-Content -AsByteStream TESTDRIVE:/file.txt
-            # THE TEST
-            It $msg -Skip:$skipTest {
-                $observedBytes.Count | Should -Be $expectedBytes.Count
-                for($i = 0;$i -lt $observedBytes.Count; $i++) {
-                    $observedBytes[$i] | Should -Be $expectedBytes[$i]
-                }
+        $encodingName = $encoding.EncodingName
+        $msg = "Overriding encoding for Out-File is respected for $encodingName"
+        $BOM = $encoding.GetPreamble()
+        $TXT = $encoding.GetBytes($asciiString)
+        $CR  = $encoding.GetBytes($asciiCR)
+        $expectedBytes = .{ $BOM; $TXT; $CR }
+        $PSDefaultParameterValues["Out-File:Encoding"] = $encoding
+        $asciiString > TESTDRIVE:/file.txt
+        $observedBytes = Get-Content -AsByteStream TESTDRIVE:/file.txt
+        # THE TEST
+        It $msg {
+            $observedBytes.Count | Should -Be $expectedBytes.Count
+            for($i = 0;$i -lt $observedBytes.Count; $i++) {
+                $observedBytes[$i] | Should -Be $expectedBytes[$i]
             }
-
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -97,6 +97,7 @@ Describe "Get-Content" -Tags "CI" {
         @{EncodingName = 'String'},
         @{EncodingName = 'Unicode'},
         @{EncodingName = 'BigEndianUnicode'},
+        @{EncodingName = 'BigEndianUTF32'},
         @{EncodingName = 'UTF8'},
         @{EncodingName = 'UTF7'},
         @{EncodingName = 'UTF32'},

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Hex.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Hex.Tests.ps1
@@ -433,6 +433,13 @@ public enum TestSByteEnum : sbyte {
                 ExpectedResult = "0000000000000000   00 68 00 65 00 6C 00 6C 00 6F                     h e l l o"
             }
             @{
+                Name                 = "Can process BigEndianUTF32 encoding 'fhx -InputObject 'hello' -Encoding BigEndianUTF32'"
+                Encoding             = "BigEndianUTF32"
+                Count                = 2
+                ExpectedResult       = "0000000000000000   00 00 00 68 00 00 00 65 00 00 00 6C 00 00 00 6C     h   e   l   l"
+                ExpectedSecondResult = "0000000000000010   00 00 00 6F                                         o"
+            }           
+            @{
                 Name           = "Can process Unicode encoding 'fhx -InputObject 'hello' -Encoding Unicode'"
                 Encoding       = "Unicode"
                 Count          = 1


### PR DESCRIPTION
# PR Summary

Added Support For Big Endian UTF-32 to common encoding enumerations/classes.

## PR Context

Big Endian UTF-32 is a somewhat common encoding and was supported under Windows PowerShell.  This pull adds support for it and also addresses a small bug that resulted in a test being effectively skipped.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/PowerShell/PowerShell/issues/11645
- **Testing - New and feature**
    - [] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
