### PR TITLE
Update the build to sign any unsigned files as 3rd party Dlls

### DIFF
--- a/tools/packaging/packaging.psd1
+++ b/tools/packaging/packaging.psd1
@@ -6,7 +6,7 @@ Copyright="Copyright (c) Microsoft Corporation."
 ModuleVersion="1.0.0"
 PowerShellVersion="5.0"
 CmdletsToExport=@()
-FunctionsToExport=@('Start-PSPackage','New-PSSignedBuildZip', 'New-MSIPatch', 'Expand-PSSignedBuild', 'Publish-NugetToMyGet', 'New-DotnetSdkContainerFxdPackage', 'New-GlobalToolNupkg', 'New-ILNugetPackage')
+FunctionsToExport=@('Start-PSPackage','New-PSSignedBuildZip', 'New-PSBuildZip', 'New-MSIPatch', 'Expand-PSSignedBuild', 'Publish-NugetToMyGet', 'New-DotnetSdkContainerFxdPackage', 'New-GlobalToolNupkg', 'New-ILNugetPackage', 'Update-PSSignedBuildFolder')
 RootModule="packaging.psm1"
 RequiredModules = @("build")
 }

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -598,20 +598,27 @@ function New-PSSignedBuildZip
         [string]$VstsVariableName
     )
 
-    # Replace unsigned binaries with signed
-    $signedFilesFilter = Join-Path -Path $signedFilesPath -ChildPath '*'
-    Get-ChildItem -path $signedFilesFilter -Recurse -File | Select-Object -ExpandProperty FullName | Foreach-Object -Process {
-        $relativePath = $_.ToLowerInvariant().Replace($signedFilesPath.ToLowerInvariant(),'')
-        $destination = Join-Path -Path $buildPath -ChildPath $relativePath
-        Write-Log "replacing $destination with $_"
-        Copy-Item -Path $_ -Destination $destination -force
-    }
+    Update-PSSignedBuildFolder -BuildPath $BuildPath -SignedFilesPath $SignedFilesPath
 
     # Remove '$signedFilesPath' now that signed binaries are copied
     if (Test-Path $signedFilesPath)
     {
         Remove-Item -Recurse -Force -Path $signedFilesPath
     }
+
+    New-PSBuildZip -BuildPath $BuildPath -DestinationFolder $DestinationFolder -VstsVariableName $VstsVariableName
+}
+
+function New-PSBuildZip
+{
+    param(
+        [Parameter(Mandatory)]
+        [string]$BuildPath,
+        [Parameter(Mandatory)]
+        [string]$DestinationFolder,
+        [parameter(HelpMessage='VSTS variable to set for path to zip')]
+        [string]$VstsVariableName
+    )
 
     $name = split-path -Path $BuildPath -Leaf
     $zipLocationPath = Join-Path -Path $DestinationFolder -ChildPath "$name-signed.zip"
@@ -627,6 +634,27 @@ function New-PSSignedBuildZip
         return $zipLocationPath
     }
 }
+
+
+function Update-PSSignedBuildFolder
+{
+    param(
+        [Parameter(Mandatory)]
+        [string]$BuildPath,
+        [Parameter(Mandatory)]
+        [string]$SignedFilesPath
+    )
+
+    # Replace unsigned binaries with signed
+    $signedFilesFilter = Join-Path -Path $SignedFilesPath -ChildPath '*'
+    Get-ChildItem -path $signedFilesFilter -Recurse -File | Select-Object -ExpandProperty FullName | Foreach-Object -Process {
+        $relativePath = $_.ToLowerInvariant().Replace($SignedFilesPath.ToLowerInvariant(),'')
+        $destination = Join-Path -Path $BuildPath -ChildPath $relativePath
+        Write-Log "replacing $destination with $_"
+        Copy-Item -Path $_ -Destination $destination -force
+    }
+}
+
 
 function Expand-PSSignedBuild
 {

--- a/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
@@ -134,14 +134,52 @@ jobs:
   - powershell: |
       Import-Module $(PowerShellRoot)/build.psm1 -Force
       Import-Module $(PowerShellRoot)/tools/packaging -Force
-
       $signedFilesPath = '$(System.ArtifactsDirectory)\signed\'
+      $BuildPath = '$(System.ArtifactsDirectory)\$(SymbolsFolder)'
+
+      Update-PSSignedBuildFolder -BuildPath $BuildPath -SignedFilesPath $SignedFilesPath
+      $dlls = Get-ChildItem $BuildPath\*.dll -Recurse
+      $signatures = $dlls | Get-AuthenticodeSignature
+      $missingSignatures = $signatures | Where-Object { $_.status -eq 'notsigned'}| select-object -ExpandProperty Path
+      tools/releaseBuild/generatePackgeSigning.ps1 -ThirdPartyFiles $missingSignatures -path "$(System.ArtifactsDirectory)\thirtdparty.xml"
+    displayName: Create ThirdParty Signing Xml
+    condition: and(succeeded(), eq(variables['SHOULD_SIGN'], 'true'))
+
+  - task: PkgESCodeSign@10
+    displayName: 'CodeSign ThirdParty $(Architecture)'
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    inputs:
+      signConfigXml: '$(System.ArtifactsDirectory)\thirtdparty.xml'
+      inPathRoot: '$(System.ArtifactsDirectory)\$(SymbolsFolder)'
+      outPathRoot: '$(System.ArtifactsDirectory)\signedThirdParty'
+    condition: and(succeeded(), eq(variables['SHOULD_SIGN'], 'true'))
+
+  - powershell: |
+      Get-ChildItem '$(System.ArtifactsDirectory)\signedThirdParty\*'
+    displayName: Captrue ThirdParty Signed files
+    condition: and(succeeded(), eq(variables['SHOULD_SIGN'], 'true'))
+
+  - powershell: |
+      Import-Module $(PowerShellRoot)/build.psm1 -Force
+      Import-Module $(PowerShellRoot)/tools/packaging -Force
+      $signedFilesPath = '$(System.ArtifactsDirectory)\signedThirdParty\'
+      $BuildPath = '$(System.ArtifactsDirectory)\$(SymbolsFolder)'
+
+      Update-PSSignedBuildFolder -BuildPath $BuildPath -SignedFilesPath $SignedFilesPath
+    displayName: Merge ThirdParty signed files with Build
+    condition: and(succeeded(), eq(variables['SHOULD_SIGN'], 'true'))
+
+  - powershell: |
+      Import-Module $(PowerShellRoot)/build.psm1 -Force
+      Import-Module $(PowerShellRoot)/tools/packaging -Force
+
       $destFolder = '$(System.ArtifactsDirectory)\signedZip'
       $BuildPath = '$(System.ArtifactsDirectory)\$(SymbolsFolder)'
 
       New-Item -ItemType Directory -Path $destFolder -Force
 
-      $BuildPackagePath = New-PSSignedBuildZip -BuildPath $BuildPath -SignedFilesPath $SignedFilesPath -DestinationFolder $destFolder
+      $BuildPackagePath = New-PSBuildZip -BuildPath $BuildPath -DestinationFolder $destFolder
 
       Write-Verbose -Verbose "New-PSSignedBuildZip returned `$BuildPackagePath as: $BuildPackagePath"
       Write-Host "##vso[artifact.upload containerfolder=results;artifactname=results]$BuildPackagePath"

--- a/tools/releaseBuild/generatePackgeSigning.ps1
+++ b/tools/releaseBuild/generatePackgeSigning.ps1
@@ -7,14 +7,16 @@ param(
     [string[]] $AuthenticodeFiles,
     [string[]] $NuPkgFiles,
     [string[]] $MacDeveloperFiles,
-    [string[]] $LinuxFiles
+    [string[]] $LinuxFiles,
+    [string[]] $ThirtPartyFiles
 )
 
 if ((!$AuthenticodeDualFiles -or $AuthenticodeDualFiles.Count -eq 0) -and
     (!$AuthenticodeFiles -or $AuthenticodeFiles.Count -eq 0) -and
     (!$NuPkgFiles -or $NuPkgFiles.Count -eq 0) -and
     (!$MacDeveloperFiles -or $MacDeveloperFiles.Count -eq 0) -and
-    (!$LinuxFiles -or $LinuxFiles.Count -eq 0))
+    (!$LinuxFiles -or $LinuxFiles.Count -eq 0) -and
+    (!$ThirdPartyFiles -or $ThirdPartyFiles.Count -eq 0))
 {
     throw "At least one file must be specified"
 }
@@ -87,6 +89,10 @@ foreach ($file in $MacDeveloperFiles) {
 
 foreach ($file in $LinuxFiles) {
     New-FileElement -File $file -SignType 'LinuxPack' -XmlDoc $signingXml -Job $job
+}
+
+foreach ($file in $ThirtPartyFiles) {
+    New-FileElement -File $file -SignType 'ThirdParty' -XmlDoc $signingXml -Job $job
 }
 
 $signingXml.Save($path)

--- a/tools/releaseBuild/generatePackgeSigning.ps1
+++ b/tools/releaseBuild/generatePackgeSigning.ps1
@@ -8,7 +8,7 @@ param(
     [string[]] $NuPkgFiles,
     [string[]] $MacDeveloperFiles,
     [string[]] $LinuxFiles,
-    [string[]] $ThirtPartyFiles
+    [string[]] $ThirdPartyFiles
 )
 
 if ((!$AuthenticodeDualFiles -or $AuthenticodeDualFiles.Count -eq 0) -and
@@ -91,7 +91,7 @@ foreach ($file in $LinuxFiles) {
     New-FileElement -File $file -SignType 'LinuxPack' -XmlDoc $signingXml -Job $job
 }
 
-foreach ($file in $ThirtPartyFiles) {
+foreach ($file in $ThirdPartyFiles) {
     New-FileElement -File $file -SignType 'ThirdParty' -XmlDoc $signingXml -Job $job
 }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Update the release build to sign any unsigned files as 3rd party binaries


## PR Context

Fixes #12452

Before the change the following files were not changed (these are the only affected files)
```
-a----         5/5/2020   1:07 AM        1152400 Markdig.Signed.dll                                                    
-a----         5/5/2020   1:07 AM         859040 Microsoft.ApplicationInsights.dll                                     
-a----         5/5/2020   1:07 AM       14264208 Microsoft.CodeAnalysis.CSharp.dll                                     
-a----         5/5/2020   1:07 AM        5957008 Microsoft.CodeAnalysis.dll                                            
-a----         5/5/2020   1:07 AM        1007504 Microsoft.CSharp.dll                                                  
-a----         5/5/2020   1:07 AM         298400 Microsoft.Management.Infrastructure.dll                               
-a----         5/5/2020   1:07 AM         255896 Microsoft.Management.Infrastructure.Native.dll                        
-a----         5/5/2020   1:07 AM         984992 Microsoft.PowerShell.GraphicalHost.dll                                
-a----         5/5/2020   1:07 AM         141728 Microsoft.PowerShell.SDK.dll                                          
-a----         5/5/2020   1:07 AM          21392 Microsoft.Win32.Registry.AccessControl.dll                            
-a----         5/5/2020   1:07 AM          97168 Microsoft.Win32.Registry.dll                                          
-a----         5/5/2020   1:07 AM          80800 Microsoft.Win32.SystemEvents.dll                                      
-a----         5/5/2020   1:07 AM         143760 Namotion.Reflection.dll                                               
-a----         5/5/2020   1:07 AM        1848224 Newtonsoft.Json.dll                                                   
-a----         5/5/2020   1:07 AM         615840 NJsonSchema.dll                                                       
-a----         5/5/2020   1:07 AM         477600 System.CodeDom.dll                                                    
-a----         5/5/2020   1:07 AM         186256 System.Collections.Concurrent.dll                                     
-a----         5/5/2020   1:07 AM         327056 System.Collections.dll                                                
-a----         5/5/2020   1:07 AM          91552 System.Collections.Specialized.dll                                    
-a----         5/5/2020   1:07 AM         722776 System.ComponentModel.Composition.dll                                 
-a----         5/5/2020   1:07 AM          95136 System.ComponentModel.Composition.Registration.dll                    
-a----         5/5/2020   1:07 AM         977312 System.Configuration.ConfigurationManager.dll                         
-a----         5/5/2020   1:07 AM         150432 System.Console.dll                                                    
-a----         5/5/2020   1:07 AM         608144 System.Data.Odbc.dll                                                  
-a----         5/5/2020   1:07 AM         850312 System.Data.OleDb.dll                                                 
-a----         5/5/2020   1:07 AM        2537872 System.Data.SqlClient.dll                                             
-a----         5/5/2020   1:07 AM         301456 System.Diagnostics.EventLog.dll                                       
-a----         5/5/2020   1:07 AM          30112 System.Diagnostics.FileVersionInfo.dll                                
-a----         5/5/2020   1:07 AM         267152 System.Diagnostics.PerformanceCounter.dll                             
-a----         5/5/2020   1:07 AM         267152 System.Diagnostics.Process.dll                                        
-a----         5/5/2020   1:07 AM         723352 System.DirectoryServices.AccountManagement.dll                        
-a----         5/5/2020   1:07 AM        1027472 System.DirectoryServices.dll                                          
-a----         5/5/2020   1:07 AM         274848 System.DirectoryServices.Protocols.dll                                
-a----         5/5/2020   1:07 AM         966552 System.Drawing.Common.dll                                             
-a----         5/5/2020   1:07 AM         127376 System.IO.FileSystem.AccessControl.dll                                
-a----         5/5/2020   1:07 AM         218000 System.IO.FileSystem.dll                                              
-a----         5/5/2020   1:07 AM         271264 System.IO.Packaging.dll                                               
-a----         5/5/2020   1:07 AM         134552 System.IO.Pipes.dll                                                   
-a----         5/5/2020   1:07 AM         146840 System.IO.Ports.dll                                                   
-a----         5/5/2020   1:07 AM         422288 System.Linq.dll                                                       
-a----         5/5/2020   1:07 AM        5247384 System.Linq.Expressions.dll                                           
-a----         5/5/2020   1:07 AM         844184 System.Management.dll                                                 
-a----         5/5/2020   1:07 AM         265632 System.Net.Http.WinHttpHandler.dll                                    
-a----         5/5/2020   1:07 AM        5483928 System.Private.ServiceModel.dll                                       
-a----         5/5/2020   1:07 AM         236440 System.Private.Uri.dll                                                
-a----         5/5/2020   1:07 AM         194448 System.Reflection.Context.dll                                         
-a----         5/5/2020   1:07 AM         197016 System.Runtime.Caching.dll                                            
-a----         5/5/2020   1:07 AM          19352 System.Runtime.CompilerServices.Unsafe.dll                            
-a----         5/5/2020   1:07 AM          17296 System.Runtime.Extensions.dll                                         
-a----         5/5/2020   1:07 AM         229280 System.Security.AccessControl.dll                                     
```

Signing after the change.

**NOTE 1**: if the origin starts signing the file, this code will automatically stop signing the binary.
**NOTE 2**: some of these files are crossgen'ed for performance and the signature is lost.  See the list of crossgen'ed binaries below.

```
subject                                                                                              path
-------                                                                                              ----
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Console.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US Newtonsoft.Json.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US NJsonSchema.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Security.Cryptography.Pkcs.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Management.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Security.Cryptography.ProtectedData.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Security.Cryptography.Xml.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Security.Permissions.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Security.Principal.Windows.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Linq.Expressions.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Linq.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.IO.Ports.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Private.ServiceModel.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.IO.Packaging.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.ServiceModel.Syndication.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.ServiceProcess.ServiceController.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Text.Encoding.CodePages.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Text.Encodings.Web.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Security.Cryptography.Cng.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.IO.FileSystem.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Net.Http.WinHttpHandler.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US Namotion.Reflection.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Reflection.Context.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US Microsoft.Management.Infrastructure.Native.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US Microsoft.Management.Infrastructure.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US Microsoft.CSharp.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US Microsoft.CodeAnalysis.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US Microsoft.CodeAnalysis.CSharp.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US Microsoft.ApplicationInsights.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US Markdig.Signed.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US Microsoft.PowerShell.GraphicalHost.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Configuration.ConfigurationManager.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US Microsoft.PowerShell.SDK.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Runtime.Caching.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Runtime.CompilerServices.Unsafe.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Runtime.Extensions.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US Microsoft.Win32.Registry.AccessControl.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US Microsoft.Win32.Registry.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US Microsoft.Win32.SystemEvents.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Security.AccessControl.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Threading.AccessControl.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.IO.Pipes.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Threading.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Collections.Concurrent.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Windows.Extensions.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.DirectoryServices.Protocols.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.DirectoryServices.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.DirectoryServices.AccountManagement.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Collections.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.IO.FileSystem.AccessControl.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Collections.Specialized.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Diagnostics.Process.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Diagnostics.PerformanceCounter.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Diagnostics.FileVersionInfo.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Diagnostics.EventLog.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.ComponentModel.Composition.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.ComponentModel.Composition.Registration.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Data.SqlClient.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Data.OleDb.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Data.Odbc.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Drawing.Common.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.CodeDom.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Private.Uri.dll
CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US System.Threading.Tasks.Parallel.dll
```

Here is the full file signature manifest

[signatures.txt](https://github.com/PowerShell/PowerShell/files/4582898/signatures.txt)


### CrossGen'ed binaries

```
        "Microsoft.CodeAnalysis.CSharp.dll"
        "Microsoft.CodeAnalysis.dll"
        "System.Linq.Expressions.dll"
        "Microsoft.CSharp.dll"
        "System.Runtime.Extensions.dll"
        "System.Linq.dll"
        "System.Collections.Concurrent.dll"
        "System.Collections.dll"
        "Newtonsoft.Json.dll"
        "System.IO.FileSystem.dll"
        "System.Diagnostics.Process.dll"
        "System.Threading.Tasks.Parallel.dll"
        "System.Security.AccessControl.dll"
        "System.Text.Encoding.CodePages.dll"
        "System.Private.Uri.dll"
        "System.Threading.dll"
        "System.Security.Principal.Windows.dll"
        "System.Console.dll"
        "Microsoft.Win32.Registry.dll"
        "System.IO.Pipes.dll"
        "System.Diagnostics.FileVersionInfo.dll"
        "System.Collections.Specialized.dll"
        "Microsoft.ApplicationInsights.dll"
```

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
