### PR TITLE
Support passing PSPath to native commands

### DIFF
--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -121,8 +121,8 @@ namespace System.Management.Automation
                     name: "PSCultureInvariantReplaceOperator",
                     description: "Use culture invariant to-string convertor for lval in replace operator"),
                 new ExperimentalFeature(
-                    name: "NativePSDrive",
-                    description: "Convert PSDrive path to filesystem path for native commands"),
+                    name: "PSNativePSPathResolution",
+                    description: "Convert PSPath to filesystem path, if possible, for native commands"),
             };
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);
 

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -120,6 +120,9 @@ namespace System.Management.Automation
                 new ExperimentalFeature(
                     name: "PSCultureInvariantReplaceOperator",
                     description: "Use culture invariant to-string convertor for lval in replace operator"),
+                new ExperimentalFeature(
+                    name: "NativePSDrive",
+                    description: "Convert PSDrive path to filesystem path for native commands"),
             };
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);
 

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -266,7 +266,7 @@ namespace System.Management.Automation
             // On UNIX systems, we expand arguments containing wildcard expressions against
             // the file system just like bash, etc.
 
-            if (stringConstantType != StringConstantType.SingleQuoted && WildcardPattern.ContainsWildcardCharacters(arg))
+            if (stringConstantType == StringConstantType.BareWord && WildcardPattern.ContainsWildcardCharacters(arg))
             {
                 // See if the current working directory is a filesystem provider location
                 // We won't do the expansion if it isn't since native commands can only access the file system.
@@ -320,7 +320,7 @@ namespace System.Management.Automation
                     }
                 }
             }
-            else if (stringConstantType != StringConstantType.SingleQuoted)
+            else if (stringConstantType == StringConstantType.BareWord)
             {
                 // Even if there are no wildcards, we still need to possibly
                 // expand ~ into the filesystem provider home directory path
@@ -367,11 +367,8 @@ namespace System.Management.Automation
                 {
                     try
                     {
-                        Collection<PathInfo> paths = Context.SessionState.Path.GetResolvedPSPathFromPSPath("~");
-                        if (paths.Count == 1)
-                        {
-                            return (paths[0].Path + path.Substring(1)).Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
-                        }
+                        ProviderInfo fileSystemProvider = Context.EngineSessionState.GetSingleProvider(FileSystemProvider.ProviderName);
+                        return (fileSystemProvider.Home + path.Substring(1)).Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
                     }
                     catch
                     {
@@ -386,7 +383,7 @@ namespace System.Management.Automation
                     {
                         ProviderInfo provider;
                         Collection<string> paths = Context.SessionState.Path.GetResolvedProviderPathFromPSPath($"{driveName}:", out provider);
-                        if (paths.Count == 1 && provider.Name.Equals("FileSystem", StringComparison.InvariantCultureIgnoreCase))
+                        if (paths.Count == 1 && provider.Name.Equals(FileSystemProvider.ProviderName))
                         {
                             // + 2 to replace the colon and the trailing slash which is part of the returned pspath
                             return (paths[0] + path.Substring(driveName.Length + 2)).Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -130,8 +130,7 @@ namespace System.Management.Automation
                             stringConstantType = StringConstantType.DoubleQuoted;
                         }
 
-                        appendOneNativeArgument(Context, argValue,
-                            arrayLiteralAst, sawVerbatimArgumentMarker, stringConstantType);
+                        AppendOneNativeArgument(Context, argValue, arrayLiteralAst, sawVerbatimArgumentMarker, stringConstantType);
                     }
                 }
             }
@@ -166,13 +165,11 @@ namespace System.Management.Automation
         /// <param name="argArrayAst">If the argument was an array literal, the Ast, otherwise null.</param>
         /// <param name="sawVerbatimArgumentMarker">True if the argument occurs after --%.</param>
         /// <param name="stringConstantType">Bare, SingleQuoted, or DoubleQuoted.</param>
-        private void appendOneNativeArgument(ExecutionContext context, object obj, ArrayLiteralAst argArrayAst, bool sawVerbatimArgumentMarker, StringConstantType stringConstantType)
+        private void AppendOneNativeArgument(ExecutionContext context, object obj, ArrayLiteralAst argArrayAst, bool sawVerbatimArgumentMarker, StringConstantType stringConstantType)
         {
             IEnumerator list = LanguagePrimitives.GetEnumerator(obj);
 
-            Diagnostics.Assert(argArrayAst == null
-                || obj is object[] && ((object[])obj).Length == argArrayAst.Elements.Count,
-                "array argument and ArrayLiteralAst differ in number of elements");
+            Diagnostics.Assert((argArrayAst == null) || obj is object[] && ((object[])obj).Length == argArrayAst.Elements.Count, "array argument and ArrayLiteralAst differ in number of elements");
 
             int currentElement = -1;
             string separator = string.Empty;
@@ -251,7 +248,8 @@ namespace System.Management.Automation
                         }
                     }
                 }
-            } while (list != null);
+            }
+            while (list != null);
         }
 
         /// <summary>
@@ -357,6 +355,8 @@ namespace System.Management.Automation
         /// <summary>
         /// Check if string is prefixed by psdrive, if so, expand it if filesystem path.
         /// </summary>
+        /// <param name="path">The potential PSPath to resolve.static</param>
+        /// <returns>Resolved PSPath if applicable otherwise the original path</returns>
         internal string ResolvePath(string path)
         {
             if (ExperimentalFeature.IsEnabled("PSNativePSPathResolution"))

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -372,7 +372,7 @@ namespace System.Management.Automation
                     try
                     {
                         ProviderInfo fileSystemProvider = context.EngineSessionState.GetSingleProvider(FileSystemProvider.ProviderName);
-                        return new StringBuilder(fileSystemProvider.Name)
+                        return new StringBuilder(fileSystemProvider.Home)
                             .Append(path.Substring(1))
                             .Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)
                             .ToString();

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -343,7 +343,7 @@ namespace System.Management.Automation
             }
 #endif // UNIX
 
-            if (arg.Contains(':') && stringConstantType != StringConstantType.SingleQuoted)
+            if (stringConstantType != StringConstantType.SingleQuoted)
             {
                 arg = ResolvePath(arg, Context);
             }
@@ -379,6 +379,18 @@ namespace System.Management.Automation
                     catch
                     {
                         return path;
+                    }
+                }
+
+                // check if the driveName is an actual disk drive on Windows, if so, no expansion
+                if (path.Length >= 2 && path[1] == ':')
+                {
+                    foreach (var drive in DriveInfo.GetDrives())
+                    {
+                        if (drive.Name.StartsWith(new string(path[0], 1), StringComparison.OrdinalIgnoreCase))
+                        {
+                            return path;
+                        }
                     }
                 }
 #endif

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -383,21 +383,24 @@ namespace System.Management.Automation
                 }
 #endif
 
-                LocationGlobber globber = new LocationGlobber(context.SessionState);
-                try
+                if (path.Contains(':'))
                 {
-                    ProviderInfo providerInfo;
-
-                    // replace the argument with resolved path if it's a filesystem path
-                    string pspath = globber.GetProviderPath(path, out providerInfo);
-                    if (string.Equals(providerInfo.Name, FileSystemProvider.ProviderName, StringComparison.OrdinalIgnoreCase))
+                    LocationGlobber globber = new LocationGlobber(context.SessionState);
+                    try
                     {
-                        path = pspath;
+                        ProviderInfo providerInfo;
+
+                        // replace the argument with resolved path if it's a filesystem path
+                        string pspath = globber.GetProviderPath(path, out providerInfo);
+                        if (string.Equals(providerInfo.Name, FileSystemProvider.ProviderName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            path = pspath;
+                        }
                     }
-                }
-                catch
-                {
-                    // if it's not a provider path, do nothing
+                    catch
+                    {
+                        // if it's not a provider path, do nothing
+                    }
                 }
             }
 

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -364,7 +364,7 @@ namespace System.Management.Automation
             {
                 string driveName;
 #if !UNIX
-                if (path.Equals("~") || path.StartsWith("~" + Path.DirectorySeparatorChar) || path.StartsWith("~" + Path.AltDirectorySeparatorChar))
+                if (string.Equals(path, "~") || path.StartsWith("~" + Path.DirectorySeparatorChar) || path.StartsWith("~" + Path.AltDirectorySeparatorChar))
                 {
                     try
                     {
@@ -394,7 +394,7 @@ namespace System.Management.Automation
                     {
                         ProviderInfo provider;
                         Collection<string> paths = context.SessionState.Path.GetResolvedProviderPathFromPSPath($"{driveName}:", out provider);
-                        if (paths.Count == 1 && provider.Name.Equals(FileSystemProvider.ProviderName))
+                        if (paths.Count == 1 && string.Equals(provider.Name, FileSystemProvider.ProviderName))
                         {
                             // + 2 to replace the colon and the trailing slash which is part of the returned pspath
                             return (paths[0] + path.Substring(driveName.Length + 2)).Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -380,6 +380,16 @@ namespace System.Management.Automation
 #endif
                 if (context.SessionState.Path.IsPSAbsolute(path, out driveName))
                 {
+#if !UNIX
+                    // check if the driveName is an actual disk drive on Windows, if so, no expansion
+                    foreach (var drive in DriveInfo.GetDrives())
+                    {
+                        if (drive.Name.StartsWith(driveName))
+                        {
+                            return path;
+                        }
+                    }
+#endif
                     try
                     {
                         ProviderInfo provider;

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -364,7 +364,7 @@ namespace System.Management.Automation
             {
                 string driveName;
 #if !UNIX
-                if (string.Equals(path, "~") || path.StartsWith("~" + Path.DirectorySeparatorChar) || path.StartsWith("~" + Path.AltDirectorySeparatorChar))
+                if (string.Equals(path, "~", StringComparison.Ordinal) || path.StartsWith("~" + Path.DirectorySeparatorChar, StringComparison.Ordinal) || path.StartsWith("~" + Path.AltDirectorySeparatorChar, StringComparison.Ordinal))
                 {
                     try
                     {

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
@@ -68,6 +68,9 @@ Describe "Native Command Arguments" -tags "CI" {
 Describe 'PSPath to native commands' {
     BeforeAll {
         $featureEnabled = $EnabledExperimentalFeatures.Contains('PSNativePSPathResolution')
+        $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
+
+        $PSDefaultParameterValues["it:skip"] = (-not $featureEnabled)
 
         if ($IsWindows) {
             $cmd = "cmd"
@@ -87,26 +90,31 @@ Describe 'PSPath to native commands' {
         Set-Content -Path "env:/test var" -Value 'Hello'
         $filePath = Join-Path -Path ~ -ChildPath (New-Guid)
         Set-Content -Path $filePath -Value 'Home'
+        $complexDriveName = 'My test! ;+drive'
+        New-PSDrive -Name $complexDriveName -Root $testdrive -PSProvider FileSystem
     }
 
     AfterAll {
+        $global:PSDefaultParameterValues = $originalDefaultParameterValues
+
         Remove-Item -Path "env:/test var"
         Remove-Item -Path $filePath
+        Remove-PSDrive -Name $complexDriveName
     }
 
-    It 'PSPath with ~/path works' -Skip:(-not $featureEnabled) {
+    It 'PSPath with ~/path works' {
         $out = & $cmd $cmdArg1 $cmdArg2 $filePath
         $LASTEXITCODE | Should -Be 0
         $out | Should -BeExactly 'Home'
     }
 
-    It 'PSPath with ~ works' -Skip:(-not $featureEnabled) {
+    It 'PSPath with ~ works' {
         $out = & $dir $dirArg1 $dirArg2 ~
         $LASTEXITCODE | Should -Be 0
         $out | Should -Not -BeNullOrEmpty
     }
 
-    It 'PSPath that is file system path works with native commands: <path>' -Skip:(-not $featureEnabled) -TestCases @(
+    It 'PSPath that is file system path works with native commands: <path>' -TestCases @(
         @{ path = "testdrive:/test.txt" }
         @{ path = "testdrive:/test file.txt" }
     ){
@@ -117,13 +125,13 @@ Describe 'PSPath to native commands' {
         $out | Should -BeExactly 'Hello'
     }
 
-    It 'PSPath passed with single quotes should be treated as literal' -Skip:(-not $featureEnabled) {
+    It 'PSPath passed with single quotes should be treated as literal' {
         $out = & $cmd $cmdArg1 $cmdArg2 'testdrive:/test.txt'
         $LASTEXITCODE | Should -Not -Be 0
         $out | Should -BeNullOrEmpty
     }
 
-    It 'PSPath that is not a file system path fails with native commands: <path>' -Skip:(-not $featureEnabled) -TestCases @(
+    It 'PSPath that is not a file system path fails with native commands: <path>' -TestCases @(
         @{ path = "env:/PSModulePath" }
         @{ path = "env:/test var" }
     ){
@@ -132,5 +140,22 @@ Describe 'PSPath to native commands' {
         $out = & $cmd $cmdArg1 $cmdArg2 "$path"
         $LASTEXITCODE | Should -Not -Be 0
         $out | Should -BeNullOrEmpty
+    }
+
+    It 'Relative PSPath works' {
+        New-Item -Path $testdrive -Name TestFolder -ItemType Directory -ErrorAction Stop
+        $pwd = Get-Location
+        Set-Content -Path (Join-Path -Path $testdrive -ChildPath 'TestFolder' -AdditionalChildPath 'test.txt') -Value 'hello'
+        Set-Location -Path (Join-Path -Path $testdrive -ChildPath 'TestFolder')
+        Set-Location -Path $pwd
+        $out = & $cmd $cmdArg1 $cmdArg2 "TestDrive:test.txt"
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -BeExactly 'Hello'
+    }
+
+    It 'Complex PSDrive name works' {
+        $out = & $cmd $cmdArg1 $cmdArg2 "${complexDriveName}:/test.txt"
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -BeExactly 'Hello'
     }
 }

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
@@ -95,7 +95,7 @@ Describe 'PSPath to native commands' {
     }
 
     It 'PSPath with ~/path works' -Skip:(-not $featureEnabled) {
-        $out = & $cmd $cmdArg1 $cmdArg2 "$filePath"
+        $out = & $cmd $cmdArg1 $cmdArg2 $filePath
         $LASTEXITCODE | Should -Be 0
         $out | Should -BeExactly 'Home'
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add a new `PSNativePSPathResolution` Experimental Feature where if a PSDrive is passed to a native command and uses the FileSystem provider, then the resolved file path is passed to the native command.  This means something like:

```powershell
code temp:/test.txt
```

now works as expected.  Also, on Windows, if the path starts with `~`, then that will get resolved before passing to a native command.  In both cases, the path is normalized to the directory separators for the relevant operating system.  Note:

- if the path is not a psdrive nor ~ (on Windows), then path normalization doesn't occur
- if the path is in single quotes, then it's not resolved and treated as literal

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/10675
Fix https://github.com/PowerShell/PowerShell/issues/11386

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [x] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [x] Experimental feature name(s): PSNativePSPathResolution
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [X] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/5848
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
