### PR TITLE
Fix foreach parallel when current drive is not available

### DIFF
--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -449,6 +449,10 @@ namespace System.Management.Automation.PSTasks
                     Runspace.DefaultRunspace = runspace;
                     runspace.ExecutionContext.SessionState.Internal.SetLocation(_currentLocationPath);
                 }
+                catch (DriveNotFoundException)
+                {
+                    // Allow task to run if current drive is not available.
+                }
                 finally
                 {
                     Runspace.DefaultRunspace = oldDefaultRunspace;

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
@@ -104,6 +104,20 @@ Describe 'ForEach-Object -Parallel Basic Tests' -Tags 'CI' {
         $parallelScriptLocation = 1..1 | ForEach-Object -Parallel { $PWD }
         $parallelScriptLocation.Path | Should -BeExactly $PWD.Path
     }
+
+    It 'Verifies no terminating error if current working drive is not found' {
+        $oldLocation = Get-Location
+        try
+        {
+            New-PSDrive -Name ZZ -PSProvider FileSystem -Root $TestDrive
+            Set-Location -Path 'ZZ:'
+            { 1..1 | ForEach-Object -Parallel { $_ } } | Should -Not -Throw
+        }
+        finally
+        {
+            Set-Location -Path $oldLocation
+        }
+    }
 }
 
 Describe 'ForEach-Object -Parallel common parameters' -Tags 'CI' {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR addresses issue #12194, and fixes a terminating error that is thrown if the current directory is not in a default system drive.

## PR Context

Currently we don't initialize a loop iteration runspace with the current runspace state that is running the ForEach-Object command.  So if the current directory is in a temporary PowerShell drive a terminating error is thrown because the drive cannot be found, and the ForEach-Object command fails.

Fix is to catch this error and allow the ForEach-Object command to continue.  We can look at initializing loop iteration runspaces as a new feature in the future.


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
