### PR TITLE
"Path is not parsed correctly if '[' is present in the path"

### DIFF
--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -282,7 +282,7 @@ namespace System.Management.Automation
         /// </param>
         /// <returns>True if the string has wild card chars, false otherwise..</returns>
         /// <remarks>
-        /// Currently { '*', '?', '[' } are considered wild card chars and
+        /// Currently { '*', '?', '[', ']' } are considered wild card chars and
         /// '`' is the escape character.
         /// </remarks>
         public static bool ContainsWildcardCharacters(string pattern)
@@ -293,24 +293,43 @@ namespace System.Management.Automation
             }
 
             bool result = false;
+            bool leftBracket = false;
 
             for (int index = 0; index < pattern.Length; ++index)
             {
                 if (IsWildcardChar(pattern[index]))
                 {
+                    // If '[' or ']' is present alone, then it should not be treated as wildcard chars
+                    //
+                    // Check if both the '[' and the ']' brackets are present.
+                    // If present they should be in order, first '[' and then ']'
+                    // Otherwise, just treat ('[' or ']') as normal literal
+
+					// Check if we got '['
+                    if ( IsLeftBracket(pattern[index]) )
+                    {
+						// got '['.
+                        leftBracket = true;
+                        continue;
+                    }
+					// got the ']' without the '['
+                    else if ( (leftBracket == false) && IsRightBracket(pattern[index]) )
+                    {
+						// Ignore the ']' and continue
+                        continue;
+                    }
+
                     result = true;
                     break;
                 }
 
                 // If it is an escape character then advance past
                 // the next character
-
                 if (pattern[index] == escapeChar)
                 {
                     ++index;
                 }
             }
-
             return result;
         }
 
@@ -401,6 +420,16 @@ namespace System.Management.Automation
         private static bool IsWildcardChar(char ch)
         {
             return (ch == '*') || (ch == '?') || (ch == '[') || (ch == ']');
+        }
+
+        private static bool IsLeftBracket(char ch)
+        {
+            return (ch == '[');
+        }
+
+        private static bool IsRightBracket(char ch)
+        {
+            return (ch == ']');
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -305,17 +305,16 @@ namespace System.Management.Automation
                     // If present they should be in order, first '[' and then ']'
                     // Otherwise, just treat ('[' or ']') as normal literal
 
-					// Check if we got '['
-                    if (IsLeftBracket(pattern[index]))
+                    // Check if we got '['
+                    if (ch == '[')
                     {
-						// got '['.
+                        // got '['.
                         leftBracket = true;
                         continue;
                     }
-					// got the ']' without the '['
-                    else if (!leftBracket && IsRightBracket(pattern[index]))
+                    else if (!leftBracket && ch == ']')
                     {
-						// Ignore the ']' and continue
+                        // got the ']' without the '['. Ignore the ']' and continue
                         continue;
                     }
 
@@ -330,6 +329,7 @@ namespace System.Management.Automation
                     ++index;
                 }
             }
+            
             return result;
         }
 
@@ -420,16 +420,6 @@ namespace System.Management.Automation
         private static bool IsWildcardChar(char ch)
         {
             return (ch == '*') || (ch == '?') || (ch == '[') || (ch == ']');
-        }
-
-        private static bool IsLeftBracket(char ch)
-        {
-            return (ch == '[');
-        }
-
-        private static bool IsRightBracket(char ch)
-        {
-            return (ch == ']');
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -306,7 +306,7 @@ namespace System.Management.Automation
                     // Otherwise, just treat ('[' or ']') as normal literal
 
 					// Check if we got '['
-                    if ( IsLeftBracket(pattern[index]) )
+                    if (IsLeftBracket(pattern[index]))
                     {
 						// got '['.
                         leftBracket = true;
@@ -1376,4 +1376,3 @@ namespace System.Management.Automation
         }
     }
 }
-

--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -306,13 +306,13 @@ namespace System.Management.Automation
                     // Otherwise, just treat ('[' or ']') as normal literal
 
                     // Check if we got '['
-                    if (ch == '[')
+                    if (pattern[index] == '[')
                     {
                         // got '['.
                         leftBracket = true;
                         continue;
                     }
-                    else if (!leftBracket && ch == ']')
+                    else if (!leftBracket && pattern[index] == ']')
                     {
                         // got the ']' without the '['. Ignore the ']' and continue
                         continue;

--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -313,7 +313,7 @@ namespace System.Management.Automation
                         continue;
                     }
 					// got the ']' without the '['
-                    else if ( (leftBracket == false) && IsRightBracket(pattern[index]) )
+                    else if (!leftBracket && IsRightBracket(pattern[index]))
                     {
 						// Ignore the ']' and continue
                         continue;

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Path.Tests.ps1
@@ -2,6 +2,32 @@
 # Licensed under the MIT License.
 Describe "Test-Path" -Tags "CI" {
     BeforeAll {
+        $testDirnames = @(
+            'WildCardCommandA'
+            'WildCardCommand[B]'
+            '['
+            'goose]'
+            'du[[ck'
+            'du][ck'
+            'duck]]'
+        )
+
+        $testFailDirnames = @(
+            'WildCardCommand'
+            ']'
+            'goos]e'
+            'du[ck'
+            'du]ck'
+            'du]]ck'
+            'duc]k]'
+        )
+
+        foreach($currentDir in $testDirNames)
+        {
+            $expandedFile = Join-Path $TestDrive -ChildPath $currentDir
+            New-Item -Path $expandedFile -ItemType Directory 
+        }
+    
         $testdirectory = $TestDrive
         $testfilename = New-Item -path $testdirectory -Name testfile.txt -ItemType file -Value 1 -force
 
@@ -141,4 +167,17 @@ Describe "Test-Path" -Tags "CI" {
         Test-Path Env:\PATH  | Should -BeTrue
     }
 
+    It "Validate Test-Path scenario where DestinationPath has incomplete brackets" {
+        foreach($currentDir in $testDirNames)
+        {
+            $expandedFile = Join-Path $TestDrive -ChildPath $currentDir
+            Test-Path -Path $expandedFile | Should Be $True
+        }
+
+        foreach($currentDir in $testFailDirnames)
+        {
+            $expandedFile = Join-Path $TestDrive -ChildPath $currentDir
+            Test-Path -Path $expandedFile | Should Be $False
+        }
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Path.Tests.ps1
@@ -4,7 +4,6 @@ Describe "Test-Path" -Tags "CI" {
     BeforeAll {
         $testDirnames = @(
             'WildCardCommandA'
-            'WildCardCommand[B]'
             '['
             'goose]'
             'du[[ck'


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
This PR helps to fix this issue that I raised. Path is not parsed correctly if '[' is present in the path #12168

Issues fixed:
Having '[' character in directory doesn't work. 

Create a directory: e:\[test
Repro 1:
Test-Path 'e:\[test\'
Output: Error
Expected Output: True

Repro 2:
Test-Path "e:\`[test\"
Output: Error
Expected Output: True

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
