### PR TITLE
Add support types implementing IEquatable in Compare-Object cmdlet

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -356,7 +356,9 @@ function Start-PSBuild {
         Write-Warning @"
 The currently installed .NET Command Line Tools is not the required version.
 
-Installed version: $dotnetCLIInstalledVersion
+Installed version(s):
+$($dotnetCLIInstalledVersion -join [Environment]::Newline)
+
 Required version: $dotnetCLIRequiredVersion
 
 Fix steps:

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Compare-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Compare-Object.cs
@@ -168,7 +168,7 @@ namespace Microsoft.PowerShell.Commands
             // 2005/07/19 Switched order of referenceEntry and differenceEntry
             //   so that we cast differenceEntry to the type of referenceEntry.
             if (referenceEntry != null && differenceEntry != null &&
-                0 == _comparer.Compare(referenceEntry, differenceEntry))
+                _comparer.Equals(referenceEntry, differenceEntry))
             {
                 EmitMatch(referenceEntry);
                 return;
@@ -284,7 +284,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 OrderByPropertyEntry listEntry = list[i];
                 Diagnostics.Assert(listEntry != null, "null listEntry " + i);
-                if (0 == _comparer.Compare(match, listEntry))
+                if (_comparer.Equals(match, listEntry))
                 {
                     list.RemoveAt(i);
                     return listEntry;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ObjectCommandComparer.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ObjectCommandComparer.cs
@@ -179,6 +179,16 @@ namespace Microsoft.PowerShell.Commands
             return 0;
         }
 
+        internal bool Equals(ObjectCommandPropertyValue first, ObjectCommandPropertyValue second)
+        {
+            if (first.IsExistingProperty && second.IsExistingProperty)
+            {
+                return Equals(first.PropertyValue, second.PropertyValue);
+            }
+
+            return false;
+        }
+
         /// <summary>
         /// Main method that will compare first and second by their keys considering case and order.
         /// </summary>
@@ -223,6 +233,28 @@ namespace Microsoft.PowerShell.Commands
             string secondString = PSObject.AsPSObject(second).ToString();
 
             return _cultureInfo.CompareInfo.Compare(firstString, secondString, _caseSensitive ? CompareOptions.None : CompareOptions.IgnoreCase) * (_ascendingOrder ? 1 : -1);
+        }
+
+        internal new bool Equals(object first, object second)
+        {
+            // This method will never throw exceptions, two null
+            // objects are considered the same
+            if (IsValueNull(first) && IsValueNull(second))
+            {
+                return true;
+            }
+
+            if (first is PSObject firstMsh)
+            {
+                first = firstMsh.BaseObject;
+            }
+
+            if (second is PSObject secondMsh)
+            {
+                second = secondMsh.BaseObject;
+            }
+
+            return LanguagePrimitives.Equals(first, second, !_caseSensitive, _cultureInfo);
         }
 
         private CultureInfo _cultureInfo = null;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/OrderObjectBase.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/OrderObjectBase.cs
@@ -663,6 +663,26 @@ namespace Microsoft.PowerShell.Commands
             return order;
         }
 
+        public bool Equals(OrderByPropertyEntry firstEntry, OrderByPropertyEntry secondEntry)
+        {
+            // we have to take into consideration that some vectors
+            // might be shorter than others
+            for (int k = 0; k < _propertyComparers.Length; k++)
+            {
+                ObjectCommandPropertyValue firstValue = (k < firstEntry.orderValues.Count) ?
+                    firstEntry.orderValues[k] : ObjectCommandPropertyValue.NonExistingProperty;
+                ObjectCommandPropertyValue secondValue = (k < secondEntry.orderValues.Count) ?
+                    secondEntry.orderValues[k] : ObjectCommandPropertyValue.NonExistingProperty;
+
+                if (!_propertyComparers[k].Equals(firstValue, secondValue))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
         internal static OrderByPropertyComparer CreateComparer(List<OrderByPropertyEntry> orderMatrix, bool ascendingFlag, bool?[] ascendingOverrides, CultureInfo cultureInfo, bool caseSensitive)
         {
             if (orderMatrix.Count == 0)

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -696,6 +696,12 @@ namespace System.Management.Automation
             try
             {
                 object secondConverted = LanguagePrimitives.ConvertTo(second, firstType, culture);
+
+                if (first is IComparable firstComparable)
+                {
+                    return firstComparable.CompareTo(secondConverted) == 0;
+                }
+
                 return first.Equals(secondConverted);
             }
             catch (InvalidCastException)

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -697,12 +697,18 @@ namespace System.Management.Automation
                 }
             }
 
-            if (typeof(IEquatable<>).MakeGenericType(firstType).IsAssignableFrom(firstType))
+            bool isGenericEquatable = typeof(IEquatable<>).MakeGenericType(firstType).IsAssignableFrom(firstType);
+            if (isGenericEquatable && firstType == secondType)
             {
                 // We assume the class is implemented correctly
                 // and both object.Equals() and IEquatable<T>.Equals()
                 // work the same way so that we simply return object.Equals()
                 return firstEquals;
+            }
+
+            if (isGenericEquatable && TryConvertTo(second, firstType, culture, out object secondIEquatableConverted))
+            {
+                return first.Equals(secondIEquatableConverted);
             }
 
             if (first is IComparable firstComparable && TryConvertTo(second, firstType, culture, out object secondConverted))

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Compare-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Compare-Object.Tests.ps1
@@ -473,6 +473,7 @@ Describe "Compare-Object DRT basic functionality" -Tags "CI" {
                     public bool Equals(TestIEquatableClass other) { return Bar == other.Bar; }
                     public override bool Equals(object o) { return o is TestIEquatableClass && Equals((TestIEquatableClass) o); }
                     public override int GetHashCode() { return Bar; }
+                    public override string ToString() { return string.Format("TestIEquatableClass_Bar{0}", Bar); }
                 }
 '@
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Address #12498

1. Currently Compare-Object is based on Compare() method pattern. The pattern is used for _ordering_  but the cmdlet must check _equality_. With the PR we implement Equal() methods and use them instead of Compare() methods.
2. This add support types implementing IEquatable interface.
3. As side effect performance of the cmdlet increases up to 35% (if compare Pester tests before and after the PR.)

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
