### PR TITLE
Make GetWindowsPowerShellModulePath compatible with multiple PS installations

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -1274,7 +1274,7 @@ namespace System.Management.Automation
                     }
                     else
                     {
-                        if (!File.Exists(Path.Combine(possiblePwshDir, "pwsh.exe")))
+                        if (!File.Exists(Path.Combine(possiblePwshDir, "pwsh.dll")))
                         {
                             modulePathList.Add(trimmedPath);
                         }

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -1266,13 +1266,15 @@ namespace System.Management.Automation
                 {
                     // make sure this module path is Not part of other PS Core installation
                     var possiblePwshDir = Path.GetDirectoryName(trimmedPath);
-                    if (string.IsNullOrEmpty(possiblePwshDir)) // i.e. module dir is in the drive root
+
+                    if (string.IsNullOrEmpty(possiblePwshDir))
                     {
+                        // i.e. module dir is in the drive root
                         modulePathList.Add(trimmedPath);
                     }
                     else
                     {
-                        if (! File.Exists(Path.Combine(possiblePwshDir, "pwsh.exe")))
+                        if (!File.Exists(Path.Combine(possiblePwshDir, "pwsh.exe")))
                         {
                             modulePathList.Add(trimmedPath);
                         }

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -1234,7 +1234,7 @@ namespace System.Management.Automation
 
 #if !UNIX
         /// <summary>
-        /// Returns a PSModulePath suiteable for Windows PowerShell by removing this PowerShell's specific
+        /// Returns a PSModulePath suiteable for Windows PowerShell by removing PowerShell's specific
         /// paths from current PSModulePath.
         /// </summary>
         /// <returns>
@@ -1261,9 +1261,22 @@ namespace System.Management.Automation
             var modulePathList = new List<string>();
             foreach (var path in currentModulePath.Split(';'))
             {
-                if (!excludeModulePaths.Contains(path))
+                var trimmedPath = path.Trim();
+                if (!excludeModulePaths.Contains(trimmedPath))
                 {
-                    modulePathList.Add(path);
+                    // make sure this module path is Not part of other PS Core installation
+                    var possiblePwshDir = Path.GetDirectoryName(trimmedPath);
+                    if (string.IsNullOrEmpty(possiblePwshDir)) // i.e. module dir is in the drive root
+                    {
+                        modulePathList.Add(trimmedPath);
+                    }
+                    else
+                    {
+                        if (! File.Exists(Path.Combine(possiblePwshDir, "pwsh.exe")))
+                        {
+                            modulePathList.Add(trimmedPath);
+                        }
+                    }
                 }
             }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -646,6 +646,10 @@ Describe "PSModulePath changes interacting with other PowerShell processes" -Tag
             $errors | Should -Be $null
         }
 
+        It "Allows Windows PowerShell subprocesses to load WinPS version of `$PSHOME modules" {
+            powershell.exe -Command "Get-ChildItem | Out-Null;(Get-Module Microsoft.PowerShell.Management).Path" | Should -BeLike "*system32*"
+        }
+
         It "Allows PowerShell subprocesses to call core modules" {
             $errors = & $pwsh -Command "Get-ChildItem" 2>&1 | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] }
             $errors | Should -Be $null


### PR DESCRIPTION
# PR Summary

`NativeCommandProcessor` and `WinCompat` rely on [`GetWindowsPowerShellModulePath` function](https://github.com/PowerShell/PowerShell/blob/7193800bc2394297fb701ef743b324691237f5d4/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs#L1243) to filter out PS-Core-specific module paths so that WindowsPS loads its own version of modules instead of PS-Core versions.
However, when several side-by-side PS-Core installations (eg: MSI-installed, daily build, manual zip-based installation, etc...) started from each-other the filtering function does not work because it does not filter out the `$PSHOME\Modules` of the parent PS process.
The fix is to add additional check for each component of PSModulePath (that is set for WinPS process) - if it is has `pwsh.exe` in the parent directory, then it is considered another PS Core installation and this location is also filtered out.

Before the change:
```powershell
PS C:\> $PSHome
c:\PowerShell-7.1.0-preview.1-win-x64

PS C:\> E:\UserA-PowerShell\src\powershell-win-core\bin\Debug\netcoreapp5.0\win7-x64\publish\pwsh.exe
PowerShell 7.0.0-preview.6-324-g5f89a10f5b872406a9ac6cb1fcdea8078ea6a4ca

PS C:\> $env:psmodulepath -split ';'
C:\Users\UserA\Documents\PowerShell\Modules
C:\Program Files\PowerShell\Modules
e:\UserA-powershell\src\powershell-win-core\bin\debug\netcoreapp5.0\win7-x64\publish\Modules
c:\powershell-7.1.0-preview.1-win-x64\Modules
C:\Program Files\WindowsPowerShell\Modules
C:\windows\system32\WindowsPowerShell\v1.0\Modules

PS C:\> powershell.exe -c "'WinPS PSModulePath:';`$env:PSModulePath -split ';';Get-ChildItem | Out-Null;'';'Module in WinPS loaded from:';(Get-Module Microsoft.PowerShell.Management).Path"
WinPS PSModulePath:
c:\powershell-7.1.0-preview.1-win-x64\Modules
C:\Program Files\WindowsPowerShell\Modules
C:\windows\system32\WindowsPowerShell\v1.0\Modules

Module in WinPS loaded from:
C:\powershell-7.1.0-preview.1-win-x64\Modules\Microsoft.PowerShell.Management\Microsoft.PowerShell.Management.psd1
PS C:\> # Module in WinPS loaded from parent PS Core installation
```

After the change:
```powershell
PS C:\> $PSHome
c:\PowerShell-7.1.0-preview.1-win-x64

PS C:\> E:\UserA-PowerShell\src\powershell-win-core\bin\Debug\netcoreapp5.0\win7-x64\publish\pwsh.exe
PowerShell 7.0.0-preview.6-324-g5f89a10f5b872406a9ac6cb1fcdea8078ea6a4ca

PS C:\> $env:psmodulepath -split ';'
C:\Users\UserA\Documents\PowerShell\Modules
C:\Program Files\PowerShell\Modules
e:\UserA-powershell\src\powershell-win-core\bin\debug\netcoreapp5.0\win7-x64\publish\Modules
c:\powershell-7.1.0-preview.1-win-x64\Modules
C:\Program Files\WindowsPowerShell\Modules
C:\windows\system32\WindowsPowerShell\v1.0\Modules

PS C:\> powershell.exe -c "'WinPS PSModulePath:';`$env:PSModulePath -split ';';Get-ChildItem | Out-Null;'';'Module in WinPS loaded from:';(Get-Module Microsoft.PowerShell.Management).Path"
WinPS PSModulePath:
C:\Users\UserA\Documents\WindowsPowerShell\Modules
C:\Program Files\WindowsPowerShell\Modules
C:\windows\system32\WindowsPowerShell\v1.0\Modules

Module in WinPS loaded from:
C:\windows\system32\WindowsPowerShell\v1.0\Modules\Microsoft.PowerShell.Management\Microsoft.PowerShell.Management.psd1
PS C:\> # Module in WinPS loaded from WinPS module path
```

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
