### PR TITLE
Adjust the side indicators of Compare-Object to prevent misinterpreting `<=` as less-than-or-equal

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Compare-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Compare-Object.cs
@@ -111,8 +111,8 @@ namespace Microsoft.PowerShell.Commands
         // These are programmatic strings, not subject to INTL
         private const string SideIndicatorPropertyName = "SideIndicator";
         private const string SideIndicatorMatch = "==";
-        private const string SideIndicatorReference = "<=";
-        private const string SideIndicatorDifference = "=>";
+        private const string SideIndicatorReference = "<-";
+        private const string SideIndicatorDifference = "->";
         private const string InputObjectPropertyName = "InputObject";
 
         /// <summary>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Compare-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Compare-Object.Tests.ps1
@@ -35,13 +35,13 @@ Describe "Compare-Object" -Tags "CI" {
     It "Should indicate data that exists only in the reference dataset" {
 	$actualOutput = Compare-Object -ReferenceObject $(Get-Content $file3) -DifferenceObject $(Get-Content $file4)
 
-	$actualOutput[1].SideIndicator | Should -BeExactly "<="
+	$actualOutput[1].SideIndicator | Should -BeExactly "<-"
     }
 
     It "Should indicate data that exists only in the difference dataset" {
 	$actualOutput = Compare-Object -ReferenceObject $(Get-Content $file3) -DifferenceObject $(Get-Content $file4)
 
-	$actualOutput[1].SideIndicator | Should -BeExactly "<="
+	$actualOutput[1].SideIndicator | Should -BeExactly "<-"
     }
 
     It "Should indicate data that exists in both datasets when the includeEqual switch is used" {
@@ -115,10 +115,10 @@ Describe "Compare-Object" -Tags "CI" {
 	$actualOutput[2].InputObject | Should -Be 1
 	$actualOutput[3].InputObject | Should -Be 15
 
-	$actualOutput[0].SideIndicator | Should -BeExactly "=>"
-	$actualOutput[1].SideIndicator | Should -BeExactly "<="
-	$actualOutput[2].SideIndicator | Should -BeExactly "=>"
-	$actualOutput[3].SideIndicator | Should -BeExactly "<="
+	$actualOutput[0].SideIndicator | Should -BeExactly "->"
+	$actualOutput[1].SideIndicator | Should -BeExactly "<-"
+	$actualOutput[2].SideIndicator | Should -BeExactly "->"
+	$actualOutput[3].SideIndicator | Should -BeExactly "<-"
     }
 }
 
@@ -240,8 +240,8 @@ Describe "Compare-Object DRT basic functionality" -Tags "CI" {
 						{
 							$result[0].InputObject | Should -Be $empsDifference
 							$result[1].InputObject | Should -Be $empsReference
-							$result[0].SideIndicator | Should -BeExactly "=>"
-							$result[1].SideIndicator | Should -BeExactly "<="
+							$result[0].SideIndicator | Should -BeExactly "->"
+							$result[1].SideIndicator | Should -BeExactly "<-"
 						}
 					}
 					else
@@ -279,7 +279,7 @@ Describe "Compare-Object DRT basic functionality" -Tags "CI" {
 								$result[0].InputObject | Should -Be $empsReference[0]
 								$result[1].InputObject | Should -Be $empsReference[1]
 								$result[0].SideIndicator | Should -BeExactly "=="
-								$result[1].SideIndicator | Should -BeExactly "<="
+								$result[1].SideIndicator | Should -BeExactly "<-"
 							}
 						}
 						else
@@ -306,7 +306,7 @@ Describe "Compare-Object DRT basic functionality" -Tags "CI" {
 							else
 							{
 								$result.InputObject | Should -Be $empsReference[1]
-								$result.SideIndicator | Should -BeExactly "<="
+								$result.SideIndicator | Should -BeExactly "<-"
 							}
 						}
 						else
@@ -345,7 +345,7 @@ Describe "Compare-Object DRT basic functionality" -Tags "CI" {
 								$result[0].InputObject | Should -Be $empsReference
 								$result[1].InputObject | Should -Be $empsDifference[1]
 								$result[0].SideIndicator | Should -BeExactly "=="
-								$result[1].SideIndicator | Should -BeExactly "=>"
+								$result[1].SideIndicator | Should -BeExactly "->"
 							}
 						}
 						else
@@ -372,7 +372,7 @@ Describe "Compare-Object DRT basic functionality" -Tags "CI" {
 							else
 							{
 								$result.InputObject | Should -Be $empsDifference[1]
-								$result.SideIndicator | Should -BeExactly "=>"
+								$result.SideIndicator | Should -BeExactly "->"
 							}
 						}
 						else
@@ -434,10 +434,10 @@ Describe "Compare-Object DRT basic functionality" -Tags "CI" {
 		$result = Compare-Object $a $b -IncludeEqual -Property {$_.Major},{$_.Minor}
 		$result[0] | Select-Object -ExpandProperty "*Major" | Should -Be 5
 		$result[0] | Select-Object -ExpandProperty "*Minor" | Should -Be 6
-		$result[0].SideIndicator | Should -BeExactly "=>"
+		$result[0].SideIndicator | Should -BeExactly "->"
 		$result[1] | Select-Object -ExpandProperty "*Major" | Should -Be 1
 		$result[1] | Select-Object -ExpandProperty "*Minor" | Should -Be 2
-		$result[1].SideIndicator | Should -BeExactly "<="
+		$result[1].SideIndicator | Should -BeExactly "<-"
 	}
 
 	It "Compare-Object with no ReferenceObject nor DifferenceObject: output nothing, no error and should work"{
@@ -448,12 +448,12 @@ Describe "Compare-Object DRT basic functionality" -Tags "CI" {
 	It "Compare-Object with no DifferenceObject should work"{
 		$result = Compare-Object @() @("diffObject")
 		$result.InputObject | Should -BeExactly "diffObject"
-		$result.SideIndicator | Should -BeExactly "=>"
+		$result.SideIndicator | Should -BeExactly "->"
 	}
 
 	It "Compare-Object with no ReferenceObject should work"{
 		$result = Compare-Object @("refObject") @()
 		$result.InputObject | Should -BeExactly "refObject"
-		$result.SideIndicator | Should -BeExactly "<="
+		$result.SideIndicator | Should -BeExactly "<-"
 	}
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The side indicators in the output of Compare-Object have been changed from `<=` and `=>` to `<-` and `->`.

## PR Context

The symbol `<=` is most often used to mean less-than-or-equal.
This is particularly poignant using fonts that support ligatures, such as Cascadia Code.
This PR avoids this and changes the difference side indicator to match the style of the non-ambiguous reference side indicator.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**; **User-facing changes**
    - [x] Scripts reading from the `SideIndicator` fields in `Compare-Object`'s output might no longer work.
        - Notably, using `.Contains` on the `SideIndicator` value works before and after this PR
- **Testing - New and feature**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] See breaking changes above