### PR TITLE
Use correct casing for cmdlet name and cmdlet parameter name in *.ps1 files

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -538,10 +538,10 @@ Fix steps:
                 $cryptoTarget = "/lib64/libcrypto.so.10"
             }
 
-            if ( ! (test-path "$publishPath/libssl.so.1.0.0")) {
+            if ( ! (Test-Path "$publishPath/libssl.so.1.0.0")) {
                 $null = New-Item -Force -ItemType SymbolicLink -Target $sslTarget -Path "$publishPath/libssl.so.1.0.0" -ErrorAction Stop
             }
-            if ( ! (test-path "$publishPath/libcrypto.so.1.0.0")) {
+            if ( ! (Test-Path "$publishPath/libcrypto.so.1.0.0")) {
                 $null = New-Item -Force -ItemType SymbolicLink -Target $cryptoTarget -Path "$publishPath/libcrypto.so.1.0.0" -ErrorAction Stop
             }
         }
@@ -888,7 +888,7 @@ function Get-PesterTag {
     $alltags = @{}
     $warnings = @()
 
-    get-childitem -Recurse $testbase -File | Where-Object {$_.name -match "tests.ps1"}| ForEach-Object {
+    Get-ChildItem -Recurse $testbase -File | Where-Object {$_.name -match "tests.ps1"}| ForEach-Object {
         $fullname = $_.fullname
         $tok = $err = $null
         $ast = [System.Management.Automation.Language.Parser]::ParseFile($FullName, [ref]$tok,[ref]$err)
@@ -1276,7 +1276,7 @@ function Start-PSPester {
                     break
                 }
 
-                $count = ($lines | measure-object).Count
+                $count = ($lines | Measure-Object).Count
                 if ($count -eq 0)
                 {
                     Start-Sleep -Seconds 1
@@ -1469,7 +1469,7 @@ function Test-XUnitTestResults
         throw "Cannot convert $TestResultsFile to xml : $($_.message)"
     }
 
-    $failedTests = $results.assemblies.assembly.collection | Where-Object failed -gt 0
+    $failedTests = $results.assemblies.assembly.collection | Where-Object failed -GT 0
 
     if(-not $failedTests)
     {
@@ -1521,7 +1521,7 @@ function Test-PSPesterResults
             throw "Test result file '$testResultsFile' not found for $TestArea."
         }
 
-        $x = [xml](Get-Content -raw $testResultsFile)
+        $x = [xml](Get-Content -Raw $testResultsFile)
         if ([int]$x.'test-results'.failures -gt 0)
         {
             Write-Log -Error "TEST FAILURES"
@@ -2093,7 +2093,7 @@ function script:Use-MSBuild {
     # msbuild v14 and msbuild v4 behaviors are different for XAML generation
     $frameworkMsBuildLocation = "${env:SystemRoot}\Microsoft.Net\Framework\v4.0.30319\msbuild"
 
-    $msbuild = get-command msbuild -ErrorAction Ignore
+    $msbuild = Get-Command msbuild -ErrorAction Ignore
     if ($msbuild) {
         # all good, nothing to do
         return
@@ -2873,17 +2873,17 @@ assembly
     PROCESS {
         #### MAIN ####
         foreach ( $log in $Logfile ) {
-            foreach ( $logpath in (resolve-path $log).path ) {
-                write-progress "converting file $logpath"
+            foreach ( $logpath in (Resolve-Path $log).path ) {
+                Write-Progress "converting file $logpath"
                 if ( ! $logpath) { throw "Cannot resolve $Logfile" }
-                $x = [xml](get-content -raw -readcount 0 $logpath)
+                $x = [xml](Get-Content -Raw -ReadCount 0 $logpath)
 
                 if ( $x.psobject.properties['test-results'] ) {
                     $Logs += convert-pesterlog $x $logpath -includeempty:$includeempty
                 } elseif ( $x.psobject.properties['assemblies'] ) {
                     $Logs += convert-xunitlog $x $logpath -includeEmpty:$includeEmpty
                 } else {
-                    write-error "Cannot determine log type"
+                    Write-Error "Cannot determine log type"
                 }
             }
         }

--- a/demos/Apache/apache-demo.ps1
+++ b/demos/Apache/apache-demo.ps1
@@ -8,12 +8,12 @@ Write-Host -Foreground Blue "Get installed Apache Modules like *proxy* and Sort 
 Get-ApacheModule | Where-Object {$_.ModuleName -like "*proxy*"} | Sort-Object ModuleName | Out-Host
 
 #Graceful restart of Apache
-Write-host -Foreground Blue "Restart Apache Server gracefully"
+Write-Host -Foreground Blue "Restart Apache Server gracefully"
 Restart-ApacheHTTPServer -Graceful | Out-Host
 
 #Enumerate current virtual hosts (web sites)
 Write-Host -Foreground Blue "Enumerate configured Apache Virtual Hosts"
-Get-ApacheVHost |out-host
+Get-ApacheVHost |Out-Host
 
 #Add a new virtual host
 Write-Host -Foreground Yellow "Create a new Apache Virtual Host"
@@ -21,7 +21,7 @@ New-ApacheVHost -ServerName "mytestserver" -DocumentRoot /var/www/html/mytestser
 
 #Enumerate new set of virtual hosts
 Write-Host -Foreground Blue "Enumerate Apache Virtual Hosts Again"
-Get-ApacheVHost |out-host
+Get-ApacheVHost |Out-Host
 
 #Cleanup
 Write-Host -Foreground Blue "Remove demo virtual host"

--- a/demos/DSC/dsc-demo.ps1
+++ b/demos/DSC/dsc-demo.ps1
@@ -44,7 +44,7 @@ Configuration ApacheServer{
 
         nxFile vHostDirectory{
             DestinationPath = $VhostDir
-            type = "Directory"
+            Type = "Directory"
             Ensure = "Present"
             Owner = "root"
             Mode = "744"
@@ -69,7 +69,7 @@ Configuration ApacheServer{
         #Ensure website is defined
         nxFile DefaultSiteDir{
             DestinationPath = "/var/www/html/defaultsite"
-            type = "Directory"
+            Type = "Directory"
             Owner = "root"
             Mode = "744"
             Ensure = "Present"

--- a/demos/DSC/dsc-demo.ps1
+++ b/demos/DSC/dsc-demo.ps1
@@ -44,7 +44,7 @@ Configuration ApacheServer{
 
         nxFile vHostDirectory{
             DestinationPath = $VhostDir
-            Type = "Directory"
+            type = "Directory"
             Ensure = "Present"
             Owner = "root"
             Mode = "744"
@@ -69,7 +69,7 @@ Configuration ApacheServer{
         #Ensure website is defined
         nxFile DefaultSiteDir{
             DestinationPath = "/var/www/html/defaultsite"
-            Type = "Directory"
+            type = "Directory"
             Owner = "root"
             Mode = "744"
             Ensure = "Present"

--- a/demos/Docker-PowerShell/Docker-PowerShell.ps1
+++ b/demos/Docker-PowerShell/Docker-PowerShell.ps1
@@ -20,10 +20,10 @@ Run-ContainerImage hello-world # Linux
 cls
 
 # List all containers that have exited
-Get-Container | Where-Object State -eq "exited"
+Get-Container | Where-Object State -EQ "exited"
 
 # That found the right one, so go ahead and remove it
-Get-Container | Where-Object State -eq "exited" | Remove-Container
+Get-Container | Where-Object State -EQ "exited" | Remove-Container
 
 # Now remove the container image
 Remove-ContainerImage hello-world

--- a/demos/SystemD/SystemD/SystemD.psm1
+++ b/demos/SystemD/SystemD/SystemD.psm1
@@ -11,7 +11,7 @@ Function Get-SystemDJournal {
         $Result = & $sudocmd $cmd $journalctlParameters -o json --no-pager
         Try
         {
-                  $JSONResult = $Result|ConvertFrom-JSON
+                  $JSONResult = $Result|ConvertFrom-Json
                   $JSONResult
         }
         Catch

--- a/demos/SystemD/journalctl-demo.ps1
+++ b/demos/SystemD/journalctl-demo.ps1
@@ -4,9 +4,9 @@
 Import-Module $PSScriptRoot/SystemD/SystemD.psm1
 
 #list recent journal events
-Write-host -Foreground Blue "Get recent SystemD journal messages"
+Write-Host -Foreground Blue "Get recent SystemD journal messages"
 Get-SystemDJournal -args "-xe" |Out-Host
 
 #Drill into SystemD unit messages
-Write-host -Foreground Blue "Get recent SystemD journal messages for services and return Unit, Message"
-Get-SystemDJournal -args "-xe" | Where-Object {$_._SYSTEMD_UNIT -like "*.service"} | Format-Table _SYSTEMD_UNIT, MESSAGE | Select-Object -first 10 | Out-Host
+Write-Host -Foreground Blue "Get recent SystemD journal messages for services and return Unit, Message"
+Get-SystemDJournal -args "-xe" | Where-Object {$_._SYSTEMD_UNIT -like "*.service"} | Format-Table _SYSTEMD_UNIT, MESSAGE | Select-Object -First 10 | Out-Host

--- a/demos/python/class1.ps1
+++ b/demos/python/class1.ps1
@@ -10,5 +10,5 @@
 # picking up the Python script from the same directory
 #
 
-& $PSScriptRoot/class1.py | ConvertFrom-JSON
+& $PSScriptRoot/class1.py | ConvertFrom-Json
 

--- a/demos/python/demo_script.ps1
+++ b/demos/python/demo_script.ps1
@@ -20,7 +20,7 @@ $data
 @"
 #!/usr/bin/python3
 print('Hi!')
-"@ | out-file -encoding ascii hi
+"@ | Out-File -Encoding ascii hi
 
 # Make it executable
 chmod +x hi
@@ -35,7 +35,7 @@ cat class1.py
 ./class1.py
 
 # Capture the data as structured objects (arrays and hashtables)
-$data = ./class1.py | ConvertFrom-JSON
+$data = ./class1.py | ConvertFrom-Json
 
 # look at the first element of the returned array
 $data[0]

--- a/src/Modules/Windows/PSDiagnostics/PSDiagnostics.psm1
+++ b/src/Modules/Windows/PSDiagnostics/PSDiagnostics.psm1
@@ -130,35 +130,35 @@ function Enable-WSManTrace
 {
 
     # winrm
-    "{04c6e16d-b99f-4a3a-9b3e-b8325bbc781e} 0xffffffff 0xff" | out-file $script:wsmprovfile -encoding ascii
+    "{04c6e16d-b99f-4a3a-9b3e-b8325bbc781e} 0xffffffff 0xff" | Out-File $script:wsmprovfile -Encoding ascii
 
     # winrsmgr
-    "{c0a36be8-a515-4cfa-b2b6-2676366efff7} 0xffffffff 0xff" | out-file $script:wsmprovfile -encoding ascii -append
+    "{c0a36be8-a515-4cfa-b2b6-2676366efff7} 0xffffffff 0xff" | Out-File $script:wsmprovfile -Encoding ascii -Append
 
     # WinrsExe
-    "{f1cab2c0-8beb-4fa2-90e1-8f17e0acdd5d} 0xffffffff 0xff" | out-file $script:wsmprovfile -encoding ascii -append
+    "{f1cab2c0-8beb-4fa2-90e1-8f17e0acdd5d} 0xffffffff 0xff" | Out-File $script:wsmprovfile -Encoding ascii -Append
 
     # WinrsCmd
-    "{03992646-3dfe-4477-80e3-85936ace7abb} 0xffffffff 0xff" | out-file $script:wsmprovfile -encoding ascii -append
+    "{03992646-3dfe-4477-80e3-85936ace7abb} 0xffffffff 0xff" | Out-File $script:wsmprovfile -Encoding ascii -Append
 
     # IPMIPrv
-    "{651d672b-e11f-41b7-add3-c2f6a4023672} 0xffffffff 0xff" | out-file $script:wsmprovfile -encoding ascii -append
+    "{651d672b-e11f-41b7-add3-c2f6a4023672} 0xffffffff 0xff" | Out-File $script:wsmprovfile -Encoding ascii -Append
 
     #IpmiDrv
-    "{D5C6A3E9-FA9C-434e-9653-165B4FC869E4} 0xffffffff 0xff" | out-file $script:wsmprovfile -encoding ascii -append
+    "{D5C6A3E9-FA9C-434e-9653-165B4FC869E4} 0xffffffff 0xff" | Out-File $script:wsmprovfile -Encoding ascii -Append
 
     # WSManProvHost
-    "{6e1b64d7-d3be-4651-90fb-3583af89d7f1} 0xffffffff 0xff" | out-file $script:wsmprovfile -encoding ascii -append
+    "{6e1b64d7-d3be-4651-90fb-3583af89d7f1} 0xffffffff 0xff" | Out-File $script:wsmprovfile -Encoding ascii -Append
 
     # Event Forwarding
-    "{6FCDF39A-EF67-483D-A661-76D715C6B008} 0xffffffff 0xff" | out-file $script:wsmprovfile -encoding ascii -append
+    "{6FCDF39A-EF67-483D-A661-76D715C6B008} 0xffffffff 0xff" | Out-File $script:wsmprovfile -Encoding ascii -Append
 
-    Start-Trace -SessionName $script:wsmsession -ETS -OutputFilePath $script:wsmanlogfile -Format bincirc -MinBuffers 16 -MaxBuffers 256 -BufferSizeInKb 64 -MaxLogFileSizeInMB 256 -ProviderFilePath $script:wsmprovfile
+    Start-Trace -SessionName $script:wsmsession -ETS -OutputFilePath $script:wsmanlogfile -Format bincirc -MinBuffers 16 -MaxBuffers 256 -BufferSizeInKB 64 -MaxLogFileSizeInMB 256 -ProviderFilePath $script:wsmprovfile
 }
 
 function Disable-WSManTrace
 {
-    Stop-Trace $script:wsmsession -ets
+    Stop-Trace $script:wsmsession -ETS
 }
 
 function Enable-PSWSManCombinedTrace
@@ -177,27 +177,27 @@ function Enable-PSWSManCombinedTrace
         $logfile = $PSHOME + "\\Traces\\PSTrace.etl"
     }
 
-    "Microsoft-Windows-PowerShell 0 5" | out-file $provfile -encoding ascii
-    "Microsoft-Windows-WinRM 0 5" | out-file $provfile -encoding ascii -append
+    "Microsoft-Windows-PowerShell 0 5" | Out-File $provfile -Encoding ascii
+    "Microsoft-Windows-WinRM 0 5" | Out-File $provfile -Encoding ascii -Append
 
     if (!(Test-Path $PSHOME\Traces))
     {
-        New-Item -ItemType Directory -Force $PSHOME\Traces | out-null
+        New-Item -ItemType Directory -Force $PSHOME\Traces | Out-Null
     }
 
     if (Test-Path $logfile)
     {
-        Remove-Item -Force $logfile | out-null
+        Remove-Item -Force $logfile | Out-Null
     }
 
-    Start-Trace -SessionName $script:pssession -OutputFilePath $logfile -ProviderFilePath $provfile -ets
+    Start-Trace -SessionName $script:pssession -OutputFilePath $logfile -ProviderFilePath $provfile -ETS
 
-    remove-item $provfile -Force -ea 0
+    Remove-Item $provfile -Force -ea 0
 }
 
 function Disable-PSWSManCombinedTrace
 {
-    Stop-Trace -SessionName $script:pssession -ets
+    Stop-Trace -SessionName $script:pssession -ETS
 }
 
 function Set-LogProperties
@@ -220,7 +220,7 @@ function Set-LogProperties
         $retention = $LogDetails.Retention.ToString()
         $autobackup = $LogDetails.AutoBackup.ToString()
         $maxLogSize = $LogDetails.MaxLogSize.ToString()
-        $osVersion = [Version] (Get-Ciminstance Win32_OperatingSystem).Version
+        $osVersion = [Version] (Get-CimInstance Win32_OperatingSystem).Version
 
         if (($LogDetails.Type -eq "Analytic") -or ($LogDetails.Type -eq "Debug"))
         {
@@ -347,7 +347,7 @@ function Disable-PSTrace
 		}
 	}
 }
-add-type @"
+Add-Type @"
 using System;
 
 namespace Microsoft.PowerShell.Diagnostics

--- a/src/powershell-native/Install-PowerShellRemoting.ps1
+++ b/src/powershell-native/Install-PowerShellRemoting.ps1
@@ -215,7 +215,7 @@ function Install-PluginEndpoint {
 
     try
     {
-        Write-Host "`nGet-PSSessionConfiguration $pluginEndpointName" -foregroundcolor "green"
+        Write-Host "`nGet-PSSessionConfiguration $pluginEndpointName" -ForegroundColor "green"
         Get-PSSessionConfiguration $pluginEndpointName -ErrorAction Stop
     }
     catch [Microsoft.PowerShell.Commands.WriteErrorException]
@@ -227,6 +227,6 @@ function Install-PluginEndpoint {
 Install-PluginEndpoint -Force $Force
 Install-PluginEndpoint -Force $Force -VersionIndependent
 
-Write-Host "Restarting WinRM to ensure that the plugin configuration change takes effect.`nThis is required for WinRM running on Windows SKUs prior to Windows 10." -foregroundcolor Magenta
+Write-Host "Restarting WinRM to ensure that the plugin configuration change takes effect.`nThis is required for WinRM running on Windows SKUs prior to Windows 10." -ForegroundColor Magenta
 Restart-Service winrm
 

--- a/test/SSHRemoting/SSHRemoting.Basic.Tests.ps1
+++ b/test/SSHRemoting/SSHRemoting.Basic.Tests.ps1
@@ -23,8 +23,8 @@ Describe "SSHRemoting Basic Tests" -tags CI {
     Context "New-PSSession Tests" {
 
         AfterEach {
-            if ($script:session -ne $null) { Remove-PSSession -session $script:session }
-            if ($script:sessions -ne $null) { Remove-PSSession -session $script:sessions }
+            if ($script:session -ne $null) { Remove-PSSession -Session $script:session }
+            if ($script:sessions -ne $null) { Remove-PSSession -Session $script:sessions }
         }
 
         It "Verifies new connection with implicit current User" {

--- a/test/common/markdown/markdown-link.tests.ps1
+++ b/test/common/markdown/markdown-link.tests.ps1
@@ -17,12 +17,12 @@ Describe "Verify Markdown Links" {
         }
 
         # Cleanup jobs for reliability
-        get-job | remove-job -force
+        Get-Job | Remove-Job -Force
     }
 
     AfterAll {
         # Cleanup jobs to leave the process the same
-        get-job | remove-job -force
+        Get-Job | Remove-Job -Force
     }
 
     $groups = Get-ChildItem -Path "$PSScriptRoot\..\..\..\*.md" -Recurse | Where-Object {$_.DirectoryName -notlike '*node_modules*'} | Group-Object -Property directory
@@ -31,7 +31,7 @@ Describe "Verify Markdown Links" {
     # start all link verification in parallel
     Foreach($group in $groups)
     {
-        Write-Verbose -verbose "starting jobs for $($group.Name) ..."
+        Write-Verbose -Verbose "starting jobs for $($group.Name) ..."
         $job = Start-ThreadJob {
             param([object] $group)
             foreach($file in $group.Group)
@@ -46,13 +46,13 @@ Describe "Verify Markdown Links" {
         $jobs.add($group.name,$job)
     }
 
-    Write-Verbose -verbose "Getting results ..."
+    Write-Verbose -Verbose "Getting results ..."
     # Get the results and verify
     foreach($key in $jobs.keys)
     {
         $job = $jobs.$key
         $results = Receive-Job -Job $job -Wait
-        Remove-job -job $Job
+        Remove-Job -Job $Job
         foreach($jobResult in $results)
         {
             $file = $jobResult.file
@@ -85,14 +85,14 @@ Describe "Verify Markdown Links" {
 
                 if($passes)
                 {
-                    it "<url> should work" -TestCases $passes {
+                    It "<url> should work" -TestCases $passes {
                         noop
                     }
                 }
 
                 if($trueFailures)
                 {
-                    it "<url> should work" -TestCases $trueFailures  {
+                    It "<url> should work" -TestCases $trueFailures  {
                         param($url)
 
                         # there could be multiple reasons why a failure is ok
@@ -111,7 +111,7 @@ Describe "Verify Markdown Links" {
                             # If invoke-WebRequest can handle the URL, re-verify, with 6 retries
                             try
                             {
-                                $null = Invoke-WebRequest -uri $url -RetryIntervalSec 10 -MaximumRetryCount 6
+                                $null = Invoke-WebRequest -Uri $url -RetryIntervalSec 10 -MaximumRetryCount 6
                             }
                             catch [Microsoft.PowerShell.Commands.HttpResponseException]
                             {
@@ -128,7 +128,7 @@ Describe "Verify Markdown Links" {
 
                 if($verifyFailures)
                 {
-                    it "<url> should work" -TestCases $verifyFailures -Pending  {
+                    It "<url> should work" -TestCases $verifyFailures -Pending  {
                     }
                 }
 

--- a/test/docker/networktest/DockerRemoting.Tests.ps1
+++ b/test/docker/networktest/DockerRemoting.Tests.ps1
@@ -7,7 +7,7 @@ Describe "Basic remoting test with docker" -tags @("Scenario","Slow"){
         $dockerimage = docker images --format "{{ .Repository }}" $imageName
         if ( $dockerimage -ne $imageName ) {
             $pending = $true
-            write-warning "Docker image '$imageName' not found, not running tests"
+            Write-Warning "Docker image '$imageName' not found, not running tests"
             return
         }
         else {
@@ -15,18 +15,18 @@ Describe "Basic remoting test with docker" -tags @("Scenario","Slow"){
         }
 
         # give the containers something to do, otherwise they will exit and be removed
-        Write-Verbose -verbose "setting up docker container PowerShell server"
+        Write-Verbose -Verbose "setting up docker container PowerShell server"
         $server = docker run -d $imageName powershell -c Start-Sleep -Seconds $timeout
-        Write-Verbose -verbose "setting up docker container PowerShell client"
+        Write-Verbose -Verbose "setting up docker container PowerShell client"
         $client = docker run -d $imageName powershell -c Start-Sleep -Seconds $timeout
 
         # get fullpath to installed core powershell
-        Write-Verbose -verbose "Getting path to PowerShell"
+        Write-Verbose -Verbose "Getting path to PowerShell"
         $powershellcorepath = docker exec $server powershell -c "(get-childitem 'c:\program files\powershell\*\pwsh.exe').fullname"
         if ( ! $powershellcorepath )
         {
             $pending = $true
-            write-warning "Cannot find powershell executable, not running tests"
+            Write-Warning "Cannot find powershell executable, not running tests"
             return
         }
         $powershellcoreversion = ($powershellcorepath -split "[\\/]")[-2]
@@ -34,27 +34,27 @@ Describe "Basic remoting test with docker" -tags @("Scenario","Slow"){
         $powershellcoreConfiguration = "powershell.${powershellcoreversion}"
 
         # capture the hostnames of the containers which will be used by the tests
-        write-verbose -verbose "getting server hostname"
+        Write-Verbose -Verbose "getting server hostname"
         $serverhostname = docker exec $server hostname
-        write-verbose -verbose "getting client hostname"
+        Write-Verbose -Verbose "getting client hostname"
         $clienthostname = docker exec $client hostname
 
         # capture the versions of full and core PowerShell
-        write-verbose -verbose "getting powershell full version"
+        Write-Verbose -Verbose "getting powershell full version"
         $fullVersion = docker exec $client powershell -c "`$PSVersionTable.psversion.tostring()"
         if ( ! $fullVersion )
         {
             $pending = $true
-            write-warning "Cannot determine PowerShell full version, not running tests"
+            Write-Warning "Cannot determine PowerShell full version, not running tests"
             return
         }
 
-        write-verbose -verbose "getting powershell version"
+        Write-Verbose -Verbose "getting powershell version"
         $coreVersion = docker exec $client "$powershellcorepath" -c "`$PSVersionTable.psversion.tostring()"
         if ( ! $coreVersion )
         {
             $pending = $true
-            write-warning "Cannot determine PowerShell version, not running tests"
+            Write-Warning "Cannot determine PowerShell version, not running tests"
             return
         }
     }
@@ -67,22 +67,22 @@ Describe "Basic remoting test with docker" -tags @("Scenario","Slow"){
         }
     }
 
-    It "Full powershell can get correct remote powershell version" -pending:$pending {
+    It "Full powershell can get correct remote powershell version" -Pending:$pending {
         $result = docker exec $client powershell -c "`$ss = [security.securestring]::new(); '11aa!!AA'.ToCharArray() | ForEach-Object { `$ss.appendchar(`$_)}; `$c = [pscredential]::new('testuser',`$ss); `$ses=new-pssession $serverhostname -configurationname $powershellcoreConfiguration -auth basic -credential `$c; invoke-command -session `$ses { `$PSVersionTable.psversion.tostring() }"
         $result | Should -Be $coreVersion
     }
 
-    It "Full powershell can get correct remote powershell full version" -pending:$pending {
+    It "Full powershell can get correct remote powershell full version" -Pending:$pending {
         $result = docker exec $client powershell -c "`$ss = [security.securestring]::new(); '11aa!!AA'.ToCharArray() | ForEach-Object { `$ss.appendchar(`$_)}; `$c = [pscredential]::new('testuser',`$ss); `$ses=new-pssession $serverhostname -auth basic -credential `$c; invoke-command -session `$ses { `$PSVersionTable.psversion.tostring() }"
         $result | Should -Be $fullVersion
     }
 
-    It "Core powershell can get correct remote powershell version" -pending:$pending {
+    It "Core powershell can get correct remote powershell version" -Pending:$pending {
         $result = docker exec $client "$powershellcorepath" -c "`$ss = [security.securestring]::new(); '11aa!!AA'.ToCharArray() | ForEach-Object { `$ss.appendchar(`$_)}; `$c = [pscredential]::new('testuser',`$ss); `$ses=new-pssession $serverhostname -configurationname $powershellcoreConfiguration -auth basic -credential `$c; invoke-command -session `$ses { `$PSVersionTable.psversion.tostring() }"
         $result | Should -Be $coreVersion
     }
 
-    It "Core powershell can get correct remote powershell full version" -pending:$pending {
+    It "Core powershell can get correct remote powershell full version" -Pending:$pending {
         $result = docker exec $client "$powershellcorepath" -c "`$ss = [security.securestring]::new(); '11aa!!AA'.ToCharArray() | ForEach-Object { `$ss.appendchar(`$_)}; `$c = [pscredential]::new('testuser',`$ss); `$ses=new-pssession $serverhostname -auth basic -credential `$c; invoke-command -session `$ses { `$PSVersionTable.psversion.tostring() }"
         $result | Should -Be $fullVersion
     }

--- a/test/docker/networktest/New-DockerTestBuild.ps1
+++ b/test/docker/networktest/New-DockerTestBuild.ps1
@@ -16,7 +16,7 @@ $script:Constants =  @{
 
 #### DOCKER OPS #####
 # is docker installed?
-$dockerExe = get-command docker -ea silentlycontinue
+$dockerExe = Get-Command docker -ea silentlycontinue
 if ( $dockerExe.name -ne "docker.exe" ) {
     throw "Cannot find docker, is it installed?"
 }
@@ -43,7 +43,7 @@ if ( $TestImage -eq $Constants.TestImageName)
 
 #### MSI CHECKS ####
 # check to see if the MSI is present
-$MsiExists = test-path $Constants.MsiName
+$MsiExists = Test-Path $Constants.MsiName
 $msg = "{0} exists, use -Force to remove or -UseExistingMsi to use" -f $Constants.MsiName
 if ( $MsiExists -and ! ($force -or $useExistingMsi))
 {
@@ -53,7 +53,7 @@ if ( $MsiExists -and ! ($force -or $useExistingMsi))
 # remove the msi
 if ( $MsiExists -and $Force -and ! $UseExistingMsi )
 {
-    Remove-Item -force $Constants.MsiName
+    Remove-Item -Force $Constants.MsiName
     $MsiExists = $false
 }
 
@@ -70,7 +70,7 @@ elseif ( $MsiExists -and ! $UseExistingMsi )
 }
 
 # last check before bulding the image
-if ( ! (test-path $Constants.MsiName) )
+if ( ! (Test-Path $Constants.MsiName) )
 {
     throw ("{0} does not exist, giving up" -f $Constants.MsiName)
 }

--- a/test/nanoserver/nanoserver.tests.ps1
+++ b/test/nanoserver/nanoserver.tests.ps1
@@ -4,14 +4,14 @@
 Describe "Verify PowerShell Runs" {
     BeforeAll{
         $options = (Get-PSOptions)
-        $path = split-path -path $options.Output
+        $path = Split-Path -Path $options.Output
         Write-Verbose "Path: '$path'" -Verbose
-        $rootPath = split-Path -path $path
+        $rootPath = Split-Path -Path $path
         $mount = 'C:\powershell'
         $container = 'mcr.microsoft.com/powershell:nanoserver-1803'
     }
 
-    it "Verify Version " {
+    It "Verify Version " {
         $version = docker run --rm -v "${rootPath}:${mount}" ${container} "${mount}\publish\pwsh" -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'
         $version | Should -Match '^7\.'
     }

--- a/test/powershell/Host/Base-Directory.Tests.ps1
+++ b/test/powershell/Host/Base-Directory.Tests.ps1
@@ -50,7 +50,7 @@ Describe "Configuration file locations" -tags "CI","Slow" {
         }
 
         It @ItArgs "PSReadLine history save location should be correct" {
-            & $powershell -noprofile { (Get-PSReadlineOption).HistorySavePath } | Should -Be $expectedReadline
+            & $powershell -noprofile { (Get-PSReadLineOption).HistorySavePath } | Should -Be $expectedReadline
         }
 
         # This feature (and thus test) has been disabled because of the AssemblyLoadContext scenario
@@ -104,7 +104,7 @@ Describe "Configuration file locations" -tags "CI","Slow" {
         It @ItArgs "PSReadLine history should respect XDG_DATA_HOME" {
             $env:XDG_DATA_HOME = $TestDrive
             $expected = [IO.Path]::Combine($TestDrive, "powershell", "PSReadLine", "ConsoleHost_history.txt")
-            & $powershell -noprofile { (Get-PSReadlineOption).HistorySavePath } | Should -Be $expected
+            & $powershell -noprofile { (Get-PSReadLineOption).HistorySavePath } | Should -Be $expected
         }
 
         # This feature (and thus test) has been disabled because of the AssemblyLoadContext scenario

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -351,12 +351,12 @@ export $envVarName='$guid'
         # must use an explicit scope of LocalMachine to ensure the setting is written to the expected file.
         # Skip the tests on Unix platforms because *-ExecutionPolicy cmdlets don't work by design.
 
-        It "Verifies PowerShell reads from the custom -settingsFile" -skip:(!$IsWindows) {
+        It "Verifies PowerShell reads from the custom -settingsFile" -Skip:(!$IsWindows) {
             $actualValue = & $powershell -NoProfile -SettingsFile $CustomSettingsFile -Command {(Get-ExecutionPolicy -Scope LocalMachine).ToString()}
             $actualValue  | Should -Be $DefaultExecutionPolicy
         }
 
-        It "Verifies PowerShell writes to the custom -settingsFile" -skip:(!$IsWindows) {
+        It "Verifies PowerShell writes to the custom -settingsFile" -Skip:(!$IsWindows) {
             $expectedValue = 'AllSigned'
 
             # Update the execution policy; this should update the settings file.
@@ -371,7 +371,7 @@ export $envVarName='$guid'
             $actualValue  | Should -Be $expectedValue
         }
 
-        It "Verify PowerShell removes a setting from the custom -settingsFile" -skip:(!$IsWindows) {
+        It "Verify PowerShell removes a setting from the custom -settingsFile" -Skip:(!$IsWindows) {
             # Remove the LocalMachine execution policy; this should update the settings file.
             & $powershell -NoProfile -SettingsFile $CustomSettingsFile -Command {Set-ExecutionPolicy -ExecutionPolicy Undefined -Scope LocalMachine }
 
@@ -385,8 +385,8 @@ export $envVarName='$guid'
         $p = [PSCustomObject]@{X=10;Y=20}
 
         It "xml input" {
-            $p | & $powershell -noprofile { $input | Foreach-Object {$a = 0} { $a += $_.X + $_.Y } { $a } } | Should -Be 30
-            $p | & $powershell -noprofile -inputFormat xml { $input | Foreach-Object {$a = 0} { $a += $_.X + $_.Y } { $a } } | Should -Be 30
+            $p | & $powershell -noprofile { $input | ForEach-Object {$a = 0} { $a += $_.X + $_.Y } { $a } } | Should -Be 30
+            $p | & $powershell -noprofile -inputFormat xml { $input | ForEach-Object {$a = 0} { $a += $_.X + $_.Y } { $a } } | Should -Be 30
         }
 
         It "text input" {
@@ -395,8 +395,8 @@ export $envVarName='$guid'
         }
 
         It "xml output" {
-            & $powershell -noprofile { [PSCustomObject]@{X=10;Y=20} } | Foreach-Object {$a = 0} { $a += $_.X + $_.Y } { $a } | Should -Be 30
-            & $powershell -noprofile -outputFormat xml { [PSCustomObject]@{X=10;Y=20} } | Foreach-Object {$a = 0} { $a += $_.X + $_.Y } { $a } | Should -Be 30
+            & $powershell -noprofile { [PSCustomObject]@{X=10;Y=20} } | ForEach-Object {$a = 0} { $a += $_.X + $_.Y } { $a } | Should -Be 30
+            & $powershell -noprofile -outputFormat xml { [PSCustomObject]@{X=10;Y=20} } | ForEach-Object {$a = 0} { $a += $_.X + $_.Y } { $a } | Should -Be 30
         }
 
         It "text output" {
@@ -638,17 +638,17 @@ namespace StackTest {
             $env:XDG_CONFIG_HOME = $XDG_CONFIG_HOME
         }
 
-        It "Should start if Data, Config, and Cache location is not accessible" -skip:($IsWindows) {
+        It "Should start if Data, Config, and Cache location is not accessible" -Skip:($IsWindows) {
             $env:XDG_CACHE_HOME = "/dev/cpu"
             $env:XDG_DATA_HOME = "/dev/cpu"
             $env:XDG_CONFIG_HOME = "/dev/cpu"
-            $output = & $powershell -noprofile -Command { (get-command).count }
+            $output = & $powershell -noprofile -Command { (Get-Command).count }
             [int]$output | Should -BeGreaterThan 0
         }
     }
 
     Context "HOME environment variable" {
-        It "Should start if HOME is not defined" -skip:($IsWindows) {
+        It "Should start if HOME is not defined" -Skip:($IsWindows) {
             bash -c "unset HOME;$powershell -c '1+1'" | Should -BeExactly 2
         }
     }
@@ -769,7 +769,7 @@ namespace StackTest {
     Context "ApartmentState WPF tests" -Tag Slow {
 
         It "WPF requires STA and will work" -Skip:(!$IsWindows -or [System.Management.Automation.Platform]::IsNanoServer) {
-            add-type -AssemblyName presentationframework
+            Add-Type -AssemblyName presentationframework
 
             $xaml = [xml]@"
             <Window
@@ -970,12 +970,12 @@ Describe 'Pwsh startup in directories that contain wild cards' -Tag CI {
         $dirnames = "[T]est","[Test","T][est","Test"
         $testcases = @()
         foreach ( $d in $dirnames ) {
-            $null = New-Item -type Directory -path "${TESTDRIVE}/$d"
+            $null = New-Item -type Directory -Path "${TESTDRIVE}/$d"
             $testcases += @{ Dirname = $d }
         }
     }
 
-    It "pwsh can startup in a directory named <dirname>" -testcases $testcases {
+    It "pwsh can startup in a directory named <dirname>" -TestCases $testcases {
         param ( $dirname )
         try {
             Push-Location -LiteralPath "${TESTDRIVE}/${dirname}"
@@ -1013,6 +1013,6 @@ Describe 'Pwsh startup and PATH' -Tag CI {
 Describe 'Console host name' -Tag CI {
     It 'Name is pwsh' -Pending {
         # waiting on https://github.com/dotnet/runtime/issues/33673
-        (Get-Process -id $PID).Name | Should -BeExactly 'pwsh'
+        (Get-Process -Id $PID).Name | Should -BeExactly 'pwsh'
     }
 }

--- a/test/powershell/Host/Logging.Tests.ps1
+++ b/test/powershell/Host/Logging.Tests.ps1
@@ -204,7 +204,7 @@ $PID
 
         $items | Should -Not -Be $null
         $items.Count | Should -BeGreaterThan 2
-        $createdEvents = $items | where-object {$_.EventId -eq 'ScriptBlock_Compile_Detail:ExecuteCommand.Create.Verbose'}
+        $createdEvents = $items | Where-Object {$_.EventId -eq 'ScriptBlock_Compile_Detail:ExecuteCommand.Create.Verbose'}
         $createdEvents.Count | Should -BeGreaterOrEqual 3
 
         # Verify we log that we are executing a file
@@ -233,7 +233,7 @@ $PID
 
         $items | Should -Not -Be $null
         $items.Count | Should -BeGreaterThan 2
-        $createdEvents = $items | where-object {$_.EventId -eq 'ScriptBlock_Compile_Detail:ExecuteCommand.Create.Verbose'}
+        $createdEvents = $items | Where-Object {$_.EventId -eq 'ScriptBlock_Compile_Detail:ExecuteCommand.Create.Verbose'}
         $createdEvents.Count | Should -BeGreaterOrEqual 3
 
         # Verify we log that we are executing a file
@@ -353,7 +353,7 @@ $PID
 
             $items | Should -Not -Be $null
             $items.Count | Should -BeGreaterThan 2
-            $createdEvents = $items | where-object {$_.EventId -eq 'ScriptBlock_Compile_Detail:ExecuteCommand.Create.Verbose'}
+            $createdEvents = $items | Where-Object {$_.EventId -eq 'ScriptBlock_Compile_Detail:ExecuteCommand.Create.Verbose'}
             $createdEvents.Count | Should -BeGreaterOrEqual 3
 
             # Verify we log that we are executing a file
@@ -391,7 +391,7 @@ $PID
 
             $items | Should -Not -Be $null
             $items.Count | Should -BeGreaterThan 2
-            $createdEvents = $items | where-object {$_.EventId -eq 'ScriptBlock_Compile_Detail:ExecuteCommand.Create.Verbose'}
+            $createdEvents = $items | Where-Object {$_.EventId -eq 'ScriptBlock_Compile_Detail:ExecuteCommand.Create.Verbose'}
             $createdEvents.Count | Should -BeGreaterOrEqual 3
 
             # Verify we log that we are executing a file

--- a/test/powershell/Host/Startup.Tests.ps1
+++ b/test/powershell/Host/Startup.Tests.ps1
@@ -105,8 +105,8 @@ Describe "Validate start of console host" -Tag CI {
         $diffs = Compare-Object -ReferenceObject $allowedAssemblies -DifferenceObject $loadedAssemblies
 
         if ($null -ne $diffs) {
-            $assembliesAllowedButNotLoaded = $diffs | Where-Object SideIndicator -eq "<=" | ForEach-Object InputObject
-            $assembliesLoadedButNotAllowed = $diffs | Where-Object SideIndicator -eq "=>" | ForEach-Object InputObject
+            $assembliesAllowedButNotLoaded = $diffs | Where-Object SideIndicator -EQ "<=" | ForEach-Object InputObject
+            $assembliesLoadedButNotAllowed = $diffs | Where-Object SideIndicator -EQ "=>" | ForEach-Object InputObject
 
             if ($assembliesAllowedButNotLoaded) {
                 Write-Host ("Assemblies that are expected but not loaded: {0}" -f ($assembliesAllowedButNotLoaded -join ", "))

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -34,12 +34,12 @@ Describe "TabCompletion" -Tags CI {
         $res.CompletionMatches[0].CompletionText | Should -BeExactly 'ToString('
     }
 
-    It 'Should complete dotnet method with null conditional operator' -skip:$nullConditionalFeatureDisabled {
+    It 'Should complete dotnet method with null conditional operator' -Skip:$nullConditionalFeatureDisabled {
         $res = TabExpansion2 -inputScript '(1)?.ToSt' -cursorColumn '(1)?.ToSt'.Length
         $res.CompletionMatches[0].CompletionText | Should -BeExactly 'ToString('
     }
 
-    It 'Should complete dotnet method with null conditional operator without first letter' -skip:$nullConditionalFeatureDisabled {
+    It 'Should complete dotnet method with null conditional operator without first letter' -Skip:$nullConditionalFeatureDisabled {
         $res = TabExpansion2 -inputScript '(1)?.' -cursorColumn '(1)?.'.Length
         $res.CompletionMatches[0].CompletionText | Should -BeExactly 'CompareTo('
     }
@@ -147,18 +147,18 @@ Describe "TabCompletion" -Tags CI {
         $res.CompletionMatches.Count | Should -BeGreaterThan 0
     }
 
-    It 'Should complete keyword' -skip {
+    It 'Should complete keyword' -Skip {
         $res = TabExpansion2 -inputScript 'using nam' -cursorColumn 'using nam'.Length
         $res.CompletionMatches[0].CompletionText | Should -BeExactly 'namespace'
     }
 
-    It 'Should first suggest -Full and then -Functionality when using Get-Help -Fu<tab>' -skip {
+    It 'Should first suggest -Full and then -Functionality when using Get-Help -Fu<tab>' -Skip {
         $res = TabExpansion2 -inputScript 'Get-Help -Fu' -cursorColumn 'Get-Help -Fu'.Length
         $res.CompletionMatches[0].CompletionText | Should -BeExactly '-Full'
         $res.CompletionMatches[1].CompletionText | Should -BeExactly '-Functionality'
     }
 
-    It 'Should first suggest -Full and then -Functionality when using help -Fu<tab>' -skip {
+    It 'Should first suggest -Full and then -Functionality when using help -Fu<tab>' -Skip {
         $res = TabExpansion2 -inputScript 'help -Fu' -cursorColumn 'help -Fu'.Length
         $res.CompletionMatches[0].CompletionText | Should -BeExactly '-Full'
         $res.CompletionMatches[1].CompletionText | Should -BeExactly '-Functionality'
@@ -349,7 +349,7 @@ Describe "TabCompletion" -Tags CI {
                 }
             }
             $line = "$nativeCommand --f"
-            $res = TaBexpansion2 -inputScript $line -cursorColumn $line.Length
+            $res = TabExpansion2 -inputScript $line -cursorColumn $line.Length
             $res.CompletionMatches | Should -HaveCount 1
             $res.CompletionMatches.CompletionText | Should -BeExactly "--flag"
         }
@@ -365,7 +365,7 @@ Describe "TabCompletion" -Tags CI {
                 }
             }
             $line = "$nativeCommand -o"
-            $res = TaBexpansion2 -inputScript $line -cursorColumn $line.Length
+            $res = TabExpansion2 -inputScript $line -cursorColumn $line.Length
             $res.CompletionMatches | Should -HaveCount 1
             $res.CompletionMatches.CompletionText | Should -BeExactly "-option"
         }
@@ -380,8 +380,8 @@ Describe "TabCompletion" -Tags CI {
 
     Context "Script name completion" {
         BeforeAll {
-            setup -f 'install-powershell.ps1' -content ""
-            setup -f 'remove-powershell.ps1' -content ""
+            Setup -f 'install-powershell.ps1' -Content ""
+            Setup -f 'remove-powershell.ps1' -Content ""
 
             $scriptWithWildcardCases = @(
                 @{
@@ -415,7 +415,7 @@ Describe "TabCompletion" -Tags CI {
             Pop-Location
         }
 
-        it "Input <name> should successfully complete" -TestCases $scriptWithWildcardCases {
+        It "Input <name> should successfully complete" -TestCases $scriptWithWildcardCases {
             param($command, $expectedCommand)
             $res = TabExpansion2 -inputScript $command -cursorColumn $command.Length
             $res.CompletionMatches.Count | Should -BeGreaterThan 0
@@ -699,7 +699,7 @@ Describe "TabCompletion" -Tags CI {
                 ## if $PSHOME contains a space tabcompletion adds ' around the path
                 @{ inputStr = 'cd $PSHOME\Modu'; expected = if($PSHOME.Contains(' ')) { "'$(Join-Path $PSHOME 'Modules')'" } else { Join-Path $PSHOME 'Modules' }; setup = $null }
                 @{ inputStr = 'cd "$PSHOME\Modu"'; expected = "`"$(Join-Path $PSHOME 'Modules')`""; setup = $null }
-                @{ inputStr = '$PSHOME\System.Management.Au'; expected = if($PSHOME.Contains(' ')) { "`& '$(Join-Path $PSHOME 'System.Management.Automation.dll')'" }  else { Join-Path $PSHOME 'System.Management.Automation.dll'; setup = $null }}
+                @{ inputStr = '$PSHOME\System.Management.Au'; expected = if($PSHOME.Contains(' ')) { "`& '$(Join-Path $PSHOME 'System.Management.Automation.dll')'" }  else { Join-Path $PSHOME 'System.Management.Automation.dll'; Setup = $null }}
                 @{ inputStr = '"$PSHOME\System.Management.Au"'; expected = "`"$(Join-Path $PSHOME 'System.Management.Automation.dll')`""; setup = $null }
                 @{ inputStr = '& "$PSHOME\System.Management.Au"'; expected = "`"$(Join-Path $PSHOME 'System.Management.Automation.dll')`""; setup = $null }
                 ## tab completion AST-based tests

--- a/test/powershell/Installer/WindowsInstaller.Tests.ps1
+++ b/test/powershell/Installer/WindowsInstaller.Tests.ps1
@@ -13,7 +13,7 @@ Describe "Windows Installer" -Tags "Scenario" {
         )
     }
 
-    It "WiX (Windows Installer XML) file contains pre-requisites link $preRequisitesLink" -skip:$skipTest {
+    It "WiX (Windows Installer XML) file contains pre-requisites link $preRequisitesLink" -Skip:$skipTest {
         $wixProductFile = Join-Path -Path $PSScriptRoot -ChildPath "..\..\..\assets\Product.wxs"
         (Get-Content $wixProductFile -Raw).Contains($preRequisitesLink) | Should -BeTrue
     }
@@ -21,7 +21,7 @@ Describe "Windows Installer" -Tags "Scenario" {
     ## Running 'Invoke-WebRequest' with WMF download URLs has been failing intermittently,
     ## because sometimes the URLs lead to a 'this download is no longer available' page.
     ## We use a retry logic here. Retry for 5 times with 1 second interval.
-    It "Pre-Requisistes link for '<Name>' is reachable: <url>" -TestCases $linkCheckTestCases -skip:$skipTest {
+    It "Pre-Requisistes link for '<Name>' is reachable: <url>" -TestCases $linkCheckTestCases -Skip:$skipTest {
         param ($Url)
 
         foreach ($i in 1..5) {

--- a/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
@@ -105,7 +105,7 @@ Describe 'Positive Parse Properties Tests' -Tags "CI" {
         class C12c { [void] f() { [System.Management.Automation.Host.Rectangle]$foo = [System.Management.Automation.Host.Rectangle]::new(0, 0, 0, 0) } }
     }
 
-    context "Positive ParseMethods return type Test" {
+    Context "Positive ParseMethods return type Test" {
         # Method with return type of self
         class C9 { [C9] f() { return [C9]::new() } }
         $c9 = [C9]::new().f()
@@ -710,7 +710,7 @@ visibleX visibleY
 
         # Get-Member should not include hidden members by default
         $member = $instance | Get-Member hiddenZ
-        it "Get-Member should not find hidden member w/o -Force" { $member | Should -BeNullOrEmpty }
+        It "Get-Member should not find hidden member w/o -Force" { $member | Should -BeNullOrEmpty }
 
         # Get-Member should include hidden members with -Force
         $member = $instance | Get-Member hiddenZ -Force
@@ -742,10 +742,10 @@ Describe 'Scoped Types Test' -Tags "CI" {
         {
             class C1 { [string] GetContext() { return "f2 scope" } }
 
-            return (new-object C1).GetContext()
+            return (New-Object C1).GetContext()
         }
 
-        It "New-Object at test scope" { (new-object C1).GetContext() | Should -BeExactly "Test scope" }
+        It "New-Object at test scope" { (New-Object C1).GetContext() | Should -BeExactly "Test scope" }
         It "[C1]::new() at test scope" { [C1]::new().GetContext() | Should -BeExactly "Test scope" }
 
         It "[C1]::new() in nested scope" { (f1) | Should -BeExactly "f1 scope" }
@@ -804,7 +804,7 @@ Describe 'Type building' -Tags "CI" {
 
 Describe 'RuntimeType created for TypeDefinitionAst' -Tags "CI" {
 
-    It 'can make cast to the right RuntimeType in two different contexts' -pending {
+    It 'can make cast to the right RuntimeType in two different contexts' -Pending {
 
         $ssfe = [System.Management.Automation.Runspaces.SessionStateFunctionEntry]::new("foo", @'
 class Base

--- a/test/powershell/Language/Classes/scripting.Classes.NestedModules.tests.ps1
+++ b/test/powershell/Language/Classes/scripting.Classes.NestedModules.tests.ps1
@@ -9,7 +9,7 @@ Describe 'NestedModules' -Tags "CI" {
             [string[]]$NestedContents
         )
 
-        new-item -type directory -Force "TestDrive:\$Name" > $null
+        New-Item -type directory -Force "TestDrive:\$Name" > $null
         $manifestParams = @{
             Path = "TestDrive:\$Name\$Name.psd1"
         }
@@ -21,7 +21,7 @@ Describe 'NestedModules' -Tags "CI" {
 
         if ($NestedContents) {
             $manifestParams['NestedModules'] = 1..$NestedContents.Count | ForEach-Object {
-                $null = new-item -type directory TestDrive:\$Name\Nested$_
+                $null = New-Item -type directory TestDrive:\$Name\Nested$_
                 $null = Set-Content -Path "${TestDrive}\$Name\Nested$_\Nested$_.psm1" -Value $NestedContents[$_ - 1]
                 "Nested$_"
             }
@@ -29,7 +29,7 @@ Describe 'NestedModules' -Tags "CI" {
 
         New-ModuleManifest @manifestParams
 
-        $resolvedTestDrivePath = Split-Path ((get-childitem TestDrive:\)[0].FullName)
+        $resolvedTestDrivePath = Split-Path ((Get-ChildItem TestDrive:\)[0].FullName)
         if (-not ($env:PSModulePath -like "*$resolvedTestDrivePath*")) {
             $env:PSModulePath += "$([System.IO.Path]::PathSeparator)$resolvedTestDrivePath"
         }
@@ -103,7 +103,7 @@ using module WithRoot
             # We need to think about it: should it work or not.
             # Currently, types are resolved in compile-time to the 'local' versions
             # So at runtime we don't call the module versions.
-            It 'Can execute type creation in the module context with new()' -pending {
+            It 'Can execute type creation in the module context with new()' -Pending {
                 & (Get-Module ABC) { [C]::new().foo() } | Should -Be C
                 & (Get-Module NoRoot) { [A]::new().foo() } | Should -Be A2
                 & (Get-Module WithRoot) { [A]::new().foo() } | Should -Be A0

--- a/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
+++ b/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
@@ -103,7 +103,7 @@ Describe 'Classes inheritance syntax' -Tags "CI" {
                 [void]ExitNestedPrompt(){ throw "Unsupported" }
                 [void]NotifyBeginApplication() { }
                 [void]NotifyEndApplication() { }
-                [string]get_Name() { return $this.myName; write-host "MyName" }
+                [string]get_Name() { return $this.myName; Write-Host "MyName" }
                 [version]get_Version() { return $this.myVersion }
                 [System.Globalization.CultureInfo]get_CurrentCulture() { return $this.myCurrentCulture }
                 [System.Globalization.CultureInfo]get_CurrentUICulture() { return $this.myCurrentUICulture }

--- a/test/powershell/Language/Classes/scripting.Classes.using.tests.ps1
+++ b/test/powershell/Language/Classes/scripting.Classes.using.tests.ps1
@@ -14,15 +14,15 @@ Describe 'using module' -Tags "CI" {
             )
 
             if ($manifest) {
-                new-item -type directory -Force "${TestDrive}\$ModulePathPrefix\$Name\$Version" > $null
+                New-Item -type directory -Force "${TestDrive}\$ModulePathPrefix\$Name\$Version" > $null
                 Set-Content -Path "${TestDrive}\$ModulePathPrefix\$Name\$Version\$Name.psm1" -Value $Content
                 New-ModuleManifest -RootModule "$Name.psm1" -Path "${TestDrive}\$ModulePathPrefix\$Name\$Version\$Name.psd1" -ModuleVersion $Version
             } else {
-                new-item -type directory -Force "${TestDrive}\$ModulePathPrefix\$Name" > $null
+                New-Item -type directory -Force "${TestDrive}\$ModulePathPrefix\$Name" > $null
                 Set-Content -Path "${TestDrive}\$ModulePathPrefix\$Name\$Name.psm1" -Value $Content
             }
 
-            $resolvedTestDrivePath = Split-Path ((get-childitem "${TestDrive}\$ModulePathPrefix")[0].FullName)
+            $resolvedTestDrivePath = Split-Path ((Get-ChildItem "${TestDrive}\$ModulePathPrefix")[0].FullName)
             if (-not ($env:PSModulePath -like "*$resolvedTestDrivePath*")) {
                 $env:PSModulePath += "$([System.IO.Path]::PathSeparator)$resolvedTestDrivePath"
             }
@@ -416,7 +416,7 @@ function foo()
 }
 '@
             # resolve name to absolute path
-            $scriptToProcessPath = (get-childitem $scriptToProcessPath).FullName
+            $scriptToProcessPath = (Get-ChildItem $scriptToProcessPath).FullName
             $iss = [System.Management.Automation.Runspaces.initialsessionstate]::CreateDefault()
             $iss.StartupScripts.Add($scriptToProcessPath)
 
@@ -442,7 +442,7 @@ function foo()
             New-TestModule -Name FooForPaths -Content 'class Foo { [string] GetModuleName() { return "FooForPaths" } }'
             $env:PSModulePath = $originalPSModulePath
 
-            new-item -type directory -Force TestDrive:\FooRelativeConsumer
+            New-Item -type directory -Force TestDrive:\FooRelativeConsumer
             Set-Content -Path "${TestDrive}\FooRelativeConsumer\FooRelativeConsumer.ps1" -Value @'
 using module ..\modules\FooForPaths
 class Bar : Foo {}
@@ -471,7 +471,7 @@ class Bar : Foo {}
         }
 
         It "can be accessed by absolute path" {
-            $resolvedTestDrivePath = Split-Path ((get-childitem TestDrive:\modules)[0].FullName)
+            $resolvedTestDrivePath = Split-Path ((Get-ChildItem TestDrive:\modules)[0].FullName)
             $s = @"
 using module $resolvedTestDrivePath\FooForPaths
 [Foo]::new()
@@ -483,7 +483,7 @@ using module $resolvedTestDrivePath\FooForPaths
         }
 
         It "can be accessed by absolute path with file extension" {
-            $resolvedTestDrivePath = Split-Path ((get-childitem TestDrive:\modules)[0].FullName)
+            $resolvedTestDrivePath = Split-Path ((Get-ChildItem TestDrive:\modules)[0].FullName)
             $barObject = [scriptblock]::Create(@"
 using module $resolvedTestDrivePath\FooForPaths\FooForPaths.psm1
 [Foo]::new()

--- a/test/powershell/Language/Operators/ComparisonOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/ComparisonOperator.Tests.ps1
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-Describe "ComparisonOperator" -tag "CI" {
+Describe "ComparisonOperator" -Tag "CI" {
 
     It "Should be <result> for <lhs> <operator> <rhs>" -TestCases @(
         @{lhs = 1; operator = "-lt"; rhs = 2; result = $true},
@@ -84,7 +84,7 @@ Describe "ComparisonOperator" -tag "CI" {
     }
 }
 
-Describe "Bytewise Operator" -tag "CI" {
+Describe "Bytewise Operator" -Tag "CI" {
 
     It "Test -bor on enum with [byte] as underlying type" {
         $result = [System.Security.AccessControl.AceFlags]::ObjectInherit -bxor `

--- a/test/powershell/Language/Operators/PipelineChainOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/PipelineChainOperator.Tests.ps1
@@ -341,6 +341,6 @@ function Test-FullyTerminatingError
     It "Recognises invalid assignment" {
         {
             Invoke-Expression -Command '$x = $x, $y += $z = testexe -returncode 0 && testexe -returncode 1'
-        } | Should -Throw -ErrorID 'InvalidLeftHandSide,Microsoft.PowerShell.Commands.InvokeExpressionCommand'
+        } | Should -Throw -ErrorId 'InvalidLeftHandSide,Microsoft.PowerShell.Commands.InvokeExpressionCommand'
     }
 }

--- a/test/powershell/Language/Operators/TernaryOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/TernaryOperator.Tests.ps1
@@ -40,7 +40,7 @@ Describe "Using of ternary operator" -Tags CI {
             @{ Script = { $IsCoreCLR ? $false ? 'nested-if-true' : $true ? 'nested-nested-if-true' : 'nested-nested-if-false' : 'if-false' }; ExpectedValue = 'nested-nested-if-true' }
 
             ## Binary operator has higher precedence order than ternary
-            @{ Script = { !$IsCoreCLR ? 'Core' : 'Desktop' -eq 'Core' };  ExpectedValue = !$IsCoreCLR ? 'Core' : ('Desktop' -eq 'Core') }
+            @{ Script = { !$IsCoreCLR ? 'Core' : 'Desktop' -EQ 'Core' };  ExpectedValue = !$IsCoreCLR ? 'Core' : ('Desktop' -eq 'Core') }
             @{ Script = { ($IsCoreCLR ? 'Core' : 'Desktop') -eq 'Core' }; ExpectedValue = $true }
         )
     }
@@ -57,7 +57,7 @@ Describe "Using of ternary operator" -Tags CI {
     }
 
     It "Ternary expression which generates a terminating error should halt appropriately" {
-        { (write-error -Message error -ErrorAction Stop) ? 1 : 2 } | Should -Throw -ErrorId Microsoft.PowerShell.Commands.WriteErrorException
+        { (Write-Error -Message error -ErrorAction Stop) ? 1 : 2 } | Should -Throw -ErrorId Microsoft.PowerShell.Commands.WriteErrorException
     }
 
     It "Use ternary operator in parameter default values" {

--- a/test/powershell/Language/Parser/ExtensibleCompletion.Tests.ps1
+++ b/test/powershell/Language/Parser/ExtensibleCompletion.Tests.ps1
@@ -108,7 +108,7 @@ function Test-Completions
                 {
                     $skip = $false
                     if ( $expected.CompletionText -Match "System.Management.Automation.PerformanceData|System.Management.Automation.Security" ) { $skip = $true }
-                    It ($expected.CompletionText) -skip:$skip {
+                    It ($expected.CompletionText) -Skip:$skip {
                         $expected.Found | Should -BeTrue
                     }
                 }
@@ -435,7 +435,7 @@ Describe "ArgumentCompletionsAttribute tests" -Tags "CI" {
         param($attributeName, $cmdletName)
 
         $line = "$cmdletName -Alpha val"
-        $res = TaBexpansion2 -inputScript $line -cursorColumn $line.Length
+        $res = TabExpansion2 -inputScript $line -cursorColumn $line.Length
         $res.CompletionMatches.Count | Should -Be 3
         $res.CompletionMatches.CompletionText -join " " | Should -BeExactly "value1 value2 value3"
         { TestArgumentCompletionsAttribute -Alpha unExpectedValue } | Should -Not -Throw
@@ -445,7 +445,7 @@ Describe "ArgumentCompletionsAttribute tests" -Tags "CI" {
         param($attributeName, $cmdletName)
 
         $line = "$cmdletName -Param1 val"
-        $res = TaBexpansion2 -inputScript $line -cursorColumn $line.Length
+        $res = TabExpansion2 -inputScript $line -cursorColumn $line.Length
         $res.CompletionMatches.Count | Should -Be 3
         $res.CompletionMatches.CompletionText -join " " | Should -BeExactly "value1 value2 value3"
         { TestArgumentCompletionsAttribute -Param1 unExpectedValue } | Should -Not -Throw

--- a/test/powershell/Language/Parser/LanguageAndParser.TestFollowup.Tests.ps1
+++ b/test/powershell/Language/Parser/LanguageAndParser.TestFollowup.Tests.ps1
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-$powershellexe = (get-process -id $PID).mainmodule.filename
+$powershellexe = (Get-Process -Id $PID).mainmodule.filename
 
 Describe "Clone array" -Tags "CI" {
     It "Cast in target expr" {
@@ -27,7 +27,7 @@ Describe "Set fields through PSMemberInfo" -Tags "CI" {
         ([AStruct]@{s = "abc" }).s | Should -BeExactly "abc"
     }
     It "via new-object" {
-        (new-object AStruct -prop @{s="abc"}).s | Should -BeExactly "abc"
+        (New-Object AStruct -prop @{s="abc"}).s | Should -BeExactly "abc"
     }
     It "via PSObject" {
         $x = [AStruct]::new()

--- a/test/powershell/Language/Parser/ParameterBinding.Tests.ps1
+++ b/test/powershell/Language/Parser/ParameterBinding.Tests.ps1
@@ -79,23 +79,23 @@ Describe 'Argument transformation attribute on optional argument with explicit $
     It "Script function takes uint64" {
         Invoke-ScriptFunctionTakesUInt64 | Should -Be 42
     }
-    it "csharp cmdlet takes object" {
+    It "csharp cmdlet takes object" {
         Invoke-CSharpCmdletTakesObject | Should -Be "passed in null"
     }
-    it "csharp cmdlet takes uint64" {
+    It "csharp cmdlet takes uint64" {
         Invoke-CSharpCmdletTakesUInt64 | Should -Be 0
     }
 
-    it "script function takes object when parameter is null" {
+    It "script function takes object when parameter is null" {
         Invoke-ScriptFunctionTakesObject -Address $null | Should -Be 42
     }
-    it "script function takes unit64 when parameter is null" {
+    It "script function takes unit64 when parameter is null" {
         Invoke-ScriptFunctionTakesUInt64 -Address $null | Should -Be 42
     }
-    it "script csharp cmdlet takes object when parameter is null" {
+    It "script csharp cmdlet takes object when parameter is null" {
         Invoke-CSharpCmdletTakesObject -Address $null | Should -Be 42
     }
-    it "script csharp cmdlet takes uint64 when parameter is null" {
+    It "script csharp cmdlet takes uint64 when parameter is null" {
         Invoke-CSharpCmdletTakesUInt64 -Address $null | Should -Be 42
     }
 }

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -703,7 +703,7 @@ foo``u{2195}abc
         if ( $IsLinux -or $IsMacOS ) {
             # because we execute on *nix based on executable bit, and the file name doesn't matter
             # so we can use the same filename as for windows, just make sure it's executable with chmod
-            "#!/bin/sh`necho ""Hello World""" | Out-File -encoding ASCII $shellfile
+            "#!/bin/sh`necho ""Hello World""" | Out-File -Encoding ASCII $shellfile
             /bin/chmod +x $shellfile
         }
         else {

--- a/test/powershell/Language/Parser/Parsing.Tests.ps1
+++ b/test/powershell/Language/Parser/Parsing.Tests.ps1
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-set-strictmode -v 2
+Set-StrictMode -v 2
 
 Describe 'for statement parsing' -Tags "CI" {
     ShouldBeParseError 'for' MissingOpenParenthesisAfterKeyword 4 -CheckColumnNumber

--- a/test/powershell/Language/Parser/UsingAssembly.Tests.ps1
+++ b/test/powershell/Language/Parser/UsingAssembly.Tests.ps1
@@ -44,7 +44,7 @@ public class ABC {}
             $err[0].ErrorId | Should -Be CannotLoadAssemblyWithUriSchema
         }
 
-        It "parse does not load the assembly" -pending {
+        It "parse does not load the assembly" -Pending {
             $assemblies = [Appdomain]::CurrentDomain.GetAssemblies().GetName().Name
             $assemblies -contains "UsingAssemblyTest$guid" | Should -BeFalse
 
@@ -73,7 +73,7 @@ public class ABC {}
             $e.Exception.InnerException.ErrorRecord.FullyQualifiedErrorId | Should -Be 'ErrorLoadingAssembly'
         }
 #>
-        It "Assembly loaded at runtime" -pending {
+        It "Assembly loaded at runtime" -Pending {
             $assemblies = & "$PSHOME/pwsh" -noprofile -command @"
     using assembly .\UsingAssemblyTest$guid.dll
     [Appdomain]::CurrentDomain.GetAssemblies().GetName().Name

--- a/test/powershell/Language/Parser/UsingNamespace.Tests.ps1
+++ b/test/powershell/Language/Parser/UsingNamespace.Tests.ps1
@@ -60,7 +60,7 @@ Describe "Using Namespace" -Tags "CI" {
         New-Object CompilerGeneratedAttribute | Should -Be System.Runtime.CompilerServices.CompilerGeneratedAttribute
     }
 
-    It "Attributes w/ using namespace" -pending {
+    It "Attributes w/ using namespace" -Pending {
         function foo
         {
             [DebuggerStepThrough()]

--- a/test/powershell/Language/Scripting/ActionPreference.Tests.ps1
+++ b/test/powershell/Language/Scripting/ActionPreference.Tests.ps1
@@ -209,7 +209,7 @@ Describe "Tests for (error, warning, etc) action preference" -Tags "CI" {
     }
 }
 
-Describe 'ActionPreference.Break tests' -tag 'CI' {
+Describe 'ActionPreference.Break tests' -Tag 'CI' {
 
     BeforeAll {
         Register-DebuggerHandler
@@ -239,7 +239,7 @@ Describe 'ActionPreference.Break tests' -tag 'CI' {
                 Test-Break -ErrorAction Break
             }
 
-            $results = @(Test-Debugger -ScriptBlock $testScript -CommandQueue 'v', 'v')
+            $results = @(Test-Debugger -Scriptblock $testScript -CommandQueue 'v', 'v')
         }
 
         It 'Should show 3 debugger commands were invoked' {
@@ -280,7 +280,7 @@ Describe 'ActionPreference.Break tests' -tag 'CI' {
                 Test-Break -ErrorAction Break
             }
 
-            $results = @(Test-Debugger -ScriptBlock $testScript -CommandQueue 'v', 'v')
+            $results = @(Test-Debugger -Scriptblock $testScript -CommandQueue 'v', 'v')
         }
 
         It 'Should show 3 debugger commands were invoked' {
@@ -321,7 +321,7 @@ Describe 'ActionPreference.Break tests' -tag 'CI' {
                 Test-Break -ErrorAction Break
             }
 
-            $results = @(Test-Debugger -ScriptBlock $testScript)
+            $results = @(Test-Debugger -Scriptblock $testScript)
         }
 
         It 'Should show 1 debugger command was invoked' {
@@ -354,7 +354,7 @@ Describe 'ActionPreference.Break tests' -tag 'CI' {
                 Test-Break -ErrorAction Break
             }
 
-            $results = @(Test-Debugger -ScriptBlock $testScript)
+            $results = @(Test-Debugger -Scriptblock $testScript)
         }
 
         It 'Should show 2 debugger commands were invoked' {
@@ -390,7 +390,7 @@ Describe 'ActionPreference.Break tests' -tag 'CI' {
                 Test-Break *>$null
             }
 
-            $results = @(Test-Debugger -ScriptBlock $testScript)
+            $results = @(Test-Debugger -Scriptblock $testScript)
         }
 
         It 'Should show 7 debugger commands were invoked' {

--- a/test/powershell/Language/Scripting/CheckRestrictedlanguage.Tests.ps1
+++ b/test/powershell/Language/Scripting/CheckRestrictedlanguage.Tests.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 Describe "Test restricted language check method on scriptblocks" -Tags "CI" {
         BeforeAll {
-            set-strictmode -v 2
+            Set-StrictMode -v 2
             function list {
 
             $l = [System.Collections.Generic.List[String]]::new()
@@ -62,12 +62,12 @@ Describe "Test restricted language check method on scriptblocks" -Tags "CI" {
         }
 
         It 'Check for restricted commands' {
-            { {get-date}.CheckRestrictedLangauge($null, $null, $false) } | Should -Throw -ErrorId 'MethodNotFound'
+            { {Get-Date}.CheckRestrictedLangauge($null, $null, $false) } | Should -Throw -ErrorId 'MethodNotFound'
         }
 
         It 'Check for allowed commands and variables' {
 
-            { { get-process | where name -Match $pattern | foreach $prop }.CheckRestrictedLanguage(
+            { { Get-Process | where name -Match $pattern | foreach $prop }.CheckRestrictedLanguage(
                 (list get-process where foreach),
                 (list prop pattern)
                 , $false) } | Should -Not -Throw

--- a/test/powershell/Language/Scripting/Debugging/DebuggerCommand.Tests.ps1
+++ b/test/powershell/Language/Scripting/Debugging/DebuggerCommand.Tests.ps1
@@ -127,7 +127,7 @@ Describe 'Basic debugger command tests' -Tag 'CI' {
             $testScriptList = @'
     4:*                     Get-Process -Id $PID > $null
     5:                  } finally {
-    6:                      Remove-PSBreakPoint -Breakpoint $bp
+    6:                      Remove-PSBreakpoint -Breakpoint $bp
     7:                  }
     8:
 '@

--- a/test/powershell/Language/Scripting/Debugging/DebuggerCommand.Tests.ps1
+++ b/test/powershell/Language/Scripting/Debugging/DebuggerCommand.Tests.ps1
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Describe 'Basic debugger command tests' -tag 'CI' {
+Describe 'Basic debugger command tests' -Tag 'CI' {
 
     BeforeAll {
         Register-DebuggerHandler
@@ -27,11 +27,11 @@ Describe 'Basic debugger command tests' -tag 'CI' {
                     $bp = Set-PSBreakpoint -Command Get-Process
                     Get-Process -Id $PID > $null
                 } finally {
-                    Remove-PSBreakPoint -Breakpoint $bp
+                    Remove-PSBreakpoint -Breakpoint $bp
                 }
             }
 
-            $results = @(Test-Debugger -ScriptBlock $testScript -CommandQueue '?','h')
+            $results = @(Test-Debugger -Scriptblock $testScript -CommandQueue '?','h')
             $result = @{
                 '?' = if ($results.Count -gt 0) {$results[0].Output -join [Environment]::NewLine}
                 'h' = if ($results.Count -gt 1) {$results[1].Output -join [Environment]::NewLine}
@@ -71,7 +71,7 @@ Describe 'Basic debugger command tests' -tag 'CI' {
                     $bp = Set-PSBreakpoint -Command Get-Process
                     Get-Process -Id $PID > $null
                 } finally {
-                    Remove-PSBreakPoint -Breakpoint $bp
+                    Remove-PSBreakpoint -Breakpoint $bp
                 }
             }
 
@@ -87,7 +87,7 @@ Describe 'Basic debugger command tests' -tag 'CI' {
 '@
             $testScriptList = NormalizeLineEnd -string $testScriptList
 
-            $results = @(Test-Debugger -ScriptBlock $testScript -CommandQueue 'l','list')
+            $results = @(Test-Debugger -Scriptblock $testScript -CommandQueue 'l','list')
             $result = @{
                 'l' = if ($results.Count -gt 0) {$results[0].Output -replace '\s+$' -join [Environment]::NewLine -replace "^[`r`n]+|[`r`n]+$"}
                 'list' = if ($results.Count -gt 1) {$results[1].Output -replace '\s+$' -join [Environment]::NewLine -replace "^[`r`n]+|[`r`n]+$"}
@@ -120,7 +120,7 @@ Describe 'Basic debugger command tests' -tag 'CI' {
                     $bp = Set-PSBreakpoint -Command Get-Process
                     Get-Process -Id $PID > $null
                 } finally {
-                    Remove-PSBreakPoint -Breakpoint $bp
+                    Remove-PSBreakpoint -Breakpoint $bp
                 }
             }
 
@@ -134,7 +134,7 @@ Describe 'Basic debugger command tests' -tag 'CI' {
 
             $testScriptList = NormalizeLineEnd -string $testScriptList
 
-            $results = @(Test-Debugger -ScriptBlock $testScript -CommandQueue 'l 4','list 4')
+            $results = @(Test-Debugger -Scriptblock $testScript -CommandQueue 'l 4','list 4')
             $result = @{
                 'l 4' = if ($results.Count -gt 0) {$results[0].Output -replace '\s+$' -join [Environment]::NewLine -replace "^[`r`n]+|[`r`n]+$"}
                 'list 4' = if ($results.Count -gt 1) {$results[1].Output -replace '\s+$' -join [Environment]::NewLine -replace "^[`r`n]+|[`r`n]+$"}
@@ -167,7 +167,7 @@ Describe 'Basic debugger command tests' -tag 'CI' {
                     $bp = Set-PSBreakpoint -Command Get-Process
                     Get-Process -Id $PID > $null
                 } finally {
-                    Remove-PSBreakPoint -Breakpoint $bp
+                    Remove-PSBreakpoint -Breakpoint $bp
                 }
             }
 
@@ -178,7 +178,7 @@ Describe 'Basic debugger command tests' -tag 'CI' {
 
             $testScriptList = NormalizeLineEnd -string $testScriptList
 
-            $results = @(Test-Debugger -ScriptBlock $testScript -CommandQueue 'l 3 2','list 3 2')
+            $results = @(Test-Debugger -Scriptblock $testScript -CommandQueue 'l 3 2','list 3 2')
             $result = @{
                 'l 3 2' = if ($results.Count -gt 0) {$results[0].Output -replace '\s+$' -join [Environment]::NewLine -replace "^[`r`n]+|[`r`n]+$"}
                 'list 3 2' = if ($results.Count -gt 1) {$results[1].Output -replace '\s+$' -join [Environment]::NewLine -replace "^[`r`n]+|[`r`n]+$"}
@@ -211,11 +211,11 @@ Describe 'Basic debugger command tests' -tag 'CI' {
                     $bp = Set-PSBreakpoint -Command Get-Process
                     Get-Process -Id $PID > $null
                 } finally {
-                    Remove-PSBreakPoint -Breakpoint $bp
+                    Remove-PSBreakpoint -Breakpoint $bp
                 }
             }
 
-            $results = @(Test-Debugger -ScriptBlock $testScript -CommandQueue 'k','Get-PSCallStack')
+            $results = @(Test-Debugger -Scriptblock $testScript -CommandQueue 'k','Get-PSCallStack')
             $result = @{
                 'k' = if ($results.Count -gt 0) {$results[0].Output}
                 'Get-PSCallStack' = if ($results.Count -gt 1) {$results[1].Output}
@@ -238,7 +238,7 @@ Describe 'Basic debugger command tests' -tag 'CI' {
 
 }
 
-Describe 'Simple debugger stepping command tests' -tag 'CI' {
+Describe 'Simple debugger stepping command tests' -Tag 'CI' {
 
     BeforeAll {
         Register-DebuggerHandler
@@ -258,13 +258,13 @@ Describe 'Simple debugger stepping command tests' -tag 'CI' {
                         'Red fish, blue fish'
                     } *> $null
                 } finally {
-                    Remove-PSBreakPoint -Breakpoint $bp
+                    Remove-PSBreakpoint -Breakpoint $bp
                 }
             }
 
             $result = @{
-                's' = @(Test-Debugger -ScriptBlock $testScript -CommandQueue 's','s','s','s')
-                'stepInto' = @(Test-Debugger -ScriptBlock $testScript -CommandQueue 'stepInto','stepInto','stepInto','stepInto')
+                's' = @(Test-Debugger -Scriptblock $testScript -CommandQueue 's','s','s','s')
+                'stepInto' = @(Test-Debugger -Scriptblock $testScript -CommandQueue 'stepInto','stepInto','stepInto','stepInto')
             }
         }
 
@@ -311,13 +311,13 @@ Describe 'Simple debugger stepping command tests' -tag 'CI' {
                         Get-Date | ConvertTo-Csv
                     } *> $null
                 } finally {
-                    Remove-PSBreakPoint -Breakpoint $bp1,$bp2
+                    Remove-PSBreakpoint -Breakpoint $bp1,$bp2
                 }
             }
 
             $result = @{
-                'v' = @(Test-Debugger -ScriptBlock $testScript -CommandQueue 'v','v','v','v')
-                'stepOver' = @(Test-Debugger -ScriptBlock $testScript -CommandQueue 'stepOver','stepOver','stepOver','stepOver')
+                'v' = @(Test-Debugger -Scriptblock $testScript -CommandQueue 'v','v','v','v')
+                'stepOver' = @(Test-Debugger -Scriptblock $testScript -CommandQueue 'stepOver','stepOver','stepOver','stepOver')
             }
         }
 
@@ -362,13 +362,13 @@ Describe 'Simple debugger stepping command tests' -tag 'CI' {
                     $date = Get-Date
                     $date | ConvertTo-Csv
                 } finally {
-                    Remove-PSBreakPoint -Breakpoint $bps
+                    Remove-PSBreakpoint -Breakpoint $bps
                 }
             }
 
             $result = @{
-                'o' = @(Test-Debugger -ScriptBlock $testScript -CommandQueue 'o','o','o')
-                'stepOut' = @(Test-Debugger -ScriptBlock $testScript -CommandQueue 'stepOut','stepOut','stepOut')
+                'o' = @(Test-Debugger -Scriptblock $testScript -CommandQueue 'o','o','o')
+                'stepOut' = @(Test-Debugger -Scriptblock $testScript -CommandQueue 'stepOut','stepOut','stepOut')
             }
         }
 
@@ -398,7 +398,7 @@ Describe 'Simple debugger stepping command tests' -tag 'CI' {
     }
 }
 
-Describe 'Debugger bug fix tests' -tag 'CI' {
+Describe 'Debugger bug fix tests' -Tag 'CI' {
 
     BeforeAll {
         Register-DebuggerHandler
@@ -413,16 +413,16 @@ Describe 'Debugger bug fix tests' -tag 'CI' {
             $testScript = {
                 function Test-Issue9824 {
                     $bp = Set-PSBreakpoint -Command Remove-PSBreakpoint
-                    Remove-PSBreakPoint -Breakpoint $bp
+                    Remove-PSBreakpoint -Breakpoint $bp
                 }
                 Test-Issue9824
                 1 + 1
             }
 
             $result = @{
-                's' = @(Test-Debugger -ScriptBlock $testScript -CommandQueue 's','s','s')
-                'v' = @(Test-Debugger -ScriptBlock $testScript -CommandQueue 'v','v','v')
-                'o' = @(Test-Debugger -ScriptBlock $testScript -CommandQueue 'o','o')
+                's' = @(Test-Debugger -Scriptblock $testScript -CommandQueue 's','s','s')
+                'v' = @(Test-Debugger -Scriptblock $testScript -CommandQueue 'v','v','v')
+                'o' = @(Test-Debugger -Scriptblock $testScript -CommandQueue 'o','o')
             }
         }
 

--- a/test/powershell/Language/Scripting/Debugging/DebuggerCommand.Tests.ps1
+++ b/test/powershell/Language/Scripting/Debugging/DebuggerCommand.Tests.ps1
@@ -81,7 +81,7 @@ Describe 'Basic debugger command tests' -Tag 'CI' {
     3:                      $bp = Set-PSBreakpoint -Command Get-Process
     4:*                     Get-Process -Id $PID > $null
     5:                  } finally {
-    6:                      Remove-PSBreakPoint -Breakpoint $bp
+    6:                      Remove-PSBreakpoint -Breakpoint $bp
     7:                  }
     8:
 '@

--- a/test/powershell/Language/Scripting/Debugging/DebuggerScriptTests.Tests.ps1
+++ b/test/powershell/Language/Scripting/Debugging/DebuggerScriptTests.Tests.ps1
@@ -22,18 +22,18 @@ Describe "Breakpoints set on custom FileSystem provider files should work" -Tags
         $scriptName = "DebuggerScriptTests-ExposeBug221362.ps1"
         $scriptFullName = [io.path]::Combine($scriptPath, $scriptName)
 
-        write-output '"hello"' > $scriptFullName
+        Write-Output '"hello"' > $scriptFullName
 
         #
         # Create a file system provider
         #
-        new-psdrive -name tmpTestA1 -psprovider FileSystem -root $scriptPath > $null
+        New-PSDrive -Name tmpTestA1 -PSProvider FileSystem -Root $scriptPath > $null
 
         #
         # Verify that the breakpoint is hit when using the provider
         #
         Push-Location tmpTestA1:\
-        $breakpoint = set-psbreakpoint .\$scriptName 1 -action { continue }
+        $breakpoint = Set-PSBreakpoint .\$scriptName 1 -Action { continue }
         & .\$scriptName
 
 	    It "Breakpoint hit count" {
@@ -44,7 +44,7 @@ Describe "Breakpoints set on custom FileSystem provider files should work" -Tags
     {
         Pop-Location
 
-        if ($null -ne $breakpoint) { $breakpoint | remove-psbreakpoint }
+        if ($null -ne $breakpoint) { $breakpoint | Remove-PSBreakpoint }
         if (Test-Path $scriptFullName) { Remove-Item $scriptFullName -Force }
         if ($null -ne (Get-PSDrive -Name tmpTestA1 2> $null)) { Remove-PSDrive -Name tmpTestA1 -Force }
     }
@@ -64,7 +64,7 @@ Describe "Tests line breakpoints on dot-sourced files" -Tags "CI" {
         #
         $scriptFile = [io.path]::Combine([io.path]::GetTempPath(), "DebuggerScriptTests-ExposeBug245331.ps1")
 
-        write-output '
+        Write-Output '
         function fibonacci
         {
             param($number)
@@ -89,7 +89,7 @@ Describe "Tests line breakpoints on dot-sourced files" -Tags "CI" {
         #
         # Set the breakpoint and verify it is hit
         #
-        $breakpoint = Set-PsBreakpoint $scriptFile 17 -action { continue; }
+        $breakpoint = Set-PSBreakpoint $scriptFile 17 -Action { continue; }
 
         & $scriptFile
 
@@ -99,7 +99,7 @@ Describe "Tests line breakpoints on dot-sourced files" -Tags "CI" {
     }
     finally
     {
-        if ($null -ne $breakpoint) { $breakpoint | remove-psbreakpoint }
+        if ($null -ne $breakpoint) { $breakpoint | Remove-PSBreakpoint }
         if (Test-Path $scriptFile) { Remove-Item -Path $scriptFile -Force }
     }
 }
@@ -123,7 +123,7 @@ Describe "Function calls clear debugger cache too early" -Tags "CI" {
         #
         $scriptFile = [io.path]::Combine([io.path]::GetTempPath(), "DebuggerScriptTests-ExposeBug248703.ps1")
 
-        write-output '
+        Write-Output '
         function Hello
         {
             write-output "hello"
@@ -137,8 +137,8 @@ Describe "Function calls clear debugger cache too early" -Tags "CI" {
         #
         # Set the breakpoints and verify they are hit
         #
-        $breakpoint1 = Set-PsBreakpoint $scriptFile 7 -action { continue; }
-        $breakpoint2 = Set-PsBreakpoint $scriptFile 9 -action { continue; }
+        $breakpoint1 = Set-PSBreakpoint $scriptFile 7 -Action { continue; }
+        $breakpoint2 = Set-PSBreakpoint $scriptFile 9 -Action { continue; }
 
         & $scriptFile
 
@@ -152,8 +152,8 @@ Describe "Function calls clear debugger cache too early" -Tags "CI" {
     }
     finally
     {
-        if ($null -ne $breakpoint1) { $breakpoint1 | remove-psbreakpoint }
-        if ($null -ne $breakpoint2) { $breakpoint2 | remove-psbreakpoint }
+        if ($null -ne $breakpoint1) { $breakpoint1 | Remove-PSBreakpoint }
+        if ($null -ne $breakpoint2) { $breakpoint2 | Remove-PSBreakpoint }
         if (Test-Path $scriptFile) { Remove-Item $scriptFile -Force }
     }
 }
@@ -180,7 +180,7 @@ Describe "Line breakpoints on commands in multi-line pipelines" -Tags "CI" {
         get-unique
 '@
 
-        $breakpoints = Set-PsBreakpoint $script 1,2,3 -action { continue }
+        $breakpoints = Set-PSBreakpoint $script 1,2,3 -Action { continue }
 
         $null = & $script
 
@@ -198,7 +198,7 @@ Describe "Line breakpoints on commands in multi-line pipelines" -Tags "CI" {
     }
     finally
     {
-        if ($null -ne $breakpoints) { $breakpoints | remove-psbreakpoint }
+        if ($null -ne $breakpoints) { $breakpoints | Remove-PSBreakpoint }
         if (Test-Path $script)
         {
             Remove-Item $script -Force
@@ -210,7 +210,7 @@ Describe "Line breakpoints on commands in multi-line pipelines" -Tags "CI" {
         BeforeAll {
             if ( $IsCoreCLR ) { return } # no COM on core
             $scriptPath1 = Join-Path $TestDrive SBPShortPathBug133807.DRT.tmp.ps1
-            $scriptPath1 = setup -f SBPShortPathBug133807.DRT.tmp.ps1 -content '
+            $scriptPath1 = Setup -f SBPShortPathBug133807.DRT.tmp.ps1 -Content '
             1..3 |
             ForEach-Object { $_ } | sort-object |
             get-unique'
@@ -218,7 +218,7 @@ Describe "Line breakpoints on commands in multi-line pipelines" -Tags "CI" {
             $f = $a.GetFile($scriptPath1)
             $scriptPath2 = $f.ShortPath
 
-            $breakpoints = Set-PsBreakpoint $scriptPath2 1,2,3 -action { continue }
+            $breakpoints = Set-PSBreakpoint $scriptPath2 1,2,3 -Action { continue }
             $null = & $scriptPath2
         }
 
@@ -227,15 +227,15 @@ Describe "Line breakpoints on commands in multi-line pipelines" -Tags "CI" {
             if ($null -ne $breakpoints) { $breakpoints | Remove-PSBreakpoint }
         }
 
-        It "Short path Breakpoint on line 1 hit count" -skip:$IsCoreCLR {
+        It "Short path Breakpoint on line 1 hit count" -Skip:$IsCoreCLR {
             $breakpoints[0].HitCount | Should -Be 1
         }
 
-        It "Short path Breakpoint on line 2 hit count" -skip:$IsCoreCLR {
+        It "Short path Breakpoint on line 2 hit count" -Skip:$IsCoreCLR {
             $breakpoints[1].HitCount | Should -Be 3
         }
 
-        It "Short path Breakpoint on line 3 hit count" -skip:$IsCoreCLR {
+        It "Short path Breakpoint on line 3 hit count" -Skip:$IsCoreCLR {
             $breakpoints[2].HitCount | Should -Be 1
         }
     }
@@ -251,7 +251,7 @@ Describe "Unit tests for various script breakpoints" -Tags "CI" {
 
     if ($null -eq $path)
     {
-        $path = split-path $MyInvocation.InvocationName
+        $path = Split-Path $MyInvocation.InvocationName
     }
 
     #
@@ -290,7 +290,7 @@ Describe "Unit tests for various script breakpoints" -Tags "CI" {
         #
         # Ensure there are no breakpoints at start of test
         #
-        Get-PsBreakpoint | Remove-PsBreakpoint
+        Get-PSBreakpoint | Remove-PSBreakpoint
 
         #
         # Create a couple of scripts
@@ -298,54 +298,54 @@ Describe "Unit tests for various script breakpoints" -Tags "CI" {
         $scriptFile1 = [io.path]::Combine([io.path]::GetTempPath(), "DebuggerScriptTests-Get-PsBreakpoint1.ps1")
         $scriptFile2 = [io.path]::Combine([io.path]::GetTempPath(), "DebuggerScriptTests-Get-PsBreakpoint2.ps1")
 
-        write-output '' > $scriptFile1
-        write-output '' > $scriptFile2
+        Write-Output '' > $scriptFile1
+        Write-Output '' > $scriptFile2
 
         #
         # Set several breakpoints of different types
         #
-        $line1 = Set-PsBreakpoint $scriptFile1 1
-        $line2 = Set-PsBreakpoint $scriptFile2 2
+        $line1 = Set-PSBreakpoint $scriptFile1 1
+        $line2 = Set-PSBreakpoint $scriptFile2 2
 
-        $cmd1 = Set-PsBreakpoint -c command1 -s $scriptFile1
-        $cmd2 = Set-PsBreakpoint -c command2 -s $scriptFile2
-        $cmd3 = Set-PsBreakpoint -c command3
+        $cmd1 = Set-PSBreakpoint -c command1 -s $scriptFile1
+        $cmd2 = Set-PSBreakpoint -c command2 -s $scriptFile2
+        $cmd3 = Set-PSBreakpoint -c command3
 
-        $var1 = Set-PsBreakpoint -v variable1 -s $scriptFile1
-        $var2 = Set-PsBreakpoint -v variable2 -s $scriptFile2
-        $var3 = Set-PsBreakpoint -v variable3
+        $var1 = Set-PSBreakpoint -v variable1 -s $scriptFile1
+        $var2 = Set-PSBreakpoint -v variable2 -s $scriptFile2
+        $var3 = Set-PSBreakpoint -v variable3
 
         #
         # The default parameter set must return all breakpoints
         #
-        Verify { get-psbreakpoint } $line1,$line2,$cmd1,$cmd2,$cmd3,$var1,$var2,$var3
+        Verify { Get-PSBreakpoint } $line1,$line2,$cmd1,$cmd2,$cmd3,$var1,$var2,$var3
 
         #
         # Query by ID
         #
-        Verify { get-psbreakpoint -id $line1.ID,$cmd1.ID,$var1.ID } $line1,$cmd1,$var1 # -id
-        Verify { get-psbreakpoint $line2.ID,$cmd2.ID,$var2.ID }     $line2,$cmd2,$var2 # positional
-        Verify { $cmd3.ID,$var3.ID | get-psbreakpoint }             $cmd3,$var3        # value from pipeline
+        Verify { Get-PSBreakpoint -Id $line1.ID,$cmd1.ID,$var1.ID } $line1,$cmd1,$var1 # -id
+        Verify { Get-PSBreakpoint $line2.ID,$cmd2.ID,$var2.ID }     $line2,$cmd2,$var2 # positional
+        Verify { $cmd3.ID,$var3.ID | Get-PSBreakpoint }             $cmd3,$var3        # value from pipeline
 
-        VerifyException { get-psbreakpoint -id $null } "ParameterBindingValidationException"
-        VerifyException { get-psbreakpoint -id $line1.ID -script $scriptFile1 } "ParameterBindingException"
+        VerifyException { Get-PSBreakpoint -Id $null } "ParameterBindingValidationException"
+        VerifyException { Get-PSBreakpoint -Id $line1.ID -Script $scriptFile1 } "ParameterBindingException"
 
         #
         # Query by Script
         #
-        Verify { get-psbreakpoint -script $scriptFile1 } $line1,$cmd1,$var1 # -script
-        Verify { get-psbreakpoint $scriptFile2 }         $line2,$cmd2,$var2 # positional
-        Verify { $scriptFile2 | get-psbreakpoint }       $line2,$cmd2,$var2 # value from pipeline
+        Verify { Get-PSBreakpoint -Script $scriptFile1 } $line1,$cmd1,$var1 # -script
+        Verify { Get-PSBreakpoint $scriptFile2 }         $line2,$cmd2,$var2 # positional
+        Verify { $scriptFile2 | Get-PSBreakpoint }       $line2,$cmd2,$var2 # value from pipeline
 
-        VerifyException { get-psbreakpoint -script $null } "ParameterBindingValidationException"
-        VerifyException { get-psbreakpoint -script $scriptFile1,$null } "ParameterBindingValidationException"
+        VerifyException { Get-PSBreakpoint -Script $null } "ParameterBindingValidationException"
+        VerifyException { Get-PSBreakpoint -Script $scriptFile1,$null } "ParameterBindingValidationException"
 
         # Verify that relative paths are handled correctly
         $directoryName = [System.IO.Path]::GetDirectoryName($scriptFile1)
         $fileName = [System.IO.Path]::GetFileName($scriptFile1)
 
         Push-Location $directoryName
-        Verify { get-psbreakpoint -script $fileName } $line1,$cmd1,$var1
+        Verify { Get-PSBreakpoint -Script $fileName } $line1,$cmd1,$var1
         Pop-Location
 
         #
@@ -354,28 +354,28 @@ Describe "Unit tests for various script breakpoints" -Tags "CI" {
         $commandType = [Microsoft.PowerShell.Commands.BreakpointType]"command"
         $variableType = [Microsoft.PowerShell.Commands.BreakpointType]"variable"
 
-        Verify { get-psbreakpoint -type "line" }                      $line1,$line2     # -type
-        Verify { get-psbreakpoint $commandType }                      $cmd1,$cmd2,$cmd3 # positional
-        Verify { $variableType | get-psbreakpoint }                   $var1,$var2,$var3 # value from pipeline
-        Verify { get-psbreakpoint -type "line" -script $scriptFile1 } @($line1)         # -script parameter
+        Verify { Get-PSBreakpoint -Type "line" }                      $line1,$line2     # -type
+        Verify { Get-PSBreakpoint $commandType }                      $cmd1,$cmd2,$cmd3 # positional
+        Verify { $variableType | Get-PSBreakpoint }                   $var1,$var2,$var3 # value from pipeline
+        Verify { Get-PSBreakpoint -Type "line" -Script $scriptFile1 } @($line1)         # -script parameter
 
-        VerifyException { get-psbreakpoint -type $null } "ParameterBindingValidationException"
+        VerifyException { Get-PSBreakpoint -Type $null } "ParameterBindingValidationException"
 
         #
         # Query by Command
         #
-        Verify { get-psbreakpoint -command "command1","command2" }                       $cmd1,$cmd2 # -command
-        Verify { get-psbreakpoint -command "command1","command2" -script $scriptFile1 }  @($cmd1)    # -script parameter
+        Verify { Get-PSBreakpoint -Command "command1","command2" }                       $cmd1,$cmd2 # -command
+        Verify { Get-PSBreakpoint -Command "command1","command2" -Script $scriptFile1 }  @($cmd1)    # -script parameter
 
-        VerifyException { get-psbreakpoint -command $null } "ParameterBindingValidationException"
+        VerifyException { Get-PSBreakpoint -Command $null } "ParameterBindingValidationException"
 
         #
         # Query by Variable
         #
-        Verify { get-psbreakpoint -variable "variable1","variable2" }                       $var1,$var2 # -command
-        Verify { get-psbreakpoint -variable "variable1","variable2" -script $scriptFile1 }  @($var1)    # -script parameter
+        Verify { Get-PSBreakpoint -Variable "variable1","variable2" }                       $var1,$var2 # -command
+        Verify { Get-PSBreakpoint -Variable "variable1","variable2" -Script $scriptFile1 }  @($var1)    # -script parameter
 
-        VerifyException { get-psbreakpoint -variable $null } "ParameterBindingValidationException"
+        VerifyException { Get-PSBreakpoint -Variable $null } "ParameterBindingValidationException"
     }
     finally
     {
@@ -404,7 +404,7 @@ Describe "Unit tests for line breakpoints on dot-sourced files" -Tags "CI" {
 
     if ($null -eq $path)
     {
-        $path = split-path $MyInvocation.InvocationName
+        $path = Split-Path $MyInvocation.InvocationName
     }
 
     try
@@ -414,7 +414,7 @@ Describe "Unit tests for line breakpoints on dot-sourced files" -Tags "CI" {
         #
         $scriptFile = [io.path]::Combine([io.path]::GetTempPath(), "DebuggerScriptTests-InMemoryBreakpoints.ps1")
 
-        write-output '
+        Write-Output '
         function Function1
         {
             write-host "In Function1" # line 4
@@ -450,9 +450,9 @@ Describe "Unit tests for line breakpoints on dot-sourced files" -Tags "CI" {
         #
         # Set a couple of line breakpoints on the file, dot-source it and verify that the breakpoints are hit
         #
-        $breakpoint1 = Set-PsBreakpoint $scriptFile 4 -action { continue; }
-        $breakpoint2 = Set-PsBreakpoint $scriptFile 9 -action { continue; }
-        $breakpoint3 = Set-PsBreakpoint $scriptFile 24 -action { continue; }
+        $breakpoint1 = Set-PSBreakpoint $scriptFile 4 -Action { continue; }
+        $breakpoint2 = Set-PSBreakpoint $scriptFile 9 -Action { continue; }
+        $breakpoint3 = Set-PSBreakpoint $scriptFile 24 -Action { continue; }
 
         . $scriptFile
 
@@ -500,7 +500,7 @@ Describe "Unit tests for line breakpoints on modules" -Tags "CI" {
 
         New-Item -ItemType Directory $moduleDirectory 2> $null
 
-        write-output '
+        Write-Output '
         function ModuleFunction1
         {
             write-output "In ModuleFunction1" # line 4
@@ -542,15 +542,15 @@ Describe "Unit tests for line breakpoints on modules" -Tags "CI" {
         #
         $ENV:PSModulePath = $moduleRoot
 
-        import-module $moduleName
+        Import-Module $moduleName
 
         #
         # Set a couple of line breakpoints on the module and verify that they are hit
         #
-        $breakpoint1 = Set-PsBreakpoint $moduleFile 4 -action { continue }
-        $breakpoint2 = Set-PsBreakpoint $moduleFile 9 -action { continue }
-        $breakpoint3 = Set-PsBreakpoint $moduleFile 24 -Action { continue }
-        $breakpoint4 = Set-PsBreakpoint $moduleFile 25 -Action { continue }
+        $breakpoint1 = Set-PSBreakpoint $moduleFile 4 -Action { continue }
+        $breakpoint2 = Set-PSBreakpoint $moduleFile 9 -Action { continue }
+        $breakpoint3 = Set-PSBreakpoint $moduleFile 24 -Action { continue }
+        $breakpoint4 = Set-PSBreakpoint $moduleFile 25 -Action { continue }
 
         ModuleFunction1
 
@@ -579,8 +579,8 @@ Describe "Unit tests for line breakpoints on modules" -Tags "CI" {
         if ($null -ne $breakpoint2) { Remove-PSBreakpoint $breakpoint2 }
         if ($null -ne $breakpoint3) { Remove-PSBreakpoint $breakpoint3 }
         if ($null -ne $breakpoint4) { Remove-PSBreakpoint $breakpoint4 }
-        get-module $moduleName | remove-module
-        if (Test-Path $moduleDirectory) { Remove-Item $moduleDirectory -Recurse -force -ErrorAction silentlycontinue }
+        Get-Module $moduleName | Remove-Module
+        if (Test-Path $moduleDirectory) { Remove-Item $moduleDirectory -Recurse -Force -ErrorAction silentlycontinue }
     }
 }
 
@@ -639,7 +639,7 @@ Describe "Sometimes line breakpoints are ignored" -Tags "CI" {
         if ($null -ne $bp1) { Remove-PSBreakpoint $bp1 }
         if ($null -ne $bp2) { Remove-PSBreakpoint $bp2 }
 
-        if (Test-Path -Path $tempFileName1) { Remove-Item $tempFileName1 -force }
-        if (Test-Path -Path $tempFileName2) { Remove-Item $tempFileName2 -force }
+        if (Test-Path -Path $tempFileName1) { Remove-Item $tempFileName1 -Force }
+        if (Test-Path -Path $tempFileName2) { Remove-Item $tempFileName2 -Force }
     }
 }

--- a/test/powershell/Language/Scripting/Debugging/Debugging.Tests.ps1
+++ b/test/powershell/Language/Scripting/Debugging/Debugging.Tests.ps1
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Describe 'Basic debugger tests' -tag 'CI' {
+Describe 'Basic debugger tests' -Tag 'CI' {
 
     BeforeAll {
         Register-DebuggerHandler
@@ -17,7 +17,7 @@ Describe 'Basic debugger tests' -tag 'CI' {
                 function Test-DollarQuestionMark {
                     [CmdletBinding()]
                     param()
-                    Get-Process -id ([int]::MaxValue)
+                    Get-Process -Id ([int]::MaxValue)
                     if (-not $?) {
                         'The value of $? was preserved during debugging.'
                     } else {
@@ -27,7 +27,7 @@ Describe 'Basic debugger tests' -tag 'CI' {
                 $global:DollarQuestionMarkResults = Test-DollarQuestionMark -ErrorAction Break
             }
 
-            $global:results = @(Test-Debugger -ScriptBlock $testScript -CommandQueue '$?')
+            $global:results = @(Test-Debugger -Scriptblock $testScript -CommandQueue '$?')
         }
 
         AfterAll {
@@ -51,7 +51,7 @@ Describe 'Basic debugger tests' -tag 'CI' {
     }
 }
 
-Describe "Breakpoints when set should be hit" -tag "CI" {
+Describe "Breakpoints when set should be hit" -Tag "CI" {
     Context "Basic tests" {
         BeforeAll {
             $script = @'
@@ -63,11 +63,11 @@ Describe "Breakpoints when set should be hit" -tag "CI" {
 'bbb'
 '@
             $path = Setup -PassThru -File BasicTest.ps1 -Content $script
-            $bps = 1..6 | ForEach-Object { set-psbreakpoint -script $path -line $_ -Action { continue } }
+            $bps = 1..6 | ForEach-Object { Set-PSBreakpoint -Script $path -Line $_ -Action { continue } }
         }
 
         AfterAll {
-            $bps | Remove-PSBreakPoint
+            $bps | Remove-PSBreakpoint
         }
 
         It "A redirected breakpoint is hit" {
@@ -333,7 +333,7 @@ elseif (Test-Path $PSCommandPath)
     }
 }
 
-Describe "It should be possible to reset runspace debugging" -tag "Feature" {
+Describe "It should be possible to reset runspace debugging" -Tag "Feature" {
     BeforeAll {
         $script = @'
 "line 1"

--- a/test/powershell/Language/Scripting/Debugging/DebuggingInHost.Tests.ps1
+++ b/test/powershell/Language/Scripting/Debugging/DebuggingInHost.Tests.ps1
@@ -3,7 +3,7 @@
 
 Describe "Tests Debugger GetCallStack() on runspaces when attached to a WinRM host process" -Tags "CI" {
 
-    It -skip "Disabled test because it is fragile and does not consistently succeed on test VMs" { }
+    It -Skip "Disabled test because it is fragile and does not consistently succeed on test VMs" { }
     return
 
     try

--- a/test/powershell/Language/Scripting/DeserializedTypeConversion.Tests.ps1
+++ b/test/powershell/Language/Scripting/DeserializedTypeConversion.Tests.ps1
@@ -88,7 +88,7 @@ Describe "Tests conversion of deserialized types to original type using object p
 
     Context 'Type conversion and parameter binding of deserialized Type case 1: type definition contains public fields' {
         BeforeAll {
-            $t1 = new-object test1 -Property @{name="TestName1";port=80;scriptText="1..5"}
+            $t1 = New-Object test1 -Property @{name="TestName1";port=80;scriptText="1..5"}
             $s = [System.Management.Automation.PSSerializer]::Serialize($t1)
             $dst1 = [System.Management.Automation.PSSerializer]::Deserialize($s)
         }
@@ -114,7 +114,7 @@ Describe "Tests conversion of deserialized types to original type using object p
 
     Context 'Type conversion and parameter binding of deserialized Type case 2: type definition contains public properties' {
         BeforeAll {
-            $t2 = new-object test2 -Property @{Name="TestName2";Port=80;ScriptText="1..5"}
+            $t2 = New-Object test2 -Property @{Name="TestName2";Port=80;ScriptText="1..5"}
             $s = [System.Management.Automation.PSSerializer]::Serialize($t2)
             $dst2 = [System.Management.Automation.PSSerializer]::Deserialize($s)
         }
@@ -138,7 +138,7 @@ Describe "Tests conversion of deserialized types to original type using object p
 
     Context 'Type conversion and parameter binding of deserialized Type case 1: type definition contains 2 public properties and 1 read only property' {
         BeforeAll {
-            $t3 = new-object test3 -Property @{Name="TestName3";Port=80}
+            $t3 = New-Object test3 -Property @{Name="TestName3";Port=80}
             $s = [System.Management.Automation.PSSerializer]::Serialize($t3)
             $dst3 = [System.Management.Automation.PSSerializer]::Deserialize($s)
         }
@@ -165,7 +165,7 @@ Describe "Tests conversion of deserialized types to original type using object p
 
     Context 'Type conversion and parameter binding of deserialized Type case 1: type definition contains 2 public properties' {
         BeforeAll {
-            $t4 = new-object test4 -Property @{Name="TestName4";Port=80}
+            $t4 = New-Object test4 -Property @{Name="TestName4";Port=80}
             $s = [System.Management.Automation.PSSerializer]::Serialize($t4)
             $dst4 = [System.Management.Automation.PSSerializer]::Deserialize($s)
         }

--- a/test/powershell/Language/Scripting/Dynamicparameters.Tests.ps1
+++ b/test/powershell/Language/Scripting/Dynamicparameters.Tests.ps1
@@ -76,6 +76,6 @@ Describe "Dynamic parameter support in script cmdlets." -Tags "CI" {
     }
 
     It "Parameter is defined in Class" {
-        foo-bar -path class -name "myName" | Should -BeExactly 'myName'
+        foo-bar -path class -Name "myName" | Should -BeExactly 'myName'
     }
 }

--- a/test/powershell/Language/Scripting/Generics.Tests.ps1
+++ b/test/powershell/Language/Scripting/Generics.Tests.ps1
@@ -50,7 +50,7 @@ Describe "Generics support" -Tags "CI" {
         $x = [dictionary[dictionary[list[int],string], stack[double]]]::new()
         $x.gettype().fullname | Should -Match "double"
 
-        $y = new-object "dictionary[dictionary[list[int],string], stack[double]]"
+        $y = New-Object "dictionary[dictionary[list[int],string], stack[double]]"
         $y.gettype().fullname | Should -Match "double"
     }
 
@@ -65,7 +65,7 @@ Describe "Generics support" -Tags "CI" {
         $e | Should -Match "\[T\]"
     }
 
-    It 'Array type works properly' -skip:$IsCoreCLR{
+    It 'Array type works properly' -Skip:$IsCoreCLR{
         $x = [system.array]::ConvertAll.OverloadDefinitions
         $x | Should -Match "static\s+TOutput\[\]\s+ConvertAll\[TInput,\s+TOutput\]\("
     }

--- a/test/powershell/Language/Scripting/HashtableToPSCustomObjectConversion.Tests.ps1
+++ b/test/powershell/Language/Scripting/HashtableToPSCustomObjectConversion.Tests.ps1
@@ -35,7 +35,7 @@ Describe "Tests for hashtable to PSCustomObject conversion" -Tags "CI" {
 
     It 'Type Validation: <Name>' -TestCases:$testdata {
         param ($Name, $Cmd, $ExpectedType)
-        Invoke-expression $Cmd -OutVariable a
+        Invoke-Expression $Cmd -OutVariable a
         $a = Get-Variable -Name a -ValueOnly
         $a | Should -BeOfType $ExpectedType
     }
@@ -47,7 +47,7 @@ Describe "Tests for hashtable to PSCustomObject conversion" -Tags "CI" {
 
         $p = 0
         # Checks if the first property is One
-        $x.psobject.Properties | foreach-object  `
+        $x.psobject.Properties | ForEach-Object  `
                                 {
                                     if ($p -eq 0)
                                     {
@@ -64,7 +64,7 @@ Describe "Tests for hashtable to PSCustomObject conversion" -Tags "CI" {
 
        $p = 0
        # Checks if the first property is One
-       $x.psobject.Properties | foreach-object  `
+       $x.psobject.Properties | ForEach-Object  `
                                 {
                                     if ($p -eq 0)
                                     {
@@ -136,7 +136,7 @@ Describe "Tests for hashtable to PSCustomObject conversion" -Tags "CI" {
         $obj = $null
         $ht = @{one=1;two=2}
 
-        { $obj = New-Object System.Management.Automation.PSCustomObject -property $ht } |
+        { $obj = New-Object System.Management.Automation.PSCustomObject -Property $ht } |
             Should -Throw -ErrorId "CannotFindAppropriateCtor,Microsoft.PowerShell.Commands.NewObjectCommand"
         $obj | Should -BeNullOrEmpty
     }

--- a/test/powershell/Language/Scripting/I18n.Tests.ps1
+++ b/test/powershell/Language/Scripting/I18n.Tests.ps1
@@ -30,7 +30,7 @@ Describe 'Testing of script internationalization' -Tags "CI" {
 
     It 'Import default culture is done correctly' {
 
-        import-localizedData mydata;
+        Import-LocalizedData mydata;
 
         $mydata.string1 | Should -BeExactly 'string1 for en-US'
         $mydata.string2 | Should -BeExactly 'string2 for en-US'
@@ -38,12 +38,12 @@ Describe 'Testing of script internationalization' -Tags "CI" {
 
     It 'Import specific culture(en-US)' {
 
-        import-localizedData mydata -uiculture en-US
+        Import-LocalizedData mydata -UICulture en-US
 
         $mydata.string1 | Should -BeExactly 'string1 for en-US'
         $mydata.string2 | Should -BeExactly 'string2 for en-US'
 
-        import-localizedData mydata -uiculture fr-FR
+        Import-LocalizedData mydata -UICulture fr-FR
 
         $mydata.string1 | Should -BeExactly 'string1 for fr-FR'
         $mydata.string2 | Should -BeExactly 'string2 for fr-FR'
@@ -51,7 +51,7 @@ Describe 'Testing of script internationalization' -Tags "CI" {
 
     It 'Import non existing culture is done correctly' {
 
-        import-localizedData mydata -uiculture nl-NL -ErrorAction SilentlyContinue -ErrorVariable ev
+        Import-LocalizedData mydata -UICulture nl-NL -ErrorAction SilentlyContinue -ErrorVariable ev
 
         $ev | Should -Not -BeNullOrEmpty
         $ev[0].Exception | Should -BeOfType System.Management.Automation.PSInvalidOperationException
@@ -59,12 +59,12 @@ Describe 'Testing of script internationalization' -Tags "CI" {
 
     It 'Import different file name is done correctly' {
 
-        import-localizedData mydata -filename foo
+        Import-LocalizedData mydata -FileName foo
 
         $mydata.string1 | Should -BeExactly 'string1 from foo in en-US'
         $mydata.string2 | Should -BeExactly 'string2 from foo in en-US'
 
-        import-localizedData mydata -filename foo -uiculture fr-FR
+        Import-LocalizedData mydata -FileName foo -UICulture fr-FR
 
         $mydata.string1 | Should -BeExactly 'string1 from foo in fr-FR'
         $mydata.string2 | Should -BeExactly 'string2 from foo in fr-FR'
@@ -72,12 +72,12 @@ Describe 'Testing of script internationalization' -Tags "CI" {
 
     It 'Import different file base is done correctly' {
 
-        import-localizedData mydata -basedirectory "${dir}\newbase"
+        Import-LocalizedData mydata -BaseDirectory "${dir}\newbase"
 
         $mydata.string1 | Should -BeExactly 'string1 for en-US under newbase'
         $mydata.string2 | Should -BeExactly 'string2 for en-US under newbase'
 
-        import-localizedData mydata -basedirectory "${dir}\newbase" -uiculture fr-FR
+        Import-LocalizedData mydata -BaseDirectory "${dir}\newbase" -UICulture fr-FR
 
         $mydata.string1 | Should -BeExactly 'string1 for fr-FR under newbase'
         $mydata.string2 | Should -BeExactly 'string2 for fr-FR under newbase'
@@ -85,12 +85,12 @@ Describe 'Testing of script internationalization' -Tags "CI" {
 
     It 'Import different file base and file name' {
 
-        import-localizedData mydata -basedirectory "${dir}\newbase" -filename foo
+        Import-LocalizedData mydata -BaseDirectory "${dir}\newbase" -FileName foo
 
         $mydata.string1 | Should -BeExactly 'string1 for en-US from foo under newbase'
         $mydata.string2 | Should -BeExactly 'string2 for en-US from foo under newbase'
 
-        import-localizedData mydata -basedirectory "${dir}\newbase" -filename foo -uiculture fr-FR
+        Import-LocalizedData mydata -BaseDirectory "${dir}\newbase" -FileName foo -UICulture fr-FR
 
         $mydata.string1 | Should -BeExactly 'string1 for fr-FR from foo under newbase'
         $mydata.string2 | Should -BeExactly 'string2 for fr-FR from foo under newbase'
@@ -98,7 +98,7 @@ Describe 'Testing of script internationalization' -Tags "CI" {
 
     It "Import variable that doesn't exist" {
 
-        import-localizedData mydata2
+        Import-LocalizedData mydata2
 
         $mydata2.string1 | Should -BeExactly 'string1 for en-US'
         $mydata2.string2 | Should -BeExactly 'string2 for en-US'
@@ -109,7 +109,7 @@ Describe 'Testing of script internationalization' -Tags "CI" {
         $script:exception = $null
         & {
             trap {$script:exception = $_ ; continue }
-            import-localizedData mydata -filename bad
+            Import-LocalizedData mydata -FileName bad
           }
 
         $script:exception.exception | Should -Not -BeNullOrEmpty
@@ -118,7 +118,7 @@ Describe 'Testing of script internationalization' -Tags "CI" {
 
     It 'Import if psd1 file is done correctly' {
 
-        import-localizedData mydata -filename if
+        Import-LocalizedData mydata -FileName if
 
         if ($PSCulture -eq 'en-US')
         {
@@ -143,13 +143,13 @@ Describe 'Testing of script internationalization' -Tags "CI" {
         $script:exception = $null
         & {
             trap {$script:exception = $_.Exception ; continue }
-            invoke-expression $cmd
+            Invoke-Expression $cmd
         }
 
         $exception | Should -Match $Expected
     }
 
-    it 'Check alternate syntax that also supports complex variable names' {
+    It 'Check alternate syntax that also supports complex variable names' {
 
        & {
             $script:mydata = data { 123 }
@@ -159,22 +159,22 @@ Describe 'Testing of script internationalization' -Tags "CI" {
         $mydata = data { 456 }
         & {
             # This import should not clobber the one at script scope
-            import-localizedData mydata -uiculture en-US
+            Import-LocalizedData mydata -UICulture en-US
         }
         $mydata | Should -Be 456
 
         & {
             # This import should clobber the one at script scope
-            import-localizedData script:mydata -uiculture en-US
+            Import-LocalizedData script:mydata -UICulture en-US
         }
         $script:mydata.string1 | Should -BeExactly 'string1 for en-US'
     }
 
     It 'Check fallback to current directory plus -SupportedCommand parameter is done correctly' {
 
-        new-alias MyConvertFrom-StringData ConvertFrom-StringData
+        New-Alias MyConvertFrom-StringData ConvertFrom-StringData
 
-        import-localizeddata local:mydata -uiculture fr-ca -filename I18n.Tests_fallback.psd1 -SupportedCommand MyConvertFrom-StringData
+        Import-LocalizedData local:mydata -UICulture fr-ca -FileName I18n.Tests_fallback.psd1 -SupportedCommand MyConvertFrom-StringData
         $mydata[0].string1 | Should -BeExactly 'fallback string1 for en-US'
         $mydata[1] | Should -Be 42
     }

--- a/test/powershell/Language/Scripting/LineEndings.Tests.ps1
+++ b/test/powershell/Language/Scripting/LineEndings.Tests.ps1
@@ -130,8 +130,8 @@ Describe 'Line endings' -Tags "CI" {
         # wrap the content in the specified begin and end quoting characters.
         $content = "$($Begin)$($expected)$($End)"
         # BUG: Set-Content is failing on linux if the file does not exit.
-        $null = New-item -path TESTDRIVE:$fileName -force
-        $content | Set-content -NoNewline -Encoding ascii -Path TESTDRIVE:\$fileName
+        $null = New-Item -Path TESTDRIVE:$fileName -Force
+        $content | Set-Content -NoNewline -Encoding ascii -Path TESTDRIVE:\$fileName
         $actual = &( "TESTDRIVE:\$fileName")
 
         # $actual should be the content string ($expected) without the begin and end quoting characters.

--- a/test/powershell/Language/Scripting/NativeExecution/NativeLinuxCommands.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeLinuxCommands.Tests.ps1
@@ -14,7 +14,7 @@ Describe "NativeLinuxCommands" -tags "CI" {
     }
 
     It "Should find Application grep" {
-        (get-command grep).CommandType | Should -Be Application
+        (Get-Command grep).CommandType | Should -Be Application
     }
 
     It "Should pipe to grep and get result" {
@@ -22,7 +22,7 @@ Describe "NativeLinuxCommands" -tags "CI" {
     }
 
     It "Should find Application touch" {
-        (get-command touch).CommandType | Should -Be Application
+        (Get-Command touch).CommandType | Should -Be Application
     }
 
     It "Should not redirect standard input if native command is the first command in pipeline (1)" {

--- a/test/powershell/Language/Scripting/OrderedAttributeForHashTables.Tests.ps1
+++ b/test/powershell/Language/Scripting/OrderedAttributeForHashTables.Tests.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 Describe 'Test for cmdlet to support Ordered Attribute on hash literal nodes' -Tags "CI" {
     It 'New-Object - Property Parameter Must take IDictionary' {
-        $a = new-object psobject -property ([ordered]@{one=1;two=2})
+        $a = New-Object psobject -Property ([ordered]@{one=1;two=2})
         $a | Should -Not -BeNullOrEmpty
         $a.one | Should -Be 1
     }
@@ -26,7 +26,7 @@ Describe 'Test for cmdlet to support Ordered Attribute on hash literal nodes' -T
 </helpItems>
 '@
 
-        { $script:a = select-xml -content $helpXml -xpath "//command:name" -namespace (
+        { $script:a = Select-Xml -Content $helpXml -XPath "//command:name" -Namespace (
                         [ordered]@{command="http://schemas.microsoft.com/maml/dev/command/2004/10";
                                    maml="http://schemas.microsoft.com/maml/2004/10";
                                    dev="http://schemas.microsoft.com/maml/dev/2004/10"})  } | Should -Not -Throw
@@ -64,7 +64,7 @@ Describe 'Test for cmdlet to support Ordered Attribute on hash literal nodes' -T
 
         $script:a = $null
 
-        {$script:a = Get-ChildItem | select-object -property Name, (
+        {$script:a = Get-ChildItem | Select-Object -Property Name, (
                     [ordered]@{Name="IsDirectory";
                                Expression ={$_.PSIsContainer}})} | Should -Not -Throw
 

--- a/test/powershell/Language/Scripting/OutErrorVariable.Tests.ps1
+++ b/test/powershell/Language/Scripting/OutErrorVariable.Tests.ps1
@@ -25,7 +25,7 @@ Describe "Tests OutVariable only" -Tags "CI" {
             param()
 
             "bar"
-            get-foo1 -outVariable script:a
+            get-foo1 -OutVariable script:a
         }
     }
 
@@ -71,7 +71,7 @@ Describe "Tests OutVariable only" -Tags "CI" {
 
     It 'Nested OutVariable' {
 
-        get-bar -outVariable b > $null
+        get-bar -OutVariable b > $null
         $script:a | Should -BeExactly 'foo'
         $b | Should -BeExactly @("bar", "foo")
     }
@@ -84,7 +84,7 @@ Describe "Test ErrorVariable only" -Tags "CI" {
             [CmdletBinding()]
             param()
 
-            write-error "foo"
+            Write-Error "foo"
         }
 
         function get-foo2
@@ -100,8 +100,8 @@ Describe "Test ErrorVariable only" -Tags "CI" {
             [CmdletBinding()]
             param()
 
-            write-error "bar"
-            get-foo1 -errorVariable script:a
+            Write-Error "bar"
+            get-foo1 -ErrorVariable script:a
         }
     }
 
@@ -141,10 +141,10 @@ Describe "Test ErrorVariable only" -Tags "CI" {
     }
 
     It 'Appending ErrorVariable Case 2: $PSCmdlet.writeerror' {
-        write-error "foo" -errorVariable script:foo 2> $null
+        Write-Error "foo" -ErrorVariable script:foo 2> $null
         $a = 'a','b'
 
-        get-foo2 -errorVariable +a 2> $null
+        get-foo2 -ErrorVariable +a 2> $null
 
         $a.count | Should -Be 3
         $a| ForEach-Object {$_.ToString()} | Should -BeExactly @('a', 'b', 'foo')
@@ -152,7 +152,7 @@ Describe "Test ErrorVariable only" -Tags "CI" {
 
     It 'Nested ErrorVariable' {
 
-        get-bar -errorVariable b 2> $null
+        get-bar -ErrorVariable b 2> $null
 
         $script:a | Should -BeExactly 'foo'
         $b | Should -BeExactly @("bar","foo")
@@ -160,7 +160,7 @@ Describe "Test ErrorVariable only" -Tags "CI" {
 
     It 'Nested ErrorVariable with redirection' {
 
-        get-bar -errorVariable b 2>&1 > $null
+        get-bar -ErrorVariable b 2>&1 > $null
 
         $script:a | Should -BeExactly 'foo'
         $b | Should -BeExactly @("bar", "foo")
@@ -176,8 +176,8 @@ Describe "Update both OutVariable and ErrorVariable" -Tags "CI" {
           [CmdletBinding()]
           param()
 
-          write-output "foo-output"
-          write-error  "foo-error"
+          Write-Output "foo-output"
+          Write-Error  "foo-error"
         }
 
         function get-foo1
@@ -185,7 +185,7 @@ Describe "Update both OutVariable and ErrorVariable" -Tags "CI" {
             [CmdletBinding()]
             param()
 
-            write-error "foo"
+            Write-Error "foo"
         }
 
         function get-foo2
@@ -201,8 +201,8 @@ Describe "Update both OutVariable and ErrorVariable" -Tags "CI" {
             [CmdletBinding()]
             param()
 
-            write-error "bar"
-            get-foo1 -errorVariable script:a
+            Write-Error "bar"
+            get-foo1 -ErrorVariable script:a
         }
 
         function get-foo3
@@ -211,8 +211,8 @@ Describe "Update both OutVariable and ErrorVariable" -Tags "CI" {
             param()
 
             "foo-output-0"
-            write-output "foo-output-1"
-            write-error "foo-error"
+            Write-Output "foo-output-1"
+            Write-Error "foo-error"
         }
 
         function get-bar2
@@ -221,15 +221,15 @@ Describe "Update both OutVariable and ErrorVariable" -Tags "CI" {
             param()
 
             "bar-output-0"
-            write-output "bar-output-1"
-            write-error "bar-error"
-            get-foo3 -OutVariable script:foo_out -errorVariable script:foo_err
+            Write-Output "bar-output-1"
+            Write-Error "bar-error"
+            get-foo3 -OutVariable script:foo_out -ErrorVariable script:foo_err
         }
     }
 
     It 'Update OutVariable and ErrorVariable' {
 
-        get-foo3 -OutVariable out -errorVariable err 2> $null > $null
+        get-foo3 -OutVariable out -ErrorVariable err 2> $null > $null
 
         $out | Should -BeExactly @("foo-output-0", "foo-output-1")
         $err | Should -BeExactly "foo-error"
@@ -237,7 +237,7 @@ Describe "Update both OutVariable and ErrorVariable" -Tags "CI" {
 
     It 'Update OutVariable and ErrorVariable' {
 
-        get-bar2 -OutVariable script:bar_out -errorVariable script:bar_err 2> $null > $null
+        get-bar2 -OutVariable script:bar_out -ErrorVariable script:bar_err 2> $null > $null
 
         $foo_out | Should -BeExactly @("foo-output-0", "foo-output-1")
         $foo_err | Should -BeExactly 'foo-error'
@@ -252,7 +252,7 @@ Describe "Update both OutVariable and ErrorVariable" -Tags "CI" {
             [CmdletBinding()]
             param()
 
-            write-error "foo-error"
+            Write-Error "foo-error"
 
             try
             {
@@ -262,7 +262,7 @@ Describe "Update both OutVariable and ErrorVariable" -Tags "CI" {
             {}
         }
 
-        get-foo4 -errorVariable err 2> $null
+        get-foo4 -ErrorVariable err 2> $null
 
         $err | Should -BeExactly @("foo-error", "foo-exception")
     }
@@ -275,8 +275,8 @@ Describe "Update both OutVariable and ErrorVariable" -Tags "CI" {
 
           process
           {
-            write-output $foo
-            write-error  $foo
+            Write-Output $foo
+            Write-Error  $foo
           }
         }
 
@@ -293,7 +293,7 @@ Describe "Update both OutVariable and ErrorVariable" -Tags "CI" {
     Context 'Error variable in multi-command pipeline (with native cmdlet)' {
 
         BeforeAll {
-            (get-foo -ErrorVariable foo_err | get-item -ErrorVariable get_item_err ) 2>&1 > $null
+            (get-foo -ErrorVariable foo_err | Get-Item -ErrorVariable get_item_err ) 2>&1 > $null
         }
 
         It '$foo_err should be "foo-error"' {
@@ -314,12 +314,12 @@ Describe "Update both OutVariable and ErrorVariable" -Tags "CI" {
             [CmdletBinding()]
             param([Parameter(ValueFromPipeline = $true)][string] $i)
 
-            write-error  'bar-error'
-            write-output 'bar-output'
+            Write-Error  'bar-error'
+            Write-Output 'bar-output'
             get-foo
         }
 
-        (get-foo -errorVariable foo_err | get-bar3 -errorVariable bar_err) 2>&1 > $null
+        (get-foo -ErrorVariable foo_err | get-bar3 -ErrorVariable bar_err) 2>&1 > $null
 
         $foo_err | Should -BeExactly 'foo-error'
         $bar_err | Should -BeExactly @("bar-error", "foo-error")
@@ -332,8 +332,8 @@ Describe "Update both OutVariable and ErrorVariable" -Tags "CI" {
             [CmdletBinding()]
             param([Parameter(ValueFromPipeline = $true)][string] $i)
 
-            write-error  "foo-error"
-            write-output $i
+            Write-Error  "foo-error"
+            Write-Output $i
         }
 
         function get-bar4
@@ -341,11 +341,11 @@ Describe "Update both OutVariable and ErrorVariable" -Tags "CI" {
             [CmdletBinding()]
             param([Parameter(ValueFromPipeline = $true)][string] $i)
 
-            write-error  "bar-error"
-            get-foo6 "foo-output" -errorVariable script:foo_err1 | get-foo6 -errorVariable script:foo_err2
+            Write-Error  "bar-error"
+            get-foo6 "foo-output" -ErrorVariable script:foo_err1 | get-foo6 -ErrorVariable script:foo_err2
         }
 
-        get-bar4 -errorVariable script:bar_err 2>&1 > $null
+        get-bar4 -ErrorVariable script:bar_err 2>&1 > $null
 
         $script:foo_err1 | Should -BeExactly "foo-error"
         $script:foo_err2 | Should -BeExactly "foo-error"
@@ -359,7 +359,7 @@ Describe "Update both OutVariable and ErrorVariable" -Tags "CI" {
             param([Parameter(ValueFromPipeline = $true)][string] $output)
 
             $output
-            write-error "foo-error"
+            Write-Error "foo-error"
         }
 
         function get-bar5
@@ -368,7 +368,7 @@ Describe "Update both OutVariable and ErrorVariable" -Tags "CI" {
             param()
 
             "bar-output"
-            write-error  "bar-error"
+            Write-Error  "bar-error"
             get-foo7 "foo-output" -ErrorVariable script:foo_err1 -ov script:foo_out1 | get-foo7 -ErrorVariable script:foo_err2 -ov script:foo_out2
             get-foo7 "foo-output" -ErrorVariable script:foo_err3 -ov script:foo_out3 | get-foo7 -ErrorVariable script:foo_err4 -ov script:foo_out4
         }

--- a/test/powershell/Language/Scripting/ParameterBinding.Tests.ps1
+++ b/test/powershell/Language/Scripting/ParameterBinding.Tests.ps1
@@ -137,7 +137,7 @@ Describe "Tests for parameter binding" -Tags "CI" {
             }
         }
 
-        $b = 1..10 | select-object @{name='foo'; expression={$_ * 10}} | get-foo
+        $b = 1..10 | Select-Object @{name='foo'; expression={$_ * 10}} | get-foo
         $b -join ',' | Should -BeExactly '10,20,30,40,50,60,70,80,90,100'
     }
 
@@ -451,12 +451,12 @@ Describe "Tests for parameter binding" -Tags "CI" {
     }
 
     #known issue 2069
-    It 'Some conversions should be attempted before trying to encode a collection' -skip:$IsCoreCLR {
+    It 'Some conversions should be attempted before trying to encode a collection' -Skip:$IsCoreCLR {
         try {
                  $null = [Test.Language.ParameterBinding.MyClass]
             }
             catch {
-                add-type -PassThru -TypeDefinition @'
+                Add-Type -PassThru -TypeDefinition @'
                 using System.Management.Automation;
                 using System;
                 using System.Collections;
@@ -486,7 +486,7 @@ Describe "Tests for parameter binding" -Tags "CI" {
                         }
                     }
                 }
-'@ | ForEach-Object {$_.assembly} | Import-module
+'@ | ForEach-Object {$_.assembly} | Import-Module
             }
 
         Get-TestCmdlet -MyParameter @{ a = 42 } | Should -BeExactly 'hashtable'

--- a/test/powershell/Language/Scripting/ScriptHelp.Tests.ps1
+++ b/test/powershell/Language/Scripting/ScriptHelp.Tests.ps1
@@ -134,44 +134,44 @@ Describe 'get-help HelpFunc1' -Tags "Feature" {
     }
 
     Context 'Get-Help helpFunc1' {
-        $x = get-help helpFunc1
+        $x = Get-Help helpFunc1
         TestHelpFunc1 $x
     }
 
     Context 'Get-Help dynamicHelpFunc1' {
-        $x = get-help dynamicHelpFunc1
+        $x = Get-Help dynamicHelpFunc1
         TestHelpFunc1 $x
     }
 
     Context 'get-help helpFunc1 -component blah' {
-        $x = get-help helpFunc1 -component blah -ErrorAction SilentlyContinue -ErrorVariable e
+        $x = Get-Help helpFunc1 -Component blah -ErrorAction SilentlyContinue -ErrorVariable e
         TestHelpError $x $e 'HelpNotFound,Microsoft.PowerShell.Commands.GetHelpCommand'
     }
 
     Context 'get-help helpFunc1 -component Something' {
-        $x = get-help helpFunc1 -component Something -ErrorAction SilentlyContinue -ErrorVariable e
+        $x = Get-Help helpFunc1 -Component Something -ErrorAction SilentlyContinue -ErrorVariable e
         TestHelpFunc1 $x
         It '$e should be empty' { $e.Count | Should -Be 0 }
     }
 
     Context 'get-help helpFunc1 -role blah' {
-        $x = get-help helpFunc1 -component blah -ErrorAction SilentlyContinue -ErrorVariable e
+        $x = Get-Help helpFunc1 -Component blah -ErrorAction SilentlyContinue -ErrorVariable e
         TestHelpError $x $e 'HelpNotFound,Microsoft.PowerShell.Commands.GetHelpCommand'
     }
 
     Context 'get-help helpFunc1 -role CrazyUser' {
-        $x = get-help helpFunc1 -role CrazyUser -ErrorAction SilentlyContinue -ErrorVariable e
+        $x = Get-Help helpFunc1 -Role CrazyUser -ErrorAction SilentlyContinue -ErrorVariable e
         TestHelpFunc1 $x
         It '$e should be empty' { $e.Count | Should -Be 0 }
     }
 
     Context '$x = get-help helpFunc1 -functionality blah' {
-        $x = get-help helpFunc1 -functionality blah -ErrorAction SilentlyContinue -ErrorVariable e
+        $x = Get-Help helpFunc1 -Functionality blah -ErrorAction SilentlyContinue -ErrorVariable e
         TestHelpError $x $e 'HelpNotFound,Microsoft.PowerShell.Commands.GetHelpCommand'
     }
 
     Context '$x = get-help helpFunc1 -functionality Useless' {
-        $x = get-help helpFunc1 -functionality Useless -ErrorAction SilentlyContinue -ErrorVariable e
+        $x = Get-Help helpFunc1 -Functionality Useless -ErrorAction SilentlyContinue -ErrorVariable e
         TestHelpFunc1 $x
         It '$e should be empty' { $e.Count | Should -Be 0 }
     }
@@ -187,7 +187,7 @@ Describe 'get-help file' -Tags "CI" {
     }
 
     AfterAll {
-        remove-item $tmpfile -Force -ErrorAction silentlycontinue
+        Remove-Item $tmpfile -Force -ErrorAction silentlycontinue
     }
 
     Context 'get-help file1' {
@@ -202,7 +202,7 @@ Describe 'get-help file' -Tags "CI" {
     get-help foo
 '@ > $tmpfile
 
-        $x = get-help $tmpfile
+        $x = Get-Help $tmpfile
         It '$x should not be $null' { $x | Should -Not -BeNullOrEmpty }
         $x = & $tmpfile
         It '$x.Synopsis' { $x.Synopsis | Should -BeExactly 'Function help, not script help' }
@@ -223,7 +223,7 @@ Describe 'get-help file' -Tags "CI" {
         get-help foo
 '@ > $tmpfile
 
-        $x = get-help $tmpfile
+        $x = Get-Help $tmpfile
         It '$x.Synopsis' { $x.Synopsis | Should -BeExactly 'Script help, not function help' }
         $x = & $tmpfile
         It '$x should not be $null' { $x | Should -Not -BeNullOrEmpty }
@@ -240,7 +240,7 @@ Describe 'get-help other tests' -Tags "CI" {
     }
 
     AfterAll {
-        remove-item $tempFile -Force -ErrorAction silentlycontinue
+        Remove-Item $tempFile -Force -ErrorAction silentlycontinue
     }
 
     Context 'get-help missingHelp' {
@@ -253,7 +253,7 @@ Describe 'get-help other tests' -Tags "CI" {
 
 
         function missingHelp { param($abc) }
-            $x = get-help missingHelp
+            $x = Get-Help missingHelp
             It '$x should not be $null' { $x | Should -Not -BeNullOrEmpty }
             It '$x.Synopsis' { $x.Synopsis.Trim() | Should -BeExactly 'missingHelp [[-abc] <Object>]' }
         }
@@ -267,7 +267,7 @@ Describe 'get-help other tests' -Tags "CI" {
 
     function helpFunc2 { param($abc) }
 
-        $x = get-help helpFunc2
+        $x = Get-Help helpFunc2
         It '$x should not be $null' { $x | Should -Not -BeNullOrEmpty }
         It '$x.Synopsis' { $x.Synopsis.Trim() | Should -BeExactly 'This help block goes on helpFunc2' }
     }
@@ -289,7 +289,7 @@ Describe 'get-help other tests' -Tags "CI" {
 "@
 
         Set-Content $tempFile $script
-        $x = get-help $tempFile
+        $x = Get-Help $tempFile
         It '$x.Synopsis' { $x.Synopsis | Should -BeExactly "This is script help" }
 
         $x = & $tempFile
@@ -313,7 +313,7 @@ Describe 'get-help other tests' -Tags "CI" {
 "@
 
         Set-Content $tempFile $script
-        $x = get-help $tempFile
+        $x = Get-Help $tempFile
         It $x.Synopsis { $x.Synopsis | Should -BeExactly "This is script help" }
 
         $x = & $tempFile
@@ -348,7 +348,7 @@ Describe 'get-help other tests' -Tags "CI" {
 '@
 
         Set-Content $tempFile $script
-        $x = get-help $tempFile
+        $x = Get-Help $tempFile
 
         It '$x.Synopsis' { $x.Synopsis | Should -BeExactly "Changes Admin passwords across all KDE servers." }
         It '$x.parameters.parameter[0].required' { $x.parameters.parameter[0].required | Should -BeTrue}
@@ -393,7 +393,7 @@ Describe 'get-help other tests' -Tags "CI" {
         {
         }
 
-        $x = get-help helpFunc4
+        $x = Get-Help helpFunc4
         $x.Synopsis | Should -BeExactly ""
     }
 
@@ -403,7 +403,7 @@ Describe 'get-help other tests' -Tags "CI" {
         {
             # .EXTERNALHELP scriptHelp.Tests.xml
         }
-        $x = get-help helpFunc5
+        $x = Get-Help helpFunc5
         It '$x should not be $null' { $x | Should -Not -BeNullOrEmpty }
         It '$x.Synopsis' { $x.Synopsis | Should -BeExactly "A useless function, really." }
     }
@@ -415,7 +415,7 @@ Describe 'get-help other tests' -Tags "CI" {
         }
         if ($PSUICulture -ieq "en-us")
         {
-            $x = get-help helpFunc6
+            $x = Get-Help helpFunc6
             It '$x should not be $null' { $x | Should -Not -BeNullOrEmpty }
             It '$x.Synopsis' { $x.Synopsis | Should -BeExactly "Useless.  Really, trust me on this one." }
         }
@@ -428,7 +428,7 @@ Describe 'get-help other tests' -Tags "CI" {
         }
         if ($PSUICulture -ieq "en-us")
         {
-            $x = get-help helpFunc6
+            $x = Get-Help helpFunc6
             It '$x should not be $null' { $x | Should -Not -BeNullOrEmpty }
             It '$x.Synopsis' { $x.Synopsis | Should -BeExactly "Useless in newbase.  Really, trust me on this one." }
         }
@@ -446,9 +446,9 @@ Describe 'get-help other tests' -Tags "CI" {
         It '$x.Category' { $x.Category | Should -BeExactly 'Cmdlet' }
 
         # Make sure help is a function, or the test would fail
-        if ($null -ne (get-command -type Function help))
+        if ($null -ne (Get-Command -type Function help))
         {
-            if ((get-content function:help) -Match "FORWARDHELP")
+            if ((Get-Content function:help) -Match "FORWARDHELP")
             {
                 $x = Get-Help help
                 It '$x.Name' { $x.Name | Should -BeExactly 'Get-Help' }
@@ -466,7 +466,7 @@ Describe 'get-help other tests' -Tags "CI" {
             function helpFunc8
             {
             }
-            get-help helpFunc8
+            Get-Help helpFunc8
         }
 
         $x = Get-Help func8
@@ -486,7 +486,7 @@ Describe 'get-help other tests' -Tags "CI" {
             function func9
             {
             }
-            get-help func9
+            Get-Help func9
         }
         $x = Get-Help helpFunc9
         It 'help is on the outer functon' { $x.Synopsis | Should -BeExactly 'Help on helpFunc9, not func9' }
@@ -503,7 +503,7 @@ Describe 'get-help other tests' -Tags "CI" {
         {
         }
 
-        $x = get-help helpFunc10
+        $x = Get-Help helpFunc10
         $x.Synopsis | Should -BeExactly 'Help on helpFunc10'
     }
 
@@ -539,7 +539,7 @@ Describe 'get-help other tests' -Tags "CI" {
                 )
         }
 
-        $x = get-help helpFunc11 -det
+        $x = Get-Help helpFunc11 -det
         $x.Parameters.parameter | ForEach-Object {
         It '$_.description' { $_.description[0].text | Should -Match "^$($_.Name)\s+help" }
         }
@@ -573,8 +573,8 @@ Describe 'get-help other tests' -Tags "CI" {
             Adds .txt to bar
          #>
         }
-        $x = get-help helpFunc12
-        It '$x.syntax' { ($x.syntax | Out-String -width 250) | Should -Match "helpFunc12 \[-Name] <String> \[\[-Extension] <String>] \[\[-NoType] <Object>] \[-ASwitch] \[\[-AnEnum] \{Alias.*All}] \[<CommonParameters>]" }
+        $x = Get-Help helpFunc12
+        It '$x.syntax' { ($x.syntax | Out-String -Width 250) | Should -Match "helpFunc12 \[-Name] <String> \[\[-Extension] <String>] \[\[-NoType] <Object>] \[-ASwitch] \[\[-AnEnum] \{Alias.*All}] \[<CommonParameters>]" }
         It '$x.syntax.syntaxItem.parameter[3].position' { $x.syntax.syntaxItem.parameter[3].position | Should -BeExactly 'named' }
         It '$x.syntax.syntaxItem.parameter[3].parameterValue' { $x.syntax.syntaxItem.parameter[3].parameterValue | Should -BeNullOrEmpty }
         It '$x.parameters.parameter[3].parameterValue' { $x.parameters.parameter[3].parameterValue | Should -Not -BeNullOrEmpty }
@@ -607,7 +607,7 @@ Describe 'get-help other tests' -Tags "CI" {
             )
         }
 
-        $x = get-help helpFunc13
+        $x = Get-Help helpFunc13
 
         It '$x.Parameters.parameter[0].globbing' { $x.Parameters.parameter[0].globbing | Should -BeExactly 'true' }
         It '$x.Parameters.parameter[1].defaultValue' { $x.Parameters.parameter[1].defaultValue | Should -BeExactly '42' }
@@ -664,7 +664,7 @@ Describe 'get-help other tests' -Tags "CI" {
               param()
         }
 
-        $x = get-help foo
+        $x = Get-Help foo
         It '$x.examples.example[0].introduction[0].text' { $x.examples.example[0].introduction[0].text | Should -BeExactly "PS > " }
         It '$x.examples.example[0].code' { $x.examples.example[0].code | Should -BeExactly "`$a = Get-Service`n`$a | group Status" }
         It '$x.examples.example[0].remarks[0].text' { $x.examples.example[0].remarks[0].text | Should -BeNullOrEmpty }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -346,7 +346,7 @@ Describe "Import-Module from CompatiblePSEditions-checked paths" -Tag "CI" {
                 (Invoke-Command -Session $s {Get-Location}).Path | Should -BeExactly $PWD.Path
 
                 # after WinCompat cleanup local $PWD changes should not cause errors
-                Remove-module $ModuleName -Force
+                Remove-Module $ModuleName -Force
 
                 Pop-Location
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Enter-PSHostProcess.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Enter-PSHostProcess.Tests.ps1
@@ -145,7 +145,7 @@ Describe "Enter-PSHostProcess tests" -Tag Feature {
 
                 # If opening the runspace fails, then print out the trace with the callstack
                 Wait-UntilTrue { $rs.RunspaceStateInfo.State -eq [System.Management.Automation.Runspaces.RunspaceState]::Opened } |
-                    Should -BeTrue -Because (get-content $splat.FilePath -Raw)
+                    Should -BeTrue -Because (Get-Content $splat.FilePath -Raw)
 
                 $ps = [powershell]::Create()
                 $ps.Runspace = $rs

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Command.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Command.Tests.ps1
@@ -245,7 +245,7 @@ Describe "Get-Command Tests" -Tags "CI" {
     }
 
     It "verify if get the proper dynamic parameter type skipped by issue #1430" -Pending {
-        $results = Get-Command TestGetCommand-DynamicParametersDCR -TestToRun returngenericparameter -parametertype System.Diagnostics.Process
+        $results = Get-Command TestGetCommand-DynamicParametersDCR -TestToRun returngenericparameter -ParameterType System.Diagnostics.Process
         VerifyParameterType -cmdlet $results[0] -parameterName "TypedValue" -parameterType System.Diagnostics.Process
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/History.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/History.Tests.ps1
@@ -122,7 +122,7 @@ Describe "History cmdlet test cases" -Tags "CI" {
             EndExecutionTime   = $end
         }
         $history | Add-History
-        $h = Get-History -count 1
+        $h = Get-History -Count 1
         $h.Duration | Should -Be $duration
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -81,7 +81,7 @@ Describe "Import-Module with ScriptsToProcess" -Tags "CI" {
 
     AfterEach {
         $m = @('module1','module2','script1','script2')
-        remove-module $m -Force -ErrorAction SilentlyContinue
+        Remove-Module $m -Force -ErrorAction SilentlyContinue
         Remove-Item out.txt -Force -ErrorAction SilentlyContinue
     }
 
@@ -163,7 +163,7 @@ Describe "Import-Module for Binary Modules" -Tags 'CI' {
         try {
             $TestModulePath = Join-Path $TESTDRIVE "System.$extension"
             $job = Start-Job -ScriptBlock {
-                $module = Import-Module $using:TestModulePath -Passthru;
+                $module = Import-Module $using:TestModulePath -PassThru;
                 $module.ImplementingAssembly.Location;
                 Test-BinaryModuleCmdlet1
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Job.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Job.Tests.ps1
@@ -29,8 +29,8 @@ Describe "Job Cmdlet Tests" -Tag "CI" {
             { Get-Job $j -ErrorAction Stop } | Should -Throw -ErrorId "JobWithSpecifiedNameNotFound,Microsoft.PowerShell.Commands.GetJobCommand"
         }
         It "Receive-Job can retrieve job results" {
-            Wait-Job -Timeout 60 -id $j.id | Should -Not -BeNullOrEmpty
-            receive-job -id $j.id | Should -Be 2
+            Wait-Job -Timeout 60 -Id $j.id | Should -Not -BeNullOrEmpty
+            Receive-Job -Id $j.id | Should -Be 2
         }
         It "-RunAs32 not supported from 64-bit pwsh" -Skip:(-not [System.Environment]::Is64BitProcess) {
             { Start-Job -ScriptBlock {} -RunAs32 } | Should -Throw -ErrorId "RunAs32NotSupported,Microsoft.PowerShell.Commands.StartJobCommand"
@@ -44,7 +44,7 @@ Describe "Job Cmdlet Tests" -Tag "CI" {
         It "Start-Job accepts arguments" {
             $sb = { Write-Output $args[1]; Write-Output $args[0] }
             $j = Start-Job -ScriptBlock $sb -ArgumentList "$TestDrive", 42
-            Wait-job -Timeout (5 * 60) $j | Should -Be $j
+            Wait-Job -Timeout (5 * 60) $j | Should -Be $j
             $r = Receive-Job $j
             $r -Join "," | Should -Be "42,$TestDrive"
         }
@@ -150,7 +150,7 @@ Describe "Job Cmdlet Tests" -Tag "CI" {
         }
     }
 }
-Describe "Debug-job test" -tag "Feature" {
+Describe "Debug-job test" -Tag "Feature" {
     BeforeAll {
         $rs = [runspacefactory]::CreateRunspace()
         $rs.Open()
@@ -165,7 +165,7 @@ Describe "Debug-job test" -tag "Feature" {
     }
     # we check this via implication.
     # if we're debugging a job, then the debugger will have a callstack
-    It "Debug-Job will break into debugger" -pending {
+    It "Debug-Job will break into debugger" -Pending {
         $ps.AddScript('$job = start-job { 1..300 | ForEach-Object { Start-Sleep 1 } }').Invoke()
         $ps.Commands.Clear()
         $ps.Runspace.Debugger.GetCallStack() | Should -BeNullOrEmpty
@@ -178,7 +178,7 @@ Describe "Debug-job test" -tag "Feature" {
     }
 }
 
-Describe "Ampersand background test" -tag "CI","Slow" {
+Describe "Ampersand background test" -Tag "CI","Slow" {
     Context "Simple background job" {
         AfterEach {
             Get-Job | Remove-Job -Force
@@ -194,7 +194,7 @@ Describe "Ampersand background test" -tag "CI","Slow" {
         }
         It "doesn't cause error when variable is missing" {
             Remove-Item variable:name -ErrorAction Ignore
-            $j = write-output "Hi $name" &
+            $j = Write-Output "Hi $name" &
             Receive-Job $j -Wait | Should -BeExactly "Hi "
         }
         It "Copies variables to the child process" {
@@ -215,7 +215,7 @@ Describe "Ampersand background test" -tag "CI","Slow" {
             $PID | Should -Not -BeExactly $cpid
         }
         It "starts in the current directory" {
-            $j = Get-Location | Foreach-Object -MemberName Path &
+            $j = Get-Location | ForEach-Object -MemberName Path &
             Receive-Job -Wait $j | Should -Be ($PWD.Path)
         }
         It "Test that output redirection is done in the background job" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Default.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Default.Tests.ps1
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-Describe "Out-Default Tests" -tag CI {
+Describe "Out-Default Tests" -Tag CI {
     BeforeAll {
         # due to https://github.com/PowerShell/PowerShell/issues/3405, `Out-Default -Transcript` emits output to pipeline
         # as running in Pester effectively wraps everything in parenthesis, workaround is to use another powershell

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Host.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Host.Tests.ps1
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-Describe "Out-Host Tests" -tag CI {
+Describe "Out-Host Tests" -Tag CI {
     BeforeAll {
         $th = New-TestHost
         $rs = [runspacefactory]::Createrunspace($th)

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Pester.Commands.Cmdlets.GetCommand.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Pester.Commands.Cmdlets.GetCommand.Tests.ps1
@@ -34,15 +34,15 @@ Describe "Tests Get-Command with relative paths and wildcards" -Tag "CI" {
     }
 
     It "Test wildcard with relative directory path" {
-        push-location $TestDrive
+        Push-Location $TestDrive
         $result = Get-Command -Name .\WildCardCommandA*
-        pop-location
+        Pop-Location
         $result | Should -Not -BeNullOrEmpty
         $result | Should -Be WildCardCommandA.exe
     }
 
     It "Test with PowerShell wildcard and relative path" {
-        push-location $TestDrive
+        Push-Location $TestDrive
 
         # This should use the wildcard to find WildCardCommandA.exe
         $result = Get-Command -Name .\WildCardCommand[A].exe
@@ -59,7 +59,7 @@ Describe "Tests Get-Command with relative paths and wildcards" -Tag "CI" {
 
     It "Get-Command -ShowCommandInfo property field test" {
         $properties = ($commandInfo | Get-Member -MemberType NoteProperty)
-        $propertiesAsString =  $properties.name | out-string
+        $propertiesAsString =  $properties.name | Out-String
         $propertiesAsString | Should -MatchExactly 'CommandType'
         $propertiesAsString | Should -MatchExactly 'Definition'
         $propertiesAsString | Should -MatchExactly 'Module'
@@ -86,7 +86,7 @@ Describe "Tests Get-Command with relative paths and wildcards" -Tag "CI" {
 
     It "Get-Command -ShowCommandInfo ParameterSets property field test" {
         $properties = ($commandInfo.ParameterSets[0] | Get-Member -MemberType NoteProperty)
-        $propertiesAsString =  $properties.name | out-string
+        $propertiesAsString =  $properties.name | Out-String
         $propertiesAsString | Should -MatchExactly 'IsDefault'
         $propertiesAsString | Should -MatchExactly 'Name'
         $propertiesAsString | Should -MatchExactly 'Parameters'
@@ -94,7 +94,7 @@ Describe "Tests Get-Command with relative paths and wildcards" -Tag "CI" {
 
     It "Get-Command -ShowCommandInfo Parameters property field test" {
         $properties = ($commandInfo.ParameterSets[0].Parameters | Get-Member -MemberType NoteProperty)
-        $propertiesAsString =  $properties.name | out-string
+        $propertiesAsString =  $properties.name | Out-String
         $propertiesAsString | Should -MatchExactly 'HasParameterSet'
         $propertiesAsString | Should -MatchExactly 'IsMandatory'
         $propertiesAsString | Should -MatchExactly 'Name'

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/RemoteImportModule.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/RemoteImportModule.Tests.ps1
@@ -9,7 +9,7 @@ Describe "Remote import-module tests" -Tags 'Feature','RequireAdminOnWindows' {
             $PSDefaultParameterValues["it:skip"] = $true
         } else {
             $pssession = New-RemoteSession
-            Invoke-Command -Session $pssession -ScriptBlock { $env:PSModulePath += ";${using:testdrive}" }
+            Invoke-Command -Session $pssession -Scriptblock { $env:PSModulePath += ";${using:testdrive}" }
             # pending https://github.com/PowerShell/PowerShell/issues/4819
             # $cimsession = New-RemoteSession -CimSession
             $null = New-Item -ItemType Directory -Path $modulePath

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Where-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Where-Object.Tests.ps1
@@ -51,7 +51,7 @@ Describe "Where-Object" -Tags "CI" {
     }
 
     It 'Where-Object Prop -contains Value' {
-        $Result = $Computers | Where-Object Drives -contains 'D'
+        $Result = $Computers | Where-Object Drives -Contains 'D'
         $Result | Should -HaveCount 2
     }
 
@@ -63,7 +63,7 @@ Describe "Where-Object" -Tags "CI" {
 
     It 'Where-Object $Array -in Prop' {
         $Array = 'SPC-1234','BGP-5678'
-        $Result = $Computers | Where-Object ComputerName -in $Array
+        $Result = $Computers | Where-Object ComputerName -In $Array
         $Result | Should -HaveCount 2
     }
 
@@ -73,7 +73,7 @@ Describe "Where-Object" -Tags "CI" {
     }
 
     It 'Where-Object Prop -ge 2' {
-        $Result = $Computers | Where-Object NumberOfCores -ge 2
+        $Result = $Computers | Where-Object NumberOfCores -GE 2
         $Result | Should -HaveCount 2
     }
 
@@ -83,7 +83,7 @@ Describe "Where-Object" -Tags "CI" {
     }
 
     It 'Where-Object Prop -gt 2' {
-        $Result = $Computers | Where-Object NumberOfCores -gt 2
+        $Result = $Computers | Where-Object NumberOfCores -GT 2
         $Result | Should -HaveCount 1
     }
 
@@ -93,7 +93,7 @@ Describe "Where-Object" -Tags "CI" {
     }
 
     It 'Where-Object Prop -le 2' {
-        $Result = $Computers | Where-Object NumberOfCores -le 2
+        $Result = $Computers | Where-Object NumberOfCores -LE 2
         $Result | Should -HaveCount 2
     }
 
@@ -103,7 +103,7 @@ Describe "Where-Object" -Tags "CI" {
     }
 
     It 'Where-Object Prop -lt 2' {
-        $Result = $Computers | Where-Object NumberOfCores -lt 2
+        $Result = $Computers | Where-Object NumberOfCores -LT 2
         $Result | Should -HaveCount 1
     }
 
@@ -113,7 +113,7 @@ Describe "Where-Object" -Tags "CI" {
     }
 
     It 'Where-Object Prop -like Value' {
-        $Result = $Computers | Where-Object ComputerName -like 'MGC-9101'
+        $Result = $Computers | Where-Object ComputerName -Like 'MGC-9101'
         $Result | Should -HaveCount 1
     }
 
@@ -123,13 +123,13 @@ Describe "Where-Object" -Tags "CI" {
     }
 
     It 'Where-Object Prop -like Value' {
-        $Result = $Computers | Where-Object ComputerName -match '^MGC.+'
+        $Result = $Computers | Where-Object ComputerName -Match '^MGC.+'
         $Result | Should -HaveCount 1
     }
 
     It 'Where-Object should handle dynamic (DLR) objects' {
         $dynObj = [TestDynamic]::new()
-        $Result = $dynObj, $dynObj | Where-Object FooProp -eq 123
+        $Result = $dynObj, $dynObj | Where-Object FooProp -EQ 123
         $Result | Should -HaveCount 2
         $Result[0] | Should -Be $dynObj
         $Result[1] | Should -Be $dynObj
@@ -137,7 +137,7 @@ Describe "Where-Object" -Tags "CI" {
 
     It 'Where-Object should handle dynamic (DLR) objects, even without property name hint' {
         $dynObj = [TestDynamic]::new()
-        $Result = $dynObj, $dynObj | Where-Object HiddenProp -eq 789
+        $Result = $dynObj, $dynObj | Where-Object HiddenProp -EQ 789
         $Result | Should -HaveCount 2
         $Result[0] | Should -Be $dynObj
         $Result[1] | Should -Be $dynObj

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-WinEvent.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-WinEvent.Tests.ps1
@@ -15,12 +15,12 @@ Describe 'Get-WinEvent' -Tags "CI" {
     }
     Context "Get-WinEvent ListProvider parameter" {
         It 'Get-WinEvent can list the providers' {
-            $result = Get-WinEvent -listprovider * -erroraction ignore
+            $result = Get-WinEvent -ListProvider * -ErrorAction ignore
             $result | Should -Not -BeNullOrEmpty
         }
         It 'Get-WinEvent can get a provider by name' {
-            $providers = Get-WinEvent -listprovider MSI* -erroraction ignore
-            $result = Get-WinEvent -listprovider ($providers[0].name)
+            $providers = Get-WinEvent -ListProvider MSI* -ErrorAction ignore
+            $result = Get-WinEvent -ListProvider ($providers[0].name)
             $result | Should -Not -BeNullOrEmpty
         }
 
@@ -30,9 +30,9 @@ Describe 'Get-WinEvent' -Tags "CI" {
         BeforeAll {
             if ( ! $IsWindows ) { return }
             $foundEvents = $false
-            $providers = Get-WinEvent -listprovider * -erroraction ignore
+            $providers = Get-WinEvent -ListProvider * -ErrorAction ignore
             foreach($provider in $providers) {
-                $events = Get-WinEvent -provider $provider.name -erroraction ignore
+                $events = Get-WinEvent -provider $provider.name -ErrorAction ignore
                 if ( $events.Count -gt 2 ) {
                     $providerForTests = $provider
                     $foundEvents = $true
@@ -48,17 +48,17 @@ Describe 'Get-WinEvent' -Tags "CI" {
             }
         }
         It 'Get-WinEvent can get events via logname' {
-            $results = get-winevent -logname $providerForTests.LogLinks.LogName -MaxEvents 10
+            $results = Get-WinEvent -LogName $providerForTests.LogLinks.LogName -MaxEvents 10
             $results | Should -Not -BeNullOrEmpty
         }
         It 'Throw if count of lognames exceeds Windows API limit' {
             if ([System.Environment]::OSVersion.Version.Major -ge 10) {
-                { get-winevent -logname * } | Should -Throw -ErrorId "LogCountLimitExceeded,Microsoft.PowerShell.Commands.GetWinEventCommand"
+                { Get-WinEvent -LogName * } | Should -Throw -ErrorId "LogCountLimitExceeded,Microsoft.PowerShell.Commands.GetWinEventCommand"
             }
         }
         It 'Get-WinEvent can use the simplest of filters' {
             $filter = @{ ProviderName = $providerForTests.Name }
-            $testEvents = Get-WinEvent -filterhashtable $filter
+            $testEvents = Get-WinEvent -FilterHashtable $filter
 
             $testEventDict = [System.Collections.Generic.Dictionary[int, System.Diagnostics.Eventing.Reader.EventLogRecord]]::new()
             foreach ($te in $testEvents)
@@ -78,21 +78,21 @@ Describe 'Get-WinEvent' -Tags "CI" {
         }
         It 'Get-WinEvent can use a filter which includes two items' {
             $filter = @{ ProviderName = $providerForTests.Name; Id = $events[0].Id}
-            $results = Get-WinEvent -filterHashtable $filter
+            $results = Get-WinEvent -FilterHashtable $filter
             $results | Should -Not -BeNullOrEmpty
         }
         It 'Get-WinEvent can retrieve event via XmlQuery' {
             $level = $events[0].Level
             $logname = $providerForTests.loglinks.logname
             $filter = "<QueryList><Query><Select Path='${logname}'>*[System[Level=${level}]]</Select></Query></QueryList>"
-            $results = Get-WinEvent -filterXml $filter -max 3
+            $results = Get-WinEvent -FilterXml $filter -max 3
             $results | Should -Not -BeNullOrEmpty
         }
         It 'Get-WinEvent can retrieve event via XPath' {
             $level = $events[0].Level
             $logname  = $providerForTests.loglinks.logname
             $xpathFilter = "*[System[Level=$level]]"
-            $results = Get-WinEvent -logname $logname -filterXPath $xpathFilter -max 3
+            $results = Get-WinEvent -LogName $logname -FilterXPath $xpathFilter -max 3
             $results | Should -Not -BeNullOrEmpty
         }
 
@@ -112,7 +112,7 @@ Describe 'Get-WinEvent' -Tags "CI" {
             # the provided log file has been edited to remove MS PII, so we must use -ErrorAction silentlycontinue
             $eventLogFile = [io.path]::Combine($PSScriptRoot, "assets", "Saved-Events.evtx")
             $filter = @{ path = "$eventLogFile"; Param2 = "Windows x64"}
-            $results = Get-WinEvent -filterHashtable $filter -ErrorAction silentlycontinue
+            $results = Get-WinEvent -FilterHashtable $filter -ErrorAction silentlycontinue
             @($results).Count | Should -Be 1
             $results.RecordId | Should -Be 10
         }
@@ -121,7 +121,7 @@ Describe 'Get-WinEvent' -Tags "CI" {
             # the provided log file has been edited to remove MS PII, so we must use -ErrorAction silentlycontinue
             $eventLogFile = [io.path]::Combine($PSScriptRoot, "assets", "Saved-Events.evtx")
             $filter = @{ path = "$eventLogFile"; DriverName = "Remote Desktop Easy Print", "Microsoft enhanced Point and Print compatibility driver" }
-            $results = Get-WinEvent -filterHashtable $filter -ErrorAction silentlycontinue
+            $results = Get-WinEvent -FilterHashtable $filter -ErrorAction silentlycontinue
             @($results).Count | Should -Be 2
             ($results.RecordId -contains 9) | Should -BeTrue
             ($results.RecordId -contains 11) | Should -BeTrue
@@ -131,7 +131,7 @@ Describe 'Get-WinEvent' -Tags "CI" {
             # the provided log file has been edited to remove MS PII, so we must use -ErrorAction silentlycontinue
             $eventLogFile = [io.path]::Combine($PSScriptRoot, "assets", "Saved-Events.evtx")
             $filter = @{ path = "$eventLogFile"; PackageAware="Not package aware"; DriverName = "Remote Desktop Easy Print", "Microsoft enhanced Point and Print compatibility driver" }
-            $results = Get-WinEvent -filterHashtable $filter -ErrorAction silentlycontinue
+            $results = Get-WinEvent -FilterHashtable $filter -ErrorAction silentlycontinue
             @($results).Count | Should -Be 2
             ($results.RecordId -contains 9) | Should -BeTrue
             ($results.RecordId -contains 11) | Should -BeTrue
@@ -141,7 +141,7 @@ Describe 'Get-WinEvent' -Tags "CI" {
             # the provided log file has been edited to remove MS PII, so we must use -ErrorAction silentlycontinue
             $eventLogFile = [io.path]::Combine($PSScriptRoot, "assets", "Saved-Events.evtx")
             $filter = "*/UserData/*/Param2='Windows x64'"
-            $results = Get-WinEvent -path $eventLogFile -filterXPath $filter -ErrorAction silentlycontinue
+            $results = Get-WinEvent -Path $eventLogFile -FilterXPath $filter -ErrorAction silentlycontinue
             @($results).Count | Should -Be 1
             $results.RecordId | Should -Be 10
         }
@@ -152,9 +152,9 @@ Describe 'Get-WinEvent' -Tags "CI" {
             # the provided log file has been edited to remove MS PII, so we must use -ErrorAction silentlycontinue
             $eventLogFile = [io.path]::Combine($PSScriptRoot, "assets", "Saved-Events.evtx")
             $filter = @{ path = "$eventLogFile"}
-            $results = Get-WinEvent -filterHashtable $filter -ErrorAction silentlycontinue
+            $results = Get-WinEvent -FilterHashtable $filter -ErrorAction silentlycontinue
             $filterSuppress = @{ path = "$eventLogFile";  SuppressHashFilter=@{Id=370}}
-            $resultsSuppress = Get-WinEvent -filterHashtable $filterSuppress -ErrorAction silentlycontinue
+            $resultsSuppress = Get-WinEvent -FilterHashtable $filterSuppress -ErrorAction silentlycontinue
             @($results).Count | Should -Be 3
             @($resultsSuppress).Count | Should -Be 2
         }
@@ -163,9 +163,9 @@ Describe 'Get-WinEvent' -Tags "CI" {
             # the provided log file has been edited to remove MS PII, so we must use -ErrorAction silentlycontinue
             $eventLogFile = [io.path]::Combine($PSScriptRoot, "assets", "Saved-Events.evtx")
             $filter = @{ path = "$eventLogFile"}
-            $results = Get-WinEvent -filterHashtable $filter -ErrorAction silentlycontinue
+            $results = Get-WinEvent -FilterHashtable $filter -ErrorAction silentlycontinue
             $filterSuppress = @{ path = "$eventLogFile";  SuppressHashFilter=@{Param2 = "Windows x64"}}
-            $resultsSuppress = Get-WinEvent -filterHashtable $filterSuppress -ErrorAction silentlycontinue
+            $resultsSuppress = Get-WinEvent -FilterHashtable $filterSuppress -ErrorAction silentlycontinue
             @($results).Count | Should -Be 3
             @($resultsSuppress).Count | Should -Be 2
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/New-WinEvent.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/New-WinEvent.Tests.ps1
@@ -22,7 +22,7 @@ Describe 'New-WinEvent' -Tags "CI" {
         It 'Simple New-WinEvent without any payload' {
             New-WinEvent -ProviderName $ProviderName -Id $SimpleEventId -Version 1
             $filter = @{ ProviderName = $ProviderName; Id = $SimpleEventId}
-            (Get-WinEvent -filterHashtable $filter).Count | Should -BeGreaterThan 0
+            (Get-WinEvent -FilterHashtable $filter).Count | Should -BeGreaterThan 0
         }
 
         It 'No provider found error' {
@@ -42,7 +42,7 @@ Describe 'New-WinEvent' -Tags "CI" {
         }
 
         It 'PayloadMismatch error' {
-            $logPath = join-path $TestDrive 'testlog1.txt'
+            $logPath = Join-Path $TestDrive 'testlog1.txt'
             # this will print the warning with expected event template to the file
             New-WinEvent -ProviderName $ProviderName -Id $ComplexEventId *> $logPath
             Get-Content $logPath -Raw | Should -Match 'data name="FragmentPayload"'

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
@@ -222,7 +222,7 @@ try {
 
         It "Errors on adding nonexistent user to group" {
             $sb = {
-                Add-LocalGroupMember -name TestGroup1 -Member TestNonexistentUser1
+                Add-LocalGroupMember -Name TestGroup1 -Member TestNonexistentUser1
             }
             VerifyFailingTest $sb "PrincipalNotFound,Microsoft.PowerShell.Commands.AddLocalGroupMemberCommand"
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
@@ -6,9 +6,9 @@
 
 return
 
-Set-Variable dateInFuture -option Constant -value "12/12/2036 09:00"
-Set-Variable dateInPast -option Constant -value "12/12/2010 09:00"
-Set-Variable dateInvalid -option Constant -value "12/12/2016 25:00"
+Set-Variable dateInFuture -Option Constant -Value "12/12/2036 09:00"
+Set-Variable dateInPast -Option Constant -Value "12/12/2010 09:00"
+Set-Variable dateInvalid -Option Constant -Value "12/12/2016 25:00"
 
 function RemoveTestUsers
 {
@@ -66,7 +66,7 @@ try {
     Describe "Verify Expected LocalUser Aliases are present" -Tags @('CI', 'RequireAdminOnWindows') {
 
         It "Test command presence" {
-            $result = get-alias | ForEach-Object { if ($_.Source -eq "Microsoft.PowerShell.LocalAccounts") {$_}}
+            $result = Get-Alias | ForEach-Object { if ($_.Source -eq "Microsoft.PowerShell.LocalAccounts") {$_}}
 
             $result.Name -contains "algm" | Should -BeTrue
             $result.Name -contains "dlu" | Should -BeTrue
@@ -328,7 +328,7 @@ try {
 
         It "Errors when Password is an empty string" {
             $sb = {
-                New-LocalUser TestUserNew1 -Password (ConvertTo-SecureString "" -Asplaintext -Force)
+                New-LocalUser TestUserNew1 -Password (ConvertTo-SecureString "" -AsPlainText -Force)
             }
             VerifyFailingTest $sb "ParameterArgumentValidationErrorEmptyStringNotAllowed,Microsoft.PowerShell.Commands.ConvertToSecureStringCommand"
         }
@@ -375,7 +375,7 @@ try {
 
         It "Can set PasswordNeverExpires to create a user with null for PasswordExpires date" {
             #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
-            $result = New-LocalUser TestUserNew1 -Password (ConvertTo-SecureString "p@ssw0rd" -Asplaintext -Force) -PasswordNeverExpires
+            $result = New-LocalUser TestUserNew1 -Password (ConvertTo-SecureString "p@ssw0rd" -AsPlainText -Force) -PasswordNeverExpires
 
             $result.Name | Should -BeExactly TestUserNew1
             $result.PasswordExpires | Should -BeNullOrEmpty
@@ -750,21 +750,21 @@ try {
 
         It "Errors when Password is an empty string" {
             $sb = {
-                Set-LocalUser -Name TestUserSet1 -Password (ConvertTo-SecureString "" -Asplaintext -Force)
+                Set-LocalUser -Name TestUserSet1 -Password (ConvertTo-SecureString "" -AsPlainText -Force)
             }
             VerifyFailingTest $sb "ParameterArgumentValidationErrorEmptyStringNotAllowed,Microsoft.PowerShell.Commands.ConvertToSecureStringCommand"
         }
 
         It "Errors when Password is null" {
             $sb = {
-                Set-LocalUser -Name TestUserSet1 -Password (ConvertTo-SecureString $null -Asplaintext -Force)
+                Set-LocalUser -Name TestUserSet1 -Password (ConvertTo-SecureString $null -AsPlainText -Force)
             }
             VerifyFailingTest $sb "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.ConvertToSecureStringCommand"
         }
 
         It "Can set Password value at max 256" {
             #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
-            Set-LocalUser -Name TestUserSet1 -Password (ConvertTo-SecureString ("123@"+"A"*252) -asplaintext -Force)
+            Set-LocalUser -Name TestUserSet1 -Password (ConvertTo-SecureString ("123@"+"A"*252) -AsPlainText -Force)
             $result = Get-LocalUser -Name TestUserSet1
 
             $result.Name | Should -BeExactly TestUserSet1
@@ -775,14 +775,14 @@ try {
 
         It "Errors when Password over max 257" {
             $sb = {
-                Set-LocalUser -Name TestUserSet1 -Password (ConvertTo-SecureString ("A"*257) -asplaintext -Force) -ErrorAction Stop
+                Set-LocalUser -Name TestUserSet1 -Password (ConvertTo-SecureString ("A"*257) -AsPlainText -Force) -ErrorAction Stop
             }
             VerifyFailingTest $sb "InvalidPassword,Microsoft.PowerShell.Commands.SetLocalUserCommand"
         }
 
         It 'Can use PasswordNeverExpires:$true to null a PasswordExpires date' {
             #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
-            $user = New-LocalUser TestUserSet2 -Password (ConvertTo-SecureString "p@ssw0rd" -Asplaintext -Force)
+            $user = New-LocalUser TestUserSet2 -Password (ConvertTo-SecureString "p@ssw0rd" -AsPlainText -Force)
             $user | Set-LocalUser -PasswordNeverExpires:$true
             $result = Get-LocalUser TestUserSet2
 
@@ -792,7 +792,7 @@ try {
 
         It 'Can use PasswordNeverExpires:$false to activate a PasswordExpires date' {
             #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
-            $user = New-LocalUser TestUserSet2 -Password (ConvertTo-SecureString "p@ssw0rd" -Asplaintext -Force) -PasswordNeverExpires
+            $user = New-LocalUser TestUserSet2 -Password (ConvertTo-SecureString "p@ssw0rd" -AsPlainText -Force) -PasswordNeverExpires
             $user | Set-LocalUser -PasswordNeverExpires:$false
             $result = Get-LocalUser TestUserSet2
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Alias.Tests.ps1
@@ -76,7 +76,7 @@ Describe "Extended Alias Provider Tests" -Tags "Feature" {
 
         It "Verifying Whatif" {
             $before = (Get-Item -Path "Alias:\${testAliasName}").Definition
-            Set-Item -Path "Alias:\${testAliasName}" -Value "Get-Location" -Whatif
+            Set-Item -Path "Alias:\${testAliasName}" -Value "Get-Location" -WhatIf
             $after = (Get-Item -Path "Alias:\${testAliasName}").Definition
             $after | Should -BeExactly $before # Definition should not have changed
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-Content.Tests.ps1
@@ -65,7 +65,7 @@ Describe "Clear-Content cmdlet tests" -Tags "CI" {
     }
 
     # we could suppress the WhatIf output here if we use the testhost, but it's not necessary
-    It "The filesystem provider supports should process" -skip:(!$IsWindows) {
+    It "The filesystem provider supports should process" -Skip:(!$IsWindows) {
       Clear-Content -Path TestDrive:\$file2 -WhatIf
       "TestDrive:\$file2" | Should -FileContentMatch "This is content"
     }
@@ -75,7 +75,7 @@ Describe "Clear-Content cmdlet tests" -Tags "CI" {
       $cci.SupportsShouldProcess | Should -BeTrue
     }
 
-    It "Alternate streams should be cleared with clear-content" -skip:(!$IsWindows) {
+    It "Alternate streams should be cleared with clear-content" -Skip:(!$IsWindows) {
       # make sure that the content is correct
       # this is here rather than BeforeAll because only windows can write to an alternate stream
       Set-Content -Path "TestDrive:/$file3" -Stream $streamName -Value $streamContent

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-EventLog.Tests.ps1
@@ -14,7 +14,7 @@ Describe "Clear-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
     It "should be able to Clear-EventLog" -Pending:($true) {
       Remove-EventLog -LogName TestLog -ErrorAction Ignore
       { New-EventLog -LogName TestLog -Source TestSource -ErrorAction Stop } | Should -Not -Throw
-      { Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ErrorAction Stop } | Should -Not -Throw
+      { Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventId 1 -ErrorAction Stop } | Should -Not -Throw
       { Get-EventLog -LogName TestLog }                           | Should -Not -Throw
       $result = Get-EventLog -LogName TestLog
       $result.Count                                               | Should -Be 1

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/ControlService.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/ControlService.Tests.ps1
@@ -84,11 +84,11 @@ Describe "Control Service cmdlet tests" -Tags "Feature","RequireAdminOnWindows" 
     @{script={Stop-Service dcomlaunch -ErrorAction Stop};errorid="ServiceHasDependentServices,Microsoft.PowerShell.Commands.StopServiceCommand"},
     @{script={Suspend-Service winrm -ErrorAction Stop};errorid="CouldNotSuspendServiceNotSupported,Microsoft.PowerShell.Commands.SuspendServiceCommand"},
     @{script={Resume-Service winrm -ErrorAction Stop};errorid="CouldNotResumeServiceNotSupported,Microsoft.PowerShell.Commands.ResumeServiceCommand"},
-    @{script={Stop-Service $(new-guid) -ErrorAction Stop};errorid="NoServiceFoundForGivenName,Microsoft.PowerShell.Commands.StopServiceCommand"},
-    @{script={Start-Service $(new-guid) -ErrorAction Stop};errorid="NoServiceFoundForGivenName,Microsoft.PowerShell.Commands.StartServiceCommand"},
-    @{script={Resume-Service $(new-guid) -ErrorAction Stop};errorid="NoServiceFoundForGivenName,Microsoft.PowerShell.Commands.ResumeServiceCommand"},
-    @{script={Suspend-Service $(new-guid) -ErrorAction Stop};errorid="NoServiceFoundForGivenName,Microsoft.PowerShell.Commands.SuspendServiceCommand"},
-    @{script={Restart-Service $(new-guid) -ErrorAction Stop};errorid="NoServiceFoundForGivenName,Microsoft.PowerShell.Commands.RestartServiceCommand"}
+    @{script={Stop-Service $(New-Guid) -ErrorAction Stop};errorid="NoServiceFoundForGivenName,Microsoft.PowerShell.Commands.StopServiceCommand"},
+    @{script={Start-Service $(New-Guid) -ErrorAction Stop};errorid="NoServiceFoundForGivenName,Microsoft.PowerShell.Commands.StartServiceCommand"},
+    @{script={Resume-Service $(New-Guid) -ErrorAction Stop};errorid="NoServiceFoundForGivenName,Microsoft.PowerShell.Commands.ResumeServiceCommand"},
+    @{script={Suspend-Service $(New-Guid) -ErrorAction Stop};errorid="NoServiceFoundForGivenName,Microsoft.PowerShell.Commands.SuspendServiceCommand"},
+    @{script={Restart-Service $(New-Guid) -ErrorAction Stop};errorid="NoServiceFoundForGivenName,Microsoft.PowerShell.Commands.RestartServiceCommand"}
   ) {
       param($script,$errorid)
       { & $script } | Should -Throw -ErrorId $errorid

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Copy.Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Copy.Item.Tests.ps1
@@ -550,7 +550,7 @@ Describe "Validate Copy-Item Remotely" -Tags "CI" {
         BeforeAll {
             # Create test file.
             $testFilePath = Join-Path "TestDrive:" "testfile.txt"
-            if (test-path $testFilePath)
+            if (Test-Path $testFilePath)
             {
                 Remove-Item $testFilePath -Force -ErrorAction SilentlyContinue
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -703,8 +703,8 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
             $link = Join-Path $TestDrive "sym-to-folder"
             New-Item -ItemType Directory -Path $folder > $null
             New-Item -ItemType File -Path $file -Value "some content" > $null
-            New-Item -ItemType SymbolicLink -Path $link -value $folder > $null
-            $childA = Get-Childitem $folder
+            New-Item -ItemType SymbolicLink -Path $link -Value $folder > $null
+            $childA = Get-ChildItem $folder
             Remove-Item -Path $link -Recurse
             $childB = Get-ChildItem $folder
             $childB.Count | Should -Be 1
@@ -983,7 +983,7 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
         }
 
         It "Verify Filter" {
-            $result = Get-Item -Path "TestDrive:\*" -filter "*2.txt"
+            $result = Get-Item -Path "TestDrive:\*" -Filter "*2.txt"
             $result.Name | Should -BeExactly $testFile2
         }
 
@@ -1085,7 +1085,7 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
         }
 
         It "Verify Include and Exclude Intersection" {
-            Remove-Item "TestDrive:\*" -Include "*.txt" -exclude "*2*"
+            Remove-Item "TestDrive:\*" -Include "*.txt" -Exclude "*2*"
             $file1 = Get-Item $testFile -ErrorAction SilentlyContinue
             $file2 = Get-Item $testFile2 -ErrorAction SilentlyContinue
             $file1 | Should -BeNullOrEmpty

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -83,7 +83,7 @@ Describe "Get-ChildItem" -Tags "CI" {
         }
 
         It "Should have all the proper fields and be populated" {
-            $var = Get-Childitem .
+            $var = Get-ChildItem .
 
             $var.Name.Length   | Should -BeGreaterThan 0
             $var.Mode.Length   | Should -BeGreaterThan 0
@@ -92,7 +92,7 @@ Describe "Get-ChildItem" -Tags "CI" {
         }
 
         It "Should have mode property populated for protected files on Windows" -Skip:(!$IsWindows) {
-            $files = Get-Childitem -Force ~\NT*
+            $files = Get-ChildItem -Force ~\NT*
             $files.Count | Should -BeGreaterThan 0
             foreach ($file in $files)
             {
@@ -110,14 +110,14 @@ Describe "Get-ChildItem" -Tags "CI" {
         }
 
         It "Should list hidden files as well when 'Force' parameter is used" {
-            $files = Get-ChildItem -path $TestDrive -Force
+            $files = Get-ChildItem -Path $TestDrive -Force
             $files | Should -Not -BeNullOrEmpty
             $files.Count | Should -Be 6
             $files.Name.Contains($item_F) | Should -BeTrue
         }
 
         It "Should list only hidden files when 'Hidden' parameter is used" {
-            $files = Get-ChildItem -path $TestDrive -Hidden
+            $files = Get-ChildItem -Path $TestDrive -Hidden
             $files | Should -Not -BeNullOrEmpty
             $files.Count | Should -Be 1
             $files[0].Name | Should -BeExactly $item_F
@@ -170,7 +170,7 @@ Describe "Get-ChildItem" -Tags "CI" {
         # VSTS machines don't have a page file
         It "Should give .sys file if the fullpath is specified with hidden and force parameter" -Pending {
             # Don't remove!!! It is special test for hidden and opened file with exclusive lock.
-            $file = Get-ChildItem -path "$env:SystemDrive\\pagefile.sys" -Hidden
+            $file = Get-ChildItem -Path "$env:SystemDrive\\pagefile.sys" -Hidden
             $file | Should -Not -Be $null
             $file.Count | Should -Be 1
             $file.Name | Should -Be "pagefile.sys"
@@ -217,7 +217,7 @@ Describe "Get-ChildItem" -Tags "CI" {
                 $env:__FOODBAR = 'food'
                 $env:__foodbar = 'bar'
 
-                $foodbar = Get-Childitem env: | Where-Object {$_.Name -eq '__foodbar'}
+                $foodbar = Get-ChildItem env: | Where-Object {$_.Name -eq '__foodbar'}
                 $count = if ($IsWindows) { 1 } else { 2 }
                 ($foodbar | Measure-Object).Count | Should -Be $count
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ComputerInfo.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ComputerInfo.Tests.ps1
@@ -472,7 +472,7 @@ public static extern int LCIDToLocaleName(uint localeID, System.Text.StringBuild
     {
         $hal = $null
         $systemDirectory =  Get-CimClassPropVal Win32_OperatingSystem SystemDirectory
-        $halPath = Join-Path -path $systemDirectory -ChildPath "hal.dll"
+        $halPath = Join-Path -Path $systemDirectory -ChildPath "hal.dll"
         $query = 'SELECT * FROM CIM_DataFile Where Name="C:\WINDOWS\system32\hal.dll"'
         $query = $query -replace '\\','\\'
         $instance = Get-CimInstance -Query $query
@@ -1049,7 +1049,7 @@ try {
                     $ObservedList = $ComputerInformation.$property
                     $ExpectedList = $Expected.$property
                     $SpecialPropertyList = ($ObservedList)[0].psobject.properties.name
-                    Compare-Object $ObservedList $ExpectedList -property $SpecialPropertyList | Should -BeNullOrEmpty
+                    Compare-Object $ObservedList $ExpectedList -Property $SpecialPropertyList | Should -BeNullOrEmpty
                 }
                 else
                 {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-EventLog.Tests.ps1
@@ -28,7 +28,7 @@ Describe "Get-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
       $logs.Count                                           | Should -BeGreaterThan 3
     }
     It "should be able to Get-EventLog -LogName Application -Newest 100" -Pending:($true) {
-      { $result=get-eventlog -LogName Application -Newest 100 -ErrorAction Stop } | Should -Not -Throw
+      { $result=Get-EventLog -LogName Application -Newest 100 -ErrorAction Stop } | Should -Not -Throw
       $result                                                                     | Should -Not -BeNullOrEmpty
       $result.Length                                                              | Should -BeLessThan 100
       $result[0]                                                                  | Should -BeOfType EventLogEntry
@@ -37,7 +37,7 @@ Describe "Get-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
       { Get-EventLog -LogName System -List -ErrorAction Stop } | Should -Throw -ErrorId "AmbiguousParameterSet,Microsoft.PowerShell.Commands.GetEventLogCommand"
     }
     It "should be able to Get-EventLog -LogName * with multiple matches" -Pending:($true) {
-      { $result=get-eventlog -LogName *  -ErrorAction Stop }  | Should -Not -Throw
+      { $result=Get-EventLog -LogName *  -ErrorAction Stop }  | Should -Not -Throw
       $result                                                 | Should -Not -BeNullOrEmpty
       $result                                                 | Should -BeExactly "Security"
       $result.Count                                           | Should -BeGreaterThan 3

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-HotFix.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-HotFix.Tests.ps1
@@ -60,7 +60,7 @@ Describe "Get-HotFix Tests" -Tag CI {
     }
 
     It "Get-Hotfix can accept ComputerName via pipeline" {
-        { [PSCustomObject]@{ComputerName = 'UnavailableComputer'} | Get-HotFix } | Should -Throw -ErrorID 'Microsoft.PowerShell.Commands.GetHotFixCommand'
+        { [PSCustomObject]@{ComputerName = 'UnavailableComputer'} | Get-HotFix } | Should -Throw -ErrorId 'Microsoft.PowerShell.Commands.GetHotFixCommand'
         [PSCustomObject]@{ComputerName = 'localhost'} | Get-HotFix | Should -Not -BeNullOrEmpty
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
@@ -31,13 +31,13 @@ Describe "Get-Item" -Tags "CI" {
         $null = New-Item -type file "$TESTDRIVE/file[abc].txt"
         $null = New-Item -type file "$TESTDRIVE/filea.txt"
         # if literalpath is not correct we would see filea.txt
-        $item = Get-Item -literalpath "$TESTDRIVE/file[abc].txt"
+        $item = Get-Item -LiteralPath "$TESTDRIVE/file[abc].txt"
         @($item).Count | Should -Be 1
         $item.Name | Should -BeExactly 'file[abc].txt'
     }
 
     It "Should have mode flags set" {
-        Get-ChildItem $PSScriptRoot | foreach-object { $_.Mode | Should -Not -BeNullOrEmpty }
+        Get-ChildItem $PSScriptRoot | ForEach-Object { $_.Mode | Should -Not -BeNullOrEmpty }
     }
 
     It "Should not return the item unless force is used if hidden" {
@@ -48,11 +48,11 @@ Describe "Get-Item" -Tags "CI" {
         }
         ${result} = Get-Item "${hiddenFile}" -ErrorAction SilentlyContinue
         ${result} | Should -BeNullOrEmpty
-        ${result} = Get-Item -force "${hiddenFile}" -ErrorAction SilentlyContinue
+        ${result} = Get-Item -Force "${hiddenFile}" -ErrorAction SilentlyContinue
         ${result}.FullName | Should -BeExactly ${item}.FullName
     }
 
-    It "Should get properties for special reparse points" -skip:$skipNotWindows {
+    It "Should get properties for special reparse points" -Skip:$skipNotWindows {
         $result = Get-Item -Path $HOME/Cookies -Force
         $result.LinkType | Should -BeExactly "Junction"
         $result.Target | Should -Not -BeNullOrEmpty
@@ -89,7 +89,7 @@ Describe "Get-Item" -Tags "CI" {
             $result.Name | Should -BeExactly "file2.txt"
         }
         It "Should respect combinations of filter, include, and exclude" {
-            $result = get-item "${testBaseDir}/*" -filter *.txt -include "file[12].txt" -exclude file2.txt
+            $result = Get-Item "${testBaseDir}/*" -Filter *.txt -Include "file[12].txt" -Exclude file2.txt
             ($result).Count | Should -Be 1
             $result.Name | Should -BeExactly "file1.txt"
         }
@@ -114,10 +114,10 @@ Describe "Get-Item" -Tags "CI" {
             $altStreamPath = "$TESTDRIVE/altStream.txt"
             $stringData = "test data"
             $streamName = "test"
-            $item = new-item -type file $altStreamPath
-            Set-Content -path $altStreamPath -Stream $streamName -Value $stringData
+            $item = New-Item -type file $altStreamPath
+            Set-Content -Path $altStreamPath -Stream $streamName -Value $stringData
         }
-        It "Should find an alternate stream if present" -skip:$skipNotWindows {
+        It "Should find an alternate stream if present" -Skip:$skipNotWindows {
             $result = Get-Item $altStreamPath -Stream $streamName
             $result.Length | Should -Be ($stringData.Length + [Environment]::NewLine.Length)
             $result.Stream | Should -Be $streamName
@@ -125,13 +125,13 @@ Describe "Get-Item" -Tags "CI" {
     }
 
     Context "Registry Provider" {
-        It "Can retrieve an item from registry" -skip:$skipNotWindows {
+        It "Can retrieve an item from registry" -Skip:$skipNotWindows {
             ${result} = Get-Item HKLM:/Software
             ${result} | Should -BeOfType Microsoft.Win32.RegistryKey
         }
     }
 
-    Context "Environment provider" -tag "CI" {
+    Context "Environment provider" -Tag "CI" {
         BeforeAll {
             $env:testvar="b"
             $env:testVar="a"
@@ -143,7 +143,7 @@ Describe "Get-Item" -Tags "CI" {
         }
 
         It "get-item testVar" {
-            (get-item env:\testVar).Value | Should -BeExactly "a"
+            (Get-Item env:\testVar).Value | Should -BeExactly "a"
         }
 
         It "get-item is case-sensitive/insensitive as appropriate" {
@@ -153,7 +153,7 @@ Describe "Get-Item" -Tags "CI" {
                 $expectedValue = "a"
             }
 
-            (get-item env:\testvar).Value | Should -BeExactly $expectedValue
+            (Get-Item env:\testvar).Value | Should -BeExactly $expectedValue
         }
     }
 }
@@ -165,7 +165,7 @@ Describe "Get-Item environment provider on Windows with accidental case-variant 
     AfterAll {
         $env:testVar = $null
     }
-    It "Reports the effective value among accidental case-variant duplicates on Windows" -skip:$skipNotWindows {
+    It "Reports the effective value among accidental case-variant duplicates on Windows" -Skip:$skipNotWindows {
         if (-not (Get-Command -ErrorAction Ignore node.exe)) {
             Write-Warning "Test skipped, because prerequisite Node.js is not installed."
         } else {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Location.Tests.ps1
@@ -7,7 +7,7 @@ Describe "Get-Location" -Tags "CI" {
     }
 
     AfterEach {
-	Pop-location
+	Pop-Location
     }
 
     It "Should list the output of the current working directory" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
@@ -50,7 +50,7 @@ Describe "Get-Process" -Tags "CI" {
     }
 
     It "Should have not empty Name flags set for Get-Process object" -Pending:$IsMacOS {
-        $ps | foreach-object { $_.Name | Should -Not -BeNullOrEmpty }
+        $ps | ForEach-Object { $_.Name | Should -Not -BeNullOrEmpty }
     }
 
     It "Should throw an error for non existing process id." {
@@ -59,7 +59,7 @@ Describe "Get-Process" -Tags "CI" {
     }
 
     It "Should throw an exception when process id is null." {
-        { Get-Process -id $null } | Should -Throw -ErrorId "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.GetProcessCommand"
+        { Get-Process -Id $null } | Should -Throw -ErrorId "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.GetProcessCommand"
     }
 
     It "Should throw an exception when -InputObject parameter is null." {
@@ -118,12 +118,12 @@ Describe "Get-Process Formatting" -Tags "Feature" {
 
 Describe "Process Parent property" -Tags "CI" {
     It "Has Parent process property" {
-        $powershellexe = (get-process -id $PID).mainmodule.filename
+        $powershellexe = (Get-Process -Id $PID).mainmodule.filename
         & $powershellexe -noprofile -command '(Get-Process -Id $PID).Parent' | Should -Not -BeNullOrEmpty
     }
 
     It "Has valid parent process ID property" {
-        $powershellexe = (get-process -id $PID).mainmodule.filename
+        $powershellexe = (Get-Process -Id $PID).mainmodule.filename
         & $powershellexe -noprofile -command '(Get-Process -Id $PID).Parent.Id' | Should -Be $PID
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Service.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Service.Tests.ps1
@@ -55,10 +55,10 @@ Describe "Get-Service cmdlet tests" -Tags "CI" {
     @{ script = { Get-Service -DisplayName Net* }               ; expected = { Get-Service | Where-Object { $_.DisplayName -like 'Net*' } } },
     @{ script = { Get-Service -Include Net* -Exclude *logon }   ; expected = { Get-Service | Where-Object { $_.Name -match '^net.*?(?<!logon)$' } } }
     @{ script = { Get-Service -Name Net* | Get-Service }        ; expected = { Get-Service -Name Net* } },
-    @{ script = { Get-Service -Name "$(new-guid)*" }            ; expected = $null },
-    @{ script = { Get-Service -DisplayName "$(new-guid)*" }     ; expected = $null },
+    @{ script = { Get-Service -Name "$(New-Guid)*" }            ; expected = $null },
+    @{ script = { Get-Service -DisplayName "$(New-Guid)*" }     ; expected = $null },
     @{ script = { Get-Service -DependentServices -Name winmgmt }; expected = { (Get-Service -Name winmgmt).DependentServices } },
-    @{ script = { Get-Service -RequiredServices -Name winmgmt } ; expected = { (Get-Service -name winmgmt).RequiredServices } }
+    @{ script = { Get-Service -RequiredServices -Name winmgmt } ; expected = { (Get-Service -Name winmgmt).RequiredServices } }
   ) {
     param($script, $expected)
     $services = & $script
@@ -66,16 +66,16 @@ Describe "Get-Service cmdlet tests" -Tags "CI" {
       $servicesCheck = & $expected
     }
     if ($servicesCheck -ne $null) {
-      Compare-object $services $servicesCheck | Out-String | Should -BeNullOrEmpty
+      Compare-Object $services $servicesCheck | Out-String | Should -BeNullOrEmpty
     } else {
       $services | Should -BeNullOrEmpty
     }
   }
 
   It "Get-Service fails for non-existing service using '<script>'" -TestCases @(
-    @{ script  = { Get-Service -Name (new-guid) -ErrorAction Stop}       ;
+    @{ script  = { Get-Service -Name (New-Guid) -ErrorAction Stop}       ;
        ErrorId = "NoServiceFoundForGivenName,Microsoft.PowerShell.Commands.GetServiceCommand" },
-    @{ script  = { Get-Service -DisplayName (new-guid) -ErrorAction Stop};
+    @{ script  = { Get-Service -DisplayName (New-Guid) -ErrorAction Stop};
        ErrorId = "NoServiceFoundForGivenDisplayName,Microsoft.PowerShell.Commands.GetServiceCommand" }
   ) {
     param($script,$errorid)

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/ItemProperty.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/ItemProperty.Tests.ps1
@@ -2,20 +2,20 @@
 # Licensed under the MIT License.
 Describe "Simple ItemProperty Tests" -Tag "CI" {
     It "Can retrieve the PropertyValue with Get-ItemPropertyValue" {
-        Get-ItemPropertyValue -path $TESTDRIVE -Name Attributes | Should -Be "Directory"
+        Get-ItemPropertyValue -Path $TESTDRIVE -Name Attributes | Should -Be "Directory"
     }
     It "Can clear the PropertyValue with Clear-ItemProperty" {
-        setup -f file1.txt
+        Setup -f file1.txt
         Set-ItemProperty $TESTDRIVE/file1.txt -Name Attributes -Value ReadOnly
-        Get-ItemPropertyValue -path $TESTDRIVE/file1.txt -Name Attributes | Should -Match "ReadOnly"
+        Get-ItemPropertyValue -Path $TESTDRIVE/file1.txt -Name Attributes | Should -Match "ReadOnly"
         Clear-ItemProperty $TESTDRIVE/file1.txt -Name Attributes
-        Get-ItemPropertyValue -path $TESTDRIVE/file1.txt -Name Attributes | Should -Not -Match "ReadOnly"
+        Get-ItemPropertyValue -Path $TESTDRIVE/file1.txt -Name Attributes | Should -Not -Match "ReadOnly"
     }
     # these cmdlets are targeted at the windows registry, and don't have an linux equivalent
     Context "Registry targeted cmdlets" {
-        It "Copy ItemProperty" -pending { }
-        It "Move ItemProperty" -pending { }
-        It "New ItemProperty" -pending { }
-        It "Rename ItemProperty" -pending { }
+        It "Copy ItemProperty" -Pending { }
+        It "Move ItemProperty" -Pending { }
+        It "New ItemProperty" -Pending { }
+        It "Rename ItemProperty" -Pending { }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
@@ -10,20 +10,20 @@ Describe "Join-Path cmdlet tests" -Tags "CI" {
   }
   It "should output multiple paths when called with multiple -Path targets" {
     Setup -Dir SubDir1
-    (Join-Path -Path TestDrive:,$TestDrive -ChildPath "SubDir1" -resolve).Length | Should -Be 2
+    (Join-Path -Path TestDrive:,$TestDrive -ChildPath "SubDir1" -Resolve).Length | Should -Be 2
   }
   It "should throw 'DriveNotFound' when called with -Resolve and drive does not exist" {
-    { Join-Path bogusdrive:\\somedir otherdir -resolve -ErrorAction Stop; Throw "Previous statement unexpectedly succeeded..." } |
+    { Join-Path bogusdrive:\\somedir otherdir -Resolve -ErrorAction Stop; Throw "Previous statement unexpectedly succeeded..." } |
       Should -Throw -ErrorId "DriveNotFound,Microsoft.PowerShell.Commands.JoinPathCommand"
   }
   It "should throw 'PathNotFound' when called with -Resolve and item does not exist" {
-    { Join-Path "Bogus" "Path" -resolve -ErrorAction Stop; Throw "Previous statement unexpectedly succeeded..." } |
+    { Join-Path "Bogus" "Path" -Resolve -ErrorAction Stop; Throw "Previous statement unexpectedly succeeded..." } |
       Should -Throw -ErrorId "PathNotFound,Microsoft.PowerShell.Commands.JoinPathCommand"
   }
   #[BugId(BugDatabase.WindowsOutOfBandReleases, 905237)] Note: Result should be the same on non-Windows platforms too
   It "should return one object when called with a Windows FileSystem::Redirector" {
-    set-location ("env:"+$SepChar)
-    $result=join-path FileSystem::windir system32
+    Set-Location ("env:"+$SepChar)
+    $result=Join-Path FileSystem::windir system32
     $result.Count | Should -Be 1
     $result       | Should -BeExactly ("FileSystem::windir"+$SepChar+"system32")
   }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Move-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Move-Item.Tests.ps1
@@ -3,10 +3,10 @@
 Describe "Move-Item tests" -Tag "CI" {
     BeforeAll {
         $content = "This is content"
-        Setup -f originalfile.txt -content "This is content"
+        Setup -f originalfile.txt -Content "This is content"
         $source = "$TESTDRIVE/originalfile.txt"
         $target = "$TESTDRIVE/ItemWhichHasBeenMoved.txt"
-        Setup -f [orig-file].txt -content "This is not content"
+        Setup -f [orig-file].txt -Content "This is not content"
         $sourceSp = "$TestDrive/``[orig-file``].txt"
         $targetSpName = "$TestDrive/ItemWhichHasBeen[Moved].txt"
         $targetSp = "$TestDrive/ItemWhichHasBeen``[Moved``].txt"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-EventLog.Tests.ps1
@@ -20,34 +20,34 @@ Describe "New-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
 
     It "should be able to create a New-EventLog with a -Source parameter" -Skip:($true) {
       {New-EventLog -LogName TestLog -Source TestSource -ErrorAction Stop} | Should -Not -Throw
-      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ErrorAction Stop} | Should -Not -Throw
+      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventId 1 -ErrorAction Stop} | Should -Not -Throw
       $result=Get-EventLog -LogName TestLog
       $result.Count   | Should -Be 1
     }
     It "should be able to create a New-EventLog with a -ComputerName parameter" -Skip:($true) {
       {New-EventLog -LogName TestLog -Source TestSource -ComputerName $env:COMPUTERNAME -ErrorAction Stop} | Should -Not -Throw
-      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ErrorAction Stop} | Should -Not -Throw
+      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventId 1 -ErrorAction Stop} | Should -Not -Throw
       $result=Get-EventLog -LogName TestLog
       $result.Count   | Should -Be 1
       $result.EventID | Should -Be 1
     }
     It "should be able to create a New-EventLog with a -CategoryResourceFile parameter" -Skip:($true) {
       {New-EventLog -LogName TestLog -Source TestSource -CategoryResourceFile "CategoryMessageFile" -ErrorAction Stop} | Should -Not -Throw
-      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 2 -ErrorAction Stop} | Should -Not -Throw
+      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventId 2 -ErrorAction Stop} | Should -Not -Throw
       $result=Get-EventLog -LogName TestLog
       $result.Count   | Should -Be 1
       $result.EventID | Should -Be 2
     }
     It "should be able to create a New-EventLog with a -MessageResourceFile parameter" -Skip:($true) {
       {New-EventLog -LogName TestLog -Source TestSource -MessageResourceFile "ResourceMessageFile" -ErrorAction Stop} | Should -Not -Throw
-      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 3 -ErrorAction Stop} | Should -Not -Throw
+      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventId 3 -ErrorAction Stop} | Should -Not -Throw
       $result=Get-EventLog -LogName TestLog
       $result.Count   | Should -Be 1
       $result.EventID | Should -Be 3
     }
     It "should be able to create a New-EventLog with a -ParameterResourceFile parameter" -Skip:($true) {
       {New-EventLog -LogName TestLog -Source TestSource -ParameterResourceFile "ParameterMessageFile" -ErrorAction Stop} | Should -Not -Throw
-      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 4 -ErrorAction Stop} | Should -Not -Throw
+      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventId 4 -ErrorAction Stop} | Should -Not -Throw
       $result=Get-EventLog -LogName TestLog
       $result.Count   | Should -Be 1
       $result.EventID | Should -Be 4

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-PSDrive.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-PSDrive.Tests.ps1
@@ -17,11 +17,11 @@ Describe "Tests for New-PSDrive cmdlet." -Tag "CI","RequireAdminOnWindows" {
             { New-PSDrive -Name $PSDriveName -PSProvider FileSystem -Root $RemoteShare -Persist -ErrorAction Stop } | Should -Not -Throw
         }
 
-        it "Should throw exception if root is not a remote share." -Skip:(-not $IsWindows) {
+        It "Should throw exception if root is not a remote share." -Skip:(-not $IsWindows) {
             { New-PSDrive -Name $PSDriveName -PSProvider FileSystem -Root "TestDrive:\" -Persist -ErrorAction Stop } | Should -Throw -ErrorId 'DriveRootNotNetworkPath'
         }
 
-        it "Should throw exception if PSDrive is not a drive letter supported by operating system." -Skip:(-not $IsWindows) {
+        It "Should throw exception if PSDrive is not a drive letter supported by operating system." -Skip:(-not $IsWindows) {
             $PSDriveName = 'AB'
             { New-PSDrive -Name $PSDriveName -PSProvider FileSystem -Root $RemoteShare -Persist -ErrorAction Stop } | Should -Throw -ErrorId 'DriveNameNotSupportedForPersistence'
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Registry.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Registry.Tests.ps1
@@ -97,7 +97,7 @@ Describe "Basic Registry Provider Tests" -Tags @("CI", "RequireAdminOnWindows") 
 
         It "Verify Rename-Item" {
             $existBefore = Test-Path $testKey
-            $renamedKey = Rename-Item -path $testKey -NewName "RenamedKey" -PassThru
+            $renamedKey = Rename-Item -Path $testKey -NewName "RenamedKey" -PassThru
             $existAfter = Test-Path $testKey
             $existBefore | Should -BeTrue
             $existAfter | Should -BeFalse
@@ -260,13 +260,13 @@ Describe "Extended Registry Provider Tests" -Tags @("Feature", "RequireAdminOnWi
         }
 
         It "Verify Confirm can be bypassed" {
-            $result = New-ItemProperty -Path $testKey -Name $testPropertyName -Value $testPropertyValue -force -Confirm:$false
+            $result = New-ItemProperty -Path $testKey -Name $testPropertyName -Value $testPropertyValue -Force -Confirm:$false
             $result."$testPropertyName" | Should -Be $testPropertyValue
             $result.PSChildName | Should -BeExactly $testKey
         }
 
         It "Verify WhatIf" {
-            $result = New-ItemProperty -Path $testKey -Name $testPropertyName -Value $testPropertyValue -whatif
+            $result = New-ItemProperty -Path $testKey -Name $testPropertyName -Value $testPropertyValue -WhatIf
             $result | Should -BeNullOrEmpty
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-EventLog.Tests.ps1
@@ -16,19 +16,19 @@ Describe "New-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
         if ($IsNotSkipped) {
             Remove-EventLog -LogName TestLog -ErrorAction Ignore
             {New-EventLog -LogName TestLog -Source TestSource -ErrorAction Stop}                              | Should -Not -Throw
-            {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ErrorAction Stop} | Should -Not -Throw
+            {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventId 1 -ErrorAction Stop} | Should -Not -Throw
         }
     }
     #CmdLet is NYI - change to -Skip:($NonWinAdmin) when implemented
     It "should be able to Remove-EventLog -LogName <string> -ComputerName <string>" -Pending:($true) {
       { Remove-EventLog -LogName TestLog -ComputerName $env:COMPUTERNAME -ErrorAction Stop }              | Should -Not -Throw
-      { Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ErrorAction Stop } | Should -Throw -ErrorId "Microsoft.PowerShell.Commands.WriteEventLogCommand"
+      { Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventId 1 -ErrorAction Stop } | Should -Throw -ErrorId "Microsoft.PowerShell.Commands.WriteEventLogCommand"
       { Get-EventLog -LogName TestLog -ErrorAction Stop } | Should -Throw -ErrorId "System.InvalidOperationException,Microsoft.PowerShell.Commands.GetEventLogCommand"
     }
     #CmdLet is NYI - change to -Skip:($NonWinAdmin) when implemented
     It "should be able to Remove-EventLog -Source <string> -ComputerName <string>"  -Pending:($true) {
       {Remove-EventLog -Source TestSource -ComputerName $env:COMPUTERNAME -ErrorAction Stop} | Should -Not -Throw
-      { Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ErrorAction Stop } | Should -Throw -ErrorId "Microsoft.PowerShell.Commands.WriteEventLogCommand"
+      { Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventId 1 -ErrorAction Stop } | Should -Throw -ErrorId "Microsoft.PowerShell.Commands.WriteEventLogCommand"
       { Get-EventLog -LogName TestLog -ErrorAction Stop; } | Should -Throw -ErrorId "System.InvalidOperationException,Microsoft.PowerShell.Commands.GetEventLogCommand"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
@@ -75,9 +75,9 @@ Describe "Remove-Item" -Tags "CI" {
 	    # Delete the specific string
 	    Remove-Item (Join-Path -Path $testpath -ChildPath "*") -Include file*.txt
 	    # validate that the string under test was deleted, and the nonmatching strings still exist
-	    Test-path (Join-Path -Path $testpath -ChildPath file1.txt) | Should -BeFalse
-	    Test-path (Join-Path -Path $testpath -ChildPath file2.txt) | Should -BeFalse
-	    Test-path (Join-Path -Path $testpath -ChildPath file3.txt) | Should -BeFalse
+	    Test-Path (Join-Path -Path $testpath -ChildPath file1.txt) | Should -BeFalse
+	    Test-Path (Join-Path -Path $testpath -ChildPath file2.txt) | Should -BeFalse
+	    Test-Path (Join-Path -Path $testpath -ChildPath file3.txt) | Should -BeFalse
 	    Test-Path $testfilepath  | Should -BeTrue
 
 	    # Delete the non-matching strings
@@ -131,7 +131,7 @@ Describe "Remove-Item" -Tags "CI" {
 	    New-Item -Name $testfile -Path $testsubdirectory -ItemType "file" -Value "lorem ipsum"
 
 	    $complexDirectory = Join-Path -Path $testsubdirectory -ChildPath $testfile
-	    test-path $complexDirectory | Should -BeTrue
+	    Test-Path $complexDirectory | Should -BeTrue
 
 	    { Remove-Item $testdirectory -Recurse} | Should -Not -Throw
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Rename-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Rename-Item.Tests.ps1
@@ -33,7 +33,7 @@ Describe "Rename-Item tests" -Tag "CI" {
         $newSp = "$wdSp/``[renamed``]file.txt"
         In $wdSp -execute {
             $null = New-Item -Name $oldSpName -ItemType File -Value $content -Force
-            Rename-Item -path $oldSpBName $newSpName
+            Rename-Item -Path $oldSpBName $newSpName
         }
         $oldSp | Should -Not -Exist
         $newSp | Should -Exist

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Rename-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Rename-Item.Tests.ps1
@@ -2,10 +2,10 @@
 # Licensed under the MIT License.
 Describe "Rename-Item tests" -Tag "CI" {
     BeforeAll {
-        Setup -f originalFile.txt -content "This is content"
+        Setup -f originalFile.txt -Content "This is content"
         $source = "$TESTDRIVE/originalFile.txt"
         $target = "$TESTDRIVE/ItemWhichHasBeenRenamed.txt"
-        Setup -f [orig-file].txt -content "This is not content"
+        Setup -f [orig-file].txt -Content "This is not content"
         $sourceSp = "$TestDrive/``[orig-file``].txt"
         $targetSpName = "ItemWhichHasBeen[Renamed].txt"
         $targetSp = "$TestDrive/ItemWhichHasBeen``[Renamed``].txt"
@@ -14,8 +14,8 @@ Describe "Rename-Item tests" -Tag "CI" {
     }
     It "Rename-Item will rename a file" {
         Rename-Item $source $target
-        test-path $source | Should -BeFalse
-        test-path $target | Should -BeTrue
+        Test-Path $source | Should -BeFalse
+        Test-Path $target | Should -BeTrue
         "$target" | Should -FileContentMatchExactly "This is content"
     }
     It "Rename-Item will rename a file when path contains special char" {
@@ -31,9 +31,9 @@ Describe "Rename-Item tests" -Tag "CI" {
         $oldSp = "$wdSp/$oldSpBName"
         $newSpName = "[renamed]file.txt"
         $newSp = "$wdSp/``[renamed``]file.txt"
-        In $wdSp -Execute {
+        In $wdSp -execute {
             $null = New-Item -Name $oldSpName -ItemType File -Value $content -Force
-            Rename-Item -Path $oldSpBName $newSpName
+            Rename-Item -path $oldSpBName $newSpName
         }
         $oldSp | Should -Not -Exist
         $newSp | Should -Exist
@@ -46,7 +46,7 @@ Describe "Rename-Item tests" -Tag "CI" {
         $oldSp = "$wdSp/$oldSpBName"
         $newSpName = "[renamed]file2.txt"
         $newSp = "$wdSp/``[renamed``]file2.txt"
-        In $wdSp -Execute {
+        In $wdSp -execute {
             $null = New-Item -Name $oldSpName -ItemType File -Value $content -Force
             Rename-Item -LiteralPath $oldSpName $newSpName
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
@@ -81,7 +81,7 @@ try
             }
 
             It "Should not support timeout on Unix" -Skip:($IsWindows) {
-                { Restart-Computer -timeout 3 -ErrorAction Stop } | Should -Throw -ErrorId "NamedParameterNotFound,Microsoft.PowerShell.Commands.RestartComputerCommand"
+                { Restart-Computer -Timeout 3 -ErrorAction Stop } | Should -Throw -ErrorId "NamedParameterNotFound,Microsoft.PowerShell.Commands.RestartComputerCommand"
             }
 
             It "Should not support Delay on Unix" -Skip:($IsWindows) {
@@ -90,12 +90,12 @@ try
 
             It "Should not support timeout on localhost" -Skip:(!$IsWindows) {
                 Set-TesthookResult -testhookName $restartTesthookResultName -value $defaultResultValue
-                { Restart-Computer -timeout 3 -ErrorAction Stop } | Should -Throw -ErrorId "RestartComputerInvalidParameter,Microsoft.PowerShell.Commands.RestartComputerCommand"
+                { Restart-Computer -Timeout 3 -ErrorAction Stop } | Should -Throw -ErrorId "RestartComputerInvalidParameter,Microsoft.PowerShell.Commands.RestartComputerCommand"
             }
 
             It "Should not support timeout on localhost" -Skip:(!$IsWindows) {
                 Set-TesthookResult -testhookName $restartTesthookResultName -value $defaultResultValue
-                { Restart-Computer -timeout 3 -ErrorAction Stop } | Should -Throw -ErrorId "RestartComputerInvalidParameter,Microsoft.PowerShell.Commands.RestartComputerCommand"
+                { Restart-Computer -Timeout 3 -ErrorAction Stop } | Should -Throw -ErrorId "RestartComputerInvalidParameter,Microsoft.PowerShell.Commands.RestartComputerCommand"
             }
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Content.Tests.ps1
@@ -60,7 +60,7 @@ Describe "Set-Content cmdlet tests" -Tags "CI" {
         It "should throw 'ParameterArgumentValidationErrorNullNotAllowed' when -Path is `$()" {
             { Set-Content -Path $() -Value "ShouldNotWorkBecausePathIsInvalid" -ErrorAction Stop } | Should -Throw -ErrorId "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.SetContentCommand"
         }
-        It "should throw 'PSNotSupportedException' when you Set-Content to an unsupported provider" -skip:$skipRegistry {
+        It "should throw 'PSNotSupportedException' when you Set-Content to an unsupported provider" -Skip:$skipRegistry {
             { Set-Content -Path HKLM:\\software\\microsoft -Value "ShouldNotWorkBecausePathIsUnsupported" -ErrorAction Stop } | Should -Throw -ErrorId "NotSupported,Microsoft.PowerShell.Commands.SetContentCommand"
         }
         #[BugId(BugDatabase.WindowsOutOfBandReleases, 9058182)]

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Item.Tests.ps1
@@ -1,14 +1,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 Describe "Set-Item" -Tag "CI" {
-    $testCases = @{ Path = "variable:SetItemTestCase"; Value = "TestData"; Validate = { $SetItemTestCase | Should -Be "TestData" }; Reset = {remove-item variable:SetItemTestCase} },
-        @{ Path = "alias:SetItemTestCase"; Value = "Get-Alias"; Validate = { (Get-Alias SetItemTestCase).Definition | Should -Be "Get-Alias"}; Reset = { remove-item alias:SetItemTestCase } },
-        @{ Path = "function:SetItemTestCase"; Value = { 1 }; Validate = { SetItemTestCase | Should -Be 1 }; Reset = { remove-item function:SetItemTestCase } },
-        @{ Path = "env:SetItemTestCase"; Value = { 1 }; Validate = { $env:SetItemTestCase | Should -Be 1 }; Reset = { remove-item env:SetItemTestCase } }
+    $testCases = @{ Path = "variable:SetItemTestCase"; Value = "TestData"; Validate = { $SetItemTestCase | Should -Be "TestData" }; Reset = {Remove-Item variable:SetItemTestCase} },
+        @{ Path = "alias:SetItemTestCase"; Value = "Get-Alias"; Validate = { (Get-Alias SetItemTestCase).Definition | Should -Be "Get-Alias"}; Reset = { Remove-Item alias:SetItemTestCase } },
+        @{ Path = "function:SetItemTestCase"; Value = { 1 }; Validate = { SetItemTestCase | Should -Be 1 }; Reset = { Remove-Item function:SetItemTestCase } },
+        @{ Path = "env:SetItemTestCase"; Value = { 1 }; Validate = { $env:SetItemTestCase | Should -Be 1 }; Reset = { Remove-Item env:SetItemTestCase } }
 
     It "Set-Item should be able to handle <Path>" -TestCase $testCases {
         param ( $Path, $Value, $Validate, $Reset )
-        Set-item -path $path -Value $value
+        Set-Item -Path $path -Value $value
         try {
             & $Validate
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
@@ -80,14 +80,14 @@ Describe "Start-Process" -Tag "Feature","RequireAdminOnWindows" {
 
     It "Should handle stdout redirection without error" {
         $process = Start-Process ping -ArgumentList $pingParam -Wait -RedirectStandardOutput $tempFile  @extraArgs
-        $dirEntry = get-childitem $tempFile
+        $dirEntry = Get-ChildItem $tempFile
         $dirEntry.Length | Should -BeGreaterThan 0
     }
 
     # Marking this test 'pending' to unblock daily builds. Filed issue : https://github.com/PowerShell/PowerShell/issues/2396
     It "Should handle stdin redirection without error" -Pending {
         $process = Start-Process sort -Wait -RedirectStandardOutput $tempFile -RedirectStandardInput $assetsFile  @extraArgs
-        $dirEntry = get-childitem $tempFile
+        $dirEntry = Get-ChildItem $tempFile
         $dirEntry.Length | Should -BeGreaterThan 0
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -27,7 +27,7 @@ Describe "Test-Connection" -tags "CI" {
             $pingResults.Count | Should -Be 4
 
             $result = $pingResults |
-                Where-Object Status -eq 'Success' |
+                Where-Object Status -EQ 'Success' |
                 Select-Object -First 1
 
             $result | Should -BeOfType Microsoft.PowerShell.Commands.TestConnectionCommand+PingStatus
@@ -118,7 +118,7 @@ Describe "Test-Connection" -tags "CI" {
             # be a lack of or inconsistent support for IPv6 in CI environments.
             It "Allows us to Force IPv6" -Pending {
                 $result = Test-Connection $targetName -IPv6 -Count 4 |
-                    Where-Object Status -eq Success |
+                    Where-Object Status -EQ Success |
                     Select-Object -First 1
 
                 $result.Address | Should -BeExactly $targetAddressIPv6
@@ -127,7 +127,7 @@ Describe "Test-Connection" -tags "CI" {
 
             It 'can convert IPv6 addresses to IPv4 with -IPv4 parameter' -Pending {
                 $result = Test-Connection '2001:4860:4860::8888' -IPv4 -Count 4 |
-                    Where-Object Status -eq Success |
+                    Where-Object Status -EQ Success |
                     Select-Object -First 1
                 # Google's DNS can resolve to either address.
                 $result.Address.IPAddressToString | Should -BeIn @('8.8.8.8', '8.8.4.4')
@@ -136,7 +136,7 @@ Describe "Test-Connection" -tags "CI" {
 
             It 'can convert IPv4 addresses to IPv6 with -IPv6 parameter' -Pending {
                 $result = Test-Connection '8.8.8.8' -IPv6 -Count 4 |
-                    Where-Object Status -eq Success |
+                    Where-Object Status -EQ Success |
                     Select-Object -First 1
                 # Google's DNS can resolve to either address.
                 $result.Address.IPAddressToString | Should -BeIn @('2001:4860:4860::8888', '2001:4860:4860::8844')

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Path.Tests.ps1
@@ -3,12 +3,12 @@
 Describe "Test-Path" -Tags "CI" {
     BeforeAll {
         $testdirectory = $TestDrive
-        $testfilename = New-Item -path $testdirectory -Name testfile.txt -ItemType file -Value 1 -force
+        $testfilename = New-Item -Path $testdirectory -Name testfile.txt -ItemType file -Value 1 -Force
 
         # populate with additional files
-        New-Item -Path $testdirectory -Name datestfile -value 1 -ItemType file | Out-Null
-        New-Item -Path $testdirectory -Name gatestfile -value 1 -ItemType file | Out-Null
-        New-Item -Path $testdirectory -Name usr -value 1 -ItemType directory | Out-Null
+        New-Item -Path $testdirectory -Name datestfile -Value 1 -ItemType file | Out-Null
+        New-Item -Path $testdirectory -Name gatestfile -Value 1 -ItemType file | Out-Null
+        New-Item -Path $testdirectory -Name usr -Value 1 -ItemType directory | Out-Null
 
         $nonExistentDir = Join-Path -Path (Join-Path -Path $testdirectory -ChildPath usr) -ChildPath bin
         $nonExistentPath = Join-Path -Path (Join-Path -Path (Join-Path -Path $testdirectory -ChildPath usr) -ChildPath bin) -ChildPath error

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1
@@ -143,7 +143,7 @@ try {
         }
         AfterAll {
             if ($IsWindows) {
-                Set-TimeZone -ID $originalTimeZoneId
+                Set-TimeZone -Id $originalTimeZoneId
             }
         }
 
@@ -172,7 +172,7 @@ try {
         }
         AfterAll {
             if ($IsWindows) {
-                Set-TimeZone -ID $originalTimeZoneId
+                Set-TimeZone -Id $originalTimeZoneId
             }
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/UnixStat.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/UnixStat.Tests.ps1
@@ -29,7 +29,7 @@ Describe "UnixFileSystem additions" -Tag "CI" {
 
         It "The UnixStat property should be the correct type" {
             $expected = "System.Management.Automation.Platform+Unix+CommonStat"
-            $i = (get-item /).psobject.properties['UnixStat'].TypeNameOfValue
+            $i = (Get-Item /).psobject.properties['UnixStat'].TypeNameOfValue
             $i | Should -Be $expected
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/AclCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/AclCmdlets.Tests.ps1
@@ -1,19 +1,19 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 Describe "Acl cmdlets are available and operate properly" -Tag CI {
-    It "Get-Acl returns an ACL object" -pending:(!$IsWindows) {
-        $ACL = get-acl $TESTDRIVE
+    It "Get-Acl returns an ACL object" -Pending:(!$IsWindows) {
+        $ACL = Get-Acl $TESTDRIVE
         $ACL | Should -BeOfType System.Security.AccessControl.DirectorySecurity
     }
-    It "Set-Acl can set the ACL of a directory" -pending {
+    It "Set-Acl can set the ACL of a directory" -Pending {
         Setup -d testdir
         $directory = "$TESTDRIVE/testdir"
-        $acl = get-acl $directory
+        $acl = Get-Acl $directory
         $accessRule = [System.Security.AccessControl.FileSystemAccessRule]::New("Everyone","FullControl","ContainerInherit,ObjectInherit","None","Allow")
         $acl.AddAccessRule($accessRule)
         { $acl | Set-Acl $directory } | Should -Not -Throw
 
-        $newacl = get-acl $directory
+        $newacl = Get-Acl $directory
         $newrule = $newacl.Access | Where-Object { $accessrule.FileSystemRights -eq $_.FileSystemRights -and $accessrule.AccessControlType -eq $_.AccessControlType -and $accessrule.IdentityReference -eq $_.IdentityReference }
         $newrule | Should -Not -BeNullOrEmpty
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
@@ -44,7 +44,7 @@ Describe "Certificate Provider tests" -Tags "CI" {
     }
 
     Context "Get-Item tests" {
-        it "Should be able to get a certificate store, path: <path>" -TestCases $testLocations {
+        It "Should be able to get a certificate store, path: <path>" -TestCases $testLocations {
             param([string] $path)
             $expectedResolvedPath = Resolve-Path -LiteralPath $path
             $result = Get-Item -LiteralPath $path
@@ -55,24 +55,24 @@ Describe "Certificate Provider tests" -Tags "CI" {
                 $resolvedPath.ProviderPath.TrimStart('\') | Should -Be $expectedResolvedPath.ProviderPath.TrimStart('\')
             }
         }
-        it "Should return two items at the root of the provider" {
+        It "Should return two items at the root of the provider" {
             (Get-Item -Path cert:\*).Count | Should -Be 2
         }
-        it "Should be able to get multiple items explictly" {
-            (get-item cert:\LocalMachine , cert:\CurrentUser).Count | Should -Be 2
+        It "Should be able to get multiple items explictly" {
+            (Get-Item cert:\LocalMachine , cert:\CurrentUser).Count | Should -Be 2
         }
-        it "Should return PathNotFound when getting a non-existant certificate store" {
+        It "Should return PathNotFound when getting a non-existant certificate store" {
             {Get-Item cert:\IDONTEXIST -ErrorAction Stop} | Should -Throw -ErrorId "PathNotFound,Microsoft.PowerShell.Commands.GetItemCommand"
         }
-        it "Should return PathNotFound when getting a non-existant certificate" {
+        It "Should return PathNotFound when getting a non-existant certificate" {
             {Get-Item cert:\currentuser\my\IDONTEXIST -ErrorAction Stop} | Should -Throw -ErrorId "PathNotFound,Microsoft.PowerShell.Commands.GetItemCommand"
         }
     }
     Context "Get-ChildItem tests"{
-        it "should be able to get a container using a wildcard" {
+        It "should be able to get a container using a wildcard" {
             (Get-ChildItem Cert:\CurrentUser\M?).PSPath | Should -Be 'Microsoft.PowerShell.Security\Certificate::CurrentUser\My'
         }
-        it "Should return two items at the root of the provider" {
+        It "Should return two items at the root of the provider" {
             (Get-ChildItem -Path cert:\).Count | Should -Be 2
         }
     }
@@ -106,49 +106,49 @@ Describe "Certificate Provider tests" -Tags "Feature" {
     }
 
     Context "Get-Item tests" {
-        it "Should be able to get certifate by path: <path>" -TestCases $currentUserMyLocations {
+        It "Should be able to get certifate by path: <path>" -TestCases $currentUserMyLocations {
             param([string] $path)
             $expectedThumbprint = (Get-GoodCertificateObject).Thumbprint
             $leafPath = Join-Path -Path $path -ChildPath $expectedThumbprint
-            $cert = (Get-item -LiteralPath $leafPath)
+            $cert = (Get-Item -LiteralPath $leafPath)
             $cert | Should -Not -Be null
             $cert.Thumbprint | Should -Be $expectedThumbprint
         }
-        it "Should be able to get DnsNameList of certifate by path: <path>" -TestCases $currentUserMyLocations {
+        It "Should be able to get DnsNameList of certifate by path: <path>" -TestCases $currentUserMyLocations {
             param([string] $path)
             $expectedThumbprint = (Get-GoodCertificateObject).Thumbprint
             $expectedName = (Get-GoodCertificateObject).DnsNameList[0].Unicode
             $expectedEncodedName = (Get-GoodCertificateObject).DnsNameList[0].Punycode
             $leafPath = Join-Path -Path $path -ChildPath $expectedThumbprint
-            $cert = (Get-item -LiteralPath $leafPath)
+            $cert = (Get-Item -LiteralPath $leafPath)
             $cert | Should -Not -Be null
             $cert.DnsNameList | Should -Not -Be null
             $cert.DnsNameList.Count | Should -Be 1
             $cert.DnsNameList[0].Unicode | Should -Be $expectedName
             $cert.DnsNameList[0].Punycode | Should -Be $expectedEncodedName
         }
-        it "Should be able to get DNSNameList of certifate by path: <path>" -TestCases $currentUserMyLocations {
+        It "Should be able to get DNSNameList of certifate by path: <path>" -TestCases $currentUserMyLocations {
             param([string] $path)
             $expectedThumbprint = (Get-GoodCertificateObject).Thumbprint
             $expectedOid = (Get-GoodCertificateObject).EnhancedKeyUsageList[0].ObjectId
             $leafPath = Join-Path -Path $path -ChildPath $expectedThumbprint
-            $cert = (Get-item -LiteralPath $leafPath)
+            $cert = (Get-Item -LiteralPath $leafPath)
             $cert | Should -Not -Be null
             $cert.EnhancedKeyUsageList | Should -Not -Be null
             $cert.EnhancedKeyUsageList.Count | Should -Be 1
             $cert.EnhancedKeyUsageList[0].ObjectId.Length | Should -Not -Be 0
             $cert.EnhancedKeyUsageList[0].ObjectId | Should -Be $expectedOid
         }
-        it "Should filter to codesign certificates" {
-            $allCerts = get-item cert:\CurrentUser\My\*
-            $codeSignCerts = get-item cert:\CurrentUser\My\* -CodeSigningCert
+        It "Should filter to codesign certificates" {
+            $allCerts = Get-Item cert:\CurrentUser\My\*
+            $codeSignCerts = Get-Item cert:\CurrentUser\My\* -CodeSigningCert
             $codeSignCerts | Should -Not -Be null
             $allCerts | Should -Not -Be null
             $nonCodeSignCertCount = $allCerts.Count - $codeSignCerts.Count
             $nonCodeSignCertCount | Should -Not -Be 0
         }
-        it "Should be able to exclude by thumbprint" {
-            $allCerts = get-item cert:\CurrentUser\My\*
+        It "Should be able to exclude by thumbprint" {
+            $allCerts = Get-Item cert:\CurrentUser\My\*
             $testThumbprint = (Get-GoodCertificateObject).Thumbprint
             $allCertsExceptOne = (Get-Item "cert:\currentuser\my\*" -Exclude $testThumbprint)
             $allCerts | Should -Not -Be null
@@ -158,9 +158,9 @@ Describe "Certificate Provider tests" -Tags "Feature" {
         }
     }
     Context "Get-ChildItem tests"{
-        it "Should filter to codesign certificates" {
-            $allCerts = get-ChildItem cert:\CurrentUser\My
-            $codeSignCerts = get-ChildItem cert:\CurrentUser\My -CodeSigningCert
+        It "Should filter to codesign certificates" {
+            $allCerts = Get-ChildItem cert:\CurrentUser\My
+            $codeSignCerts = Get-ChildItem cert:\CurrentUser\My -CodeSigningCert
             $codeSignCerts | Should -Not -Be null
             $allCerts | Should -Not -Be null
             $nonCodeSignCertCount = $allCerts.Count - $codeSignCerts.Count

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/CmsMessage2.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/CmsMessage2.Tests.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright (c) Microsoft Corporation.
+# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
 using namespace System.Security.Cryptography.X509Certificates

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
@@ -56,7 +56,7 @@ try {
 
         # Skip the test if Storage module is not available, return a pseudo result
         # ExecutionPolicy only works on windows
-        It "Test for Get-Help Get-Disk" -skip:(!(Test-Path (Join-Path -Path $PSHOME -ChildPath Modules\Storage\Storage.psd1)) -or $ShouldSkipTest) {
+        It "Test for Get-Help Get-Disk" -Skip:(!(Test-Path (Join-Path -Path $PSHOME -ChildPath Modules\Storage\Storage.psd1)) -or $ShouldSkipTest) {
 
                 try
                 {
@@ -458,7 +458,7 @@ try {
                         }
                     }
 
-                    set-content $filePath -Value $content
+                    Set-Content $filePath -Value $content
 
                     ## Valida File types and their corresponding int values are :
                     ##
@@ -476,7 +476,7 @@ try {
 [ZoneTransfer]
 ZoneId=$FileType
 "@
-                        Add-Content -Path $filePath -Value $alternateStreamContent -stream Zone.Identifier
+                        Add-Content -Path $filePath -Value $alternateStreamContent -Stream Zone.Identifier
                     }
                 }
 
@@ -1111,7 +1111,7 @@ ZoneId=$FileType
 
         BeforeAll {
             if ($IsNotSkipped) {
-                $originalPolicies = Get-ExecutionPolicy -list
+                $originalPolicies = Get-ExecutionPolicy -List
             }
         }
 
@@ -1145,7 +1145,7 @@ ZoneId=$FileType
         BeforeAll {
             if ($IsNotSkipped)
             {
-                $originalPolicies = Get-ExecutionPolicy -list
+                $originalPolicies = Get-ExecutionPolicy -List
             }
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/FileCatalog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/FileCatalog.Tests.ps1
@@ -232,7 +232,7 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
             $catalogPath = "$env:TEMP\UserConfigProv\catalog.cat"
             try
             {
-                copy-item "$testDataPath\UserConfigProv" $env:temp -Recurse -ErrorAction SilentlyContinue
+                Copy-Item "$testDataPath\UserConfigProv" $env:temp -Recurse -ErrorAction SilentlyContinue
                 Push-Location "$env:TEMP\UserConfigProv"
                 # When -Path is not specified, it should use current directory
                 $null = New-FileCatalog -CatalogFilePath $catalogPath -CatalogVersion 1.0
@@ -316,9 +316,9 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
 
             $script:catalogPath = "$env:TEMP\TestCatalogWhenNewFileAddedtoFolderBeforeValidation.cat"
             $null = New-FileCatalog -Path $testDataPath\UserConfigProv\ -CatalogFilePath $script:catalogPath -CatalogVersion 2.0
-            $null = copy-item $testDataPath\UserConfigProv $env:temp -Recurse -ErrorAction SilentlyContinue
+            $null = Copy-Item $testDataPath\UserConfigProv $env:temp -Recurse -ErrorAction SilentlyContinue
             $null = New-Item $env:temp\UserConfigProv\DSCResources\NewFile.txt -ItemType File
-            Add-Content $env:temp\UserConfigProv\DSCResources\NewFile.txt -Value "More Data" -force
+            Add-Content $env:temp\UserConfigProv\DSCResources\NewFile.txt -Value "More Data" -Force
             $result = Test-FileCatalog -Path $env:temp\UserConfigProv -CatalogFilePath $script:catalogPath -Detailed
 
             $result.Status | Should -Be "ValidationFailed"
@@ -336,8 +336,8 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
 
             $script:catalogPath = "$env:TEMP\TestCatalogWhenNewFileDeletedFromFolderBeforeValidation.cat"
             $null = New-FileCatalog -Path $testDataPath\UserConfigProv\ -CatalogFilePath $script:catalogPath -CatalogVersion 1.0
-            $null = copy-item $testDataPath\UserConfigProv $env:temp -Recurse -ErrorAction SilentlyContinue
-            del $env:temp\UserConfigProv\DSCResources\UserConfigProviderModVersion1\UserConfigProviderModVersion1.psm1 -force -ErrorAction SilentlyContinue
+            $null = Copy-Item $testDataPath\UserConfigProv $env:temp -Recurse -ErrorAction SilentlyContinue
+            del $env:temp\UserConfigProv\DSCResources\UserConfigProviderModVersion1\UserConfigProviderModVersion1.psm1 -Force -ErrorAction SilentlyContinue
             $result = Test-FileCatalog -Path $env:temp\UserConfigProv -CatalogFilePath $script:catalogPath -Detailed
 
             $result.Status | Should -Be "ValidationFailed"
@@ -355,7 +355,7 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
 
             $script:catalogPath = "$env:TEMP\TestCatalogWhenFileContentModifiedBeforeValidation.cat"
             $null = New-FileCatalog -Path $testDataPath\UserConfigProv\ -CatalogFilePath $script:catalogPath -CatalogVersion 1.0
-            $null = copy-item $testDataPath\UserConfigProv $env:temp -Recurse -ErrorAction SilentlyContinue
+            $null = Copy-Item $testDataPath\UserConfigProv $env:temp -Recurse -ErrorAction SilentlyContinue
             Add-Content $env:temp\UserConfigProv\DSCResources\UserConfigProviderModVersion1\UserConfigProviderModVersion1.psm1 -Value "More Data" -Force
             $result = Test-FileCatalog -Path $env:temp\UserConfigProv -CatalogFilePath $script:catalogPath -Detailed
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-Describe "Get-Credential Test" -tag "CI" {
+Describe "Get-Credential Test" -Tag "CI" {
     BeforeAll {
         $th = New-TestHost
         $th.UI.StringForSecureString = "This is a test"
@@ -75,7 +75,7 @@ Describe "Get-Credential Test" -tag "CI" {
         $netcred.Password | Should -Be "This is a test"
         $th.ui.Streams.Prompt[-1] | Should -Match "Credential:[^:]+:[^:]+"
     }
-    it "Get-Credential Joe" {
+    It "Get-Credential Joe" {
         $cred = $ps.AddScript("Get-Credential Joe").Invoke() | Select-Object -First 1
         $cred | Should -BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()
@@ -83,7 +83,7 @@ Describe "Get-Credential Test" -tag "CI" {
         $netcred.Password | Should -Be "This is a test"
         $th.ui.Streams.Prompt[-1] | Should -Match "Credential:[^:]+:[^:]+"
     }
-    it "Get-Credential -Credential Joe" {
+    It "Get-Credential -Credential Joe" {
         $cred = $ps.AddScript("Get-Credential Joe").Invoke() | Select-Object -First 1
         $cred | Should -BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()
@@ -91,7 +91,7 @@ Describe "Get-Credential Test" -tag "CI" {
         $netcred.Password | Should -Be "This is a test"
         $th.ui.Streams.Prompt[-1] | Should -Match "Credential:[^:]+:[^:]+"
     }
-    it "Get-Credential `$credential" {
+    It "Get-Credential `$credential" {
         #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
         $password = ConvertTo-SecureString -String "CredTest" -AsPlainText -Force
         $credential = [pscredential]::new("John", $password)

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1
@@ -4,17 +4,17 @@ Describe "SecureString conversion tests" -Tags "CI" {
     BeforeAll {
         $string = "ABCD"
         $secureString = [System.Security.SecureString]::New()
-        $string.ToCharArray() | foreach-object { $securestring.AppendChar($_) }
+        $string.ToCharArray() | ForEach-Object { $securestring.AppendChar($_) }
     }
 
     It "using null arguments to ConvertFrom-SecureString produces an exception" {
-        { ConvertFrom-SecureString -secureString $null -key $null } |
+        { ConvertFrom-SecureString -SecureString $null -Key $null } |
             Should -Throw -ErrorId "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.ConvertFromSecureStringCommand"
     }
 
     It "using a bad key produces an exception" {
         $badkey = [byte[]]@(1,2)
-        { ConvertFrom-SecureString -securestring $secureString -key $badkey } |
+        { ConvertFrom-SecureString -SecureString $secureString -Key $badkey } |
             Should -Throw -ErrorId "Argument,Microsoft.PowerShell.Commands.ConvertFromSecureStringCommand"
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/TestData/CatalogTestData/UserConfigProv/DSCResources/UserConfigProviderModVersion1/UserConfigProviderModVersion1.psm1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/TestData/CatalogTestData/UserConfigProv/DSCResources/UserConfigProviderModVersion1/UserConfigProviderModVersion1.psm1
@@ -37,7 +37,7 @@ function Set-TargetResource
        $text
      )
 	$path = "$env:SystemDrive\dscTestPath\hello1.txt"
- 	New-Item -Path $path -Type File -force
+ 	New-Item -Path $path -Type File -Force
 	Add-Content -Path $path -Value $text
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/TestData/CatalogTestData/UserConfigProv/DSCResources/UserConfigProviderModVersion2/UserConfigProviderModVersion2.psm1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/TestData/CatalogTestData/UserConfigProv/DSCResources/UserConfigProviderModVersion2/UserConfigProviderModVersion2.psm1
@@ -38,7 +38,7 @@ function Set-TargetResource
      )
 
  	$path = "$env:SystemDrive\dscTestPath\hello2.txt"
- 	New-Item -Path $path -Type File -force
+ 	New-Item -Path $path -Type File -Force
 	Add-Content -Path $path -Value $text
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/TestData/CatalogTestData/UserConfigProv/DSCResources/UserConfigProviderModVersion3/UserConfigProviderModVersion3.psm1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/TestData/CatalogTestData/UserConfigProv/DSCResources/UserConfigProviderModVersion3/UserConfigProviderModVersion3.psm1
@@ -38,7 +38,7 @@ function Set-TargetResource
      )
 
  	$path = "$env:SystemDrive\dscTestPath\hello3.txt"
- 	New-Item -Path $path -Type File -force
+ 	New-Item -Path $path -Type File -Force
 	Add-Content -Path $path -Value $text
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Member.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Member.Tests.ps1
@@ -24,7 +24,7 @@ Describe "Add-Member DRT Unit Tests" -Tags "CI" {
         $memberTypesWhereV1CannotBeNull = "CodeMethod", "MemberSet", "PropertySet", "ScriptMethod", "NoteProperty"
         foreach ($memberType in $memberTypesWhereV1CannotBeNull)
         {
-            { Add-Member -InputObject a -memberType $memberType -Name Name -Value something -SecondValue somethingElse } |
+            { Add-Member -InputObject a -MemberType $memberType -Name Name -Value something -SecondValue somethingElse } |
                 Should -Throw -ErrorId "Value2ShouldNotBeSpecified,Microsoft.PowerShell.Commands.AddMemberCommand"
         }
     }
@@ -33,10 +33,10 @@ Describe "Add-Member DRT Unit Tests" -Tags "CI" {
         $membersYouCannotAdd = "Method", "Property", "ParameterizedProperty"
         foreach ($member in $membersYouCannotAdd)
         {
-            { Add-Member -InputObject a -memberType $member -Name Name } | Should -Throw -ErrorId "CannotAddMemberType,Microsoft.PowerShell.Commands.AddMemberCommand"
+            { Add-Member -InputObject a -MemberType $member -Name Name } | Should -Throw -ErrorId "CannotAddMemberType,Microsoft.PowerShell.Commands.AddMemberCommand"
         }
 
-        { Add-Member -InputObject a -memberType AnythingElse -Name Name } | Should -Throw -ErrorId "CannotConvertArgumentNoMessage,Microsoft.PowerShell.Commands.AddMemberCommand"
+        { Add-Member -InputObject a -MemberType AnythingElse -Name Name } | Should -Throw -ErrorId "CannotConvertArgumentNoMessage,Microsoft.PowerShell.Commands.AddMemberCommand"
 
     }
 
@@ -44,7 +44,7 @@ Describe "Add-Member DRT Unit Tests" -Tags "CI" {
         $memberTypes = "CodeProperty", "ScriptProperty"
         foreach ($memberType in $memberTypes)
         {
-            { Add-Member -memberType $memberType -Name PropertyName -Value $null -SecondValue $null -InputObject a } |
+            { Add-Member -MemberType $memberType -Name PropertyName -Value $null -SecondValue $null -InputObject a } |
                 Should -Throw -ErrorId "Value1AndValue2AreNotBothNull,Microsoft.PowerShell.Commands.AddMemberCommand"
         }
 
@@ -56,13 +56,13 @@ Describe "Add-Member DRT Unit Tests" -Tags "CI" {
     }
 
     It "Successful alias, no type" {
-        $results = Add-Member -InputObject a -MemberType AliasProperty -Name Cnt -Value Length -passthru
+        $results = Add-Member -InputObject a -MemberType AliasProperty -Name Cnt -Value Length -PassThru
         $results.Cnt | Should -BeOfType Int32
         $results.Cnt | Should -Be 1
     }
 
     It "Successful alias, with type" {
-        $results = add-member -InputObject a -MemberType AliasProperty -Name Cnt -Value Length -SecondValue String -passthru
+        $results = Add-Member -InputObject a -MemberType AliasProperty -Name Cnt -Value Length -SecondValue String -PassThru
         $results.Cnt | Should -BeOfType String
         $results.Cnt | Should -Be '1'
     }
@@ -73,16 +73,16 @@ Describe "Add-Member DRT Unit Tests" -Tags "CI" {
     }
 
     It "Empty Member Set Null Value1" {
-        $results = add-member -InputObject a -MemberType MemberSet -Name Name -Value $null -passthru
+        $results = Add-Member -InputObject a -MemberType MemberSet -Name Name -Value $null -PassThru
         $results.Length | Should -Be 1
         $results.Name.a | Should -BeNullOrEmpty
     }
 
     It "Member Set With 1 Member" {
-        $members = new-object System.Collections.ObjectModel.Collection[System.Management.Automation.PSMemberInfo]
-        $n=new-object Management.Automation.PSNoteProperty a,1
+        $members = New-Object System.Collections.ObjectModel.Collection[System.Management.Automation.PSMemberInfo]
+        $n=New-Object Management.Automation.PSNoteProperty a,1
         $members.Add($n)
-        $r=Add-Member -InputObject a -MemberType MemberSet -Name Name -Value $members -passthru
+        $r=Add-Member -InputObject a -MemberType MemberSet -Name Name -Value $members -PassThru
         $r.Name.a | Should -Be '1'
     }
 
@@ -108,8 +108,8 @@ Describe "Add-Member DRT Unit Tests" -Tags "CI" {
     }
 
     It "Add ScriptProperty Success" {
-        set-alias ScriptPropertyTestAlias dir
-        $al=(get-alias ScriptPropertyTestAlias)
+        Set-Alias ScriptPropertyTestAlias dir
+        $al=(Get-Alias ScriptPropertyTestAlias)
         $al.Description="MyDescription"
         $al | Add-Member -MemberType ScriptProperty -Name NewDescription -Value {$this.Description} -SecondValue {$this.Description=$args[0]}
         $al.NewDescription | Should -BeExactly 'MyDescription'
@@ -118,12 +118,12 @@ Describe "Add-Member DRT Unit Tests" -Tags "CI" {
     }
 
     It "Add TypeName MemberSet Success" {
-        $a = 'string' | add-member -MemberType NoteProperty -Name TestNote -Value Any -TypeName MyType -passthru
+        $a = 'string' | Add-Member -MemberType NoteProperty -Name TestNote -Value Any -TypeName MyType -PassThru
         $a.PSTypeNames[0] | Should -Be MyType
     }
 
     It "Add TypeName Existing Name Success" {
-        $a = 'string' | add-member -TypeName System.Object -passthru
+        $a = 'string' | Add-Member -TypeName System.Object -PassThru
         $a.PSTypeNames[0] | Should -Be System.Object
     }
 
@@ -134,43 +134,43 @@ Describe "Add-Member DRT Unit Tests" -Tags "CI" {
     }
 
     It "Add Multiple Note Members" {
-        $obj=new-object psobject
+        $obj=New-Object psobject
         $hash=@{Name='Name';TestInt=1;TestNull=$null}
-        add-member -InputObject $obj $hash
+        Add-Member -InputObject $obj $hash
         $obj.Name | Should -Be 'Name'
         $obj.TestInt | Should -Be 1
         $obj.TestNull | Should -BeNullOrEmpty
     }
 
     It "Add Multiple Note With TypeName" {
-        $obj=new-object psobject
+        $obj=New-Object psobject
         $hash=@{Name='Name';TestInt=1;TestNull=$null}
-        $obj = add-member -InputObject $obj $hash -TypeName MyType -Passthru
+        $obj = Add-Member -InputObject $obj $hash -TypeName MyType -PassThru
         $obj.PSTypeNames[0] | Should -Be MyType
     }
 
     It "Add Multiple Members With Force" {
-        $obj=new-object psobject
+        $obj=New-Object psobject
         $hash=@{TestNote='hello'}
         $obj | Add-Member -MemberType NoteProperty -Name TestNote -Value 1
-        $obj | add-member $hash -force
+        $obj | Add-Member $hash -Force
         $obj.TestNote | Should -Be 'hello'
     }
 
     It "Simplified Add-Member should support using 'Property' as the NoteProperty member name" {
-        $results = add-member -InputObject a property Any -passthru
+        $results = Add-Member -InputObject a property Any -PassThru
         $results.property | Should -BeExactly 'Any'
 
-        $results = add-member -InputObject a Method Any -passthru
+        $results = Add-Member -InputObject a Method Any -PassThru
         $results.Method | Should -BeExactly 'Any'
 
-        $results = add-member -InputObject a 23 Any -passthru
+        $results = Add-Member -InputObject a 23 Any -PassThru
         $results.23 | Should -BeExactly 'Any'
 
-        $results = add-member -InputObject a 8 np Any -passthru
+        $results = Add-Member -InputObject a 8 np Any -PassThru
         $results.np | Should -BeExactly 'Any'
 
-        $results = add-member -InputObject a 16 sp {1+1} -passthru
+        $results = Add-Member -InputObject a 16 sp {1+1} -PassThru
         $results.sp | Should -Be 2
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Compare-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Compare-Object.Tests.ps1
@@ -95,7 +95,7 @@ Describe "Compare-Object" -Tags "CI" {
     }
 
     It "Should be able to pass objects to pipeline using the passthru switch" {
-	{ Compare-Object -ReferenceObject $(Get-Content $file3) -DifferenceObject $(Get-Content $file4) -Passthru | Format-Wide } | Should -Not -Throw
+	{ Compare-Object -ReferenceObject $(Get-Content $file3) -DifferenceObject $(Get-Content $file4) -PassThru | Format-Wide } | Should -Not -Throw
     }
 
     It "Should be able to specify the property of two objects to compare" {
@@ -106,15 +106,15 @@ Describe "Compare-Object" -Tags "CI" {
     }
 
     It "Should be able to specify the syncwindow without error" {
-	{ Compare-Object -ReferenceObject $(Get-Content $file3) -DifferenceObject $(Get-Content $file4) -syncWindow 5 } | Should -Not -Throw
-	{ Compare-Object -ReferenceObject $(Get-Content $file3) -DifferenceObject $(Get-Content $file4) -syncWindow 8 } | Should -Not -Throw
+	{ Compare-Object -ReferenceObject $(Get-Content $file3) -DifferenceObject $(Get-Content $file4) -SyncWindow 5 } | Should -Not -Throw
+	{ Compare-Object -ReferenceObject $(Get-Content $file3) -DifferenceObject $(Get-Content $file4) -SyncWindow 8 } | Should -Not -Throw
     }
 
     It "Should have the expected output when changing the syncwindow" {
 	$var1 = 1..15
 	$var2 = 15..1
 
-	$actualOutput = Compare-Object -ReferenceObject $var1 -DifferenceObject $var2 -syncWindow 6
+	$actualOutput = Compare-Object -ReferenceObject $var1 -DifferenceObject $var2 -SyncWindow 6
 
 	$actualOutput[0].InputObject | Should -Be 15
 	$actualOutput[1].InputObject | Should -Be 1
@@ -232,7 +232,7 @@ Describe "Compare-Object DRT basic functionality" -Tags "CI" {
 			{
 				foreach($passthru in $boolvalues)
 				{
-					$result = Compare-Object -ReferenceObject $empsReference -IncludeEqual:$recordEqual -ExcludeDifferent:$excludeDifferent -Passthru:$passthru -DifferenceObject $empsDifference
+					$result = Compare-Object -ReferenceObject $empsReference -IncludeEqual:$recordEqual -ExcludeDifferent:$excludeDifferent -PassThru:$passthru -DifferenceObject $empsDifference
 
 					if(!$excludeDifferent)
 					{
@@ -269,7 +269,7 @@ Describe "Compare-Object DRT basic functionality" -Tags "CI" {
 			{
 				foreach($passthru in $boolvalues)
 				{
-					$result = Compare-Object -ReferenceObject $empsReference -IncludeEqual:$recordEqual -ExcludeDifferent:$excludeDifferent -Passthru:$passthru -DifferenceObject $empsDifference
+					$result = Compare-Object -ReferenceObject $empsReference -IncludeEqual:$recordEqual -ExcludeDifferent:$excludeDifferent -PassThru:$passthru -DifferenceObject $empsDifference
 					if($recordEqual)
 					{
 						if(!$excludeDifferent)
@@ -335,7 +335,7 @@ Describe "Compare-Object DRT basic functionality" -Tags "CI" {
 			{
 				foreach($passthru in $boolvalues)
 				{
-					$result = Compare-Object -ReferenceObject $empsReference -IncludeEqual:$recordEqual -ExcludeDifferent:$excludeDifferent -Passthru:$passthru -DifferenceObject $empsDifference -SyncWindow:0
+					$result = Compare-Object -ReferenceObject $empsReference -IncludeEqual:$recordEqual -ExcludeDifferent:$excludeDifferent -PassThru:$passthru -DifferenceObject $empsDifference -SyncWindow:0
 					if($recordEqual)
 					{
 						if(!$excludeDifferent)
@@ -401,7 +401,7 @@ Describe "Compare-Object DRT basic functionality" -Tags "CI" {
 			{
 				foreach($passthru in $boolvalues)
 				{
-					$result = Compare-Object -ReferenceObject $empsReference -IncludeEqual:$recordEqual -ExcludeDifferent:$excludeDifferent -Passthru:$passthru -DifferenceObject $empsDifference -SyncWindow:2
+					$result = Compare-Object -ReferenceObject $empsReference -IncludeEqual:$recordEqual -ExcludeDifferent:$excludeDifferent -PassThru:$passthru -DifferenceObject $empsDifference -SyncWindow:2
 
 					if($recordEqual)
 					{

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Html.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Html.Tests.ps1
@@ -120,7 +120,7 @@ After the object
     }
 
     It "Test ConvertTo-HTML meta"{
-        $returnString = ($customObject | ConvertTo-HTML -Meta @{"author"="John Doe"}) -join $newLine
+        $returnString = ($customObject | ConvertTo-Html -Meta @{"author"="John Doe"}) -join $newLine
         $expectedValue = normalizeLineEnds @"
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -141,12 +141,12 @@ After the object
     It "Test ConvertTo-HTML meta with invalid properties should throw warning" {
         $parms = @{"authors"="John Doe";"keywords"="PowerShell,PSv6"}
         # make this a string, rather than an array of string so match will behave
-        [string]$observedProperties = $customObject | ConvertTo-HTML -Meta $parms 3>&1
+        [string]$observedProperties = $customObject | ConvertTo-Html -Meta $parms 3>&1
         $observedProperties | Should -Match $parms["authors"]
     }
 
     It "Test ConvertTo-HTML charset"{
-        $returnString = ($customObject | ConvertTo-HTML -Charset "utf-8") -join $newLine
+        $returnString = ($customObject | ConvertTo-Html -Charset "utf-8") -join $newLine
         $expectedValue = normalizeLineEnds @"
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -165,17 +165,17 @@ After the object
     }
 
     It "Test ConvertTo-HTML transitional"{
-        $returnString = $customObject | ConvertTo-HTML -Transitional | Select-Object -First 1
+        $returnString = $customObject | ConvertTo-Html -Transitional | Select-Object -First 1
         $returnString | Should -Be '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">'
     }
 
     It "Test ConvertTo-HTML supports scriptblock-based calculated properties: by hashtable" {
-        $returnString = ($customObject | ConvertTo-HTML @{ l = 'NewAge'; e = { $_.Age + 1 } }) -join $newLine
+        $returnString = ($customObject | ConvertTo-Html @{ l = 'NewAge'; e = { $_.Age + 1 } }) -join $newLine
         $returnString | Should -Match '\b43\b'
     }
 
     It "Test ConvertTo-HTML supports scriptblock-based calculated properties: directly" {
-        $returnString = ($customObject | ConvertTo-HTML { $_.Age + 1 }) -join $newLine
+        $returnString = ($customObject | ConvertTo-Html { $_.Age + 1 }) -join $newLine
         $returnString | Should -Match '\b43\b'
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
@@ -26,7 +26,7 @@ Describe 'ConvertTo-Json' -tags "CI" {
         $null = $ps.AddScript({
             $obj = [PSCustomObject]@{P1 = ''; P2 = ''; P3 = ''; P4 = ''; P5 = ''; P6 = ''}
             $obj.P1 = $obj.P2 = $obj.P3 = $obj.P4 = $obj.P5 = $obj.P6 = $obj
-            1..100 | Foreach-Object { $obj } | ConvertTo-Json -Depth 10 -Verbose
+            1..100 | ForEach-Object { $obj } | ConvertTo-Json -Depth 10 -Verbose
             # the conversion is expected to take some time, this throw is in case it doesn't
             throw "Should not have thrown exception"
         })

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-SecureString.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-SecureString.Tests.ps1
@@ -6,7 +6,7 @@
 
 	It "Should return System.Security.SecureString after converting plaintext variable"{
         #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
-	    $PesterTestConvert = (ConvertTo-SecureString "plaintextpester" -AsPlainText -force)
+	    $PesterTestConvert = (ConvertTo-SecureString "plaintextpester" -AsPlainText -Force)
 	    $PesterTestConvert | Should -BeOfType securestring
 
 	}

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Debug-Runspace.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Debug-Runspace.Tests.ps1
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-Describe "Debug-Runspace" -tag "CI" {
+Describe "Debug-Runspace" -Tag "CI" {
     BeforeAll {
         $rs1 = [runspacefactory]::CreateRunspace()
         $rs1.Open()
@@ -24,12 +24,12 @@ Describe "Debug-Runspace" -tag "CI" {
 
     It "Debugging a runspace should fail if the runspace is not open" {
         $rs2.Close()
-        { Debug-Runspace -runspace $rs2 -ErrorAction stop } | Should -Throw -ErrorId "InvalidOperation,Microsoft.PowerShell.Commands.DebugRunspaceCommand"
+        { Debug-Runspace -Runspace $rs2 -ErrorAction stop } | Should -Throw -ErrorId "InvalidOperation,Microsoft.PowerShell.Commands.DebugRunspaceCommand"
     }
 
     It "Debugging a runspace should fail if the runspace has no debugger" {
         $rs1.Debugger.SetDebugMode("None")
-        { Debug-Runspace -runspace $rs1 -ErrorAction stop } | Should -Throw -ErrorId "InvalidOperation,Microsoft.PowerShell.Commands.DebugRunspaceCommand"
+        { Debug-Runspace -Runspace $rs1 -ErrorAction stop } | Should -Throw -ErrorId "InvalidOperation,Microsoft.PowerShell.Commands.DebugRunspaceCommand"
     }
 
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Eventing.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Eventing.Tests.ps1
@@ -12,25 +12,25 @@ Describe "Event Subscriber Tests" -Tags "Feature" {
     # can't let this case to work
     It "Register an event with no action, trigger it and wait for it to be raised." -Pending:$true{
         Get-EventSubscriber | Should -BeNullOrEmpty
-        $messageData = new-object psobject
+        $messageData = New-Object psobject
         $job = Start-Job { Start-Sleep -Seconds 5; 1..5 }
         $null = Register-ObjectEvent $job -EventName StateChanged -SourceIdentifier EventSIDTest -Action {} -MessageData $messageData
-        new-event EventSIDTest
+        New-Event EventSIDTest
 
-        wait-event EventSIDTest
-        $eventdata = get-event EventSIDTest
+        Wait-Event EventSIDTest
+        $eventdata = Get-Event EventSIDTest
         $eventdata.MessageData | Should -Be $messageData
-        remove-event EventSIDTest
+        Remove-Event EventSIDTest
         Unregister-Event EventSIDTest
         Get-EventSubscriber | Should -BeNullOrEmpty
     }
 
     It "Access a global variable from an event action." {
         Get-EventSubscriber | Should -BeNullOrEmpty
-        set-variable incomingGlobal -scope global -value globVarValue
-        $null = register-engineevent -SourceIdentifier foo -Action {set-variable -scope global -name aglobalvariable -value $incomingGlobal}
-        new-event foo
-        $getvar = get-variable aglobalvariable -scope global
+        Set-Variable incomingGlobal -Scope global -Value globVarValue
+        $null = Register-EngineEvent -SourceIdentifier foo -Action {Set-Variable -Scope global -Name aglobalvariable -Value $incomingGlobal}
+        New-Event foo
+        $getvar = Get-Variable aglobalvariable -Scope global
         $getvar.Name | Should -Be aglobalvariable
         $getvar.Value | Should -Be globVarValue
         Unregister-Event foo
@@ -44,7 +44,7 @@ Describe "Event Subscriber Tests" -Tags "Feature" {
             try{
                 try{} finally{}
             }
-            catch{ Write-Host "Exception" -Nonewline }
+            catch{ Write-Host "Exception" -NoNewline }
         }
         } | Out-String
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Alias.Tests.ps1
@@ -10,21 +10,21 @@ Describe "Export-Alias DRT Unit Tests" -Tags "CI" {
 		$testAliases        = "TestAliases"
     	$fulltestpath       = Join-Path -Path $testAliasDirectory -ChildPath $testAliases
 
-		remove-item alias:abcd* -force -ErrorAction SilentlyContinue
-		remove-item alias:ijkl* -force -ErrorAction SilentlyContinue
-		set-alias abcd01 efgh01
-		set-alias abcd02 efgh02
-		set-alias abcd03 efgh03
-		set-alias abcd04 efgh04
-		set-alias ijkl01 mnop01
-		set-alias ijkl02 mnop02
-		set-alias ijkl03 mnop03
-		set-alias ijkl04 mnop04
+		Remove-Item alias:abcd* -Force -ErrorAction SilentlyContinue
+		Remove-Item alias:ijkl* -Force -ErrorAction SilentlyContinue
+		Set-Alias abcd01 efgh01
+		Set-Alias abcd02 efgh02
+		Set-Alias abcd03 efgh03
+		Set-Alias abcd04 efgh04
+		Set-Alias ijkl01 mnop01
+		Set-Alias ijkl02 mnop02
+		Set-Alias ijkl03 mnop03
+		Set-Alias ijkl04 mnop04
 	}
 
 	AfterAll {
-		remove-item alias:abcd* -force -ErrorAction SilentlyContinue
-		remove-item alias:ijkl* -force -ErrorAction SilentlyContinue
+		Remove-Item alias:abcd* -Force -ErrorAction SilentlyContinue
+		Remove-Item alias:ijkl* -Force -ErrorAction SilentlyContinue
 	}
 
     BeforeEach {
@@ -50,27 +50,27 @@ Describe "Export-Alias DRT Unit Tests" -Tags "CI" {
 	}
 
 	It "Export-Alias with Invalid Scope will throw PSArgumentException" {
-		{ Export-Alias $fulltestpath -scope foodbar } | Should -Throw -ErrorId "Argument,Microsoft.PowerShell.Commands.ExportAliasCommand"
+		{ Export-Alias $fulltestpath -Scope foodbar } | Should -Throw -ErrorId "Argument,Microsoft.PowerShell.Commands.ExportAliasCommand"
 	}
 
 	It "Export-Alias for Default"{
-		Export-Alias $fulltestpath abcd01 -passthru
+		Export-Alias $fulltestpath abcd01 -PassThru
 		$fulltestpath | Should -FileContentMatchExactly '"abcd01","efgh01","","None"'
     }
 
 	It "Export-Alias As CSV"{
-		Export-Alias $fulltestpath abcd01 -As CSV -passthru
+		Export-Alias $fulltestpath abcd01 -As CSV -PassThru
 		$fulltestpath | Should -FileContentMatchExactly '"abcd01","efgh01","","None"'
     }
 
 	It "Export-Alias As CSV With Description"{
-		Export-Alias $fulltestpath abcd01 -As CSV -description "My Aliases" -passthru
+		Export-Alias $fulltestpath abcd01 -As CSV -Description "My Aliases" -PassThru
 		$fulltestpath | Should -FileContentMatchExactly '"abcd01","efgh01","","None"'
 		$fulltestpath | Should -FileContentMatchExactly "My Aliases"
     }
 
 	It "Export-Alias As CSV With Multiline Description"{
-		Export-Alias $fulltestpath abcd01 -As CSV -description "My Aliases\nYour Aliases\nEveryones Aliases" -passthru
+		Export-Alias $fulltestpath abcd01 -As CSV -Description "My Aliases\nYour Aliases\nEveryones Aliases" -PassThru
 		$fulltestpath | Should -FileContentMatchExactly '"abcd01","efgh01","","None"'
 		$fulltestpath | Should -FileContentMatchExactly "My Aliases"
 		$fulltestpath | Should -FileContentMatchExactly "Your Aliases"
@@ -78,12 +78,12 @@ Describe "Export-Alias DRT Unit Tests" -Tags "CI" {
     }
 
 	It "Export-Alias As Script"{
-		Export-Alias $fulltestpath abcd01 -As Script -passthru
+		Export-Alias $fulltestpath abcd01 -As Script -PassThru
 		$fulltestpath | Should -FileContentMatchExactly 'set-alias -Name:"abcd01" -Value:"efgh01" -Description:"" -Option:"None"'
     }
 
 	It "Export-Alias As Script With Multiline Description"{
-		Export-Alias $fulltestpath abcd01 -As Script -description "My Aliases\nYour Aliases\nEveryones Aliases" -passthru
+		Export-Alias $fulltestpath abcd01 -As Script -Description "My Aliases\nYour Aliases\nEveryones Aliases" -PassThru
 		$fulltestpath | Should -FileContentMatchExactly 'set-alias -Name:"abcd01" -Value:"efgh01" -Description:"" -Option:"None"'
 		$fulltestpath | Should -FileContentMatchExactly "My Aliases"
 		$fulltestpath | Should -FileContentMatchExactly "Your Aliases"
@@ -92,7 +92,7 @@ Describe "Export-Alias DRT Unit Tests" -Tags "CI" {
 
 	It "Export-Alias for Force Test"{
 		Export-Alias $fulltestpath abcd01
-		Export-Alias $fulltestpath abcd02 -force
+		Export-Alias $fulltestpath abcd02 -Force
 		$fulltestpath | Should -Not -FileContentMatchExactly '"abcd01","efgh01","","None"'
 		$fulltestpath | Should -FileContentMatchExactly '"abcd02","efgh02","","None"'
     }
@@ -109,7 +109,7 @@ Describe "Export-Alias DRT Unit Tests" -Tags "CI" {
 		}
 
 		{ Export-Alias $fulltestpath abcd02 } | Should -Throw -ErrorId "FileOpenFailure,Microsoft.PowerShell.Commands.ExportAliasCommand"
-		Export-Alias $fulltestpath abcd03 -force
+		Export-Alias $fulltestpath abcd03 -Force
 		$fulltestpath | Should -Not -FileContentMatchExactly '"abcd01","efgh01","","None"'
 		$fulltestpath | Should -Not -FileContentMatchExactly '"abcd02","efgh02","","None"'
 		$fulltestpath | Should -FileContentMatchExactly '"abcd03","efgh03","","None"'

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-FormatData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-FormatData.Tests.ps1
@@ -14,7 +14,7 @@ Describe "Export-FormatData" -Tags "CI" {
     It "Can export all types" {
         try
         {
-            $fd | Export-FormatData -path $TESTDRIVE\allformat.ps1xml -IncludeScriptBlock
+            $fd | Export-FormatData -Path $TESTDRIVE\allformat.ps1xml -IncludeScriptBlock
 
             $sessionState = [System.Management.Automation.Runspaces.InitialSessionState]::CreateDefault()
             $sessionState.Formats.Clear()

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
@@ -223,7 +223,7 @@ Describe 'ForEach-Object -Parallel -AsJob Basic Tests' -Tags 'CI' {
         $Var2 = "Goodbye"
         $Var3 = 105
         $Var4 = "One","Two","Three"
-        $job = 1..1 | Foreach-Object -AsJob -Parallel {
+        $job = 1..1 | ForEach-Object -AsJob -Parallel {
             Write-Output $using:Var1
             Write-Output $using:Var2
             Write-Output $using:Var3

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Custom.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Custom.Tests.ps1
@@ -14,7 +14,7 @@ Describe "Format-Custom" -Tags "CI" {
     Context "Check specific flags on Format-Custom" {
 
         It "Should be able to specify the depth in output" {
-            $getprocesspester =  Get-FormatData | Format-Custom -depth 1
+            $getprocesspester =  Get-FormatData | Format-Custom -Depth 1
             ($getprocesspester).Count | Should -BeGreaterThan 0
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
@@ -20,8 +20,8 @@ Describe "Format-Table" -Tags "CI" {
         }
 
         It "Format-Table with not existing table with force should throw PipelineStoppedException"{
-                $obj = New-Object -typename PSObject
-                $e = { $obj | Format-Table -view bar -force -ErrorAction Stop } |
+                $obj = New-Object -TypeName PSObject
+                $e = { $obj | Format-Table -View bar -Force -ErrorAction Stop } |
                     Should -Throw -ErrorId "FormatViewNotFound,Microsoft.PowerShell.Commands.FormatTableCommand" -PassThru
                 $e.CategoryInfo | Should -Match "PipelineStoppedException"
         }
@@ -36,7 +36,7 @@ Describe "Format-Table" -Tags "CI" {
 
         It "Format-Table with Negative Count should work" {
                 $FormatEnumerationLimit = -1
-                $result = Format-Table -inputobject @{'test'= 1, 2}
+                $result = Format-Table -InputObject @{'test'= 1, 2}
                 $resultStr = $result | Out-String
                 $resultStr | Should -Match "test\s+{1, 2}"
         }
@@ -44,28 +44,28 @@ Describe "Format-Table" -Tags "CI" {
         # Pending on issue#888
         It "Format-Table with Zero Count should work" -Pending {
                 $FormatEnumerationLimit = 0
-                $result = Format-Table -inputobject @{'test'= 1, 2}
+                $result = Format-Table -InputObject @{'test'= 1, 2}
                 $resultStr = $result | Out-String
                 $resultStr | Should -Match "test\s+{...}"
         }
 
         It "Format-Table with Less Count should work" {
                 $FormatEnumerationLimit = 1
-                $result = Format-Table -inputobject @{'test'= 1, 2}
+                $result = Format-Table -InputObject @{'test'= 1, 2}
                 $resultStr = $result | Out-String
                 $resultStr | Should -Match "test\s+{1...}"
         }
 
         It "Format-Table with More Count should work" {
                 $FormatEnumerationLimit = 10
-                $result = Format-Table -inputobject @{'test'= 1, 2}
+                $result = Format-Table -InputObject @{'test'= 1, 2}
                 $resultStr = $result | Out-String
                 $resultStr | Should -Match "test\s+{1, 2}"
         }
 
         It "Format-Table with Equal Count should work" {
                 $FormatEnumerationLimit = 2
-                $result = Format-Table -inputobject @{'test'= 1, 2}
+                $result = Format-Table -InputObject @{'test'= 1, 2}
                 $resultStr = $result | Out-String
                 $resultStr | Should -Match "test\s+{1, 2}"
         }
@@ -73,7 +73,7 @@ Describe "Format-Table" -Tags "CI" {
         # Pending on issue#888
         It "Format-Table with Bogus Count should throw Exception" -Pending {
                 $FormatEnumerationLimit = "abc"
-                $result = Format-Table -inputobject @{'test'= 1, 2}
+                $result = Format-Table -InputObject @{'test'= 1, 2}
                 $resultStr = $result|Out-String
                 $resultStr | Should -Match "test\s+{1, 2}"
         }
@@ -82,7 +82,7 @@ Describe "Format-Table" -Tags "CI" {
         It "Format-Table with Var Deleted should throw Exception" -Pending {
                 $FormatEnumerationLimit = 2
                 Remove-Variable FormatEnumerationLimit
-                $result = Format-Table -inputobject @{'test'= 1, 2}
+                $result = Format-Table -InputObject @{'test'= 1, 2}
                 $resultStr = $result | Out-String
                 $resultStr | Should -Match "test\s+{1, 2}"
         }
@@ -112,7 +112,7 @@ Describe "Format-Table" -Tags "CI" {
                 $IPs = New-Object System.Collections.ArrayList
                 $IPs.Add($IP1)
                 $IPs.Add($IP2)
-                $result = $IPs | Format-Table -Autosize | Out-String
+                $result = $IPs | Format-Table -AutoSize | Out-String
                 $result | Should -Match "name size booleanValue"
                 $result | Should -Match "---- ---- ------------"
                 $result | Should -Match "Bob\s+1234\s+True"
@@ -785,7 +785,7 @@ A Name                                  B
                 # Fill the console window with the string, so that it reaches its max width.
                 # Check if the max width is equal to default value (120), to test test hook set.
                 $testObject = @{ test = '1' * 200}
-                Format-table -inputobject $testObject | Out-String -Stream | ForEach-Object{$_.length} | Sort-Object -Bottom 1 | Should -Be 120
+                Format-Table -InputObject $testObject | Out-String -Stream | ForEach-Object{$_.length} | Sort-Object -Bottom 1 | Should -Be 120
             }
             finally {
                 [system.management.automation.internal.internaltesthooks]::SetTestHook('SetConsoleWidthToZero', $false)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Wide.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Wide.Tests.ps1
@@ -12,8 +12,8 @@ Describe "Format-Wide" -Tags "CI" {
     }
 
     It "Should be able to use the autosize switch" {
-        { $pathList | Format-Wide -Autosize } | Should -Not -Throw
-        { $pathList | Format-Wide -Autosize | Out-String } | Should -Not -Throw
+        { $pathList | Format-Wide -AutoSize } | Should -Not -Throw
+        { $pathList | Format-Wide -AutoSize | Out-String } | Should -Not -Throw
     }
 
     It "Should be able to take inputobject instead of pipe" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
@@ -80,17 +80,17 @@ Describe "Get-Alias DRT Unit Tests" -Tags "CI" {
             $result.Description | Should -BeNullOrEmpty
             $result.Options | Should -BeExactly "None"
 
-            Set-Alias -Name ABCD -Value "localfoo" -scope local
-            $result=Get-Alias -Name ABCD -scope local
+            Set-Alias -Name ABCD -Value "localfoo" -Scope local
+            $result=Get-Alias -Name ABCD -Scope local
             $result.Name | Should -BeExactly "ABCD"
             $result.Definition | Should -BeExactly "localfoo"
             $result.Description | Should -BeNullOrEmpty
             $result.Options | Should -BeExactly "None"
 
-            Set-Alias -Name ABCD -Value "globalfoo" -scope global
-            Set-Alias -Name ABCD -Value "scriptfoo" -scope "script"
-            Set-Alias -Name ABCD -Value "foo0" -scope "0"
-            Set-Alias -Name ABCD -Value "foo1" -scope "1"
+            Set-Alias -Name ABCD -Value "globalfoo" -Scope global
+            Set-Alias -Name ABCD -Value "scriptfoo" -Scope "script"
+            Set-Alias -Name ABCD -Value "foo0" -Scope "0"
+            Set-Alias -Name ABCD -Value "foo1" -Scope "1"
 
             $result=Get-Alias -Name ABCD
             $result.Name | Should -BeExactly "ABCD"
@@ -98,31 +98,31 @@ Describe "Get-Alias DRT Unit Tests" -Tags "CI" {
             $result.Description | Should -BeNullOrEmpty
             $result.Options | Should -BeExactly "None"
 
-            $result=Get-Alias -Name ABCD -scope local
+            $result=Get-Alias -Name ABCD -Scope local
             $result.Name | Should -BeExactly "ABCD"
             $result.Definition | Should -BeExactly "foo0"
             $result.Description | Should -BeNullOrEmpty
             $result.Options | Should -BeExactly "None"
 
-            $result=Get-Alias -Name ABCD -scope global
+            $result=Get-Alias -Name ABCD -Scope global
             $result.Name | Should -BeExactly "ABCD"
             $result.Definition | Should -BeExactly "globalfoo"
             $result.Description | Should -BeNullOrEmpty
             $result.Options | Should -BeExactly "None"
 
-            $result=Get-Alias -Name ABCD -scope "script"
+            $result=Get-Alias -Name ABCD -Scope "script"
             $result.Name | Should -BeExactly "ABCD"
             $result.Definition | Should -BeExactly "scriptfoo"
             $result.Description | Should -BeNullOrEmpty
             $result.Options | Should -BeExactly "None"
 
-            $result=Get-Alias -Name ABCD -scope "0"
+            $result=Get-Alias -Name ABCD -Scope "0"
             $result.Name | Should -BeExactly "ABCD"
             $result.Definition | Should -BeExactly "foo0"
             $result.Description | Should -BeNullOrEmpty
             $result.Options | Should -BeExactly "None"
 
-            $result=Get-Alias -Name ABCD -scope "1"
+            $result=Get-Alias -Name ABCD -Scope "1"
             $result.Name | Should -BeExactly "ABCD"
             $result.Definition | Should -BeExactly "foo1"
             $result.Description | Should -BeNullOrEmpty
@@ -139,7 +139,7 @@ Describe "Get-Alias DRT Unit Tests" -Tags "CI" {
             $result.Description | Should -BeNullOrEmpty
             $result.Options | Should -BeExactly "None"
 
-            $result=Get-Alias -Name ABCD -scope "0"
+            $result=Get-Alias -Name ABCD -Scope "0"
             $result.Name | Should -BeExactly "ABCD"
             $result.Definition | Should -BeExactly "foo"
             $result.Description | Should -BeNullOrEmpty

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
@@ -95,7 +95,7 @@ Describe "Get-Command Feature tests" -Tag Feature {
         }
 
         It "Non-existing cmdlets returns non-terminating error" {
-            { get-command g-adf -ErrorAction Stop } | Should -Throw -ErrorId "CommandNotFoundException,Microsoft.PowerShell.Commands.GetCommandCommand"
+            { Get-Command g-adf -ErrorAction Stop } | Should -Throw -ErrorId "CommandNotFoundException,Microsoft.PowerShell.Commands.GetCommandCommand"
         }
 
         It "No results if wildcard is used" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
@@ -16,21 +16,21 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
     }
 
     It "using -displayhint produces the correct output" {
-        $d = Get-date -Date:"Jan 1, 2020"  -DisplayHint Date | Out-String
+        $d = Get-Date -Date:"Jan 1, 2020"  -DisplayHint Date | Out-String
         $d.Trim() | Should -Be "Wednesday, January 1, 2020"
     }
 
     It "using -format produces the correct output" {
-        Get-date -Date:"Jan 1, 2020"  -Format:"MMM-dd-yy" | Should -Be "Jan-01-20"
+        Get-Date -Date:"Jan 1, 2020"  -Format:"MMM-dd-yy" | Should -Be "Jan-01-20"
     }
 
     It "using -AsUTC produces the correct output" {
-        (Get-date -Date:"2020-01-01T00:00:00").Kind | Should -Be Unspecified
-        (Get-date -Date:"2020-01-01T00:00:00" -AsUTC).Kind | Should -Be Utc
+        (Get-Date -Date:"2020-01-01T00:00:00").Kind | Should -Be Unspecified
+        (Get-Date -Date:"2020-01-01T00:00:00" -AsUTC).Kind | Should -Be Utc
     }
 
     It "using -uformat %s produces the correct output" {
-        $seconds = Get-date -Date:"Jan 1, 2020Z" -UFormat:"%s"
+        $seconds = Get-Date -Date:"Jan 1, 2020Z" -UFormat:"%s"
 
         $seconds | Should -Be "1577836800"
         if ($IsLinux) {
@@ -44,15 +44,15 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
     }
 
     It "using -uformat 'ymdH' produces the correct output" {
-        Get-date -Date 0030-01-01T00:00:00 -uformat %y/%m/%d-%H | Should -Be "30/01/01-00"
+        Get-Date -Date 0030-01-01T00:00:00 -UFormat %y/%m/%d-%H | Should -Be "30/01/01-00"
     }
 
     It "using -uformat 'aAbBcCdDehHIkljmMpr' produces the correct output" {
-        Get-date -Date 1/1/0030 -uformat "%a%A%b%B%c%C%d%D%e%h%H%I%k%l%j%m%M%p%r" | Should -Be "TueTuesdayJanJanuaryTue 01 Jan 0030 00:00:0000101/01/30 1Jan0012 0120010100AM12:00:00 AM"
+        Get-Date -Date 1/1/0030 -UFormat "%a%A%b%B%c%C%d%D%e%h%H%I%k%l%j%m%M%p%r" | Should -Be "TueTuesdayJanJanuaryTue 01 Jan 0030 00:00:0000101/01/30 1Jan0012 0120010100AM12:00:00 AM"
     }
 
     It "using -uformat 'sStTuUVwWxXyYZ' produces the correct output" {
-        Get-date -Date 1/1/0030 -uformat %S%T%u%U%w%W%x%X%y%Y%% | Should -Be "0000:00:00202001/01/3000:00:00300030%"
+        Get-Date -Date 1/1/0030 -UFormat %S%T%u%U%w%W%x%X%y%Y%% | Should -Be "0000:00:00202001/01/3000:00:00300030%"
     }
 
     # The 'week of year' test cases is from https://en.wikipedia.org/wiki/ISO_week_date
@@ -94,7 +94,7 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
         @{date="2031-01-03"; week = "01"}
     ) {
         param($date, $week)
-        Get-date -Date $date -uformat %V | Should -BeExactly $week
+        Get-Date -Date $date -UFormat %V | Should -BeExactly $week
     }
 
     It "Passing '<name>' to -uformat produces a descriptive error" -TestCases @(
@@ -102,14 +102,14 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
         @{ name = "empty string"; value = "" }
     ) {
         param($value)
-        { Get-date -Date 1/1/1970 -uformat $value -ErrorAction Stop } | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.GetDateCommand"
+        { Get-Date -Date 1/1/1970 -UFormat $value -ErrorAction Stop } | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.GetDateCommand"
     }
 
     It "Get-date works with pipeline input" {
-        $x = new-object System.Management.Automation.PSObject
-        $x | add-member NoteProperty Date ([DateTime]::Now)
+        $x = New-Object System.Management.Automation.PSObject
+        $x | Add-Member NoteProperty Date ([DateTime]::Now)
         $y = @($x,$x)
-        ($y | Get-date).Length | Should -Be 2
+        ($y | Get-Date).Length | Should -Be 2
     }
 
     It "the LastWriteTime alias works with pipeline input" {
@@ -129,8 +129,8 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
 
         }
 
-        $result1 = get-childitem -path $pathString | get-date
-        $result2 = get-childitem -path $pathString | get-date
+        $result1 = Get-ChildItem -Path $pathString | Get-Date
+        $result2 = Get-ChildItem -Path $pathString | Get-Date
 
         $result1.Length | Should -Be 10
         $result1.Length -eq $result2.Length | Should -BeTrue
@@ -148,19 +148,19 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
 
 Describe "Get-Date" -Tags "CI" {
     It "-Format FileDate works" {
-        Get-date -Date 0030-01-01T01:02:03.0004 -Format FileDate | Should -Be "00300101"
+        Get-Date -Date 0030-01-01T01:02:03.0004 -Format FileDate | Should -Be "00300101"
     }
 
     It "-Format FileDateTime works" {
-        Get-date -Date 0030-01-01T01:02:03.0004 -Format FileDateTime | Should -Be "00300101T0102030004"
+        Get-Date -Date 0030-01-01T01:02:03.0004 -Format FileDateTime | Should -Be "00300101T0102030004"
     }
 
     It "-Format FileDateTimeUniversal works" {
-        Get-date -Date 0030-01-01T01:02:03.0004z -Format FileDateTimeUniversal | Should -Be "00300101T0102030004Z"
+        Get-Date -Date 0030-01-01T01:02:03.0004z -Format FileDateTimeUniversal | Should -Be "00300101T0102030004Z"
     }
 
     It "-Format FileDateTimeUniversal works" {
-        Get-date -Date 0030-01-01T01:02:03.0004z -Format FileDateUniversal | Should -Be "00300101Z"
+        Get-Date -Date 0030-01-01T01:02:03.0004z -Format FileDateUniversal | Should -Be "00300101Z"
     }
 
     It "Should have colons when ToString method is used" {
@@ -205,9 +205,9 @@ Describe "Get-Date" -Tags "CI" {
 
 Describe "Get-Date -UFormat tests" -Tags "CI" {
     BeforeAll {
-        $date1 = Get-date -Date "2030-4-5 1:2:3.09"
-        $date2 = Get-date -Date "2030-4-15 13:2:3"
-        $date3 = Get-date -Date "2030-4-15 21:2:3"
+        $date1 = Get-Date -Date "2030-4-5 1:2:3.09"
+        $date2 = Get-Date -Date "2030-4-15 13:2:3"
+        $date3 = Get-Date -Date "2030-4-15 21:2:3"
 
         # 5 come from $date1 - 2030-4-5 is Friday - 5th day (the enum starts with 0 - Sunday)
         $shortDay1 = [System.Globalization.CultureInfo]::CurrentCulture.DateTimeFormat.AbbreviatedDayNames[5]

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
@@ -38,7 +38,7 @@ Describe 'Get-Error tests' -Tag CI {
         }
 
         try {
-            get-item (new-guid) -ErrorAction SilentlyContinue
+            Get-Item (New-Guid) -ErrorAction SilentlyContinue
         }
         catch {
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Event.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Event.Tests.ps1
@@ -3,7 +3,7 @@
 Describe "Get-Event" -Tags "CI" {
 
     BeforeEach {
-	( New-Event -SourceIdentifier PesterTestEvent -sender Windows.timer -messagedata "PesterTestMessage" )
+	( New-Event -SourceIdentifier PesterTestEvent -Sender Windows.timer -MessageData "PesterTestMessage" )
     }
 
     AfterEach {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Member.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Member.Tests.ps1
@@ -247,14 +247,14 @@ Describe "Get-Member DRT Unit Tests" -Tags "CI" {
 
     Context "Verify Get-Member with other parameters" {
         It 'works with View Parameter' {
-            $results = [xml]'<a>some text</a>' | Get-Member -view adapted
-            $results | Where-Object Name -eq a | Should -Not -BeNullOrEmpty
-            $results | Where-Object Name -eq CreateElement | Should -Not -BeNullOrEmpty
-            $results | Where-Object Name -eq CreateNode | Should -Not -BeNullOrEmpty
+            $results = [xml]'<a>some text</a>' | Get-Member -View adapted
+            $results | Where-Object Name -EQ a | Should -Not -BeNullOrEmpty
+            $results | Where-Object Name -EQ CreateElement | Should -Not -BeNullOrEmpty
+            $results | Where-Object Name -EQ CreateNode | Should -Not -BeNullOrEmpty
         }
 
         It 'Get hidden members' {
-            $results = 'abc' | Get-Member -force
+            $results = 'abc' | Get-Member -Force
             $hiddenMembers = "psbase", "psextended", "psadapted", "pstypenames", "psobject"
             foreach ($member in $hiddenMembers) {
                 foreach ($result in $results) {
@@ -267,7 +267,7 @@ Describe "Get-Member DRT Unit Tests" -Tags "CI" {
         }
 
         It 'Get Set Property Accessors On PsBase' {
-            $results = ('abc').psbase | Get-Member -force get_*
+            $results = ('abc').psbase | Get-Member -Force get_*
             $expectedMembers = "get_Chars", "get_Length"
             foreach ($member in $expectedMembers) {
                 foreach ($result in $results) {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Random.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Random.Tests.ps1
@@ -90,8 +90,8 @@ Describe "Get-Random DRT Unit Tests" -Tags "CI" {
     }
 
     It "Tests for setting the seed" {
-        $result1 = (get-random -SetSeed 123), (get-random)
-        $result2 = (get-random -SetSeed 123), (get-random)
+        $result1 = (Get-Random -SetSeed 123), (Get-Random)
+        $result2 = (Get-Random -SetSeed 123), (Get-Random)
         $result1 | Should -Be $result2
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Variable.Tests.ps1
@@ -9,14 +9,14 @@ Describe "Get-Variable DRT Unit Tests" -Tags "CI" {
 
 	It "Get-Variable of existing variable Name with include and bogus exclude should work"{
 		Set-Variable newVar testing
-		$var1=get-variable -Name newVar -Include newVar -Exclude bogus
+		$var1=Get-Variable -Name newVar -Include newVar -Exclude bogus
 		$var1.Name | Should -BeExactly "newVar"
 		$var1.Value | Should -BeExactly "testing"
 	}
 
 	It "Get-Variable of existing variable Name with Description and Option should work"{
 		Set-Variable newVar testing -Option ReadOnly -Description "testing description"
-		$var1=get-variable -Name newVar
+		$var1=Get-Variable -Name newVar
 		$var1.Name | Should -BeExactly "newVar"
 		$var1.Value | Should -BeExactly "testing"
 		$var1.Options | Should -BeExactly "ReadOnly"
@@ -27,7 +27,7 @@ Describe "Get-Variable DRT Unit Tests" -Tags "CI" {
 		Set-Variable abcaVar testing
 		Set-Variable bcdaVar "another test"
 		Set-Variable aVarfoo wow
-		$var1=get-variable -Name *aVar* -Scope local
+		$var1=Get-Variable -Name *aVar* -Scope local
 		$var1.Count | Should -Be 3
 		$var1[0].Name | Should -BeExactly "abcaVar"
 		$var1[0].Value | Should -BeExactly "testing"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Verb.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Verb.Tests.ps1
@@ -7,8 +7,8 @@ Describe "Get-Verb" -Tags "CI" {
     }
 
     It "Should get a specific verb" {
-        @(Get-Verb -Verb Add).Count | Should -Be 1
-        @(Get-Verb -Verb Add -Group Common).Count | Should -Be 1
+        @(Get-Verb -verb Add).Count | Should -Be 1
+        @(Get-Verb -verb Add -Group Common).Count | Should -Be 1
     }
 
     It "Should get a specific group" {
@@ -16,7 +16,7 @@ Describe "Get-Verb" -Tags "CI" {
     }
 
     It "Should not return duplicate Verbs with Verb paramater" {
-        $dups = Get-Verb -Verb Add,ad*,a*
+        $dups = Get-Verb -verb Add,ad*,a*
         $unique = $dups |
             Select-Object -Property * -Unique
         $dups.Count | Should -Be $unique.Count
@@ -30,7 +30,7 @@ Describe "Get-Verb" -Tags "CI" {
     }
 
     It "Should filter using the Verb parameter" {
-        Get-Verb -Verb fakeVerbNeverExists | Should -BeNullOrEmpty
+        Get-Verb -verb fakeVerbNeverExists | Should -BeNullOrEmpty
     }
 
     It "Should not accept Groups that are not in the validate set" {
@@ -59,7 +59,7 @@ Describe "Get-Verb" -Tags "CI" {
     }
 
     It "Should not have duplicate alias prefixes" {
-        $dupPrefixVerbs = ((Get-Verb | Group-Object -Property AliasPrefix | Where-Object Count -gt 1).Group).Verb -join ", "
+        $dupPrefixVerbs = ((Get-Verb | Group-Object -Property AliasPrefix | Where-Object Count -GT 1).Group).Verb -join ", "
         $dupPrefixVerbs | Should -BeNullOrEmpty
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Group-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Group-Object.Tests.ps1
@@ -108,7 +108,7 @@ Describe "Group-Object" -Tags "CI" {
 
     It "Should be able to retrieve objects by key when using -AsHashTable without -AsString" {
         $testObject = [pscustomobject] @{a="one"; b=2}, [pscustomobject] @{a="two"; b=10}
-        $result = $testObject | Group-Object -AsHashtable -Property a
+        $result = $testObject | Group-Object -AsHashTable -Property a
         $result.one.b | Should -Be 2
         $result["two"].b | Should -Be 10
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Implicit.Remoting.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Implicit.Remoting.Tests.ps1
@@ -151,7 +151,7 @@ try
 
         It "Verifies that get-help name for remote proxied commands matches the get-command name" {
             try {
-                $module = Import-PSSession $session -Name Select-Object -prefix My -AllowClobber
+                $module = Import-PSSession $session -Name Select-Object -Prefix My -AllowClobber
                 $gcmOutPut = (Get-Command Select-MyObject ).Name
                 $getHelpOutPut = (Get-Help Select-MyObject).Name
 
@@ -227,7 +227,7 @@ try
             BeforeAll {
                 if ($skipTest) { return }
 
-                Invoke-Command $session { function foo1{1; write-error 2; 3; write-error 4; 5; write-error 6} }
+                Invoke-Command $session { function foo1{1; Write-Error 2; 3; Write-Error 4; 5; Write-Error 6} }
                 $module = Import-PSSession $session -CommandName foo1 -AllowClobber
 
                 $icmErr = $($icmOut = Invoke-Command $session { foo1 }) 2>&1
@@ -259,8 +259,8 @@ try
             }
 
             It "Verifies proxied order = icm order (for mixed error and output results)" {
-                $icmOrder = Invoke-Command $session { foo1 } 2>&1 | out-string
-                $proxiedOrder = foo1 2>&1 | out-string
+                $icmOrder = Invoke-Command $session { foo1 } 2>&1 | Out-String
+                $proxiedOrder = foo1 2>&1 | Out-String
 
                 $icmOrder | Should -Be $proxiedOrder
             }
@@ -390,7 +390,7 @@ try
         Context "Proxy module should create a new session" {
             BeforeAll {
                 if ($skipTest) { return }
-                $module = import-Module $file -PassThru -Force
+                $module = Import-Module $file -PassThru -Force
                 $internalSession = & $module { $script:PSSession }
             }
             AfterAll {
@@ -420,7 +420,7 @@ try
             BeforeAll {
                 if ($skipTest) { return }
                 $explicitSessionOption = New-PSSessionOption -Culture fr-FR -UICulture de-DE
-                $module = import-Module $file -PassThru -Force -ArgumentList $null, $explicitSessionOption
+                $module = Import-Module $file -PassThru -Force -ArgumentList $null, $explicitSessionOption
                 $internalSession = & $module { $script:PSSession }
             }
             AfterAll {
@@ -455,7 +455,7 @@ try
                 if ($skipTest) { return }
 
                 $newSession = New-RemoteSession
-                $module = import-Module $file -PassThru -Force -ArgumentList $newSession
+                $module = Import-Module $file -PassThru -Force -ArgumentList $newSession
                 $internalSession = & $module { $script:PSSession }
             }
             AfterAll {
@@ -554,7 +554,7 @@ try
 		        </Members>
 	        </Type>
 	    </Types>
-"@ | set-content $tmpFile
+"@ | Set-Content $tmpFile
 	            $tmpFile
             }
 
@@ -593,7 +593,7 @@ try
 		    </View>
 	        </ViewDefinitions>
 	    </Configuration>
-"@ | set-content $tmpFile
+"@ | Set-Content $tmpFile
                 $tmpFile
             }
 
@@ -613,7 +613,7 @@ try
             BeforeAll {
                 if ($skipTest) { return }
 
-                $formattingScript = { new-object System.Management.Automation.Host.Size | ForEach-Object { $_.Width = 123; $_.Height = 456; $_ } | Out-String }
+                $formattingScript = { New-Object System.Management.Automation.Host.Size | ForEach-Object { $_.Width = 123; $_.Height = 456; $_ } | Out-String }
                 $originalLocalFormatting = & $formattingScript
 
                 # Original local and remote formatting should be equal (sanity check)
@@ -692,7 +692,7 @@ try
                 Invoke-Command -Session $session -Script { function foo { New-Object MyTest.Root "root" } }
                 Invoke-Command -Session $session -Script { function bar { param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]$Son) $Son.Grandson.text } }
 
-                $module = import-pssession $session foo,bar -AllowClobber
+                $module = Import-PSSession $session foo,bar -AllowClobber
             }
 
             AfterAll {
@@ -844,7 +844,7 @@ try
             BeforeAll {
                 if ($skipTest) { return }
 
-                Invoke-Command -Session $session -ScriptBlock {
+                Invoke-Command -Session $session -Scriptblock {
                     function foo {
                         [cmdletbinding(defaultparametersetname="string")]
                         param(
@@ -886,7 +886,7 @@ try
             BeforeAll {
                 if ($skipTest) { return }
 
-                Invoke-Command -Session $session -ScriptBlock {
+                Invoke-Command -Session $session -Scriptblock {
                     function foo {
                         param(
                             [string]
@@ -927,7 +927,7 @@ try
             BeforeAll {
                 if ($skipTest) { return }
 
-                Invoke-Command -Session $session -ScriptBlock {
+                Invoke-Command -Session $session -Scriptblock {
                     function foo {
                         param(
                             [DateTime]
@@ -946,7 +946,7 @@ try
                 # Sanity checks.
                 Invoke-Command $session {Get-Date | foo} | Should -BeExactly "Bound parameter: date"
                 Invoke-Command $session {[ipaddress]::parse("127.0.0.1") | foo} | Should -BeExactly "Bound parameter: ipaddress"
-                Invoke-Command $session {[ipaddress]::parse("127.0.0.1") | foo -date (get-date)} | Should -BeExactly "Bound parameter: date ipaddress"
+                Invoke-Command $session {[ipaddress]::parse("127.0.0.1") | foo -date (Get-Date)} | Should -BeExactly "Bound parameter: date ipaddress"
                 Invoke-Command $session {Get-Date | foo -ipaddress ([ipaddress]::parse("127.0.0.1"))} | Should -BeExactly "Bound parameter: date ipaddress"
 
                 $module = Import-PSSession $session foo -AllowClobber
@@ -978,7 +978,7 @@ try
             BeforeAll {
                 if ($skipTest) { return }
 
-                Invoke-Command -Session $session -ScriptBlock {
+                Invoke-Command -Session $session -Scriptblock {
                     function foo {
                         param(
                             [System.TimeSpan]
@@ -1008,15 +1008,15 @@ try
             }
 
             It "Pipeline binding works by property name" {
-                (Get-Process -id $PID | foo) | Should -BeExactly "Bound parameter: PriorityClass TotalProcessorTime"
+                (Get-Process -Id $PID | foo) | Should -BeExactly "Bound parameter: PriorityClass TotalProcessorTime"
             }
 
             It "Pipeline binding works by property name" {
-                (Get-Process -id $PID | foo -Total 5) | Should -BeExactly "Bound parameter: PriorityClass TotalProcessorTime"
+                (Get-Process -Id $PID | foo -Total 5) | Should -BeExactly "Bound parameter: PriorityClass TotalProcessorTime"
             }
 
             It "Pipeline binding works by property name" {
-                (Get-Process -id $PID | foo -Priority normal) | Should -BeExactly "Bound parameter: PriorityClass TotalProcessorTime"
+                (Get-Process -Id $PID | foo -Priority normal) | Should -BeExactly "Bound parameter: PriorityClass TotalProcessorTime"
             }
         }
 
@@ -1024,7 +1024,7 @@ try
             BeforeAll {
                 if ($skipTest) { return }
 
-                Invoke-Command -Session $session -ScriptBlock {
+                Invoke-Command -Session $session -Scriptblock {
                     function foo {
                         param(
                             [string]
@@ -1065,7 +1065,7 @@ try
             BeforeAll {
                 if ($skipTest) { return }
 
-                Invoke-Command -Session $session -ScriptBlock {
+                Invoke-Command -Session $session -Scriptblock {
                     function foo {
                         param(
                             [object]
@@ -1121,7 +1121,7 @@ try
             BeforeAll {
                 if ($skipTest) { return }
 
-                Invoke-Command -Session $session -ScriptBlock {
+                Invoke-Command -Session $session -Scriptblock {
                     function foo {
                         param(
                             [string]
@@ -1187,7 +1187,7 @@ try
             BeforeAll {
                 if ($skipTest) { return }
 
-                Invoke-Command -Session $session -ScriptBlock {
+                Invoke-Command -Session $session -Scriptblock {
                     function foo {
                         param(
                             $firstArg,
@@ -1268,7 +1268,7 @@ try
             BeforeAll {
                 if ($skipTest) { return }
 
-                Invoke-Command -Session $session -ScriptBlock {
+                Invoke-Command -Session $session -Scriptblock {
                     function MyInitializerFunction { param($x = $PID) $x }
                 }
 
@@ -1598,14 +1598,14 @@ try
             }
 
             It "'Completed' progress record should be present" {
-                ($powerShell.Streams.Progress | Select-Object -last 1).RecordType.ToString() | Should -BeExactly "Completed"
+                ($powerShell.Streams.Progress | Select-Object -Last 1).RecordType.ToString() | Should -BeExactly "Completed"
             }
         }
 
         Context "display of property-less objects (not sure if this test belongs here) (Windows 7: #248499)" {
             BeforeAll {
                 if ($skipTest) { return }
-                $x = new-object random
+                $x = New-Object random
 	            $expected = $x.ToString()
             }
 
@@ -1615,7 +1615,7 @@ try
                 ($x | Out-String).Trim() | Should -Be $expected
             }
             It "Display of remote property-less objects" {
-                (Invoke-Command $session { Import-Module Microsoft.PowerShell.Utility; New-Object random } | out-string).Trim() | Should -Be $expected
+                (Invoke-Command $session { Import-Module Microsoft.PowerShell.Utility; New-Object random } | Out-String).Trim() | Should -Be $expected
             }
         }
 
@@ -1642,7 +1642,7 @@ try
         It "Non-terminating error from remote end got duplicated locally" {
             try {
                 Invoke-Command $session { $oldGetCommand = ${function:Get-Command} }
-                Invoke-Command $session { function Get-Command { write-error blah } }
+                Invoke-Command $session { function Get-Command { Write-Error blah } }
                 $module = Import-PSSession -Session $session -ErrorAction SilentlyContinue -ErrorVariable expectedError -AllowClobber
 
                 $expectedError | Should -Not -BeNullOrEmpty
@@ -1923,7 +1923,7 @@ try
 
             $session = New-RemoteSession -Name Session102
             $remotePid = Invoke-Command $session { $PID }
-            $module = Import-PSSession $session Get-Variable -prefix Remote -AllowClobber
+            $module = Import-PSSession $session Get-Variable -Prefix Remote -AllowClobber
         }
 
         AfterAll {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
@@ -7,16 +7,16 @@ Describe "Import-Alias DRT Unit Tests" -Tags "CI" {
 
     BeforeEach {
         New-Item -Path $testAliasDirectory -ItemType Directory -Force
-        remove-item alias:abcd* -force -ErrorAction SilentlyContinue
-        remove-item alias:ijkl* -force -ErrorAction SilentlyContinue
-        set-alias abcd01 efgh01
-        set-alias abcd02 efgh02
-        set-alias abcd03 efgh03
-        set-alias abcd04 efgh04
-        set-alias ijkl01 mnop01
-        set-alias ijkl02 mnop02
-        set-alias ijkl03 mnop03
-        set-alias ijkl04 mnop04
+        Remove-Item alias:abcd* -Force -ErrorAction SilentlyContinue
+        Remove-Item alias:ijkl* -Force -ErrorAction SilentlyContinue
+        Set-Alias abcd01 efgh01
+        Set-Alias abcd02 efgh02
+        Set-Alias abcd03 efgh03
+        Set-Alias abcd04 efgh04
+        Set-Alias ijkl01 mnop01
+        Set-Alias ijkl02 mnop02
+        Set-Alias ijkl03 mnop03
+        Set-Alias ijkl04 mnop04
     }
 
     AfterEach {
@@ -34,7 +34,7 @@ Describe "Import-Alias DRT Unit Tests" -Tags "CI" {
 
     It "Import-Alias Into Invalid Scope should throw PSArgumentException"{
         { Export-Alias  $fulltestpath abcd* } | Should -Not -Throw
-        { Import-Alias $fulltestpath -scope bogus } | Should -Throw -ErrorId "Argument,Microsoft.PowerShell.Commands.ImportAliasCommand"
+        { Import-Alias $fulltestpath -Scope bogus } | Should -Throw -ErrorId "Argument,Microsoft.PowerShell.Commands.ImportAliasCommand"
     }
 
     It "Import-Alias From Exported Alias File Aliases Already Exist using force should not throw"{

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ImportExportCSV.Delimiter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ImportExportCSV.Delimiter.Tests.ps1
@@ -11,7 +11,7 @@ Describe "Using delimiters with Export-CSV and Import-CSV behave correctly" -tag
         # With CORECLR the CurrentCulture.TextInfo.ListSeparator is not writable, so
         # we need to use an entirely new CultureInfo which we can modify
         $enCulture = [System.Globalization.CultureInfo]::new("en-us")
-        $d = get-date
+        $d = Get-Date
         $testCases = @(
             foreach($del in $delimiters)
             {
@@ -37,23 +37,23 @@ Describe "Using delimiters with Export-CSV and Import-CSV behave correctly" -tag
         else {
             [System.Globalization.CultureInfo]::CurrentCulture.TextInfo.ListSeparator = $defaultDelimiter
         }
-        remove-item -force -ErrorAction silentlycontinue TESTDRIVE:/file.csv
+        Remove-Item -Force -ErrorAction silentlycontinue TESTDRIVE:/file.csv
     }
 
     It "Disallow use of null delimiter" {
-        $d | export-csv TESTDRIVE:/file.csv
-        { import-csv -path TESTDRIVE:/file.csv -delimiter $null } | Should -Throw "Delimiter"
+        $d | Export-Csv TESTDRIVE:/file.csv
+        { Import-Csv -Path TESTDRIVE:/file.csv -Delimiter $null } | Should -Throw "Delimiter"
     }
 
     It "Disallow use of delimiter with useCulture parameter" {
-        $d | export-csv TESTDRIVE:/file.csv
-        { import-csv -path TESTDRIVE:/file.csv -useCulture "," } | Should -Throw "','"
+        $d | Export-Csv TESTDRIVE:/file.csv
+        { Import-Csv -Path TESTDRIVE:/file.csv -UseCulture "," } | Should -Throw "','"
     }
 
     It "Imports the same properties as exported" {
         $a = [pscustomobject]@{ a = 1; b = 2; c = 3 }
-        $a | export-Csv TESTDRIVE:/file.csv
-        $b = import-csv TESTDRIVE:/file.csv
+        $a | Export-Csv TESTDRIVE:/file.csv
+        $b = Import-Csv TESTDRIVE:/file.csv
         @($b.psobject.properties).count | Should -Be 3
         $b.a | Should -Be $a.a
         $b.b | Should -Be $a.b
@@ -61,26 +61,26 @@ Describe "Using delimiters with Export-CSV and Import-CSV behave correctly" -tag
     }
 
     # parameter generated tests
-    It 'Delimiter <Delimiter> with CSV import will fail correctly when culture does not match' -testCases $testCases {
+    It 'Delimiter <Delimiter> with CSV import will fail correctly when culture does not match' -TestCases $testCases {
         param ($delimiter, $Data, $ExpectedResult)
         set-Delimiter $delimiter
-        $Data | export-CSV TESTDRIVE:\File.csv -useCulture
-        $i = Import-CSV TESTDRIVE:\File.csv
+        $Data | Export-Csv TESTDRIVE:\File.csv -UseCulture
+        $i = Import-Csv TESTDRIVE:\File.csv
         $i.Ticks | Should -Not -Be $ExpectedResult
     }
 
-    It 'Delimiter <Delimiter> with CSV import will succeed when culture matches export' -testCases $testCases {
+    It 'Delimiter <Delimiter> with CSV import will succeed when culture matches export' -TestCases $testCases {
         param ($delimiter, $Data, $ExpectedResult)
         set-Delimiter $delimiter
-        $Data | export-CSV TESTDRIVE:\File.csv -useCulture
-        $i = Import-CSV TESTDRIVE:\File.csv -useCulture
+        $Data | Export-Csv TESTDRIVE:\File.csv -UseCulture
+        $i = Import-Csv TESTDRIVE:\File.csv -UseCulture
         $i.Ticks | Should -Be $ExpectedResult
     }
 
-    It 'Delimiter <Delimiter> with CSV import will succeed when delimiter is used explicitly' -testCases $testCases {
+    It 'Delimiter <Delimiter> with CSV import will succeed when delimiter is used explicitly' -TestCases $testCases {
         param ($delimiter, $Data, $ExpectedResult)
-        $Data | export-CSV TESTDRIVE:\File.csv -delimiter $delimiter
-        $i = Import-CSV TESTDRIVE:\File.csv -delimiter $delimiter
+        $Data | Export-Csv TESTDRIVE:\File.csv -Delimiter $delimiter
+        $i = Import-Csv TESTDRIVE:\File.csv -Delimiter $delimiter
         $i.Ticks | Should -Be $ExpectedResult
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Expression.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Expression.Tests.ps1
@@ -5,7 +5,7 @@ Describe "Invoke-Expression" -Tags "CI" {
     Context "Should execute the invoked command validly" {
 
 	It "Should return the echoed text" {
-	    (Invoke-Expression -command "echo pestertest1") | Should -BeExactly "pestertest1"
+	    (Invoke-Expression -Command "echo pestertest1") | Should -BeExactly "pestertest1"
 	}
 
 	It "Should return the echoed text from a script" {
@@ -19,7 +19,7 @@ Describe "Invoke-Expression" -Tags "CI" {
 }
 Describe "Invoke-Expression DRT Unit Tests" -Tags "CI" {
 	It "Invoke-Expression should work"{
-		$result=invoke-expression -Command 2+2
+		$result=Invoke-Expression -Command 2+2
 		$result | Should -Be 4
 	}
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
@@ -116,7 +116,7 @@ Describe "Invoke-Item basic tests" -Tags "Feature" {
             while (((Get-Date) - $startTime).TotalSeconds -lt 30 -and ($title -ne $expectedTitle))
             {
                 Start-Sleep -Milliseconds 100
-                $title = Get-WindowsTitleMacOS -name TextEdit
+                $title = Get-WindowsTitleMacOS -Name TextEdit
             }
             $afterCount = Get-WindowCountMacOS -Name TextEdit
             $afterCount | Should -Be ($beforeCount + 1) -Because "There should be one more 'textEdit' windows open than when the tests started and there was $beforeCount"
@@ -294,11 +294,11 @@ Describe "Invoke-Item tests on Windows" -Tags "CI","RequireAdminOnWindows" {
     }
 
     It "Should invoke a file without error on Windows full SKUs" -Skip:(-not $isFullWin) {
-        invoke-item $testfilepath
+        Invoke-Item $testfilepath
         # Waiting subprocess start and rename file
         {
             $startTime = [Datetime]::Now
-            while (-not (test-path $renamedtestfilepath))
+            while (-not (Test-Path $renamedtestfilepath))
             {
                 Start-Sleep -Milliseconds 100
                 if (([Datetime]::Now - $startTime) -ge [timespan]"00:00:05") { throw "Timeout exception" }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Join-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Join-String.Tests.ps1
@@ -116,7 +116,7 @@ Describe "Join-String" -Tags "CI" {
 
     It "Should tabcomplete InputObject properties" {
         $cmd = '[io.fileinfo]::new("c:\temp") | Join-String -Property '
-        $res = tabexpansion2 $cmd $cmd.length
+        $res = TabExpansion2 $cmd $cmd.length
         $completionTexts = $res.CompletionMatches.CompletionText
         $Properties = [io.fileinfo]::new($PSScriptRoot).psobject.properties.Name
         foreach ($n in $Properties) {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
@@ -50,7 +50,7 @@ Describe "Json Tests" -Tags "Feature" {
 
             # Test follow-up for bug WinBlue: 11484 - ConvertTo-Json can't handle terms with double quotes.
 
-            $notcompressed = ConvertTo-JSON @{ FirstName = 'Hello " World' }
+            $notcompressed = ConvertTo-Json @{ FirstName = 'Hello " World' }
             $compressed = ConvertTo-Json @{ FirstName = 'Hello " World' } -Compress
             $valueFromNotCompressedResult = ConvertFrom-Json -InputObject $notcompressed
             $valueFromCompressedResult = ConvertFrom-Json -InputObject $compressed
@@ -62,11 +62,11 @@ Describe "Json Tests" -Tags "Feature" {
 
             # Test follow-up for bug Win8: 378368 Convertto-Json problems with Enum based on Int64.
             if ( $null -eq ("JsonEnumTest" -as "Type")) {
-                $enum1 = "TestEnum" + (get-random)
-                $enum2 = "TestEnum" + (get-random)
-                $enum3 = "TestEnum" + (get-random)
+                $enum1 = "TestEnum" + (Get-Random)
+                $enum2 = "TestEnum" + (Get-Random)
+                $enum3 = "TestEnum" + (Get-Random)
 
-                $jsontype = add-type -pass -TypeDef "
+                $jsontype = Add-Type -pass -TypeDef "
                 public enum $enum1 : ulong { One = 1, Two = 2 };
                 public enum $enum2 : long  { One = 1, Two = 2 };
                 public enum $enum3 : int   { One = 1, Two = 2 };
@@ -76,7 +76,7 @@ Describe "Json Tests" -Tags "Feature" {
                     public $enum3 TestEnum3 = ${enum3}.One;
                 }"
             }
-            $op = [JsonEnumTest]::New() | convertto-json | convertfrom-json
+            $op = [JsonEnumTest]::New() | ConvertTo-Json | ConvertFrom-Json
             $op.TestEnum1 | Should -BeExactly "One"
             $op.TestEnum2 | Should -BeExactly "Two"
             $op.TestEnum3 | Should -Be 1
@@ -101,7 +101,7 @@ Describe "Json Tests" -Tags "Feature" {
             $response.d.Name.First | Should -Match "Joel"
         }
 
-        It "Convert to Json using PSObject" -pending:($IsCoreCLR) {
+        It "Convert to Json using PSObject" -Pending:($IsCoreCLR) {
 
             $response = ConvertFrom-Json '{"d":{"__type":"SimpleJsonObject","Name":{"First":"Joel","Last":"Wood"},"Greeting":"Hello"}}'
 
@@ -140,7 +140,7 @@ Describe "Json Tests" -Tags "Feature" {
             $response2 = ConvertTo-Json -InputObject $response -Depth 1
             $response2 | Should -Match $result2
 
-            $arraylist = new-Object System.Collections.ArrayList
+            $arraylist = New-Object System.Collections.ArrayList
             [void]$arraylist.Add("one")
             [void]$arraylist.Add("two")
             [void]$arraylist.Add("three")
@@ -161,7 +161,7 @@ Describe "Json Tests" -Tags "Feature" {
             $response2 | Should -Be $result3
         }
 
-        It "Convert to Json using hashtable" -pending:($IsCoreCLR) {
+        It "Convert to Json using hashtable" -Pending:($IsCoreCLR) {
 
             $nameHash = @{First="Joe1";Last="Wood"}
             $dHash = @{Name=$nameHash; Greeting="Hello"}
@@ -1237,7 +1237,7 @@ Describe "Validate Json serialization" -Tags "CI" {
             param ($testCase)
 
             if ( $TestCase.TestInput -eq "[char]::MinValue" ) { $pending = $true } else { $pending = $false }
-            It "Validate '$($testCase.TestInput) | ConvertTo-Json' and '$($testCase.TestInput) | ConvertTo-Json | ConvertFrom-Json'" -pending:$pending {
+            It "Validate '$($testCase.TestInput) | ConvertTo-Json' and '$($testCase.TestInput) | ConvertTo-Json | ConvertFrom-Json'" -Pending:$pending {
 
                 # The test case input is executed via invoke-expression. Then, we use this value as an input to ConvertTo-Json,
                 # and the result is saved into in the $result.ToJson variable. Lastly, this value is deserialized back using
@@ -1292,7 +1292,7 @@ Describe "Validate Json serialization" -Tags "CI" {
             }
         }
 
-        It "Validate that CimClass Properties for win32_bios can be serialized using ConvertTo-Json and ConvertFrom-Json" -skip {
+        It "Validate that CimClass Properties for win32_bios can be serialized using ConvertTo-Json and ConvertFrom-Json" -Skip {
 
             $class = Get-CimClass win32_bios
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Event.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Event.Tests.ps1
@@ -11,15 +11,15 @@ Describe "New-Event" -Tags "CI" {
 
     Context "Check New-Event can register an event"{
 	It "Should return PesterTestMessage as the MessageData" {
-	    (New-Event -sourceidentifier PesterTimer -sender Windows.timer -messagedata "PesterTestMessage")
+	    (New-Event -SourceIdentifier PesterTimer -Sender Windows.timer -MessageData "PesterTestMessage")
 	    (Get-Event -SourceIdentifier PesterTimer).MessageData  | Should -BeExactly "PesterTestMessage"
-	    Remove-Event -sourceidentifier PesterTimer
+	    Remove-Event -SourceIdentifier PesterTimer
 	}
 
 	It "Should return Sender as Windows.timer" {
-	    (New-Event -sourceidentifier PesterTimer -sender Windows.timer -messagedata "PesterTestMessage")
+	    (New-Event -SourceIdentifier PesterTimer -Sender Windows.timer -MessageData "PesterTestMessage")
 	    (Get-Event -SourceIdentifier PesterTimer).Sender  | Should -Be Windows.timer
-	    Remove-Event -sourceIdentifier PesterTimer
+	    Remove-Event -SourceIdentifier PesterTimer
 	}
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Object.Tests.ps1
@@ -126,7 +126,7 @@ Describe "New-Object DRT basic functionality" -Tags "CI" {
     }
 
     It "New-Object with TypeName and Property parameter should work"{
-        $result = New-Object -TypeName PSObject -property @{foo=123}
+        $result = New-Object -TypeName PSObject -Property @{foo=123}
         $result.foo | Should -Be 123
     }
 }
@@ -154,7 +154,7 @@ try
             param($Name, $Property, $Type)
             $comObject = New-Object -ComObject $name
             $comObject.$Property | Should -Not -BeNullOrEmpty
-            $comObject.$Property | Should -Beoftype $Type
+            $comObject.$Property | Should -BeOfType $Type
         }
 
         It "Should fail with correct error when creating a COM object that dose not exist" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Variable.Tests.ps1
@@ -3,7 +3,7 @@
 
 Describe "New-Variable DRT Unit Tests" -Tags "CI" {
 	It "New-Variable variable with description should works"{
-		New-Variable foo bar -description "my description"
+		New-Variable foo bar -Description "my description"
 		$var1=Get-Variable -Name foo
 		$var1.Name | Should -BeExactly "foo"
 		$var1.Value | Should -BeExactly "bar"
@@ -12,7 +12,7 @@ Describe "New-Variable DRT Unit Tests" -Tags "CI" {
 	}
 
 	It "New-Variable variable with option should works"{
-		New-Variable foo bar -option Constant
+		New-Variable foo bar -Option Constant
 		$var1=Get-Variable -Name foo
 		$var1.Name | Should -BeExactly "foo"
 		$var1.Value | Should -BeExactly "bar"
@@ -36,7 +36,7 @@ Describe "New-Variable DRT Unit Tests" -Tags "CI" {
 	}
 
 	It "New-Variable ReadOnly variable twice should throw Exception"{
-		New-Variable foo bogus -option ReadOnly
+		New-Variable foo bogus -Option ReadOnly
 
 		$e = { New-Variable foo bar -Scope 1 -ErrorAction Stop } |
 		    Should -Throw -ErrorId "VariableAlreadyExists,Microsoft.PowerShell.Commands.NewVariableCommand" -PassThru
@@ -122,7 +122,7 @@ Describe "New-Variable" -Tags "CI" {
 	}
 
 	It "Should default to none as the value for options" {
-		 (new-variable -name var2 -value 4 -passthru).Options | Should -BeExactly "None"
+		 (New-Variable -Name var2 -Value 4 -PassThru).Options | Should -BeExactly "None"
 	}
 
 	It "Should be able to set ReadOnly option" {
@@ -197,38 +197,38 @@ Describe "New-Variable" -Tags "CI" {
 
     Context "Scope Tests" {
     BeforeAll {
-        if ( get-variable -scope global -name globalVar1 -ErrorAction SilentlyContinue )
+        if ( Get-Variable -Scope global -Name globalVar1 -ErrorAction SilentlyContinue )
         {
-            Remove-Variable -scope global -name globalVar1
+            Remove-Variable -Scope global -Name globalVar1
         }
-        if ( get-variable -scope script -name scriptvar -ErrorAction SilentlyContinue )
+        if ( Get-Variable -Scope script -Name scriptvar -ErrorAction SilentlyContinue )
         {
-            remove-variable -scope script -name scriptvar
+            Remove-Variable -Scope script -Name scriptvar
         }
         # no check for local scope variable as that scope is created with test invocation
     }
     AfterAll {
-        if ( get-variable -scope global -name globalVar1 )
+        if ( Get-Variable -Scope global -Name globalVar1 )
         {
-            Remove-Variable -scope global -name globalVar1
+            Remove-Variable -Scope global -Name globalVar1
         }
-        if ( get-variable -scope script -name scriptvar )
+        if ( Get-Variable -Scope script -Name scriptvar )
         {
-            remove-variable -scope script -name scriptvar
+            Remove-Variable -Scope script -Name scriptvar
         }
     }
     It "Should be able to create a global scope variable using the global switch" {
-        new-variable -Scope global -name globalvar1 -value 1
-        get-variable -Scope global -name globalVar1 -ValueOnly | Should -Be 1
+        New-Variable -Scope global -Name globalvar1 -Value 1
+        Get-Variable -Scope global -Name globalVar1 -ValueOnly | Should -Be 1
     }
     It "Should be able to create a local scope variable using the local switch" {
-        Get-Variable -scope local -name localvar -ValueOnly -ErrorAction silentlycontinue | Should -BeNullOrEmpty
-        New-Variable -Scope local -Name localVar -value 10
-        get-variable -scope local -name localvar -ValueOnly | Should -Be 10
+        Get-Variable -Scope local -Name localvar -ValueOnly -ErrorAction silentlycontinue | Should -BeNullOrEmpty
+        New-Variable -Scope local -Name localVar -Value 10
+        Get-Variable -Scope local -Name localvar -ValueOnly | Should -Be 10
     }
     It "Should be able to create a script scope variable using the script switch" {
-        new-variable -scope script -name scriptvar -value 100
-        get-variable -scope script -name scriptvar -ValueOnly | Should -Be 100
+        New-Variable -Scope script -Name scriptvar -Value 100
+        Get-Variable -Scope script -Name scriptvar -ValueOnly | Should -Be 100
     }
 	}
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
@@ -11,8 +11,8 @@ Describe "Out-File DRT Unit Tests" -Tags "CI" {
 
     It "Should be able to write the contents into a file with -pspath" {
         $tempFile = Join-Path -Path $TestDrive -ChildPath "outfileAppendTest.txt"
-        { 'This is first line.' | out-file $tempFile } | Should -Not -Throw
-        { 'This is second line.' | out-file -append $tempFile } | Should -Not -Throw
+        { 'This is first line.' | Out-File $tempFile } | Should -Not -Throw
+        { 'This is second line.' | Out-File -Append $tempFile } | Should -Not -Throw
         $tempFile | Should -FileContentMatch "first"
         $tempFile | Should -FileContentMatch "second"
         Remove-Item $tempFile -Force

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-String.Tests.ps1
@@ -3,7 +3,7 @@
 Describe "Out-String DRT Unit Tests" -Tags "CI" {
 
     It "check display of properties with names containing wildcard characters" {
-        $results = new-object psobject | add-member -passthru noteproperty 'name with square brackets: [0]' 'myvalue' | out-string
+        $results = New-Object psobject | Add-Member -PassThru noteproperty 'name with square brackets: [0]' 'myvalue' | Out-String
         $results.Length | Should -BeGreaterThan 1
         $results | Should -BeOfType System.String
         $results.Contains("myvalue") | Should -BeTrue

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/PowerShellData.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/PowerShellData.tests.ps1
@@ -15,19 +15,19 @@ Describe "Tests for the Import-PowerShellDataFile cmdlet" -Tags "CI" {
 
     It "Generates a good error on an insecure file" {
 
-        $path = Setup -f insecure.psd1 -content '@{ Foo = Get-Process }' -pass
+        $path = Setup -f insecure.psd1 -Content '@{ Foo = Get-Process }' -pass
         { Import-PowerShellDataFile $path -ErrorAction Stop } |
             Should -Throw -ErrorId "System.InvalidOperationException,Microsoft.PowerShell.Commands.ImportPowerShellDataFileCommand"
     }
 
     It "Generates a good error on a file that isn't a PowerShell Data File (missing the hashtable root)" {
-        $path = setup -f NotAPSDataFile -content '"Hello World"' -Pass
+        $path = Setup -f NotAPSDataFile -Content '"Hello World"' -Pass
         { Import-PowerShellDataFile $path -ErrorAction Stop } |
             Should -Throw -ErrorId "CouldNotParseAsPowerShellDataFileNoHashtableRoot,Microsoft.PowerShell.Commands.ImportPowerShellDataFileCommand"
     }
 
     It "Can parse a PowerShell Data File (detailed tests are in AST.SafeGetValue tests)" {
-        $path = Setup -F gooddatafile -content '@{ "Hello" = "World" }' -pass
+        $path = Setup -F gooddatafile -Content '@{ "Hello" = "World" }' -pass
         $result = Import-PowerShellDataFile $path -ErrorAction Stop
         $result.Hello | Should -BeExactly "World"
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Read-Host.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Read-Host.Tests.ps1
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-Describe "Read-Host Test" -tag "CI" {
+Describe "Read-Host Test" -Tag "CI" {
     BeforeAll {
         $th = New-TestHost
         $rs = [runspacefactory]::Createrunspace($th)
@@ -33,7 +33,7 @@ Describe "Read-Host Test" -tag "CI" {
     }
 
     It "Read-Host returns a secure string when using -AsSecureString parameter" {
-        $result = $ps.AddScript("Read-Host -AsSecureString").Invoke() | select-object -first 1
+        $result = $ps.AddScript("Read-Host -AsSecureString").Invoke() | Select-Object -First 1
         $result | Should -BeOfType SecureString
         [pscredential]::New("foo",$result).GetNetworkCredential().Password | Should -BeExactly TEST
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Register-EngineEvent.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Register-EngineEvent.Tests.ps1
@@ -5,7 +5,7 @@ Describe "Register-EngineEvent" -Tags "CI" {
     Context "Check return type of Register-EngineEvent" {
 	It "Should return System.Management.Automation.PSEventJob as return type of Register-EngineEvent" {
 	    Register-EngineEvent -SourceIdentifier PesterTestRegister -Action {Write-Output registerengineevent} | Should -BeOfType System.Management.Automation.PSEventJob
-	    Unregister-Event -sourceidentifier PesterTestRegister
+	    Unregister-Event -SourceIdentifier PesterTestRegister
 	}
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Remove-Event.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Remove-Event.Tests.ps1
@@ -3,22 +3,22 @@
 Describe "Remove-Event" -Tags "CI" {
 
     BeforeEach {
-	New-Event -sourceidentifier PesterTimer  -sender Windows.timer -messagedata "PesterTestMessage"
+	New-Event -SourceIdentifier PesterTimer  -Sender Windows.timer -MessageData "PesterTestMessage"
     }
 
     AfterEach {
-	Remove-Event -sourceidentifier PesterTimer -ErrorAction SilentlyContinue
+	Remove-Event -SourceIdentifier PesterTimer -ErrorAction SilentlyContinue
     }
 
     Context "Check Remove-Event can validly remove events" {
 
 	It "Should remove an event given a sourceidentifier" {
-	    { Remove-Event -sourceidentifier PesterTimer }
+	    { Remove-Event -SourceIdentifier PesterTimer }
 	    { Get-Event -ErrorAction SilentlyContinue | Should -Not FileMatchContent PesterTimer }
 	}
 
 	It "Should remove an event given an event identifier" {
-	    { $events = Get-Event -sourceidentifier PesterTimer }
+	    { $events = Get-Event -SourceIdentifier PesterTimer }
 	    { $events = $events.EventIdentifier }
 	    { Remove-Event -EventIdentifier $events }
 	    { $events = Get-Event -ErrorAction SilentlyContinue}
@@ -26,13 +26,13 @@ Describe "Remove-Event" -Tags "CI" {
 	}
 
 	It "Should be able to remove an event given a pipe from Get-Event" {
-	    { Get-Event -sourceidentifier PesterTimer | Remove-Event }
+	    { Get-Event -SourceIdentifier PesterTimer | Remove-Event }
 	    { Get-Event -ErrorAction SilentlyContinue | Should -Not FileMatchContent "PesterTimer" }
 
 	}
 
 	It "Should NOT remove an event given the whatif flag" {
-	    { Remove-Event -sourceidentifier PesterTimer -whatif }
+	    { Remove-Event -SourceIdentifier PesterTimer -WhatIf }
 	    { $events = Get-Event }
 	    { $events.SourceIdentifier  | Should -FileContentMatch "PesterTimer" }
 	}

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/RunspaceCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/RunspaceCmdlets.Tests.ps1
@@ -7,24 +7,24 @@ Describe "Get-Runspace cmdlet tests" -Tag "CI" {
         $ExpectedId = $currentRunspace.Id
     }
     It "Get-Runspace should return the current runspace" {
-        $runspace = get-runspace |Sort-Object -property id | Select-Object -first 1
+        $runspace = Get-Runspace |Sort-Object -Property id | Select-Object -First 1
         $runspace.InstanceId | Should -Be $ExpectedInstanceId
     }
     It "Get-Runspace with runspace InstanceId should return the correct runspace" {
-        $runspace = get-runspace -instanceid $CurrentRunspace.InstanceId
+        $runspace = Get-Runspace -InstanceId $CurrentRunspace.InstanceId
         $runspace.InstanceId | Should -Be $ExpectedInstanceId
     }
     It "Get-Runspace with runspace name should return the correct runspace" {
-        $runspace = get-runspace -name $currentRunspace.Name
+        $runspace = Get-Runspace -Name $currentRunspace.Name
         $runspace.InstanceId | Should -Be $ExpectedInstanceId
     }
     It "Get-Runspace with runspace Id should return the correct runspace" {
-        $runspace = get-runspace -id $CurrentRunspace.Id
+        $runspace = Get-Runspace -Id $CurrentRunspace.Id
         $runspace.InstanceId | Should -Be $ExpectedInstanceId
     }
     Context "Multiple Runspaces" {
         BeforeAll {
-            $runspaceCount = @(get-runspace).count
+            $runspaceCount = @(Get-Runspace).count
             $r1 = [runspacefactory]::CreateRunspace()
             $r1.Open()
             $r2 = [runspacefactory]::CreateRunspace()
@@ -34,7 +34,7 @@ Describe "Get-Runspace cmdlet tests" -Tag "CI" {
             $r2.Dispose()
         }
         It "Get-Runspace should return the new runspaces" {
-            $result = get-runspace
+            $result = Get-Runspace
             # if the ids don't match, we'll get null passed to should
             $result.id | Where-Object {$_ -eq $r1.id } | Should -Be $r1.id
             $result.id | Where-Object {$_ -eq $r2.id } | Should -Be $r2.id

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
@@ -15,7 +15,7 @@ Describe "Select-Object" -Tags "CI" {
     }
 
     It "Should treat input as a single object with the inputObject parameter" {
-	$result   = $(Select-Object -inputObject $dirObject -last $TestLength).Length
+	$result   = $(Select-Object -InputObject $dirObject -Last $TestLength).Length
 	$expected = $dirObject.Length
 
 	$result | Should -Be $expected
@@ -131,13 +131,13 @@ Describe "Select-Object DRT basic functionality" -Tags "CI" {
 	}
 
 	It "Select-Object with empty script block property should throw"{
-		$e = { "bar" | select-object -Prop {} -ErrorAction Stop } |
+		$e = { "bar" | Select-Object -Prop {} -ErrorAction Stop } |
 			Should -Throw -ErrorId "EmptyScriptBlockAndNoName,Microsoft.PowerShell.Commands.SelectObjectCommand" -PassThru
 		$e.CategoryInfo | Should -Match "PSArgumentException"
 	}
 
 	It "Select-Object with string property should work"{
-		$result = "bar" | select-object -Prop foo | Measure-Object
+		$result = "bar" | Select-Object -Prop foo | Measure-Object
 		$result.Count | Should -Be 1
 	}
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -17,30 +17,30 @@ Describe "Select-String" -Tags "CI" {
             $testinputtwo = "hello","Hello"
         }
 
-        it "Should be called without errors" {
+        It "Should be called without errors" {
             { $testinputone | Select-String -Pattern "hello" } | Should -Not -Throw
         }
 
-        it "Should return an array data type when multiple matches are found" {
+        It "Should return an array data type when multiple matches are found" {
             $result = $testinputtwo | Select-String -Pattern "hello"
             ,$result | Should -BeOfType System.Array
         }
 
-        it "Should return an object type when one match is found" {
+        It "Should return an object type when one match is found" {
             $result = $testinputtwo | Select-String -Pattern "hello" -CaseSensitive
             ,$result | Should -BeOfType System.Object
         }
 
-        it "Should return matchinfo type" {
+        It "Should return matchinfo type" {
             $result = $testinputtwo | Select-String -Pattern "hello" -CaseSensitive
             ,$result | Should -BeOfType Microsoft.PowerShell.Commands.MatchInfo
         }
 
-        it "Should be called without an error using ca for casesensitive " {
+        It "Should be called without an error using ca for casesensitive " {
             {$testinputone | Select-String -Pattern "hello" -ca } | Should -Not -Throw
         }
 
-        it "Should use the ca alias for casesensitive" {
+        It "Should use the ca alias for casesensitive" {
             $firstMatch = $testinputtwo  | Select-String -Pattern "hello" -CaseSensitive
             $secondMatch = $testinputtwo | Select-String -Pattern "hello" -ca
 
@@ -48,40 +48,40 @@ Describe "Select-String" -Tags "CI" {
             $equal | Should -BeTrue
         }
 
-        it "Should only return the case sensitive match when the casesensitive switch is used" {
+        It "Should only return the case sensitive match when the casesensitive switch is used" {
             $testinputtwo | Select-String -Pattern "hello" -CaseSensitive | Should -Be "hello"
         }
 
-        it "Should accept a collection of strings from the input object" {
+        It "Should accept a collection of strings from the input object" {
             { Select-String -InputObject "some stuff", "other stuff" -Pattern "other" } | Should -Not -Throw
         }
 
-        it "Should return system.object when the input object switch is used on a collection" {
-            $result = Select-String -InputObject "some stuff", "other stuff" -pattern "other"
+        It "Should return system.object when the input object switch is used on a collection" {
+            $result = Select-String -InputObject "some stuff", "other stuff" -Pattern "other"
             ,$result | Should -BeOfType System.Object
         }
 
-        it "Should return null or empty when the input object switch is used on a collection and the pattern does not exist" {
+        It "Should return null or empty when the input object switch is used on a collection and the pattern does not exist" {
             Select-String -InputObject "some stuff", "other stuff" -Pattern "neither" | Should -BeNullOrEmpty
         }
 
-        it "Should return a bool type when the quiet switch is used" {
+        It "Should return a bool type when the quiet switch is used" {
             ,($testinputtwo | Select-String -Quiet "hello" -CaseSensitive) | Should -BeOfType System.Boolean
         }
 
-        it "Should be true when select string returns a positive result when the quiet switch is used" {
+        It "Should be true when select string returns a positive result when the quiet switch is used" {
             ($testinputtwo | Select-String -Quiet "hello" -CaseSensitive) | Should -BeTrue
         }
 
-        it "Should be empty when select string does not return a result when the quiet switch is used" {
+        It "Should be empty when select string does not return a result when the quiet switch is used" {
             $testinputtwo | Select-String -Quiet "goodbye"  | Should -BeNullOrEmpty
         }
 
-        it "Should return an array of non matching strings when the switch of NotMatch is used and the string do not match" {
+        It "Should return an array of non matching strings when the switch of NotMatch is used and the string do not match" {
             $testinputone | Select-String -Pattern "goodbye" -NotMatch | Should -BeExactly "hello", "Hello"
         }
 
-        it "Should output a string with the first match highlighted" {
+        It "Should output a string with the first match highlighted" {
             if ($Host.UI.SupportsVirtualTerminal -and !(Test-Path env:__SuppressAnsiEscapeSequences))
             {
                 $result = $testinputone | Select-String -Pattern "l" | Out-String
@@ -94,7 +94,7 @@ Describe "Select-String" -Tags "CI" {
             }
         }
 
-        it "Should output a string with all matches highlighted when AllMatch is used" {
+        It "Should output a string with all matches highlighted when AllMatch is used" {
             if ($Host.UI.SupportsVirtualTerminal -and !(Test-Path env:__SuppressAnsiEscapeSequences))
             {
                 $result = $testinputone | Select-String -Pattern "l" -AllMatch | Out-String
@@ -107,7 +107,7 @@ Describe "Select-String" -Tags "CI" {
             }
         }
 
-        it "Should output a string with the first match highlighted when SimpleMatch is used" {
+        It "Should output a string with the first match highlighted when SimpleMatch is used" {
             if ($Host.UI.SupportsVirtualTerminal -and !(Test-Path env:__SuppressAnsiEscapeSequences))
             {
                 $result = $testinputone | Select-String -Pattern "l" -SimpleMatch | Out-String
@@ -120,12 +120,12 @@ Describe "Select-String" -Tags "CI" {
             }
         }
 
-        it "Should output a string without highlighting when NoEmphasis is used" {
+        It "Should output a string without highlighting when NoEmphasis is used" {
             $result = $testinputone | Select-String -Pattern "l" -NoEmphasis | Out-String
             $result | Should -Be "${nl}hello${nl}Hello${nl}${nl}"
         }
 
-        it "Should return an array of matching strings without virtual terminal sequences" {
+        It "Should return an array of matching strings without virtual terminal sequences" {
             $testinputone | Select-String -Pattern "l" | Should -Be "hello", "hello"
         }
 
@@ -144,7 +144,7 @@ Describe "Select-String" -Tags "CI" {
         $testInputFile = Join-Path -Path $testDirectory -ChildPath testfile1.txt
 
         BeforeEach {
-            New-Item $testInputFile -Itemtype "file" -Force -Value "This is a text string, and another string${nl}This is the second line${nl}This is the third line${nl}This is the fourth line${nl}No matches"
+            New-Item $testInputFile -ItemType "file" -Force -Value "This is a text string, and another string${nl}This is the second line${nl}This is the third line${nl}This is the fourth line${nl}No matches"
         }
 
         AfterEach {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Alias.Tests.ps1
@@ -47,8 +47,8 @@ Describe "Set-Alias DRT Unit Tests" -Tags "CI" {
 			$result.Options | Should -BeExactly "None"
 	}
 	It "Set-Alias Scope Valid"{
-			Set-Alias -Name ABCD -Value "localfoo" -scope local -Force:$true
-			Set-Alias -Name ABCD -Value "foo1" -scope "1" -Force:$true
+			Set-Alias -Name ABCD -Value "localfoo" -Scope local -Force:$true
+			Set-Alias -Name ABCD -Value "foo1" -Scope "1" -Force:$true
 
 			$result=Get-Alias -Name ABCD
 			$result.Name | Should -BeExactly "ABCD"
@@ -56,13 +56,13 @@ Describe "Set-Alias DRT Unit Tests" -Tags "CI" {
 			$result.Description | Should -BeNullOrEmpty
 			$result.Options | Should -BeExactly "None"
 
-			$result=Get-Alias -Name ABCD -scope local
+			$result=Get-Alias -Name ABCD -Scope local
 			$result.Name | Should -BeExactly "ABCD"
 			$result.Definition | Should -BeExactly "localfoo"
 			$result.Description | Should -BeNullOrEmpty
 			$result.Options | Should -BeExactly "None"
 
-			$result=Get-Alias -Name ABCD -scope "1"
+			$result=Get-Alias -Name ABCD -Scope "1"
 			$result.Name | Should -BeExactly "ABCD"
 			$result.Definition | Should -BeExactly "foo1"
 			$result.Description | Should -BeNullOrEmpty
@@ -77,11 +77,11 @@ Describe "Set-Alias" -Tags "CI" {
     Mock Get-Date { return "Friday, October 30, 2015 3:38:08 PM" }
     It "Should be able to set alias without error" {
 
-	{ set-alias -Name gd -Value Get-Date } | Should -Not -Throw
+	{ Set-Alias -Name gd -Value Get-Date } | Should -Not -Throw
     }
 
     It "Should be able to have the same output between set-alias and the output of the function being aliased" {
-	set-alias -Name gd -Value Get-Date
+	Set-Alias -Name gd -Value Get-Date
 	gd | Should -Be $(Get-Date)
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-PSBreakpoint.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-PSBreakpoint.Tests.ps1
@@ -41,49 +41,49 @@ set-psbreakpoint -command foo
     It "Should be able to set psbreakpoints for -Line" {
         $brk = Set-PSBreakpoint -Line 13 -Script $scriptFileName
         $brk.Line | Should -Be 13
-        Remove-PSBreakPoint -Id $brk.Id
+        Remove-PSBreakpoint -Id $brk.Id
     }
 
     It "Should be able to set psbreakpoints for -Line and -column" {
-        $brk = set-psbreakpoint -line 13 -column 1 -script $scriptFileName
+        $brk = Set-PSBreakpoint -Line 13 -Column 1 -Script $scriptFileName
         $brk.Line | Should -Be 13
         $brk.Column | Should -Be 1
-        Remove-PSBreakPoint -Id $brk.Id
+        Remove-PSBreakpoint -Id $brk.Id
     }
 
     It "Should be able to set psbreakpoints for -Line and -action" {
-        $brk = set-psbreakpoint -line 13 -action {{ break; }} -script $scriptFileName
+        $brk = Set-PSBreakpoint -Line 13 -Action {{ break; }} -Script $scriptFileName
         $brk.Line | Should -Be 13
         $brk.Action | Should -Match "break"
-        Remove-PSBreakPoint -Id $brk.Id
+        Remove-PSBreakpoint -Id $brk.Id
     }
 
     It "Should be able to set psbreakpoints for -Line, -column and -action" {
-        $brk = set-psbreakpoint -line 13 -column 1 -action {{ break; }} -script $scriptFileName
+        $brk = Set-PSBreakpoint -Line 13 -Column 1 -Action {{ break; }} -Script $scriptFileName
         $brk.Line | Should -Be 13
         $brk.Column | Should -Be 1
         $brk.Action | Should -Match "break"
-        Remove-PSBreakPoint -Id $brk.Id
+        Remove-PSBreakpoint -Id $brk.Id
     }
 
     It "-script and -line can take multiple items" {
-        $brk = Set-PSBreakpoint -line 11,12,13 -column 1 -script $scriptFileName,$scriptFileName
+        $brk = Set-PSBreakpoint -Line 11,12,13 -Column 1 -Script $scriptFileName,$scriptFileName
         $brk.Line | Should -BeIn 11,12,13
         $brk.Column | Should -BeIn 1
-        Remove-PSBreakPoint -Id $brk.Id
+        Remove-PSBreakpoint -Id $brk.Id
     }
 
     It "-script and -line are positional" {
         $brk = Set-PSBreakpoint $scriptFileName 13
         $brk.Line | Should -Be 13
-        Remove-PSBreakPoint -Id $brk.Id
+        Remove-PSBreakpoint -Id $brk.Id
     }
 
     It "-script, -line and -column are positional" {
         $brk = Set-PSBreakpoint $scriptFileName 13 1
         $brk.Line | Should -Be 13
         $brk.Column | Should -Be 1
-        Remove-PSBreakPoint -Id $brk.Id
+        Remove-PSBreakpoint -Id $brk.Id
     }
 
     It "Should throw Exception when missing mandatory parameter -line" -Pending {
@@ -97,52 +97,52 @@ set-psbreakpoint -command foo
     }
 
     It "Should be able to set psbreakpoints for -command" {
-        $brk = set-psbreakpoint -command "write-host"
+        $brk = Set-PSBreakpoint -Command "write-host"
         $brk.Command | Should -BeExactly "write-host"
-        Remove-PSBreakPoint -Id $brk.Id
+        Remove-PSBreakpoint -Id $brk.Id
     }
 
     It "Should be able to set psbreakpoints for -command, -script" {
-        $brk = set-psbreakpoint -command "write-host" -script $scriptFileName
+        $brk = Set-PSBreakpoint -Command "write-host" -Script $scriptFileName
         $brk.Command | Should -BeExactly "write-host"
-        Remove-PSBreakPoint -Id $brk.Id
+        Remove-PSBreakpoint -Id $brk.Id
     }
 
     It "Should be able to set psbreakpoints for -command, -action and -script" {
-        $brk = set-psbreakpoint -command "write-host" -action {{ break; }} -script $scriptFileName
+        $brk = Set-PSBreakpoint -Command "write-host" -Action {{ break; }} -Script $scriptFileName
         $brk.Action | Should -Match "break"
-        Remove-PSBreakPoint -Id $brk.Id
+        Remove-PSBreakpoint -Id $brk.Id
     }
 
     It "-Command can take multiple items" {
-        $brk = set-psbreakpoint -command write-host,Hello
+        $brk = Set-PSBreakpoint -Command write-host,Hello
         $brk.Command | Should -Be write-host,Hello
-        Remove-PSBreakPoint -Id $brk.Id
+        Remove-PSBreakpoint -Id $brk.Id
     }
 
     It "-Script is positional" {
-        $brk = set-psbreakpoint -command "Hello" $scriptFileName
+        $brk = Set-PSBreakpoint -Command "Hello" $scriptFileName
         $brk.Command | Should -BeExactly "Hello"
-        Remove-PSBreakPoint -Id $brk.Id
+        Remove-PSBreakpoint -Id $brk.Id
 
-        $brk = set-psbreakpoint $scriptFileName -command "Hello"
+        $brk = Set-PSBreakpoint $scriptFileName -Command "Hello"
         $brk.Command | Should -BeExactly "Hello"
-        Remove-PSBreakPoint -Id $brk.Id
+        Remove-PSBreakpoint -Id $brk.Id
     }
 
     It "Should be able to set breakpoints on functions" {
-        $brk = set-psbreakpoint -command Hello,Goodbye -script $scriptFileName
+        $brk = Set-PSBreakpoint -Command Hello,Goodbye -Script $scriptFileName
         $brk.Command | Should -Be Hello,Goodbye
-        Remove-PSBreakPoint -Id $brk.Id
+        Remove-PSBreakpoint -Id $brk.Id
     }
 
     It "Should be throw Exception when Column number less than 1" {
-        { set-psbreakpoint -line 1 -column -1 -script $scriptFileName } | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.SetPSBreakpointCommand"
+        { Set-PSBreakpoint -Line 1 -Column -1 -Script $scriptFileName } | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.SetPSBreakpointCommand"
     }
 
     It "Should be throw Exception when Line number less than 1" {
         $ErrorActionPreference = "Stop"
-        { set-psbreakpoint -line -1 -script $scriptFileName } | Should -Throw -ErrorId "SetPSBreakpoint:LineLessThanOne,Microsoft.PowerShell.Commands.SetPSBreakpointCommand"
+        { Set-PSBreakpoint -Line -1 -Script $scriptFileName } | Should -Throw -ErrorId "SetPSBreakpoint:LineLessThanOne,Microsoft.PowerShell.Commands.SetPSBreakpointCommand"
         $ErrorActionPreference = "SilentlyContinue"
     }
 
@@ -187,7 +187,7 @@ Describe "Set-PSBreakpoint" -Tags "CI" {
         $lineNumber = 1
         $brk = Set-PSBreakpoint -Line $lineNumber -Script $testScript
         $brk.Line | Should -Be $lineNumber
-        Remove-PSBreakPoint -Id $brk.Id
+        Remove-PSBreakpoint -Id $brk.Id
     }
 
     It "Should throw when a string is entered for a line number" {
@@ -202,14 +202,14 @@ Describe "Set-PSBreakpoint" -Tags "CI" {
         $command = "theCommand"
         $brk = Set-PSBreakpoint -Command $command -Script $testScript
         $brk.Command | Should -Be $command
-        Remove-PSBreakPoint -Id $brk.Id
+        Remove-PSBreakpoint -Id $brk.Id
     }
 
     It "Should be able to set a psbreakpoint on a variable" {
         $var = "theVariable"
         $brk = Set-PSBreakpoint -Command $var -Script $testScript
         $brk.Command | Should -Be $var
-        Remove-PSBreakPoint -Id $brk.Id
+        Remove-PSBreakpoint -Id $brk.Id
     }
 
     # clean up after ourselves

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Variable.Tests.ps1
@@ -24,21 +24,21 @@ Describe "Set-Variable DRT Unit Tests" -Tags "CI" {
 		Set-Variable -Name foo -Value bar0
 
 		Set-Variable -Name foo -Value bar -Scope "1"
-		$var1=Get-Variable -Name foo -scope "1"
+		$var1=Get-Variable -Name foo -Scope "1"
 		$var1.Name | Should -BeExactly "foo"
 		$var1.Value | Should -BeExactly "bar"
 		$var1.Options | Should -BeExactly "None"
 		$var1.Description | Should -BeNullOrEmpty
 
 		Set-Variable -Name foo -Value newValue -Scope "local"
-		$var1=Get-Variable -Name foo -scope "local"
+		$var1=Get-Variable -Name foo -Scope "local"
 		$var1.Name | Should -BeExactly "foo"
 		$var1.Value | Should -BeExactly "newValue"
 		$var1.Options | Should -BeExactly "None"
 		$var1.Description | Should -BeNullOrEmpty
 
 		Set-Variable -Name foo -Value newValue2 -Scope "script"
-		$var1=Get-Variable -Name foo -scope "script"
+		$var1=Get-Variable -Name foo -Scope "script"
 		$var1.Name | Should -BeExactly "foo"
 		$var1.Value | Should -BeExactly "newValue2"
 		$var1.Options | Should -BeExactly "None"
@@ -126,7 +126,7 @@ Describe "Set-Variable DRT Unit Tests" -Tags "CI" {
 	}
 
 	It "Set-Variable of ReadOnly variable with private scope should work"{
-		Set-Variable foo bar -Description "new description" -Option ReadOnly -scope "private"
+		Set-Variable foo bar -Description "new description" -Option ReadOnly -Scope "private"
 		$var1=Get-Variable -Name foo
 		$var1.Name | Should -BeExactly "foo"
 		$var1.Value | Should -BeExactly "bar"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Sort-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Sort-Object.Tests.ps1
@@ -103,12 +103,12 @@ Describe "Sort-Object DRT Unit Tests" -Tags "CI" {
 	}
 
 	It "Sort-Object with Non Existing And Null Script Property should work"{
-		$n = new-object microsoft.powershell.commands.newobjectcommand
-		$d = new-object microsoft.powershell.commands.newobjectcommand
+		$n = New-Object microsoft.powershell.commands.newobjectcommand
+		$d = New-Object microsoft.powershell.commands.newobjectcommand
 		$d.TypeName = 'Deetype'
-		$b = new-object microsoft.powershell.commands.newobjectcommand
+		$b = New-Object microsoft.powershell.commands.newobjectcommand
 		$b.TypeName = 'btype'
-		$a = new-object microsoft.powershell.commands.newobjectcommand
+		$a = New-Object microsoft.powershell.commands.newobjectcommand
 		$a.TypeName = 'atype'
 		$results = $n, $d, $b, 'b', $a | Sort-Object -proper {$_.TypeName}
 		$results.Count | Should -Be 5
@@ -119,13 +119,13 @@ Describe "Sort-Object DRT Unit Tests" -Tags "CI" {
 	}
 
 	It "Sort-Object with Non Existing And Null Property should work"{
-		$n = new-object microsoft.powershell.commands.newobjectcommand
+		$n = New-Object microsoft.powershell.commands.newobjectcommand
 		$n.TypeName = $null
-		$d = new-object microsoft.powershell.commands.newobjectcommand
+		$d = New-Object microsoft.powershell.commands.newobjectcommand
 		$d.TypeName = 'Deetype'
-		$b = new-object microsoft.powershell.commands.newobjectcommand
+		$b = New-Object microsoft.powershell.commands.newobjectcommand
 		$b.TypeName = 'btype'
-		$a = new-object microsoft.powershell.commands.newobjectcommand
+		$a = New-Object microsoft.powershell.commands.newobjectcommand
 		$a.TypeName = 'atype'
 		$results = $n, $d, $b, 'b', $a | Sort-Object -prop TypeName
 		$results.Count | Should -Be 5

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Tee-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Tee-Object.Tests.ps1
@@ -8,7 +8,7 @@ Describe "Tee-Object" -Tags "CI" {
 
 	    It "Should return the output to the screen and to the variable" {
 	        $teefile = $testfile
-	        Write-Output teeobjecttest1 | Tee-Object -variable teeresults
+	        Write-Output teeobjecttest1 | Tee-Object -Variable teeresults
 	        $teeresults         | Should -BeExactly "teeobjecttest1"
 	        Remove-Item $teefile -ErrorAction SilentlyContinue
 	    }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Trace-Command.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Trace-Command.Tests.ps1
@@ -54,7 +54,7 @@ Describe "Trace-Command" -tags "CI" {
 
         It "None options has no effect" {
             Trace-Command -Name * -Expression {Write-Output Foo} -ListenerOption None -FilePath $actualLogfile
-            Trace-Command -name * -Expression {Write-Output Foo} -FilePath $logfile
+            Trace-Command -Name * -Expression {Write-Output Foo} -FilePath $logfile
 
             Compare-Object (Get-Content $actualLogfile) (Get-Content $logfile) | Should -BeNullOrEmpty
         }
@@ -87,7 +87,7 @@ Describe "Trace-Command" -tags "CI" {
     Context "Trace-Command tests for code coverage" {
 
         BeforeAll {
-            $filePath = join-path $TestDrive 'testtracefile.txt'
+            $filePath = Join-Path $TestDrive 'testtracefile.txt'
         }
 
         AfterEach {
@@ -95,7 +95,7 @@ Describe "Trace-Command" -tags "CI" {
         }
 
         It "Get non-existing trace source" {
-            { '34E7F9FA-EBFB-4D21-A7D2-D7D102E2CC2F' | get-tracesource -ErrorAction Stop} | Should -Throw -ErrorId 'TraceSourceNotFound,Microsoft.PowerShell.Commands.GetTraceSourceCommand'
+            { '34E7F9FA-EBFB-4D21-A7D2-D7D102E2CC2F' | Get-TraceSource -ErrorAction Stop} | Should -Throw -ErrorId 'TraceSourceNotFound,Microsoft.PowerShell.Commands.GetTraceSourceCommand'
         }
 
         It "Set-TraceSource to file and RemoveFileListener wildcard" {
@@ -115,7 +115,7 @@ Describe "Trace-Command" -tags "CI" {
 
         It "Trace-Command to readonly file" {
             $null = New-Item $filePath -Force
-            Set-ItemProperty $filePath -name IsReadOnly -value $true
+            Set-ItemProperty $filePath -Name IsReadOnly -Value $true
             Trace-Command -Name ParameterBinding -Command 'Get-PSDrive' -FilePath $filePath -Force
             Get-Content $filePath -Raw | Should -Match 'ParameterBinding Information'
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Unblock-File.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Unblock-File.Tests.ps1
@@ -25,7 +25,7 @@ Describe "Unblock-File" -Tags "CI" {
 
                 function Block-File {
                     param($path)
-                    Set-Content -Path $path -value 'test'
+                    Set-Content -Path $path -Value 'test'
                     xattr -w com.apple.quarantine '0081;5dd5c373;Microsoft Edge;1A9A933D-619A-4036-BAF3-17A7966A1BA8' $path
 
                 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Update-FormatData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Update-FormatData.Tests.ps1
@@ -14,7 +14,7 @@ Describe "Update-FormatData" -Tags "CI" {
 
         It "Should validly load formatting data" {
             $path = Join-Path -Path $TestDrive -ChildPath "outputfile.ps1xml"
-            Get-FormatData -typename System.Diagnostics.Process | Export-FormatData -Path $path
+            Get-FormatData -TypeName System.Diagnostics.Process | Export-FormatData -Path $path
             $null = $ps.AddScript("Update-FormatData -prependPath $path")
             $ps.Invoke()
             $ps.HadErrors | Should -BeFalse

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Update-TypeData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Update-TypeData.Tests.ps1
@@ -291,7 +291,7 @@ Describe "Update-TypeData basic functionality" -Tags "CI" {
     }
 
 # this looks identical to the test directly above
-	It "Update-TypeData with ISS Type Table API Test Add And Remove TypeData should work" -pending {
+	It "Update-TypeData with ISS Type Table API Test Add And Remove TypeData should work" -Pending {
 		try{
 			Update-TypeData -TypeName System.Object[] -MemberType NoteProperty -MemberName TestNote -Value "TestNote"
 			Update-TypeData -TypeName System.Object[] -MemberType AliasProperty -MemberName TestAlias -Value "Length"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Wait-Debugger.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Wait-Debugger.Tests.ps1
@@ -22,7 +22,7 @@ Describe 'Tests for Wait-Debugger' -Tags "CI" {
                 Test-Break
             }
 
-            $results = @(Test-Debugger -ScriptBlock $testScript)
+            $results = @(Test-Debugger -Scriptblock $testScript)
         }
 
         It 'Should show 1 debugger command was invoked' {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -299,7 +299,7 @@ function ExecuteRestMethod {
             throw "No verbose output was found"
         }
     } catch {
-        $result.Error = $_ | select-object * | Out-String
+        $result.Error = $_ | Select-Object * | Out-String
     } finally {
         $VerbosePreference = $verbosePreferenceSave
         if (Test-Path -Path $verboseFile) {
@@ -1754,7 +1754,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
             # Download the entire file to reference in tests
             $referenceFile = Join-Path $TestDrive "reference.txt"
             $resumeUri = Get-WebListenerUrl -Test 'Resume'
-            Invoke-WebRequest -uri $resumeUri -OutFile $referenceFile -ErrorAction Stop
+            Invoke-WebRequest -Uri $resumeUri -OutFile $referenceFile -ErrorAction Stop
             $referenceFileHash = Get-FileHash -Algorithm SHA256 -Path $referenceFile
             $referenceFileSize = Get-Item $referenceFile | Select-Object -ExpandProperty Length
         }
@@ -1769,7 +1769,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
         }
 
         It "Invoke-WebRequest -Resume Downloads the whole file when the file does not exist" {
-            $response = Invoke-WebRequest -uri $resumeUri -OutFile $outFile -Resume -PassThru
+            $response = Invoke-WebRequest -Uri $resumeUri -OutFile $outFile -Resume -PassThru
 
             $outFileHash = Get-FileHash -Algorithm SHA256 -Path $outFile
             $outFileHash.Hash | Should -BeExactly $referenceFileHash.Hash
@@ -1786,7 +1786,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
             1..$largerFileSize | ForEach-Object { [Byte]$_ } | Set-Content -AsByteStream $outFile
             $largerFileSize = Get-Item $outFile | Select-Object -ExpandProperty Length
 
-            $response = Invoke-WebRequest -uri $resumeUri -OutFile $outFile -Resume -PassThru
+            $response = Invoke-WebRequest -Uri $resumeUri -OutFile $outFile -Resume -PassThru
 
             $outFileHash = Get-FileHash -Algorithm SHA256 -Path $outFile
             $outFileHash.Hash | Should -BeExactly $referenceFileHash.Hash
@@ -1824,10 +1824,10 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
             param($bytes, $statuscode)
             # Simulate partial download
             $uri = Get-WebListenerUrl -Test 'Resume' -TestValue "Bytes/$bytes"
-            $null = Invoke-WebRequest -uri $uri -OutFile $outFile
+            $null = Invoke-WebRequest -Uri $uri -OutFile $outFile
             Get-Item $outFile | Select-Object -ExpandProperty Length | Should -Be $bytes
 
-            $response = Invoke-WebRequest -uri $resumeUri -OutFile $outFile -Resume -PassThru
+            $response = Invoke-WebRequest -Uri $resumeUri -OutFile $outFile -Resume -PassThru
 
             $outFileHash = Get-FileHash -Algorithm SHA256 -Path $outFile
             $outFileHash.Hash | Should -BeExactly $referenceFileHash.Hash
@@ -1841,10 +1841,10 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
         It "Invoke-WebRequest -Resume assumes the file was successfully completed when the local and remote file are the same size." {
             # Download the entire file
             $uri = Get-WebListenerUrl -Test 'Resume' -TestValue 'NoResume'
-            $null = Invoke-WebRequest -uri $uri -OutFile $outFile
+            $null = Invoke-WebRequest -Uri $uri -OutFile $outFile
             $fileSize = Get-Item $outFile | Select-Object -ExpandProperty Length
 
-            $response = Invoke-WebRequest -uri $resumeUri -OutFile $outFile -Resume -PassThru
+            $response = Invoke-WebRequest -Uri $resumeUri -OutFile $outFile -Resume -PassThru
 
             $outFileHash = Get-FileHash -Algorithm SHA256 -Path $outFile
             $outFileHash.Hash | Should -BeExactly $referenceFileHash.Hash
@@ -1923,7 +1923,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
             [TimeSpan] $timeSpan = Measure-Command {
                 $response = Invoke-WebRequest -Uri $dosUri
                 $script:content = $response.content
-                $response.Images | out-null
+                $response.Images | Out-Null
             }
 
             $script:content | Should -Not -BeNullOrEmpty
@@ -2653,7 +2653,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
         It "Verifies Invoke-RestMethod Certificate Authentication Successful with -Certificate" {
             $uri = Get-WebListenerUrl -Https -Test 'Cert'
             $certificate = Get-WebListenerClientCertificate
-            $result = Invoke-RestMethod -uri $uri -Certificate $certificate -SkipCertificateCheck
+            $result = Invoke-RestMethod -Uri $uri -Certificate $certificate -SkipCertificateCheck
 
             $result.Status | Should -Be 'OK'
             $result.Thumbprint | Should -Be $certificate.Thumbprint
@@ -3278,7 +3278,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
             # Download the entire file to reference in tests
             $referenceFile = Join-Path $TestDrive "reference.txt"
             $resumeUri = Get-WebListenerUrl -Test 'Resume'
-            Invoke-RestMethod -uri $resumeUri -OutFile $referenceFile -ErrorAction Stop
+            Invoke-RestMethod -Uri $resumeUri -OutFile $referenceFile -ErrorAction Stop
             $referenceFileHash = Get-FileHash -Algorithm SHA256 -Path $referenceFile
             $referenceFileSize = Get-Item $referenceFile | Select-Object -ExpandProperty Length
         }
@@ -3296,7 +3296,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
             # ensure the file does not exist
             Remove-Item -Force -ErrorAction 'SilentlyContinue' -Path $outFile
 
-            Invoke-RestMethod -uri $resumeUri -OutFile $outFile -ResponseHeadersVariable 'Headers' -Resume
+            Invoke-RestMethod -Uri $resumeUri -OutFile $outFile -ResponseHeadersVariable 'Headers' -Resume
 
             $outFileHash = Get-FileHash -Algorithm SHA256 -Path $outFile
             $outFileHash.Hash | Should -BeExactly $referenceFileHash.Hash
@@ -3312,7 +3312,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
             1..$largerFileSize | ForEach-Object { [Byte]$_ } | Set-Content -AsByteStream $outFile
             $largerFileSize = Get-Item $outFile | Select-Object -ExpandProperty Length
 
-            $response = Invoke-RestMethod -uri $resumeUri -OutFile $outFile -ResponseHeadersVariable 'Headers' -Resume
+            $response = Invoke-RestMethod -Uri $resumeUri -OutFile $outFile -ResponseHeadersVariable 'Headers' -Resume
 
             $outFileHash = Get-FileHash -Algorithm SHA256 -Path $outFile
             $outFileHash.Hash | Should -BeExactly $referenceFileHash.Hash
@@ -3329,7 +3329,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
             $largerFileSize = Get-Item $outFile | Select-Object -ExpandProperty Length
 
             $uri = Get-WebListenerUrl -Test 'Resume' -TestValue 'NoResume'
-            $response = Invoke-RestMethod -uri $uri -OutFile $outFile -ResponseHeadersVariable 'Headers' -Resume
+            $response = Invoke-RestMethod -Uri $uri -OutFile $outFile -ResponseHeadersVariable 'Headers' -Resume
 
             $outFileHash = Get-FileHash -Algorithm SHA256 -Path $outFile
             $outFileHash.Hash | Should -BeExactly $referenceFileHash.Hash
@@ -3349,10 +3349,10 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
             param($bytes)
             # Simulate partial download
             $uri = Get-WebListenerUrl -Test 'Resume' -TestValue "Bytes/$bytes"
-            $null = Invoke-RestMethod -uri $uri -OutFile $outFile
+            $null = Invoke-RestMethod -Uri $uri -OutFile $outFile
             Get-Item $outFile | Select-Object -ExpandProperty Length | Should -Be $bytes
 
-            $response = Invoke-RestMethod -uri $resumeUri -OutFile $outFile -ResponseHeadersVariable 'Headers' -Resume
+            $response = Invoke-RestMethod -Uri $resumeUri -OutFile $outFile -ResponseHeadersVariable 'Headers' -Resume
 
             $outFileHash = Get-FileHash -Algorithm SHA256 -Path $outFile
             $outFileHash.Hash | Should -BeExactly $referenceFileHash.Hash
@@ -3365,10 +3365,10 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
         It "Invoke-RestMethod -Resume assumes the file was successfully completed when the local and remote file are the same size." {
             # Download the entire file
             $uri = Get-WebListenerUrl -Test 'Resume' -TestValue 'NoResume'
-            $null = Invoke-RestMethod -uri $uri -OutFile $outFile
+            $null = Invoke-RestMethod -Uri $uri -OutFile $outFile
             $fileSize = Get-Item $outFile | Select-Object -ExpandProperty Length
 
-            $response = Invoke-RestMethod -uri $resumeUri -OutFile $outFile -ResponseHeadersVariable 'Headers' -Resume
+            $response = Invoke-RestMethod -Uri $resumeUri -OutFile $outFile -ResponseHeadersVariable 'Headers' -Resume
 
             $outFileHash = Get-FileHash -Algorithm SHA256 -Path $outFile
             $outFileHash.Hash | Should -BeExactly $referenceFileHash.Hash

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
@@ -69,7 +69,7 @@ Describe "Write-Error Tests" -Tags "CI" {
     }
 
     It "Should be works with all parameters" {
-        $e = write-error -Activity fooAct -Reason fooReason -TargetName fooTargetName -TargetType fooTargetType -Message fooMessage 2>&1
+        $e = Write-Error -Activity fooAct -Reason fooReason -TargetName fooTargetName -TargetType fooTargetType -Message fooMessage 2>&1
         $e.CategoryInfo.Activity | Should -Be 'fooAct'
         $e.CategoryInfo.Reason | Should -Be 'fooReason'
         $e.CategoryInfo.TargetName | Should -Be 'fooTargetName'
@@ -91,7 +91,7 @@ Describe "Write-Error Tests" -Tags "CI" {
 
     It "Should output the error message to the `$error automatic variable" {
         $theError = "Error: Too many input values."
-        write-error -message $theError -category InvalidArgument -ErrorAction SilentlyContinue
+        Write-Error -Message $theError -Category InvalidArgument -ErrorAction SilentlyContinue
 
         [string]$error[0] | Should -Be $theError
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Progress.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Progress.Tests.ps1
@@ -6,20 +6,20 @@ Describe "Write-Progress DRT Unit Tests" -Tags "CI" {
     }
 
     It "Should be able to throw exception when running Write-Progress with bad percentage" {
-        { write-progress -activity 'myactivity' -status 'mystatus' -percent 101 } |
+        { Write-Progress -Activity 'myactivity' -Status 'mystatus' -percent 101 } |
 	    Should -Throw -ErrorId 'ParameterArgumentValidationError,Microsoft.PowerShell.Commands.WriteProgressCommand'
     }
 
     It "Should be able to throw exception when running Write-Progress with bad parent id " {
-        { write-progress -activity 'myactivity' -status 'mystatus' -id 1 -parentid -2 } |
+        { Write-Progress -Activity 'myactivity' -Status 'mystatus' -Id 1 -ParentId -2 } |
 	    Should -Throw -ErrorId 'ParameterArgumentValidationError,Microsoft.PowerShell.Commands.WriteProgressCommand'
     }
 
     It "all mandatory params works" -Pending {
-        { write-progress -activity 'myactivity' -status 'mystatus' } | Should -Not -Throw
+        { Write-Progress -Activity 'myactivity' -Status 'mystatus' } | Should -Not -Throw
     }
 
     It "all params works" -Pending {
-        { write-progress -activity 'myactivity' -status 'mystatus' -id 1 -parentId 2 -completed:$false -current 'current' -sec 1 -percent 1 } | Should -Not -Throw
+        { Write-Progress -Activity 'myactivity' -Status 'mystatus' -Id 1 -ParentId 2 -Completed:$false -current 'current' -sec 1 -percent 1 } | Should -Not -Throw
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/XMLCommand.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/XMLCommand.Tests.ps1
@@ -32,7 +32,7 @@ Describe "XmlCommand DRT basic functionality Tests" -Tags "CI" {
 	}
 
     AfterEach {
-		remove-item $testfile -Force -ErrorAction SilentlyContinue
+		Remove-Item $testfile -Force -ErrorAction SilentlyContinue
     }
 
  	It "Import with CliXml directive should work" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/assets/localized.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/assets/localized.ps1
@@ -23,5 +23,5 @@ $a = $Day.d0, $Day.d1, $Day.d2, $Day.d3, $Day.d4, $Day.d5, $Day.d6
         # Index into $a to get the name of the day.
         # Use string formatting to build a sentence.
 
-        "{0} {1}" -f $Day.messageDate, $a[(get-date -uformat %u)] | Out-Host
+        "{0} {1}" -f $Day.messageDate, $a[(Get-Date -UFormat %u)] | Out-Host
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/clixml.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/clixml.tests.ps1
@@ -6,7 +6,7 @@ Describe "CliXml test" -Tags "CI" {
         $testFilePath = Join-Path "testdrive:\" "testCliXml"
         $subFilePath = Join-Path $testFilePath ".test"
 
-        if(test-path $testFilePath)
+        if(Test-Path $testFilePath)
         {
             Remove-Item $testFilePath -Force -Recurse
         }
@@ -207,7 +207,7 @@ Describe "Deserializing corrupted Cim classes should not instantiate non-Cim typ
         }
     }
 
-    It "Verifies that importing the corrupted Cim class does not launch calc.exe" -skip:$skipNotWindows {
+    It "Verifies that importing the corrupted Cim class does not launch calc.exe" -Skip:$skipNotWindows {
 
         Import-Clixml -Path (Join-Path $PSScriptRoot "assets\CorruptedCim.clixml")
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/command.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/command.tests.ps1
@@ -4,28 +4,28 @@ Describe "Trace-Command" -tags "Feature" {
 
     Context "Listener options" {
         BeforeAll {
-            $logFile = setup -f traceCommandLog.txt -pass
-            $actualLogFile = setup -f actualTraceCommandLog.txt -pass
+            $logFile = Setup -f traceCommandLog.txt -pass
+            $actualLogFile = Setup -f actualTraceCommandLog.txt -pass
         }
 
         AfterEach {
-            if ( test-path $logfile ) { Remove-Item $logFile }
-            if ( test-path $actualLogFile ) { Remove-Item $actualLogFile }
+            if ( Test-Path $logfile ) { Remove-Item $logFile }
+            if ( Test-Path $actualLogFile ) { Remove-Item $actualLogFile }
         }
 
-        It "LogicalOperationStack works" -pending:($IsCoreCLR) {
+        It "LogicalOperationStack works" -Pending:($IsCoreCLR) {
             $keyword = "Trace_Command_ListenerOption_LogicalOperationStack_Foo"
             $stack = [System.Diagnostics.Trace]::CorrelationManager.LogicalOperationStack
             $stack.Push($keyword)
 
-            Trace-Command -Name * -Expression {write-output Foo} -ListenerOption LogicalOperationStack -FilePath $logfile
+            Trace-Command -Name * -Expression {Write-Output Foo} -ListenerOption LogicalOperationStack -FilePath $logfile
 
             $log = Get-Content $logfile | Where-Object {$_ -like "*LogicalOperationStack=$keyword*"}
             $log.Count | Should -BeGreaterThan 0
         }
 
-        It "Callstack works" -pending:($IsCoreCLR) {
-            Trace-Command -Name * -Expression {write-output Foo} -ListenerOption Callstack -FilePath $logfile
+        It "Callstack works" -Pending:($IsCoreCLR) {
+            Trace-Command -Name * -Expression {Write-Output Foo} -ListenerOption Callstack -FilePath $logfile
             $log = Get-Content $logfile | Where-Object {$_ -like "*Callstack=   * System.Environment.GetStackTrace(Exception e, Boolean needFileInfo)*"}
             $log.Count | Should -BeGreaterThan 0
         }
@@ -49,14 +49,14 @@ Describe "Trace-Command" -tags "Feature" {
         }
 
         It "None options has no effect" {
-            Trace-Command -Name * -Expression {write-output Foo} -ListenerOption None -FilePath $actualLogfile
-            Trace-Command -name * -Expression {write-output Foo} -FilePath $logfile
+            Trace-Command -Name * -Expression {Write-Output Foo} -ListenerOption None -FilePath $actualLogfile
+            Trace-Command -Name * -Expression {Write-Output Foo} -FilePath $logfile
 
             Compare-Object (Get-Content $actualLogfile) (Get-Content $logfile) | Should -BeNullOrEmpty
         }
 
         It "ThreadID works" {
-            Trace-Command -Name * -Expression {write-output Foo} -ListenerOption ThreadId -FilePath $logfile
+            Trace-Command -Name * -Expression {Write-Output Foo} -ListenerOption ThreadId -FilePath $logfile
             $log = Get-Content $logfile | Where-Object {$_ -like "*ThreadID=*"}
             $results = $log | ForEach-Object {$_.Split("=")[1]}
 
@@ -64,7 +64,7 @@ Describe "Trace-Command" -tags "Feature" {
         }
 
         It "Timestamp creates logs in ascending order" {
-            Trace-Command -Name * -Expression {write-output Foo} -ListenerOption Timestamp -FilePath $logfile
+            Trace-Command -Name * -Expression {Write-Output Foo} -ListenerOption Timestamp -FilePath $logfile
             $log = Get-Content $logfile | Where-Object {$_ -like "*Timestamp=*"}
             $results = $log | ForEach-Object {$_.Split("=")[1]}
             $sortedResults = $results | Sort-Object
@@ -72,7 +72,7 @@ Describe "Trace-Command" -tags "Feature" {
         }
 
         It "ProcessId logs current process Id" {
-            Trace-Command -Name * -Expression {write-output Foo} -ListenerOption ProcessId -FilePath $logfile
+            Trace-Command -Name * -Expression {Write-Output Foo} -ListenerOption ProcessId -FilePath $logfile
             $log = Get-Content $logfile | Where-Object {$_ -like "*ProcessID=*"}
             $results = $log | ForEach-Object {$_.Split("=")[1]}
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/object.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/object.tests.ps1
@@ -35,13 +35,13 @@ Describe "Object cmdlets" -Tags "CI" {
             $firstValue = "9995788.71"
             $expectedFirstValue = $null
             $null = [System.Management.Automation.LanguagePrimitives]::TryConvertTo($firstValue, [double], [cultureinfo]::InvariantCulture, [ref] $expectedFirstValue)
-            $firstObject = new-object psobject
+            $firstObject = New-Object psobject
             $firstObject | Add-Member -NotePropertyName Header -NotePropertyValue $firstValue
 
             $secondValue = "15847577.7"
             $expectedSecondValue = $null
             $null = [System.Management.Automation.LanguagePrimitives]::TryConvertTo($secondValue, [double], [cultureinfo]::InvariantCulture, [ref] $expectedSecondValue)
-            $secondObject = new-object psobject
+            $secondObject = New-Object psobject
             $secondObject | Add-Member -NotePropertyName Header -NotePropertyValue $secondValue
 
             $testCases = @(
@@ -85,17 +85,17 @@ Describe "Object cmdlets" -Tags "CI" {
         }
 
         It 'returns a GenericMeasureInfoObject' {
-            $gmi = 1,2,3 | measure-object -max -min
+            $gmi = 1,2,3 | Measure-Object -max -min
             $gmi | Should -BeOfType Microsoft.PowerShell.Commands.GenericMeasureInfo
         }
 
         It 'should return correct error for non-numeric input' {
-            $gmi = "abc",[Datetime]::Now | Measure-Object -sum -max -ErrorVariable err -ErrorAction silentlycontinue
+            $gmi = "abc",[Datetime]::Now | Measure-Object -Sum -max -ErrorVariable err -ErrorAction silentlycontinue
             $err | ForEach-Object { $_.FullyQualifiedErrorId | Should -Be 'NonNumericInputObject,Microsoft.PowerShell.Commands.MeasureObjectCommand' }
         }
 
         It 'should have the correct count' {
-            $gmi = "abc",[Datetime]::Now | Measure-Object -sum -max -ErrorVariable err -ErrorAction silentlycontinue
+            $gmi = "abc",[Datetime]::Now | Measure-Object -Sum -max -ErrorVariable err -ErrorAction silentlycontinue
             $gmi.Count | Should -Be 2
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/string.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/string.tests.ps1
@@ -33,37 +33,37 @@ Describe "String cmdlets" -Tags "CI" {
         }
 
         It "Select-String does not throw on subdirectory (path without wildcard)" {
-            { select-string -Path  $pathWithoutWildcard "noExists" -ErrorAction Stop } | Should -Not -Throw
+            { Select-String -Path  $pathWithoutWildcard "noExists" -ErrorAction Stop } | Should -Not -Throw
         }
 
         It "Select-String does not throw on subdirectory (path with wildcard)" {
-            { select-string -Path  $pathWithWildcard "noExists" -ErrorAction Stop } | Should -Not -Throw
+            { Select-String -Path  $pathWithWildcard "noExists" -ErrorAction Stop } | Should -Not -Throw
         }
 
         It "LiteralPath with relative path" {
-            (select-string -LiteralPath (Get-Item -LiteralPath $fileName).Name "b").count | Should -Be 2
+            (Select-String -LiteralPath (Get-Item -LiteralPath $fileName).Name "b").count | Should -Be 2
         }
 
         It "LiteralPath with absolute path" {
-            (select-string -LiteralPath $fileName "b").count | Should -Be 2
+            (Select-String -LiteralPath $fileName "b").count | Should -Be 2
         }
 
         It "LiteralPath with dots in path" {
-            (select-string -LiteralPath $fileNameWithDots "b").count | Should -Be 2
+            (Select-String -LiteralPath $fileNameWithDots "b").count | Should -Be 2
         }
 
-        It "Network path" -skip:(!$IsWindows) {
-            (select-string -LiteralPath $fileNameAsNetworkPath "b").count | Should -Be 2
+        It "Network path" -Skip:(!$IsWindows) {
+            (Select-String -LiteralPath $fileNameAsNetworkPath "b").count | Should -Be 2
         }
 
         It "throws error for non filesystem providers" {
             $aaa = "aaaaaaaaaa"
-            select-string -literalPath variable:\aaa "a" -ErrorAction SilentlyContinue -ErrorVariable selectStringError
+            Select-String -LiteralPath variable:\aaa "a" -ErrorAction SilentlyContinue -ErrorVariable selectStringError
             $selectStringError.FullyQualifiedErrorId | Should -Be 'ProcessingFile,Microsoft.PowerShell.Commands.SelectStringCommand'
         }
 
         It "throws parameter binding exception for invalid context" {
-            { select-string It $PSScriptRoot -Context -1,-1 } | Should -Throw Context
+            { Select-String It $PSScriptRoot -Context -1,-1 } | Should -Throw Context
         }
 
         It "match object supports RelativePath method" {

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -47,7 +47,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         }
         ## function ends here
 
-        $transcriptFilePath = join-path $TestDrive "transcriptdata.txt"
+        $transcriptFilePath = Join-Path $TestDrive "transcriptdata.txt"
         Remove-Item $transcriptFilePath -Force -ErrorAction SilentlyContinue
     }
 
@@ -83,7 +83,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
     }
     It "Should create Transcript file with 'OutputDirectory' parameter" {
         $script = "Start-Transcript -OutputDirectory $TestDrive"
-        $outputFilePath = join-path $TestDrive "PowerShell_transcript*"
+        $outputFilePath = Join-Path $TestDrive "PowerShell_transcript*"
         ValidateTranscription -scriptToExecute $script -outputFilePath $outputFilePath
     }
     It "Should Append Transcript data in existing file if 'Append' parameter is used with Path parameter" {
@@ -102,7 +102,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
     }
     It "Should return an error if file path is invalid" {
         $fileName = (Get-Random).ToString()
-        $inputPath = join-path $TestDrive $fileName
+        $inputPath = Join-Path $TestDrive $fileName
         $null = New-Item -Path $inputPath -ItemType File -Force -ErrorAction SilentlyContinue
         $script = "Start-Transcript -OutputDirectory $inputPath"
         $expectedError = "CannotStartTranscription,Microsoft.PowerShell.Commands.StartTranscriptCommand"

--- a/test/powershell/Modules/PSDesiredStateConfiguration/MOF-Compilation.Tests.ps1
+++ b/test/powershell/Modules/PSDesiredStateConfiguration/MOF-Compilation.Tests.ps1
@@ -22,8 +22,8 @@ Describe "DSC MOF Compilation" -tags "CI" {
         Copy-Item $testResourceSchemaPath $baseSchemaPath -Recurse -Force
 
         $_modulePath = $env:PSModulePath
-        $powershellexe = (get-process -pid $PID).MainModule.FileName
-        $env:PSModulePath = join-path ([io.path]::GetDirectoryName($powershellexe)) Modules
+        $powershellexe = (Get-Process -pid $PID).MainModule.FileName
+        $env:PSModulePath = Join-Path ([io.path]::GetDirectoryName($powershellexe)) Modules
     }
 
     It "Should be able to compile a MOF from a basic configuration" -Skip:($IsMacOS -or $IsWindows -or $SkipAdditionalPlatforms) {

--- a/test/powershell/Modules/PSDesiredStateConfiguration/PSDesiredStateConfiguration.Tests.ps1
+++ b/test/powershell/Modules/PSDesiredStateConfiguration/PSDesiredStateConfiguration.Tests.ps1
@@ -118,7 +118,7 @@ Describe "Test PSDesiredStateConfiguration" -tags CI {
             $Global:ProgressPreference = $origProgress
         }
 
-        it "should be able to get <Name> - <TestCaseName>" -TestCases $testCases {
+        It "should be able to get <Name> - <TestCaseName>" -TestCases $testCases {
             param($Name)
 
             if ($IsWindows) {
@@ -141,7 +141,7 @@ Describe "Test PSDesiredStateConfiguration" -tags CI {
 
         }
 
-        it "should be able to get <Name> from <ModuleName> - <TestCaseName>" -TestCases $testCases {
+        It "should be able to get <Name> from <ModuleName> - <TestCaseName>" -TestCases $testCases {
             param($Name, $ModuleName, $PendingBecause)
 
             if ($IsLinux) {
@@ -218,7 +218,7 @@ Describe "Test PSDesiredStateConfiguration" -tags CI {
             $Global:ProgressPreference = $origProgress
         }
 
-        it "should be able to get <Name> - <TestCaseName>" -TestCases $testCases {
+        It "should be able to get <Name> - <TestCaseName>" -TestCases $testCases {
             param($Name)
 
             if ($IsWindows) {
@@ -247,7 +247,7 @@ Describe "Test PSDesiredStateConfiguration" -tags CI {
             }
         }
 
-        it "should be able to get <Name> from <ModuleName> - <TestCaseName>" -TestCases $testCases {
+        It "should be able to get <Name> from <ModuleName> - <TestCaseName>" -TestCases $testCases {
             param($Name, $ModuleName, $PendingBecause)
 
             if ($IsLinux) {
@@ -271,7 +271,7 @@ Describe "Test PSDesiredStateConfiguration" -tags CI {
             }
         }
 
-        it "should throw when resource is not found" {
+        It "should throw when resource is not found" {
             Set-ItResult -Pending -Because "https://github.com/PowerShell/PSDesiredStateConfiguration/issues/17"
             {
                 Get-DscResource -Name antoehusatnoheusntahoesnuthao -Module tanshoeusnthaosnetuhasntoheusnathoseun
@@ -308,7 +308,7 @@ Describe "Test PSDesiredStateConfiguration" -tags CI {
             $global:ProgressPreference = $origProgress
         }
 
-        it "should be able to get class resource - <Name> from <ModuleName> - <TestCaseName>" -TestCases $classTestCases {
+        It "should be able to get class resource - <Name> from <ModuleName> - <TestCaseName>" -TestCases $classTestCases {
             param($Name, $ModuleName, $PendingBecause)
 
             if ($MissingLibmi) {
@@ -330,7 +330,7 @@ Describe "Test PSDesiredStateConfiguration" -tags CI {
             }
         }
 
-        it "should be able to get class resource - <Name> - <TestCaseName>" -TestCases $classTestCases {
+        It "should be able to get class resource - <Name> - <TestCaseName>" -TestCases $classTestCases {
             param($Name, $ModuleName, $PendingBecause)
             if ($IsWindows) {
                 Set-ItResult -Pending -Because "https://github.com/PowerShell/PSDesiredStateConfiguration/issues/19"
@@ -397,7 +397,7 @@ Describe "Test PSDesiredStateConfiguration" -tags CI {
 
                 $psGetModuleSpecification = @{ModuleName = $module.Name; ModuleVersion = $module.Version.ToString() }
             }
-            it "Set method should work" -Skip:(!(Test-IsInvokeDscResourceEnable)) {
+            It "Set method should work" -Skip:(!(Test-IsInvokeDscResourceEnable)) {
                 if ($MissingLibmi) {
                     Set-ItResult -Pending -Because "Libmi not available for this platform"
                 }
@@ -414,10 +414,10 @@ Describe "Test PSDesiredStateConfiguration" -tags CI {
                 }
 
                 $result.RebootRequired | Should -BeFalse
-                $module = Get-module PsDscResources -ListAvailable
+                $module = Get-Module PsDscResources -ListAvailable
                 $module | Should -Not -BeNullOrEmpty -Because "Resource should have installed module"
             }
-            it 'Set method should return RebootRequired=<expectedResult> when $global:DSCMachineStatus = <value>'  -Skip:(!(Test-IsInvokeDscResourceEnable))  -TestCases $dscMachineStatusCases {
+            It 'Set method should return RebootRequired=<expectedResult> when $global:DSCMachineStatus = <value>'  -Skip:(!(Test-IsInvokeDscResourceEnable))  -TestCases $dscMachineStatusCases {
                 param(
                     $value,
                     $ExpectedResult
@@ -434,7 +434,7 @@ Describe "Test PSDesiredStateConfiguration" -tags CI {
                 $result.RebootRequired | Should -BeExactly $expectedResult
             }
 
-            it "Test method should return false"  -Skip:(!(Test-IsInvokeDscResourceEnable)) {
+            It "Test method should return false"  -Skip:(!(Test-IsInvokeDscResourceEnable)) {
                 if ($MissingLibmi) {
                     Set-ItResult -Pending -Because "Libmi not available for this platform"
                 }
@@ -444,7 +444,7 @@ Describe "Test PSDesiredStateConfiguration" -tags CI {
                 $result.InDesiredState | Should -BeFalse -Because "Test method return false"
             }
 
-            it "Test method should return true"  -Skip:(!(Test-IsInvokeDscResourceEnable)) {
+            It "Test method should return true"  -Skip:(!(Test-IsInvokeDscResourceEnable)) {
                 if ($MissingLibmi) {
                     Set-ItResult -Pending -Because "Libmi not available for this platform"
                 }
@@ -453,18 +453,18 @@ Describe "Test PSDesiredStateConfiguration" -tags CI {
                 $result | Should -BeTrue -Because "Test method return true"
             }
 
-            it "Test method should return true with moduleSpecification"  -Skip:(!(Test-IsInvokeDscResourceEnable)) {
+            It "Test method should return true with moduleSpecification"  -Skip:(!(Test-IsInvokeDscResourceEnable)) {
                 if ($MissingLibmi) {
                     Set-ItResult -Pending -Because "Libmi not available for this platform"
                 }
 
-                $module = get-module PsDscResources -ListAvailable
+                $module = Get-Module PsDscResources -ListAvailable
                 $moduleSpecification = @{ModuleName = $module.Name; ModuleVersion = $module.Version.ToString() }
                 $result = Invoke-DscResource -Name Script -ModuleName $moduleSpecification -Method Test -Property @{TestScript = { Write-Verbose 'test'; return $true }; GetScript = { return @{ } }; SetScript = { return } }
                 $result | Should -BeTrue -Because "Test method return true"
             }
 
-            it "Invalid moduleSpecification"  -Skip:(!(Test-IsInvokeDscResourceEnable)) {
+            It "Invalid moduleSpecification"  -Skip:(!(Test-IsInvokeDscResourceEnable)) {
                 Set-ItResult -Pending -Because "https://github.com/PowerShell/PSDesiredStateConfiguration/issues/17"
                 $moduleSpecification = @{ModuleName = 'PsDscResources'; ModuleVersion = '99.99.99.993' }
                 {
@@ -473,7 +473,7 @@ Describe "Test PSDesiredStateConfiguration" -tags CI {
                 Should -Throw -ErrorId 'InvalidResourceSpecification,Invoke-DscResource' -ExpectedMessage 'Invalid Resource Name ''Script'' or module specification.'
             }
 
-            it "Resource with embedded resource not supported and a warning should be produced"  {
+            It "Resource with embedded resource not supported and a warning should be produced"  {
 
                 Set-ItResult -Pending -Because "Test is unreliable in release automation."
 
@@ -496,7 +496,7 @@ Describe "Test PSDesiredStateConfiguration" -tags CI {
                 $warnings[0] | Should -Match 'embedded resources.*not support'
             }
 
-            it "Using PsDscRunAsCredential should say not supported" -Skip:(!(Test-IsInvokeDscResourceEnable)) {
+            It "Using PsDscRunAsCredential should say not supported" -Skip:(!(Test-IsInvokeDscResourceEnable)) {
                 {
                     Invoke-DscResource -Name Script -ModuleName PSDscResources -Method Set -Property @{TestScript = { Write-Output 'test'; return $false }; GetScript = { return @{ } }; SetScript = {return}; PsDscRunAsCredential='natoheu'}  -ErrorAction Stop
                 } |
@@ -504,7 +504,7 @@ Describe "Test PSDesiredStateConfiguration" -tags CI {
             }
 
             # waiting on Get-DscResource to be fixed
-            it "Invalid module name" -Skip:(!(Test-IsInvokeDscResourceEnable)) {
+            It "Invalid module name" -Skip:(!(Test-IsInvokeDscResourceEnable)) {
                 Set-ItResult -Pending -Because "https://github.com/PowerShell/PSDesiredStateConfiguration/issues/17"
                 {
                     Invoke-DscResource -Name Script -ModuleName santoheusnaasonteuhsantoheu -Method Test -Property @{TestScript = { Write-Host 'test'; return $true }; GetScript = { return @{ } }; SetScript = { return } } -ErrorAction Stop
@@ -512,7 +512,7 @@ Describe "Test PSDesiredStateConfiguration" -tags CI {
                 Should -Throw -ErrorId 'Microsoft.PowerShell.Commands.WriteErrorException,CheckResourceFound'
             }
 
-            it "Invalid resource name" -Skip:(!(Test-IsInvokeDscResourceEnable)) {
+            It "Invalid resource name" -Skip:(!(Test-IsInvokeDscResourceEnable)) {
                 if ($IsWindows) {
                     Set-ItResult -Pending -Because "https://github.com/PowerShell/PSDesiredStateConfiguration/issues/17"
                 }
@@ -527,7 +527,7 @@ Describe "Test PSDesiredStateConfiguration" -tags CI {
                 Should -Throw -ErrorId 'Microsoft.PowerShell.Commands.WriteErrorException,CheckResourceFound'
             }
 
-            it "Get method should work"  -Skip:(!(Test-IsInvokeDscResourceEnable)) {
+            It "Get method should work"  -Skip:(!(Test-IsInvokeDscResourceEnable)) {
                 if ($IsLinux) {
                     Set-ItResult -Pending -Because "https://github.com/PowerShell/PSDesiredStateConfiguration/issues/12 and https://github.com/PowerShell/PowerShellGet/pull/529"
                 }
@@ -568,7 +568,7 @@ Describe "Test PSDesiredStateConfiguration" -tags CI {
                 $resolvedXmlPath = (Resolve-Path -Path $testXmlPath).ProviderPath
             }
 
-            it 'Set method should work'  -Skip:(!(Test-IsInvokeDscResourceEnable)) {
+            It 'Set method should work'  -Skip:(!(Test-IsInvokeDscResourceEnable)) {
                 param(
                     $value,
                     $ExpectedResult

--- a/test/powershell/Modules/PSDesiredStateConfiguration/configuration.Tests.ps1
+++ b/test/powershell/Modules/PSDesiredStateConfiguration/configuration.Tests.ps1
@@ -16,7 +16,7 @@ Describe "DSC MOF Compilation" -tags "CI" {
             Set-ItResult -Pending -Because "https://github.com/PowerShell/PowerShellGet/pull/529"
         }
 
-        Write-Verbose "DSC_HOME: ${env:DSC_HOME}" -verbose
+        Write-Verbose "DSC_HOME: ${env:DSC_HOME}" -Verbose
         [Scriptblock]::Create(@"
         configuration DSCTestConfig
         {

--- a/test/powershell/Modules/PSDiagnostics/PSDiagnostics.Tests.ps1
+++ b/test/powershell/Modules/PSDiagnostics/PSDiagnostics.Tests.ps1
@@ -20,7 +20,7 @@ Describe "PSDiagnostics cmdlets tests." -Tag "CI", "RequireAdminOnWindows" {
     }
 
     Context "Test for Enable-PSTrace and Disable-PSTrace cmdlets." {
-        it "Should enable $LogType logs for Microsoft-Windows-PowerShell." {
+        It "Should enable $LogType logs for Microsoft-Windows-PowerShell." {
             [XML]$CurrentSetting = & wevtutil gl Microsoft-Windows-PowerShell/$LogType /f:xml
             if($CurrentSetting.Channel.Enabled -eq 'true'){
                 & wevtutil sl Microsoft-Windows-PowerShell/$LogType /e:false /q
@@ -33,7 +33,7 @@ Describe "PSDiagnostics cmdlets tests." -Tag "CI", "RequireAdminOnWindows" {
             $ExpectedOutput.Channel.enabled | Should -BeExactly 'true'
         }
 
-        it "Should disable $LogType logs for Microsoft-Windows-PowerShell." {
+        It "Should disable $LogType logs for Microsoft-Windows-PowerShell." {
             [XML]$CurrentState = & wevtutil gl Microsoft-Windows-PowerShell/$LogType /f:xml
             if($CurrentState.channel.enabled -eq 'false'){
                 & wevtutil sl Microsoft-Windows-PowerShell/$LogType /e:true /q
@@ -47,7 +47,7 @@ Describe "PSDiagnostics cmdlets tests." -Tag "CI", "RequireAdminOnWindows" {
     }
 
     Context "Test for Get-LogProperties cmdlet." {
-        it "Should return properties of $LogType logs for 'Microsoft-Windows-PowerShell'." {
+        It "Should return properties of $LogType logs for 'Microsoft-Windows-PowerShell'." {
             [XML]$ExpectedOutput = wevtutil gl Microsoft-Windows-PowerShell/$LogType /f:xml
 
             $LogProperty = Get-LogProperties -Name Microsoft-Windows-PowerShell/$LogType
@@ -78,7 +78,7 @@ Describe "PSDiagnostics cmdlets tests." -Tag "CI", "RequireAdminOnWindows" {
             }
         }
 
-        it "Should invert AutoBackup setting of $LogType logs for 'Microsoft-Windows-PowerShell'." {
+        It "Should invert AutoBackup setting of $LogType logs for 'Microsoft-Windows-PowerShell'." {
             $LogPropertyToSet.AutoBackup = -not $LogPropertyToSet.AutoBackup
             Set-LogProperties -LogDetails $LogPropertyToSet -Force
 
@@ -86,7 +86,7 @@ Describe "PSDiagnostics cmdlets tests." -Tag "CI", "RequireAdminOnWindows" {
             (Get-LogProperties -Name Microsoft-Windows-PowerShell/$LogType).AutoBackup | Should -Be ([bool]::Parse($ExpectedOutput.Channel.Logging.AutoBackup))
         }
 
-        it "Should throw exception for invalid LogName." {
+        It "Should throw exception for invalid LogName." {
             {Set-LogProperties -LogDetails 'Foo' -Force } | Should -Throw -ErrorId 'ParameterArgumentTransformationError'
         }
     }

--- a/test/powershell/Modules/PSReadLine/PSReadLine.Tests.ps1
+++ b/test/powershell/Modules/PSReadLine/PSReadLine.Tests.ps1
@@ -22,39 +22,39 @@ Describe "PSReadLine" -tags "CI" {
         $module.Path | Should -Be (Join-Path -Path $PSHOME -ChildPath "Modules/PSReadLine/PSReadLine.psd1")
     }
 
-    It "Should use Emacs Bindings on Linux and macOS" -skip:$IsWindows {
+    It "Should use Emacs Bindings on Linux and macOS" -Skip:$IsWindows {
         (Get-PSReadLineOption).EditMode | Should -BeExactly 'Emacs'
-        (Get-PSReadlineKeyHandler | Where-Object { $_.Key -eq "Ctrl+A" }).Function | Should -BeExactly 'BeginningOfLine'
+        (Get-PSReadLineKeyHandler | Where-Object { $_.Key -eq "Ctrl+A" }).Function | Should -BeExactly 'BeginningOfLine'
     }
 
-    It "Should use Windows Bindings on Windows" -skip:(-not $IsWindows) {
+    It "Should use Windows Bindings on Windows" -Skip:(-not $IsWindows) {
         (Get-PSReadLineOption).EditMode | Should -BeExactly 'Windows'
-        (Get-PSReadlineKeyHandler | Where-Object { $_.Key -eq "Ctrl+a" }).Function | Should -BeExactly 'SelectAll'
+        (Get-PSReadLineKeyHandler | Where-Object { $_.Key -eq "Ctrl+a" }).Function | Should -BeExactly 'SelectAll'
     }
 
     It "Should set the edit mode" {
-        Set-PSReadlineOption -EditMode Windows
-        (Get-PSReadlineKeyHandler | Where-Object { $_.Key -eq "Ctrl+A" }).Function | Should -BeExactly 'SelectAll'
+        Set-PSReadLineOption -EditMode Windows
+        (Get-PSReadLineKeyHandler | Where-Object { $_.Key -eq "Ctrl+A" }).Function | Should -BeExactly 'SelectAll'
 
-        Set-PSReadlineOption -EditMode Emacs
-        (Get-PSReadlineKeyHandler | Where-Object { $_.Key -eq "Ctrl+A" }).Function | Should -BeExactly 'BeginningOfLine'
+        Set-PSReadLineOption -EditMode Emacs
+        (Get-PSReadLineKeyHandler | Where-Object { $_.Key -eq "Ctrl+A" }).Function | Should -BeExactly 'BeginningOfLine'
     }
 
     It "Should allow custom bindings for plain keys" {
-        Set-PSReadlineKeyHandler -Key '"' -Function SelfInsert
+        Set-PSReadLineKeyHandler -Key '"' -Function SelfInsert
         (Get-PSReadLineKeyHandler | Where-Object { $_.Key -eq '"' }).Function | Should -BeExactly 'SelfInsert'
     }
 
     It "Should report Capitalized bindings correctly" {
-        Set-PSReadlineOption -EditMode Emacs
+        Set-PSReadLineOption -EditMode Emacs
         (Get-PSReadLineKeyHandler | Where-Object { $_.Key -ceq "Alt+b" }).Function | Should -BeExactly 'BackwardWord'
         (Get-PSReadLineKeyHandler | Where-Object { $_.Key -ceq "Alt+B" }).Function | Should -BeExactly 'SelectBackwardWord'
     }
 
     It "Should ignore case when using Function binding" {
         $lowerCaseFunctionName = "yank"
-        Set-PSReadlineKeyHandler "Ctrl+F24" -Function $lowerCaseFunctionName
-        (Get-PSReadlineKeyHandler | Where-Object { $_.Key -eq "Ctrl+F24"}).Function | Should -BeExactly "Yank"
+        Set-PSReadLineKeyHandler "Ctrl+F24" -Function $lowerCaseFunctionName
+        (Get-PSReadLineKeyHandler | Where-Object { $_.Key -eq "Ctrl+F24"}).Function | Should -BeExactly "Yank"
     }
 
     AfterAll {
@@ -62,7 +62,7 @@ Describe "PSReadLine" -tags "CI" {
 
         if ($originalEditMode) {
             Import-Module PSReadLine
-            Set-PSReadlineOption -EditMode $originalEditMode
+            Set-PSReadLineOption -EditMode $originalEditMode
         }
     }
 }

--- a/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1
+++ b/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1
@@ -19,7 +19,7 @@ $InternalSource = 'OneGetTestSource'
 Describe "PackageManagement Acceptance Test" -Tags "Feature" {
 
  BeforeAll{
-    Register-PackageSource -Name Nugettest -provider NuGet -Location https://www.nuget.org/api/v2 -force
+    Register-PackageSource -Name Nugettest -provider NuGet -Location https://www.nuget.org/api/v2 -Force
     Register-PackageSource -Name $InternalSource -Location $InternalGallery -ProviderName 'PowerShellGet' -Trusted -ErrorAction SilentlyContinue
     $SavedProgressPreference = $ProgressPreference
     $ProgressPreference = "SilentlyContinue"
@@ -37,37 +37,37 @@ Describe "PackageManagement Acceptance Test" -Tags "Feature" {
     }
 
     It "find-packageprovider PowerShellGet" {
-        $fpp = (Find-PackageProvider -Name "PowerShellGet" -force).name
+        $fpp = (Find-PackageProvider -Name "PowerShellGet" -Force).name
         $fpp | Should -Contain "PowerShellGet"
     }
 
      It "install-packageprovider, Expect succeed" {
-        $ipp = (install-PackageProvider -name gistprovider -force -source $InternalSource -Scope CurrentUser).name
+        $ipp = (Install-PackageProvider -Name gistprovider -Force -Source $InternalSource -Scope CurrentUser).name
         $ipp | Should -Contain "gistprovider"
     }
 
-    it "Find-package"  {
-        $f = Find-Package -ProviderName NuGet -Name jquery -source Nugettest
+    It "Find-package"  {
+        $f = Find-Package -ProviderName NuGet -Name jquery -Source Nugettest
         $f.Name | Should -Contain "jquery"
 	}
 
-    it "Install-package"  {
-        $i = install-Package -ProviderName NuGet -Name jquery -force -source Nugettest -Scope CurrentUser
+    It "Install-package"  {
+        $i = Install-Package -ProviderName NuGet -Name jquery -Force -Source Nugettest -Scope CurrentUser
         $i.Name | Should -Contain "jquery"
 	}
 
-    it "Get-package"  {
+    It "Get-package"  {
         $g = Get-Package -ProviderName NuGet -Name jquery
         $g.Name | Should -Contain "jquery"
 	}
 
-    it "save-package"  {
-        $s = save-Package -ProviderName NuGet -Name jquery -path $TestDrive -force -source Nugettest
+    It "save-package"  {
+        $s = Save-Package -ProviderName NuGet -Name jquery -Path $TestDrive -Force -Source Nugettest
         $s.Name | Should -Contain "jquery"
 	}
 
-    it "uninstall-package"  {
-        $u = uninstall-Package -ProviderName NuGet -Name jquery
+    It "uninstall-package"  {
+        $u = Uninstall-Package -ProviderName NuGet -Name jquery
         $u.Name | Should -Contain "jquery"
 	}
 }

--- a/test/powershell/Modules/ThreadJob/ThreadJob.Tests.ps1
+++ b/test/powershell/Modules/ThreadJob/ThreadJob.Tests.ps1
@@ -79,7 +79,7 @@ Describe 'Basic ThreadJob Tests' -Tags 'CI' {
     }
 
     AfterEach {
-        Get-Job | Where-Object PSJobTypeName -eq "ThreadJob" | Remove-Job -Force
+        Get-Job | Where-Object PSJobTypeName -EQ "ThreadJob" | Remove-Job -Force
     }
 
     It 'ThreadJob with ScriptBlock' {
@@ -241,7 +241,7 @@ Describe 'Basic ThreadJob Tests' -Tags 'CI' {
         try
         {
             # Start four thread jobs with ThrottleLimit set to two
-            Get-Job | Where-Object PSJobTypeName -eq "ThreadJob" | Remove-Job -Force
+            Get-Job | Where-Object PSJobTypeName -EQ "ThreadJob" | Remove-Job -Force
             $job1 = Start-ThreadJob -ScriptBlock { Start-Sleep -Seconds 60 } -ThrottleLimit 2
             $job2 = Start-ThreadJob -ScriptBlock { Start-Sleep -Seconds 60 }
             $job3 = Start-ThreadJob -ScriptBlock { Start-Sleep -Seconds 60 }
@@ -255,10 +255,10 @@ Describe 'Basic ThreadJob Tests' -Tags 'CI' {
         }
         finally
         {
-            Get-Job | Where-Object PSJobTypeName -eq "ThreadJob" | Remove-Job -Force
+            Get-Job | Where-Object PSJobTypeName -EQ "ThreadJob" | Remove-Job -Force
         }
 
-        Get-Job | Where-Object PSJobTypeName -eq "ThreadJob" | Should -HaveCount 0
+        Get-Job | Where-Object PSJobTypeName -EQ "ThreadJob" | Should -HaveCount 0
     }
 
     It 'ThreadJob Runspaces should be cleaned up at completion' {
@@ -332,7 +332,7 @@ Describe 'Basic ThreadJob Tests' -Tags 'CI' {
 
     It 'ThreadJob jobs should work with Receive-Job -AutoRemoveJob' {
 
-        Get-Job | Where-Object PSJobTypeName -eq "ThreadJob" | Remove-Job -Force
+        Get-Job | Where-Object PSJobTypeName -EQ "ThreadJob" | Remove-Job -Force
 
         $job1 = Start-ThreadJob -ScriptBlock { 1..2 | ForEach-Object { Start-Sleep -Milliseconds 100; "Output $_" } } -ThrottleLimit 5
         $job2 = Start-ThreadJob -ScriptBlock { 1..2 | ForEach-Object { Start-Sleep -Milliseconds 100; "Output $_" } }
@@ -341,7 +341,7 @@ Describe 'Basic ThreadJob Tests' -Tags 'CI' {
 
         $null = $job1,$job2,$job3,$job4 | Receive-Job -Wait -AutoRemoveJob
 
-        Get-Job | Where-Object PSJobTypeName -eq "ThreadJob" | Should -HaveCount 0
+        Get-Job | Where-Object PSJobTypeName -EQ "ThreadJob" | Should -HaveCount 0
     }
 
     It 'ThreadJob jobs should run in FullLanguage mode by default' {
@@ -354,7 +354,7 @@ Describe 'Basic ThreadJob Tests' -Tags 'CI' {
 Describe 'Job2 class API tests' -Tags 'CI' {
 
     AfterEach {
-        Get-Job | Where-Object PSJobTypeName -eq "ThreadJob" | Remove-Job -Force
+        Get-Job | Where-Object PSJobTypeName -EQ "ThreadJob" | Remove-Job -Force
     }
 
     It 'Verifies StopJob API' {

--- a/test/powershell/Provider/AutomountVHDDrive.ps1
+++ b/test/powershell/Provider/AutomountVHDDrive.ps1
@@ -6,15 +6,15 @@ param([switch]$useModule, [string]$VHDPath)
 
 function CreateVHD ($VHDPath, $Size)
 {
-  $drive = (New-VHD -path $vhdpath -SizeBytes $size -Dynamic   | `
+  $drive = (New-VHD -Path $vhdpath -SizeBytes $size -Dynamic   | `
               Mount-VHD -Passthru |  `
-              get-disk -number {$_.DiskNumber} | `
+              Get-Disk -Number {$_.DiskNumber} | `
               Initialize-Disk -PartitionStyle MBR -PassThru | `
               New-Partition -UseMaximumSize -AssignDriveLetter:$false -MbrType IFS | `
-              Format-Volume -Confirm:$false -FileSystem NTFS -force | `
-              get-partition | `
+              Format-Volume -Confirm:$false -FileSystem NTFS -Force | `
+              Get-Partition | `
               Add-PartitionAccessPath -AssignDriveLetter -PassThru | `
-              get-volume).DriveLetter
+              Get-Volume).DriveLetter
 
     $drive
 }

--- a/test/powershell/Provider/Pester.AutomountedDrives.Tests.ps1
+++ b/test/powershell/Provider/Pester.AutomountedDrives.Tests.ps1
@@ -25,7 +25,7 @@ Describe "Test suite for validating automounted PowerShell drives" -Tags @('Feat
         try
         {
             $tmpVhdPath = Join-Path $TestDrive 'TestVHD.vhd'
-            New-VHD -path $tmpVhdPath -SizeBytes 5mb -Dynamic -ErrorAction Stop
+            New-VHD -Path $tmpVhdPath -SizeBytes 5mb -Dynamic -ErrorAction Stop
             Remove-Item $tmpVhdPath
             $VHDToolsNotFound = (Get-Module Hyper-V).PrivateData.ImplicitRemoting -eq $true
             Remove-Module Hyper-V

--- a/test/powershell/Provider/ProviderIntrinsics.Tests.ps1
+++ b/test/powershell/Provider/ProviderIntrinsics.Tests.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 Describe "ProviderIntrinsics Tests" -tags "CI" {
     BeforeAll {
-        setup -d TestDir
+        Setup -d TestDir
     }
     It 'If a childitem exists, HasChild method returns $true' {
         $ExecutionContext.InvokeProvider.ChildItem.HasChild("$TESTDRIVE") | Should -BeTrue

--- a/test/powershell/SDK/Breakpoint.Tests.ps1
+++ b/test/powershell/SDK/Breakpoint.Tests.ps1
@@ -5,7 +5,7 @@ Describe 'Breakpoint SDK Unit Tests' -Tags 'CI' {
 
     BeforeAll {
         # Start a job; this will create a runspace in which we can manage breakpoints
-        $job = Start-Job -ScriptBlock {
+        $job = Start-Job -Scriptblock {
             Set-PSBreakpoint -Command Start-Sleep
             1..240 | ForEach-Object {
                 Start-Sleep -Milliseconds 250

--- a/test/powershell/SDK/PSDebugging.Tests.ps1
+++ b/test/powershell/SDK/PSDebugging.Tests.ps1
@@ -183,7 +183,7 @@ Describe "PowerShell Command Debugging" -tags "CI" {
 }
 
 # Scripting\Debugging\RunspaceDebuggingTests.cs
-Describe "Runspace Debugging API tests" -tag CI {
+Describe "Runspace Debugging API tests" -Tag CI {
     Context "PSStandaloneMonitorRunspaceInfo tests" {
         BeforeAll {
             $runspace = [runspacefactory]::CreateRunspace()
@@ -204,7 +204,7 @@ Describe "Runspace Debugging API tests" -tag CI {
                 Should -Throw -ErrorId 'PSArgumentNullException'
         }
 
-        it "PSStandaloneMonitorRunspaceInfo properties should have proper values" {
+        It "PSStandaloneMonitorRunspaceInfo properties should have proper values" {
             $monitorInfo.Runspace.InstanceId | Should -Be $InstanceId
             $monitorInfo.RunspaceType | Should -BeExactly "Standalone"
             $monitorInfo.NestedDebugger | Should -BeNullOrEmpty

--- a/test/powershell/engine/Api/BasicEngine.Tests.ps1
+++ b/test/powershell/engine/Api/BasicEngine.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'Basic engine APIs' -Tags "CI" {
             { [powershell]::Create([runspace]$null) } | Should -Throw -ErrorId 'PSArgumentNullException'
         }
 
-        It "can load the default snapin 'Microsoft.WSMan.Management'" -skip:(-not $IsWindows) {
+        It "can load the default snapin 'Microsoft.WSMan.Management'" -Skip:(-not $IsWindows) {
             $ps = [powershell]::Create()
             $ps.AddScript("Get-Command -Name Test-WSMan") > $null
 

--- a/test/powershell/engine/Api/Serialization.Tests.ps1
+++ b/test/powershell/engine/Api/Serialization.Tests.ps1
@@ -37,7 +37,7 @@ Describe "Serialization Tests" -tags "CI" {
     }
 
     It 'Test DateTime stamps serialize and deserialize work as expected.' {
-        $objs = [System.DateTime]::MaxValue, [System.DateTime]::MinValue, [System.DateTime]::Today, (new-object System.DateTime), (new-object System.DateTime 123456789)
+        $objs = [System.DateTime]::MaxValue, [System.DateTime]::MinValue, [System.DateTime]::Today, (New-Object System.DateTime), (New-Object System.DateTime 123456789)
         foreach($inputObject in $objs)
         {
            SerializeAndDeserialize($inputObject) | Should -Be $inputObject
@@ -49,7 +49,7 @@ Describe "Serialization Tests" -tags "CI" {
         $uristrings = "http://www.microsoft.com","http://www.microsoft.com:8000","http://www.microsoft.com/index.html","http://www.microsoft.com/default.asp","http://www.microsoft.com/Hello%20World.htm"
         foreach($uristring in $uristrings)
         {
-           $inputObject = new-object System.Uri $uristring
+           $inputObject = New-Object System.Uri $uristring
            SerializeAndDeserialize($inputObject) | Should -Be $inputObject
         }
     }
@@ -86,7 +86,7 @@ Describe "Serialization Tests" -tags "CI" {
 
     It 'Test SecureString serialize and deserialize work as expected.' {
         #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
-        $inputObject = Convertto-Securestring -String "PowerShellRocks!" -AsPlainText -Force
+        $inputObject = ConvertTo-SecureString -String "PowerShellRocks!" -AsPlainText -Force
         SerializeAndDeserialize($inputObject).Length | Should -Be $inputObject.Length
 
     }

--- a/test/powershell/engine/Api/TypeInference.Tests.ps1
+++ b/test/powershell/engine/Api/TypeInference.Tests.ps1
@@ -399,21 +399,21 @@ Describe "Type inference Tests" -tags "CI" {
     }
 
     It 'Infers typeof Foreach-Object -Member when Member is Property' {
-        $ast = {Get-Process | Foreach-Object -Member FileVersion}.Ast
+        $ast = {Get-Process | ForEach-Object -Member FileVersion}.Ast
         $typeNames = [AstTypeInference]::InferTypeof($ast, [TypeInferenceRuntimePermissions]::AllowSafeEval)
         $typeNames.Count | Should -Be 1
         $typeNames[0] | Should -Be 'System.String'
     }
 
     It 'Infers typeof Foreach-Object -Member when member is ScriptProperty' {
-        $ast = {Get-Process | Foreach-Object -Member Description}.Ast
+        $ast = {Get-Process | ForEach-Object -Member Description}.Ast
         $typeNames = [AstTypeInference]::InferTypeof($ast, [TypeInferenceRuntimePermissions]::AllowSafeEval)
         $typeNames.Count | Should -Be 1
         $typeNames[0] | Should -Be 'System.String'
     }
 
     It 'Infers typeof Foreach-Object -Member when Member is Alias' {
-        $ast = {Get-Process | Foreach-Object -Member Handles}.Ast
+        $ast = {Get-Process | ForEach-Object -Member Handles}.Ast
         $typeNames = [AstTypeInference]::InferTypeof($ast, [TypeInferenceRuntimePermissions]::AllowSafeEval)
         $typeNames.Count | Should -Be 1
         $typeNames[0] | Should -Be 'System.Int32'
@@ -433,7 +433,7 @@ Describe "Type inference Tests" -tags "CI" {
         Update-TypeData -TypeName InferScriptPropLevel1 -MemberName TheValue -MemberType ScriptProperty -Value { return $this.Value } -Force
         Update-TypeData -TypeName InferScriptPropLevel2 -MemberName XVal -MemberType ScriptProperty -Value {return $this.X } -Force
         try {
-            $ast = {[InferScriptPropLevel2]::new() | Foreach-Object -MemberName XVal | ForEach-Object -MemberName TheValue}.Ast
+            $ast = {[InferScriptPropLevel2]::new() | ForEach-Object -MemberName XVal | ForEach-Object -MemberName TheValue}.Ast
             $typeNames = [AstTypeInference]::InferTypeof($ast, [TypeInferenceRuntimePermissions]::AllowSafeEval)
             $typeNames.Count | Should -Be 1
             $typeNames[0] | Should -Be 'System.String'
@@ -525,43 +525,43 @@ Describe "Type inference Tests" -tags "CI" {
     }
 
     It "Infers typeof Group-Object Group" {
-        $res = [AstTypeInference]::InferTypeOf( { Get-ChildItem | Group-Object | Foreach-Object Group  }.Ast)
+        $res = [AstTypeInference]::InferTypeOf( { Get-ChildItem | Group-Object | ForEach-Object Group  }.Ast)
         $res.Count | Should -Be 3
         ($res.Name | Sort-Object)[1,2] -join ', ' | Should -Be "System.IO.DirectoryInfo, System.IO.FileInfo"
     }
 
     It "Infers typeof Group-Object Values" {
-        $res = [AstTypeInference]::InferTypeOf( { Get-ChildItem | Group-Object | Foreach-Object Values  }.Ast)
+        $res = [AstTypeInference]::InferTypeOf( { Get-ChildItem | Group-Object | ForEach-Object Values  }.Ast)
         $res.Count | Should -Be 3
         ($res.Name | Sort-Object)[1,2] -join ', ' | Should -Be "System.IO.DirectoryInfo, System.IO.FileInfo"
     }
 
     It "Infers typeof Group-Object Group with Property" {
-        $res = [AstTypeInference]::InferTypeOf( { Get-ChildItem | Group-Object -Property Name | Foreach-Object Group  }.Ast)
+        $res = [AstTypeInference]::InferTypeOf( { Get-ChildItem | Group-Object -Property Name | ForEach-Object Group  }.Ast)
         $res.Count | Should -Be 3
         ($res.Name | Sort-Object)[1,2] -join ', ' | Should -Be "System.IO.DirectoryInfo, System.IO.FileInfo"
     }
 
     It "Infers typeof Group-Object Values with Property" {
-        $res = [AstTypeInference]::InferTypeOf( { Get-ChildItem | Group-Object -Property Name | Foreach-Object Values  }.Ast)
+        $res = [AstTypeInference]::InferTypeOf( { Get-ChildItem | Group-Object -Property Name | ForEach-Object Values  }.Ast)
         $res.Count | Should -Be 2
         $res.Name -join ', ' | Should -Be "System.String, System.Collections.ArrayList"
     }
 
     It "Infers typeof Group-Object Group with NoElement" {
-        $res = [AstTypeInference]::InferTypeOf( { Get-ChildItem | Group-Object -Property Name -NoElement | Foreach-Object Group  }.Ast)
+        $res = [AstTypeInference]::InferTypeOf( { Get-ChildItem | Group-Object -Property Name -NoElement | ForEach-Object Group  }.Ast)
         $res.Count | Should -Be 1
         $res.Name | Should -BeLike "*Collection*PSObject*"
     }
 
     It "Infers typeof Group-Object Values with Properties" {
-        $res = [AstTypeInference]::InferTypeOf( { Get-ChildItem | Group-Object -Property Name,CreationTime | Foreach-Object Values  }.Ast)
+        $res = [AstTypeInference]::InferTypeOf( { Get-ChildItem | Group-Object -Property Name,CreationTime | ForEach-Object Values  }.Ast)
         $res.Count | Should -Be 3
         ($res.Name | Sort-Object)  -join ', ' | Should -Be "System.Collections.ArrayList, System.DateTime, System.String"
     }
 
     It "ignores Group-Object Group with Scriptblock" {
-        $res = [AstTypeInference]::InferTypeOf( { Get-ChildItem | Group-Object -Property {$_.Name} | Foreach-Object Values  }.Ast)
+        $res = [AstTypeInference]::InferTypeOf( { Get-ChildItem | Group-Object -Property {$_.Name} | ForEach-Object Values  }.Ast)
         $res.Count | Should -Be 1
         $res.Name | Should -Be "System.Collections.ArrayList"
     }
@@ -841,7 +841,7 @@ Describe "Type inference Tests" -tags "CI" {
         class X {
             [int] $Length
         }
-        Update-TypeData -Typename X -MemberType AliasProperty -MemberName AliasLength -Value Length -Force
+        Update-TypeData -TypeName X -MemberType AliasProperty -MemberName AliasLength -Value Length -Force
         $res = [AstTypeInference]::InferTypeOf( {
                 [x]::new().AliasLength
             }.Ast)
@@ -991,7 +991,7 @@ Describe "Type inference Tests" -tags "CI" {
         BeforeAll {
             $errors = $null
             $tokens = $null
-            $p = Resolve-path TestDrive:/
+            $p = Resolve-Path TestDrive:/
         }
         It 'Infers type of command parameter' {
             $ast = [Language.Parser]::ParseInput("Get-ChildItem -Path $p/foo.txt", [ref] $tokens, [ref] $errors)
@@ -1032,7 +1032,7 @@ Describe "Type inference Tests" -tags "CI" {
     }
 
     It 'Infers type of variable $_ in hashtable in command parameter' {
-        $variableAst = {1..10 | Format-table @{n = 'x'; ex = {$_}}}.ast.Find( {param($a) $a -is [System.Management.Automation.Language.VariableExpressionAst]}, $true)
+        $variableAst = {1..10 | Format-Table @{n = 'x'; ex = {$_}}}.ast.Find( {param($a) $a -is [System.Management.Automation.Language.VariableExpressionAst]}, $true)
         $res = [AstTypeInference]::InferTypeOf( $variableAst)
 
         $res.Count | Should -Be 1
@@ -1040,7 +1040,7 @@ Describe "Type inference Tests" -tags "CI" {
     }
 
     It 'Infers type of variable $_ in hashtable from Array' {
-        $variableAst = { [int[]]::new(10) | Format-table @{n = 'x'; ex = {$_}}}.ast.Find( {param($a) $a -is [System.Management.Automation.Language.VariableExpressionAst]}, $true)
+        $variableAst = { [int[]]::new(10) | Format-Table @{n = 'x'; ex = {$_}}}.ast.Find( {param($a) $a -is [System.Management.Automation.Language.VariableExpressionAst]}, $true)
         $res = [AstTypeInference]::InferTypeOf( $variableAst)
 
         $res.Count | Should -Be 1
@@ -1048,7 +1048,7 @@ Describe "Type inference Tests" -tags "CI" {
     }
 
     It 'Infers type of variable $_ in hashtable from generic IEnumerable ' {
-        $variableAst = { [System.Collections.Generic.List[int]]::new() | Format-table @{n = 'x'; ex = {$_}}}.ast.Find( {param($a) $a -is [System.Management.Automation.Language.VariableExpressionAst]}, $true)
+        $variableAst = { [System.Collections.Generic.List[int]]::new() | Format-Table @{n = 'x'; ex = {$_}}}.ast.Find( {param($a) $a -is [System.Management.Automation.Language.VariableExpressionAst]}, $true)
         $res = [AstTypeInference]::InferTypeOf( $variableAst)
 
         $res.Count | Should -Be 1

--- a/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
+++ b/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
@@ -4,8 +4,8 @@
 Describe "Command Discovery tests" -Tags "CI" {
 
     BeforeAll {
-        setup -f testscript.ps1 -content "'This script should not run. Running from testscript.ps1'"
-        setup -f testscripp.ps1 -content "'This script should not run. Running from testscripp.ps1'"
+        Setup -f testscript.ps1 -Content "'This script should not run. Running from testscript.ps1'"
+        Setup -f testscripp.ps1 -Content "'This script should not run. Running from testscripp.ps1'"
 
         $TestCasesCommandNotFound = @(
                         @{command = 'CommandThatDoesnotExist' ; testName = 'Non-existent command'}
@@ -30,7 +30,7 @@ Describe "Command Discovery tests" -Tags "CI" {
             New-Item -Path "$TestDrive\\TestFunctionA\TestFunctionA.psm1" -Value "function TestFunctionA {}" | Out-Null
 
             $env:PSModulePath = "$TestDrive" + [System.IO.Path]::PathSeparator + "$TestDrive"
-            (Get-command 'TestFunctionA').count | Should -Be 1
+            (Get-Command 'TestFunctionA').count | Should -Be 1
         }
         finally
         {
@@ -83,7 +83,7 @@ Describe "Command Discovery tests" -Tags "CI" {
     }
 
     It "Get- is prepended to commands" {
-        (& 'location').Path | Should -Be (get-location).Path
+        (& 'location').Path | Should -Be (Get-Location).Path
     }
 
     Context "Use literal path first when executing scripts" {
@@ -94,17 +94,17 @@ Describe "Command Discovery tests" -Tags "CI" {
             $firstResult = "executing $firstFileName in root"
             $secondResult = "executing $secondFileName in root"
             $thirdResult = "executing $thirdFileName in root"
-            setup -f $firstFileName -content "'$firstResult'"
-            setup -f $secondFileName -content "'$secondResult'"
-            setup -f $thirdFileName -content "'$thirdResult'"
+            Setup -f $firstFileName -Content "'$firstResult'"
+            Setup -f $secondFileName -Content "'$secondResult'"
+            Setup -f $thirdFileName -Content "'$thirdResult'"
 
             $subFolder = 'subFolder'
             $firstFileInSubFolder = Join-Path $subFolder -ChildPath $firstFileName
             $secondFileInSubFolder = Join-Path $subFolder -ChildPath $secondFileName
             $thirdFileInSubFolder = Join-Path $subFolder -ChildPath $thirdFileName
-            setup -f $firstFileInSubFolder -content "'$firstResult'"
-            setup -f $secondFileInSubFolder -content "'$secondResult'"
-            setup -f $thirdFileInSubFolder -content "'$thirdResult'"
+            Setup -f $firstFileInSubFolder -Content "'$firstResult'"
+            Setup -f $secondFileInSubFolder -Content "'$secondResult'"
+            Setup -f $thirdFileInSubFolder -Content "'$thirdResult'"
 
             $secondFileSearchInSubfolder = (Join-Path -Path $subFolder -ChildPath '[t1].ps1')
 
@@ -176,9 +176,9 @@ Describe "Command Discovery tests" -Tags "CI" {
             $firstResult = '[first script]'
             $secondResult = 'alt script'
             $thirdResult = 'bad script'
-            setup -f '[test1].ps1' -content "'$firstResult'"
-            setup -f '1.ps1' -content "'$secondResult'"
-            setup -f '2.ps1' -content "'$thirdResult'"
+            Setup -f '[test1].ps1' -Content "'$firstResult'"
+            Setup -f '1.ps1' -Content "'$secondResult'"
+            Setup -f '2.ps1' -Content "'$thirdResult'"
 
             $gcmWithWildcardCases = @(
                 @{command = '.\?[tb]est1?.ps1'; expectedCommand = '[test1].ps1'; expectedCommandCount =1; name = '''.\?[tb]est1?.ps1'''}
@@ -223,7 +223,7 @@ Describe "Command Discovery tests" -Tags "CI" {
             (Get-Command -Name "ping" -CommandType Application).Name | Should -Match $expectedName
         }
 
-        It 'Can discover a native command with extension on Windows' -skip:(-not $IsWindows) {
+        It 'Can discover a native command with extension on Windows' -Skip:(-not $IsWindows) {
             (Get-Command -Name "ping.exe" -CommandType Application).Name | Should -Match "ping.exe"
         }
     }

--- a/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
+++ b/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
@@ -531,7 +531,7 @@ Describe "Verify approved aliases list" -Tags "CI" {
                 $currentCmdletList = & $getCommands $moduleList
             }
 
-            $commandList  = $commandString | ConvertFrom-CSV -Delimiter ","
+            $commandList  = $commandString | ConvertFrom-Csv -Delimiter ","
             $aliasFullList  = $commandList | Where-Object { $_.Present -eq "True" -and $_.CommandType -eq "Alias"  }
     }
 

--- a/test/powershell/engine/Basic/Encoding.Tests.ps1
+++ b/test/powershell/engine/Basic/Encoding.Tests.ps1
@@ -45,7 +45,7 @@ Describe "File encoding tests" -Tag CI {
             }
         }
 
-        It "<command> produces correct content '<Expected>'" -Testcases $simpleTestCases {
+        It "<command> produces correct content '<Expected>'" -TestCases $simpleTestCases {
             param ( $Command, $parameters, $Expected, $Operator)
             & $command @parameters
             $bytes = Get-FileBytes $outputFile

--- a/test/powershell/engine/Basic/GroupPolicySettings.Tests.ps1
+++ b/test/powershell/engine/Basic/GroupPolicySettings.Tests.ps1
@@ -29,8 +29,8 @@ Describe 'Group policy settings tests' -Tag CI,RequireAdminOnWindows {
         }
 
         AfterEach {
-            Remove-item $KeyRoot -Recurse -Force > $null
-            Remove-item $WinPSKeyRoot -Recurse -Force > $null
+            Remove-Item $KeyRoot -Recurse -Force > $null
+            Remove-Item $WinPSKeyRoot -Recurse -Force > $null
         }
 
         It 'Execution policy test' {
@@ -82,7 +82,7 @@ Describe 'Group policy settings tests' -Tag CI,RequireAdminOnWindows {
 
                 (Get-Module $ModuleToLog).LogPipelineExecutionDetails = $false # turn off logging
                 Remove-ItemProperty -Path $KeyPath -Name EnableModuleLogging -Force # turn off GP setting
-                Remove-item $ModuleNamesKeyPath -Recurse -Force
+                Remove-Item $ModuleNamesKeyPath -Recurse -Force
                 # usually event becomes visible in the log after ~500 ms
                 # set timeout for 5 seconds
                 Wait-UntilTrue -sb { Get-WinEvent -FilterHashtable @{ ProviderName="PowerShellCore"; Id = 4103 } -MaxEvents 5 | ? {$_.Message.Contains($RareCommand)} } -TimeoutInMilliseconds (5*1000) -IntervalInMilliseconds 100 | Should -BeTrue
@@ -143,14 +143,14 @@ Describe 'Group policy settings tests' -Tag CI,RequireAdminOnWindows {
             {
                 param([string]$KeyPath)
 
-                $OutputDirectory = Join-path $([System.IO.Path]::GetTempPath()) $(Get-Random)
+                $OutputDirectory = Join-Path $([System.IO.Path]::GetTempPath()) $(Get-Random)
                 $null = New-Item -Type Directory -Path $OutputDirectory -Force
 
                 Set-ItemProperty -Path $KeyPath -Name EnableTranscripting -Value 1 -Force
                 Set-ItemProperty -Path $KeyPath -Name OutputDirectory -Value $OutputDirectory -Force
                 Set-ItemProperty -Path $KeyPath -Name EnableInvocationHeader -Value 1 -Force
 
-                $number = get-random
+                $number = Get-Random
                 $null = & "$PSHOME/pwsh" -NoProfile -NonInteractive -c "$number"
 
                 Remove-ItemProperty -Path $KeyPath -Name OutputDirectory -Force
@@ -182,7 +182,7 @@ Describe 'Group policy settings tests' -Tag CI,RequireAdminOnWindows {
             {
                 param([string]$KeyPath)
 
-                $HelpPath = Join-path 'TestDrive:\' $(Get-Random)
+                $HelpPath = Join-Path 'TestDrive:\' $(Get-Random)
                 $null = New-Item -Type Directory -Path $HelpPath -ErrorAction SilentlyContinue
                 $ModuleName = 'Microsoft.PowerShell.Utility'
                 Save-Help -Module $ModuleName -DestinationPath $HelpPath -Force
@@ -213,8 +213,8 @@ Describe 'Group policy settings tests' -Tag CI,RequireAdminOnWindows {
 
             TestFeature -KeyPath $WinKeyPath
 
-            Remove-item $HKLM_KeyRoot -Recurse -Force
-            Remove-item $HKLM_WinPSKeyRoot -Recurse -Force
+            Remove-Item $HKLM_KeyRoot -Recurse -Force
+            Remove-Item $HKLM_WinPSKeyRoot -Recurse -Force
         }
 
         It 'Session configuration policy test' {
@@ -223,7 +223,7 @@ Describe 'Group policy settings tests' -Tag CI,RequireAdminOnWindows {
                 param([string]$KeyPath)
 
                 # set policy to use unique non-existing configuration session name
-                $SessionName = "TestSessionConfiguration-$(get-random)"
+                $SessionName = "TestSessionConfiguration-$(Get-Random)"
                 Set-ItemProperty -Path $KeyPath -Name EnableConsoleSessionConfiguration -Value 1 -Force
                 Set-ItemProperty -Path $KeyPath -Name ConsoleSessionConfigurationName -Value $SessionName -Force
 

--- a/test/powershell/engine/Cdxml/Cdxml.Tests.ps1
+++ b/test/powershell/engine/Cdxml/Cdxml.Tests.ps1
@@ -75,16 +75,16 @@ Describe "Cdxml cmdlets are supported" -Tag CI,RequireAdminOnWindows {
 
         # now load the cdxml module
         if ( Get-Module CimTest ) {
-            Remove-Module -force CimTest
+            Remove-Module -Force CimTest
         }
-        Import-Module -force ${script:ModuleDir}
+        Import-Module -Force ${script:ModuleDir}
     }
 
     AfterAll {
         if ( $skipNotWindows ) {
             return
         }
-        if ( get-module CimTest ) {
+        if ( Get-Module CimTest ) {
             Remove-Module CimTest -Force
         }
         $null = MofComp.exe $deleteMof
@@ -108,7 +108,7 @@ Describe "Cdxml cmdlets are supported" -Tag CI,RequireAdminOnWindows {
         It "The CimTest module should have the proper cmdlets" @ItSkipOrPending {
             $result = Get-Command -Module CimTest
             $result.Count | Should -Be 4
-            ($result.Name | sort-object ) -join "," | Should -Be "Get-CimTest,New-CimTest,Remove-CimTest,Set-CimTest"
+            ($result.Name | Sort-Object ) -join "," | Should -Be "Get-CimTest,New-CimTest,Remove-CimTest,Set-CimTest"
         }
     }
 
@@ -116,7 +116,7 @@ Describe "Cdxml cmdlets are supported" -Tag CI,RequireAdminOnWindows {
         It "The Get-CimTest cmdlet should return 4 objects" @ItSkipOrPending {
             $result = Get-CimTest
             $result.Count | Should -Be 4
-            ($result.id |sort-object) -join ","  | Should -Be "1,2,3,4"
+            ($result.id |Sort-Object) -join ","  | Should -Be "1,2,3,4"
         }
 
         It "The Get-CimTest cmdlet should retrieve an object via id" @ItSkipOrPending {
@@ -126,9 +126,9 @@ Describe "Cdxml cmdlets are supported" -Tag CI,RequireAdminOnWindows {
         }
 
         It "The Get-CimTest cmdlet should retrieve an object by piped id" @ItSkipOrPending {
-            $result = 1,2,4 | foreach-object { [pscustomobject]@{ id = $_ } } | Get-CimTest
+            $result = 1,2,4 | ForEach-Object { [pscustomobject]@{ id = $_ } } | Get-CimTest
             @($result).Count | Should -Be 3
-            ( $result.id | sort-object ) -join "," | Should -Be "1,2,4"
+            ( $result.id | Sort-Object ) -join "," | Should -Be "1,2,4"
         }
 
         It "The Get-CimTest cmdlet should retrieve an object by datetime" @ItSkipOrPending {
@@ -148,20 +148,20 @@ Describe "Cdxml cmdlets are supported" -Tag CI,RequireAdminOnWindows {
                 # wait up to 10 seconds, then the test will fail
                 # we need to wait long enough, but not too long
                 # the time can be adjusted
-                $null = Wait-Job -Job $job -timeout 10
+                $null = Wait-Job -Job $job -Timeout 10
                 $result = $job | Receive-Job
                 $result.Count | Should -Be 4
-                ( $result.id | sort-object ) -join "," | Should -Be "1,2,3,4"
+                ( $result.id | Sort-Object ) -join "," | Should -Be "1,2,3,4"
             }
             finally {
                 if ( $job ) {
-                    $job | Remove-Job -force
+                    $job | Remove-Job -Force
                 }
             }
         }
 
         It "Should be possible to invoke a method on an object returned by Get-CimTest" @ItSkipOrPending {
-            $result = Get-CimTest | Select-Object -first 1
+            $result = Get-CimTest | Select-Object -First 1
             $result.GetCimSessionInstanceId() | Should -BeOfType guid
         }
     }
@@ -169,7 +169,7 @@ Describe "Cdxml cmdlets are supported" -Tag CI,RequireAdminOnWindows {
     Context "Remove-CimTest cmdlet" {
         BeforeEach {
             Get-CimTest | Remove-CimTest
-            1..4 | Foreach-Object { New-CimInstance -namespace root/default -class PSCore_Test1 -property @{
+            1..4 | ForEach-Object { New-CimInstance -Namespace root/default -class PSCore_Test1 -Property @{
                 id = "$_"
                 field1 = "field $_"
                 field2 = 10 * $_
@@ -181,14 +181,14 @@ Describe "Cdxml cmdlets are supported" -Tag CI,RequireAdminOnWindows {
             Remove-CimTest -id 1
             $result = Get-CimTest
             $result.Count | Should -Be 3
-            ($result.id |sort-object) -join ","  | Should -Be "2,3,4"
+            ($result.id |Sort-Object) -join ","  | Should -Be "2,3,4"
         }
 
         It "The Remove-CimTest cmdlet should remove piped objects" @ItSkipOrPending {
             Get-CimTest -id 2 | Remove-CimTest
             $result  = Get-CimTest
             @($result).Count | Should -Be 3
-            ($result.id |sort-object) -join ","  | Should -Be "1,3,4"
+            ($result.id |Sort-Object) -join ","  | Should -Be "1,3,4"
         }
 
         It "The Remove-CimTest cmdlet should work as a job" @ItSkipOrPending {
@@ -201,11 +201,11 @@ Describe "Cdxml cmdlets are supported" -Tag CI,RequireAdminOnWindows {
                 $null = Wait-Job -Job $job -Timeout 10
                 $result  = Get-CimTest
                 @($result).Count | Should -Be 3
-                ($result.id |sort-object) -join ","  | Should -Be "1,2,4"
+                ($result.id |Sort-Object) -join ","  | Should -Be "1,2,4"
             }
             finally {
                 if ( $job ) {
-                    $job | Remove-Job -force
+                    $job | Remove-Job -Force
                 }
             }
         }
@@ -219,7 +219,7 @@ Describe "Cdxml cmdlets are supported" -Tag CI,RequireAdminOnWindows {
                 field2 = 0
             }
             New-CimTest @instanceArgs
-            $result = Get-CimInstance -namespace root/default -class PSCore_Test1 | Where-Object {$_.id -eq "telephone"}
+            $result = Get-CimInstance -Namespace root/default -class PSCore_Test1 | Where-Object {$_.id -eq "telephone"}
             $result.field2 | Should -Be 0
             $result.field1 | Should -Be $instanceArgs.field1
         }

--- a/test/powershell/engine/ETS/Adapter.Tests.ps1
+++ b/test/powershell/engine/ETS/Adapter.Tests.ps1
@@ -21,7 +21,7 @@ Describe "Adapter Tests" -tags "CI" {
             $testmethod = [TestCodeMethodClass].GetMethod("TestCodeMethod")
             $psmemberset | Add-Member -MemberType CodeMethod -Name TestCodeMethod -Value $testmethod
 
-            $document = new-object System.Xml.XmlDocument
+            $document = New-Object System.Xml.XmlDocument
             $document.LoadXml("<book ISBN='12345'><title>Pride And Prejudice</title><price>19.95</price></book>")
             $doc = $document.DocumentElement
         }

--- a/test/powershell/engine/ETS/CimAdapter.Tests.ps1
+++ b/test/powershell/engine/ETS/CimAdapter.Tests.ps1
@@ -20,7 +20,7 @@ try {
             if ( ! $IsWindows ) {
                 return
             }
-            $p = get-ciminstance win32_process |Select-object -first 1
+            $p = Get-CimInstance win32_process |Select-Object -First 1
 
             $indexOf_namespaceQualified_Win32Process            = getIndex $p.PSTypeNames "*root?cimv2?Win32_Process"
             $indexOf_namespaceQualified_CimProcess              = getIndex $p.PSTypeNames "*root?cimv2?CIM_Process"
@@ -36,7 +36,7 @@ try {
             $PSDefaultParameterValues.Remove("it:pending")
         }
 
-        It "Namespace-qualified Win32_Process is present" -skip:(!$IsWindows) {
+        It "Namespace-qualified Win32_Process is present" -Skip:(!$IsWindows) {
             $indexOf_namespaceQualified_Win32Process | Should -Not -Be (-1)
         }
         It "Namespace-qualified CIM_Process is present" {
@@ -49,7 +49,7 @@ try {
             $indexOf_namespaceQualified_CimManagedSystemElement | Should -Not -Be (-1)
         }
 
-        It "Classname of Win32_Process is present" -skip:(!$IsWindows) {
+        It "Classname of Win32_Process is present" -Skip:(!$IsWindows) {
             $indexOf_className_Win32Process | Should -Not -Be (-1)
         }
         It "Classname of CIM_Process is present" {
@@ -62,7 +62,7 @@ try {
             $indexOf_className_CimManagedSystemElement | Should -Not -Be (-1)
         }
 
-        It "Win32_Process comes after CIM_Process (namespace qualified)" -skip:(!$IsWindows) {
+        It "Win32_Process comes after CIM_Process (namespace qualified)" -Skip:(!$IsWindows) {
             $indexOf_namespaceQualified_Win32Process | Should -BeLessThan $indexOf_namespaceQualified_CimProcess
         }
         It "CIM_Process comes after CIM_LogicalElement (namespace qualified)" {
@@ -72,7 +72,7 @@ try {
             $indexOf_namespaceQualified_CimLogicalElement | Should -BeLessThan $indexOf_namespaceQualified_CimManagedSystemElement
         }
 
-        It "Win32_Process comes after CIM_Process (classname only)" -skip:(!$IsWindows) {
+        It "Win32_Process comes after CIM_Process (classname only)" -Skip:(!$IsWindows) {
             $indexOf_className_Win32Process | Should -BeLessThan $indexOf_className_CimProcess
         }
         It "CIM_Process comes after CIM_LogicalElement (classname only)" {
@@ -82,7 +82,7 @@ try {
             $indexOf_className_CimLogicalElement | Should -BeLessThan $indexOf_className_CimManagedSystemElement
         }
 
-        It "Namespace qualified PSTypenames comes after class-only PSTypeNames" -skip:(!$IsWindows) {
+        It "Namespace qualified PSTypenames comes after class-only PSTypeNames" -Skip:(!$IsWindows) {
             $indexOf_namespaceQualified_CimManagedSystemElement | Should -BeLessThan $indexOf_className_Win32Process
         }
     }

--- a/test/powershell/engine/ETS/TypeTable.Tests.ps1
+++ b/test/powershell/engine/ETS/TypeTable.Tests.ps1
@@ -30,7 +30,7 @@ Describe "Built-in type information tests" -Tag "CI" {
     }
 
     It "Should have expected member info for 'System.Diagnostics.ProcessModule'" {
-        $typeData = $types | Where-Object TypeName -eq "System.Diagnostics.ProcessModule"
+        $typeData = $types | Where-Object TypeName -EQ "System.Diagnostics.ProcessModule"
         $typeData | Should -Not -BeNullOrEmpty
 
         $typeData.Members.Count | Should -BeExactly 6
@@ -86,7 +86,7 @@ Describe "Built-in type information tests" -Tag "CI" {
     }
 
     It "Should have expected member info for 'System.Management.Automation.ParameterSetMetadata'" {
-        $typeData = $types | Where-Object TypeName -eq "System.Management.Automation.ParameterSetMetadata"
+        $typeData = $types | Where-Object TypeName -EQ "System.Management.Automation.ParameterSetMetadata"
         $typeData | Should -Not -BeNullOrEmpty
 
         $typeData.Members.Count | Should -BeExactly 1
@@ -112,7 +112,7 @@ Describe "Built-in type information tests" -Tag "CI" {
     }
 
     It "Should have expected member info for 'System.Management.Automation.JobStateEventArgs'" {
-        $typeData = $types | Where-Object TypeName -eq "System.Management.Automation.JobStateEventArgs"
+        $typeData = $types | Where-Object TypeName -EQ "System.Management.Automation.JobStateEventArgs"
         $typeData | Should -Not -BeNullOrEmpty
 
         $typeData.Members.Count | Should -BeExactly 0

--- a/test/powershell/engine/Formatting/ErrorView.Tests.ps1
+++ b/test/powershell/engine/Formatting/ErrorView.Tests.ps1
@@ -49,7 +49,7 @@ Describe 'Tests for $ErrorView' -Tag CI {
         }
 
         It "Remote errors show up correctly" {
-            Start-Job -ScriptBlock { get-item (new-guid) } | Wait-Job | Receive-Job -ErrorVariable e -ErrorAction SilentlyContinue
+            Start-Job -ScriptBlock { Get-Item (New-Guid) } | Wait-Job | Receive-Job -ErrorVariable e -ErrorAction SilentlyContinue
             ($e | Out-String).Trim().Count | Should -Be 1
         }
 
@@ -59,7 +59,7 @@ Describe 'Tests for $ErrorView' -Tag CI {
         }
 
         It "Function shows up correctly" {
-            function test-myerror { [cmdletbinding()] param() write-error 'myError' }
+            function test-myerror { [cmdletbinding()] param() Write-Error 'myError' }
 
             $e = & "$PSHOME/pwsh" -noprofile -command 'function test-myerror { [cmdletbinding()] param() write-error "myError" }; test-myerror -ErrorAction SilentlyContinue; $error[0] | Out-String'
             [string]::Join('', $e).Trim() | Should -BeLike "*test-myerror:*myError*" # wildcard due to VT100

--- a/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
@@ -89,8 +89,8 @@ Describe 'Get-Help -Online opens the default web browser and navigates to the cm
         }
     }
 
-    It "Get-Help get-process -online" -skip:$skipTest {
-        { Get-Help get-process -online } | Should -Not -Throw
+    It "Get-Help get-process -online" -Skip:$skipTest {
+        { Get-Help get-process -Online } | Should -Not -Throw
     }
 }
 
@@ -98,7 +98,7 @@ Describe 'Get-Help -Online is not supported on Nano Server and IoT' -Tags "CI" {
 
     $skipTest = -not ([System.Management.Automation.Platform]::IsIoT -or [System.Management.Automation.Platform]::IsNanoServer)
 
-    It "Get-help -online <cmdletName> throws InvalidOperation." -skip:$skipTest {
+    It "Get-help -online <cmdletName> throws InvalidOperation." -Skip:$skipTest {
         { Get-Help Get-Help -Online } | Should -Throw -ErrorId "InvalidOperation,Microsoft.PowerShell.Commands.GetHelpCommand"
     }
 }

--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -60,7 +60,7 @@ Describe "Validate that the Help function can Run in strict mode" -Tags @('CI') 
         $help = & {
             # run in nested scope to keep strict mode from affecting other tests
             Set-StrictMode -Version 3.0
-            Help
+            help
         }
         # the help function renders the help content as text so just verify that there is content
         $help | Should -Not -BeNullOrEmpty
@@ -91,7 +91,7 @@ Describe "Validate that get-help works for CurrentUserScope" -Tags @('CI') {
 
         It "Validate -Description and -Examples sections in help content. Run 'Get-help -name <cmdletName>" -TestCases $testCases {
             param($cmdletName)
-            $help = get-help -name $cmdletName
+            $help = Get-Help -Name $cmdletName
             $help.Description | Out-String | Should -Match $cmdletName
             $help.Examples | Out-String | Should -Match $cmdletName
         }
@@ -135,7 +135,7 @@ Describe "Validate that get-help works for AllUsers Scope" -Tags @('Feature', 'R
 
         It "Validate -Description and -Examples sections in help content. Run 'Get-help -name <cmdletName>" -TestCases $testCases -Skip:(!(Test-CanWriteToPsHome)) {
             param($cmdletName)
-            $help = get-help -name $cmdletName
+            $help = Get-Help -Name $cmdletName
             $help.Description | Out-String | Should -Match $cmdletName
             $help.Examples | Out-String | Should -Match $cmdletName
         }

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -347,7 +347,7 @@ Describe "Validate Update-Help from the Web for one PowerShell module." -Tags @(
         $ProgressPreference = $SavedProgressPreference
     }
 
-    RunUpdateHelpTests -tag "CI" -Scope 'AllUsers'
+    RunUpdateHelpTests -Tag "CI" -Scope 'AllUsers'
 }
 
 Describe "Validate Update-Help from the Web for one PowerShell module for user scope." -Tags @('CI', 'RequireAdminOnWindows', 'RequireSudoOnUnix') {
@@ -359,7 +359,7 @@ Describe "Validate Update-Help from the Web for one PowerShell module for user s
         $ProgressPreference = $SavedProgressPreference
     }
 
-    RunUpdateHelpTests -tag "CI" -Scope 'CurrentUser'
+    RunUpdateHelpTests -Tag "CI" -Scope 'CurrentUser'
 }
 
 Describe "Validate Update-Help from the Web for all PowerShell modules." -Tags @('Feature', 'RequireAdminOnWindows', 'RequireSudoOnUnix') {
@@ -371,7 +371,7 @@ Describe "Validate Update-Help from the Web for all PowerShell modules." -Tags @
         $ProgressPreference = $SavedProgressPreference
     }
 
-    RunUpdateHelpTests -tag "Feature" -Scope 'AllUsers'
+    RunUpdateHelpTests -Tag "Feature" -Scope 'AllUsers'
 }
 
 Describe "Validate Update-Help from the Web for all PowerShell modules for user scope." -Tags @('Feature', 'RequireAdminOnWindows', 'RequireSudoOnUnix') {
@@ -383,7 +383,7 @@ Describe "Validate Update-Help from the Web for all PowerShell modules for user 
         $ProgressPreference = $SavedProgressPreference
     }
 
-    RunUpdateHelpTests -tag "Feature" -Scope 'CurrentUser'
+    RunUpdateHelpTests -Tag "Feature" -Scope 'CurrentUser'
 }
 
 Describe "Validate Update-Help -SourcePath for one PowerShell module." -Tags @('CI', 'RequireAdminOnWindows', 'RequireSudoOnUnix') {
@@ -395,7 +395,7 @@ Describe "Validate Update-Help -SourcePath for one PowerShell module." -Tags @('
         $ProgressPreference = $SavedProgressPreference
     }
 
-    RunUpdateHelpTests -tag "CI" -useSourcePath -Scope 'AllUsers'
+    RunUpdateHelpTests -Tag "CI" -useSourcePath -Scope 'AllUsers'
 }
 
 Describe "Validate Update-Help -SourcePath for one PowerShell module for user scope." -Tags @('CI', 'RequireAdminOnWindows', 'RequireSudoOnUnix') {
@@ -407,7 +407,7 @@ Describe "Validate Update-Help -SourcePath for one PowerShell module for user sc
         $ProgressPreference = $SavedProgressPreference
     }
 
-    RunUpdateHelpTests -tag "CI" -useSourcePath -Scope 'CurrentUser'
+    RunUpdateHelpTests -Tag "CI" -useSourcePath -Scope 'CurrentUser'
 }
 
 Describe "Validate Update-Help -SourcePath for all PowerShell modules." -Tags @('Feature', 'RequireAdminOnWindows', 'RequireSudoOnUnix') {
@@ -419,7 +419,7 @@ Describe "Validate Update-Help -SourcePath for all PowerShell modules." -Tags @(
         $ProgressPreference = $SavedProgressPreference
     }
 
-    RunUpdateHelpTests -tag "Feature" -useSourcePath -Scope 'AllUsers'
+    RunUpdateHelpTests -Tag "Feature" -useSourcePath -Scope 'AllUsers'
 }
 
 Describe "Validate Update-Help -SourcePath for all PowerShell modules for user scope." -Tags @('Feature', 'RequireAdminOnWindows', 'RequireSudoOnUnix') {
@@ -431,7 +431,7 @@ Describe "Validate Update-Help -SourcePath for all PowerShell modules for user s
         $ProgressPreference = $SavedProgressPreference
     }
 
-    RunUpdateHelpTests -tag "Feature" -useSourcePath -Scope 'CurrentUser'
+    RunUpdateHelpTests -Tag "Feature" -useSourcePath -Scope 'CurrentUser'
 }
 
 Describe "Validate 'Save-Help -DestinationPath for one PowerShell modules." -Tags @('CI', 'RequireAdminOnWindows') {
@@ -442,7 +442,7 @@ Describe "Validate 'Save-Help -DestinationPath for one PowerShell modules." -Tag
     AfterAll {
         $ProgressPreference = $SavedProgressPreference
     }
-    RunSaveHelpTests -tag "CI"
+    RunSaveHelpTests -Tag "CI"
 }
 
 Describe "Validate 'Save-Help -DestinationPath for all PowerShell modules." -Tags @('Feature', 'RequireAdminOnWindows') {
@@ -453,5 +453,5 @@ Describe "Validate 'Save-Help -DestinationPath for all PowerShell modules." -Tag
     AfterAll {
         $ProgressPreference = $SavedProgressPreference
     }
-    RunSaveHelpTests -tag "Feature"
+    RunSaveHelpTests -Tag "Feature"
 }

--- a/test/powershell/engine/Job/Jobs.Tests.ps1
+++ b/test/powershell/engine/Job/Jobs.Tests.ps1
@@ -6,7 +6,7 @@ Describe 'Basic Job Tests' -Tags 'Feature' {
         # Make sure we do not have any jobs running
         Get-Job | Remove-Job -Force
         $timeBeforeStartedJob = Get-Date
-        $startedJob = Start-Job -Name 'StartedJob' -ScriptBlock { 1 + 1 } | Wait-Job
+        $startedJob = Start-Job -Name 'StartedJob' -Scriptblock { 1 + 1 } | Wait-Job
         $timeAfterStartedJob = Get-Date
 
         function script:ValidateJobInfo($job, $state, $hasMoreData, $command)
@@ -114,7 +114,7 @@ Describe 'Basic Job Tests' -Tags 'Feature' {
 
         It "Create job with native command" {
             try {
-                $nativeJob = Start-job { & "$PSHOME/pwsh" -c 1+1 }
+                $nativeJob = Start-Job { & "$PSHOME/pwsh" -c 1+1 }
                 $nativeJob | Wait-Job
                 $nativeJob.State | Should -BeExactly "Completed"
                 $nativeJob.HasMoreData | Should -BeTrue
@@ -315,7 +315,7 @@ Describe 'Basic Job Tests' -Tags 'Feature' {
 
         BeforeEach {
             # 20 seconds is chosen to be large, so that the job is in running state when Stop-Job is called.
-            $jobToStop = Start-Job -ScriptBlock {
+            $jobToStop = Start-Job -Scriptblock {
                 1..80 | ForEach-Object {
                     Write-Output $_
                     Start-Sleep -Milliseconds 250

--- a/test/powershell/engine/Module/TestModuleManifest.Tests.ps1
+++ b/test/powershell/engine/Module/TestModuleManifest.Tests.ps1
@@ -160,7 +160,7 @@ Describe "Tests for circular references in required modules" -tags "CI" {
             $ModuleVersion = '3.0'
             $GUID = New-Guid
 
-            New-ModuleManifest ((join-path $moduleDir.Name $moduleDir.Name) + ".psd1") -RequiredModules $RequiredModulesSpecs -ModuleVersion $ModuleVersion -Guid $GUID
+            New-ModuleManifest ((Join-Path $moduleDir.Name $moduleDir.Name) + ".psd1") -RequiredModules $RequiredModulesSpecs -ModuleVersion $ModuleVersion -Guid $GUID
 
             $lastItem = @{ ModuleName = $moduleDir.Name}
             if ($AddVersion) {$lastItem += @{ ModuleVersion = $ModuleVersion}}
@@ -185,7 +185,7 @@ Describe "Tests for circular references in required modules" -tags "CI" {
                 $RequiredModulesSpecs = $lastItem.ModuleName
             }
 
-            New-ModuleManifest ((join-path $firstModuleName $firstModuleName) + ".psd1") -RequiredModules $RequiredModulesSpecs -ModuleVersion $firstModuleVersion -Guid $firstModuleGuid
+            New-ModuleManifest ((Join-Path $firstModuleName $firstModuleName) + ".psd1") -RequiredModules $RequiredModulesSpecs -ModuleVersion $firstModuleVersion -Guid $firstModuleGuid
         }
     }
 
@@ -250,7 +250,7 @@ Describe "Test-ModuleManifest Performance bug followup" -tags "CI" {
 
     It "Test-ModuleManifest should not load unnessary modules" -Skip:(!(Test-CanWriteToPsHome)) {
 
-        $job = start-job -name "job1" -ScriptBlock {test-modulemanifest "$using:PSHomeModulesPath\ModuleWithDependencies2\2.0\ModuleWithDependencies2.psd1" -verbose} | Wait-Job
+        $job = Start-Job -Name "job1" -ScriptBlock {Test-ModuleManifest "$using:PSHomeModulesPath\ModuleWithDependencies2\2.0\ModuleWithDependencies2.psd1" -Verbose} | Wait-Job
 
         $verbose = $job.ChildJobs[0].Verbose.ReadAll()
         # Before the fix, all modules under $PSHOME will be imported and will be far more than 15 verbose messages. However, we cannot fix the number in case verbose message may vary.

--- a/test/powershell/engine/Remoting/PSSession.Tests.ps1
+++ b/test/powershell/engine/Remoting/PSSession.Tests.ps1
@@ -60,12 +60,12 @@ Describe "SkipCACheck and SkipCNCheck PSSession options are required for New-PSS
         },
         @{
             Name = 'Verifies expected error when SkipCACheck option is missing'
-            ScriptBlock = { New-PSSession -cn localhost -Credential $cred -Authentication Basic -UseSSl -SessionOption $soSkipCN }
+            ScriptBlock = { New-PSSession -cn localhost -Credential $cred -Authentication Basic -UseSSL -SessionOption $soSkipCN }
             ExpectedErrorCode = 825
         },
         @{
             Name = 'Verifies expected error when SkipCNCheck option is missing'
-            ScriptBlock = { New-PSSession -cn localhost -Credential $cred -Authentication Basic -UseSSl -SessionOption $soSkipCA }
+            ScriptBlock = { New-PSSession -cn localhost -Credential $cred -Authentication Basic -UseSSL -SessionOption $soSkipCA }
             ExpectedErrorCode = 825
         }
     )

--- a/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
+++ b/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
@@ -21,7 +21,7 @@ Describe "New-PSSession basic test" -Tag @("CI") {
 }
 
 Describe "Basic Auth over HTTP not allowed on Unix" -Tag @("CI") {
-    It "New-PSSession should throw when specifying Basic Auth over HTTP on Unix" -skip:($IsWindows) {
+    It "New-PSSession should throw when specifying Basic Auth over HTTP on Unix" -Skip:($IsWindows) {
         $platformInfo = Get-PlatformInfo
         if (
             ($platformInfo.Platform -match "alpine|raspbian") -or
@@ -42,7 +42,7 @@ Describe "Basic Auth over HTTP not allowed on Unix" -Tag @("CI") {
         $err.Exception.ErrorCode | Should -Be 801
     }
 
-    It "New-PSSession should NOT throw a ConnectFailed exception when specifying Basic Auth over HTTPS on Unix" -skip:($IsWindows) {
+    It "New-PSSession should NOT throw a ConnectFailed exception when specifying Basic Auth over HTTPS on Unix" -Skip:($IsWindows) {
         $platformInfo = Get-PlatformInfo
         if (
             ($platformInfo.Platform -match "alpine|raspbian") -or

--- a/test/powershell/engine/Remoting/SSHRemotingCmdlets.Tests.ps1
+++ b/test/powershell/engine/Remoting/SSHRemotingCmdlets.Tests.ps1
@@ -11,7 +11,7 @@ Describe "SSHTransport switch parameter value" -Tags 'Feature' {
         $TestCasesSSHTransport = @(
             @{scriptBlock = {New-PSSession -HostName localhost -UserName UserA -SSHTransport:$false}; testName = 'New-PSSession SSHTransport parameter cannot have false value'}
             @{scriptBlock = {Enter-PSSession -HostName localhost -UserName UserA -SSHTransport:$false}; testName = 'Enter-PSSession SSHTransport parameter cannot have false value'}
-            @{scriptBlock = {Invoke-Command -ScriptBlock {"Hello"} -HostName localhost -UserName UserA -SSHTransport:$false}; testName = 'Invoke-Command SSHTransport parameter cannot have false value'}
+            @{scriptBlock = {Invoke-Command -Scriptblock {"Hello"} -HostName localhost -UserName UserA -SSHTransport:$false}; testName = 'Invoke-Command SSHTransport parameter cannot have false value'}
         )
     }
 

--- a/test/powershell/engine/ResourceValidation/CimCmdletsResources.Tests.ps1
+++ b/test/powershell/engine/ResourceValidation/CimCmdletsResources.Tests.ps1
@@ -10,7 +10,7 @@ $excludeList = @()
 # load the module since it isn't there by default
 if ( $IsWindows )
 {
-    import-module CimCmdlets
+    Import-Module CimCmdlets
 }
 
 # run the tests

--- a/test/powershell/engine/ResourceValidation/SecurityResources.Tests.ps1
+++ b/test/powershell/engine/ResourceValidation/SecurityResources.Tests.ps1
@@ -8,7 +8,7 @@ $assemblyName = "Microsoft.PowerShell.Security"
 # entries in the csproj for the assembly
 $excludeList = @("SecurityMshSnapinResources.resx")
 # load the module since it isn't there by default
-import-module Microsoft.PowerShell.Security
+Import-Module Microsoft.PowerShell.Security
 
 # run the tests
 Test-ResourceStrings -AssemblyName $AssemblyName -ExcludeList $excludeList

--- a/test/powershell/engine/ResourceValidation/TestRunner.ps1
+++ b/test/powershell/engine/ResourceValidation/TestRunner.ps1
@@ -35,7 +35,7 @@ function Test-ResourceStrings
     #
     # This is the reason why this is not a general module for use. There is
     # no other way to run these tests
-    Describe "Resources strings in $AssemblyName (was -ResGen used with Start-PSBuild)" -tag Feature {
+    Describe "Resources strings in $AssemblyName (was -ResGen used with Start-PSBuild)" -Tag Feature {
 
         function NormalizeLineEnd
         {

--- a/test/powershell/engine/ResourceValidation/UtilityResources.Tests.ps1
+++ b/test/powershell/engine/ResourceValidation/UtilityResources.Tests.ps1
@@ -15,6 +15,6 @@ $excludeList = "CoreMshSnapinResources.resx",
     "ConvertStringResources.resx",
     "FlashExtractStrings.resx",
     "ImmutableStrings.resx"
-import-module Microsoft.Powershell.Utility
+Import-Module Microsoft.Powershell.Utility
 # run the tests
 Test-ResourceStrings -AssemblyName $AssemblyName -ExcludeList $excludeList

--- a/test/powershell/engine/ResourceValidation/WSManResources.Tests.ps1
+++ b/test/powershell/engine/ResourceValidation/WSManResources.Tests.ps1
@@ -9,7 +9,7 @@ $assemblyName = "Microsoft.WSMan.Management"
 $excludeList = @()
 # load the module since it isn't there by default
 if ( $IsWindows ) {
-    import-module Microsoft.WSMan.Management
+    Import-Module Microsoft.WSMan.Management
 }
 
 # run the tests

--- a/test/shebang/script.ps1
+++ b/test/shebang/script.ps1
@@ -1,5 +1,5 @@
 #!/usr/bin/env powershell
 
-get-process
-get-module
+Get-Process
+Get-Module
 

--- a/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
+++ b/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
@@ -178,21 +178,21 @@ try
     {
         Remove-Item $CoverageZipFilePath -Force
     }
-    Invoke-WebRequest -uri $codeCoverageZip -outfile "$outputBaseFolder\PSCodeCoverage.zip"
+    Invoke-WebRequest -Uri $codeCoverageZip -OutFile "$outputBaseFolder\PSCodeCoverage.zip"
 
     $TestsZipFilePath = "$outputBaseFolder\tests.zip"
     if(Test-Path $TestsZipFilePath)
     {
         Remove-Item $TestsZipFilePath -Force
     }
-    Invoke-WebRequest -uri $testContentZip -outfile $TestsZipFilePath
+    Invoke-WebRequest -Uri $testContentZip -OutFile $TestsZipFilePath
 
     $OpenCoverZipFilePath = "$outputBaseFolder\OpenCover.zip"
     if(Test-Path $OpenCoverZipFilePath)
     {
         Remove-Item $OpenCoverZipFilePath -Force
     }
-    Invoke-WebRequest -uri $openCoverZip -outfile $OpenCoverZipFilePath
+    Invoke-WebRequest -Uri $openCoverZip -OutFile $OpenCoverZipFilePath
 
     Write-LogPassThru -Message "Downloads complete. Starting expansion"
 
@@ -200,19 +200,19 @@ try
     {
         Remove-Item -Force -Recurse $psBinPath
     }
-    Expand-Archive -path $CoverageZipFilePath -destinationpath "$psBinPath" -Force
+    Expand-Archive -Path $CoverageZipFilePath -DestinationPath "$psBinPath" -Force
 
     if(Test-Path $testRootPath)
     {
         Remove-Item -Force -Recurse $testRootPath
     }
-    Expand-Archive -path $TestsZipFilePath -destinationpath $testRootPath -Force
+    Expand-Archive -Path $TestsZipFilePath -DestinationPath $testRootPath -Force
 
     if(Test-Path $openCoverPath)
     {
         Remove-Item -Force -Recurse $openCoverPath
     }
-    Expand-Archive -path $OpenCoverZipFilePath -destinationpath $openCoverPath -Force
+    Expand-Archive -Path $OpenCoverZipFilePath -DestinationPath $openCoverPath -Force
     Write-LogPassThru -Message "Expansion complete."
 
     if(Test-Path $elevatedLogs)
@@ -318,12 +318,12 @@ try
     }
     catch {
         ("ERROR: " + $_.ScriptStackTrace) | Write-LogPassThru
-        $_ 2>&1 | out-string -Stream | %{ "ERROR: $_" } | Write-LogPassThru
+        $_ 2>&1 | Out-String -Stream | %{ "ERROR: $_" } | Write-LogPassThru
     }
 
     if(Test-Path $outputLog)
     {
-        Write-LogPassThru -Message (get-childitem $outputLog).FullName
+        Write-LogPassThru -Message (Get-ChildItem $outputLog).FullName
     }
 
     Write-LogPassThru -Message "Test run done."

--- a/test/tools/Modules/HelpersCommon/HelpersCommon.psm1
+++ b/test/tools/Modules/HelpersCommon/HelpersCommon.psm1
@@ -42,7 +42,7 @@ function Test-IsElevated
         # on Windows we can determine whether we're executing in an
         # elevated context
         $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
-        $windowsPrincipal = new-object 'Security.Principal.WindowsPrincipal' $identity
+        $windowsPrincipal = New-Object 'Security.Principal.WindowsPrincipal' $identity
         if ($windowsPrincipal.IsInRole("Administrators") -eq 1)
         {
             $IsElevated = $true
@@ -209,7 +209,7 @@ function Send-VstsLogFile {
         $Path
     )
 
-    $logFolder = Join-Path -path $PWD -ChildPath 'logfile'
+    $logFolder = Join-Path -Path $PWD -ChildPath 'logfile'
     if(!(Test-Path -Path $logFolder))
     {
         $null = New-Item -Path $logFolder -ItemType Directory
@@ -222,13 +222,13 @@ function Send-VstsLogFile {
     if($Contents)
     {
         $logFile = Join-Path -Path $logFolder -ChildPath ([System.Io.Path]::GetRandomFileName() + "-$LogName.txt")
-        $name = Split-Path -leaf -Path $logFile
+        $name = Split-Path -Leaf -Path $logFile
 
-        $Contents | out-file -path $logFile -Encoding ascii
+        $Contents | Out-File -path $logFile -Encoding ascii
     }
     else
     {
-        $name = Split-Path -leaf -Path $path
+        $name = Split-Path -Leaf -Path $path
         $logFile = Join-Path -Path $logFolder -ChildPath ([System.Io.Path]::GetRandomFileName() + '-' + $name)
         Copy-Item -Path $Path -Destination $logFile
     }

--- a/test/tools/Modules/HelpersHostCS/HelpersHostCS.psm1
+++ b/test/tools/Modules/HelpersHostCS/HelpersHostCS.psm1
@@ -310,7 +310,7 @@ function New-TestHost
     }
 
     if ( ! ("TestHost.TestHost" -as "type" )) {
-       $t = add-Type -pass $definition -ref $references
+       $t = Add-Type -pass $definition -ref $references
     }
 
     [TestHost.TestHost]::New()

--- a/test/tools/Modules/HelpersSecurity/HelpersSecurity.psm1
+++ b/test/tools/Modules/HelpersSecurity/HelpersSecurity.psm1
@@ -50,7 +50,7 @@ if ($IsWindows)
     if (-not (Get-Command Invoke-LanguageModeTestingSupportCmdlet -ErrorAction Ignore))
     {
         $moduleName = Get-RandomFileName
-        $moduleDirectory = join-path $TestDrive\Modules $moduleName
+        $moduleDirectory = Join-Path $TestDrive\Modules $moduleName
         if (-not (Test-Path $moduleDirectory))
         {
             $null = New-Item -ItemType Directory $moduleDirectory -Force

--- a/test/tools/Modules/HttpListener/HttpListener.psm1
+++ b/test/tools/Modules/HttpListener/HttpListener.psm1
@@ -319,7 +319,7 @@ Function Start-HTTPListener {
             }
             catch
             {
-                $errormsg = $_ | convertto-json
+                $errormsg = $_ | ConvertTo-Json
                 Write-Error $errormsg
             }
             finally

--- a/test/tools/Modules/PSSysLog/PSSysLog.psm1
+++ b/test/tools/Modules/PSSysLog/PSSysLog.psm1
@@ -615,7 +615,7 @@ function Get-PSSysLog
     else
     {
         [string] $filter = [string]::Format(" {0}[", $id)
-        Get-Content @contentParms -filter {$_.Contains($filter)} | ConvertFrom-SysLog -Id $Id -After $After | Select-Object -First $maxItems
+        Get-Content @contentParms -Filter {$_.Contains($filter)} | ConvertFrom-SysLog -Id $Id -After $After | Select-Object -First $maxItems
     }
 }
 
@@ -811,7 +811,7 @@ function Get-PSOsLog
     {
         [string] $filter = [string]::Format("com.microsoft.powershell.{0}: (", $id)
         Write-Warning "this code path `Get-PSOsLog -TotalCount` should not be used if the message field is needed!"
-        Get-Content @contentParms -filter {$_.Contains($filter)} | Where-Object {![string]::IsNullOrEmpty($_)} | ConvertFrom-OsLog -Id $Id -After $After | Select-Object -First $maxItems
+        Get-Content @contentParms -Filter {$_.Contains($filter)} | Where-Object {![string]::IsNullOrEmpty($_)} | ConvertFrom-OsLog -Id $Id -After $After | Select-Object -First $maxItems
     }
 }
 
@@ -1009,7 +1009,7 @@ function Get-OsLogPersistence
         # Not configured
         # Expecting a format like the following:
         # Mode for 'com.microsoft.powershell'  PERSIST_DEFAULT
-        $result = new-object PSObject -Property @{
+        $result = New-Object PSObject -Property @{
             Level = 'DEFAULT'
             Persist = $parts[$parts.Length- 1]
             Enabled = $false
@@ -1019,7 +1019,7 @@ function Get-OsLogPersistence
     {
         # Expecting a format like the following:
         # Mode for 'com.microsoft.powershell'  INFO PERSIST_INFO
-        $result = new-object PSObject -Property @{
+        $result = New-Object PSObject -Property @{
             Level = $parts[$parts.Length - 2]
             Persist = $parts[$parts.Length -1]
             Enabled = $true
@@ -1077,7 +1077,7 @@ function Wait-PSWinEvent
 
         $recordsToReturn = @()
 
-        foreach ($thisRecord in (get-winevent -FilterHashtable $filterHashtable -Oldest 2> $null))
+        foreach ($thisRecord in (Get-WinEvent -FilterHashtable $filterHashtable -Oldest 2> $null))
         {
             if($PSCmdlet.ParameterSetName -eq "ByPropertyName")
             {

--- a/test/tools/Modules/WebListener/WebListener.psm1
+++ b/test/tools/Modules/WebListener/WebListener.psm1
@@ -120,7 +120,7 @@ function Start-WebListener
         }
 
         $initTimeoutSeconds  = 15
-        $appExe              = (get-command WebListener).Path
+        $appExe              = (Get-Command WebListener).Path
         $serverPfx           = 'ServerCert.pfx'
         $serverPfxPassword   = New-RandomHexString
         $clientPfx           = 'ClientCert.pfx'
@@ -134,7 +134,7 @@ function Start-WebListener
         New-ClientCertificate -CertificatePath $Script:ClientPfxPath -Password $Script:ClientPfxPassword
 
         $Job = Start-Job {
-            $path = Split-Path -parent (get-command WebListener).Path -Verbose
+            $path = Split-Path -Parent (Get-Command WebListener).Path -Verbose
             Push-Location $path -Verbose
             'appEXE: {0}' -f $using:appExe
             'serverPfxPath: {0}' -f $using:serverPfxPath

--- a/test/tools/OpenCover/OpenCover.psm1
+++ b/test/tools/OpenCover/OpenCover.psm1
@@ -129,8 +129,8 @@ function Format-FileCoverage
     PROCESS {
         $file = $CoverageData.Path
         $filepath = $file -replace "$oldBase","${newBase}"
-        if ( test-path $filepath ) {
-            $content = get-content $filepath
+        if ( Test-Path $filepath ) {
+            $content = Get-Content $filepath
             for($i = 0; $i -lt $content.length; $i++ ) {
                 if ( $CoverageData.Hit -contains ($i+1)) {
                     $sign = "+"
@@ -142,9 +142,9 @@ function Format-FileCoverage
                     $sign = " "
                 }
                 $outputline = "{0:0000} {1} {2}" -f ($i+1),$sign,$content[$i]
-                if ( $sign -eq "+" ) { write-host -fore green $outputline }
-                elseif ( $sign -eq "-" ) { write-host -fore red $outputline }
-                else { write-host -fore white $outputline }
+                if ( $sign -eq "+" ) { Write-Host -fore green $outputline }
+                elseif ( $sign -eq "-" ) { Write-Host -fore red $outputline }
+                else { Write-Host -fore white $outputline }
             }
         }
         else {
@@ -158,7 +158,7 @@ function Get-FileCoverageData([xml]$CoverageData)
     $result = [Collections.Generic.Dictionary[string,FileCoverage]]::new()
     $count = 0
     Write-Progress "collecting files"
-    $filehash = $CoverageData.SelectNodes(".//File") | Foreach-Object { $h = @{} } { $h[$_.uid] = $_.fullpath } { $h }
+    $filehash = $CoverageData.SelectNodes(".//File") | ForEach-Object { $h = @{} } { $h[$_.uid] = $_.fullpath } { $h }
     Write-Progress "collecting sequence points"
     $nodes = $CoverageData.SelectNodes(".//SequencePoint")
     $ncount = $nodes.count
@@ -209,7 +209,7 @@ function Get-FileCoverageData([xml]$CoverageData)
 function Get-CodeCoverageChange($r1, $r2, [string[]]$ClassName)
 {
     $h = @{}
-    $Deltas = new-object "System.Collections.ArrayList"
+    $Deltas = New-Object "System.Collections.ArrayList"
 
     if ( $ClassName ) {
         foreach ( $Class in $ClassName ) {
@@ -272,7 +272,7 @@ function Get-AssemblyCoverageChange($r1, $r2)
         $r2 = @{ AssemblyName = $r1.AssemblyName ; Branch = 0 ; Sequence = 0 }
     }
 
-    if ( compare-object $r1.assemblyname $r2.assemblyname ) { throw "different assemblies" }
+    if ( Compare-Object $r1.assemblyname $r2.assemblyname ) { throw "different assemblies" }
 
     $AssemblyCoverageChange = [pscustomobject] @{
         AssemblyName = $r1.AssemblyName
@@ -287,7 +287,7 @@ function Get-AssemblyCoverageChange($r1, $r2)
 
 function Get-CoverageData($xmlPath)
 {
-    [xml]$CoverageXml = get-content -readcount 0 $xmlPath
+    [xml]$CoverageXml = Get-Content -ReadCount 0 $xmlPath
     if ( $null -eq $CoverageXml.CoverageSession ) { throw "CoverageSession data not found" }
 
     $assemblies = New-Object System.Collections.ArrayList
@@ -425,7 +425,7 @@ function Expand-ZipArchive([string] $Path, [string] $DestinationPath)
 function Get-CodeCoverage
 {
     param ( [string]$CoverageXmlFile = "$HOME/Documents/OpenCover.xml" )
-    $xmlPath = (get-item $CoverageXmlFile).Fullname
+    $xmlPath = (Get-Item $CoverageXmlFile).Fullname
     (Get-CoverageData -xmlPath $xmlPath)
 }
 
@@ -500,10 +500,10 @@ function Compare-CodeCoverage
 
     if ( $PSCmdlet.ParameterSetName -eq "file" )
     {
-        [string]$xmlPath1 = (get-item $Run1File).Fullname
+        [string]$xmlPath1 = (Get-Item $Run1File).Fullname
         $Run1 = (Get-CoverageData -xmlPath $xmlPath1)
 
-        [string]$xmlPath2 = (get-item $Run1File).Fullname
+        [string]$xmlPath2 = (Get-Item $Run1File).Fullname
         $Run2 = (Get-CoverageData -xmlPath $xmlPath2)
     }
 
@@ -527,10 +527,10 @@ function Compare-FileCoverage
     )
     # create a couple of hashtables where the key is the path
     # so we can compare file coverage
-    $reference = $ReferenceCoverage.GetFileCoverage($FileName) | Foreach-Object { $h = @{} } { $h[$_.path] = $_ } {$h}
-    $difference = $differenceCoverage.GetFileCoverage($FileName) | Foreach-Object { $h = @{}}{ $h[$_.path] = $_ }{$h }
+    $reference = $ReferenceCoverage.GetFileCoverage($FileName) | ForEach-Object { $h = @{} } { $h[$_.path] = $_ } {$h}
+    $difference = $differenceCoverage.GetFileCoverage($FileName) | ForEach-Object { $h = @{}}{ $h[$_.path] = $_ }{$h }
     # based on the paths, create objects which show the difference between the two runs
-    $reference.Keys | Sort-Object | Foreach-Object {
+    $reference.Keys | Sort-Object | ForEach-Object {
         $referenceObject = $reference[$_]
         $differenceObject = $difference[$_]
         if ( $differenceObject )
@@ -569,22 +569,22 @@ function Install-OpenCover
     $filename =  "opencover.${version}.zip"
     $tempPath = "$env:TEMP/$Filename"
     $packageUrl = "https://github.com/OpenCover/opencover/releases/download/${version}/${filename}"
-    if ( test-path $tempPath )
+    if ( Test-Path $tempPath )
     {
         if ( $force )
         {
-            remove-item -force $tempPath
+            Remove-Item -Force $tempPath
         }
         else
         {
             throw "Package already exists at $tempPath, not continuing.  Use -force to re-install"
         }
     }
-    if ( test-path "$TargetDirectory/OpenCover" )
+    if ( Test-Path "$TargetDirectory/OpenCover" )
     {
         if ( $force )
         {
-            remove-item -recurse -force "$TargetDirectory/OpenCover"
+            Remove-Item -Recurse -Force "$TargetDirectory/OpenCover"
         }
         else
         {
@@ -593,20 +593,20 @@ function Install-OpenCover
     }
 
     Invoke-WebRequest -Uri $packageUrl -OutFile "$tempPath"
-    if ( ! (test-path $tempPath) )
+    if ( ! (Test-Path $tempPath) )
     {
         throw "Download failed: $packageUrl"
     }
 
     ## We add ErrorAction as we do not have this module on PS v4 and below. Calling import-module will throw an error otherwise.
-    import-module Microsoft.PowerShell.Archive -ErrorAction SilentlyContinue
+    Import-Module Microsoft.PowerShell.Archive -ErrorAction SilentlyContinue
 
     if ($null -ne (Get-Command Expand-Archive -ErrorAction Ignore)) {
         Expand-Archive -Path $tempPath -DestinationPath "$TargetDirectory/OpenCover"
     } else {
         Expand-ZipArchive -Path $tempPath -DestinationPath "$TargetDirectory/OpenCover"
     }
-    Remove-Item -force $tempPath
+    Remove-Item -Force $tempPath
 }
 
 <#
@@ -647,7 +647,7 @@ function Invoke-OpenCover
 
     $OpenCoverBin = "$OpenCoverPath\opencover.console.exe"
 
-    if ( ! (test-path $OpenCoverBin))
+    if ( ! (Test-Path $OpenCoverBin))
     {
         # see if it's somewhere else in the path
         $openCoverBin = (Get-Command -Name 'opencover.console' -ErrorAction Ignore).Source
@@ -658,7 +658,7 @@ function Invoke-OpenCover
 
     # check to be sure that pwsh.exe is present
     $target = "${PowerShellExeDirectory}\pwsh.exe"
-    if ( ! (test-path $target) )
+    if ( ! (Test-Path $target) )
     {
         throw "$target does not exist, use 'Start-PSBuild -configuration CodeCoverage'"
     }
@@ -704,7 +704,7 @@ function Invoke-OpenCover
             # Write the command line to a file and then invoke file.
             # '&' invoke caused issues with cmdline parameters for opencover.console.exe
             $elevatedFile = "$env:temp\elevated.ps1"
-            "$OpenCoverBin $cmdlineElevated" | Out-File -FilePath $elevatedFile -force
+            "$OpenCoverBin $cmdlineElevated" | Out-File -FilePath $elevatedFile -Force
             powershell.exe -file $elevatedFile
 
             # invoke OpenCover unelevated and poll for completion
@@ -738,8 +738,8 @@ function Invoke-OpenCover
         }
         finally
         {
-            Remove-Item $elevatedFile -force -ErrorAction SilentlyContinue
-            Remove-Item $unelevatedFile -force -ErrorAction SilentlyContinue
+            Remove-Item $elevatedFile -Force -ErrorAction SilentlyContinue
+            Remove-Item $unelevatedFile -Force -ErrorAction SilentlyContinue
         }
     }
 }

--- a/tools/UpdateDotnetRuntime.ps1
+++ b/tools/UpdateDotnetRuntime.ps1
@@ -81,7 +81,7 @@ function Update-PackageVersion {
     $versionPattern = (Get-Content "$PSScriptRoot/../DotnetRuntimeMetadata.json" | ConvertFrom-Json).sdk.packageVersionPattern
 
     $packages.GetEnumerator() | ForEach-Object {
-        $pkgs = Find-Package -Name $_.Key -AllVersions -AllowPreReleaseVersions -Source 'dotnet5'
+        $pkgs = Find-Package -Name $_.Key -AllVersions -AllowPrereleaseVersions -Source 'dotnet5'
 
         foreach ($v in $_.Value) {
             $version = $v.Version
@@ -109,7 +109,7 @@ function Update-PackageVersion {
  .DESCRIPTION Update package versions to the latest as per the pattern mentioned in DotnetRuntimeMetadata.json
 #>
 function Update-CsprojFile([string] $path, $values) {
-    $fileContent = Get-Content $path -raw
+    $fileContent = Get-Content $path -Raw
     $updated = $false
 
     foreach ($v in $values) {
@@ -141,7 +141,7 @@ if(-not (Get-PackageSource -Name 'dotnet5' -ErrorAction SilentlyContinue))
 {
     $nugetFeed = ([xml](Get-Content .\nuget.config -Raw)).Configuration.packagesources.add | Where-Object { $_.Key -eq 'dotnet5' } | Select-Object -ExpandProperty Value
     Register-PackageSource -Name 'dotnet5' -Location $nugetFeed -ProviderName NuGet
-    Write-Verbose -Message "Register new package source 'dotnet5'" -verbose
+    Write-Verbose -Message "Register new package source 'dotnet5'" -Verbose
 }
 
 ## Install latest version from the channel

--- a/tools/WindowsCI.psm1
+++ b/tools/WindowsCI.psm1
@@ -30,8 +30,8 @@ function New-LocalUser
   )
   $LocalComputer = [ADSI] "WinNT://$env:computername";
   $user = $LocalComputer.Create('user', $username);
-  $user.SetPassword($password) | out-null;
-  $user.SetInfo() | out-null;
+  $user.SetPassword($password) | Out-Null;
+  $user.SetInfo() | Out-Null;
 }
 
 <#
@@ -43,7 +43,7 @@ function ConvertTo-NtAccount
     [Parameter(Mandatory=$true)]
     [string] $sid
   )
-	(new-object System.Security.Principal.SecurityIdentifier($sid)).translate([System.Security.Principal.NTAccount]).Value
+	(New-Object System.Security.Principal.SecurityIdentifier($sid)).translate([System.Security.Principal.NTAccount]).Value
 }
 
 <#

--- a/tools/ci.psm1
+++ b/tools/ci.psm1
@@ -17,12 +17,12 @@ if(Test-Path $dotNetPath)
 
 # import build into the global scope so it can be used by packaging
 Import-Module (Join-Path $repoRoot 'build.psm1') -Scope Global
-Import-Module (Join-Path $repoRoot 'tools\packaging') -scope Global
+Import-Module (Join-Path $repoRoot 'tools\packaging') -Scope Global
 
 # import the windows specific functcion only in Windows PowerShell or on Windows
 if($PSVersionTable.PSEdition -eq 'Desktop' -or $IsWindows)
 {
-    Import-Module (Join-Path $PSScriptRoot 'WindowsCI.psm1') -scope Global
+    Import-Module (Join-Path $PSScriptRoot 'WindowsCI.psm1') -Scope Global
 }
 
 # tests if we should run a daily build
@@ -104,7 +104,7 @@ function Invoke-CIBuild
 
     $options = (Get-PSOptions)
 
-    $path = split-path -path $options.Output
+    $path = Split-Path -Path $options.Output
 
     $psOptionsPath = (Join-Path -Path $PSScriptRoot -ChildPath '../psoptions.json')
     $buildZipPath = (Join-Path -Path $PSScriptRoot -ChildPath '../build.zip')
@@ -129,7 +129,7 @@ function Invoke-CIInstall
     {
         if ($env:BUILD_REASON -eq 'Schedule')
         {
-            Write-Host "##vso[build.updatebuildnumber]Daily-$env:BUILD_SOURCEBRANCHNAME-$env:BUILD_SOURCEVERSION-$((get-date).ToString("yyyyMMddhhss"))"
+            Write-Host "##vso[build.updatebuildnumber]Daily-$env:BUILD_SOURCEBRANCHNAME-$env:BUILD_SOURCEVERSION-$((Get-Date).ToString("yyyyMMddhhss"))"
         }
     }
 
@@ -145,7 +145,7 @@ function Invoke-CIInstall
 
         # Account
         $userName = 'ciRemote'
-        New-LocalUser -username $userName -password $password
+        New-LocalUser -username $userName -Password $password
         Add-UserToGroup -username $userName -groupSid $script:administratorsGroupSID
 
         # Provide credentials globally for remote tests.
@@ -192,7 +192,7 @@ function Invoke-CIxUnit
         throw "CoreCLR pwsh.exe was not built"
     }
 
-    $xUnitTestResultsFile = Join-Path -Path $PWD -childpath "xUnitTestResults.xml"
+    $xUnitTestResultsFile = Join-Path -Path $PWD -ChildPath "xUnitTestResults.xml"
 
     Start-PSxUnit -xUnitTestResultsFile $xUnitTestResultsFile
     Push-Artifact -Path $xUnitTestResultsFile -name xunit
@@ -414,7 +414,7 @@ function Compress-CoverageArtifacts
     $null = $artifacts.Add($zipOpenCoverPath)
 
     $zipCodeCoveragePath = Join-Path $PWD "CodeCoverage.zip"
-    Write-Verbose "Zipping ${CodeCoverageOutput} into $zipCodeCoveragePath" -verbose
+    Write-Verbose "Zipping ${CodeCoverageOutput} into $zipCodeCoveragePath" -Verbose
     [System.IO.Compression.ZipFile]::CreateFromDirectory($CodeCoverageOutput, $zipCodeCoveragePath)
     $null = $artifacts.Add($zipCodeCoveragePath)
 

--- a/tools/install-powershell.ps1
+++ b/tools/install-powershell.ps1
@@ -224,7 +224,7 @@ Function Add-PathTToSettings {
 
     # $key is null here if it the user was unable to get ReadWriteSubTree access.
     if ($null -eq $Key) {
-        throw (new-object -typeName 'System.Security.SecurityException' -ArgumentList "Unable to access the target registry")
+        throw (New-Object -TypeName 'System.Security.SecurityException' -ArgumentList "Unable to access the target registry")
     }
 
     # Get current unexpanded value

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -620,7 +620,7 @@ function New-PSBuildZip
         [string]$VstsVariableName
     )
 
-    $name = split-path -Path $BuildPath -Leaf
+    $name = Split-Path -Path $BuildPath -Leaf
     $zipLocationPath = Join-Path -Path $DestinationFolder -ChildPath "$name-signed.zip"
     Compress-Archive -Path $BuildPath\* -DestinationPath $zipLocationPath
     if ($VstsVariableName)
@@ -647,11 +647,11 @@ function Update-PSSignedBuildFolder
 
     # Replace unsigned binaries with signed
     $signedFilesFilter = Join-Path -Path $SignedFilesPath -ChildPath '*'
-    Get-ChildItem -path $signedFilesFilter -Recurse -File | Select-Object -ExpandProperty FullName | Foreach-Object -Process {
+    Get-ChildItem -Path $signedFilesFilter -Recurse -File | Select-Object -ExpandProperty FullName | ForEach-Object -Process {
         $relativePath = $_.ToLowerInvariant().Replace($SignedFilesPath.ToLowerInvariant(),'')
         $destination = Join-Path -Path $BuildPath -ChildPath $relativePath
         Write-Log "replacing $destination with $_"
-        Copy-Item -Path $_ -Destination $destination -force
+        Copy-Item -Path $_ -Destination $destination -Force
     }
 }
 
@@ -665,11 +665,11 @@ function Expand-PSSignedBuild
         [Switch]$SkipPwshExeCheck
     )
 
-    $psModulePath = Split-Path -path $PSScriptRoot
+    $psModulePath = Split-Path -Path $PSScriptRoot
     # Expand signed build
-    $buildPath = Join-Path -path $psModulePath -childpath 'ExpandedBuild'
-    $null = New-Item -path $buildPath -itemtype Directory -force
-    Expand-Archive -path $BuildZip -destinationpath $buildPath -Force
+    $buildPath = Join-Path -Path $psModulePath -ChildPath 'ExpandedBuild'
+    $null = New-Item -Path $buildPath -ItemType Directory -Force
+    Expand-Archive -Path $BuildZip -DestinationPath $buildPath -Force
     # Remove the zip file that contains only those files from the parent folder of 'publish'.
     # That zip file is used for compliance scan.
     Remove-Item -Path (Join-Path -Path $buildPath -ChildPath '*.zip') -Recurse
@@ -955,10 +955,10 @@ function New-UnixPackage {
                 }
             }
             if ($AfterScriptInfo.AfterInstallScript) {
-                Remove-Item -erroraction 'silentlycontinue' $AfterScriptInfo.AfterInstallScript -Force
+                Remove-Item -ErrorAction 'silentlycontinue' $AfterScriptInfo.AfterInstallScript -Force
             }
             if ($AfterScriptInfo.AfterRemoveScript) {
-                Remove-Item -erroraction 'silentlycontinue' $AfterScriptInfo.AfterRemoveScript -Force
+                Remove-Item -ErrorAction 'silentlycontinue' $AfterScriptInfo.AfterRemoveScript -Force
             }
             Remove-Item -Path $ManGzipInfo.GzipFile -Force -ErrorAction SilentlyContinue
         }
@@ -997,7 +997,7 @@ Function New-LinkInfo
         $linkTarget
     )
 
-    $linkDir = Join-Path -path '/tmp' -ChildPath ([System.IO.Path]::GetRandomFileName())
+    $linkDir = Join-Path -Path '/tmp' -ChildPath ([System.IO.Path]::GetRandomFileName())
     $null = New-Item -ItemType Directory -Path $linkDir
     $linkSource = Join-Path -Path $linkDir -ChildPath 'pwsh'
 
@@ -1027,19 +1027,19 @@ function New-MacOsDistributionPackage
         throw 'New-MacOsDistributionPackage is only supported on macOS!'
     }
 
-    $packageName = Split-Path -leaf -Path $FpmPackage
+    $packageName = Split-Path -Leaf -Path $FpmPackage
 
     # Create a temp directory to store the needed files
     $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
     New-Item -ItemType Directory -Path $tempDir -Force > $null
 
-    $resourcesDir = Join-Path -path $tempDir -childPath 'resources'
+    $resourcesDir = Join-Path -Path $tempDir -ChildPath 'resources'
     New-Item -ItemType Directory -Path $resourcesDir -Force > $null
     #Copy background file to temp directory
     $backgroundFile = "$RepoRoot/assets/macDialog.png"
     Copy-Item -Path $backgroundFile -Destination $resourcesDir
     # Move the current package to the temp directory
-    $tempPackagePath = Join-Path -path $tempDir -ChildPath $packageName
+    $tempPackagePath = Join-Path -Path $tempDir -ChildPath $packageName
     Move-Item -Path $FpmPackage -Destination $tempPackagePath -Force
 
     # Add the OS information to the macOS package file name.
@@ -1080,7 +1080,7 @@ function New-MacOsDistributionPackage
     finally
     {
         Pop-Location
-        Remove-item -Path $tempDir -Recurse -Force
+        Remove-Item -Path $tempDir -Recurse -Force
     }
 
     return (Get-Item $newPackagePath)
@@ -1431,7 +1431,7 @@ function New-ManGzip
     {
         $prodName = if ($IsLTS) { 'pwsh-lts' } else { 'pwsh-preview' }
         $newRonnFile = $RonnFile -replace 'pwsh', $prodName
-        Copy-Item -Path $RonnFile -Destination $newRonnFile -force
+        Copy-Item -Path $RonnFile -Destination $newRonnFile -Force
         $RonnFile = $newRonnFile
     }
 
@@ -1443,7 +1443,7 @@ function New-ManGzip
 
     if ($IsPreview.IsPresent)
     {
-        Remove-item $RonnFile
+        Remove-Item $RonnFile
     }
 
     # gzip in assets directory
@@ -1642,7 +1642,7 @@ function New-ZipPackage
             $staging = "$PSScriptRoot/staging"
             New-StagingFolder -StagingPath $staging -PackageSourcePath $PackageSourcePath
 
-            Get-ChildItem $staging -Filter *.pdb -recurse | Remove-Item -Force
+            Get-ChildItem $staging -Filter *.pdb -Recurse | Remove-Item -Force
 
             Compress-Archive -Path $staging\* -DestinationPath $zipLocationPath
         }
@@ -2077,7 +2077,7 @@ function Get-ProjectPackageInformation
     )
 
     $csproj = "$RepoRoot\src\$ProjectName\$ProjectName.csproj"
-    [xml] $csprojXml = (Get-content -Raw -Path $csproj)
+    [xml] $csprojXml = (Get-Content -Raw -Path $csproj)
 
     # get the package references
     $packages=$csprojXml.Project.ItemGroup.PackageReference
@@ -2560,7 +2560,7 @@ function New-NugetContentPackage
 
     # Setup staging directory so we don't change the original source directory
     $stagingRoot = New-SubFolder -Path $PSScriptRoot -ChildPath 'nugetStaging' -Clean
-    $contentFolder = Join-Path -path $stagingRoot -ChildPath 'content'
+    $contentFolder = Join-Path -Path $stagingRoot -ChildPath 'content'
     if ($PSCmdlet.ShouldProcess("Create staging folder")) {
         New-StagingFolder -StagingPath $contentFolder -PackageSourcePath $PackageSourcePath
     }
@@ -2579,7 +2579,7 @@ function New-NugetContentPackage
 
     Write-Log "Running dotnet $arguments"
     Write-Log "Use -verbose to see output..."
-    Start-NativeExecution -sb {dotnet $arguments} | Foreach-Object {Write-Verbose $_}
+    Start-NativeExecution -sb {dotnet $arguments} | ForEach-Object {Write-Verbose $_}
 
     $nupkgFile = "${nugetFolder}\${nuspecPackageName}-${packageRuntime}.${nugetSemanticVersion}.nupkg"
     if (Test-Path $nupkgFile)
@@ -2991,7 +2991,7 @@ function New-MSIPackage
     $staging = "$PSScriptRoot/staging"
     New-StagingFolder -StagingPath $staging -PackageSourcePath $ProductSourcePath
 
-    Get-ChildItem $staging -Filter *.pdb -recurse | Remove-Item -Force
+    Get-ChildItem $staging -Filter *.pdb -Recurse | Remove-Item -Force
 
     New-Item $assetsInSourcePath -type directory -Force | Write-Verbose
 
@@ -3383,7 +3383,7 @@ function Test-FileWxs
     {
         $newXmlFileName = Join-Path -Path $env:TEMP -ChildPath ([System.io.path]::GetRandomFileName() + '.wxs')
         $newFilesAssetXml.Save($newXmlFileName)
-        $newXml = Get-Content -raw $newXmlFileName
+        $newXml = Get-Content -Raw $newXmlFileName
         $newXml = $newXml -replace 'amd64', '$(var.FileArchitecture)'
         $newXml = $newXml -replace 'x86', '$(var.FileArchitecture)'
         $newXml | Out-File -FilePath $newXmlFileName -Encoding ascii

--- a/tools/releaseBuild/Images/GenericLinuxFiles/PowerShellPackage.ps1
+++ b/tools/releaseBuild/Images/GenericLinuxFiles/PowerShellPackage.ps1
@@ -61,7 +61,7 @@ function BuildPackages {
             $buildParams.Add("Runtime", 'alpine-x64')
         } else {
             # make the artifact name unique
-            $projectAssetsZipName = "linuxProjectAssets-$((get-date).Ticks)-symbols.zip"
+            $projectAssetsZipName = "linuxProjectAssets-$((Get-Date).Ticks)-symbols.zip"
             $buildParams.Add("Crossgen", $true)
         }
 
@@ -106,10 +106,10 @@ foreach ($linuxPackage in $linuxPackages)
 {
     $filePath = $linuxPackage.FullName
     Write-Verbose "Copying $filePath to $destination" -Verbose
-    Copy-Item -Path $filePath -Destination $destination -force
+    Copy-Item -Path $filePath -Destination $destination -Force
 }
 
-Write-Verbose "Exporting project.assets files ..." -verbose
+Write-Verbose "Exporting project.assets files ..." -Verbose
 
 $projectAssetsCounter = 1
 $projectAssetsFolder = Join-Path -Path $destination -ChildPath 'projectAssets'
@@ -120,7 +120,7 @@ Get-ChildItem $location\project.assets.json -Recurse | ForEach-Object {
     $itemDestination = Join-Path -Path $projectAssetsFolder -ChildPath $subfolder
     New-Item -Path $itemDestination -ItemType Directory -Force
     $file = $_.FullName
-    Write-Verbose "Copying $file to $itemDestination" -verbose
+    Write-Verbose "Copying $file to $itemDestination" -Verbose
     Copy-Item -Path $file -Destination "$itemDestination\" -Force
     $projectAssetsCounter++
 }

--- a/tools/releaseBuild/Images/microsoft_powershell_windowsservercore/PowerShellPackage.ps1
+++ b/tools/releaseBuild/Images/microsoft_powershell_windowsservercore/PowerShellPackage.ps1
@@ -70,15 +70,15 @@ try{
     Import-Module "$location\tools\packaging" -Force
     $env:platform = $null
 
-    Write-Verbose "Sync'ing Tags..." -verbose
+    Write-Verbose "Sync'ing Tags..." -Verbose
     Sync-PSTags -AddRemoteIfMissing
 
-    Write-Verbose "Bootstrapping powershell build..." -verbose
+    Write-Verbose "Bootstrapping powershell build..." -Verbose
     Start-PSBootstrap -Force -Package
 
     if ($PSCmdlet.ParameterSetName -eq 'packageSigned')
     {
-        Write-Verbose "Expanding signed build..." -verbose
+        Write-Verbose "Expanding signed build..." -Verbose
         if($Runtime -like 'fxdependent*')
         {
             Expand-PSSignedBuild -BuildZip $BuildZip -SkipPwshExeCheck
@@ -92,7 +92,7 @@ try{
     }
     else
     {
-        Write-Verbose "Starting powershell build for RID: $Runtime and ReleaseTag: $ReleaseTag ..." -verbose
+        Write-Verbose "Starting powershell build for RID: $Runtime and ReleaseTag: $ReleaseTag ..." -Verbose
         $buildParams = @{'CrossGen'= $Runtime -notmatch "arm" -and $Runtime -notlike "fxdependent*"}
 
         if($Symbols.IsPresent)
@@ -122,7 +122,7 @@ try{
 
     if (!$ComponentRegistration.IsPresent -and !$Symbols.IsPresent -and $Runtime -notmatch 'arm' -and $Runtime -notlike 'fxdependent*')
     {
-        Write-Verbose "Starting powershell packaging(msi)..." -verbose
+        Write-Verbose "Starting powershell packaging(msi)..." -Verbose
         Start-PSPackage @pspackageParams @releaseTagParam
     }
 
@@ -130,7 +130,7 @@ try{
     {
         $pspackageParams['Type']='msix'
         $pspackageParams['WindowsRuntime']=$Runtime
-        Write-Verbose "Starting powershell packaging(msix)..." -verbose
+        Write-Verbose "Starting powershell packaging(msix)..." -Verbose
         Start-PSPackage @pspackageParams @releaseTagParam
     }
 
@@ -138,20 +138,20 @@ try{
     {
         if (!$Symbols.IsPresent) {
             $pspackageParams['Type'] = 'zip-pdb'
-            Write-Verbose "Starting powershell symbols packaging(zip)..." -verbose
+            Write-Verbose "Starting powershell symbols packaging(zip)..." -Verbose
             Start-PSPackage @pspackageParams @releaseTagParam
         }
 
         $pspackageParams['Type']='zip'
         $pspackageParams['IncludeSymbols']=$Symbols.IsPresent
-        Write-Verbose "Starting powershell packaging(zip)..." -verbose
+        Write-Verbose "Starting powershell packaging(zip)..." -Verbose
         Start-PSPackage @pspackageParams @releaseTagParam
 
-        Write-Verbose "Exporting packages ..." -verbose
+        Write-Verbose "Exporting packages ..." -Verbose
 
         Get-ChildItem $location\*.msi,$location\*.zip,$location\*.wixpdb,$location\*.msix | ForEach-Object {
             $file = $_.FullName
-            Write-Verbose "Copying $file to $destination" -verbose
+            Write-Verbose "Copying $file to $destination" -Verbose
             Copy-Item -Path $file -Destination "$destination\" -Force
         }
     }
@@ -164,13 +164,13 @@ try{
         ## Copy the fxdependent Zip package to destination.
         Get-ChildItem $location\PowerShell-*.zip | ForEach-Object {
             $file = $_.FullName
-            Write-Verbose "Copying $file to $destination" -verbose
+            Write-Verbose "Copying $file to $destination" -Verbose
             Copy-Item -Path $file -Destination "$destination\" -Force
         }
     }
     else
     {
-        Write-Verbose "Exporting project.assets files ..." -verbose
+        Write-Verbose "Exporting project.assets files ..." -Verbose
 
         $projectAssetsCounter = 1
         $projectAssetsFolder = Join-Path -Path $destination -ChildPath 'projectAssets'
@@ -181,7 +181,7 @@ try{
             $itemDestination = Join-Path -Path $projectAssetsFolder -ChildPath $subfolder
                     New-Item -Path $itemDestination -ItemType Directory -Force
             $file = $_.FullName
-            Write-Verbose "Copying $file to $itemDestination" -verbose
+            Write-Verbose "Copying $file to $itemDestination" -Verbose
             Copy-Item -Path $file -Destination "$itemDestination\" -Force
             $projectAssetsCounter++
         }
@@ -193,7 +193,7 @@ try{
 }
 finally
 {
-    Write-Verbose "Beginning build clean-up..." -verbose
+    Write-Verbose "Beginning build clean-up..." -Verbose
     if ($Wait.IsPresent)
     {
         $path = Join-Path $PSScriptRoot -ChildPath 'delete-to-continue.txt'

--- a/tools/releaseBuild/Images/microsoft_powershell_windowsservercore/dockerInstall.psm1
+++ b/tools/releaseBuild/Images/microsoft_powershell_windowsservercore/dockerInstall.psm1
@@ -24,7 +24,7 @@ function Install-ChocolateyPackage
         $Version
     )
 
-    if(-not(Get-Command -name Choco -ErrorAction SilentlyContinue))
+    if(-not(Get-Command -Name Choco -ErrorAction SilentlyContinue))
     {
         Write-Verbose "Installing Chocolatey provider..." -Verbose
         Invoke-WebRequest https://chocolatey.org/install.ps1 -UseBasicParsing | Invoke-Expression
@@ -42,25 +42,25 @@ function Install-ChocolateyPackage
     {
         Write-Verbose "Verifing $Executable is in path..." -Verbose
         $exeSource = $null
-        $exeSource = Get-ChildItem -path "$env:ProgramFiles\$Executable" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty FullName
+        $exeSource = Get-ChildItem -Path "$env:ProgramFiles\$Executable" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty FullName
         if(!$exeSource)
         {
             Write-Verbose "Falling back to x86 program files..." -Verbose
-            $exeSource = Get-ChildItem -path "${env:ProgramFiles(x86)}\$Executable" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty FullName
+            $exeSource = Get-ChildItem -Path "${env:ProgramFiles(x86)}\$Executable" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty FullName
         }
 
         # Don't search the chocolatey program data until more official locations have been searched
         if(!$exeSource)
         {
             Write-Verbose "Falling back to chocolatey..." -Verbose
-            $exeSource = Get-ChildItem -path "$env:ProgramData\chocolatey\$Executable" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty FullName
+            $exeSource = Get-ChildItem -Path "$env:ProgramData\chocolatey\$Executable" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty FullName
         }
 
         # all obvious locations are exhausted, use brute force and search from the root of the filesystem
         if(!$exeSource)
         {
             Write-Verbose "Falling back to the root of the drive..." -Verbose
-            $exeSource = Get-ChildItem -path "/$Executable" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty FullName
+            $exeSource = Get-ChildItem -Path "/$Executable" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty FullName
         }
 
         if(!$exeSource)
@@ -110,6 +110,6 @@ function Remove-Folder
     Write-Verbose "Cleaning up $Folder..." -Verbose
     $filter = Join-Path -Path $Folder -ChildPath *
     [int]$measuredCleanupMB = (Get-ChildItem $filter -Recurse | Measure-Object -Property Length -Sum).Sum / 1MB
-    Remove-Item -recurse -force $filter -ErrorAction SilentlyContinue
+    Remove-Item -Recurse -Force $filter -ErrorAction SilentlyContinue
     Write-Verbose "Cleaned up $measuredCleanupMB MB from $Folder" -Verbose
 }

--- a/tools/releaseBuild/azureDevOps/AzArtifactFeed/SyncGalleryToAzArtifacts.psm1
+++ b/tools/releaseBuild/azureDevOps/AzArtifactFeed/SyncGalleryToAzArtifacts.psm1
@@ -146,7 +146,7 @@ Function SortPackage {
 
     End {
         $versions = $allPackages.Version |
-        Foreach-Object { ($_ -split '-')[0] } |
+        ForEach-Object { ($_ -split '-')[0] } |
         Select-Object -Unique |
         Sort-Object -Descending -Property Version
 

--- a/tools/releaseBuild/generatePackgeSigning.ps1
+++ b/tools/releaseBuild/generatePackgeSigning.ps1
@@ -65,7 +65,7 @@ function New-FileElement
     }
 }
 
-[xml]$signingXml = get-content (Join-Path -Path $PSScriptRoot -ChildPath 'packagesigning.xml')
+[xml]$signingXml = Get-Content (Join-Path -Path $PSScriptRoot -ChildPath 'packagesigning.xml')
 $job = $signingXml.SignConfigXML.job
 
 foreach($file in $AuthenticodeDualFiles)

--- a/tools/releaseBuild/macOS/PowerShellPackageVsts.ps1
+++ b/tools/releaseBuild/macOS/PowerShellPackageVsts.ps1
@@ -82,11 +82,11 @@ if ($Build.IsPresent) {
     $macPackages = Get-ChildItem "$repoRoot/powershell*" -Include *.pkg, *.tar.gz
     foreach ($macPackage in $macPackages) {
         $filePath = $macPackage.FullName
-        $name = split-path -Leaf -Path $filePath
+        $name = Split-Path -Leaf -Path $filePath
         $extension = (Split-Path -Extension -Path $filePath).Replace('.', '')
         Write-Verbose "Copying $filePath to $destination" -Verbose
         Write-Host "##vso[artifact.upload containerfolder=results;artifactname=results]$filePath"
         Write-Host "##vso[task.setvariable variable=Package-$extension]$filePath"
-        Copy-Item -Path $filePath -Destination $destination -force
+        Copy-Item -Path $filePath -Destination $destination -Force
     }
 }

--- a/tools/releaseBuild/setReleaseTag.ps1
+++ b/tools/releaseBuild/setReleaseTag.ps1
@@ -65,7 +65,7 @@ if($ReleaseTag -eq 'fromBranch' -or !$ReleaseTag)
     # Branch is named release-<semver>
     if($Branch -match '^.*(release[-/])')
     {
-        Write-verbose "release branch:" -verbose
+        Write-Verbose "release branch:" -Verbose
         $releaseTag = $Branch -replace '^.*(release[-/])'
         $vstsCommandString = "vso[task.setvariable variable=$Variable]$releaseTag"
         Write-Verbose -Message "setting $Variable to $releaseTag" -Verbose
@@ -79,16 +79,16 @@ if($ReleaseTag -eq 'fromBranch' -or !$ReleaseTag)
     elseif($branchOnly -eq 'master' -or $branchOnly -like '*dailytest*')
     {
         $isDaily = $true
-        Write-verbose "daily build" -verbose
+        Write-Verbose "daily build" -Verbose
         $metaDataJsonPath = Join-Path $PSScriptRoot -ChildPath '..\metadata.json'
-        $metadata = Get-content $metaDataJsonPath | ConvertFrom-Json
+        $metadata = Get-Content $metaDataJsonPath | ConvertFrom-Json
         $versionPart = $metadata.PreviewReleaseTag
         if($versionPart -match '-.*$')
         {
             $versionPart = $versionPart -replace '-.*$'
         }
 
-        $releaseTag = "$versionPart-daily.$((get-date).ToString('yyyyMMdd'))"
+        $releaseTag = "$versionPart-daily.$((Get-Date).ToString('yyyyMMdd'))"
         $vstsCommandString = "vso[task.setvariable variable=$Variable]$releaseTag"
         Write-Verbose -Message "setting $Variable to $releaseTag" -Verbose
         Write-Host -Object "##$vstsCommandString"
@@ -100,11 +100,11 @@ if($ReleaseTag -eq 'fromBranch' -or !$ReleaseTag)
     }
     else
     {
-        Write-verbose "non-release branch" -verbose
+        Write-Verbose "non-release branch" -Verbose
         # Branch is named <previewname>
         # Get version from metadata and append -<previewname>
         $metaDataJsonPath = Join-Path $PSScriptRoot -ChildPath '..\metadata.json'
-        $metadata = Get-content $metaDataJsonPath | ConvertFrom-Json
+        $metadata = Get-Content $metaDataJsonPath | ConvertFrom-Json
         $versionPart = $metadata.PreviewReleaseTag
         if($versionPart -match '-.*$')
         {

--- a/tools/releaseBuild/vstsbuild.ps1
+++ b/tools/releaseBuild/vstsbuild.ps1
@@ -21,7 +21,7 @@ DynamicParam {
     # Add a dynamic parameter '-Name' which specifies the name of the build to run
 
     # Get the names of the builds.
-    $buildJsonPath = (Join-Path -path $PSScriptRoot -ChildPath 'build.json')
+    $buildJsonPath = (Join-Path -Path $PSScriptRoot -ChildPath 'build.json')
     $build = Get-Content -Path $buildJsonPath | ConvertFrom-Json
     $names = @($build.Windows.Name)
     foreach($name in $build.Linux.Name)
@@ -55,8 +55,8 @@ End {
     # If specified, Add package file to container
     if ($BuildPath)
     {
-        Import-Module (Join-Path -path $PSScriptRoot -childpath '..\..\build.psm1')
-        Import-Module (Join-Path -path $PSScriptRoot -childpath '..\packaging')
+        Import-Module (Join-Path -Path $PSScriptRoot -ChildPath '..\..\build.psm1')
+        Import-Module (Join-Path -Path $PSScriptRoot -ChildPath '..\packaging')
 
         # Use temp as destination if not running in VSTS
         $destFolder = $env:temp
@@ -87,7 +87,7 @@ End {
         throw "Git is required to proceed. Install from 'https://git-scm.com/download/win'"
     }
 
-    Write-Verbose "cloning -b $psReleaseBranch --quiet https://github.com/$psReleaseFork/PSRelease.git" -verbose
+    Write-Verbose "cloning -b $psReleaseBranch --quiet https://github.com/$psReleaseFork/PSRelease.git" -Verbose
     & $gitBinFullPath clone -b $psReleaseBranch --quiet https://github.com/$psReleaseFork/PSRelease.git $location
 
     Push-Location -Path $PWD.Path

--- a/tools/releaseTools.psm1
+++ b/tools/releaseTools.psm1
@@ -412,7 +412,7 @@ function Get-NewOfficalPackage
 {
     param(
         [String]
-        $Path = (Join-path -Path $PSScriptRoot -ChildPath '..\src'),
+        $Path = (Join-Path -Path $PSScriptRoot -ChildPath '..\src'),
         [Switch]
         $IncludeAll
     )
@@ -424,7 +424,7 @@ function Get-NewOfficalPackage
         $file = $_
 
         # parse the csproj
-        [xml] $csprojXml = (Get-content -Raw -Path $_)
+        [xml] $csprojXml = (Get-Content -Raw -Path $_)
 
         # get the package references
         $packages=$csprojXml.Project.ItemGroup.PackageReference
@@ -438,7 +438,7 @@ function Get-NewOfficalPackage
             if ($name)
             {
                 # Get the current package from nuget
-                $versions = find-package -Name $name -Source https://nuget.org/api/v2/  -ErrorAction SilentlyContinue -AllVersions |
+                $versions = Find-Package -Name $name -Source https://nuget.org/api/v2/  -ErrorAction SilentlyContinue -AllVersions |
                     Add-Member -Type ScriptProperty -Name Published -Value { $this.Metadata['published']} -PassThru |
                         Where-Object { Test-IncludePackageVersion -NewVersion $_.Version -Version $package.version}
 
@@ -602,25 +602,25 @@ function Update-PsVersionInCode
         $NextReleaseTag,
 
         [String]
-        $Path = (Join-path -Path $PSScriptRoot -ChildPath '..')
+        $Path = (Join-Path -Path $PSScriptRoot -ChildPath '..')
     )
 
     $metaDataPath = (Join-Path -Path $PSScriptRoot -ChildPath 'metadata.json')
-    $metaData = Get-Content -Path $metaDataPath | convertfrom-json
+    $metaData = Get-Content -Path $metaDataPath | ConvertFrom-Json
     $currentTag = $metaData.StableReleaseTag
 
     $currentVersion = $currentTag -replace '^v'
     $newVersion = $NewReleaseTag -replace '^v'
     $metaData.NextReleaseTag = $NextReleaseTag
-    Set-Content -path $metaDataPath -Encoding ascii -Force -Value ($metaData | convertto-json)
+    Set-Content -Path $metaDataPath -Encoding ascii -Force -Value ($metaData | ConvertTo-Json)
 
     Get-ChildItem -Path $Path -Recurse -File |
         Where-Object {$_.Extension -notin '.icns','.svg' -and $_.NAME -ne 'CHANGELOG.md' -and $_.DirectoryName -notmatch '[\\/]docs|demos[\\/]'} |
             Where-Object {$_ | Select-String -SimpleMatch $currentVersion -List} |
-                Foreach-Object {
+                ForEach-Object {
                     $content = Get-Content -Path $_.FullName -Raw -ReadCount 0
                     $newContent = $content.Replace($currentVersion,$newVersion)
-                    Set-Content -path $_.FullName -Encoding ascii -Force -Value $newContent -NoNewline
+                    Set-Content -Path $_.FullName -Encoding ascii -Force -Value $newContent -NoNewline
                 }
 }
 

--- a/tools/windows/Reset-PWSHSystemPath.ps1
+++ b/tools/windows/Reset-PWSHSystemPath.ps1
@@ -53,13 +53,13 @@ ForEach ($PathScopeItem in $PathScope)
 {
   $AssembledNewPath = $NewPath = ''
   #From the current path scope. retrieve the array of paths that match the pathspec of PowerShell (to use as a filter)
-  $pathstoremove = @([Environment]::GetEnvironmentVariable("PATH","$PathScopeItem").split(';') | Where { $_ -ilike "*\Program Files\Powershell\6*"})
+  $pathstoremove = @([Environment]::GetEnvironmentVariable("PATH","$PathScopeItem").split(';') | where { $_ -ilike "*\Program Files\Powershell\6*"})
   If (!$RemoveAllOccurences)
   {
     #If we are not removing all occurances of PowerShell paths, then remove the highest sorted path from the filter
-    $pathstoremove = @($pathstoremove | sort-object | Select-Object -skiplast 1)
+    $pathstoremove = @($pathstoremove | Sort-Object | Select-Object -SkipLast 1)
   }
-  Write-Verbose "Reset-PWSHSystemPath: Found $($pathstoremove.count) paths to remove from $PathScopeItem path scope: $($Pathstoremove -join ', ' | out-string)"
+  Write-Verbose "Reset-PWSHSystemPath: Found $($pathstoremove.count) paths to remove from $PathScopeItem path scope: $($Pathstoremove -join ', ' | Out-String)"
   If ($pathstoremove.count -gt 0)
   {
     foreach ($Path in [Environment]::GetEnvironmentVariable("PATH","$PathScopeItem").split(';'))


### PR DESCRIPTION
# PR Summary

* Apply PSScriptAnalyzer `PSUseCorrectCasing` rule.
* Reverted chnages to `demos\DSC\dsc-demo.ps1`, see https://github.com/PowerShell/PSScriptAnalyzer/issues/1474

## PR Context

PSScriptAnalyzer v1.19.0 introduces Cmdlet parameter name casing.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
