### PR TITLE
Replace Unicode nbsp with space in source

### DIFF
--- a/test/powershell/Language/Scripting/Debugging/DebuggerScriptTests.Tests.ps1
+++ b/test/powershell/Language/Scripting/Debugging/DebuggerScriptTests.Tests.ps1
@@ -214,8 +214,8 @@ Describe "Line breakpoints on commands in multi-line pipelines" -Tags "CI" {
             1..3 |
             ForEach-Object { $_ } | sort-object |
             get-unique'
-            $a = New-Object -ComObject Scripting.FileSystemObject
-            $f = $a.GetFile($scriptPath1)
+            $a = New-Object -ComObject Scripting.FileSystemObject
+            $f = $a.GetFile($scriptPath1)
             $scriptPath2 = $f.ShortPath
 
             $breakpoints = Set-PSBreakpoint $scriptPath2 1,2,3 -Action { continue }

--- a/test/tools/Modules/PSSysLog/PSSysLog.psm1
+++ b/test/tools/Modules/PSSysLog/PSSysLog.psm1
@@ -1068,17 +1068,17 @@ function Wait-PSWinEvent
         $All
     )
 
-    $startTime = [DateTime]::Now
+    $startTime = [DateTime]::Now
     $lastFoundCount = 0;
 
-    do
-    {
-        Start-Sleep -Seconds $pause
+    do
+    {
+        Start-Sleep -Seconds $pause
 
         $recordsToReturn = @()
 
-        foreach ($thisRecord in (Get-WinEvent -FilterHashtable $filterHashtable -Oldest 2> $null))
-        {
+        foreach ($thisRecord in (Get-WinEvent -FilterHashtable $filterHashtable -Oldest 2> $null))
+        {
             if($PSCmdlet.ParameterSetName -eq "ByPropertyName")
             {
                 if ($thisRecord."$propertyName" -like "*$propertyValue*")
@@ -1108,7 +1108,7 @@ function Wait-PSWinEvent
                     }
                 }
             }
-        }
+        }
 
         if($recordsToReturn.Count -gt 0)
         {
@@ -1119,7 +1119,7 @@ function Wait-PSWinEvent
 
             $lastFoundCount = $recordsToReturn.Count
         }
-    } while (([DateTime]::Now - $startTime).TotalSeconds -lt $timeout)
+    } while (([DateTime]::Now - $startTime).TotalSeconds -lt $timeout)
 }
 #endregion eventlog support
 

--- a/test/tools/OpenCover/OpenCover.psm1
+++ b/test/tools/OpenCover/OpenCover.psm1
@@ -31,7 +31,7 @@ function Get-ClassCoverageData([xml.xmlelement]$element)
     $classes = [system.collections.arraylist]::new()
     foreach ( $class in $element.classes.class )
     {
-        # skip classes with names like <>f__AnonymousType6`4
+        # skip classes with names like <>f__AnonymousType6`4
         if ( $class.fullname -match "<>" ) { continue }
         $name = $class.fullname
         $branch = $class.summary.branchcoverage


### PR DESCRIPTION
# PR Summary
```
-replace [char]0xA0, [char]0x20
```

## PR Context

Detected with [unicode-Substitutions](https://marketplace.visualstudio.com/items?itemName=GlenBuktenica.unicode-substitutions) vscode extension.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
