### PR TITLE
Remove extra line before formatting group

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommand.cs
@@ -288,7 +288,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             // Formating system writes newline before each object
             // so no need to add newline here like:
             //     fe.formatValueList.Add(new FormatNewLine());
-
             fed.formatEntryInfo = cve;
 
             this.WriteObject(fed);

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommand.cs
@@ -262,6 +262,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             }
             else if (transition == GroupTransition.startNew)
             {
+                // Add newline before each group except first
+                WriteNewLineObject();
+
                 // double transition
                 PopGroup(); // exit the current one
                 PushGroup(so); // start a sibling group
@@ -271,6 +274,24 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             {
                 this.WritePayloadObject(so);
             }
+        }
+
+        private void WriteNewLineObject()
+        {
+            FormatEntryData fed = new FormatEntryData();
+            fed.outOfBand = true;
+
+            ComplexViewEntry cve = new ComplexViewEntry();
+            FormatEntry fe = new FormatEntry();
+            cve.formatValueList.Add(fe);
+
+            // Formating system writes newline before each object
+            // so no need to add newline here like:
+            //     fe.formatValueList.Add(new FormatNewLine());
+
+            fed.formatEntryInfo = cve;
+
+            this.WriteObject(fed);
         }
 
         private bool ShouldProcessOutOfBand

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -476,8 +476,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
             if (goc.Data.groupingEntry != null)
             {
-                //_lo.WriteLine(string.Empty);
-
                 ComplexWriter writer = new ComplexWriter();
                 writer.Initialize(_lo, _lo.ColumnNumber);
                 writer.WriteObject(goc.Data.groupingEntry.formatValueList);

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -476,7 +476,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
             if (goc.Data.groupingEntry != null)
             {
-                _lo.WriteLine(string.Empty);
+                //_lo.WriteLine(string.Empty);
 
                 ComplexWriter writer = new ComplexWriter();
                 writer.Initialize(_lo, _lo.ColumnNumber);

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Custom.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Custom.Tests.ps1
@@ -397,7 +397,6 @@ Describe "Format-Custom with expression based EntrySelectedBy in a CustomControl
         $ps.Streams.Error.Clear()
         $expectedOutput = @'
 
-
 Entry selected by property
 
 Name
@@ -423,7 +422,6 @@ testing
         $null = $ps.AddScript($script).AddCommand('Out-String')
         $ps.Streams.Error.Clear()
         $expectedOutput = @'
-
 
 Entry selected by ScriptBlock
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #11846.

 Add newline only before each formatting group except first.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
