### PR TITLE
Implement `ForEach-Object -Parallel` runspace reuse

### DIFF
--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -585,6 +585,10 @@ namespace Microsoft.PowerShell.Commands
             _taskCollection.Complete();
             _taskDataStreamWriter.WaitAndWrite();
 
+            // TODO: Debug only
+            var warningMsg = string.Format(CultureInfo.InvariantCulture, "TaskPool runspace pool count: {0}", _taskPool.RunspaceCount);
+            Console.WriteLine(warningMsg);
+
             // Check for an unexpected error from the _taskCollection handler thread and report here.
             var ex = _taskCollectionException;
             if (ex != null)

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -260,6 +260,14 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = ForEachObjectCommand.ParallelParameterSet)]
         public SwitchParameter AsJob { get; set; }
 
+        /// <summary>
+        /// Gets or sets a flag so that a new runspace object is created for each loop iteration, instead of reusing objects
+        /// from the runspace pool.
+        /// By default, runspaces are reused from a runspace pool.
+        /// </summary>
+        [Parameter(ParameterSetName = ForEachObjectCommand.ParallelParameterSet)]
+        public SwitchParameter UseNewRunspace { get; set; }
+
         #endregion
 
         #region Overrides
@@ -437,7 +445,8 @@ namespace Microsoft.PowerShell.Commands
 
                 _taskJob = new PSTaskJob(
                     Parallel.ToString(),
-                    ThrottleLimit);
+                    ThrottleLimit,
+                    UseNewRunspace);
 
                 return;
             }
@@ -445,7 +454,7 @@ namespace Microsoft.PowerShell.Commands
             // Set up for synchronous processing and data streaming.
             _taskCollection = new PSDataCollection<System.Management.Automation.PSTasks.PSTask>();
             _taskDataStreamWriter = new PSTaskDataStreamWriter(this);
-            _taskPool = new PSTaskPool(ThrottleLimit);
+            _taskPool = new PSTaskPool(ThrottleLimit, UseNewRunspace);
             _taskPool.PoolComplete += (sender, args) =>
             {
                 _taskDataStreamWriter.Close();
@@ -584,10 +593,6 @@ namespace Microsoft.PowerShell.Commands
             _taskDataStreamWriter.WriteImmediate();
             _taskCollection.Complete();
             _taskDataStreamWriter.WaitAndWrite();
-
-            // TODO: Debug only
-            var warningMsg = string.Format(CultureInfo.InvariantCulture, "TaskPool runspace pool count: {0}", _taskPool.RunspaceCount);
-            Console.WriteLine(warningMsg);
 
             // Check for an unexpected error from the _taskCollection handler thread and report here.
             var ex = _taskCollectionException;

--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -905,24 +905,24 @@ namespace System.Management.Automation.PSTasks
 
         private void ReturnRunspace(PSTaskBase task)
         {
-            try
+            var runspace = task.Runspace;
+            Dbg.Assert(runspace != null, "Task runspace cannot be null.");
+            if (runspace.RunspaceStateInfo.State == RunspaceState.Opened &&
+                runspace.RunspaceAvailability == RunspaceAvailability.Available)
             {
-                var runspace = task.Runspace;
-                Dbg.Assert(runspace != null, "Task runspace cannot be null.");
-                if (runspace.RunspaceStateInfo.State == RunspaceState.Opened &&
-                    runspace.RunspaceAvailability == RunspaceAvailability.Available)
+                try
                 {
                     runspace.ResetRunspaceState();
                     _runspacePool.Enqueue(runspace);
+                    return;
                 }
-                else
+                catch
                 {
-                    RemoveActiveRunspace(runspace);
+                    // If the runspace cannot be reset for any reason, remove it.
                 }
             }
-            catch
-            {
-            }
+
+            RemoveActiveRunspace(runspace);
         }
 
         private void RemoveActiveRunspace(Runspace runspace)

--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -636,9 +636,9 @@ namespace System.Management.Automation.PSTasks
         private readonly ConcurrentQueue<Runspace> _runspacePool;
         private readonly ConcurrentDictionary<int, Runspace> _activeRunspaces;
         private readonly WaitHandle[] _waitHandles;
+        private readonly bool _useRunspacePool;
         private bool _isOpen;
         private bool _stopping;
-        private bool _useRunspacePool;
         private int _createdRunspaceCount;
 
         private const int AddAvailable = 0;

--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -427,6 +427,7 @@ namespace System.Management.Automation.PSTasks
         /// <summary>
         /// Start task.
         /// </summary>
+        /// <param name="runspace">Runspace used to run task.</param>
         public void Start(Runspace runspace)
         {
             if (_powershell != null)
@@ -721,6 +722,7 @@ namespace System.Management.Automation.PSTasks
             {
                 item.Value.Dispose();
             }
+            
             _activeRunspaces.Clear();
         }
 
@@ -792,7 +794,7 @@ namespace System.Management.Automation.PSTasks
         public void StopAll()
         {
             _stopping = true;
-            
+
             // Accept no more input
             Close();
             _stopAll.Set();
@@ -804,6 +806,7 @@ namespace System.Management.Automation.PSTasks
                 tasksToStop = new PSTaskBase[_taskPool.Values.Count];
                 _taskPool.Values.CopyTo(tasksToStop, 0);
             }
+
             foreach (var task in tasksToStop)
             {
                 task.Dispose();
@@ -856,6 +859,7 @@ namespace System.Management.Automation.PSTasks
                         // StopAll disposes tasks.
                         task.Dispose();
                     }
+
                     CheckForComplete();
                     break;
             }

--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -716,9 +716,9 @@ namespace System.Management.Automation.PSTasks
         /// </summary>
         internal void DisposeRunspaces()
         {
-            foreach (var runspace in _activeRunspaces.Values)
+            foreach (var item in _activeRunspaces)
             {
-                runspace.Dispose();
+                item.Value.Dispose();
             }
             _activeRunspaces.Clear();
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
@@ -314,6 +314,23 @@ Describe 'ForEach-Object -Parallel -AsJob Basic Tests' -Tags 'CI' {
     }
 }
 
+Describe 'ForEach-Object -Parallel runspace pool tests' -Tags 'CI' {
+
+    It "Verifies job allocated runspace count is limited to pool size" {
+
+        $job = 1..4 | ForEach-Object -Parallel { Start-Sleep 1 } -AsJob -ThrottleLimit 2 | Wait-Job
+        $job.AllocatedRunspaceCount | Should -BeExactly 2
+        $job | Remove-Job
+    }
+
+    It "Verifies job with -UseNewRunspace switch allocates one runspace per iteration" {
+
+        $job = 1..10 | ForEach-Object -Parallel { $_ } -AsJob -ThrottleLimit 2 -UseNewRunspace | Wait-Job
+        $job.AllocatedRunspaceCount | Should -BeExactly 10
+        $job | Remove-Job
+    }
+}
+
 Describe 'ForEach-Object -Parallel Functional Tests' -Tags 'Feature' {
 
     It 'Verifies job queuing and throttle limit' {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR addresses Issue #11478, by implementing runspace reuse.

## PR Context

The current ForEach-Object -Parallel implementation creates a new runspace for each loop iteration to ensure maximum isolation.  However, this can be a significant performance and resource hit, especially for loops that do a small amount of work compared to creating runspaces.  Or if there are a lot of iterations where each performs significant work, memory usage climbs drastically even though runspace resources are released timely.  The dotNet GC allows very large memory usage before collecting available resources.  Manually calling GC.Collect() helps significantly, bringing memory usage way down, but is onerous to implement in script.

The easiest and cleanest solution is to reuse runspaces in a pool.  However, there may be side effects of state being leaked between iterations, although runspace.ResetRunspaceState() is used.

The fix is to add a runspace pool from which runspace objects are drawn and returned.

Also added -UseNewRunspace switch to ForEach-Object -Parallel parameter set, to allow option to create new runspace per iteration, per review feedback from committee.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: 5609
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
