### PR TITLE
Turn on `ReadyToRun`

### DIFF
--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -97,6 +97,7 @@
 
     <TargetFramework>netcoreapp5.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <PublishReadyToRun>true</PublishReadyToRun>
 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/build.psm1
+++ b/build.psm1
@@ -2361,29 +2361,7 @@ function Start-CrossGen {
         "Microsoft.ApplicationInsights.dll"
     )
 
-    # Common PowerShell libraries to crossgen
-    $psCoreAssemblyList = @(
-        "pwsh.dll",
-        "Microsoft.PowerShell.Commands.Utility.dll",
-        "Microsoft.PowerShell.Commands.Management.dll",
-        "Microsoft.PowerShell.Security.dll",
-        "Microsoft.PowerShell.ConsoleHost.dll",
-        "System.Management.Automation.dll"
-    )
-
-    # Add Windows specific libraries
-    if ($environment.IsWindows) {
-        $psCoreAssemblyList += @(
-            "Microsoft.PowerShell.CoreCLR.Eventing.dll",
-            "Microsoft.WSMan.Management.dll",
-            "Microsoft.WSMan.Runtime.dll",
-            "Microsoft.PowerShell.Commands.Diagnostics.dll",
-            "Microsoft.PowerShell.GraphicalHost.dll",
-            "Microsoft.Management.Infrastructure.CimCmdlets.dll"
-        )
-    }
-
-    $fullAssemblyList = $commonAssembliesForAddType + $psCoreAssemblyList
+    $fullAssemblyList = $commonAssembliesForAddType
 
     foreach ($assemblyName in $fullAssemblyList) {
         $assemblyPath = Join-Path $PublishPath $assemblyName

--- a/build.psm1
+++ b/build.psm1
@@ -414,11 +414,10 @@ Fix steps:
 
     # handle ResGen
     # Heuristic to run ResGen on the fresh machine
-    # TODO: remove Start-ResGen after testing ReadyToRun
-    #if ($ResGen -or -not (Test-Path "$PSScriptRoot/src/Microsoft.PowerShell.ConsoleHost/gen")) {
-    #    Write-Log "Run ResGen (generating C# bindings for resx files)"
-    #    Start-ResGen
-    #}
+    if ($ResGen -or -not (Test-Path "$PSScriptRoot/src/Microsoft.PowerShell.ConsoleHost/gen")) {
+        Write-Log "Run ResGen (generating C# bindings for resx files)"
+        Start-ResGen
+    }
 
     # Handle TypeGen
     # .inc file name must be different for Windows and Linux to allow build on Windows and WSL.

--- a/build.psm1
+++ b/build.psm1
@@ -2233,8 +2233,6 @@ function Start-CrossGen {
             $CrossgenPath
         )
 
-        # TODO: remove Start-CrossGen after testing ReadyToRun.
-        return
 
         $platformAssembliesPath = Split-Path $AssemblyPath -Parent
         $crossgenFolder = Split-Path $CrossgenPath

--- a/build.psm1
+++ b/build.psm1
@@ -414,10 +414,11 @@ Fix steps:
 
     # handle ResGen
     # Heuristic to run ResGen on the fresh machine
-    if ($ResGen -or -not (Test-Path "$PSScriptRoot/src/Microsoft.PowerShell.ConsoleHost/gen")) {
-        Write-Log "Run ResGen (generating C# bindings for resx files)"
-        Start-ResGen
-    }
+    # TODO: remove Start-ResGen after testing ReadyToRun
+    #if ($ResGen -or -not (Test-Path "$PSScriptRoot/src/Microsoft.PowerShell.ConsoleHost/gen")) {
+    #    Write-Log "Run ResGen (generating C# bindings for resx files)"
+    #    Start-ResGen
+    #}
 
     # Handle TypeGen
     # .inc file name must be different for Windows and Linux to allow build on Windows and WSL.

--- a/build.psm1
+++ b/build.psm1
@@ -414,10 +414,11 @@ Fix steps:
 
     # handle ResGen
     # Heuristic to run ResGen on the fresh machine
-    if ($ResGen -or -not (Test-Path "$PSScriptRoot/src/Microsoft.PowerShell.ConsoleHost/gen")) {
-        Write-Log "Run ResGen (generating C# bindings for resx files)"
-        Start-ResGen
-    }
+    # TODO: remove Start-ResGen after testing ReadyToRun
+    #if ($ResGen -or -not (Test-Path "$PSScriptRoot/src/Microsoft.PowerShell.ConsoleHost/gen")) {
+    #    Write-Log "Run ResGen (generating C# bindings for resx files)"
+    #    Start-ResGen
+    #}
 
     # Handle TypeGen
     # .inc file name must be different for Windows and Linux to allow build on Windows and WSL.
@@ -2232,6 +2233,9 @@ function Start-CrossGen {
             [String]
             $CrossgenPath
         )
+
+        # TODO: remove Start-CrossGen after testing ReadyToRun.
+        return
 
         $platformAssembliesPath = Split-Path $AssemblyPath -Parent
         $crossgenFolder = Split-Path $CrossgenPath


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Turn on ReadyToRun for PowerShell dll-s.

We can use https://github.com/dotnet/runtime/issues/35062#issuecomment-615005834 to check dll-s.

## PR Context

Now all .Net dll-s is in ReadyToRun format and PowerShell distributive doubled in size. So we can turn on the feature too. It will add ~20Mb (10%).

Docs https://docs.microsoft.com/en-us/dotnet/core/whats-new/dotnet-core-3-0#readytorun-images

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
