### PR TITLE
Redundancy: Remove 'partial' modifier from type with a single part

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/HttpKnownHeaderNames.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/HttpKnownHeaderNames.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.PowerShell.Commands
 {
-    internal static partial class HttpKnownHeaderNames
+    internal static class HttpKnownHeaderNames
     {
         #region Known_HTTP_Header_Names
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseHelper.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseHelper.CoreClr.cs
@@ -8,7 +8,7 @@ using System.Net.Http;
 
 namespace Microsoft.PowerShell.Commands
 {
-    internal static partial class WebResponseHelper
+    internal static class WebResponseHelper
     {
         internal static string GetCharacterSet(HttpResponseMessage response)
         {

--- a/src/Microsoft.WSMan.Management/ConfigProvider.cs
+++ b/src/Microsoft.WSMan.Management/ConfigProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.WSMan.Management
     /// WsMan Provider.
     /// </summary>
     [CmdletProvider(WSManStringLiterals.ProviderName, ProviderCapabilities.Credentials)]
-    public sealed partial class WSManConfigProvider : NavigationCmdletProvider, ICmdletProviderSupportsHelp
+    public sealed class WSManConfigProvider : NavigationCmdletProvider, ICmdletProviderSupportsHelp
     {
         // Plugin Name Storage
         private PSObject objPluginNames = null;

--- a/src/System.Management.Automation/engine/cmdlet.cs
+++ b/src/System.Management.Automation/engine/cmdlet.cs
@@ -30,7 +30,7 @@ namespace System.Management.Automation
     /// task, extending the Cmdlet or PSCmdlet classes only as a thin management layer.
     /// </remarks>
     /// <seealso cref="System.Management.Automation.Internal.InternalCommand"/>
-    public abstract partial class Cmdlet : InternalCommand
+    public abstract class Cmdlet : InternalCommand
     {
         #region public_properties
 

--- a/src/System.Management.Automation/engine/interpreter/DynamicSplatInstruction.cs
+++ b/src/System.Management.Automation/engine/interpreter/DynamicSplatInstruction.cs
@@ -20,7 +20,7 @@ namespace System.Management.Automation.Interpreter
     /// <summary>
     /// Implements dynamic call site with many arguments. Wraps the arguments into <see cref="ArgumentArray"/>.
     /// </summary>
-    internal sealed partial class DynamicSplatInstruction : Instruction
+    internal sealed class DynamicSplatInstruction : Instruction
     {
         private readonly CallSite<Func<CallSite, ArgumentArray, object>> _site;
         private readonly int _argumentCount;

--- a/src/System.Management.Automation/engine/interpreter/Instruction.cs
+++ b/src/System.Management.Automation/engine/interpreter/Instruction.cs
@@ -22,7 +22,7 @@ namespace System.Management.Automation.Interpreter
         void AddInstructions(LightCompiler compiler);
     }
 
-    internal abstract partial class Instruction
+    internal abstract class Instruction
     {
         public const int UnknownInstrIndex = int.MaxValue;
 

--- a/src/System.Management.Automation/engine/interpreter/Utilities.cs
+++ b/src/System.Management.Automation/engine/interpreter/Utilities.cs
@@ -126,7 +126,7 @@ namespace System.Management.Automation.Interpreter
         }
     }
 
-    internal static partial class DelegateHelpers
+    internal static class DelegateHelpers
     {
         #region Generated Maximum Delegate Arity
 

--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -27,7 +27,7 @@ namespace Microsoft.PowerShell.Commands
     /// It contains tons of utility functions which are used all
     /// across the remoting cmdlets.
     /// </summary>
-    public abstract partial class PSRemotingCmdlet : PSCmdlet
+    public abstract class PSRemotingCmdlet : PSCmdlet
     {
         #region Overrides
 
@@ -296,7 +296,7 @@ namespace Microsoft.PowerShell.Commands
     ///     2. Invoke-Expression
     ///     3. Start-PSJob.
     /// </summary>
-    public abstract partial class PSRemotingBaseCmdlet : PSRemotingCmdlet
+    public abstract class PSRemotingBaseCmdlet : PSRemotingCmdlet
     {
         #region Enums
 
@@ -1149,7 +1149,7 @@ namespace Microsoft.PowerShell.Commands
     ///     1. Invoke-Expression
     ///     2. Start-PSJob.
     /// </summary>
-    public abstract partial class PSExecutionCmdlet : PSRemotingBaseCmdlet
+    public abstract class PSExecutionCmdlet : PSRemotingBaseCmdlet
     {
         #region Strings
 
@@ -2448,7 +2448,7 @@ namespace Microsoft.PowerShell.Commands
     ///     3. Disconnect-PSSession
     ///     4. Connect-PSSession.
     /// </summary>
-    public abstract partial class PSRunspaceCmdlet : PSRemotingCmdlet
+    public abstract class PSRunspaceCmdlet : PSRemotingCmdlet
     {
         #region Parameters
 
@@ -3222,7 +3222,7 @@ namespace Microsoft.PowerShell.Commands
     /// Base class for both the helpers. This is an abstract class
     /// and the helpers need to derive from this.
     /// </summary>
-    internal abstract partial class ExecutionCmdletHelper : IThrottleOperation
+    internal abstract class ExecutionCmdletHelper : IThrottleOperation
     {
         /// <summary>
         /// Pipeline associated with this operation.

--- a/src/System.Management.Automation/utils/ExtensionMethods.cs
+++ b/src/System.Management.Automation/utils/ExtensionMethods.cs
@@ -68,7 +68,7 @@ namespace System.Management.Automation
     /// * If you want to add an extension method that will be used only by CoreCLR powershell, please add it to the partial
     ///   'PSTypeExtensions' class in 'CorePsExtensions.cs'.
     /// </summary>
-    internal static partial class PSTypeExtensions
+    internal static class PSTypeExtensions
     {
         /// <summary>
         /// Check does the type have an instance default constructor with visibility that allows calling it from subclass.


### PR DESCRIPTION
# PR Summary

Fix RCS1043

## PR Context

https://github.com/JosefPihrt/Roslynator/blob/master/docs/analyzers/RCS1043.md

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
