### PR TITLE
Remove use of `Test-Path` in ConciseView

### DIFF
--- a/1
+++ b/1
@@ -1,0 +1,6 @@
+[91mParserError: 
+[96mLine |
+[96m   1 | [0m foreach[96m [0mabc
+[96m     | [91m        ~
+[91m[96m     | [91mMissing opening '(' after keyword 'foreach'.
+[0m

--- a/1
+++ b/1
@@ -1,6 +1,0 @@
-[91mParserError: 
-[96mLine |
-[96m   1 | [0m foreach[96m [0mabc
-[96m     | [91m        ~
-[91m[96m     | [91mMissing opening '(' after keyword 'foreach'.
-[0m

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -766,14 +766,14 @@ namespace System.Management.Automation.Runspaces
                             $maxDepth = 10
                             $ellipsis = ""`u{2026}""
                             $resetColor = ''
-                            if ($Host.UI.SupportsVirtualTerminal -and ($null -eq $env:__SuppressAnsiEscapeSequences)) {
+                            if ($Host.UI.SupportsVirtualTerminal -and ([string]::IsNullOrEmpty($env:__SuppressAnsiEscapeSequences))) {
                                 $resetColor = [System.Management.Automation.VTUtility]::GetEscapeSequence(
                                     [System.Management.Automation.VTUtility+VT]::Reset
                                 )
                             }
 
                             function Get-VT100Color([ConsoleColor] $color) {
-                                if (!$Host.UI.SupportsVirtualTerminal -or ($null -ne $env:__SuppressAnsiEscapeSequences)) {
+                                if (!$Host.UI.SupportsVirtualTerminal -or !([string]::IsNullOrEmpty($env:__SuppressAnsiEscapeSequences))) {
                                     return ''
                                 }
 
@@ -1013,14 +1013,14 @@ namespace System.Management.Automation.Runspaces
                                     function Get-ConciseViewPositionMessage {
 
                                         $resetColor = ''
-                                        if ($Host.UI.SupportsVirtualTerminal -and ($null -eq $env:__SuppressAnsiEscapeSequences)) {
+                                        if ($Host.UI.SupportsVirtualTerminal -and ([string]::IsNullOrEmpty($env:__SuppressAnsiEscapeSequences))) {
                                             $resetColor = [System.Management.Automation.VTUtility]::GetEscapeSequence(
                                                 [System.Management.Automation.VTUtility+VT]::Reset
                                             )
                                         }
 
                                         function Get-VT100Color([ConsoleColor] $color) {
-                                            if (!$Host.UI.SupportsVirtualTerminal -or ($null -ne $env:__SuppressAnsiEscapeSequences)) {
+                                            if (!$Host.UI.SupportsVirtualTerminal -or !([string]::IsNullOrEmpty($env:__SuppressAnsiEscapeSequences))) {
                                                 return ''
                                             }
 

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -766,14 +766,14 @@ namespace System.Management.Automation.Runspaces
                             $maxDepth = 10
                             $ellipsis = ""`u{2026}""
                             $resetColor = ''
-                            if ($Host.UI.SupportsVirtualTerminal -and !(Test-Path env:__SuppressAnsiEscapeSequences)) {
+                            if ($Host.UI.SupportsVirtualTerminal -and ($null -eq $env:__SuppressAnsiEscapeSequences)) {
                                 $resetColor = [System.Management.Automation.VTUtility]::GetEscapeSequence(
                                     [System.Management.Automation.VTUtility+VT]::Reset
                                 )
                             }
 
                             function Get-VT100Color([ConsoleColor] $color) {
-                                if (!$Host.UI.SupportsVirtualTerminal -or (Test-Path env:__SuppressAnsiEscapeSequences)) {
+                                if (!$Host.UI.SupportsVirtualTerminal -or ($null -ne $env:__SuppressAnsiEscapeSequences)) {
                                     return ''
                                 }
 
@@ -1013,14 +1013,14 @@ namespace System.Management.Automation.Runspaces
                                     function Get-ConciseViewPositionMessage {
 
                                         $resetColor = ''
-                                        if ($Host.UI.SupportsVirtualTerminal -and !(Test-Path env:__SuppressAnsiEscapeSequences)) {
+                                        if ($Host.UI.SupportsVirtualTerminal -and ($null -eq $env:__SuppressAnsiEscapeSequences)) {
                                             $resetColor = [System.Management.Automation.VTUtility]::GetEscapeSequence(
                                                 [System.Management.Automation.VTUtility+VT]::Reset
                                             )
                                         }
 
                                         function Get-VT100Color([ConsoleColor] $color) {
-                                            if (!$Host.UI.SupportsVirtualTerminal -or (Test-Path env:__SuppressAnsiEscapeSequences)) {
+                                            if (!$Host.UI.SupportsVirtualTerminal -or ($null -ne $env:__SuppressAnsiEscapeSequences)) {
                                                 return ''
                                             }
 

--- a/test/powershell/engine/Formatting/ErrorView.Tests.ps1
+++ b/test/powershell/engine/Formatting/ErrorView.Tests.ps1
@@ -108,7 +108,7 @@ Describe 'Tests for $ErrorView' -Tag CI {
         }
 
         It "Error shows if `$PSModuleAutoLoadingPreference is set to 'none'" {
-            $e = & "$PSHOME/pwsh" -noprofile -command '$PSModuleAutoLoadingPreference = ""none""; cmdletThatDoesntExist' 2>&1 | out-string
+            $e = & "$PSHOME/pwsh" -noprofile -command '$PSModuleAutoLoadingPreference = ""none""; cmdletThatDoesntExist' 2>&1 | Out-String
             $e | Should -BeLike "*cmdletThatDoesntExist*"
         }
     }

--- a/test/powershell/engine/Formatting/ErrorView.Tests.ps1
+++ b/test/powershell/engine/Formatting/ErrorView.Tests.ps1
@@ -102,12 +102,13 @@ Describe 'Tests for $ErrorView' -Tag CI {
 
         It "Position message does not contain line information" {
 
-            $e = & "$PSHOME/pwsh" -noprofile -command "foreach abc" | Out-String
+            $e = & "$PSHOME/pwsh" -noprofile -command "foreach abc" 2>&1 | out-string
+            $e | Should -Not -BeNullOrEmpty
             $e | Should -Not -BeLike "*At line*"
         }
 
         It "Error shows if `$PSModuleAutoLoadingPreference is set to 'none'" {
-            $e = & "$PSHOME/pwsh" -noprofile -command '$PSModuleAutoLoadingPreference = ""none""; cmdletThatDoesntExist' | Out-String
+            $e = & "$PSHOME/pwsh" -noprofile -command '$PSModuleAutoLoadingPreference = ""none""; cmdletThatDoesntExist' 2>&1 | out-string
             $e | Should -BeLike "*cmdletThatDoesntExist*"
         }
     }

--- a/test/powershell/engine/Formatting/ErrorView.Tests.ps1
+++ b/test/powershell/engine/Formatting/ErrorView.Tests.ps1
@@ -102,7 +102,7 @@ Describe 'Tests for $ErrorView' -Tag CI {
 
         It "Position message does not contain line information" {
 
-            $e = & "$PSHOME/pwsh" -noprofile -command "foreach abc" 2>&1 | out-string
+            $e = & "$PSHOME/pwsh" -noprofile -command "foreach abc" 2>&1 | Out-String
             $e | Should -Not -BeNullOrEmpty
             $e | Should -Not -BeLike "*At line*"
         }

--- a/test/powershell/engine/Formatting/ErrorView.Tests.ps1
+++ b/test/powershell/engine/Formatting/ErrorView.Tests.ps1
@@ -105,6 +105,11 @@ Describe 'Tests for $ErrorView' -Tag CI {
             $e = & "$PSHOME/pwsh" -noprofile -command "foreach abc" | Out-String
             $e | Should -Not -BeLike "*At line*"
         }
+
+        It "Error shows if `$PSModuleAutoLoadingPreference is set to 'none'" {
+            $e = & "$PSHOME/pwsh" -noprofile -command '$PSModuleAutoLoadingPreference = ""none""; cmdletThatDoesntExist' | Out-String
+            $e | Should -BeLike "*cmdletThatDoesntExist*"
+        }
     }
 
     Context 'NormalView tests' {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Both `ConciseView` and `Get-Error` used `Test-Path` which wouldn't be available if `$PSModuleAutoLoadingPreference` is set to `none`.  Fix is to simply check against `$null` instead of using that cmdlet.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/12671

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
