### PR TITLE
Discover assemblies loaded by 'Assembly.Load(byte[])' and 'Assembly.LoadFile'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin/
 obj/
+.ionide/
 project.lock.json
 *-tests.xml
 /debug/

--- a/src/System.Management.Automation/utils/ClrFacade.cs
+++ b/src/System.Management.Automation/utils/ClrFacade.cs
@@ -58,9 +58,36 @@ namespace System.Management.Automation
         /// </param>
         internal static IEnumerable<Assembly> GetAssemblies(string namespaceQualifiedTypeName = null)
         {
-            return PSAssemblyLoadContext.GetAssembly(namespaceQualifiedTypeName) ??
-                   AssemblyLoadContext.Default.Assemblies.Where(a =>
-                       !a.FullName.StartsWith(TypeDefiner.DynamicClassAssemblyFullNamePrefix, StringComparison.Ordinal));
+            return PSAssemblyLoadContext.GetAssembly(namespaceQualifiedTypeName) ?? GetPSVisibleAssemblies();
+        }
+
+        /// <summary>
+        /// Return assemblies from the default load context and the 'individual' load contexts.
+        /// The 'individual' load contexts are the ones holding assemblies loaded via 'Assembly.Load(byte[])' and 'Assembly.LoadFile'.
+        /// Assemblies loaded in any custom load contexts are not consider visible to PowerShell to avoid type identity issues.
+        /// </summary>
+        private static IEnumerable<Assembly> GetPSVisibleAssemblies()
+        {
+            const string IndividualAssemblyLoadContext = "System.Runtime.Loader.IndividualAssemblyLoadContext";
+
+            foreach (Assembly assembly in AssemblyLoadContext.Default.Assemblies)
+            {
+                if (!assembly.FullName.StartsWith(TypeDefiner.DynamicClassAssemblyFullNamePrefix, StringComparison.Ordinal))
+                {
+                    yield return assembly;
+                }
+            }
+
+            foreach (AssemblyLoadContext context in AssemblyLoadContext.All)
+            {
+                if (IndividualAssemblyLoadContext.Equals(context.GetType().FullName, StringComparison.Ordinal))
+                {
+                    foreach (Assembly assembly in context.Assemblies)
+                    {
+                        yield return assembly;
+                    }
+                }
+            }
         }
 
         /// <summary>

--- a/test/powershell/engine/Basic/Assembly.LoadBytesAndLoadFile.Tests.ps1
+++ b/test/powershell/engine/Basic/Assembly.LoadBytesAndLoadFile.Tests.ps1
@@ -1,0 +1,47 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe "Assembly loaded in IndividualAssemblyLoadContext should be visible to PowerShell" -Tags "CI" {
+    BeforeAll {
+        $code1 = @'
+        namespace LoadBytes {
+            public class MyLoadBytesTest {
+                public static string GetName() { return "MyLoadBytesTest"; }
+            }
+        }
+'@
+        $code2 = @'
+        namespace LoadFile {
+            public class MyLoadFileTest {
+                public static string GetName() { return "MyLoadFileTest"; }
+            }
+        }
+'@
+
+        $tempFolderPath = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), "IndividualALCTest")
+        New-Item $tempFolderPath -ItemType Directory -Force > $null
+        $loadBytesFile = [System.IO.Path]::Combine($tempFolderPath, "MyLoadBytesTest.dll")
+        $loadFileFile = [System.IO.Path]::Combine($tempFolderPath, "MyLoadFileTest.dll")
+
+        if (-not (Test-Path $loadBytesFile)) {
+            Add-Type -TypeDefinition $code1 -OutputAssembly $loadBytesFile
+        }
+
+        if (-not (Test-Path $loadFileFile)) {
+            Add-Type -TypeDefinition $code2 -OutputAssembly $loadFileFile
+        }
+    }
+
+    It "Assembly loaded via 'Assembly.Load(byte[])' should be discoverable" {
+        $bytes = [System.IO.File]::ReadAllBytes($loadBytesFile)
+        [System.Reflection.Assembly]::Load($bytes) > $null
+
+        [LoadBytes.MyLoadBytesTest]::GetName() | Should -BeExactly "MyLoadBytesTest"
+    }
+
+    It "Assembly loaded via 'Assembly.LoadFile' should be discoverable" {
+        [System.Reflection.Assembly]::LoadFile($loadFileFile) > $null
+
+        [LoadFile.MyLoadFileTest]::GetName() | Should -BeExactly "MyLoadFileTest"
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #12052

Fix a regression in PS 7.0 introduced by #11088 
PowerShell should discover assemblies loaded by `Assembly.Load(byte[])` and `Assembly.LoadFile` as in prior versions.

Assemblies loaded by `Assembly.Load(byte[])` and `Assembly.LoadFile` are placed in special `AssemblyLoadContext` instances of the type `System.Runtime.Loader.IndividualAssemblyLoadContext`. PowerShell should return assemblies from those load context instances.

Also include a minor change to ignore the `.ionide` folders, which are auto-generated by VS Code C# extension to hold symbol caches.

/cc @SeeminglyScience 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
