### PR TITLE
Miscellaneous minor updates to WinCompat

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -2359,7 +2359,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     if (importingModule)
                     {
-                        IList<PSModuleInfo> moduleProxies = ImportModulesUsingWinCompat(new string[] { moduleManifestPath }, null, new ImportModuleOptions());
+                        IList<PSModuleInfo> moduleProxies = ImportModulesUsingWinCompat(new string[] { moduleManifestPath }, null, options);
 
                         // we are loading by a single ManifestPath so expect max of 1
                         if (moduleProxies.Count > 0)

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -4799,6 +4799,7 @@ namespace Microsoft.PowerShell.Commands
             using var ps = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace);
             ps.AddCommand(commandInfo);
             ps.AddParameter("Name", WindowsPowerShellCompatRemotingSessionName);
+            ps.AddParameter("ErrorAction", ActionPreference.Ignore);
             var results = ps.Invoke<PSSession>();
             if (results.Count > 0)
             {

--- a/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
@@ -93,13 +93,16 @@ namespace System.Management.Automation.Runspaces
                 LoadUserProfile = true,
 #endif
             };
-
+#if !UNIX
             if (startingWindowsPowerShell51)
             {
                 _startInfo.ArgumentList.Add("-Version");
                 _startInfo.ArgumentList.Add("5.1");
-            }
 
+                // if starting Windows PowerShell, need to remove PowerShell specific segments of PSModulePath
+                _startInfo.Environment["PSModulePath"] = ModuleIntrinsics.GetWindowsPowerShellModulePath();
+            }
+#endif
             _startInfo.ArgumentList.Add("-s");
             _startInfo.ArgumentList.Add("-NoLogo");
             _startInfo.ArgumentList.Add("-NoProfile");

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -603,8 +603,7 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "Feature" {
             }
         }
 
-        It 'Windows PowerShell does not inherit path defined in powershell.config.json' -Skip:(!$IsWindows) {
-
+        It 'Windows PowerShell does not inherit path defined in powershell.config.json' {
             '{ "PSModulePath": "C:\\MyTestDir" }' | Out-File -Force $ConfigPath
             $winpsPaths =  & $pwsh -NoProfile -NonInteractive -settingsFile $ConfigPath -c "Import-Module $ModuleName2 -UseWindowsPowerShell -WarningAction Ignore;`$s = Get-PSSession -Name WinPSCompatSession;Invoke-Command -Session `$s -ScriptBlock {`$env:psmodulepath}"
             $winpsPaths | Should -Not -BeLike "*MyTestDir*"

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -130,7 +130,7 @@ function New-TestNestedModule
     # Create the manifest
     [scriptblock]::Create($newManifestCmd).Invoke()
 }
-<#
+
 Describe "Get-Module with CompatiblePSEditions-checked paths" -Tag "CI" {
 
     BeforeAll {
@@ -229,7 +229,7 @@ Describe "Get-Module with CompatiblePSEditions-checked paths" -Tag "CI" {
         }
     }
 }
-#>
+
 Describe "Import-Module from CompatiblePSEditions-checked paths" -Tag "CI" {
     BeforeAll {
         $successCases = @(
@@ -282,7 +282,7 @@ Describe "Import-Module from CompatiblePSEditions-checked paths" -Tag "CI" {
             Restore-ModulePath
         }
 
-        <#It "Successfully imports compatible modules from the module path with PSEdition <Editions>" -TestCases $successCases -Skip:(-not $IsWindows) {
+        It "Successfully imports compatible modules from the module path with PSEdition <Editions>" -TestCases $successCases -Skip:(-not $IsWindows) {
             param($Editions, $ModuleName, $Result)
 
             Import-Module $ModuleName -Force
@@ -354,7 +354,7 @@ Describe "Import-Module from CompatiblePSEditions-checked paths" -Tag "CI" {
             {
                 Set-Location $pwdBackup
             }
-        }#>
+        }
 
         It "-NoClobber and -Scope work with implicit WinCompat" -TestCases $failCases -Skip:(-not $IsWindows) {
             param($Editions, $ModuleName, $Result)
@@ -371,7 +371,7 @@ Describe "Import-Module from CompatiblePSEditions-checked paths" -Tag "CI" {
         }
     }
 
-    <#Context "Imports from absolute path" {
+    Context "Imports from absolute path" {
         It "Successfully imports compatible modules from an absolute path with PSEdition <Editions>" -TestCases $successCases -Skip:(-not $IsWindows) {
             param($Editions, $ModuleName, $Result)
 
@@ -407,9 +407,9 @@ Describe "Import-Module from CompatiblePSEditions-checked paths" -Tag "CI" {
             Import-Module $path -UseWindowsPowerShell -Force
             & "Test-${ModuleName}PSEdition" | Should -Be 'Desktop'
         }
-    }#>
+    }
 
-    <#Context "Imports using CommandDiscovery\ModuleAutoload" {
+    Context "Imports using CommandDiscovery\ModuleAutoload" {
         BeforeAll {
             Add-ModulePath $basePath
         }
@@ -429,9 +429,9 @@ Describe "Import-Module from CompatiblePSEditions-checked paths" -Tag "CI" {
 
             & "Test-${ModuleName}PSEdition" | Should -Be 'Desktop'
         }
-    }#>
+    }
 }
-<#
+
 Describe "Additional tests for Import-Module with WinCompat" -Tag "Feature" {
 
     BeforeAll {
@@ -610,8 +610,8 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "Feature" {
             $winpsPaths | Should -Not -BeLike "*MyTestDir*"
         }
     }
-}#>
-<#
+}
+
 Describe "PSModulePath changes interacting with other PowerShell processes" -Tag "Feature" {
     BeforeAll {
         $pwsh = "$PSHOME/pwsh"
@@ -1248,4 +1248,4 @@ Describe "Import-Module nested module behaviour with Edition checking" -Tag "Fea
             }
         }
     }
-}#>
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -229,7 +229,7 @@ Describe "Get-Module with CompatiblePSEditions-checked paths" -Tag "CI" {
         }
     }
 }
-
+#>
 Describe "Import-Module from CompatiblePSEditions-checked paths" -Tag "CI" {
     BeforeAll {
         $successCases = @(
@@ -282,7 +282,7 @@ Describe "Import-Module from CompatiblePSEditions-checked paths" -Tag "CI" {
             Restore-ModulePath
         }
 
-        It "Successfully imports compatible modules from the module path with PSEdition <Editions>" -TestCases $successCases -Skip:(-not $IsWindows) {
+        <#It "Successfully imports compatible modules from the module path with PSEdition <Editions>" -TestCases $successCases -Skip:(-not $IsWindows) {
             param($Editions, $ModuleName, $Result)
 
             Import-Module $ModuleName -Force
@@ -354,10 +354,24 @@ Describe "Import-Module from CompatiblePSEditions-checked paths" -Tag "CI" {
             {
                 Set-Location $pwdBackup
             }
+        }#>
+
+        It "-NoClobber and -Scope work with implicit WinCompat" -TestCases $failCases -Skip:(-not $IsWindows) {
+            param($Editions, $ModuleName, $Result)
+            try
+            {
+                Set-Item function:Test-$ModuleName {"OriginalFunctionImplementation"}
+                Import-Module $ModuleName -Force -WarningAction Ignore -Scope Local -NoClobber
+                & "Test-$ModuleName" | Should -BeExactly "OriginalFunctionImplementation"
+            }
+            finally
+            {
+                Remove-Item function:Test-$ModuleName
+            }
         }
     }
 
-    Context "Imports from absolute path" {
+    <#Context "Imports from absolute path" {
         It "Successfully imports compatible modules from an absolute path with PSEdition <Editions>" -TestCases $successCases -Skip:(-not $IsWindows) {
             param($Editions, $ModuleName, $Result)
 
@@ -393,9 +407,9 @@ Describe "Import-Module from CompatiblePSEditions-checked paths" -Tag "CI" {
             Import-Module $path -UseWindowsPowerShell -Force
             & "Test-${ModuleName}PSEdition" | Should -Be 'Desktop'
         }
-    }
+    }#>
 
-    Context "Imports using CommandDiscovery\ModuleAutoload" {
+    <#Context "Imports using CommandDiscovery\ModuleAutoload" {
         BeforeAll {
             Add-ModulePath $basePath
         }
@@ -415,9 +429,9 @@ Describe "Import-Module from CompatiblePSEditions-checked paths" -Tag "CI" {
 
             & "Test-${ModuleName}PSEdition" | Should -Be 'Desktop'
         }
-    }
-}#>
-
+    }#>
+}
+<#
 Describe "Additional tests for Import-Module with WinCompat" -Tag "Feature" {
 
     BeforeAll {
@@ -441,7 +455,7 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "Feature" {
         $global:PSDefaultParameterValues = $originalDefaultParameterValues
     }
 
-    <#Context "Tests that ErrorAction/WarningAction have effect when Import-Module with WinCompat is used" {
+    Context "Tests that ErrorAction/WarningAction have effect when Import-Module with WinCompat is used" {
         BeforeAll {
             $pwsh = "$PSHOME/pwsh"
             Add-ModulePath $basePath
@@ -538,7 +552,7 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "Feature" {
             $out = & $pwsh -NoProfile -NonInteractive -settingsFile $ConfigPath -c "[System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('TestWindowsPowerShellPSHomeLocation', `'$basePath`');`$ErrorActionPreference = 'SilentlyContinue';Test-$ModuleName2;`$error[0].FullyQualifiedErrorId"
             $out | Should -BeExactly 'CouldNotAutoloadMatchingModule'
         }
-    }#>
+    }
 
     Context "Tests around PSModulePath in WinCompat process" {
         BeforeAll {
@@ -596,7 +610,7 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "Feature" {
             $winpsPaths | Should -Not -BeLike "*MyTestDir*"
         }
     }
-}
+}#>
 <#
 Describe "PSModulePath changes interacting with other PowerShell processes" -Tag "Feature" {
     BeforeAll {

--- a/test/powershell/engine/Module/ModulePath.Tests.ps1
+++ b/test/powershell/engine/Module/ModulePath.Tests.ps1
@@ -165,9 +165,9 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
 
     It 'Windows PowerShell does not inherit PowerShell paths' -Skip:(!$IsWindows) {
         $out = powershell.exe -noprofile -command '$env:PSModulePath'
-        $out | Should -Not -Contain $expectedUserPath
-        $out | Should -Not -Contain $expectedSharedPath
-        $out | Should -Not -Contain $expectedSystemPath
+        $out | Should -Not -BeLike "*$expectedUserPath*"
+        $out | Should -Not -BeLike "*$expectedSharedPath*"
+        $out | Should -Not -BeLike "*$expectedSystemPath*"
     }
 
     It 'Windows PowerShell inherits user added paths' -Skip:(!$IsWindows) {


### PR DESCRIPTION
## PR Summary

Several small fixes to some WinCompat scenarios:

1. Removing PS-Core-specific paths from `PSModulePath` of WinCompat process (Windows PS). Similar change was done previously by #11057 for NativeCommandProcessor. This PR enables same 
`PSModulePath` behavior for WinCompat process (Windows PS) and job's process (Windows PS - for jobs started with `-PSVersion 5.1`). Without this change there could be bad cases when WinCompat process was loading PS-Core versions of the modules.

1. Some implicit WinCompat scenarios were ignoring `-NoClobber` and `-Scope` parameters. This is now fixed.

1. `Get-PSSession -Name` generates an error when the session is not found (in addition to returning nothing). When WinCompat uses `Get-PSSession` to search for existing `WinPSCompatSession` session to reuse, such error is not shown to the user but it is written to the error stream. Considering that it is normal for `WinPSCompatSession` session to not be there before the first WinCompat module import, such error is expected but it may confuse user if it is found in the error stream. The fix is to do `Get-PSSession -Name WinPSCompatSession -ErrorAction Ignore`.
Fix #11903

1. Fixed a test bug in `ModulePath.Tests.ps1`.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [X] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
