### PR TITLE
Provide parser with path to script file executed by means of -File command line argument

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -1841,7 +1841,7 @@ namespace Microsoft.PowerShell
                 if (!Path.GetExtension(filePath).Equals(".ps1", StringComparison.OrdinalIgnoreCase))
                 {
                     string script = File.ReadAllText(filePath);
-                    c = new Command(script, isScript: true, useLocalScope: false);
+                    c = new Command(script, scriptPath: filePath, useLocalScope: false);
                 }
                 else
                 {

--- a/src/System.Management.Automation/engine/hostifaces/Command.cs
+++ b/src/System.Management.Automation/engine/hostifaces/Command.cs
@@ -26,7 +26,7 @@ namespace System.Management.Automation.Runspaces
         /// <param name="command">Name of the command or script contents.</param>
         /// <exception cref="ArgumentNullException">Command is null.</exception>
         public Command(string command)
-            : this(command, isScript: false, null)
+            : this(command, isScript: false, useLocalScope: null)
         {
         }
 

--- a/src/System.Management.Automation/engine/hostifaces/Command.cs
+++ b/src/System.Management.Automation/engine/hostifaces/Command.cs
@@ -26,7 +26,7 @@ namespace System.Management.Automation.Runspaces
         /// <param name="command">Name of the command or script contents.</param>
         /// <exception cref="ArgumentNullException">Command is null.</exception>
         public Command(string command)
-            : this(command, false, null)
+            : this(command, isScript: false, null)
         {
         }
 
@@ -75,7 +75,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         internal Command(string script, string scriptPath, bool? useLocalScope)
-            : this(script, true, useLocalScope)
+            : this(script, isScript: true, useLocalScope)
         {
             ScriptPath = scriptPath;
         }
@@ -90,7 +90,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         internal Command(CommandInfo commandInfo)
-            : this(commandInfo, false)
+            : this(commandInfo, isScript: false)
         {
         }
 
@@ -136,29 +136,29 @@ namespace System.Management.Automation.Runspaces
         public CommandParameterCollection Parameters { get; } = new CommandParameterCollection();
 
         /// <summary>
-        /// Access the command string.
+        /// Gets the command string.
         /// </summary>
         /// <value>The command name, if <see cref="Command.IsScript"/> is false; otherwise; the script contents</value>
         public string CommandText { get; } = string.Empty;
 
         /// <summary>
-        /// Access the commandInfo.
+        /// Gets the commandInfo.
         /// </summary>
         /// <value>The command info object</value>
         internal CommandInfo CommandInfo { get; }
 
         /// <summary>
-        /// Access the value indicating if this <see cref="Command"/> represents a script.
+        /// Gets the value indicating if this <see cref="Command"/> represents a script.
         /// </summary>
         public bool IsScript { get; }
         
         /// <summary>
-        /// Access path to the script file if this <see cref="Command"/> represents a script loaded from file.
+        /// Gets path to the script file if this <see cref="Command"/> represents a script loaded from file.
         /// </summary>
         public string ScriptPath { get; }
 
         /// <summary>
-        /// Access the value indicating if LocalScope is to be used for running
+        /// Gets the value indicating if LocalScope is to be used for running
         /// this script command.
         /// </summary>
         /// <value>True if this command is a script and localScope is
@@ -177,7 +177,7 @@ namespace System.Management.Automation.Runspaces
         public CommandOrigin CommandOrigin { get; set; } = CommandOrigin.Runspace;
 
         /// <summary>
-        /// Access the actual value indicating if LocalScope is to be used for running
+        /// Gets the actual value indicating if LocalScope is to be used for running
         /// this script command.  Needed for serialization in remoting.
         /// </summary>
         internal bool? UseLocalScopeNullable
@@ -512,20 +512,24 @@ namespace System.Management.Automation.Runspaces
                 else if (ScriptPath != null)
                 {
                     var scriptName = Path.GetFileName(ScriptPath);
-                    var scriptInfo = new ExternalScriptInfo( scriptName, ScriptPath, executionContext);
-                    commandProcessorBase = new DlrScriptCommandProcessor( scriptInfo, 
-                        executionContext,_useLocalScope ?? false,
+                    var scriptInfo = new ExternalScriptInfo(scriptName, ScriptPath, executionContext);
+                    commandProcessorBase = new DlrScriptCommandProcessor(
+                        scriptInfo,
+                        executionContext,
+                        _useLocalScope ?? false,
                         executionContext.EngineSessionState);
 
                     commandProcessorBase.Command.MyInvocation.InvocationName = ScriptPath;
                 }
                 else
                 {
-                    commandProcessorBase = new DlrScriptCommandProcessor(scriptBlock,
-                                                                         executionContext, _useLocalScope ?? false,
-                                                                         origin,
-                                                                         executionContext.EngineSessionState,
-                                                                         DollarUnderbar);
+                    commandProcessorBase = new DlrScriptCommandProcessor(
+                        scriptBlock,
+                        executionContext,
+                        _useLocalScope ?? false,
+                        origin,
+                        executionContext.EngineSessionState,
+                        DollarUnderbar);
                 }
             }
             else
@@ -921,4 +925,3 @@ namespace System.Management.Automation.Runspaces
         }
     }
 }
-

--- a/src/System.Management.Automation/engine/hostifaces/Command.cs
+++ b/src/System.Management.Automation/engine/hostifaces/Command.cs
@@ -73,6 +73,12 @@ namespace System.Management.Automation.Runspaces
             _useLocalScope = useLocalScope;
         }
 
+        internal Command(string script, string scriptPath, bool? useLocalScope)
+            : this(script, true, useLocalScope)
+        {
+            ScriptPath = scriptPath;
+        }
+
         internal Command(string command, bool isScript, bool? useLocalScope, bool mergeUnclaimedPreviousErrorResults)
             : this(command, isScript, useLocalScope)
         {
@@ -144,6 +150,11 @@ namespace System.Management.Automation.Runspaces
         /// Access the value indicating if this <see cref="Command"/> represents a script.
         /// </summary>
         public bool IsScript { get; }
+        
+        /// <summary>
+        /// Access path to the script file if this <see cref="Command"/> represents a script loaded from file.
+        /// </summary>
+        public string ScriptPath { get; }
 
         /// <summary>
         /// Access the value indicating if LocalScope is to be used for running
@@ -466,7 +477,7 @@ namespace System.Management.Automation.Runspaces
                         null, "ScriptsNotAllowed", ParserStrings.ScriptsNotAllowed);
                 }
 
-                ScriptBlock scriptBlock = executionContext.Engine.ParseScriptBlock(CommandText, addToHistory);
+                ScriptBlock scriptBlock = executionContext.Engine.ParseScriptBlock(CommandText, ScriptPath, addToHistory);
                 if (origin == Automation.CommandOrigin.Internal)
                 {
                     scriptBlock.LanguageMode = PSLanguageMode.FullLanguage;

--- a/src/System.Management.Automation/engine/hostifaces/Command.cs
+++ b/src/System.Management.Automation/engine/hostifaces/Command.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Management.Automation.Internal;
 
 using Microsoft.Management.Infrastructure;
@@ -507,6 +508,16 @@ namespace System.Management.Automation.Runspaces
                     FunctionInfo functionInfo = new FunctionInfo(string.Empty, scriptBlock, executionContext);
                     commandProcessorBase = new CommandProcessor(functionInfo, executionContext,
                                                                 _useLocalScope ?? false, fromScriptFile: false, sessionState: executionContext.EngineSessionState);
+                }
+                else if (ScriptPath != null)
+                {
+                    var scriptName = Path.GetFileName(ScriptPath);
+                    var scriptInfo = new ExternalScriptInfo( scriptName, ScriptPath, executionContext);
+                    commandProcessorBase = new DlrScriptCommandProcessor( scriptInfo, 
+                        executionContext,_useLocalScope ?? false,
+                        executionContext.EngineSessionState);
+
+                    commandProcessorBase.Command.MyInvocation.InvocationName = ScriptPath;
                 }
                 else
                 {

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -257,6 +257,39 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             & $powershell -noprofile -c ' ' | Should -BeNullOrEmpty
             $LASTEXITCODE | Should -Be 0
         }
+
+        It "MyInvocation.MyCommand.Name should contain script file name when executing script with -File argument" -TestCases @(
+            @{Filename = "test.ps1"},
+            @{Filename = "test-no-ext"}
+        ) {
+            param($Filename)
+            $testFilePath = Join-Path $testdrive $Filename
+            Set-Content -Path $testFilePath -Value '$MyInvocation.MyCommand.Name'
+            $observed = & $powershell -File $testFilePath -NoProfile -NoLogo
+            $observed | Should -Be $Filename
+        }
+
+        It "MyInvocation.InvocationName should contain script file path when executing script with -File argument" -TestCases @(
+            @{Filename = "test.ps1"},
+            @{Filename = "test-no-ext"}
+        ) {
+            param($Filename)
+            $testFilePath = Join-Path $testdrive $Filename
+            Set-Content -Path $testFilePath -Value '$MyInvocation.InvocationName'
+            $observed = & $powershell -File $testFilePath -NoProfile -NoLogo
+            $observed | Should -Be $testFilePath
+        }
+
+        It "PSScriptRoot should contain script directory path when executing script with -File argument" -TestCases @(
+            @{Filename = "test.ps1"},
+            @{Filename = "test-no-ext"}
+        ) {
+            param($Filename)
+            $testFilePath = Join-Path $testdrive $Filename
+            Set-Content -Path $testFilePath -Value '$PSScriptRoot'
+            $observed = & $powershell -File $testFilePath -NoProfile -NoLogo
+            $observed | Should -Be ( Split-Path $testFilePath )
+        }
     }
 
     Context "-Login pwsh switch" {


### PR DESCRIPTION
# PR Summary

Allow `System.Management.Automation.Runspaces.Command` operating in `IsScript = true` mode to remember and pass on path to the script file and make use of this feature when executing script file passed as -File command line argument.

## PR Context

Fixes #4217 
