### PR TITLE
Nullable annotations for CommandSearcher

### DIFF
--- a/src/System.Management.Automation/engine/CommandPathSearch.cs
+++ b/src/System.Management.Automation/engine/CommandPathSearch.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
-
-#nullable enable
 
 namespace System.Management.Automation
 {
@@ -18,10 +18,11 @@ namespace System.Management.Automation
     internal class CommandPathSearch : IEnumerable<string>, IEnumerator<string>
     {
         [TraceSource("CommandSearch", "CommandSearch")]
-        private static PSTraceSource s_tracer = PSTraceSource.GetTracer("CommandSearch", "CommandSearch");
+        private static readonly PSTraceSource s_tracer = PSTraceSource.GetTracer("CommandSearch", "CommandSearch");
 
         /// <summary>
         /// Constructs a command searching enumerator that resolves the location
+        /// of a command using the PATH environment variable.
         /// of a command using the PATH environment variable.
         /// </summary>
         /// <param name="commandName">
@@ -44,7 +45,7 @@ namespace System.Management.Automation
             string commandName,
             LookupPathCollection lookupPaths,
             ExecutionContext context,
-            Collection<string> acceptableCommandNames,
+            Collection<string>? acceptableCommandNames,
             bool useFuzzyMatch)
         {
             _useFuzzyMatch = useFuzzyMatch;

--- a/src/System.Management.Automation/engine/CommandPathSearch.cs
+++ b/src/System.Management.Automation/engine/CommandPathSearch.cs
@@ -23,7 +23,6 @@ namespace System.Management.Automation
         /// <summary>
         /// Constructs a command searching enumerator that resolves the location
         /// of a command using the PATH environment variable.
-        /// of a command using the PATH environment variable.
         /// </summary>
         /// <param name="commandName">
         /// The command name to search for in the path.

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -364,6 +364,7 @@ namespace System.Management.Automation
             {
                 try
                 {
+                    // the previous call to setupPathSearcher ensures _pathSearcher != null
                     while (currentMatch == null && _pathSearcher!.MoveNext())
                     {
                         currentMatch = GetInfoFromPath(((IEnumerator<string>)_pathSearcher).Current);

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -1,9 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Management.Automation.Internal;
 
@@ -242,9 +245,9 @@ namespace System.Management.Automation
             return false;
         }
 
-        private CommandInfo SearchForAliases()
+        private CommandInfo? SearchForAliases()
         {
-            CommandInfo currentMatch = null;
+            CommandInfo? currentMatch = null;
 
             if (_context.EngineSessionState != null &&
                 (_commandTypes & CommandTypes.Alias) != 0)
@@ -255,9 +258,9 @@ namespace System.Management.Automation
             return currentMatch;
         }
 
-        private CommandInfo SearchForFunctions()
+        private CommandInfo? SearchForFunctions()
         {
-            CommandInfo currentMatch = null;
+            CommandInfo? currentMatch = null;
 
             if (_context.EngineSessionState != null &&
                 (_commandTypes & (CommandTypes.Function | CommandTypes.Filter | CommandTypes.Configuration)) != 0)
@@ -268,9 +271,9 @@ namespace System.Management.Automation
             return currentMatch;
         }
 
-        private CommandInfo SearchForCmdlets()
+        private CommandInfo? SearchForCmdlets()
         {
-            CommandInfo currentMatch = null;
+            CommandInfo? currentMatch = null;
 
             if ((_commandTypes & CommandTypes.Cmdlet) != 0)
             {
@@ -280,9 +283,9 @@ namespace System.Management.Automation
             return currentMatch;
         }
 
-        private CommandInfo ProcessBuiltinScriptState()
+        private CommandInfo? ProcessBuiltinScriptState()
         {
-            CommandInfo currentMatch = null;
+            CommandInfo? currentMatch = null;
 
             // Check to see if the path is qualified
 
@@ -296,9 +299,9 @@ namespace System.Management.Automation
             return currentMatch;
         }
 
-        private CommandInfo ProcessPathResolutionState()
+        private CommandInfo? ProcessPathResolutionState()
         {
-            CommandInfo currentMatch = null;
+            CommandInfo? currentMatch = null;
 
             try
             {
@@ -338,7 +341,7 @@ namespace System.Management.Automation
             return currentMatch;
         }
 
-        private CommandInfo ProcessQualifiedFileSystemState()
+        private CommandInfo? ProcessQualifiedFileSystemState()
         {
             try
             {
@@ -355,13 +358,13 @@ namespace System.Management.Automation
                 throw;
             }
 
-            CommandInfo currentMatch = null;
+            CommandInfo? currentMatch = null;
             _currentState = SearchState.PathSearch;
             if (_canDoPathLookup)
             {
                 try
                 {
-                    while (currentMatch == null && _pathSearcher.MoveNext())
+                    while (currentMatch == null && _pathSearcher!.MoveNext())
                     {
                         currentMatch = GetInfoFromPath(((IEnumerator<string>)_pathSearcher).Current);
                     }
@@ -375,10 +378,10 @@ namespace System.Management.Automation
             return currentMatch;
         }
 
-        private CommandInfo ProcessPathSearchState()
+        private CommandInfo? ProcessPathSearchState()
         {
-            CommandInfo currentMatch = null;
-            string path = DoPowerShellRelativePathLookup();
+            CommandInfo? currentMatch = null;
+            string? path = DoPowerShellRelativePathLookup();
 
             if (!string.IsNullOrEmpty(path))
             {
@@ -443,9 +446,9 @@ namespace System.Management.Automation
         /// <returns>
         /// A CommandInfo for the next command if it exists as a path, or null otherwise.
         /// </returns>
-        private CommandInfo GetNextFromPath()
+        private CommandInfo? GetNextFromPath()
         {
-            CommandInfo result = null;
+            CommandInfo? result = null;
 
             do // false loop
             {
@@ -478,7 +481,7 @@ namespace System.Management.Automation
                 if (!_commandResolutionOptions.HasFlag(SearchResolutionOptions.ResolveLiteralThenPathPatterns) &&
                     resolvedPaths.Count == 0)
                 {
-                    string path = GetNextLiteralPathThatExistsAndHandleExceptions(_commandName, out _);
+                    string? path = GetNextLiteralPathThatExistsAndHandleExceptions(_commandName, out _);
 
                     if (path != null)
                     {
@@ -520,7 +523,7 @@ namespace System.Management.Automation
         /// <returns>
         /// A collection of full paths to the commands which were found.
         /// </returns>
-        private Collection<string> GetNextFromPathUsingWildcards(string command, out ProviderInfo provider)
+        private Collection<string> GetNextFromPathUsingWildcards(string? command, out ProviderInfo? provider)
         {
             try
             {
@@ -594,9 +597,9 @@ namespace System.Management.Automation
         /// If <paramref name="path"/> refers to a cmdlet file that
         /// contains invalid metadata.
         /// </exception>
-        private CommandInfo GetInfoFromPath(string path)
+        private CommandInfo? GetInfoFromPath(string path)
         {
-            CommandInfo result = null;
+            CommandInfo? result = null;
 
             do // false loop
             {
@@ -607,7 +610,7 @@ namespace System.Management.Automation
                 }
 
                 // Now create the appropriate CommandInfo using the extension
-                string extension = null;
+                string? extension = null;
 
                 try
                 {
@@ -681,9 +684,9 @@ namespace System.Management.Automation
         /// <returns>
         /// A CommandInfo representing the next matching alias if found, otherwise null.
         /// </returns>
-        private CommandInfo GetNextAlias()
+        private CommandInfo? GetNextAlias()
         {
-            CommandInfo result = null;
+            CommandInfo? result = null;
 
             if ((_commandResolutionOptions & SearchResolutionOptions.ResolveAliasPatterns) != 0)
             {
@@ -709,7 +712,7 @@ namespace System.Management.Automation
                     }
 
                     // Process alias from modules
-                    AliasInfo c = GetAliasFromModules(_commandName);
+                    AliasInfo? c = GetAliasFromModules(_commandName);
                     if (c != null)
                     {
                         matchingAliases.Add(c);
@@ -762,15 +765,15 @@ namespace System.Management.Automation
         /// <returns>
         /// A CommandInfo representing the next matching function if found, otherwise null.
         /// </returns>
-        private CommandInfo GetNextFunction()
+        private CommandInfo? GetNextFunction()
         {
-            CommandInfo result = null;
+            CommandInfo? result = null;
 
             if (_commandResolutionOptions.HasFlag(SearchResolutionOptions.ResolveFunctionPatterns))
             {
                 if (_matchingFunctionEnumerator == null)
                 {
-                    Collection<CommandInfo> matchingFunction = new Collection<CommandInfo>();
+                    Collection<CommandInfo?> matchingFunction = new Collection<CommandInfo?>();
 
                     // Generate the enumerator of matching function names
                     WildcardPattern functionMatcher =
@@ -796,7 +799,7 @@ namespace System.Management.Automation
                     }
 
                     // Process functions from modules
-                    CommandInfo cmdInfo = GetFunctionFromModules(_commandName);
+                    CommandInfo? cmdInfo = GetFunctionFromModules(_commandName);
                     if (cmdInfo != null)
                     {
                         matchingFunction.Add(cmdInfo);
@@ -838,7 +841,7 @@ namespace System.Management.Automation
         // Don't return commands to the user if that might result in:
         //     - Trusted commands calling untrusted functions that the user has overridden
         //     - Debug prompts calling internal functions that are likely to have code injection
-        private bool ShouldSkipCommandResolutionForConstrainedLanguage(CommandInfo result, ExecutionContext executionContext)
+        private bool ShouldSkipCommandResolutionForConstrainedLanguage(CommandInfo? result, ExecutionContext executionContext)
         {
             if (result == null)
             {
@@ -870,70 +873,61 @@ namespace System.Management.Automation
             return false;
         }
 
-        private AliasInfo GetAliasFromModules(string command)
+        private AliasInfo? GetAliasFromModules(string command)
         {
-            AliasInfo result = null;
+            AliasInfo? result = null;
 
             if (command.IndexOf('\\') > 0)
             {
                 // See if it's a module qualified alias...
-                PSSnapinQualifiedName qualifiedName = PSSnapinQualifiedName.GetInstance(command);
+                PSSnapinQualifiedName? qualifiedName = PSSnapinQualifiedName.GetInstance(command);
                 if (qualifiedName != null && !string.IsNullOrEmpty(qualifiedName.PSSnapInName))
                 {
-                    PSModuleInfo module = GetImportedModuleByName(qualifiedName.PSSnapInName);
+                    PSModuleInfo? module = GetImportedModuleByName(qualifiedName.PSSnapInName);
 
-                    if (module != null)
-                    {
-                        module.ExportedAliases.TryGetValue(qualifiedName.ShortName, out result);
-                    }
+                    module?.ExportedAliases.TryGetValue(qualifiedName.ShortName, out result);
                 }
             }
 
             return result;
         }
 
-        private CommandInfo GetFunctionFromModules(string command)
+        private CommandInfo? GetFunctionFromModules(string command)
         {
-            FunctionInfo result = null;
+            FunctionInfo? result = null;
 
             if (command.IndexOf('\\') > 0)
             {
                 // See if it's a module qualified function call...
-                PSSnapinQualifiedName qualifiedName = PSSnapinQualifiedName.GetInstance(command);
+                PSSnapinQualifiedName? qualifiedName = PSSnapinQualifiedName.GetInstance(command);
                 if (qualifiedName != null && !string.IsNullOrEmpty(qualifiedName.PSSnapInName))
                 {
-                    PSModuleInfo module = GetImportedModuleByName(qualifiedName.PSSnapInName);
+                    PSModuleInfo? module = GetImportedModuleByName(qualifiedName.PSSnapInName);
 
-                    if (module != null)
-                    {
-                        module.ExportedFunctions.TryGetValue(qualifiedName.ShortName, out result);
-                    }
+                    module?.ExportedFunctions.TryGetValue(qualifiedName.ShortName, out result);
                 }
             }
 
             return result;
         }
 
-        private PSModuleInfo GetImportedModuleByName(string moduleName)
+        private PSModuleInfo? GetImportedModuleByName(string moduleName)
         {
-            PSModuleInfo module = null;
+            PSModuleInfo? module = null;
             List<PSModuleInfo> modules = _context.Modules.GetModules(new string[] { moduleName }, false);
 
             if (modules != null && modules.Count > 0)
             {
                 foreach (PSModuleInfo m in modules)
                 {
-                    if (_context.previousModuleImported.ContainsKey(m.Name) && ((string)_context.previousModuleImported[m.Name] == m.Path))
+                    if (_context.previousModuleImported.ContainsKey(m.Name) && ((string?)_context.previousModuleImported[m.Name] == m.Path))
                     {
                         module = m;
                         break;
                     }
                 }
 
-                if (module == null)
-                {
-                    module = modules[0];
-                }
+                module ??= modules[0];
             }
 
             return module;
@@ -949,9 +943,9 @@ namespace System.Management.Automation
         /// A FunctionInfo if the function name exists and is a function, a FilterInfo if
         /// the filter name exists and is a filter, or null otherwise.
         /// </returns>
-        private CommandInfo GetFunction(string function)
+        private CommandInfo? GetFunction(string function)
         {
-            CommandInfo result = _context.EngineSessionState.GetFunction(function);
+            CommandInfo? result = _context.EngineSessionState.GetFunction(function);
 
             if (result != null)
             {
@@ -991,9 +985,9 @@ namespace System.Management.Automation
         /// A CmdletInfo for the next matching Cmdlet or null if there are
         /// no more matches.
         /// </returns>
-        private CmdletInfo GetNextCmdlet()
+        private CmdletInfo? GetNextCmdlet()
         {
-            CmdletInfo result = null;
+            CmdletInfo? result = null;
             bool useAbbreviationExpansion = _commandResolutionOptions.HasFlag(SearchResolutionOptions.UseAbbreviationExpansion);
 
             if (_matchingCmdlet == null)
@@ -1002,7 +996,7 @@ namespace System.Management.Automation
                 {
                     Collection<CmdletInfo> matchingCmdletInfo = new Collection<CmdletInfo>();
 
-                    PSSnapinQualifiedName PSSnapinQualifiedCommandName =
+                    PSSnapinQualifiedName? PSSnapinQualifiedCommandName =
                         PSSnapinQualifiedName.GetInstance(_commandName);
 
                     if (!useAbbreviationExpansion && PSSnapinQualifiedCommandName == null)
@@ -1010,10 +1004,10 @@ namespace System.Management.Automation
                         return null;
                     }
 
-                    string moduleName = PSSnapinQualifiedCommandName?.PSSnapInName;
+                    string? moduleName = PSSnapinQualifiedCommandName?.PSSnapInName;
 
                     var cmdletShortName = PSSnapinQualifiedCommandName?.ShortName;
-                    WildcardPattern cmdletMatcher = cmdletShortName != null
+                    WildcardPattern? cmdletMatcher = cmdletShortName != null
                         ? WildcardPattern.Get(cmdletShortName, WildcardOptions.IgnoreCase)
                         : null;
 
@@ -1068,9 +1062,10 @@ namespace System.Management.Automation
             return traceResult(result);
         }
 
-        private IEnumerator<CmdletInfo> _matchingCmdlet;
+        private IEnumerator<CmdletInfo>? _matchingCmdlet;
 
-        private static CmdletInfo traceResult(CmdletInfo result)
+        [return: NotNullIfNotNull("result")]
+        private static CmdletInfo? traceResult(CmdletInfo? result)
         {
             if (result != null)
             {
@@ -1083,9 +1078,9 @@ namespace System.Management.Automation
             return result;
         }
 
-        private string DoPowerShellRelativePathLookup()
+        private string? DoPowerShellRelativePathLookup()
         {
-            string result = null;
+            string? result = null;
 
             if (_context.EngineSessionState != null &&
                 _context.EngineSessionState.ProviderCount > 0)
@@ -1125,14 +1120,14 @@ namespace System.Management.Automation
         /// The path that was resolved. Null if the path couldn't be resolved or was
         /// not resolved by the FileSystemProvider.
         /// </returns>
-        private string ResolvePSPath(string path)
+        private string? ResolvePSPath(string? path)
         {
-            string result = null;
+            string? result = null;
 
             try
             {
-                ProviderInfo provider = null;
-                string resolvedPath = null;
+                ProviderInfo? provider = null;
+                string? resolvedPath = null;
 
                 // Try literal path resolution if it is set to run first
                 if (_commandResolutionOptions.HasFlag(SearchResolutionOptions.ResolveLiteralThenPathPatterns))
@@ -1235,7 +1230,7 @@ namespace System.Management.Automation
         /// <returns>
         /// Full path to the command.
         /// </returns>
-        private string GetNextLiteralPathThatExistsAndHandleExceptions(string command, out ProviderInfo provider)
+        private string? GetNextLiteralPathThatExistsAndHandleExceptions(string command, out ProviderInfo? provider)
         {
             try
             {
@@ -1297,7 +1292,7 @@ namespace System.Management.Automation
         /// <returns>
         /// Full path to the command.
         /// </returns>
-        private string GetNextLiteralPathThatExists(string command, out ProviderInfo provider)
+        private string? GetNextLiteralPathThatExists(string? command, out ProviderInfo? provider)
         {
             string resolvedPath = _context.LocationGlobber.GetProviderPath(command, out provider);
 
@@ -1484,7 +1479,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Determines which command types will be globbed.
         /// </summary>
-        private SearchResolutionOptions _commandResolutionOptions;
+        private readonly SearchResolutionOptions _commandResolutionOptions;
 
         /// <summary>
         /// Determines which types of commands to look for.
@@ -1495,12 +1490,12 @@ namespace System.Management.Automation
         /// The enumerator that uses the Path to
         /// search for commands.
         /// </summary>
-        private CommandPathSearch _pathSearcher;
+        private CommandPathSearch? _pathSearcher;
 
         /// <summary>
         /// The execution context instance for the current engine...
         /// </summary>
-        private ExecutionContext _context;
+        private readonly ExecutionContext _context;
 
         /// <summary>
         /// A routine to initialize the path searcher...
@@ -1556,7 +1551,7 @@ namespace System.Management.Automation
                 {
                     _canDoPathLookup = true;
 
-                    string directory = Path.GetDirectoryName(_commandName);
+                    string? directory = Path.GetDirectoryName(_commandName);
                     var directoryCollection = new LookupPathCollection { directory };
 
                     CommandDiscovery.discoveryTracer.WriteLine(
@@ -1588,7 +1583,7 @@ namespace System.Management.Automation
                     // We must try to resolve the path as an PSPath or else we can't do
                     // path lookup for relative paths.
 
-                    string directory = Path.GetDirectoryName(_commandName);
+                    string? directory = Path.GetDirectoryName(_commandName);
                     directory = ResolvePSPath(directory);
 
                     CommandDiscovery.discoveryTracer.WriteLine(
@@ -1641,10 +1636,7 @@ namespace System.Management.Automation
                     _commandTypes &= ~CommandTypes.ExternalScript;
             }
 
-            if (_pathSearcher != null)
-            {
-                _pathSearcher.Reset();
-            }
+            _pathSearcher?.Reset();
 
             _currentMatch = null;
             _currentState = SearchState.SearchingAliases;
@@ -1664,17 +1656,17 @@ namespace System.Management.Automation
         /// <summary>
         /// An enumerator of the matching aliases.
         /// </summary>
-        private IEnumerator<AliasInfo> _matchingAlias;
+        private IEnumerator<AliasInfo>? _matchingAlias;
 
         /// <summary>
         /// An enumerator of the matching functions.
         /// </summary>
-        private IEnumerator<CommandInfo> _matchingFunctionEnumerator;
+        private IEnumerator<CommandInfo?>? _matchingFunctionEnumerator;
 
         /// <summary>
         /// The CommandInfo that references the command that matches the pattern.
         /// </summary>
-        private CommandInfo _currentMatch;
+        private CommandInfo? _currentMatch;
 
         private bool _canDoPathLookup;
         private CanDoPathLookupResult _canDoPathLookupResult = CanDoPathLookupResult.Yes;

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -928,7 +928,10 @@ namespace System.Management.Automation
                     }
                 }
 
-                module ??= modules[0];
+                if (module == null)
+                {
+                    module = modules[0];
+                }
             }
 
             return module;

--- a/src/System.Management.Automation/engine/MshSnapinQualifiedName.cs
+++ b/src/System.Management.Automation/engine/MshSnapinQualifiedName.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using Dbg = System.Management.Automation.Diagnostics;
 
 namespace System.Management.Automation
@@ -62,11 +64,11 @@ namespace System.Management.Automation
         /// <returns>
         /// An instance of the Name class.
         /// </returns>
-        internal static PSSnapinQualifiedName GetInstance(string name)
+        internal static PSSnapinQualifiedName? GetInstance(string name)
         {
             if (name == null)
                 return null;
-            PSSnapinQualifiedName result = null;
+            PSSnapinQualifiedName? result = null;
             string[] splitName = name.Split(Utils.Separators.Backslash);
             if (splitName.Length == 0 || splitName.Length > 2)
                 return null;
@@ -96,7 +98,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets the command's PSSnapin name.
         /// </summary>
-        internal string PSSnapInName
+        internal string? PSSnapInName
         {
             get
             {
@@ -104,7 +106,7 @@ namespace System.Management.Automation
             }
         }
 
-        private string _psSnapinName;
+        private string? _psSnapinName;
 
         /// <summary>
         /// Gets the command's short name.

--- a/src/System.Management.Automation/engine/MshSnapinQualifiedName.cs
+++ b/src/System.Management.Automation/engine/MshSnapinQualifiedName.cs
@@ -64,15 +64,14 @@ namespace System.Management.Automation
         /// <returns>
         /// An instance of the Name class.
         /// </returns>
-        internal static PSSnapinQualifiedName? GetInstance(string name)
+        internal static PSSnapinQualifiedName? GetInstance(string? name)
         {
             if (name == null)
                 return null;
-            PSSnapinQualifiedName? result = null;
             string[] splitName = name.Split(Utils.Separators.Backslash);
             if (splitName.Length == 0 || splitName.Length > 2)
                 return null;
-            result = new PSSnapinQualifiedName(splitName);
+            var result = new PSSnapinQualifiedName(splitName);
             // If the shortname is empty, then return null...
             if (string.IsNullOrEmpty(result.ShortName))
             {
@@ -93,7 +92,7 @@ namespace System.Management.Automation
             }
         }
 
-        private string _fullName;
+        private readonly string _fullName;
 
         /// <summary>
         /// Gets the command's PSSnapin name.
@@ -106,7 +105,7 @@ namespace System.Management.Automation
             }
         }
 
-        private string? _psSnapinName;
+        private readonly string? _psSnapinName;
 
         /// <summary>
         /// Gets the command's short name.
@@ -119,7 +118,7 @@ namespace System.Management.Automation
             }
         }
 
-        private string _shortName;
+        private readonly string _shortName;
 
         /// <summary>
         /// The full name.


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Nullable annotations for CommandSearcher

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
