### PR TITLE
Add CmdletInfo to Command Clone()

### DIFF
--- a/src/System.Management.Automation/engine/hostifaces/Command.cs
+++ b/src/System.Management.Automation/engine/hostifaces/Command.cs
@@ -109,6 +109,7 @@ namespace System.Management.Automation.Runspaces
             MergeToResult = command.MergeToResult;
             _mergeUnclaimedPreviousCommandResults = command._mergeUnclaimedPreviousCommandResults;
             IsEndOfStatement = command.IsEndOfStatement;
+            CommandInfo = command.CommandInfo;
 
             foreach (CommandParameter param in command.Parameters)
             {

--- a/test/powershell/engine/Api/PSCommand.Tests.ps1
+++ b/test/powershell/engine/Api/PSCommand.Tests.ps1
@@ -1,0 +1,70 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+Describe "PSCommand API tests" -Tag "CI" {
+    BeforeAll {
+        $shell = [PowerShell]::Create()
+    }
+
+    AfterAll {
+        $shell.Dispose()
+    }
+
+    BeforeEach {
+        $psCommand = [System.Management.Automation.PSCommand]::new()
+    }
+
+    AfterEach {
+        $shell.Commands.Clear()
+    }
+
+    Context "AddCommand method on PSCommand" {
+        It "Can add a command by name and parameter to a PSCommand" {
+            $null = $psCommand.AddCommand("Write-Output").AddParameter("InputObject", 5)
+            $shell.Commands = $psCommand
+            $result = $shell.Invoke()
+            $result | Should -Be 5
+        }
+
+        It "Can add a command by Command object and parameter to a PSCommand" {
+            $command = [System.Management.Automation.Runspaces.Command]::new("Get-Date")
+            $null = $psCommand.AddCommand($command)
+            $shell.Commands = $psCommand
+            $result = $shell.Invoke()
+            $result | Should -BeOfType System.DateTime
+        }
+    }
+
+    Context "Cloning PSCommands" {
+        It "The clone method successfully copies commands" {
+            $null = $psCommand.AddCommand("Write-Output").AddParameter("InputObject", 5)
+
+            $newCommand = $psCommand.Clone()
+
+            $newCommand.Commands | Should -Not -BeNullOrEmpty
+            $newCommand.Commands[0].CommandText | Should -Be "Write-Output"
+            $newCommand.Commands[0].Parameters | Should -Not -BeNullOrEmpty
+            $newCommand.Commands[0].Parameters[0].Name | Should -Be "InputObject"
+            $newCommand.Commands[0].Parameters[0].Value | Should -Be 5
+        }
+
+        It "clones properly when using the setter on the PowerShell type" {
+            try {
+                $otherShell = [powershell]::Create('CurrentRunspace')
+
+                # We manually create a CmdletInfo here (with an unresolable command) to verify that CmdletInfo's are cloned.
+                $cmdlet = [System.Management.Automation.CmdletInfo]::new('un-resolvable', [Microsoft.PowerShell.Commands.OutStringCommand])
+                $null = $otherShell.AddCommand($cmdlet).AddParameter("InputObject", 'test')
+
+                # Setter for "Commands" calls PSCommand.Clone()
+                $shell.Commands = $otherShell.Commands
+
+                $result = $shell.Invoke()
+                $result | Should -Be "test
+"
+            }
+            finally {
+                $otherShell.Dispose()
+            }
+        }
+    }
+}

--- a/test/powershell/engine/Api/PSCommand.Tests.ps1
+++ b/test/powershell/engine/Api/PSCommand.Tests.ps1
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+
 Describe "PSCommand API tests" -Tag "CI" {
     BeforeAll {
         $shell = [PowerShell]::Create()


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

fixes https://github.com/PowerShell/PowerShell/issues/12297

This adds copying `CmdletInfo` to the `Command` class's `Clone()`. I also added a few tests for the `PSCommand` type (more should be added for coverage as it seems that this type is not tested at all it seems...) which includes a test that covers the code change.

## PR Context

PowerShell Editor Services uses the `PSCommand` type _everywhere_. For whatever reason, there's an `PowerShell.AddCommand(CmdletInfo cmdletInfo)` but not a `PSCommand.AddCommand(CmdletInfo cmdletInfo)`. To work around this, we have an extension method that does:

`PowerShell.AddCommand(new Command(cmdletInfo))`... however, this exposed another bug as we take the `PSCommand` type and set it directly on the `PowerShell` instance:

```
powerShell.Commands = psCommand
```

This would trigger cmdlet discovery for commands regardless of if they had a `CmdletInfo` associated with it because deep down, the `CmdletInfo` property on the underlying `Command` object would not get cloned...

This PR makes sure it also gets cloned. Take a look at the very last test added which fails before this change, but passes after it.

PSES could take advantage of this if it was backported to PS 7.0. In the meantime, we have to [copy commands manually](https://github.com/PowerShell/PowerShellEditorServices/pull/1258/files#diff-39fdedf9e00646e4c04b7deaa1225bb6R744-R751)... (naturally this is what we will have to do for Windows PowerShell... but for PS7 we can use this.

cc @SeeminglyScience 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [x] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
