### PR TITLE
Add Unicode formatting tests

### DIFF
--- a/test/common/FileEncoding/FileEncoding.Tests.ps1
+++ b/test/common/FileEncoding/FileEncoding.Tests.ps1
@@ -1,0 +1,27 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe 'Verify file encoding' {
+    BeforeAll {
+        Push-Location $PSScriptRoot\..\..\..
+        $nonBinaryFiles = (git grep -I --files-with-matches -e $'')
+    }
+
+    AfterAll {
+        Pop-Location
+    }
+
+    It 'No UTF-8 BOM' {
+        filter hasUtf8Bom {
+            $_.Where{
+                $bytes = [byte[]]::new(3)
+                $stream = [System.IO.File]::OpenRead($_)
+                $stream.Read($bytes, 0, 3) > $null
+                $stream.Close()
+                $bytes[0] -eq 0xef -and $bytes[1] -eq 0xbb -and $bytes[2] -eq 0xbf
+            }
+        }
+
+        $nonBinaryFiles | hasUtf8Bom | Should -BeNullOrEmpty
+    }
+}

--- a/test/common/FileEncoding/FileEncoding.Tests.ps1
+++ b/test/common/FileEncoding/FileEncoding.Tests.ps1
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+using namespace System
+
 Describe 'Verify file encoding' {
     BeforeAll {
         Push-Location $PSScriptRoot\..\..\..
@@ -14,11 +16,12 @@ Describe 'Verify file encoding' {
     It 'No UTF-8 BOM' {
         filter hasUtf8Bom {
             $_.Where{
-                $bytes = [byte[]]::new(3)
-                $stream = [System.IO.File]::OpenRead($_)
-                $stream.Read($bytes, 0, 3) > $null
+                $bom = [Text.UnicodeEncoding]::UTF8.GetPreamble()
+                $bytes = [byte[]]::new($bom.Length)
+                $stream = [IO.File]::OpenRead($_)
+                $stream.Read($bytes, 0, $bytes.Length) > $null
                 $stream.Close()
-                $bytes[0] -eq 0xef -and $bytes[1] -eq 0xbb -and $bytes[2] -eq 0xbf
+                [Linq.Enumerable]::SequenceEqual($bom, $bytes)
             }
         }
 


### PR DESCRIPTION
# PR Summary

* exclude UTF-8 BOM from text files
* move `test\common` to `test\formatting`

## PR Context

* Fix #11554
* exclude regressions from #11546

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
