### PR TITLE
Add `dependabot` rules to ignore updates from .NET

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -8,24 +8,52 @@ update_configs:
     update_schedule: "live"
     default_labels:
       - "CL-BuildPackaging"
+    ignored_updates:
+      - match:
+          dependency_name: "System.*"
+      - match:
+          dependency_name: "Microsoft.Win32.Registry.AccessControl"
+      - match:
+          dependency_name: "Microsoft.Windows.Compatibility"
 
   - package_manager: "dotnet:nuget"
     directory: "/tools/packaging/projects/reference/Microsoft.PowerShell.Commands.Utility"
     update_schedule: "live"
     default_labels:
       - "CL-BuildPackaging"
+    ignored_updates:
+      - match:
+          dependency_name: "System.*"
+      - match:
+          dependency_name: "Microsoft.Win32.Registry.AccessControl"
+      - match:
+          dependency_name: "Microsoft.Windows.Compatibility"
 
   - package_manager: "dotnet:nuget"
     directory: "/tools/packaging/projects/reference/System.Management.Automation"
     update_schedule: "live"
     default_labels:
       - "CL-BuildPackaging"
+    ignored_updates:
+      - match:
+          dependency_name: "System.*"
+      - match:
+          dependency_name: "Microsoft.Win32.Registry.AccessControl"
+      - match:
+          dependency_name: "Microsoft.Windows.Compatibility"
 
   - package_manager: "dotnet:nuget"
     directory: "/test/tools/Modules"
     update_schedule: "live"
     default_labels:
       - "CL-BuildPackaging"
+    ignored_updates:
+      - match:
+          dependency_name: "System.*"
+      - match:
+          dependency_name: "Microsoft.Win32.Registry.AccessControl"
+      - match:
+          dependency_name: "Microsoft.Windows.Compatibility"
 
   - package_manager: "dotnet:nuget"
     directory: "/src/Modules"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Ignore taking update from .NET pre-release feed. .NET update should be taken only when the SDK / runtime is to be updated.

## PR Context

By adding the dotnet pre-release feed to nuget.config in root, dependabot is filing PRs for every package that is published. We do not need to update for every release.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
