### PR TITLE
Fix the `Sync PSGalleryModules to Artifacts` build

### DIFF
--- a/tools/releaseBuild/azureDevOps/AzArtifactFeed/PSGalleryToAzArtifacts.yml
+++ b/tools/releaseBuild/azureDevOps/AzArtifactFeed/PSGalleryToAzArtifacts.yml
@@ -8,7 +8,11 @@ queue:
   name: Hosted VS2017
 steps:
   - pwsh: |
-      Install-Module -Name PowerShellGet -MinimumVersion 2.0.1 -Force
+      $minVer = [version]::new("2.2.3")
+      $curVer = Get-Module PowerShellGet -ListAvailable | Select-Object -First 1 | ForEach-Object Version
+      if (-not $curVer -or $curVer -lt $minVer) {
+        Install-Module -Name PowerShellGet -MinimumVersion 2.2.3 -Force
+      }
     displayName: Update PSGet and PackageManagement
     condition: succeededOrFailed()
 

--- a/tools/releaseBuild/azureDevOps/AzArtifactFeed/PSGalleryToAzArtifacts.yml
+++ b/tools/releaseBuild/azureDevOps/AzArtifactFeed/PSGalleryToAzArtifacts.yml
@@ -8,7 +8,7 @@ queue:
   name: Hosted VS2017
 steps:
   - pwsh: |
-      $minVer = [version]::new("2.2.3")
+      $minVer = [version]"2.2.3"
       $curVer = Get-Module PowerShellGet -ListAvailable | Select-Object -First 1 | ForEach-Object Version
       if (-not $curVer -or $curVer -lt $minVer) {
         Install-Module -Name PowerShellGet -MinimumVersion 2.2.3 -Force

--- a/tools/releaseBuild/azureDevOps/AzArtifactFeed/SyncGalleryToAzArtifacts.psm1
+++ b/tools/releaseBuild/azureDevOps/AzArtifactFeed/SyncGalleryToAzArtifacts.psm1
@@ -66,17 +66,20 @@ function SyncGalleryToAzArtifacts {
         }
 
         # Check if Az package version is less that gallery version
-        if (CompareVersions -lt -ReferencePackage $foundPackageOnAz -DifferencePackage $foundPackageOnGallery) {
+        $pkgOnAzVersion = [System.Management.Automation.SemanticVersion]::new($foundPackageOnAz.Version)
+        $pkgOnGalleryVersion = [System.Management.Automation.SemanticVersion]::new($foundPackageOnGallery.Version)
+
+        if ($pkgOnAzVersion -lt $pkgOnGalleryVersion) {
             Write-Verbose -Verbose "Module needs to be updated $($package.Name) - $($foundPackageOnGallery.Version)"
             $modulesToUpdate += $foundPackageOnGallery
-        } elseif (CompareVersions -lt -ReferencePackage $foundPackageOnGallery -DifferencePackage $foundPackageOnAz) {
+        } elseif ($pkgOnGalleryVersion -lt $pkgOnAzVersion) {
             Write-Warning "Newer version found on Az Artifacts - $($foundPackageOnAz.Name) - $($foundPackageOnAz.Version)"
         } else {
             Write-Verbose -Verbose "Module is in sync - $($package.Name)"
         }
     }
 
-    "Gallery Packages:`n"
+    "`nGallery Packages:"
     $galleryPackages
 
     "`nAz Artifacts Packages:`n"
@@ -90,65 +93,41 @@ function SyncGalleryToAzArtifacts {
         Save-Package -Provider NuGet -Source $galleryUrl -Name $package.Name -RequiredVersion $package.Version -Path $Destination
     }
 
-    # Remove dependent packages downloaded by Save-Module if there are already present in AzArtifacts feed.
-    try {
-        $null = Register-PackageSource -Name local -Location $Destination -ProviderName NuGet -Force
-        $packageNamesToKeep = @()
-        $savedPackages = Find-Package -Source local -AllVersions -AllowPreReleaseVersion
+    if ($modulesToUpdate.Length -gt 0)
+    {
+        # Remove dependent packages downloaded by Save-Package if there are already present in AzArtifacts feed.
+        try {
+            $null = Register-PackageSource -Name local -Location $Destination -ProviderName NuGet -Force
+            $packageNamesToKeep = @()
+            $savedPackages = Find-Package -Source local -AllVersions -AllowPreReleaseVersion
 
-        Write-Verbose -Verbose "Saved packages:"
-        $savedPackages | Out-String | Write-Verbose -Verbose
+            Write-Verbose -Verbose "Saved packages:"
+            $savedPackages | Out-String | Write-Verbose -Verbose
 
-        foreach($package in $savedPackages) {
-            $pkgVersion = NormalizeVersion -version $package.Version
-            $foundMatch = $azArtifactsPackages | Where-Object { $_.Name -eq $package.Name -and (NormalizeVersion -version $_.Version) -eq $pkgVersion }
+            foreach($package in $savedPackages) {
+                $pkgVersion = NormalizeVersion -version $package.Version
+                $foundMatch = $azArtifactsPackages | Where-Object { $_.Name -eq $package.Name -and (NormalizeVersion -version $_.Version) -eq $pkgVersion }
 
-            if(-not $foundMatch) {
-                Write-Verbose "Keeping package $($package.PackageFileName)" -Verbose
-                $packageNamesToKeep += "{0}*.nupkg" -f $package.Name
+                if(-not $foundMatch) {
+                    Write-Verbose "Keeping package $($package.PackageFileName)" -Verbose
+                    $packageNamesToKeep += "{0}*.nupkg" -f $package.Name
+                }
             }
+
+            if ($packageNamesToKeep.Length -gt 0) {
+                ## Removing only if we do have some packages to keep,
+                ## otherwise the '$Destination' folder will be removed.
+                Remove-Item -Path $Destination -Exclude $packageNamesToKeep -Recurse -Force -Verbose
+            }
+
+            Write-Verbose -Verbose "Packages kept for upload"
+            Get-ChildItem $Destination | Out-String | Write-Verbose -Verbose
         }
-
-        Remove-Item -Path $Destination -Exclude $packageNamesToKeep -Recurse -Force -Verbose
-
-        Write-Verbose -Verbose "Packages kept for upload"
-        Get-ChildItem $Destination | Out-String | Write-Verbose -Verbose
-    }
-    finally {
-        Unregister-PackageSource -Name local -Force -ErrorAction SilentlyContinue
-    }
-
-}
-
-Function CompareVersions {
-    param (
-        [Microsoft.PackageManagement.Packaging.SoftwareIdentity]
-        $ReferencePackage,
-        [Microsoft.PackageManagement.Packaging.SoftwareIdentity]
-        $DifferencePackage,
-        [Parameter(Mandatory = $true, ParameterSetName='lt')]
-        [switch]
-        $lt,
-        [Parameter(Mandatory = $true, ParameterSetName='gt')]
-        [switch]
-        $gt
-    )
-
-    if ($ReferencePackage.Version -eq $DifferencePackage.Version) {
-        return $false
-    }
-
-    $latest = SortPackage -p @($ReferencePackage,$DifferencePackage) | Select-Object -First 1
-
-    if ($gt.IsPresent) {
-        return $ReferencePackage -eq $latest
-    } elseif ($lt.IsPresent) {
-        return $DifferencePackage -eq $latest
-    } else {
-        throw "Unknown parameter set"
+        finally {
+            Unregister-PackageSource -Name local -Force -ErrorAction SilentlyContinue
+        }
     }
 }
-
 
 Function SortPackage {
     param(

--- a/tools/releaseBuild/azureDevOps/AzArtifactFeed/SyncGalleryToAzArtifacts.psm1
+++ b/tools/releaseBuild/azureDevOps/AzArtifactFeed/SyncGalleryToAzArtifacts.psm1
@@ -66,8 +66,8 @@ function SyncGalleryToAzArtifacts {
         }
 
         # Check if Az package version is less that gallery version
-        $pkgOnAzVersion = [System.Management.Automation.SemanticVersion]::new($foundPackageOnAz.Version)
-        $pkgOnGalleryVersion = [System.Management.Automation.SemanticVersion]::new($foundPackageOnGallery.Version)
+        $pkgOnAzVersion = [semver]::new($foundPackageOnAz.Version)
+        $pkgOnGalleryVersion = [semver]::new($foundPackageOnGallery.Version)
 
         if ($pkgOnAzVersion -lt $pkgOnGalleryVersion) {
             Write-Verbose -Verbose "Module needs to be updated $($package.Name) - $($foundPackageOnGallery.Version)"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix the `Sync PSGalleryModules to Artifacts` build that has been failing since 3/8
The fix has been validated by the build. You can find the successful build at https://dev.azure.com/mscodehub/PowerShellCore/_build/results?buildId=131454&view=results

It's easier to review this PR when ignoring all whitespace character changes:
https://github.com/PowerShell/PowerShell/pull/12277/files?w=1

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
