### PR TITLE
Fix path handling bug in PSTask

### DIFF
--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -447,7 +447,7 @@ namespace System.Management.Automation.PSTasks
                 try
                 {
                     Runspace.DefaultRunspace = runspace;
-                    runspace.ExecutionContext.SessionState.Internal.SetLocation(_currentLocationPath);
+                    runspace.ExecutionContext.SessionState.Internal.SetLocation(_currentLocationPath, new CmdletProviderContext(runspace.ExecutionContext){ SuppressWildcardExpansion = true });
                 }
                 catch (DriveNotFoundException)
                 {

--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -447,7 +447,12 @@ namespace System.Management.Automation.PSTasks
                 try
                 {
                     Runspace.DefaultRunspace = runspace;
-                    runspace.ExecutionContext.SessionState.Internal.SetLocation(_currentLocationPath, new CmdletProviderContext(runspace.ExecutionContext){ SuppressWildcardExpansion = true });
+                    var context = new CmdletProviderContext(runspace.ExecutionContext)
+                    {
+                        // _currentLocationPath denotes the current path as-is, and should not be attempted expanded.
+                        SuppressWildcardExpansion = true
+                    };
+                    runspace.ExecutionContext.SessionState.Internal.SetLocation(_currentLocationPath, context);
                 }
                 catch (DriveNotFoundException)
                 {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
@@ -120,8 +120,8 @@ Describe 'ForEach-Object -Parallel Basic Tests' -Tags 'CI' {
         finally
         {
             Set-Location -Path $oldLocation
-            if($drive -is [System.IO.DirectoryInfo]){
-                $drive |Remove-Item -Force
+            if ($drive -is [System.IO.DirectoryInfo]) {
+                $drive | Remove-Item -Force
             }
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
@@ -105,6 +105,27 @@ Describe 'ForEach-Object -Parallel Basic Tests' -Tags 'CI' {
         $parallelScriptLocation.Path | Should -BeExactly $PWD.Path
     }
 
+    It 'Verifies that the current working directory can have wildcards in its name' {
+        $oldLocation = Get-Location
+
+        $wildcardName = New-Item -Path 'TestDrive:\' -Name '[' -ItemType Directory
+        Set-Location -LiteralPath $wildcardName.FullName
+        try
+        {
+            { 1..1 | ForEach-Object -Parallel { $PWD } } | Should -Not -Throw
+
+            $wildcardPathResult = 1..1 | ForEach-Object -Parallel { $PWD }
+            $wildcardPathResult.Path | Should -BeExactly $PWD.Path
+        }
+        finally
+        {
+            Set-Location -Path $oldLocation
+            if($drive -is [System.IO.DirectoryInfo]){
+                $drive |Remove-Item -Force
+            }
+        }
+    }
+
     It 'Verifies no terminating error if current working drive is not found' {
         $oldLocation = Get-Location
         try


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR changes the behavior PSTask to always treat the current $PWD as a literal path, in turn allowing `ForEach-Object -Parallel` to execute correctly when invoked from a path with wildcard characters in the name.

## PR Context

Fixes #12428

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
