### PR TITLE
Change recommended VS Code extension name from ms-vscode.csharp to ms-dotnettools.csharp

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
 
 	"extensions": [
 		"ms-azure-devops.azure-pipelines",
-		"ms-vscode.csharp",
+		"ms-dotnettools.csharp",
 		"ms-vscode.powershell",
 		"DavidAnson.vscode-markdownlint",
 		"vitaliymaz.vscode-svg-previewer"

--- a/.devcontainer/fedora30/devcontainer.json
+++ b/.devcontainer/fedora30/devcontainer.json
@@ -8,7 +8,7 @@
 
 	"extensions": [
 		"ms-azure-devops.azure-pipelines",
-		"ms-vscode.csharp",
+		"ms-dotnettools.csharp",
 		"ms-vscode.powershell",
 		"DavidAnson.vscode-markdownlint",
 		"vitaliymaz.vscode-svg-previewer"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,7 @@
   "recommendations": [
     "ms-azure-devops.azure-pipelines",
     "ms-vscode.cpptools",
-    "ms-vscode.csharp",
+    "ms-dotnettools.csharp",
     "ms-vscode.PowerShell",
     "twxs.cmake",
     "DavidAnson.vscode-markdownlint",


### PR DESCRIPTION
C# extension has changed its name from "ms-vscode.csharp" to "ms-dotnettools.csharp", this means all extensions depending on it needs to be updated and i.e. all repositories with extension.json containing
```json
"recommendations": [
    "ms-vscode.csharp"
 ]
```
or you get errors like

![image](https://user-images.githubusercontent.com/1647294/76144809-2c18e500-6084-11ea-80ab-f365de742c99.png)