### PR TITLE
Fix ConciseView to not show the line information within the error message

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1100,7 +1100,8 @@ namespace System.Management.Automation.Runspaces
                                                 $offsetInLine = 0
                                             }
                                             else {
-                                                $positionMessage = $myinv.PositionMessage.Split($newline)
+                                                # use newline char instead of $newline because that is what is in the message
+                                                $positionMessage = $myinv.PositionMessage.Split(""`n"")
                                                 $line = $positionMessage[1].Substring(1) # skip the '+' at the start
                                                 $highlightLine = $positionMessage[$positionMessage.Count - 1].Substring(1)
                                                 $offsetLength = $highlightLine.Trim().Length

--- a/test/powershell/engine/Formatting/ErrorView.Tests.ps1
+++ b/test/powershell/engine/Formatting/ErrorView.Tests.ps1
@@ -99,6 +99,12 @@ Describe 'Tests for $ErrorView' -Tag CI {
             $e = { throw "$msg" } | Should -Throw $msg -PassThru | Out-String
             $e | Should -BeLike "*$msg*"
         }
+
+        It "Position message does not contain line information" {
+
+            $e = & "$PSHOME/pwsh" -noprofile -command "foreach abc" | Out-String
+            $e | Should -Not -BeLike "*At line*"
+        }
     }
 
     Context 'NormalView tests' {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This is a regression from a prior change that replaced usage of `` `n`` with `$newline` but accidentally replaced a correct usage of `` `n`` as the `PositionMessage` member uses `` `n`` as the newline is from a resource string.  Fix is to change back usage of `Split()` with the newline char rather than `$newline` which may contain CRLF.  This is a regression introduced in rc.3 from rc.2

## PR Context

The error message was inadvertently including the legacy line position information.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
