### PR TITLE
Compare-Object Apply -IncludeEqual when -ExcludeDifferent is specified

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Compare-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Compare-Object.cs
@@ -379,11 +379,6 @@ namespace Microsoft.PowerShell.Commands
         {
             if (ExcludeDifferent)
             {
-                if (_isIncludeEqualSpecified == false)
-                {
-                    return;
-                }
-
                 if (_isIncludeEqualSpecified && !_includeEqual)
                 {
                     return;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Compare-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Compare-Object.cs
@@ -372,8 +372,8 @@ namespace Microsoft.PowerShell.Commands
         #region Overrides
 
         /// <summary>
-        /// If the parameter 'ExcludeDifferent' is present, then we need to turn on the
-        /// 'IncludeEqual' switch unless it's turned off by the user specifically.
+        /// If the parameter 'ExcludeDifferent' is present, then the 'IncludeEqual'
+        /// switch is turned on unless it's turned off by the user specifically.
         /// </summary>
         protected override void BeginProcessing()
         {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Compare-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Compare-Object.Tests.ps1
@@ -76,10 +76,10 @@ Describe "Compare-Object" -Tags "CI" {
 	{ Compare-Object -ReferenceObject $(Get-Content $file3) -DifferenceObject $anonexistentvariable } | Should -Throw
     }
 
-    It "Should give a 0 array when using excludedifferent switch without also using the includeequal switch" {
-	$actualOutput = Compare-Object -ReferenceObject $(Get-Content $file3) -DifferenceObject $(Get-Content $file4) -ExcludeDifferent
+    It "Should only display equal lines when excludeDifferent switch is used without the includeequal switch" {
+    $actualOutput = Compare-Object -ReferenceObject $(Get-Content $file3) -DifferenceObject $(Get-Content $file4) -ExcludeDifferent
 
-	$actualOutput.Length | Should -Be 0
+    $actualOutput.Length | Should -Be 2
     }
 
     It "Should only display equal lines when excludeDifferent switch is used alongside the includeequal switch" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Compare-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Compare-Object.Tests.ps1
@@ -88,6 +88,12 @@ Describe "Compare-Object" -Tags "CI" {
 	$actualOutput.Length | Should -Be 2
     }
 
+    It "Should give a 0 array when using excludedifferent switch when also setting the includeequal switch to false" {
+	$actualOutput = Compare-Object -ReferenceObject $(Get-Content $file3) -DifferenceObject $(Get-Content $file4) -ExcludeDifferent -IncludeEqual:$false
+
+	$actualOutput.Length | Should -Be 0
+    }
+
     It "Should be able to pass objects to pipeline using the passthru switch" {
 	{ Compare-Object -ReferenceObject $(Get-Content $file3) -DifferenceObject $(Get-Content $file4) -Passthru | Format-Wide } | Should -Not -Throw
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes #11847

## PR Context

This pull request corrects the following behavior specified in issue #11847: when Compare-Object is used with the -ExcludeDifferent switch, the -IncludeEqual switch is not inferred.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [X] Issue filed: [PowerShell-Docs issue #5789](https://github.com/MicrosoftDocs/PowerShell-Docs/issues/5789)
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
