### PR TITLE
Fix ModuleInfoGrouping format

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1658,13 +1658,20 @@ namespace System.Management.Automation.Runspaces
 
                             if (-not $editions)
                             {
-                                if ($_.PrivateData -and ($_.PrivateData.PSData.Tags -contains 'PSEdition_Desktop' -or 
+                                if ($_.PrivateData -and ($_.PrivateData.PSData.Tags -contains 'PSEdition_Desktop' -or
                                                          $_.PrivateData.PSData.Tags -contains 'PSEdition_Core'))
                                 {
                                     $editions = @(($_.PrivateData.PSData.Tags | Where-Object {$_ -like 'PSEdition_*'}) -replace 'PSEdition_', '')
                                 }
-                                else {
+                                elseif ($_.ModuleBase -like '{0}*' -f $PSHOME) {
+                                    $editions = @('Core')
+                                }
+                                elseif ($IsWindows -and
+                                        $_.ModuleBase -like '{0}\Windows\system32\WindowsPowerShell\v1.0\Modules' -f $Env:SystemDrive ) {
                                     $editions = @('Desktop')
+                                }
+                                else {
+                                    $editions = @()
                                 }
                             }
 
@@ -1673,7 +1680,7 @@ namespace System.Management.Automation.Runspaces
                                 $result += $edition.Substring(0,4)
                             }
 
-                            ($result | Sort-Object) -join ','")
+                            if ($result) { ($result | Sort-Object) -join ','}")
                         .AddScriptBlockColumn("$_.ExportedCommands.Keys")
                     .EndRowDefinition()
                 .EndTable());

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1655,9 +1655,17 @@ namespace System.Management.Automation.Runspaces
                         .AddScriptBlockColumn(@"
                             $result = [System.Collections.ArrayList]::new()
                             $editions = $_.CompatiblePSEditions
+
                             if (-not $editions)
                             {
-                                $editions = @('Desktop')
+                                if ($_.PrivateData -and ($_.PrivateData.PSData.Tags -contains 'PSEdition_Desktop' -or 
+                                                         $_.PrivateData.PSData.Tags -contains 'PSEdition_Core'))
+                                {
+                                    $editions = @(($_.PrivateData.PSData.Tags | Where-Object {$_ -like 'PSEdition_*'}) -replace 'PSEdition_', '')
+                                }
+                                else {
+                                    $editions = @('Desktop')
+                                }
                             }
 
                             foreach ($edition in $editions)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR updates the `PSEdition` column in the `Module` table format to check `PrivateData.PSData.Tags` for `PSEdition_Desktop` and `PSEdition_Core` if `CompatiblePSEditions` is not defined. This allows module authors to indicate compatible `PSEditions` without limiting module compatibility to 5.1+ by using `CompatiblePSEditions`.

If `CompatiblePSEditions` or tags are not for a module in $PSHOME it will add `Core` and if the module is in Windows in-box it will add `Desktop`.

```powershell
# Current
PS C:\> Get-Module -ListAvailable | Where-Object Name -eq Pester | Select-Object -First 1


    Directory: C:\Program Files\WindowsPowerShell\Modules

ModuleType Version    PreRelease Name                                PSEdition ExportedCommands
---------- -------    ---------- ----                                --------- ----------------
Script     4.9.0                 Pester                              Desk      {Describe, Context, It, Should…}


# New
PS C:\> Get-Module -ListAvailable | Where-Object Name -eq Pester | Select-Object -First 1


    Directory: C:\Program Files\WindowsPowerShell\Modules

ModuleType Version    PreRelease Name                                PSEdition ExportedCommands
---------- -------    ---------- ----                                --------- ----------------
Script     4.9.0                 Pester                              Core,Desk {Describe, Context, It, Should…}
```


## PR Context

This PR fixes #11927 and #7856

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
