### PR TITLE
Enable using proxy credentials in web cmdlets without specifying a proxy

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -454,14 +454,6 @@ namespace Microsoft.PowerShell.Commands
                 ThrowTerminatingError(error);
             }
 
-            // Proxy server
-            if ((Proxy == null) && ProxyCredential != null)
-            {
-                ErrorRecord error = GetValidationError(WebCmdletStrings.ProxyUriNotSupplied,
-                                                       "WebCmdletProxyUriNotSuppliedException");
-                ThrowTerminatingError(error);
-            }
-
             // request body content
             if ((Body != null) && (InFile != null))
             {
@@ -632,6 +624,10 @@ namespace Microsoft.PowerShell.Commands
             if (ProxyUseDefaultCredentials)
             {
                 HttpClient.DefaultProxy.Credentials = CredentialCache.DefaultCredentials;
+            }
+            else if (ProxyCredential != null)
+            {
+                HttpClient.DefaultProxy.Credentials = ProxyCredential.GetNetworkCredential();
             }
 
             if (Proxy != null)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -454,6 +454,13 @@ namespace Microsoft.PowerShell.Commands
                 ThrowTerminatingError(error);
             }
 
+            if (ProxyUseDefaultCredentials && (ProxyCredential != null))
+            {
+                ErrorRecord error = GetValidationError(WebCmdletStrings.ProxyCredentialConflict,
+                                                       "WebCmdletProxyCredentialConflictException");
+                ThrowTerminatingError(error);
+            }
+
             // request body content
             if ((Body != null) && (InFile != null))
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -455,13 +455,7 @@ namespace Microsoft.PowerShell.Commands
             }
 
             // Proxy server
-            if (ProxyUseDefaultCredentials && (ProxyCredential != null))
-            {
-                ErrorRecord error = GetValidationError(WebCmdletStrings.ProxyCredentialConflict,
-                                                       "WebCmdletProxyCredentialConflictException");
-                ThrowTerminatingError(error);
-            }
-            else if ((Proxy == null) && ((ProxyCredential != null) || ProxyUseDefaultCredentials))
+            if ((Proxy == null) && ProxyCredential != null)
             {
                 ErrorRecord error = GetValidationError(WebCmdletStrings.ProxyUriNotSupplied,
                                                        "WebCmdletProxyUriNotSuppliedException");
@@ -633,6 +627,11 @@ namespace Microsoft.PowerShell.Commands
             {
                 // store the UserAgent string
                 WebSession.UserAgent = UserAgent;
+            }
+
+            if (ProxyUseDefaultCredentials)
+            {
+                HttpClient.DefaultProxy.Credentials = CredentialCache.DefaultCredentials;
             }
 
             if (Proxy != null)

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
@@ -192,6 +192,9 @@
   <data name="OutFileWritingSkipped" xml:space="preserve">
     <value>The file will not be re-downloaded because the remote file is the same size as the OutFile: {0}</value>
   </data>
+  <data name="ProxyCredentialConflict" xml:space="preserve">	
+    <value>The cmdlet cannot run because the following conflicting parameters are specified: ProxyCredential and ProxyUseDefaultCredentials. Specify either ProxyCredential or ProxyUseDefaultCredentials, then retry.</value>	
+  </data>
   <data name="ReadResponseComplete" xml:space="preserve">
     <value>Reading web response completed. (Number of bytes read: {0})</value>
   </data>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
@@ -192,9 +192,6 @@
   <data name="OutFileWritingSkipped" xml:space="preserve">
     <value>The file will not be re-downloaded because the remote file is the same size as the OutFile: {0}</value>
   </data>
-  <data name="ProxyUriNotSupplied" xml:space="preserve">
-    <value>The cmdlet cannot run because the following parameter is missing: Proxy. Provide a valid proxy URI for the Proxy parameter when using the ProxyCredential or UseDefaultProxyCredentials parameters, then retry.</value>
-  </data>
   <data name="ReadResponseComplete" xml:space="preserve">
     <value>Reading web response completed. (Number of bytes read: {0})</value>
   </data>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
@@ -192,9 +192,6 @@
   <data name="OutFileWritingSkipped" xml:space="preserve">
     <value>The file will not be re-downloaded because the remote file is the same size as the OutFile: {0}</value>
   </data>
-  <data name="ProxyCredentialConflict" xml:space="preserve">
-    <value>The cmdlet cannot run because the following conflicting parameters are specified: ProxyCredential and ProxyUseDefaultCredentials. Specify either ProxyCredential or ProxyUseDefaultCredentials, then retry.</value>
-  </data>
   <data name="ProxyUriNotSupplied" xml:space="preserve">
     <value>The cmdlet cannot run because the following parameter is missing: Proxy. Provide a valid proxy URI for the Proxy parameter when using the ProxyCredential or UseDefaultProxyCredentials parameters, then retry.</value>
   </data>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -567,6 +567,13 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
         { Invoke-WebRequest -Uri http://httpbin.org -ProxyCredential $credential } | Should -Not -Throw
     }
 
+    It "Invoke-WebRequest throws on conflicting parameters: '-ProxyCredential' and '-ProxyUseDefaultCredentials'" {
+        #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
+        $token = "testpassword" | ConvertTo-SecureString -AsPlainText -Force
+        $credential = [pscredential]::new("testuser", $token)
+        { Invoke-WebRequest -Uri http://httpbin.org -ProxyCredential $credential -ProxyUseDefaultCredentials } | Should -Throw -ErrorId "WebCmdletProxyCredentialConflictException,,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
+    }
+
     # Perform the following operation for Invoke-WebRequest
     # gzip Returns gzip-encoded data.
     # deflate Returns deflate-encoded data.
@@ -2149,6 +2156,13 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
         $token = "testpassword" | ConvertTo-SecureString -AsPlainText -Force
         $credential = [pscredential]::new("testuser", $token)
         { Invoke-RestMethod -Uri http://httpbin.org -ProxyCredential $credential } | Should -Not -Throw
+    }
+
+    It "Invoke-RestMethod throws on conflicting parameters: '-ProxyCredential' and '-ProxyUseDefaultCredentials'" {
+        #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
+        $token = "testpassword" | ConvertTo-SecureString -AsPlainText -Force
+        $credential = [pscredential]::new("testuser", $token)
+        { Invoke-RestMethod -Uri http://httpbin.org -ProxyCredential $credential -ProxyUseDefaultCredentials } | Should -Throw -ErrorId "WebCmdletProxyCredentialConflictException,,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
     }
 
     # Perform the following operation for Invoke-RestMethod

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -557,6 +557,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
     }
 
     It "Invoke-WebRequest accepts '-ProxyUseDefaultCredentials' parameter" {
+        # use external url, but with proxy the external url should not actually be called
         { Invoke-WebRequest -Uri http://httpbin.org -ProxyUseDefaultCredentials } | Should -Not -Throw
     }
 
@@ -564,6 +565,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
         #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
         $token = "testpassword" | ConvertTo-SecureString -AsPlainText -Force
         $credential = [pscredential]::new("testuser", $token)
+        # use external url, but with proxy the external url should not actually be called
         { Invoke-WebRequest -Uri http://httpbin.org -ProxyCredential $credential } | Should -Not -Throw
     }
 
@@ -2148,6 +2150,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
     }
 
     It "Invoke-RestMethod accepts '-ProxyUseDefaultCredentials' parameter" {
+        # use external url, but with proxy the external url should not actually be called
         { Invoke-RestMethod -Uri http://httpbin.org -ProxyUseDefaultCredentials } | Should -Not -Throw
     }
 
@@ -2155,6 +2158,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
         #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
         $token = "testpassword" | ConvertTo-SecureString -AsPlainText -Force
         $credential = [pscredential]::new("testuser", $token)
+        # use external url, but with proxy the external url should not actually be called
         { Invoke-RestMethod -Uri http://httpbin.org -ProxyCredential $credential } | Should -Not -Throw
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -573,7 +573,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
         #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
         $token = "testpassword" | ConvertTo-SecureString -AsPlainText -Force
         $credential = [pscredential]::new("testuser", $token)
-        { Invoke-WebRequest -Uri http://httpbin.org -ProxyCredential $credential -ProxyUseDefaultCredentials } | Should -Throw -ErrorId "WebCmdletProxyCredentialConflictException,,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
+        { Invoke-WebRequest -Uri http://httpbin.org -ProxyCredential $credential -ProxyUseDefaultCredentials } | Should -Throw -ErrorId "WebCmdletProxyCredentialConflictException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
     }
 
     # Perform the following operation for Invoke-WebRequest
@@ -2166,7 +2166,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
         #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
         $token = "testpassword" | ConvertTo-SecureString -AsPlainText -Force
         $credential = [pscredential]::new("testuser", $token)
-        { Invoke-RestMethod -Uri http://httpbin.org -ProxyCredential $credential -ProxyUseDefaultCredentials } | Should -Throw -ErrorId "WebCmdletProxyCredentialConflictException,,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
+        { Invoke-RestMethod -Uri http://httpbin.org -ProxyCredential $credential -ProxyUseDefaultCredentials } | Should -Throw -ErrorId "WebCmdletProxyCredentialConflictException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
     }
 
     # Perform the following operation for Invoke-RestMethod

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -556,6 +556,10 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
         $result.Output.Content | Should -BeExactly $expectedResult.Output.Content
     }
 
+    It "Invoke-WebRequest accepts '-ProxyUseDefaultCredentials' parameter" {
+        { Invoke-WebRequest -Uri http://httpbin.org -ProxyUseDefaultCredentials } | Should -Not -Throw
+    }
+
     # Perform the following operation for Invoke-WebRequest
     # gzip Returns gzip-encoded data.
     # deflate Returns deflate-encoded data.
@@ -2127,6 +2131,10 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
         $command = "Invoke-RestMethod -Uri '${protocol}://${proxy_address}' -NoProxy"
         $expectedResult = ExecuteWebCommand -command $command
         $result.Output | Should -BeExactly $expectedResult.Output
+    }
+
+    It "Invoke-RestMethod accepts '-ProxyUseDefaultCredentials' parameter" {
+        { Invoke-RestMethod -Uri http://httpbin.org -ProxyUseDefaultCredentials } | Should -Not -Throw
     }
 
     # Perform the following operation for Invoke-RestMethod

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -560,6 +560,12 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
         { Invoke-WebRequest -Uri http://httpbin.org -ProxyUseDefaultCredentials } | Should -Not -Throw
     }
 
+    It "Invoke-WebRequest accepts '-ProxyCredential' parameter" {
+        $token = "testpassword" | ConvertTo-SecureString -AsPlainText -Force
+        $credential = [pscredential]::new("testuser", $token)
+        { Invoke-WebRequest -Uri http://httpbin.org -ProxyCredential $credential } | Should -Not -Throw
+    }
+
     # Perform the following operation for Invoke-WebRequest
     # gzip Returns gzip-encoded data.
     # deflate Returns deflate-encoded data.
@@ -2135,6 +2141,12 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
 
     It "Invoke-RestMethod accepts '-ProxyUseDefaultCredentials' parameter" {
         { Invoke-RestMethod -Uri http://httpbin.org -ProxyUseDefaultCredentials } | Should -Not -Throw
+    }
+
+    It "Invoke-RestMethod accepts '-ProxyCredential' parameter" {
+        $token = "testpassword" | ConvertTo-SecureString -AsPlainText -Force
+        $credential = [pscredential]::new("testuser", $token)
+        { Invoke-RestMethod -Uri http://httpbin.org -ProxyCredential $credential } | Should -Not -Throw
     }
 
     # Perform the following operation for Invoke-RestMethod

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -561,6 +561,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
     }
 
     It "Invoke-WebRequest accepts '-ProxyCredential' parameter" {
+        #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
         $token = "testpassword" | ConvertTo-SecureString -AsPlainText -Force
         $credential = [pscredential]::new("testuser", $token)
         { Invoke-WebRequest -Uri http://httpbin.org -ProxyCredential $credential } | Should -Not -Throw
@@ -2144,6 +2145,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
     }
 
     It "Invoke-RestMethod accepts '-ProxyCredential' parameter" {
+        #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
         $token = "testpassword" | ConvertTo-SecureString -AsPlainText -Force
         $credential = [pscredential]::new("testuser", $token)
         { Invoke-RestMethod -Uri http://httpbin.org -ProxyCredential $credential } | Should -Not -Throw


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Enable using proxy credentials in web cmdlets without specifying a proxy so that follow now works with _default proxy_:
```powershell
Invoke-WebRequest -Uri https://ya.ru -ProxyUseDefaultCredentials

Invoke-WebRequest -Uri https://ya.ru -ProxyCredentials $cred
```

Tested manually on real proxy.

Credentials are not sent by default, only with explicit parameter, so no security concern is.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
