### PR TITLE
Change Get-FileHash to close file handles before writing output

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
@@ -123,15 +123,15 @@ namespace Microsoft.PowerShell.Commands
 
                     break;
             }
-            
+
             foreach (string path in pathsToProcess)
             {
                 string hash = null;
-                
+
                 if (ComputeFileHash(path, out hash))
                 {
                     WriteHashResult(Algorithm, hash, path);
-                }                
+                }
             }
         }
 
@@ -161,20 +161,18 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>Boolean value indicating whether the hash calculation succeeded or failed.</returns>
         private bool ComputeFileHash(string path, out string hash)
         {
-            bool hashComputedSuccessfully = false;
             byte[] bytehash = null;
             Stream openfilestream = null;
 
             hash = null;
-            
+
             try
             {
                 openfilestream = File.OpenRead(path);
-            
+
                 bytehash = hasher.ComputeHash(openfilestream);
                 hash = BitConverter.ToString(bytehash).Replace("-", string.Empty);
-                
-                hashComputedSuccessfully = true;
+
             }
             catch (FileNotFoundException ex)
             {
@@ -207,8 +205,8 @@ namespace Microsoft.PowerShell.Commands
             {
                 openfilestream?.Dispose();
             }
-            
-            return hashComputedSuccessfully;
+
+            return hash != null;
         }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
@@ -128,14 +128,15 @@ namespace Microsoft.PowerShell.Commands
             {
                 byte[] bytehash = null;
                 string hash = null;
-                Stream openfilestream = null;
 
                 try
                 {
-                    openfilestream = File.OpenRead(path);
-                    bytehash = hasher.ComputeHash(openfilestream);
-
-                    hash = BitConverter.ToString(bytehash).Replace("-", string.Empty);
+                    using (Stream openfilestream = File.OpenRead(path))
+                    {
+                        bytehash = hasher.ComputeHash(openfilestream);
+                        hash = BitConverter.ToString(bytehash).Replace("-", string.Empty);
+                    }
+                    
                     WriteHashResult(Algorithm, hash, path);
                 }
                 catch (FileNotFoundException ex)
@@ -164,10 +165,6 @@ namespace Microsoft.PowerShell.Commands
                         ErrorCategory.ReadError,
                         path);
                     WriteError(errorRecord);
-                }
-                finally
-                {
-                    openfilestream?.Dispose();
                 }
             }
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
@@ -126,7 +126,6 @@ namespace Microsoft.PowerShell.Commands
             
             foreach (string path in pathsToProcess)
             {
-                byte[] bytehash = null;
                 string hash = null;
                 
                 if (ComputeFileHash(path, out hash))
@@ -162,16 +161,20 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>Boolean value indicating whether the hash calculation succeeded or failed.</returns>
         private bool ComputeFileHash(string path, out string hash)
         {
+            bool hashComputedSuccessfully = false;
+            byte[] bytehash = null;
             Stream openfilestream = null;
-        
+
+            hash = null;
+            
             try
             {
                 openfilestream = File.OpenRead(path);
             
                 bytehash = hasher.ComputeHash(openfilestream);
-                hash = BitConverter.ToString(bytehash).Replace("-", string.Empty);                    
+                hash = BitConverter.ToString(bytehash).Replace("-", string.Empty);
                 
-                return true;
+                hashComputedSuccessfully = true;
             }
             catch (FileNotFoundException ex)
             {
@@ -205,7 +208,7 @@ namespace Microsoft.PowerShell.Commands
                 openfilestream?.Dispose();
             }
             
-            return false;
+            return hashComputedSuccessfully;
         }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
@@ -126,9 +126,7 @@ namespace Microsoft.PowerShell.Commands
 
             foreach (string path in pathsToProcess)
             {
-                string hash = null;
-
-                if (ComputeFileHash(path, out hash))
+                if (ComputeFileHash(path, out string hash))
                 {
                     WriteHashResult(Algorithm, hash, path);
                 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
@@ -157,8 +157,8 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Read the file and calculate the hash.
         /// </summary>
-        /// <param name="path"></param>
-        /// <param name="hash"></param>
+        /// <param name="path">Path to file which will be hashed.</param>
+        /// <param name="hash">Will contain the hash of the file content.</param>
         /// <returns>Boolean value indicating whether the hash calculation succeeded or failed.</returns>
         private bool ComputeFileHash(string path, out string hash)
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
@@ -172,7 +172,6 @@ namespace Microsoft.PowerShell.Commands
 
                 bytehash = hasher.ComputeHash(openfilestream);
                 hash = BitConverter.ToString(bytehash).Replace("-", string.Empty);
-
             }
             catch (FileNotFoundException ex)
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
@@ -129,7 +129,7 @@ namespace Microsoft.PowerShell.Commands
                 byte[] bytehash = null;
                 string hash = null;
                 
-                if (ComputeFileHash(Algorithm, path, out hash))
+                if (ComputeFileHash(path, out hash))
                 {
                     WriteHashResult(Algorithm, hash, path);
                 }                
@@ -155,9 +155,12 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Read the file and calculate the hash
+        /// Read the file and calculate the hash.
         /// </summary>
-        private bool ComputeFileHash(string Algorithm, string path, out string hash)
+        /// <param name="path"></param>
+        /// <param name="hash"></param>
+        /// <returns>Boolean value indicating whether the hash calculation succeeded or failed.</returns>
+        private bool ComputeFileHash(string path, out string hash)
         {
             Stream openfilestream = null;
         
@@ -204,7 +207,6 @@ namespace Microsoft.PowerShell.Commands
             
             return false;
         }
-
 
         /// <summary>
         /// Create FileHashInfo object and output it.

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FileHash.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FileHash.Tests.ps1
@@ -77,4 +77,10 @@ Describe "Get-FileHash" -Tags "CI" {
             $result.Path | Should -Be $testDocument
         }
     }
+    
+    Context "Close file before writing hash details to pipeline" {
+        It "Should not hold the file open unnecessarily" {
+            {Get-FileHash $testDocument | Rename-Item -NewName {$_.Hash}} | Should -Not -Throw
+        }
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FileHash.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FileHash.Tests.ps1
@@ -86,8 +86,8 @@ Describe "Get-FileHash" -Tags "CI" {
             $testDocumentCopy = "${testDocument}-copy"
             Copy-Item -Path $testdocument -Destination $testDocumentCopy
 
-            Get-FileHash -Path $testDocumentCopy | Rename-Item -NewName {$_.Hash} -ErrorAction SilentlyContinue
-            Test-Path -Path $testDocumentCopy | Should -Be $true
+            $newPath = Get-FileHash -Path $testDocumentCopy | Rename-Item -NewName {$_.Hash} -PassThru -ErrorAction SilentlyContinue
+            Test-Path -Path $newPath.FullName -ErrorAction SilentlyContinue | Should -Be $true
 
             Remove-Item -Path $testDocumentCopy -ErrorAction SilentlyContinue
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FileHash.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FileHash.Tests.ps1
@@ -86,10 +86,10 @@ Describe "Get-FileHash" -Tags "CI" {
             $testDocumentCopy = "${testDocument}-copy"
             Copy-Item -Path $testdocument -Destination $testDocumentCopy
 
-            $newPath = Get-FileHash -Path $testDocumentCopy | Rename-Item -NewName {$_.Hash} -PassThru -ErrorAction SilentlyContinue
-            Test-Path -Path $newPath.FullName -ErrorAction SilentlyContinue | Should -Be $true
+            $newPath = Get-FileHash -Path $testDocumentCopy | Rename-Item -NewName {$_.Hash} -PassThru
+            Test-Path -Path $newPath.FullName | Should -BeTrue
 
-            Remove-Item -Path $testDocumentCopy -ErrorAction SilentlyContinue
+            Remove-Item -Path $testDocumentCopy -Force
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FileHash.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FileHash.Tests.ps1
@@ -77,17 +77,19 @@ Describe "Get-FileHash" -Tags "CI" {
             $result.Path | Should -Be $testDocument
         }
     }
-    
-    Context "Close file before writing hash details to pipeline" {
-        It "Should not hold the file open unnecessarily" {
-            # Make a copy of the test document first,
-            # because this test will rename it.
+
+    Context "File should be closed before Get-FileHash writes pipeline output" {
+        It "Should be able to edit the file without 'file is in use' exceptions" {
+            # This test runs against a copy of the document
+            # because it involves renaming it,
+            # and that might break tests added later on.
             $testDocumentCopy = "${testDocument}-copy"
             Copy-Item -Path $testdocument -Destination $testDocumentCopy
-            
-            {Get-FileHash -Path $testDocumentCopy | Rename-Item -NewName {$_.Hash} -ErrorAction Stop} | Should -Not -Throw
-            
-            Remove-Item -Path $testDocumentCopy
+
+            Get-FileHash -Path $testDocumentCopy | Rename-Item -NewName {$_.Hash} -ErrorAction SilentlyContinue
+            Test-Path -Path $testDocumentCopy | Should -Be $true
+
+            Remove-Item -Path $testDocumentCopy -ErrorAction SilentlyContinue
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FileHash.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FileHash.Tests.ps1
@@ -80,7 +80,7 @@ Describe "Get-FileHash" -Tags "CI" {
     
     Context "Close file before writing hash details to pipeline" {
         It "Should not hold the file open unnecessarily" {
-            # make a copy of the test document first
+            # Make a copy of the test document first,
             # because this test will rename it.
             $testDocumentCopy = "${testDocument}-copy"
             Copy-Item -Path $testdocument -Destination $testDocumentCopy

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FileHash.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FileHash.Tests.ps1
@@ -87,7 +87,7 @@ Describe "Get-FileHash" -Tags "CI" {
             Copy-Item -Path $testdocument -Destination $testDocumentCopy
 
             $newPath = Get-FileHash -Path $testDocumentCopy | Rename-Item -NewName {$_.Hash} -PassThru
-            Test-Path -Path $newPath.FullName | Should -BeTrue
+            $newPath.FullName | Should -Exist
 
             Remove-Item -Path $testDocumentCopy -Force
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FileHash.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FileHash.Tests.ps1
@@ -80,7 +80,14 @@ Describe "Get-FileHash" -Tags "CI" {
     
     Context "Close file before writing hash details to pipeline" {
         It "Should not hold the file open unnecessarily" {
-            {Get-FileHash $testDocument | Rename-Item -NewName {$_.Hash}} | Should -Not -Throw
+            # make a copy of the test document first
+            # because this test will rename it.
+            $testDocumentCopy = "${testDocument}-copy"
+            Copy-Item -Path $testdocument -Destination $testDocumentCopy
+            
+            {Get-FileHash -Path $testDocumentCopy | Rename-Item -NewName {$_.Hash} -ErrorAction Stop} | Should -Not -Throw
+            
+            Remove-Item -Path $testDocumentCopy
         }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #12473 where Get-FileHash holds the hashed file handles open unnecessarily long. 
Change is to hash the file contents, then dispose the file stream, then write the results, in that order.

## PR Context

`Get-ChildItem | Get-FileHash | Rename-Item -NewName {$_.Hash}` throws because the file is still open when trying to be renamed, this PR tries to fix that by closing the file handle before Get-FileHash writes output.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
