### PR TITLE
Don't write DNS resolution errors on Test-Connection -Quiet

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -58,7 +58,7 @@ namespace Microsoft.PowerShell.Commands
 
         private static byte[]? s_DefaultSendBuffer;
 
-        private CancellationTokenSource _dnsLookupCancel = new CancellationTokenSource();
+        private readonly CancellationTokenSource _dnsLookupCancel = new CancellationTokenSource();
 
         private bool _disposed;
 

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -689,6 +689,11 @@ namespace Microsoft.PowerShell.Commands
                 }
                 catch (Exception ex)
                 {
+                    if (Quiet)
+                    {
+                        return false;
+                    }
+
                     string message = StringUtil.Format(
                         TestConnectionResources.NoPingResult,
                         resolvedTargetName,

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -58,7 +58,7 @@ namespace Microsoft.PowerShell.Commands
 
         private static byte[]? s_DefaultSendBuffer;
 
-        private CancellationTokenSource? _dnsLookupCancel = new CancellationTokenSource();
+        private CancellationTokenSource _dnsLookupCancel = new CancellationTokenSource();
 
         private bool _disposed;
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -60,9 +60,7 @@ Describe "Test-Connection" -tags "CI" {
         }
 
         It 'returns false without errors for an unresolvable address when using -Quiet' {
-            $result = $true
-            { $result = Test-Connection -Quiet -ErrorAction Stop -Count 1 -TargetName "fakeHost" } | Should -Not -Throw
-            $result | Should -BeFalse
+            Test-Connection -Quiet -ErrorAction Stop -Count 1 -TargetName "fakeHost" | Should -BeFalse
         }
 
         It "Ping fake host" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -60,12 +60,13 @@ Describe "Test-Connection" -tags "CI" {
         }
 
         It 'returns false without errors for an unresolvable address when using -Quiet' {
-            { Test-Connectiong -Quiet -ErrorAction Stop -Count 1 -TargetName "fakeHost" } | Should -Not -Throw
-            Test-Connection -Quiet -TargetName "fakeHost" -Count 1 | Should -BeFalse
+            $result = $true
+            { $result = Test-Connectiong -Quiet -ErrorAction Stop -Count 1 -TargetName "fakeHost" } | Should -Not -Throw
+            $result | Should -BeFalse
         }
 
         It "Ping fake host" {
-            { $result = Test-Connection "fakeHost" -Count 1 -ErrorAction Stop } |
+            { Test-Connection "fakeHost" -Count 1 -ErrorAction Stop } |
                 Should -Throw -ErrorId "TestConnectionException,Microsoft.PowerShell.Commands.TestConnectionCommand"
             # Error code = 11001 - Host not found.
             if ((Get-PlatformInfo).Platform -match "raspbian") {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -59,7 +59,8 @@ Describe "Test-Connection" -tags "CI" {
             $result2 | Should -BeFalse
         }
 
-        It 'does not emit errors for an unresolvable address when using -Quiet' {
+        It 'returns false without errors for an unresolvable address when using -Quiet' {
+            { Test-Connectiong -Quiet -ErrorAction Stop -Count 1 -TargetName "fakeHost" } | Should -Not -Throw
             Test-Connection -Quiet -TargetName "fakeHost" -Count 1 | Should -BeFalse
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -59,18 +59,19 @@ Describe "Test-Connection" -tags "CI" {
             $result2 | Should -BeFalse
         }
 
-        It "Ping fake host" {
+        It 'does not emit errors for an unresolvable address when using -Quiet' {
+            Test-Connection -Quiet -TargetName "fakeHost" -Count 1 | Should -BeFalse
+        }
 
-            { $result = Test-Connection "fakeHost" -Count 1 -Quiet -ErrorAction Stop } |
+        It "Ping fake host" {
+            { $result = Test-Connection "fakeHost" -Count 1 -ErrorAction Stop } |
                 Should -Throw -ErrorId "TestConnectionException,Microsoft.PowerShell.Commands.TestConnectionCommand"
             # Error code = 11001 - Host not found.
             if ((Get-PlatformInfo).Platform -match "raspbian") {
                 $code = 11
-            }
-            elseif (!$IsWindows) {
+            } elseif (!$IsWindows) {
                 $code = -131073
-            }
-            else {
+            } else {
                 $code = 11001
             }
             $error[0].Exception.InnerException.ErrorCode | Should -Be $code

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -61,7 +61,7 @@ Describe "Test-Connection" -tags "CI" {
 
         It 'returns false without errors for an unresolvable address when using -Quiet' {
             $result = $true
-            { $result = Test-Connectiong -Quiet -ErrorAction Stop -Count 1 -TargetName "fakeHost" } | Should -Not -Throw
+            { $result = Test-Connection -Quiet -ErrorAction Stop -Count 1 -TargetName "fakeHost" } | Should -Not -Throw
             $result | Should -BeFalse
         }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

We don't need to write a DNS resolution error if the user uses `-Quiet`; it's the same as a `False` result in that case and can be treated the same. 

Also, currently we're not able to respond to StopProcessing() between pings due to the `Dns.GetHostEntry()` method blocking. Fix is to implement a `GetHostEntryWithCancel()` method that factors in a cancellation token.

## PR Context

Resolves #12147 
Resolves #11160  

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
