### PR TITLE
NoClobber WinCompat module import

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -1907,7 +1907,11 @@ namespace Microsoft.PowerShell.Commands
             if (!string.IsNullOrEmpty(moduleName))
             {
                 // moduleName can be just a module name and it also can be a full path to psd1 from which we need to extract the module name
-                exactModuleName = Path.GetFileNameWithoutExtension(moduleName);
+                exactModuleName = moduleName;
+                if (Path.IsPathRooted(moduleName))
+                {
+                    exactModuleName = Path.GetFileNameWithoutExtension(moduleName);
+                }
             }
             else if (moduleSpec != null)
             {
@@ -1992,7 +1996,12 @@ namespace Microsoft.PowerShell.Commands
                 foreach(var moduleName in filteredModuleNames)
                 {
                     // moduleName can be just a module name and it also can be a full path to psd1 from which we need to extract the module name
-                    var exactModuleName = Path.GetFileNameWithoutExtension(moduleName);
+                    var exactModuleName = moduleName;
+                    if (Path.IsPathRooted(moduleName))
+                    {
+                        exactModuleName = Path.GetFileNameWithoutExtension(moduleName);
+                    }
+
                     if (InitialSessionState.IsEngineModule(exactModuleName) || ((NoClobberModuleList != null) && NoClobberModuleList.Contains(exactModuleName, StringComparer.OrdinalIgnoreCase)))
                     {
                         ImportModule_LocallyViaName_Wrapper(importModuleOptions, exactModuleName);

--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -1958,7 +1958,7 @@ namespace Microsoft.PowerShell.Commands
             string coreModuleToLoad = ModuleIntrinsics.GetModuleName(moduleSpec == null ? moduleName : moduleSpec.Name);
             
             var isModuleToLoadEngineModule = InitialSessionState.IsEngineModule(coreModuleToLoad);
-            List<string> noClobberModuleList = PowerShellConfig.Instance.GetWindowsPowerShellCompatibilityNoClobberModuleList();
+            string[] noClobberModuleList = PowerShellConfig.Instance.GetWindowsPowerShellCompatibilityNoClobberModuleList();
             if (isModuleToLoadEngineModule || ((noClobberModuleList != null) && noClobberModuleList.Contains(coreModuleToLoad, StringComparer.OrdinalIgnoreCase)))
             {
                 // if it is one of engine modules - first try to load it from $PSHOME\Modules

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -99,6 +99,12 @@ namespace Microsoft.PowerShell.Commands
             /// This will be allowed when the manifest explicitly exports functions which will limit all visible module functions.
             /// </summary>
             internal bool AllowNestedModuleFunctionsToExport;
+
+            /// <summary>
+            /// Flag that controls Export-PSSession -AllowClobber parameter in generating proxy modules from remote sessions.
+            /// Historically -AllowClobber in these scenarios was set as True.
+            /// </summary>
+            internal bool NoClobberExportPSSession;
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/PSConfiguration.cs
+++ b/src/System.Management.Automation/engine/PSConfiguration.cs
@@ -51,6 +51,7 @@ namespace System.Management.Automation.Configuration
         private const string ExecutionPolicyDefaultShellKey = "Microsoft.PowerShell:ExecutionPolicy";
         private const string DisableImplicitWinCompatKey = "DisableImplicitWinCompat";
         private const string WindowsPowerShellCompatibilityModuleDenyListKey = "WindowsPowerShellCompatibilityModuleDenyList";
+        private const string WindowsPowerShellCompatibilityNoClobberModuleListKey = "WindowsPowerShellCompatibilityNoClobberModuleList";
 
         // Provide a singleton
         internal static readonly PowerShellConfig Instance = new PowerShellConfig();
@@ -235,6 +236,18 @@ namespace System.Management.Automation.Configuration
             {
                 // if the setting is not mentioned in configuration files, then the default WindowsPowerShellCompatibilityModuleDenyList value is null
                 settingValue = ReadValueFromFile<string[]>(ConfigScope.AllUsers, WindowsPowerShellCompatibilityModuleDenyListKey);
+            }
+
+            return settingValue;
+        }
+
+        internal List<string> GetWindowsPowerShellCompatibilityNoClobberModuleList()
+        {
+            List<string> settingValue = ReadValueFromFile<List<string>>(ConfigScope.CurrentUser, WindowsPowerShellCompatibilityNoClobberModuleListKey);
+            if (settingValue == null)
+            {
+                // if the setting is not mentioned in configuration files, then the default WindowsPowerShellCompatibilityNoClobberModuleList value is null
+                settingValue = ReadValueFromFile<List<string>>(ConfigScope.AllUsers, WindowsPowerShellCompatibilityNoClobberModuleListKey);
             }
 
             return settingValue;

--- a/src/System.Management.Automation/engine/PSConfiguration.cs
+++ b/src/System.Management.Automation/engine/PSConfiguration.cs
@@ -241,13 +241,13 @@ namespace System.Management.Automation.Configuration
             return settingValue;
         }
 
-        internal List<string> GetWindowsPowerShellCompatibilityNoClobberModuleList()
+        internal string[] GetWindowsPowerShellCompatibilityNoClobberModuleList()
         {
-            List<string> settingValue = ReadValueFromFile<List<string>>(ConfigScope.CurrentUser, WindowsPowerShellCompatibilityNoClobberModuleListKey);
+            string[] settingValue = ReadValueFromFile<string[]>(ConfigScope.CurrentUser, WindowsPowerShellCompatibilityNoClobberModuleListKey);
             if (settingValue == null)
             {
                 // if the setting is not mentioned in configuration files, then the default WindowsPowerShellCompatibilityNoClobberModuleList value is null
-                settingValue = ReadValueFromFile<List<string>>(ConfigScope.AllUsers, WindowsPowerShellCompatibilityNoClobberModuleListKey);
+                settingValue = ReadValueFromFile<string[]>(ConfigScope.AllUsers, WindowsPowerShellCompatibilityNoClobberModuleListKey);
             }
 
             return settingValue;

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -589,7 +589,11 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "Feature" {
             "PSModulePath(User)="+[Environment]::GetEnvironmentVariable("PSModulePath", [EnvironmentVariableTarget]::User) | Write-Verbose -Verbose
             "PSModulePath(Machine)="+[Environment]::GetEnvironmentVariable("PSModulePath", [EnvironmentVariableTarget]::Machine) | Write-Verbose -Verbose
 
-            $env:PSModulePath -split ';' | % {"Modules in '$_'";(dir $_).Name} | Write-Verbose -Verbose
+            #$env:PSModulePath -split ';' | % {"Modules in '$_'";(dir $_).Name} | Write-Verbose -Verbose
+
+            "Filtering PSModulePath..." | Write-Verbose -Verbose
+            $env:PSModulePath = ($env:PSModulePath.split(";")|?{-not $_.EndsWith('7\Modules', [StringComparison]::InvariantCultureIgnoreCase)}) -join ';'
+            "PSModulePath="+$env:PSModulePath | Write-Verbose -Verbose
 
             Import-Module Microsoft.PowerShell.Management -UseWindowsPowerShell
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -735,14 +735,14 @@ Describe "PSModulePath changes interacting with other PowerShell processes" -Tag
 
         It "Allows PowerShell subprocesses to call core modules" {
 
-            "PSModulePath="+$env:PSModulePath | Write-Verbose -Verbose
-            "PSModulePath(Process)="+[Environment]::GetEnvironmentVariable("PSModulePath", [EnvironmentVariableTarget]::Process) | Write-Verbose -Verbose
-            "PSModulePath(User)="+[Environment]::GetEnvironmentVariable("PSModulePath", [EnvironmentVariableTarget]::User) | Write-Verbose -Verbose
-            "PSModulePath(Machine)="+[Environment]::GetEnvironmentVariable("PSModulePath", [EnvironmentVariableTarget]::Machine) | Write-Verbose -Verbose
+            "CurrentProcessPath-PSModulePath="+$env:PSModulePath | Write-Verbose -Verbose
 
-            $errors = & $pwsh -Command "`$env:PSModulePath;Get-ChildItem" 2>&1 | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] }
-            $errors | Out-String | Write-Verbose -Verbose
-            $errors | Should -Be $null
+            $ConfigPath = Join-Path $TestDrive 'powershell.config.json'
+            '{"WindowsPowerShellCompatibilityModuleDenyList": ["Microsoft.PowerShell.Management"]}' | Out-File -Force $ConfigPath
+
+            & $pwsh -settingsFile $ConfigPath -Command "Get-ChildItem | Out-Null; (Get-Command Get-ChildItem).Module.Path"  | Should -Not -BeLike "*system32*"
+            #$errors | Out-String | Write-Verbose -Verbose
+            #$errors | Should -Be $null
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -589,7 +589,13 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "Feature" {
             "PSModulePath(User)="+[Environment]::GetEnvironmentVariable("PSModulePath", [EnvironmentVariableTarget]::User) | Write-Verbose -Verbose
             "PSModulePath(Machine)="+[Environment]::GetEnvironmentVariable("PSModulePath", [EnvironmentVariableTarget]::Machine) | Write-Verbose -Verbose
 
+            $env:PSModulePath -split ';' | % {"Modules in '$_'";(dir $_).Name} | Write-Verbose -Verbose
+
             Import-Module Microsoft.PowerShell.Management -UseWindowsPowerShell
+
+            $s = gsn -Name WinPSCompatSession
+            icm $s {$PSVersionTable.PSEdition + ".PSModulePath: " +$env:PSModulePath} | Write-Verbose -Verbose
+
             $modules = Get-Module -Name Microsoft.PowerShell.Management
             $modules.Count | Should -Be 2
             $proxyModule = $modules | Where-Object {$_.ModuleType -eq 'Script'}

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -573,11 +573,11 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "Feature" {
             $proxyModule = $modules | Where-Object {$_.ModuleType -eq 'Script'}
             $coreModule = $modules | Where-Object {$_.ModuleType -eq 'Manifest'}
 
-            $proxyModule.ExportedCommands.Keys | Should Contain "ConvertFrom-String"
-            $proxyModule.ExportedCommands.Keys | Should Not Contain "Get-Date"
+            $proxyModule.ExportedCommands.Keys | Should -Contain "ConvertFrom-String"
+            $proxyModule.ExportedCommands.Keys | Should -Not -Contain "Get-Date"
 
-            $coreModule.ExportedCommands.Keys | Should Contain "Get-Date"
-            $coreModule.ExportedCommands.Keys | Should Not Contain "ConvertFrom-String"
+            $coreModule.ExportedCommands.Keys | Should -Contain "Get-Date"
+            $coreModule.ExportedCommands.Keys | Should -Not -Contain "ConvertFrom-String"
 
             $proxyModule | Remove-Module -Force
         }
@@ -591,11 +591,11 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "Feature" {
             $proxyModule = $modules | Where-Object {$_.ModuleType -eq 'Script'}
             $coreModule = $modules | Where-Object {$_.ModuleType -eq 'Manifest'}
 
-            $proxyModule.ExportedCommands.Keys | Should Contain "Get-WmiObject"
-            $proxyModule.ExportedCommands.Keys | Should Not Contain "Get-Item"
+            $proxyModule.ExportedCommands.Keys | Should -Contain "Get-WmiObject"
+            $proxyModule.ExportedCommands.Keys | Should -Not -Contain "Get-Item"
 
-            $coreModule.ExportedCommands.Keys | Should Contain "Get-Item"
-            $coreModule.ExportedCommands.Keys | Should Not Contain "Get-WmiObject"
+            $coreModule.ExportedCommands.Keys | Should -Contain "Get-Item"
+            $coreModule.ExportedCommands.Keys | Should -Not -Contain "Get-WmiObject"
 
             $proxyModule | Remove-Module -Force
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -740,7 +740,8 @@ Describe "PSModulePath changes interacting with other PowerShell processes" -Tag
             "PSModulePath(User)="+[Environment]::GetEnvironmentVariable("PSModulePath", [EnvironmentVariableTarget]::User) | Write-Verbose -Verbose
             "PSModulePath(Machine)="+[Environment]::GetEnvironmentVariable("PSModulePath", [EnvironmentVariableTarget]::Machine) | Write-Verbose -Verbose
 
-            $errors = & $pwsh -Command "Get-ChildItem" 2>&1 | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] }
+            $errors = & $pwsh -Command "`$env:PSModulePath;Get-ChildItem" 2>&1 | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] }
+            $errors | Out-String | Write-Verbose -Verbose
             $errors | Should -Be $null
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -584,6 +584,11 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "Feature" {
 
         It "NoClobber WinCompat import works for an engine module through -UseWindowsPowerShell parameter" {
 
+            "PSModulePath="+$env:PSModulePath | Write-Verbose -Verbose
+            "PSModulePath(Process)="+[Environment]::GetEnvironmentVariable("PSModulePath", [EnvironmentVariableTarget]::Process) | Write-Verbose -Verbose
+            "PSModulePath(User)="+[Environment]::GetEnvironmentVariable("PSModulePath", [EnvironmentVariableTarget]::User) | Write-Verbose -Verbose
+            "PSModulePath(Machine)="+[Environment]::GetEnvironmentVariable("PSModulePath", [EnvironmentVariableTarget]::Machine) | Write-Verbose -Verbose
+
             Import-Module Microsoft.PowerShell.Management -UseWindowsPowerShell
             $modules = Get-Module -Name Microsoft.PowerShell.Management
             $modules.Count | Should -Be 2
@@ -719,6 +724,12 @@ Describe "PSModulePath changes interacting with other PowerShell processes" -Tag
         }
 
         It "Allows PowerShell subprocesses to call core modules" {
+
+            "PSModulePath="+$env:PSModulePath | Write-Verbose -Verbose
+            "PSModulePath(Process)="+[Environment]::GetEnvironmentVariable("PSModulePath", [EnvironmentVariableTarget]::Process) | Write-Verbose -Verbose
+            "PSModulePath(User)="+[Environment]::GetEnvironmentVariable("PSModulePath", [EnvironmentVariableTarget]::User) | Write-Verbose -Verbose
+            "PSModulePath(Machine)="+[Environment]::GetEnvironmentVariable("PSModulePath", [EnvironmentVariableTarget]::Machine) | Write-Verbose -Verbose
+
             $errors = & $pwsh -Command "Get-ChildItem" 2>&1 | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] }
             $errors | Should -Be $null
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -680,7 +680,7 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "Feature" {
             $winpsPaths =  & $pwsh -NoProfile -NonInteractive -settingsFile $ConfigPath -c "Import-Module $ModuleName2 -UseWindowsPowerShell -WarningAction Ignore;`$s = Get-PSSession -Name WinPSCompatSession;Invoke-Command -Session `$s -ScriptBlock {`$env:psmodulepath}"
             $winpsPaths | Should -Not -BeLike "*MyTestDir*"
         }
-    }#>
+    }
 }
 
 Describe "PSModulePath changes interacting with other PowerShell processes" -Tag "Feature" {


### PR DESCRIPTION
# PR Summary
Fix #11419
This addresses an issue where Windows PowerShell proxy modules have a priority over PS Core modules during WinCompat module import. (see  #11419 )

## PR Context

Implicit PS Remoting code (reused by WinCompat) is doing `Export-PSSession -AllowClobber`.
The fix is to omit `-AllowClobber` parameter if WinCompat:
1) is either importing a module that is one of the [`engine modules`](https://github.com/PowerShell/PowerShell/blob/b7cb335f03fe2992d0cbd61699de9d9aafa1d7c1/src/System.Management.Automation/engine/InitialSessionState.cs#L1586):
```
"Microsoft.PowerShell.Utility",
"Microsoft.PowerShell.Management",
"Microsoft.PowerShell.Diagnostics",
"Microsoft.PowerShell.Host",
"Microsoft.PowerShell.Security",
"Microsoft.WSMan.Management",
"Microsoft.PowerShell.Commands.Utility",
"Microsoft.PowerShell.Commands.Management",
"Microsoft.PowerShell.Commands.Diagnostics",
"Microsoft.PowerShell.ConsoleHost"
```
2) or is importing a module specified in `powershell.config.json` in `WindowsPowerShellCompatibilityNoClobberModuleList` list. (this list is empty by default)

If a module falls into one of these buckets, then PS-Core version of the module is imported first (for `engine modules` from `$PSHOME\Modules`), then proxies are generated for WinPS version of the module without `-AllowClobber` flag. This result s in proxy modules not having PS Core commands.

Fix #11419 
Fix #12014 

Also fixed a bug where WinCompat module DenyList was not working for module names containing dots `.` in some cases.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [X] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [X] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/5724
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
