### PR TITLE
Adding IArgumentCompleterFactory for parameterized ArgumentCompleters

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -2030,19 +2030,17 @@ namespace System.Management.Automation
             {
                 try
                 {
-                    if (argumentCompleterAttribute.Type != null)
+                    var completer = argumentCompleterAttribute.CreateArgumentCompleter();
+
+                    if (completer != null)
                     {
-                        var completer = Activator.CreateInstance(argumentCompleterAttribute.Type) as IArgumentCompleter;
-                        if (completer != null)
+                        var customResults = completer.CompleteArgument(commandName, parameterName,
+                            context.WordToComplete, commandAst, GetBoundArgumentsAsHashtable(context));
+                        if (customResults != null)
                         {
-                            var customResults = completer.CompleteArgument(commandName, parameterName,
-                                context.WordToComplete, commandAst, GetBoundArgumentsAsHashtable(context));
-                            if (customResults != null)
-                            {
-                                result.AddRange(customResults);
-                                result.Add(CompletionResult.Null);
-                                return;
-                            }
+                            result.AddRange(customResults);
+                            result.Add(CompletionResult.Null);
+                            return;
                         }
                     }
                     else

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4084,7 +4084,9 @@ namespace System.Management.Automation
         private sealed class ArgumentLocation
         {
             internal bool IsPositional { get; set; }
+
             internal int Position { get; set; }
+
             internal AstParameterArgumentPair Argument { get; set; }
         }
 
@@ -4997,6 +4999,7 @@ namespace System.Management.Automation
                     new Tuple<string, string>("Where", "Where({ expression } [, mode [, numberToReturn]])"),
                     new Tuple<string, string>("ForEach", "ForEach(expression [, arguments...])")
                 };
+
         // List of DSC collection-value variables
         private static readonly HashSet<string> s_dscCollectionVariables =
             new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "SelectedNodes", "AllNodes" };
@@ -5438,6 +5441,7 @@ namespace System.Management.Automation
         private abstract class TypeCompletionBase
         {
             internal abstract CompletionResult GetCompletionResult(string keyMatched, string prefix, string suffix);
+
             internal abstract CompletionResult GetCompletionResult(string keyMatched, string prefix, string suffix, string namespaceToRemove);
 
             internal static string RemoveBackTick(string typeName)
@@ -6954,6 +6958,7 @@ namespace System.Management.Automation
         public object VisitDoUntilStatement(DoUntilStatementAst doUntilStatementAst) { return false; }
 
         public object VisitAssignmentStatement(AssignmentStatementAst assignmentStatementAst) { return false; }
+
         // REVIEW: we could relax this to allow specific commands
         public object VisitCommand(CommandAst commandAst) { return false; }
 

--- a/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
@@ -111,9 +111,12 @@ namespace System.Management.Automation
     /// The derived attribute can have properties or constructor arguments that are used when creating the completer.
     /// </para>
     /// <example>
+    /// This example shows the intended usage of IArgumentCompleterFactory.
+    /// <code>
     /// public class NumberCompleterAttribute : ArgumentCompleterAttribute, IArgumentCompleterFactory {
     ///    private readonly int _from;
     ///    private readonly int _to;
+    /// 
     ///    public NumberCompleterAttribute(int from, int to){
     ///       _from = from;
     ///       _to = to;
@@ -122,6 +125,24 @@ namespace System.Management.Automation
     ///    // use the attribute parameters to create a parameterized completer
     ///    IArgumentCompleter Create() => new NumberCompleter(_from, _to);
     /// }
+    ///
+    /// class NumberCompleter : IArgumentCompleter {
+    ///    private readonly int _from;
+    ///    private readonly int _to;
+    ///
+    ///    public NumberCompleter(int from, int to){
+    ///       _from = from;
+    ///       _to = to;
+    ///    }
+    /// 
+    ///    IEnumerable{CompletionResult} CompleteArgument(string commandName, string parameterName, string wordToComplete,
+    ///       CommandAst commandAst, IDictionary fakeBoundParameters) {
+    ///       for(int i = _from; i &lt; _to; i++) {
+    ///           yield return new CompletionResult(i.ToString());
+    ///       }
+    ///    }
+    /// }
+    /// </code>
     /// </example>
     public interface IArgumentCompleterFactory
     {

--- a/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
@@ -156,6 +156,16 @@ namespace System.Management.Automation
     }
 
     /// <summary>
+    /// Base class for parameterized argument completer attributes.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public abstract class ArgumentCompleterFactoryAttribute : ArgumentCompleterAttribute, IArgumentCompleterFactory
+    {
+        /// <inheritdoc />
+        public abstract IArgumentCompleter Create();
+    }
+
+    /// <summary>
     /// </summary>
     [Cmdlet(VerbsLifecycle.Register, "ArgumentCompleter", HelpUri = "https://go.microsoft.com/fwlink/?LinkId=528576")]
     public class RegisterArgumentCompleterCommand : PSCmdlet

--- a/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
@@ -106,12 +106,12 @@ namespace System.Management.Automation
     /// Creates a new argument completer.
     /// </summary>
     /// <para>
-    /// If an attributes that derives from ArgumentCompleterAttribute implements this interface,
-    /// it will be used to create the IArgumentCompleter, thus giving a way to parameterize a completer.
+    /// If an attributes that derives from <see cref="ArgumentCompleterAttribute"/> implements this interface,
+    /// it will be used to create the <see cref="IArgumentCompleter"/>, thus giving a way to parameterize a completer.
     /// The derived attribute can have properties or constructor arguments that are used when creating the completer.
     /// </para>
     /// <example>
-    /// This example shows the intended usage of IArgumentCompleterFactory.
+    /// This example shows the intended usage of <see cref="IArgumentCompleterFactory"/> to pass arguments to an argument completer.
     /// <code>
     /// public class NumberCompleterAttribute : ArgumentCompleterAttribute, IArgumentCompleterFactory {
     ///    private readonly int _from;

--- a/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
@@ -41,6 +41,18 @@ namespace System.Management.Automation
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="ArgumentCompletionsAttribute"/> class.
+        /// This constructor is used by derived attributes implementing IArgumentCompleterFactory.
+        /// </summary>
+        protected ArgumentCompleterAttribute()
+        {
+            if (GetType().GetInterfaces().All(t => t != typeof(IArgumentCompleterFactory)))
+            {
+                throw PSTraceSource.NewInvalidOperationException();
+            }
+        }
+
+        /// <summary>
         /// This constructor is used primarily via PowerShell scripts.
         /// </summary>
         /// <param name="scriptBlock"></param>

--- a/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
@@ -46,7 +46,7 @@ namespace System.Management.Automation
         /// </summary>
         protected ArgumentCompleterAttribute()
         {
-            if (GetType().GetInterfaces().All(t => t != typeof(IArgumentCompleterFactory)))
+            if (!typeof(IArgumentCompleterFactory).IsAssignableFrom(this))
             {
                 throw PSTraceSource.NewInvalidOperationException();
             }

--- a/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
@@ -46,7 +46,7 @@ namespace System.Management.Automation
         /// </summary>
         protected ArgumentCompleterAttribute()
         {
-            if (!typeof(IArgumentCompleterFactory).IsAssignableFrom(this))
+            if (!(this is IArgumentCompleterFactory))
             {
                 throw PSTraceSource.NewInvalidOperationException();
             }
@@ -70,8 +70,8 @@ namespace System.Management.Automation
         {
             return Type != null
                 ? Activator.CreateInstance(Type) as IArgumentCompleter
-                : this is IArgumentCompleterFactory factory 
-                    ? factory.Create() 
+                : this is IArgumentCompleterFactory factory
+                    ? factory.Create()
                     : null;
         }
     }
@@ -118,7 +118,7 @@ namespace System.Management.Automation
     /// public class NumberCompleterAttribute : ArgumentCompleterAttribute, IArgumentCompleterFactory {
     ///    private readonly int _from;
     ///    private readonly int _to;
-    /// 
+    ///
     ///    public NumberCompleterAttribute(int from, int to){
     ///       _from = from;
     ///       _to = to;
@@ -136,7 +136,7 @@ namespace System.Management.Automation
     ///       _from = from;
     ///       _to = to;
     ///    }
-    /// 
+    ///
     ///    IEnumerable{CompletionResult} CompleteArgument(string commandName, string parameterName, string wordToComplete,
     ///       CommandAst commandAst, IDictionary fakeBoundParameters) {
     ///       for(int i = _from; i &lt; _to; i++) {

--- a/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
@@ -41,7 +41,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ArgumentCompletionsAttribute"/> class.
+        /// Initializes a new instance of the <see cref="ArgumentCompleterAttribute"/> class.
         /// This constructor is used by derived attributes implementing IArgumentCompleterFactory.
         /// </summary>
         protected ArgumentCompleterAttribute()
@@ -93,6 +93,21 @@ namespace System.Management.Automation
             string wordToComplete,
             CommandAst commandAst,
             IDictionary fakeBoundParameters);
+    }
+
+    /// <summary>
+    /// Creates a new argument completer.
+    /// If an attributes that derives from ArgumentCompleterAttribute implements this interface,
+    /// it will be used to create the IArgumentCompleter, thus giving a way to parameterize a completer.
+    /// The derived attribute can have properties or constructor arguments that are used when creating the completer.
+    /// </summary>
+    public interface IArgumentCompleterFactory
+    {
+        /// <summary>
+        /// Creates an instance of a class implementing the <see cref="IArgumentCompleter"/> interface.
+        /// </summary>
+        /// <returns>An IArgumentCompleter instance.</returns>
+        IArgumentCompleter Create();
     }
 
     /// <summary>

--- a/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
@@ -42,7 +42,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ArgumentCompleterAttribute"/> class.
-        /// This constructor is used by derived attributes implementing IArgumentCompleterFactory.
+        /// This constructor is used by derived attributes implementing <see cref="IArgumentCompleterFactory"/>.
         /// </summary>
         protected ArgumentCompleterAttribute()
         {
@@ -104,10 +104,25 @@ namespace System.Management.Automation
 
     /// <summary>
     /// Creates a new argument completer.
+    /// </summary>
+    /// <para>
     /// If an attributes that derives from ArgumentCompleterAttribute implements this interface,
     /// it will be used to create the IArgumentCompleter, thus giving a way to parameterize a completer.
     /// The derived attribute can have properties or constructor arguments that are used when creating the completer.
-    /// </summary>
+    /// </para>
+    /// <example>
+    /// public class NumberCompleterAttribute : ArgumentCompleterAttribute, IArgumentCompleterFactory {
+    ///    private readonly int _from;
+    ///    private readonly int _to;
+    ///    public NumberCompleterAttribute(int from, int to){
+    ///       _from = from;
+    ///       _to = to;
+    ///    }
+    ///
+    ///    // use the attribute parameters to create a parameterized completer
+    ///    IArgumentCompleter Create() => new NumberCompleter(_from, _to);
+    /// }
+    /// </example>
     public interface IArgumentCompleterFactory
     {
         /// <summary>

--- a/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
@@ -65,6 +65,13 @@ namespace System.Management.Automation
 
             ScriptBlock = scriptBlock;
         }
+
+        internal IArgumentCompleter CreateArgumentCompleter()
+        {
+            return Type != null
+                ? Activator.CreateInstance(Type) as IArgumentCompleter
+                : this is IArgumentCompleterFactory factory ? factory.Create() : null;
+        }
     }
 
     /// <summary>

--- a/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
@@ -46,7 +46,7 @@ namespace System.Management.Automation
         /// </summary>
         protected ArgumentCompleterAttribute()
         {
-            if (!(this is IArgumentCompleterFactory))
+            if (this is not IArgumentCompleterFactory)
             {
                 throw PSTraceSource.NewInvalidOperationException();
             }
@@ -58,7 +58,7 @@ namespace System.Management.Automation
         /// <param name="scriptBlock"></param>
         public ArgumentCompleterAttribute(ScriptBlock scriptBlock)
         {
-            if (scriptBlock == null)
+            if (scriptBlock is null)
             {
                 throw PSTraceSource.NewArgumentNullException(nameof(scriptBlock));
             }

--- a/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
@@ -70,7 +70,9 @@ namespace System.Management.Automation
         {
             return Type != null
                 ? Activator.CreateInstance(Type) as IArgumentCompleter
-                : this is IArgumentCompleterFactory factory ? factory.Create() : null;
+                : this is IArgumentCompleterFactory factory 
+                    ? factory.Create() 
+                    : null;
         }
     }
 

--- a/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
@@ -108,7 +108,7 @@ namespace System.Management.Automation
     /// Creates a new argument completer.
     /// </summary>
     /// <para>
-    /// If an attributes that derives from <see cref="ArgumentCompleterAttribute"/> implements this interface,
+    /// If an attribute that derives from <see cref="ArgumentCompleterAttribute"/> implements this interface,
     /// it will be used to create the <see cref="IArgumentCompleter"/>, thus giving a way to parameterize a completer.
     /// The derived attribute can have properties or constructor arguments that are used when creating the completer.
     /// </para>

--- a/test/powershell/Language/Parser/ExtensibleCompletion.Tests.ps1
+++ b/test/powershell/Language/Parser/ExtensibleCompletion.Tests.ps1
@@ -175,6 +175,78 @@ function TestFunction
     )
 }
 
+
+class NumberCompleter : IArgumentCompleter 
+{
+
+    [int] $From
+    [int] $To
+    [int] $Step
+    
+    NumberCompleter([int] $from, [int] $to, [int] $step) 
+    {
+        if ($from -gt $to) {
+            throw [ArgumentOutOfRangeException]::new("from")
+        }
+        $this.From = $from
+        $this.To = $to
+        $this.Step = if($step -lt 1) { 1 } else { $step }
+    }
+
+    [IEnumerable[CompletionResult]] CompleteArgument(
+        [string] $CommandName,
+        [string] $parameterName,
+        [string] $wordToComplete,
+        [CommandAst] $commandAst,
+        [IDictionary] $fakeBoundParameters)
+    {
+        $resultList = [List[CompletionResult]]::new()
+        $local:to = $this.To
+        $local:step = $this.Step -lt 1 ? 1 : $this.Step
+        for ($i = $this.From; $i -le $to; $i += $step) {
+            if ($i.ToString().StartsWith($wordToComplete, [System.StringComparison]::Ordinal)) {
+                $num = $i.ToString()
+                $resultList.Add([CompletionResult]::new($num, $num, "ParameterValue", $num))
+            }
+        }
+        
+        return $resultList
+    }
+}
+
+class NumberCompletionAttribute : ArgumentCompleterAttribute, IArgumentCompleterFactory
+{
+    [int] $From
+    [int] $To
+    [int] $Step
+    
+    NumberCompletionAttribute([int] $from, [int] $to)
+    {
+        $this.From = $from
+        $this.To = $to
+        $this.Step = 1
+    }
+
+    [IArgumentCompleter] Create() { return [NumberCompleter]::new($this.From, $this.To, $this.Step) }
+}
+
+function FactoryCompletionAdd {
+    param(
+        [NumberCompletion(0, 50, Step = 5)]
+        [int] $Number
+    )
+}
+
+Describe "Factory based extensible completion" -Tags "CI","Factory" {
+    @{
+        ExpectedResults = @(
+            @{CompletionText = "5"; ResultType = "ParameterValue" }
+            @{CompletionText = "50"; ResultType = "ParameterValue" }
+        )
+        TestInput       = 'FactoryCompletionAdd -Number 5'
+    } | Get-CompletionTestCaseData | Test-Completions
+}
+
 Describe "Script block based extensible completion" -Tags "CI" {
     @{
         ExpectedResults = @(

--- a/test/powershell/Language/Parser/ExtensibleCompletion.Tests.ps1
+++ b/test/powershell/Language/Parser/ExtensibleCompletion.Tests.ps1
@@ -236,7 +236,7 @@ function FactoryCompletionAdd {
     )
 }
 
-Describe "Factory based extensible completion" -Tags "CI","Factory" {
+Describe "Factory based extensible completion" -Tags "CI" {
     @{
         ExpectedResults = @(
             @{CompletionText = "5"; ResultType = "ParameterValue" }

--- a/test/powershell/Language/Parser/ExtensibleCompletion.Tests.ps1
+++ b/test/powershell/Language/Parser/ExtensibleCompletion.Tests.ps1
@@ -202,8 +202,7 @@ class NumberCompleter : IArgumentCompleter
     {
         $resultList = [List[CompletionResult]]::new()
         $local:to = $this.To
-        $local:step = $this.Step -lt 1 ? 1 : $this.Step
-        for ($i = $this.From; $i -le $to; $i += $step) {
+        for ($i = $this.From; $i -le $to; $i += $this.Step) {
             if ($i.ToString().StartsWith($wordToComplete, [System.StringComparison]::Ordinal)) {
                 $num = $i.ToString()
                 $resultList.Add([CompletionResult]::new($num, $num, "ParameterValue", $num))

--- a/test/powershell/Language/Parser/ExtensibleCompletion.Tests.ps1
+++ b/test/powershell/Language/Parser/ExtensibleCompletion.Tests.ps1
@@ -176,14 +176,14 @@ function TestFunction
 }
 
 
-class NumberCompleter : IArgumentCompleter 
+class NumberCompleter : IArgumentCompleter
 {
 
     [int] $From
     [int] $To
     [int] $Step
-    
-    NumberCompleter([int] $from, [int] $to, [int] $step) 
+
+    NumberCompleter([int] $from, [int] $to, [int] $step)
     {
         if ($from -gt $to) {
             throw [ArgumentOutOfRangeException]::new("from")
@@ -208,7 +208,7 @@ class NumberCompleter : IArgumentCompleter
                 $resultList.Add([CompletionResult]::new($num, $num, "ParameterValue", $num))
             }
         }
-        
+
         return $resultList
     }
 }
@@ -218,7 +218,7 @@ class NumberCompletionAttribute : ArgumentCompleterAttribute, IArgumentCompleter
     [int] $From
     [int] $To
     [int] $Step
-    
+
     NumberCompletionAttribute([int] $from, [int] $to)
     {
         $this.From = $from


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Adding support for derived, parameterized, ArgumentCompleterAttributes. This makes it possible to create more generic completers, either in libraries or shipping with the product.

This allows for parameterized ArgumentCompleters. 
Deriving from `ArgumentCompleterAttribute` makes it possible to create generic completers, like
```powershell
[DirectoryCompleter(ContainingFile="pswh.exe", Depth=2)]

[DateCompleter(WeekDay='Monday', From="LastYear")]

[GitCommits(Branch='release')]
```

The derived attributes implement the `IArgumentCompleterFactory` interface and use property values to create a specialized completer.

## PR Context

It is difficult (if even possible) to write generic completers. This PR would allow for the following:

```csharp
   /// <summary>
    /// Creates new number completions
    /// </summary>
    public class NumberCompletionsAttribute : ArgumentCompleterAttribute, IArgumentCompleterFactory
    {
        private readonly int _from;
        private readonly int _to;
        private readonly int _step;

        /// <summary>
        /// Creates a new <see cref="NumberCompletionsAttribute"/>.
        /// </summary>
        /// <param name="from"></param>
        /// <param name="to"></param>
        /// <param name="step"></param>
        public NumberCompletionsAttribute(int from, int to, int step = 1) 
        {
            _from = @from;
            _to = to;
            _step = step;
        }

        /// <inheritdoc />
        public IArgumentCompleter Create() => new NumberCompleter(_from, _to, _step);
    }

    /// <summary>
    /// Completes numbers
    /// </summary>
    public class NumberCompleter : IArgumentCompleter
    {
        private readonly int _from;
        private readonly int _to;
        private readonly int _step;

        /// <summary>
        /// Creates a new instance of a NumberCompleter
        /// </summary>
        /// <param name="from"></param>
        /// <param name="to"></param>
        /// <param name="step"></param>
        public NumberCompleter(int from, int to, int step)
        {
            _from = @from;
            _to = to;
            _step = step;
        }

        /// <inheritdoc />
        public IEnumerable<CompletionResult> CompleteArgument(string commandName, string parameterName, string wordToComplete, CommandAst commandAst, IDictionary fakeBoundParameters)
        {
            var res = new List<CompletionResult>((_to - _from) / _step);

            for (int i = _from; i <= _to; i += _step)
            {
                string completionText = i.ToString();
                if (completionText.StartsWith(wordToComplete, StringComparison.Ordinal))
                    res.Add(new CompletionResult(completionText));
            }

            return res;
        }
    }
```

or in PowerShell:
```powershell
using namespace System.Management.Automation
using namespace System.Management.Automation.Language
using namespace System.Collections
using namespace System.Collections.Generic


class NumberCompleter : IArgumentCompleter {

    [int] $From
    [int] $To
    [int] $Step
    
    NumberCompleter([int] $from, [int] $to, [int] $step) {
        if ($from -gt $to) {
            throw [ArgumentOutOfRangeException]::new("from")
        }
        $this.From = $from
        $this.To = $to
        $this.Step = $step -lt 1 ? 1 : $step
    }

    [IEnumerable[CompletionResult]] CompleteArgument(
        [string] $CommandName,
        [string] $parameterName,
        [string] $wordToComplete,
        [CommandAst] $commandAst,
        [IDictionary] $fakeBoundParameters) {
        
        $resultList = [List[CompletionResult]]::new()
        $local:to = $this.To
        $local:step = $this.Step
        for ($i = $this.From; $i -lt $to; $i += $step) {
            $resultList.Add([CompletionResult]::new($i.ToString()))
        }
        
        return $resultList
    }
}

class NumberCompletionAttribute : ArgumentCompleterAttribute, IArgumentCompleterFactory {
    [int] $From
    [int] $To
    [int] $Step
    
    NumberCompletionAttribute([int] $from, [int] $to, [int] $step) {
        $this.From = $from
        $this.To = $to
        $this.Step = $step
    }

    [IArgumentCompleter] Create() { return [NumberCompleter]::new($this.From, $this.To, $this.Step) }
}

```

Usage from PowerShell would then be:

```powershell
function Add{
    param(
       [NumberCompletions(0, 100, 5)]
       [int] $X
      ,
       [NumberCompletions(0, 100, 5)]
       [int] $Y
    )
    $X + $Y
}
```

Fix https://github.com/PowerShell/PowerShell/issues/12708

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
