### PR TITLE
Address Set-Location/Get-Item Issue With ?/* Characters

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -158,6 +158,11 @@ namespace Microsoft.PowerShell.Commands
                         // This handles short path names
                         exactPath += StringLiterals.DefaultPathSeparator + item;
                     }
+                    else if (item.IndexOfAny(new char[] { '*', '?' }) >= 0)
+                    {
+                        // This handles literal wildcard characters that could resolve erroneously
+                        exactPath += StringLiterals.DefaultPathSeparator + item;
+                    }
                     else
                     {
                         // Use GetFileSystemEntries to get the correct casing of this element

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -158,7 +158,7 @@ namespace Microsoft.PowerShell.Commands
                         // This handles short path names
                         exactPath += StringLiterals.DefaultPathSeparator + item;
                     }
-                    else if (item.IndexOfAny(new char[] { '*', '?' }) >= 0)
+                    else if (item.IndexOfAny(Utils.Separators.StarOrQuestion) >= 0)
                     {
                         // This handles literal wildcard characters that could resolve erroneously
                         exactPath += StringLiterals.DefaultPathSeparator + item;

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -153,14 +153,9 @@ namespace Microsoft.PowerShell.Commands
 
                         break;
                     }
-                    else if (item.Contains('~'))
+                    else if (item.Contains('~') || item.IndexOfAny(Utils.Separators.StarOrQuestion) >= 0)
                     {
-                        // This handles short path names
-                        exactPath += StringLiterals.DefaultPathSeparator + item;
-                    }
-                    else if (item.IndexOfAny(Utils.Separators.StarOrQuestion) >= 0)
-                    {
-                        // This handles literal wildcard characters that could resolve erroneously
+                        // This handles short path names and wildcard characters that could resolve erroneously
                         exactPath += StringLiterals.DefaultPathSeparator + item;
                     }
                     else

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
@@ -230,6 +230,26 @@ Describe "Set-Location" -Tags "CI" {
             $PWD.Path | Should -Be $location.Path
         }
     }
+
+    It 'Should should not match directory containing wildcard character *' -Skip:([System.IO.Path]::GetInvalidFileNameChars() -contains '*') {
+        Set-Location $TestDrive
+        $currentPath = (Get-Location).Path
+        $literalPathActual = Join-Path $TestDrive '*****'
+        $literalPathAttempt = Join-Path $TestDrive 'aaaaa'
+        New-Item -ItemType Directory -Path $literalPathActual
+        { Set-Location -LiteralPath $literalPathAttempt -ErrorAction Stop } | Should -Throw -ErrorId "PathNotFound,Microsoft.PowerShell.Commands.SetLocationCommand"
+        (Get-Location).Path | Should -BeExactly $currentPath
+    }
+
+    It 'Should should not match directory containing wildcard character ?' -Skip:([System.IO.Path]::GetInvalidFileNameChars() -contains '?') {
+        Set-Location $TestDrive
+        $currentPath = (Get-Location).Path
+        $literalPathActual = Join-Path $TestDrive '?????'
+        $literalPathAttempt = Join-Path $TestDrive 'aaaaa'
+        New-Item -ItemType Directory -Path $literalPathActual
+        { Set-Location -LiteralPath $literalPathAttempt -ErrorAction Stop } | Should -Throw -ErrorId "PathNotFound,Microsoft.PowerShell.Commands.SetLocationCommand"
+        (Get-Location).Path | Should -BeExactly $currentPath
+    }
 }
 
 Describe "Set-Location: Name with special/wildcards characters" -Tags "CI" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
@@ -231,7 +231,7 @@ Describe "Set-Location" -Tags "CI" {
         }
     }
 
-    It 'Should should not match directory containing wildcard character *' -Skip:([System.IO.Path]::GetInvalidFileNameChars() -contains '*') {
+    It 'Should not match directory containing wildcard character *' -Skip:([System.IO.Path]::GetInvalidFileNameChars() -contains '*') {
         Set-Location $TestDrive
         $currentPath = (Get-Location).Path
         $literalPathActual = Join-Path $TestDrive '*****'
@@ -241,7 +241,7 @@ Describe "Set-Location" -Tags "CI" {
         (Get-Location).Path | Should -BeExactly $currentPath
     }
 
-    It 'Should should not match directory containing wildcard character ?' -Skip:([System.IO.Path]::GetInvalidFileNameChars() -contains '?') {
+    It 'Should not match directory containing wildcard character ?' -Skip:([System.IO.Path]::GetInvalidFileNameChars() -contains '?') {
         Set-Location $TestDrive
         $currentPath = (Get-Location).Path
         $literalPathActual = Join-Path $TestDrive '?????'
@@ -299,7 +299,7 @@ Describe "Set-Location: Name with special/wildcards characters" -Tags "CI" {
             [System.IO.Path]::GetFileName((Get-Location).Path) | Should -BeExactly $Name
         }
         catch {
-            throw "Set-Location $Name Failed"
+            throw ("Set-Location $Name Failed; Exception: " + $_.Exception.Message)
         }
         finally { 
             Set-Location -LiteralPath $startLocation

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
@@ -262,7 +262,7 @@ Describe "Set-Location: Name with special/wildcards characters" -Tags "CI" {
         # is quite broken in many powershell cmdlets
         if ($Name.Contains('\')) 
         {
-            Set-ItResult -Skipped -Because "path elements with backslashes are not fully supported in PowerShell on this operating system."
+            Set-ItResult -Pending -Because "path elements with backslashes are not fully supported in PowerShell on MacOs/Linux."
             return
         }
 


### PR DESCRIPTION
# PR Summary

- Adjusted behavior of GetCorrectCasedPath() which attempts to search for the file on the file system in order to normalize its case.  Since some file systems support wildcard-type characters (e.g. MacOS) in path names so these need to be skipped to avoid erroneous resolution.
- Added tests to detect this behavior.

## PR Context

This corrects the behavior where Set-Location fails to change directory or changes to an entirely different child directory when the target directory contains characters such as '*'.  Similarly, Get-Item also returns errant information.

Resolves: https://github.com/PowerShell/PowerShell/issues/12299

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
