### PR TITLE
WIP: Fix improper error message in Export-CSV

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -29,14 +29,16 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Property that sets delimiter.
         /// </summary>
-        [Parameter(Position = 1, ParameterSetName = "Delimiter")]
+        [Parameter(Position = 1, ParameterSetName = "DelimiterPath")]
+        [Parameter(Position = 1, ParameterSetName = "DelimiterLiteralPath")]
         [ValidateNotNull]
         public char Delimiter { get; set; }
 
         ///<summary>
         ///Culture switch for csv conversion
         ///</summary>
-        [Parameter(ParameterSetName = "UseCulture")]
+        [Parameter(Position = 1, ParameterSetName = "CulturePath")]
+        [Parameter(Position = 1, ParameterSetName = "CultureLiteralPath")]
         public SwitchParameter UseCulture { get; set; }
 
         /// <summary>
@@ -138,7 +140,7 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// Implementation for the Export-Csv command.
     /// </summary>
-    [Cmdlet(VerbsData.Export, "Csv", SupportsShouldProcess = true, DefaultParameterSetName = "Delimiter", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=2096608")]
+    [Cmdlet(VerbsData.Export, "Csv", SupportsShouldProcess = true, DefaultParameterSetName = "DelimiterPath", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=2096608")]
     public sealed class ExportCsvCommand : BaseCsvWritingCommand, IDisposable
     {
         #region Command Line Parameters
@@ -155,7 +157,8 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Mandatory file name to write to.
         /// </summary>
-        [Parameter(Position = 0)]
+        [Parameter(Position = 0, ParameterSetName = "DelimiterPath", Mandatory = true)]
+        [Parameter(Position = 0, ParameterSetName = "CulturePath", Mandatory = true)]
         [ValidateNotNullOrEmpty]
         public string Path
         {
@@ -167,17 +170,16 @@ namespace Microsoft.PowerShell.Commands
             set
             {
                 _path = value;
-                _specifiedPath = true;
             }
         }
 
         private string _path;
-        private bool _specifiedPath = false;
 
         /// <summary>
         /// The literal path of the mandatory file name to write to.
         /// </summary>
-        [Parameter]
+        [Parameter(Position = 0, ParameterSetName = "DelimiterLiteralPath", Mandatory = true)]
+        [Parameter(Position = 0, ParameterSetName = "CultureLiteralPath", Mandatory = true)]
         [ValidateNotNullOrEmpty]
         [Alias("PSPath", "LP")]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
@@ -243,14 +245,6 @@ namespace Microsoft.PowerShell.Commands
         protected override void BeginProcessing()
         {
             base.BeginProcessing();
-
-            // Validate that they don't provide both Path and LiteralPath, but have provided at least one.
-            if (!(_specifiedPath ^ _isLiteralPath))
-            {
-                InvalidOperationException exception = new InvalidOperationException(CsvCommandStrings.CannotSpecifyPathAndLiteralPath);
-                ErrorRecord errorRecord = new ErrorRecord(exception, "CannotSpecifyPathAndLiteralPath", ErrorCategory.InvalidData, null);
-                this.ThrowTerminatingError(errorRecord);
-            }
 
             _shouldProcess = ShouldProcess(Path);
             if (!_shouldProcess)
@@ -538,12 +532,10 @@ namespace Microsoft.PowerShell.Commands
             set
             {
                 _paths = value;
-                _specifiedPath = true;
             }
         }
 
         private string[] _paths;
-        private bool _specifiedPath = false;
 
         /// <summary>
         /// Gets or sets the literal path of the mandatory file name to read from.
@@ -616,13 +608,6 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void ProcessRecord()
         {
-            // Validate that they don't provide both Path and LiteralPath, but have provided at least one.
-            if (!(_specifiedPath ^ _isLiteralPath))
-            {
-                InvalidOperationException exception = new InvalidOperationException(CsvCommandStrings.CannotSpecifyPathAndLiteralPath);
-                ErrorRecord errorRecord = new ErrorRecord(exception, "CannotSpecifyPathAndLiteralPath", ErrorCategory.InvalidData, null);
-                this.ThrowTerminatingError(errorRecord);
-            }
 
             if (_paths != null)
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -37,8 +37,8 @@ namespace Microsoft.PowerShell.Commands
         ///<summary>
         ///Culture switch for csv conversion
         ///</summary>
-        [Parameter(Position = 1, ParameterSetName = "CulturePath")]
-        [Parameter(Position = 1, ParameterSetName = "CultureLiteralPath")]
+        [Parameter(Position = 1, ParameterSetName = "CulturePath", Mandatory = true)]
+        [Parameter(Position = 1, ParameterSetName = "CultureLiteralPath", Mandatory = true)]
         public SwitchParameter UseCulture { get; set; }
 
         /// <summary>
@@ -178,8 +178,8 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// The literal path of the mandatory file name to write to.
         /// </summary>
-        [Parameter(Position = 0, ParameterSetName = "DelimiterLiteralPath", Mandatory = true)]
-        [Parameter(Position = 0, ParameterSetName = "CultureLiteralPath", Mandatory = true)]
+        [Parameter(ParameterSetName = "DelimiterLiteralPath", Mandatory = true)]
+        [Parameter(ParameterSetName = "CultureLiteralPath", Mandatory = true)]
         [ValidateNotNullOrEmpty]
         [Alias("PSPath", "LP")]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -29,14 +29,16 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Property that sets delimiter.
         /// </summary>
-        [Parameter(Position = 1, ParameterSetName = "Delimiter")]
+        [Parameter(Position = 1, ParameterSetName = "DelimiterPath")]
+        [Parameter(Position = 1, ParameterSetName = "DelimiterLiteralPath")]
         [ValidateNotNull]
         public char Delimiter { get; set; }
 
         ///<summary>
         ///Culture switch for csv conversion
         ///</summary>
-        [Parameter(ParameterSetName = "UseCulture")]
+        [Parameter(Position = 1, ParameterSetName = "CulturePath")]
+        [Parameter(Position = 1, ParameterSetName = "CultureLiteralPath")]
         public SwitchParameter UseCulture { get; set; }
 
         /// <summary>
@@ -138,7 +140,7 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// Implementation for the Export-Csv command.
     /// </summary>
-    [Cmdlet(VerbsData.Export, "Csv", SupportsShouldProcess = true, DefaultParameterSetName = "Delimiter", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=2096608")]
+    [Cmdlet(VerbsData.Export, "Csv", SupportsShouldProcess = true, DefaultParameterSetName = "DelimiterPath", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=2096608")]
     public sealed class ExportCsvCommand : BaseCsvWritingCommand, IDisposable
     {
         #region Command Line Parameters
@@ -155,7 +157,8 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Mandatory file name to write to.
         /// </summary>
-        [Parameter(Position = 0)]
+        [Parameter(Position = 0, ParameterSetName = "DelimiterPath", Mandatory = true)]
+        [Parameter(Position = 0, ParameterSetName = "CulturePath", Mandatory = true)]
         [ValidateNotNullOrEmpty]
         public string Path
         {
@@ -167,17 +170,16 @@ namespace Microsoft.PowerShell.Commands
             set
             {
                 _path = value;
-                _specifiedPath = true;
             }
         }
 
         private string _path;
-        private bool _specifiedPath = false;
 
         /// <summary>
         /// The literal path of the mandatory file name to write to.
         /// </summary>
-        [Parameter]
+        [Parameter(Position = 0, ParameterSetName = "DelimiterLiteralPath", Mandatory = true)]
+        [Parameter(Position = 0, ParameterSetName = "CultureLiteralPath", Mandatory = true)]
         [ValidateNotNullOrEmpty]
         [Alias("PSPath", "LP")]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
@@ -243,14 +245,6 @@ namespace Microsoft.PowerShell.Commands
         protected override void BeginProcessing()
         {
             base.BeginProcessing();
-
-            // Validate that they don't provide both Path and LiteralPath, but have provided at least one.
-            if (!(_specifiedPath ^ _isLiteralPath))
-            {
-                InvalidOperationException exception = new InvalidOperationException(CsvCommandStrings.CannotSpecifyPathAndLiteralPath);
-                ErrorRecord errorRecord = new ErrorRecord(exception, "CannotSpecifyPathAndLiteralPath", ErrorCategory.InvalidData, null);
-                this.ThrowTerminatingError(errorRecord);
-            }
 
             _shouldProcess = ShouldProcess(Path);
             if (!_shouldProcess)
@@ -538,12 +532,10 @@ namespace Microsoft.PowerShell.Commands
             set
             {
                 _paths = value;
-                _specifiedPath = true;
             }
         }
 
         private string[] _paths;
-        private bool _specifiedPath = false;
 
         /// <summary>
         /// Gets or sets the literal path of the mandatory file name to read from.
@@ -616,14 +608,6 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void ProcessRecord()
         {
-            // Validate that they don't provide both Path and LiteralPath, but have provided at least one.
-            if (!(_specifiedPath ^ _isLiteralPath))
-            {
-                InvalidOperationException exception = new InvalidOperationException(CsvCommandStrings.CannotSpecifyPathAndLiteralPath);
-                ErrorRecord errorRecord = new ErrorRecord(exception, "CannotSpecifyPathAndLiteralPath", ErrorCategory.InvalidData, null);
-                this.ThrowTerminatingError(errorRecord);
-            }
-
             if (_paths != null)
             {
                 foreach (string path in _paths)

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/CsvCommandStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/CsvCommandStrings.resx
@@ -133,9 +133,6 @@
   <data name="CannotSpecifyIncludeTypeInformationAndNoTypeInformation" xml:space="preserve">
     <value>You must specify either the -IncludeTypeInformation or -NoTypeInformation parameters, but not both.</value>
   </data>
-  <data name="CannotSpecifyPathAndLiteralPath" xml:space="preserve">
-    <value>You must specify either the -Path or -LiteralPath parameters, but not both.</value>
-  </data>
   <data name="UseDefaultNameForUnspecifiedHeader" xml:space="preserve">
     <value>One or more headers were not specified. Default names starting with "H" have been used in place of any missing headers.</value>
   </data>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Csv.Tests.ps1
@@ -21,10 +21,6 @@ Describe "Export-Csv" -Tags "CI" {
         { $testObject | Export-Csv -Path $testCsv -ErrorAction Stop } | Should -Not -Throw
     }
 
-    It "Should throw if an output file isn't specified" {
-        { $testObject | Export-Csv -ErrorAction Stop } | Should -Throw -ErrorId "CannotSpecifyPathAndLiteralPath,Microsoft.PowerShell.Commands.ExportCsvCommand"
-    }
-
     It "Should be a string when exporting via pipe" {
         $testObject | Export-Csv -Path  $testCsv -IncludeTypeInformation
         $results = Get-Content -Path $testCsv
@@ -80,8 +76,15 @@ Describe "Export-Csv" -Tags "CI" {
             Should -Throw -ErrorId "CannotSpecifyIncludeTypeInformationAndNoTypeInformation,Microsoft.PowerShell.Commands.ExportCsvCommand"
     }
 
-    It "Should support -LiteralPath parameter" {
-        $testObject | Export-Csv -LiteralPath $testCsv
+    It "Should support -LiteralPath parameter with Delimiter" {
+        $testObject | Export-Csv -LiteralPath $testCsv -Delimiter ','
+        $results = Import-Csv -Path  $testCsv
+
+        $results | Should -HaveCount 3
+    }
+
+    It "Should support -LiteralPath parameter with UseCulture" {
+        $testObject | Export-Csv -LiteralPath $testCsv -UseCulture
         $results = Import-Csv -Path  $testCsv
 
         $results | Should -HaveCount 3


### PR DESCRIPTION
# PR Summary

- Rework the ParameterSets in Export-CSV to reflect behaviour from
Import-CSv.
- Make -Path and -LiteralPath manadatory in their sets.
- Remove error message from Export-CSV when both -Path and -LiteralPath
are specified, because they can no lnger be specified at the same time.

fixes #11679

## PR Context
Rework ParameterSets to behave like Import-CSV. Path and LiteralPath can not be specified at the same time. ParamaterSets themselves can validate if a proper set was given or not. No further checks in the code are necessary. 

No issue filed for documentation, but prepared the necessary PR https://github.com/MicrosoftDocs/PowerShell-Docs/pull/5948

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
