### PR TITLE
Add support for some .Net intrinsic type converters

### DIFF
--- a/src/System.Management.Automation/System.Management.Automation.csproj
+++ b/src/System.Management.Automation/System.Management.Automation.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <Import Project="..\..\PowerShell.Common.props" />
   <PropertyGroup>
     <Description>PowerShell's System.Management.Automation project</Description>

--- a/src/System.Management.Automation/System.Management.Automation.csproj
+++ b/src/System.Management.Automation/System.Management.Automation.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <Import Project="..\..\PowerShell.Common.props" />
   <PropertyGroup>
     <Description>PowerShell's System.Management.Automation project</Description>

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -1519,7 +1519,7 @@ namespace System.Management.Automation
                 // PowerShell is allowed to load only TPA.
                 // Since a type is already loaded we trust to an attribute assigned to the type
                 // and can use Type.GetType() without additional checks.
-                converterType = Type.GetType(assemblyQualifiedTypeName, true, false);
+                converterType = Type.GetType(assemblyQualifiedTypeName, throwOnError: true, ignoreCase: false);
             }
             catch (Exception e)
             {

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -1535,7 +1535,7 @@ namespace System.Management.Automation
             {
                 TargetInvocationException inner = e as TargetInvocationException;
                 string message = (inner == null) || (inner.InnerException == null) ? e.Message : inner.InnerException.Message;
-                typeConversion.WriteLine("Could not create an instance of type \"{0}\". Exception is thrown: \"{1}\"", assemblyQualifiedTypeName, message);
+                typeConversion.WriteLine("Creating an instance of type \"{0}\" caused an exception to be thrown: \"{1}\"", assemblyQualifiedTypeName, message);
                 return null;
             }
         }

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -1506,47 +1506,38 @@ namespace System.Management.Automation
 
         private static object NewConverterInstance(string assemblyQualifiedTypeName)
         {
-            int typeSeparator = assemblyQualifiedTypeName.IndexOf(',');
-            if (typeSeparator == -1)
+            if (assemblyQualifiedTypeName.IndexOf(',') == -1)
             {
                 typeConversion.WriteLine("Type name \"{0}\" should be assembly qualified.", assemblyQualifiedTypeName);
                 return null;
             }
 
-            string assemblyName = assemblyQualifiedTypeName.Substring(typeSeparator + 2);
-            string typeName = assemblyQualifiedTypeName.Substring(0, typeSeparator);
-
-            foreach (Assembly assembly in ClrFacade.GetAssemblies(typeName))
+            Type converterType;
+            try
             {
-                if (assembly.FullName == assemblyName)
-                {
-                    Type converterType = null;
-                    try
-                    {
-                        converterType = assembly.GetType(typeName, false, false);
-                    }
-                    catch (ArgumentException e)
-                    {
-                        typeConversion.WriteLine("Assembly \"{0}\" threw an exception when retrieving the type \"{1}\": \"{2}\".", assemblyName, typeName, e.Message);
-                        return null;
-                    }
-
-                    try
-                    {
-                        return Activator.CreateInstance(converterType);
-                    }
-                    catch (Exception e)
-                    {
-                        TargetInvocationException inner = e as TargetInvocationException;
-                        string message = (inner == null) || (inner.InnerException == null) ? e.Message : inner.InnerException.Message;
-                        typeConversion.WriteLine("Creating an instance of type \"{0}\" caused an exception to be thrown: \"{1}\"", assemblyQualifiedTypeName, message);
-                        return null;
-                    }
-                }
+                // Type.GetType() can load an assembly.
+                // PowerShell is allowed to load only TPA.
+                // Since a type is already loaded we trust to an attribute assigned to the type
+                // and can use Type.GetType() without additional checks.
+                converterType = Type.GetType(assemblyQualifiedTypeName, true, false);
+            }
+            catch (Exception e)
+            {
+                typeConversion.WriteLine("Threw an exception when retrieving the type \"{1}\": \"{2}\".", assemblyQualifiedTypeName, e.Message);
+                return null;
             }
 
-            typeConversion.WriteLine("Could not create an instance of type \"{0}\".", assemblyQualifiedTypeName);
-            return null;
+            try
+            {
+                return Activator.CreateInstance(converterType);
+            }
+            catch (Exception e)
+            {
+                TargetInvocationException inner = e as TargetInvocationException;
+                string message = (inner == null) || (inner.InnerException == null) ? e.Message : inner.InnerException.Message;
+                typeConversion.WriteLine("Could not create an instance of type \"{0}\". Exception is thrown: \"{1}\"", assemblyQualifiedTypeName, message);
+                return null;
+            }
         }
 
         /// <summary>

--- a/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
+++ b/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
@@ -28,6 +28,39 @@ Describe "Language Primitive Tests" -Tags "CI" {
         $ObjArray.Length | Should -Be $col.Count
     }
 
+    It "Test convertion with .Net Core intrinsic type convertor" {
+        $result = [System.Management.Automation.LanguagePrimitives]::ConvertTo('2,3', [System.Drawing.Point])
+        $result | Should -BeOfType System.Drawing.Point
+        $result.X | Should -Be 2
+        $result.Y | Should -Be 3
+
+        $result = [System.Management.Automation.LanguagePrimitives]::ConvertTo([PSObject]'2,3', [System.Drawing.Point])
+        $result | Should -BeOfType System.Drawing.Point
+        $result.X | Should -Be 2
+        $result.Y | Should -Be 3
+
+        $result = [System.Management.Automation.LanguagePrimitives]::ConvertTo('http://test.site.com', [System.Uri])
+        $result | Should -BeOfType System.Uri
+        $result.AbsoluteUri | Should -BeExactly 'http://test.site.com/'
+
+        # accept relative URI path
+        $result = [System.Management.Automation.LanguagePrimitives]::ConvertTo('..\foo', [System.Uri])
+        $result | Should -BeOfType System.Uri
+        $result.OriginalString | Should -BeExactly '..\foo'
+    }
+
+    It "Test convertion with .Net Core intrinsic type convertor (Windows only types)" -Skip:(-not $IsWindows) {
+        $result = [System.Management.Automation.LanguagePrimitives]::ConvertTo('Microsoft Sans Serif,10', [System.Drawing.Font])
+        $result | Should -BeOfType System.Drawing.Font
+        $result.Size | Should -Be 10
+        $result.Name | Should -BeExactly 'Microsoft Sans Serif'
+
+        $result = [System.Management.Automation.LanguagePrimitives]::ConvertTo([PSObject]'Microsoft Sans Serif,10', [System.Drawing.Font])
+        $result | Should -BeOfType System.Drawing.Font
+        $result.Size | Should -Be 10
+        $result.Name | Should -BeExactly 'Microsoft Sans Serif'
+    }
+
     It "Casting recursive array to bool should not cause crash" {
         $a[0] = $a = [PSObject](, 1)
         [System.Management.Automation.LanguagePrimitives]::IsTrue($a) | Should -BeTrue


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #12513

1. Add reference to System.Windows.Extensions in SMA to get follow Windows type converters:
   - FontConverter
   - IconConverter
   - ImageConverter
   - ImageFormatConverter
   - MarginsConverter
2. Use Type.GetType() to resolve TypeConverterAttribute - this allows to utilize .Net Runtime features like type forwarding

## PR Context

Original code does strong check for loading assembly (TPA) by utilizing PowerShell type catalog.
We can remove this and use Type.GetType() because the type for which we are looking for a type converter is _already_ loaded. So we can trust to TypeConverter attribute defined for the type too.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
