### PR TITLE
Ensure null-coalescing LHS is evaluated only once

### DIFF
--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -982,19 +982,20 @@ namespace System.Management.Automation.Language
             {
                 return left;
             }
-            else if (leftType == typeof(AutomationNull))
-            {
-                return right;
-            }
             else
             {
-                Expression lhs = left.Cast(typeof(object));
-                Expression rhs = right.Cast(typeof(object));
-
-                return Expression.Condition(
-                    Expression.Call(CachedReflectionInfo.LanguagePrimitives_IsNull, lhs),
-                    rhs,
-                    lhs);
+                ParameterExpression lhsStoreVar = Expression.Variable(typeof(object));
+                return Expression.Block(
+                    typeof(object),
+                    new ParameterExpression[] { lhsStoreVar },
+                    new Expression[]
+                    {
+                        Expression.Assign(lhsStoreVar, left.Cast(typeof(object))),
+                        Expression.Condition(
+                            Expression.Call(CachedReflectionInfo.LanguagePrimitives_IsNull, lhsStoreVar),
+                            right.Cast(typeof(object)),
+                            lhsStoreVar),
+                    });
             }
         }
 

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -985,17 +985,20 @@ namespace System.Management.Automation.Language
             else
             {
                 ParameterExpression lhsStoreVar = Expression.Variable(typeof(object));
+                var blockParameters = new ParameterExpression[] { lhsStoreVar };
+                var blockStatements = new Expression[]
+                {
+                    Expression.Assign(lhsStoreVar, left.Cast(typeof(object))),
+                    Expression.Condition(
+                        Expression.Call(CachedReflectionInfo.LanguagePrimitives_IsNull, lhsStoreVar),
+                        right.Cast(typeof(object)),
+                        lhsStoreVar),
+                };
+
                 return Expression.Block(
                     typeof(object),
-                    new ParameterExpression[] { lhsStoreVar },
-                    new Expression[]
-                    {
-                        Expression.Assign(lhsStoreVar, left.Cast(typeof(object))),
-                        Expression.Condition(
-                            Expression.Call(CachedReflectionInfo.LanguagePrimitives_IsNull, lhsStoreVar),
-                            right.Cast(typeof(object)),
-                            lhsStoreVar),
-                    });
+                    blockParameters,
+                    blockStatements);
             }
         }
 

--- a/test/powershell/Language/Operators/NullConditional.Tests.ps1
+++ b/test/powershell/Language/Operators/NullConditional.Tests.ps1
@@ -112,13 +112,14 @@ Describe 'NullCoalesceOperations' -Tags 'CI' {
             function Set-TestStateWithNullResult {
                 [void]$testState.Value++
             }
-        }
 
-        BeforeEach {
             $testState = [pscustomobject]@{
                 Value = 0
             }
+        }
 
+        BeforeEach {
+            $testState.Value = 0
             $x = $null
         }
 

--- a/test/powershell/Language/Operators/NullConditional.Tests.ps1
+++ b/test/powershell/Language/Operators/NullConditional.Tests.ps1
@@ -103,7 +103,22 @@ Describe 'NullCoalesceOperations' -Tags 'CI' {
     }
 
     Context 'Null coalesce operator ??' {
+        BeforeAll {
+            function Set-TestStateWithStringResult {
+                'Test'
+                [void]$testState.Value++
+            }
+
+            function Set-TestStateWithNullResult {
+                [void]$testState.Value++
+            }
+        }
+
         BeforeEach {
+            $testState = [pscustomobject]@{
+                Value = 0
+            }
+
             $x = $null
         }
 
@@ -171,6 +186,16 @@ Describe 'NullCoalesceOperations' -Tags 'CI' {
 
         It 'Lhs is $?' {
             {$???$false} | Should -BeTrue
+        }
+
+        It 'Should only evaluate LHS once when it is NOT null' {
+            (Set-TestStateWithStringResult) ?? 'Nothing' | Should -BeExactly 'Test'
+            $testState.Value | Should -Be 1
+        }
+
+        It 'Should only evaluate LHS once when it IS null' {
+            (Set-TestStateWithNullResult) ?? 'Nothing' | Should -BeExactly 'Nothing'
+            $testState.Value | Should -Be 1
         }
     }
 

--- a/test/powershell/Language/Operators/NullConditional.Tests.ps1
+++ b/test/powershell/Language/Operators/NullConditional.Tests.ps1
@@ -103,23 +103,7 @@ Describe 'NullCoalesceOperations' -Tags 'CI' {
     }
 
     Context 'Null coalesce operator ??' {
-        BeforeAll {
-            function Set-TestStateWithStringResult {
-                'Test'
-                [void]$testState.Value++
-            }
-
-            function Set-TestStateWithNullResult {
-                [void]$testState.Value++
-            }
-
-            $testState = [pscustomobject]@{
-                Value = 0
-            }
-        }
-
         BeforeEach {
-            $testState.Value = 0
             $x = $null
         }
 
@@ -189,13 +173,15 @@ Describe 'NullCoalesceOperations' -Tags 'CI' {
             {$???$false} | Should -BeTrue
         }
 
-        It 'Should only evaluate LHS once when it is NOT null' {
-            (Set-TestStateWithStringResult) ?? 'Nothing' | Should -BeExactly 'Test'
+        It 'Should only evaluate LHS once when it IS null' {
+            $testState = [pscustomobject]@{ Value = 0 }
+            (& { [void]$testState.Value++ }) ?? 'Nothing' | Should -BeExactly 'Nothing'
             $testState.Value | Should -Be 1
         }
 
-        It 'Should only evaluate LHS once when it IS null' {
-            (Set-TestStateWithNullResult) ?? 'Nothing' | Should -BeExactly 'Nothing'
+        It 'Should only evaluate LHS once when it is NOT null' {
+            $testState = [pscustomobject]@{ Value = 0 }
+            (& { 'Test'; [void]$testState.Value++ }) ?? 'Nothing' | Should -BeExactly 'Test'
             $testState.Value | Should -Be 1
         }
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes https://github.com/PowerShell/PowerShell/issues/12655.

The null coalescing operator currently double-evaluates its LHS, which is an issue if it has side effects. This changes evaluates the LHS, saves the result to a temporary variable and then proceeds with the conditional operator using the variable.

This PR also removes a redundant type check for AutomationNull that could never be satisfied due to the implementation of AutomationNull.

**This PR should be considered for servicing in PS 7**

## PR Context

LHS in null coalescing expressions is currently double evaluated. It should only be evaluated once.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).

/cc @SeeminglyScience 