### PR TITLE
(#12430) Improve detection of mutable value types

### DIFF
--- a/src/System.Management.Automation/engine/hostifaces/History.cs
+++ b/src/System.Management.Automation/engine/hostifaces/History.cs
@@ -1436,6 +1436,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     break;
                 }
+
                 // Read CommandLine property
                 string commandLine = GetPropertyValue(mshObject, "CommandLine") as string;
                 if (commandLine == null)
@@ -1445,109 +1446,32 @@ namespace Microsoft.PowerShell.Commands
 
                 // Read ExecutionStatus property
                 object pipelineState = GetPropertyValue(mshObject, "ExecutionStatus");
-                if (pipelineState == null)
-                {
-                    break;
-                }
-
-                PipelineState executionStatus;
-                if (pipelineState is PipelineState)
-                {
-                    executionStatus = (PipelineState)pipelineState;
-                }
-                else if (pipelineState is PSObject)
-                {
-                    PSObject serializedPipelineState = pipelineState as PSObject;
-                    object baseObject = serializedPipelineState.BaseObject;
-                    if (baseObject is not int)
-                    {
-                        break;
-                    }
-
-                    executionStatus = (PipelineState)baseObject;
-                    if (executionStatus < PipelineState.NotStarted || executionStatus > PipelineState.Failed)
-                    {
-                        break;
-                    }
-                }
-                else if (pipelineState is string)
-                {
-                    try
-                    {
-                        executionStatus = (PipelineState)Enum.Parse(typeof(PipelineState), (string)pipelineState);
-                    }
-                    catch (ArgumentException)
-                    {
-                        break;
-                    }
-                }
-                else
+                if (pipelineState == null || !LanguagePrimitives.TryConvertTo<PipelineState>(pipelineState, out PipelineState executionStatus))
                 {
                     break;
                 }
 
                 // Read StartExecutionTime property
-                DateTime startExecutionTime;
                 object temp = GetPropertyValue(mshObject, "StartExecutionTime");
-                if (temp == null)
-                {
-                    break;
-                }
-                else if (temp is DateTime)
-                {
-                    startExecutionTime = (DateTime)temp;
-                }
-                else if (temp is string)
-                {
-                    try
-                    {
-                        startExecutionTime = DateTime.Parse((string)temp, System.Globalization.CultureInfo.CurrentCulture);
-                    }
-                    catch (FormatException)
-                    {
-                        break;
-                    }
-                }
-                else
+                if (temp == null || !LanguagePrimitives.TryConvertTo<DateTime>(temp, out DateTime startExecutionTime))
                 {
                     break;
                 }
 
                 // Read EndExecutionTime property
-                DateTime endExecutionTime;
                 temp = GetPropertyValue(mshObject, "EndExecutionTime");
-                if (temp == null)
-                {
-                    break;
-                }
-                else if (temp is DateTime)
-                {
-                    endExecutionTime = (DateTime)temp;
-                }
-                else if (temp is string)
-                {
-                    try
-                    {
-                        endExecutionTime = DateTime.Parse((string)temp, System.Globalization.CultureInfo.CurrentCulture);
-                    }
-                    catch (FormatException)
-                    {
-                        break;
-                    }
-                }
-                else
+                if (temp == null || !LanguagePrimitives.TryConvertTo<DateTime>(temp, out DateTime endExecutionTime))
                 {
                     break;
                 }
 
-                return new HistoryInfo
-                            (
-                                0,
-                                commandLine,
-                                executionStatus,
-                                startExecutionTime,
-                                endExecutionTime
-                            );
+                return new HistoryInfo(
+                    pipelineId: 0,
+                    commandLine,
+                    executionStatus,
+                    startExecutionTime,
+                    endExecutionTime
+                );
             } while (false);
 
             // If we are here, an error has occured.
@@ -1988,4 +1912,3 @@ namespace Microsoft.PowerShell.Commands
         #endregion Private
     }
 }
-

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -2040,8 +2040,9 @@ namespace System.Management.Automation.Language
 
             // If the builtin attribute is not present, check for a custom attribute from by the compiler. If the
             // library targets netstandard2.0, the compiler can't be sure the attribute will be provided by the runtime,
-            // and defines its own attribute of the same name during compilation.
-            foreach (var attribute in type.GetCustomAttributes(inherit: false))
+            // and defines its own attribute of the same name during compilation. To account for this, we must check the
+            // type by name, not by reference.
+            foreach (object attribute in type.GetCustomAttributes(inherit: false))
             {
                 if (attribute.GetType().FullName.Equals(
                     "System.Runtime.CompilerServices.IsReadOnlyAttribute",

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -2030,36 +2030,38 @@ namespace System.Management.Automation.Language
 
         internal static bool IsValueTypeMutable(Type type)
         {
-            if (type.IsPrimitive || type.IsEnum)
+            // First, check for enums/primitives and compiler-defined attributes.
+            if (type.IsPrimitive
+                || type.IsEnum
+                || type.IsDefined(typeof(System.Runtime.CompilerServices.IsReadOnlyAttribute), inherit: false))
             {
                 return false;
             }
 
-            // If there are any fields, the type is mutable.
-            if (type.GetFields(BindingFlags.Public | BindingFlags.Instance).Length > 0)
+            // If the builtin attribute is not present, check for a custom attribute from by the compiler. If the
+            // library targets netstandard2.0, the compiler can't be sure the attribute will be provided by the runtime,
+            // and defines its own attribute of the same name during compilation.
+            foreach (var attribute in type.GetCustomAttributes(inherit: false))
             {
-                return true;
+                if (attribute.GetType().FullName.Equals(
+                    "System.Runtime.CompilerServices.IsReadOnlyAttribute",
+                    StringComparison.Ordinal))
+                {
+                    return false;
+                }
             }
 
-            // If there are any properties with setters, the type is mutable.
-            var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
-            for (int index = 0; index < properties.Length; index++)
+            // Fallback: check all fields (public + private) to verify whether they're all readonly.
+            // If any field is not readonly, the value type is potentially mutable.
+            foreach (var field in type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
             {
-                var property = properties[index];
-                if (property.CanWrite)
+                if (!field.IsInitOnly)
                 {
                     return true;
                 }
             }
 
-            // If there are any methods other than the property getters, the type might
-            // be mutable, so assume the type is mutable.
-            var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance);
-            if (methods.Length != properties.Length)
-            {
-                return true;
-            }
-
+            // If all fields are init-only (read-only), then the value type is immutable.
             return false;
         }
 


### PR DESCRIPTION
# PR Summary

Currently, we have some flawed assumptions around what defines a mutable value type. Rather than make a more complicated series of checks and making assumptions, we can simply look at whether the type is defined with the `IsReadOnlyAttribute` that the compiler uses to guarantee a value type is immutable.

As a fallback, it's much safer and less complex to enumerate all public and private fields on the type, and verify whether they're all read-only.

## PR Context

Resolves #12430. See the issue for discussion and further context.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
