### PR TITLE
NRE in CommandSearcher.GetNextCmdlet

### DIFF
--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -1010,10 +1010,10 @@ namespace System.Management.Automation
                         return null;
                     }
 
-                    WildcardPattern cmdletMatcher =
-                        WildcardPattern.Get(
-                            PSSnapinQualifiedCommandName.ShortName,
-                            WildcardOptions.IgnoreCase);
+                    var cmdletShortName = PSSnapinQualifiedCommandName?.ShortName;
+                    WildcardPattern cmdletMatcher = cmdletShortName != null
+                        ? WildcardPattern.Get(cmdletShortName, WildcardOptions.IgnoreCase)
+                        : null;
 
                     SessionStateInternal ss = _context.EngineSessionState;
 
@@ -1021,13 +1021,12 @@ namespace System.Management.Automation
                     {
                         foreach (CmdletInfo cmdlet in cmdletList)
                         {
-                            if (cmdletMatcher.IsMatch(cmdlet.Name) ||
+                            if (cmdletShortName != null &&
+                                cmdletMatcher.IsMatch(cmdlet.Name) ||
                                 (_commandResolutionOptions.HasFlag(SearchResolutionOptions.FuzzyMatch) &&
-                                FuzzyMatcher.IsFuzzyMatch(cmdlet.Name, _commandName)))
+                                 FuzzyMatcher.IsFuzzyMatch(cmdlet.Name, _commandName)))
                             {
-                                if (string.IsNullOrEmpty(PSSnapinQualifiedCommandName.PSSnapInName) ||
-                                    (PSSnapinQualifiedCommandName.PSSnapInName.Equals(
-                                        cmdlet.ModuleName, StringComparison.OrdinalIgnoreCase)))
+                                if (PSSnapinQualifiedCommandName?.PSSnapInName?.Equals(cmdlet.ModuleName, StringComparison.OrdinalIgnoreCase) == true)
                                 {
                                     // If PSSnapin is specified, make sure they match
                                     matchingCmdletInfo.Add(cmdlet);

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -1026,7 +1026,8 @@ namespace System.Management.Automation
                                 (_commandResolutionOptions.HasFlag(SearchResolutionOptions.FuzzyMatch) &&
                                  FuzzyMatcher.IsFuzzyMatch(cmdlet.Name, _commandName)))
                             {
-                                if (PSSnapinQualifiedCommandName?.PSSnapInName?.Equals(cmdlet.ModuleName, StringComparison.OrdinalIgnoreCase) == true)
+                                string moduleName = PSSnapinQualifiedCommandName?.PSSnapInName;
+                                if (moduleName == null || moduleName.Equals(cmdlet.ModuleName, StringComparison.OrdinalIgnoreCase))
                                 {
                                     // If PSSnapin is specified, make sure they match
                                     matchingCmdletInfo.Add(cmdlet);

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -1010,6 +1010,8 @@ namespace System.Management.Automation
                         return null;
                     }
 
+                    string moduleName = PSSnapinQualifiedCommandName?.PSSnapInName;
+
                     var cmdletShortName = PSSnapinQualifiedCommandName?.ShortName;
                     WildcardPattern cmdletMatcher = cmdletShortName != null
                         ? WildcardPattern.Get(cmdletShortName, WildcardOptions.IgnoreCase)
@@ -1026,8 +1028,7 @@ namespace System.Management.Automation
                                 (_commandResolutionOptions.HasFlag(SearchResolutionOptions.FuzzyMatch) &&
                                  FuzzyMatcher.IsFuzzyMatch(cmdlet.Name, _commandName)))
                             {
-                                string moduleName = PSSnapinQualifiedCommandName?.PSSnapInName;
-                                if (moduleName == null || moduleName.Equals(cmdlet.ModuleName, StringComparison.OrdinalIgnoreCase))
+                                if (string.IsNullOrEmpty(moduleName) || moduleName.Equals(cmdlet.ModuleName, StringComparison.OrdinalIgnoreCase))
                                 {
                                     // If PSSnapin is specified, make sure they match
                                     matchingCmdletInfo.Add(cmdlet);

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -1023,7 +1023,7 @@ namespace System.Management.Automation
                     {
                         foreach (CmdletInfo cmdlet in cmdletList)
                         {
-                            if (cmdletShortName != null &&
+                            if (cmdletMatcher != null &&
                                 cmdletMatcher.IsMatch(cmdlet.Name) ||
                                 (_commandResolutionOptions.HasFlag(SearchResolutionOptions.FuzzyMatch) &&
                                  FuzzyMatcher.IsFuzzyMatch(cmdlet.Name, _commandName)))


### PR DESCRIPTION

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes a NullReferenceException when searching for malformed cmdlet names

## PR Context

In GetNextCmdlet, there is a check
```csharp
if (!useAbbreviationExpansion && PSSnapinQualifiedCommandName == null)
{
    return null;
}
```
i.e. the null check is only done if useAbbreviationExpansion is false.

Later on we reference PSSnapinQualifiedCommandName in anyway and get an NRE.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
