### PR TITLE
Add null check because AsNeeded parameter in ConvertTo-Csv and ExportTo-Csv cmdlets needs to analyze a value before quoting.

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -1013,7 +1013,7 @@ namespace Microsoft.PowerShell.Commands
                                 AppendStringWithEscapeAlways(_outputString, value);
                                 break;
                             case BaseCsvWritingCommand.QuoteKind.AsNeeded:
-                                if (value.Contains(_delimiter))
+                                if (value != null && value.Contains(_delimiter))
                                 {
                                     AppendStringWithEscapeAlways(_outputString, value);
                                 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Csv.Tests.ps1
@@ -40,6 +40,7 @@ Describe "ConvertTo-Csv" -Tags "CI" {
     BeforeAll {
         $Name = "Hello"; $Data = "World";
         $testObject = [pscustomobject]@{ FirstColumn = $Name; SecondColumn = $Data }
+        $testNullObject = [pscustomobject]@{ FirstColumn = $Name; SecondColumn = $null }
     }
 
     It "Should Be able to be called without error" {
@@ -121,6 +122,11 @@ Describe "ConvertTo-Csv" -Tags "CI" {
 
             $result[0] | Should -BeExactly "`"FirstColumn`",`"SecondColumn`""
             $result[1] | Should -BeExactly "`"Hello`",`"World`""
+
+            $result = $testNullObject | ConvertTo-Csv -UseQuotes Always -Delimiter ','
+
+            $result[0] | Should -BeExactly "`"FirstColumn`",`"SecondColumn`""
+            $result[1] | Should -BeExactly "`"Hello`","
         }
 
         It "UseQuotes Always is default" {
@@ -135,6 +141,11 @@ Describe "ConvertTo-Csv" -Tags "CI" {
 
             $result[0] | Should -BeExactly "FirstColumn,SecondColumn"
             $result[1] | Should -BeExactly "Hello,World"
+
+            $result = $testNullObject | ConvertTo-Csv -UseQuotes Never -Delimiter ','
+
+            $result[0] | Should -BeExactly "FirstColumn,SecondColumn"
+            $result[1] | Should -BeExactly "Hello,"
         }
 
         It "UseQuotes AsNeeded" {
@@ -142,6 +153,11 @@ Describe "ConvertTo-Csv" -Tags "CI" {
 
             $result[0] | Should -BeExactly "`"FirstColumn`"rSecondColumn"
             $result[1] | Should -BeExactly "Hellor`"World`""
+
+            $result = $testNullObject | ConvertTo-Csv -UseQuotes AsNeeded -Delimiter 'r'
+
+            $result[0] | Should -BeExactly "`"FirstColumn`"rSecondColumn"
+            $result[1] | Should -BeExactly "Hellor"
         }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #12279.

Add null check because `AsNeeded` parameter in `ConvertTo-Csv` and `ExportTo-Csv cmdlets` needs to analyze a value before quoting. 

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
