### PR TITLE
cleanup: Use single expectation for each It block

### DIFF
--- a/test/powershell/Modules/ThreadJob/ThreadJob.Tests.ps1
+++ b/test/powershell/Modules/ThreadJob/ThreadJob.Tests.ps1
@@ -93,24 +93,21 @@ Describe 'Basic ThreadJob Tests' -Tags 'CI' {
 
         $job = Start-ThreadJob -ScriptBlock { "Goodbye" } -InitializationScript { "Hello" }
         $results = $job | Receive-Job -Wait
-        $results[0] | Should -Be "Hello"
-        $results[1] | Should -Be "Goodbye"
+        $results | Should -BeExactly "Hello", "Goodbye"
     }
 
     It 'ThreadJob with ScriptBlock and Argument list' {
 
         $job = Start-ThreadJob -ScriptBlock { param ($arg1, $arg2) $arg1; $arg2 } -ArgumentList @("Hello","Goodbye")
         $results = $job | Receive-Job -Wait
-        $results[0] | Should -Be "Hello"
-        $results[1] | Should -Be "Goodbye"
+        $results | Should -BeExactly "Hello", "Goodbye"
     }
 
     It 'ThreadJob with ScriptBlock and piped input' {
 
         $job = "Hello","Goodbye" | Start-ThreadJob -ScriptBlock { $input | ForEach-Object { $_ } }
         $results = $job | Receive-Job -Wait
-        $results[0] | Should -Be "Hello"
-        $results[1] | Should -Be "Goodbye"
+        $results | Should -BeExactly "Hello", "Goodbye"
     }
 
     It 'ThreadJob with ScriptBlock and Using variables' {
@@ -130,12 +127,7 @@ Describe 'Basic ThreadJob Tests' -Tags 'CI' {
         }
 
         $results = $job | Receive-Job -Wait
-        $results[0] | Should -Be $Var1
-        $results[1] | Should -Be $Var2
-        $results[2] | Should -Be $Var3
-        $results[3] | Should -Be 2
-        $results[4] | Should -Be $Var4
-        $results[5] | Should -Be $global:GVar1
+        $results | Should -BeExactly $Var1, $Var2, $Var3, 2, $Var4, $global:GVar1
     }
 
     It 'ThreadJob with ScriptBlock and Using variables and argument list' {
@@ -172,16 +164,14 @@ Describe 'Basic ThreadJob Tests' -Tags 'CI' {
 
         $job = Start-ThreadJob -FilePath $scriptFilePath2 -ArgumentList @("Hello","Goodbye")
         $results = $job | Receive-Job -Wait
-        $results[0] | Should -Be "Hello"
-        $results[1] | Should -Be "Goodbye"
+        $results | Should -BeExactly "Hello", "Goodbye"
     }
 
     It 'ThreadJob with ScriptFile and piped input' {
 
         $job = "Hello","Goodbye" | Start-ThreadJob -FilePath $scriptFilePath3
         $results = $job | Receive-Job -Wait
-        $results[0] | Should -Be "Hello"
-        $results[1] | Should -Be "Goodbye"
+        $results | Should -BeExactly "Hello", "Goodbye"
     }
 
     It 'ThreadJob with ScriptFile and Using variables' {
@@ -191,9 +181,7 @@ Describe 'Basic ThreadJob Tests' -Tags 'CI' {
 
         $job = Start-ThreadJob -FilePath $scriptFilePath4
         $results = $job | Receive-Job -Wait
-        $results[0] | Should -Be $Var1
-        $results[1] | Should -Be 3
-        $results[2] | Should -Be $Array1
+        $results | Should -BeExactly $Var1, 3, $Array1
     }
 
     It 'ThreadJob with ScriptFile and Using variables with argument list' {
@@ -227,7 +215,7 @@ Describe 'Basic ThreadJob Tests' -Tags 'CI' {
     It 'ThreadJob and Verbose stream output' {
 
         $job = Start-ThreadJob -ScriptBlock { $VerbosePreference = 'Continue'; Write-Verbose "VerboseOut" } | Wait-Job
-        $job.Verbose | Should -Match "VerboseOut"
+        $job.Verbose | Should -BeExactly "VerboseOut"
     }
 
     It 'ThreadJob and Verbose stream output' {


### PR DESCRIPTION
# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

Convention is to assert a single expectation for each `It` block. [[1]](https://github.com/pester/Pester/wiki/It)

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [x] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
