### PR TITLE
Add support for supplying generic method type parameters

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -2104,8 +2104,8 @@ namespace System.Management.Automation
             replacementLength = completionContext.ReplacementLength;
 
             if (result.Count == 0
-                && lastAst?.Find(a => a is MemberExpressionAst, searchNestedScriptBlocks: false) != null
-                && completionContext.TokenAtCursor.TokenFlags.HasFlag(TokenFlags.TypeName))
+                && completionContext.TokenAtCursor.TokenFlags.HasFlag(TokenFlags.TypeName)
+                && lastAst?.Find(a => a is MemberExpressionAst, searchNestedScriptBlocks: false) is not null)
             {
                 result = CompletionCompleters.CompleteType(completionContext.TokenAtCursor.Text).ToList();
             }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -2103,7 +2103,9 @@ namespace System.Management.Automation
             replacementIndex = completionContext.ReplacementIndex;
             replacementLength = completionContext.ReplacementLength;
 
-            if (result.Count == 0 && completionContext.TokenAtCursor.TokenFlags.HasFlag(TokenFlags.TypeName))
+            if (result.Count == 0
+                && lastAst?.Find(a => a is MemberExpressionAst, searchNestedScriptBlocks: false) != null
+                && completionContext.TokenAtCursor.TokenFlags.HasFlag(TokenFlags.TypeName))
             {
                 result = CompletionCompleters.CompleteType(completionContext.TokenAtCursor.Text).ToList();
             }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -2102,6 +2102,12 @@ namespace System.Management.Automation
             result = CompletionCompleters.CompleteCommandArgument(completionContext);
             replacementIndex = completionContext.ReplacementIndex;
             replacementLength = completionContext.ReplacementLength;
+
+            if (result.Count == 0 && completionContext.TokenAtCursor.TokenFlags.HasFlag(TokenFlags.TypeName))
+            {
+                result = CompletionCompleters.CompleteType(completionContext.TokenAtCursor.Text).ToList();
+            }
+
             return result;
         }
 

--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -1394,32 +1394,37 @@ namespace System.Management.Automation
             // be turned into an array.
             // We also skip the optimization if the number of arguments and parameters is different
             // so we let the loop deal with possible optional parameters.
-            if ((methods.Length == 1) &&
-                (!methods[0].hasVarArgs) &&
-                (!methods[0].isGeneric) &&
-                (methods[0].method == null || !(methods[0].method.DeclaringType.IsGenericTypeDefinition)) &&
+            if (methods.Length == 1
+                && !methods[0].hasVarArgs
                 // generic methods need to be double checked in a loop below - generic methods can be rejected if type inference fails
-                (methods[0].parameters.Length == arguments.Length))
+                && !methods[0].isGeneric
+                && (methods[0].method == null || !(methods[0].method.DeclaringType.IsGenericTypeDefinition))
+                && methods[0].parameters.Length == arguments.Length)
             {
                 return methods[0];
             }
 
             Type[] argumentTypes = arguments.Select(EffectiveArgumentType).ToArray();
+            Type[] genericParameters = invocationConstraints?.GenericTypeParameters ?? Array.Empty<Type>();
             List<OverloadCandidate> candidates = new List<OverloadCandidate>();
             for (int i = 0; i < methods.Length; i++)
             {
                 MethodInformation method = methods[i];
 
-                if (method.method != null && method.method.DeclaringType.IsGenericTypeDefinition)
+                if (method.method != null && method.method.DeclaringType.IsGenericTypeDefinition
+                    || !method.isGeneric && genericParameters.Length > 0)
                 {
-                    continue; // skip methods defined by an *open* generic type
+                    // If method is defined by an *open* generic type, or
+                    // if generic parameters were provided and this method isn't generic, skip it.
+                    continue;
                 }
 
                 if (method.isGeneric)
                 {
                     Type[] argumentTypesForTypeInference = new Type[argumentTypes.Length];
                     Array.Copy(argumentTypes, argumentTypesForTypeInference, argumentTypes.Length);
-                    if (invocationConstraints != null && invocationConstraints.ParameterTypes != null)
+
+                    if (invocationConstraints?.ParameterTypes != null)
                     {
                         int parameterIndex = 0;
                         foreach (Type typeConstraintFromCallSite in invocationConstraints.ParameterTypes)
@@ -1430,6 +1435,22 @@ namespace System.Management.Automation
                             }
 
                             parameterIndex++;
+                        }
+                    }
+
+                    if (genericParameters?.Length > 0 && method.method is MethodInfo originalMethod)
+                    {
+                        try
+                        {
+                            method = new MethodInformation(
+                                originalMethod.MakeGenericMethod(genericParameters),
+                                parametersToIgnore: 0);
+                        }
+                        catch (ArgumentException)
+                        {
+                            // Just skip this possibility if the generic type parameters can't be used to make
+                            // a valid generic method here.
+                            continue;
                         }
                     }
 

--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -1611,6 +1611,22 @@ namespace System.Management.Automation
                         methods[0].method.DeclaringType.FullName);
                     return null;
                 }
+                else if (genericParameters.Length != 0 && genericParameters.Contains(null))
+                {
+                    errorId = "TypeNotFoundForGenericMethod";
+                    errorMsg = ExtendedTypeSystem.MethodGenericArgumentTypeNotFoundException;
+                    return null;
+                }
+                else if (genericParameters.Length != 0)
+                {
+                    errorId = "MethodCountCouldNotFindBestGeneric";
+                    errorMsg = string.Format(
+                        ExtendedTypeSystem.MethodGenericArgumentCountException,
+                        methods[0].method.Name,
+                        genericParameters.Length,
+                        arguments.Length);
+                    return null;
+                }
                 else
                 {
                     errorId = "MethodCountCouldNotFindBest";

--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -1411,7 +1411,7 @@ namespace System.Management.Automation
             {
                 MethodInformation methodInfo = methods[i];
 
-                if ((methodInfo.method?.DeclaringType.IsGenericTypeDefinition == true)
+                if (methodInfo.method?.DeclaringType.IsGenericTypeDefinition == true
                     || (!methodInfo.isGeneric && genericParameters.Length > 0))
                 {
                     // If method is defined by an *open* generic type, or

--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -1398,7 +1398,7 @@ namespace System.Management.Automation
                 && !methods[0].hasVarArgs
                 // generic methods need to be double checked in a loop below - generic methods can be rejected if type inference fails
                 && !methods[0].isGeneric
-                && (methods[0].method is null || !(methods[0].method.DeclaringType.IsGenericTypeDefinition))
+                && (methods[0].method is null || !methods[0].method.DeclaringType.IsGenericTypeDefinition)
                 && methods[0].parameters.Length == arguments.Length)
             {
                 return methods[0];
@@ -1411,7 +1411,7 @@ namespace System.Management.Automation
             {
                 MethodInformation methodInfo = methods[i];
 
-                if ((methodInfo.method is not null && methodInfo.method.DeclaringType.IsGenericTypeDefinition)
+                if ((methodInfo.method?.DeclaringType.IsGenericTypeDefinition == true)
                     || (!methodInfo.isGeneric && genericParameters.Length > 0))
                 {
                     // If method is defined by an *open* generic type, or
@@ -1455,7 +1455,7 @@ namespace System.Management.Automation
                     }
 
                     methodInfo = TypeInference.Infer(methodInfo, argumentTypesForTypeInference);
-                    if (methodInfo == null)
+                    if (methodInfo is null)
                     {
                         // Skip generic methods for which we cannot infer type arguments
                         continue;

--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -1424,7 +1424,7 @@ namespace System.Management.Automation
                     Type[] argumentTypesForTypeInference = new Type[argumentTypes.Length];
                     Array.Copy(argumentTypes, argumentTypesForTypeInference, argumentTypes.Length);
 
-                    if (invocationConstraints?.ParameterTypes != null)
+                    if (invocationConstraints?.ParameterTypes is not null)
                     {
                         int parameterIndex = 0;
                         foreach (Type typeConstraintFromCallSite in invocationConstraints.ParameterTypes)

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -1920,7 +1920,7 @@ namespace System.Management.Automation
         {
             MethodTargetType = methodTargetType;
             _parameterTypes = parameterTypes;
-            GenericTypeParameters = genericTypeParameters?.ToArray() ?? Array.Empty<Type>();
+            GenericTypeParameters = genericTypeParameters ?? Array.Empty<Type>();
         }
 
         /// <remarks>
@@ -1938,7 +1938,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets the generic type parameters for the method invocation.
         /// </summary>
-        public Type[] GenericTypeParameters { get; private set; }
+        public Type[] GenericTypeParameters { get; }
 
         internal static bool EqualsForCollection<T>(ICollection<T> xs, ICollection<T> ys)
         {
@@ -2017,9 +2017,9 @@ namespace System.Management.Automation
             {
                 int result = 61;
 
-                result = result * 397 + (MethodTargetType != null ? MethodTargetType.GetHashCode() : 0);
-                result = result * 397 + ParameterTypes.SequenceGetHashCode();
-                result = result * 397 + GenericTypeParameters.SequenceGetHashCode();
+                result = (result * 397) + (MethodTargetType != null ? MethodTargetType.GetHashCode() : 0);
+                result = (result * 397) + ParameterTypes.SequenceGetHashCode();
+                result = (result * 397) + GenericTypeParameters.SequenceGetHashCode();
 
                 return result;
             }
@@ -5069,7 +5069,7 @@ namespace System.Management.Automation
             private readonly PSMemberInfoInternalCollection<T> _allMembers;
 
             /// <summary>
-            /// Constructs this instance to enumerate over members.
+            /// Initializes a new instance of the <see cref="Enumerator"/> class to enumerate over members.
             /// </summary>
             /// <param name="integratingCollection">Members we are enumerating.</param>
             internal Enumerator(PSMemberInfoIntegratingCollection<T> integratingCollection)
@@ -5097,8 +5097,8 @@ namespace System.Management.Automation
             /// Moves to the next element in the enumeration.
             /// </summary>
             /// <returns>
-            /// false if there are no more elements to enumerate
-            /// true otherwise
+            /// If there are no more elements to enumerate, returns false.
+            /// Returns true otherwise.
             /// </returns>
             public bool MoveNext()
             {
@@ -5127,7 +5127,7 @@ namespace System.Management.Automation
             }
 
             /// <summary>
-            /// Current PSMemberInfo in the enumeration.
+            /// Gets the current PSMemberInfo in the enumeration.
             /// </summary>
             /// <exception cref="ArgumentException">For invalid arguments.</exception>
             T IEnumerator<T>.Current

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -1920,7 +1920,7 @@ namespace System.Management.Automation
         {
             MethodTargetType = methodTargetType;
             _parameterTypes = parameterTypes;
-            GenericTypeParameters = genericTypeParameters ?? Array.Empty<Type>();
+            GenericTypeParameters = genericTypeParameters;
         }
 
         /// <remarks>
@@ -2024,7 +2024,7 @@ namespace System.Management.Automation
                 separator = " ";
             }
 
-            if (GenericTypeParameters.Length != 0)
+            if (GenericTypeParameters != null)
             {
                 sb.Append(separator);
                 sb.Append("genericTypeParams: ");

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -2011,19 +2011,7 @@ namespace System.Management.Automation
         }
 
         public override int GetHashCode()
-        {
-            // algorithm based on https://stackoverflow.com/questions/263400/what-is-the-best-algorithm-for-an-overridden-system-object-gethashcode
-            unchecked
-            {
-                int result = 61;
-
-                result = (result * 397) + (MethodTargetType != null ? MethodTargetType.GetHashCode() : 0);
-                result = (result * 397) + ParameterTypes.SequenceGetHashCode();
-                result = (result * 397) + GenericTypeParameters.SequenceGetHashCode();
-
-                return result;
-            }
-        }
+            => HashCode.Combine(MethodTargetType, ParameterTypes, GenericTypeParameters);
 
         public override string ToString()
         {

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -6350,28 +6350,18 @@ namespace System.Management.Automation.Language
         internal static PSMethodInvocationConstraints GetInvokeMemberConstraints(BaseCtorInvokeMemberExpressionAst invokeMemberExpressionAst)
         {
             Type targetTypeConstraint = null;
+            ReadOnlyCollection<ExpressionAst> arguments = invokeMemberExpressionAst.Arguments;
             Type[] argumentTypes = null;
-            if (invokeMemberExpressionAst.Arguments is not null)
+            if (arguments is not null)
             {
-                argumentTypes = new Type[invokeMemberExpressionAst.Arguments.Count];
-                for (var i = 0; i < invokeMemberExpressionAst.Arguments.Count; i++)
+                argumentTypes = new Type[arguments.Count];
+                for (var i = 0; i < arguments.Count; i++)
                 {
-                    argumentTypes[i] = GetTypeConstraintForMethodResolution(invokeMemberExpressionAst.Arguments[i]);
+                    argumentTypes[i] = GetTypeConstraintForMethodResolution(arguments[i]);
                 }
             }
 
             TypeDefinitionAst typeDefinitionAst = Ast.GetAncestorTypeDefinitionAst(invokeMemberExpressionAst);
-
-            Type[] genericArguments = null;
-            if (invokeMemberExpressionAst.GenericTypeArguments.Count > 0)
-            {
-                genericArguments = new Type[invokeMemberExpressionAst.GenericTypeArguments.Count];
-                for (var i = 0; i < invokeMemberExpressionAst.GenericTypeArguments.Count; i++)
-                {
-                    genericArguments[i] = invokeMemberExpressionAst.GenericTypeArguments[i].GetReflectionType();
-                }
-            }
-
             if (typeDefinitionAst != null)
             {
                 targetTypeConstraint = (typeDefinitionAst as TypeDefinitionAst).Type.BaseType;
@@ -6381,7 +6371,7 @@ namespace System.Management.Automation.Language
                 Diagnostics.Assert(false, "BaseCtorInvokeMemberExpressionAst must be used only inside TypeDefinitionAst");
             }
 
-            return CombineTypeConstraintForMethodResolution(targetTypeConstraint, argumentTypes, genericArguments);
+            return CombineTypeConstraintForMethodResolution(targetTypeConstraint, argumentTypes, genericArguments: null);
         }
 
         internal Expression InvokeMember(

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -6338,7 +6338,6 @@ namespace System.Management.Automation.Language
             if (genericArguments is not null)
             {
                 genericTypeArguments = new Type[genericArguments.Count];
-
                 for (var i = 0; i < genericArguments.Count; i++)
                 {
                     genericTypeArguments[i] = genericArguments[i].GetReflectionType();

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -1437,7 +1437,7 @@ namespace System.Management.Automation.Language
             return typeName;
         }
 
-        private List<ITypeName> GenericTypeArgumentsRule(Token firstToken, bool unbracketedGenericArg, out Token lastToken)
+        private List<ITypeName> GenericTypeArgumentsRule(Token firstToken, out Token lastToken)
         {
             Diagnostics.Assert(firstToken.Kind == TokenKind.Identifier || firstToken.Kind == TokenKind.LBracket, "unexpected first token");
             RuntimeHelpers.EnsureSufficientExecutionStack();
@@ -1480,7 +1480,7 @@ namespace System.Management.Automation.Language
 
         private ITypeName GenericTypeNameRule(Token genericTypeName, Token firstToken, bool unbracketedGenericArg)
         {
-            List<ITypeName> genericArguments = GenericTypeArgumentsRule(firstToken, unbracketedGenericArg, out Token rBracketToken);
+            List<ITypeName> genericArguments = GenericTypeArgumentsRule(firstToken, out Token rBracketToken);
 
             if (rBracketToken.Kind != TokenKind.RBracket)
             {
@@ -1489,8 +1489,7 @@ namespace System.Management.Automation.Language
                 ReportIncompleteInput(
                     Before(rBracketToken),
                     nameof(ParserStrings.EndSquareBracketExpectedAtEndOfAttribute),
-                    ParserStrings.EndSquareBracketExpectedAtEndOfAttribute,
-                    rBracketToken.Text);
+                    ParserStrings.EndSquareBracketExpectedAtEndOfAttribute);
                 rBracketToken = null;
             }
 
@@ -7789,7 +7788,7 @@ namespace System.Management.Automation.Language
                 if (firstToken.Kind == TokenKind.Identifier || firstToken.Kind == TokenKind.LBracket)
                 {
                     resyncIndex = -1;
-                    genericTypes = GenericTypeArgumentsRule(firstToken, unbracketedGenericArg: false, out rBracketToken);
+                    genericTypes = GenericTypeArgumentsRule(firstToken, out rBracketToken);
 
                     if (rBracketToken.Kind != TokenKind.RBracket)
                     {

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -7895,7 +7895,11 @@ namespace System.Management.Automation.Language
             this.Member = member;
             SetParent(member);
             this.Static = @static;
-            this.GenericTypeArguments = new ReadOnlyCollection<ITypeName>(genericTypes ?? Array.Empty<ITypeName>());
+
+            if (genericTypes != null && genericTypes.Count > 0)
+            {
+                this.GenericTypeArguments = new ReadOnlyCollection<ITypeName>(genericTypes);
+            }
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -7882,7 +7882,7 @@ namespace System.Management.Automation.Language
             ExpressionAst expression,
             CommandElementAst member,
             bool @static,
-            IList<ITypeName> genericTypes = null)
+            IList<ITypeName> genericTypes)
             : base(extent)
         {
             if (expression == null || member == null)
@@ -7896,6 +7896,30 @@ namespace System.Management.Automation.Language
             SetParent(member);
             this.Static = @static;
             this.GenericTypeArguments = new ReadOnlyCollection<ITypeName>(genericTypes ?? Array.Empty<ITypeName>());
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemberExpressionAst"/> class.
+        /// </summary>
+        /// <param name="extent">
+        /// The extent of the expression, starting with the expression before the operator '.' or '::' and ending after
+        /// membername or expression naming the member.
+        /// </param>
+        /// <param name="expression">The expression before the member access operator '.' or '::'.</param>
+        /// <param name="member">The name or expression naming the member to access.</param>
+        /// <param name="static">True if the '::' operator was used, false if '.' is used.
+        /// True if the member access is for a static member, using '::', false if accessing a member on an instance using '.'.
+        /// </param>
+        /// <exception cref="PSArgumentNullException">
+        /// If <paramref name="extent"/>, <paramref name="expression"/>, or <paramref name="member"/> is null.
+        /// </exception>
+        public MemberExpressionAst(
+            IScriptExtent extent,
+            ExpressionAst expression,
+            CommandElementAst member,
+            bool @static)
+            : this(extent, expression, member, @static, genericTypes: null)
+        {
         }
 
         /// <summary>
@@ -7919,10 +7943,34 @@ namespace System.Management.Automation.Language
             CommandElementAst member,
             bool @static,
             bool nullConditional,
-            IList<ITypeName> genericTypes = null)
+            IList<ITypeName> genericTypes)
             : this(extent, expression, member, @static, genericTypes)
         {
             this.NullConditional = nullConditional;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemberExpressionAst"/> class.
+        /// </summary>
+        /// <param name="extent">
+        /// The extent of the expression, starting with the expression before the operator '.', '::' or '?.' and ending after
+        /// membername or expression naming the member.
+        /// </param>
+        /// <param name="expression">The expression before the member access operator '.', '::' or '?.'.</param>
+        /// <param name="member">The name or expression naming the member to access.</param>
+        /// <param name="static">True if the '::' operator was used, false if '.' or '?.' is used.</param>
+        /// <param name="nullConditional">True if '?.' used.</param>
+        /// <exception cref="PSArgumentNullException">
+        /// If <paramref name="extent"/>, <paramref name="expression"/>, or <paramref name="member"/> is null.
+        /// </exception>
+        public MemberExpressionAst(
+            IScriptExtent extent,
+            ExpressionAst expression,
+            CommandElementAst member,
+            bool @static,
+            bool nullConditional)
+            : this(extent, expression, member, @static, genericTypes: null)
+        {
         }
 
         /// <summary>
@@ -8022,7 +8070,7 @@ namespace System.Management.Automation.Language
             CommandElementAst method,
             IEnumerable<ExpressionAst> arguments,
             bool @static,
-            IList<ITypeName> genericTypes = null)
+            IList<ITypeName> genericTypes)
             : base(extent, expression, method, @static, genericTypes)
         {
             if (arguments != null && arguments.Any())
@@ -8030,6 +8078,32 @@ namespace System.Management.Automation.Language
                 this.Arguments = new ReadOnlyCollection<ExpressionAst>(arguments.ToArray());
                 SetParents(Arguments);
             }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvokeMemberExpressionAst"/> class.
+        /// </summary>
+        /// <param name="extent">
+        /// The extent of the expression, starting with the expression before the invocation operator and ending with the
+        /// closing paren after the arguments.
+        /// </param>
+        /// <param name="expression">The expression before the invocation operator ('.', '::').</param>
+        /// <param name="method">The method to invoke.</param>
+        /// <param name="arguments">The arguments to pass to the method.</param>
+        /// <param name="static">
+        /// True if the invocation is for a static method, using '::', false if invoking a method on an instance using '.'.
+        /// </param>
+        /// <exception cref="PSArgumentNullException">
+        /// If <paramref name="extent"/> is null.
+        /// </exception>
+        public InvokeMemberExpressionAst(
+            IScriptExtent extent,
+            ExpressionAst expression,
+            CommandElementAst method,
+            IEnumerable<ExpressionAst> arguments,
+            bool @static)
+            : this(extent, expression, method, arguments, @static, genericTypes: null)
+        {
         }
 
         /// <summary>
@@ -8057,10 +8131,38 @@ namespace System.Management.Automation.Language
             IEnumerable<ExpressionAst> arguments,
             bool @static,
             bool nullConditional,
-            IList<ITypeName> genericTypes = null)
+            IList<ITypeName> genericTypes)
             : this(extent, expression, method, arguments, @static, genericTypes)
         {
             this.NullConditional = nullConditional;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvokeMemberExpressionAst"/> class.
+        /// </summary>
+        /// <param name="extent">
+        /// The extent of the expression, starting with the expression before the invocation operator and ending with the
+        /// closing paren after the arguments.
+        /// </param>
+        /// <param name="expression">The expression before the invocation operator ('.', '::' or '?.').</param>
+        /// <param name="method">The method to invoke.</param>
+        /// <param name="arguments">The arguments to pass to the method.</param>
+        /// <param name="static">
+        /// True if the invocation is for a static method, using '::', false if invoking a method on an instance using '.' or '?.'.
+        /// </param>
+        /// <param name="nullConditional">True if the operator used is '?.'.</param>
+        /// <exception cref="PSArgumentNullException">
+        /// If <paramref name="extent"/> is null.
+        /// </exception>
+        public InvokeMemberExpressionAst(
+            IScriptExtent extent,
+            ExpressionAst expression,
+            CommandElementAst method,
+            IEnumerable<ExpressionAst> arguments,
+            bool @static,
+            bool nullConditional)
+            : this(extent, expression, method, arguments, @static, nullConditional, genericTypes: null)
+        {
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -7862,7 +7862,7 @@ namespace System.Management.Automation.Language
     public class MemberExpressionAst : ExpressionAst, ISupportsAssignment
     {
         /// <summary>
-        /// Construct an ast to reference a property.
+        /// Initializes a new instance of the <see cref="MemberExpressionAst"/> class.
         /// </summary>
         /// <param name="extent">
         /// The extent of the expression, starting with the expression before the operator '.' or '::' and ending after
@@ -7882,7 +7882,7 @@ namespace System.Management.Automation.Language
             ExpressionAst expression,
             CommandElementAst member,
             bool @static,
-            IEnumerable<ITypeName> genericTypes = null)
+            IList<ITypeName> genericTypes = null)
             : base(extent)
         {
             if (expression == null || member == null)
@@ -7895,11 +7895,7 @@ namespace System.Management.Automation.Language
             this.Member = member;
             SetParent(member);
             this.Static = @static;
-
-            if (genericTypes?.Any() == true)
-            {
-                this.GenericTypeArguments = new ReadOnlyCollection<ITypeName>(genericTypes.ToArray());
-            }
+            this.GenericTypeArguments = new ReadOnlyCollection<ITypeName>(genericTypes ?? Array.Empty<ITypeName>());
         }
 
         /// <summary>
@@ -7923,7 +7919,7 @@ namespace System.Management.Automation.Language
             CommandElementAst member,
             bool @static,
             bool nullConditional,
-            IEnumerable<ITypeName> genericTypes = null)
+            IList<ITypeName> genericTypes = null)
             : this(extent, expression, member, @static, genericTypes)
         {
             this.NullConditional = nullConditional;
@@ -7950,9 +7946,9 @@ namespace System.Management.Automation.Language
         public bool NullConditional { get; protected set; }
 
         /// <summary>
-        /// List of generic type arguments passed to this member.
+        /// Gets a list of generic type arguments passed to this member.
         /// </summary>
-        public ReadOnlyCollection<ITypeName> GenericTypeArguments { get; private set; }
+        public ReadOnlyCollection<ITypeName> GenericTypeArguments { get; }
 
         /// <summary>
         /// Copy the MemberExpressionAst instance.
@@ -8004,7 +8000,7 @@ namespace System.Management.Automation.Language
     public class InvokeMemberExpressionAst : MemberExpressionAst, ISupportsAssignment
     {
         /// <summary>
-        /// Construct an instance of a method invocation expression.
+        /// Initializes a new instance of the <see cref="InvokeMemberExpressionAst"/> class.
         /// </summary>
         /// <param name="extent">
         /// The extent of the expression, starting with the expression before the invocation operator and ending with the
@@ -8026,7 +8022,7 @@ namespace System.Management.Automation.Language
             CommandElementAst method,
             IEnumerable<ExpressionAst> arguments,
             bool @static,
-            IEnumerable<ITypeName> genericTypes = null)
+            IList<ITypeName> genericTypes = null)
             : base(extent, expression, method, @static, genericTypes)
         {
             if (arguments != null && arguments.Any())
@@ -8061,7 +8057,7 @@ namespace System.Management.Automation.Language
             IEnumerable<ExpressionAst> arguments,
             bool @static,
             bool nullConditional,
-            IEnumerable<ITypeName> genericTypes = null)
+            IList<ITypeName> genericTypes = null)
             : this(extent, expression, method, arguments, @static, genericTypes)
         {
             this.NullConditional = nullConditional;

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -7969,7 +7969,7 @@ namespace System.Management.Automation.Language
             CommandElementAst member,
             bool @static,
             bool nullConditional)
-            : this(extent, expression, member, @static, genericTypes: null)
+            : this(extent, expression, member, @static, nullConditional, genericTypes: null)
         {
         }
 

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -7873,10 +7873,16 @@ namespace System.Management.Automation.Language
         /// <param name="static">True if the '::' operator was used, false if '.' is used.
         /// True if the member access is for a static member, using '::', false if accessing a member on an instance using '.'.
         /// </param>
+        /// <param name="genericTypes">The generic type arguments passed to the member.</param>
         /// <exception cref="PSArgumentNullException">
         /// If <paramref name="extent"/>, <paramref name="expression"/>, or <paramref name="member"/> is null.
         /// </exception>
-        public MemberExpressionAst(IScriptExtent extent, ExpressionAst expression, CommandElementAst member, bool @static)
+        public MemberExpressionAst(
+            IScriptExtent extent,
+            ExpressionAst expression,
+            CommandElementAst member,
+            bool @static,
+            IEnumerable<ITypeName> genericTypes = null)
             : base(extent)
         {
             if (expression == null || member == null)
@@ -7889,6 +7895,11 @@ namespace System.Management.Automation.Language
             this.Member = member;
             SetParent(member);
             this.Static = @static;
+
+            if (genericTypes?.Any() == true)
+            {
+                this.GenericTypeArguments = new ReadOnlyCollection<ITypeName>(genericTypes.ToArray());
+            }
         }
 
         /// <summary>
@@ -7902,11 +7913,18 @@ namespace System.Management.Automation.Language
         /// <param name="member">The name or expression naming the member to access.</param>
         /// <param name="static">True if the '::' operator was used, false if '.' or '?.' is used.</param>
         /// <param name="nullConditional">True if '?.' used.</param>
+        /// <param name="genericTypes">The generic type arguments passed to the member.</param>
         /// <exception cref="PSArgumentNullException">
         /// If <paramref name="extent"/>, <paramref name="expression"/>, or <paramref name="member"/> is null.
         /// </exception>
-        public MemberExpressionAst(IScriptExtent extent, ExpressionAst expression, CommandElementAst member, bool @static, bool nullConditional)
-            : this(extent, expression, member, @static)
+        public MemberExpressionAst(
+            IScriptExtent extent,
+            ExpressionAst expression,
+            CommandElementAst member,
+            bool @static,
+            bool nullConditional,
+            IEnumerable<ITypeName> genericTypes = null)
+            : this(extent, expression, member, @static, genericTypes)
         {
             this.NullConditional = nullConditional;
         }
@@ -7932,13 +7950,25 @@ namespace System.Management.Automation.Language
         public bool NullConditional { get; protected set; }
 
         /// <summary>
+        /// List of generic type arguments passed to this member.
+        /// </summary>
+        public ReadOnlyCollection<ITypeName> GenericTypeArguments { get; private set; }
+
+        /// <summary>
         /// Copy the MemberExpressionAst instance.
         /// </summary>
         public override Ast Copy()
         {
             var newExpression = CopyElement(this.Expression);
             var newMember = CopyElement(this.Member);
-            return new MemberExpressionAst(this.Extent, newExpression, newMember, this.Static, this.NullConditional);
+
+            return new MemberExpressionAst(
+                this.Extent,
+                newExpression,
+                newMember,
+                this.Static,
+                this.NullConditional,
+                this.GenericTypeArguments);
         }
 
         #region Visitors
@@ -7986,11 +8016,18 @@ namespace System.Management.Automation.Language
         /// <param name="static">
         /// True if the invocation is for a static method, using '::', false if invoking a method on an instance using '.'.
         /// </param>
+        /// <param name="genericTypes">The generic type arguments passed to the method.</param>
         /// <exception cref="PSArgumentNullException">
         /// If <paramref name="extent"/> is null.
         /// </exception>
-        public InvokeMemberExpressionAst(IScriptExtent extent, ExpressionAst expression, CommandElementAst method, IEnumerable<ExpressionAst> arguments, bool @static)
-            : base(extent, expression, method, @static)
+        public InvokeMemberExpressionAst(
+            IScriptExtent extent,
+            ExpressionAst expression,
+            CommandElementAst method,
+            IEnumerable<ExpressionAst> arguments,
+            bool @static,
+            IEnumerable<ITypeName> genericTypes = null)
+            : base(extent, expression, method, @static, genericTypes)
         {
             if (arguments != null && arguments.Any())
             {
@@ -8013,11 +8050,19 @@ namespace System.Management.Automation.Language
         /// True if the invocation is for a static method, using '::', false if invoking a method on an instance using '.' or '?.'.
         /// </param>
         /// <param name="nullConditional">True if the operator used is '?.'.</param>
+        /// <param name="genericTypes">The generic type arguments passed to the method.</param>
         /// <exception cref="PSArgumentNullException">
         /// If <paramref name="extent"/> is null.
         /// </exception>
-        public InvokeMemberExpressionAst(IScriptExtent extent, ExpressionAst expression, CommandElementAst method, IEnumerable<ExpressionAst> arguments, bool @static, bool nullConditional)
-            : this(extent, expression, method, arguments, @static)
+        public InvokeMemberExpressionAst(
+            IScriptExtent extent,
+            ExpressionAst expression,
+            CommandElementAst method,
+            IEnumerable<ExpressionAst> arguments,
+            bool @static,
+            bool nullConditional,
+            IEnumerable<ITypeName> genericTypes = null)
+            : this(extent, expression, method, arguments, @static, genericTypes)
         {
             this.NullConditional = nullConditional;
         }
@@ -8035,7 +8080,15 @@ namespace System.Management.Automation.Language
             var newExpression = CopyElement(this.Expression);
             var newMethod = CopyElement(this.Member);
             var newArguments = CopyElements(this.Arguments);
-            return new InvokeMemberExpressionAst(this.Extent, newExpression, newMethod, newArguments, this.Static, this.NullConditional);
+
+            return new InvokeMemberExpressionAst(
+                this.Extent,
+                newExpression,
+                newMethod,
+                newArguments,
+                this.Static,
+                this.NullConditional,
+                this.GenericTypeArguments);
         }
 
         #region Visitors

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -7896,7 +7896,7 @@ namespace System.Management.Automation.Language
             SetParent(member);
             this.Static = @static;
 
-            if (genericTypes != null && genericTypes.Count > 0)
+            if (genericTypes is not null && genericTypes.Count > 0)
             {
                 this.GenericTypeArguments = new ReadOnlyCollection<ITypeName>(genericTypes);
             }

--- a/src/System.Management.Automation/resources/ExtendedTypeSystem.resx
+++ b/src/System.Management.Automation/resources/ExtendedTypeSystem.resx
@@ -156,6 +156,12 @@
   <data name="MethodArgumentCountException" xml:space="preserve">
     <value>Cannot find an overload for "{0}" and the argument count: "{1}".</value>
   </data>
+  <data name="MethodGenericArgumentCountException" xml:space="preserve">
+    <value>Could not find a suitable generic method overload for "{0}" with "{1}" type parameters, and the argument count: "{2}".</value>
+  </data>
+  <data name="MethodGenericArgumentTypeNotFoundException" xml:space="preserve">
+    <value>One or more of the generic type parameters provided for the method "{0}" refers to a type which cannot be found.</value>
+  </data>
   <data name="MethodAmbiguousException" xml:space="preserve">
     <value>Multiple ambiguous overloads found for "{0}" and the argument count: "{1}".</value>
   </data>

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -43,6 +43,22 @@ Describe "TabCompletion" -Tags CI {
         $res.CompletionMatches[0].CompletionText | Should -BeExactly 'CompareTo('
     }
 
+    It 'should complete generic type parameters for static methods' {
+        $script = '[array]::Empty[pscu'
+
+        $results = TabExpansion2 -inputScript $script -cursorColumn $script.Length
+        $results.CompletionMatches.CompletionText | Should -Contain 'pscustomobject'
+    }
+
+    It 'should complete generic type parameters for instance methods' {
+        $script = '
+            $dict = [System.Collections.Concurrent.ConcurrentDictionary[string, int]]::new()
+            $dict.AddOrUpdate[pscu'
+
+        $results = TabExpansion2 -inputScript $script -cursorColumn $script.Length
+        $results.CompletionMatches.CompletionText | Should -Contain 'pscustomobject'
+    }
+
     It 'Should complete Magic foreach' {
         $res = TabExpansion2 -inputScript '(1..10).Fo' -cursorColumn '(1..10).Fo'.Length
         $res.CompletionMatches[0].CompletionText | Should -BeExactly 'ForEach('

--- a/test/powershell/Language/Parser/MethodInvocation.Tests.ps1
+++ b/test/powershell/Language/Parser/MethodInvocation.Tests.ps1
@@ -82,7 +82,7 @@ namespace MSFT_716893
     }
 }
 
-Describe 'Generic Method invocation' {
+Describe 'Generic Method invocation' -Tags 'CI' {
 
     BeforeAll {
         $EmptyArrayCases = @(

--- a/test/powershell/Language/Parser/MethodInvocation.Tests.ps1
+++ b/test/powershell/Language/Parser/MethodInvocation.Tests.ps1
@@ -228,8 +228,8 @@ Describe 'Generic Method invocation' -Tags 'CI' {
             [array]::Empty[string, int]()
         }
         catch {
-            $_.Exception.Message | Should -BeExactly 'Cannot find an overload for "Empty" and the argument count: "0".'
-            $_.FullyQualifiedErrorId | Should -BeExactly 'MethodCountCouldNotFindBest'
+            $_.Exception.Message | Should -BeExactly 'Could not find a suitable generic method overload for "Empty" with "2" type parameters, and the argument count: "0".'
+            $_.FullyQualifiedErrorId | Should -BeExactly 'MethodCountCouldNotFindBestGeneric'
         }
     }
 
@@ -238,8 +238,8 @@ Describe 'Generic Method invocation' -Tags 'CI' {
             [array]::Empty[thisdoesnotexist]()
         }
         catch {
-            $_.Exception.Message | Should -BeExactly 'Cannot find an overload for "empty" and the argument count: "0".'
-            $_.FullyQualifiedErrorId | Should -BeExactly 'MethodCountCouldNotFindBest'
+            $_.Exception.Message | Should -BeExactly 'One or more of the generic type parameters provided for the method "Empty" refers to a type which cannot be found.'
+            $_.FullyQualifiedErrorId | Should -BeExactly 'TypeNotFoundForGenericMethod'
         }
     }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Adds support for specifying type arguments for generic methods.

For example:

```ps1
[Array]::Empty[int]()
```

```ps1
$dictionary = [System.Collections.Concurrent.ConcurrentDictionary[string, int]]::new()
$dictionary.AddOrUpdate[float]($Key, $addEntryScript, $updateEntryScript, $FloatValue)
```

Many thanks to @dlwyatt for the initial parsing implementation! 😊 💖 

## PR Context

Resolves #5146

/cc @lzybkr @daxian-dbw 

/cc @TylerLeonhardt would this necessitate an update to language spec like the `dispose{}` one did?
This may affect tools not using an actual PS parser, but in general I think the impact will be minor overall, likely requiring some updates to any regex recognition patterns for some syntax highlighting rules.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/8533
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [x] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
