### PR TITLE
Add password confirmation in Get-Credential

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -65,10 +65,9 @@ namespace Microsoft.PowerShell
         /// <param name="caption"></param>
         /// <param name="message"></param>
         /// <param name="userName"></param>
-        /// <param name="reEnterPassword"></param>
         /// <param name="targetName"></param>
         /// <returns></returns>
-        public override PSCredential PromptForCredential(string caption, string message, string userName, bool reEnterPassword, string targetName)
+        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName)
         {
             throw new PSNotImplementedException();
         }
@@ -79,12 +78,27 @@ namespace Microsoft.PowerShell
         /// <param name="caption"></param>
         /// <param name="message"></param>
         /// <param name="userName"></param>
-        /// <param name="reEnterPassword"></param>
         /// <param name="targetName"></param>
         /// <param name="allowedCredentialTypes"></param>
         /// <param name="options"></param>
         /// <returns></returns>
-        public override PSCredential PromptForCredential(string caption, string message, string userName, bool reEnterPassword, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
+        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
+        {
+            throw new PSNotImplementedException();
+        }
+
+        /// <summary>
+        /// PromptForCredential.
+        /// </summary>
+        /// <param name="caption"></param>
+        /// <param name="message"></param>
+        /// <param name="userName"></param>
+        /// <param name="reenterPassword"></param>
+        /// <param name="targetName"></param>
+        /// <param name="allowedCredentialTypes"></param>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        public override PSCredential PromptForCredential(string caption, string message, string userName, bool reenterPassword, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
         {
             throw new PSNotImplementedException();
         }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -47,7 +47,7 @@ namespace Microsoft.PowerShell
         }
 
         /// <summary>
-        /// PromptForChoice.
+        /// Prompt for choice.
         /// </summary>
         /// <param name="caption"></param>
         /// <param name="message"></param>
@@ -60,7 +60,7 @@ namespace Microsoft.PowerShell
         }
 
         /// <summary>
-        /// PromptForCredential.
+        /// Prompt for credential.
         /// </summary>
         /// <param name="caption"></param>
         /// <param name="message"></param>
@@ -73,7 +73,7 @@ namespace Microsoft.PowerShell
         }
 
         /// <summary>
-        /// PromptForCredential.
+        /// Prompt for credential.
         /// </summary>
         /// <param name="caption"></param>
         /// <param name="message"></param>
@@ -88,7 +88,7 @@ namespace Microsoft.PowerShell
         }
 
         /// <summary>
-        /// PromptForCredential.
+        /// Prompt for credential.
         /// </summary>
         /// <param name="caption"></param>
         /// <param name="message"></param>
@@ -104,7 +104,7 @@ namespace Microsoft.PowerShell
         }
 
         /// <summary>
-        /// ReadLine.
+        /// Read line.
         /// </summary>
         /// <returns></returns>
         public override string ReadLine()

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -65,9 +65,10 @@ namespace Microsoft.PowerShell
         /// <param name="caption"></param>
         /// <param name="message"></param>
         /// <param name="userName"></param>
+        /// <param name="reEnterPassword"></param>
         /// <param name="targetName"></param>
         /// <returns></returns>
-        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName)
+        public override PSCredential PromptForCredential(string caption, string message, string userName, bool reEnterPassword, string targetName)
         {
             throw new PSNotImplementedException();
         }
@@ -78,11 +79,12 @@ namespace Microsoft.PowerShell
         /// <param name="caption"></param>
         /// <param name="message"></param>
         /// <param name="userName"></param>
+        /// <param name="reEnterPassword"></param>
         /// <param name="targetName"></param>
         /// <param name="allowedCredentialTypes"></param>
         /// <param name="options"></param>
         /// <returns></returns>
-        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
+        public override PSCredential PromptForCredential(string caption, string message, string userName, bool reEnterPassword, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
         {
             throw new PSNotImplementedException();
         }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -93,12 +93,12 @@ namespace Microsoft.PowerShell
         /// <param name="caption"></param>
         /// <param name="message"></param>
         /// <param name="userName"></param>
-        /// <param name="reenterPassword"></param>
+        /// <param name="confirmPassword"></param>
         /// <param name="targetName"></param>
         /// <param name="allowedCredentialTypes"></param>
         /// <param name="options"></param>
         /// <returns></returns>
-        public override PSCredential PromptForCredential(string caption, string message, string userName, bool reenterPassword, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
+        public override PSCredential PromptForCredential(string caption, string message, string userName, bool confirmPassword, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
         {
             throw new PSNotImplementedException();
         }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfacePrompt.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfacePrompt.cs
@@ -306,6 +306,7 @@ namespace Microsoft.PowerShell
                         null,   // caption already written
                         null,   // message already written
                         null,
+                        false,
                         string.Empty);
                 convertedObj = credential;
                 cancelInput = (convertedObj == null);

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfacePrompt.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfacePrompt.cs
@@ -303,11 +303,10 @@ namespace Microsoft.PowerShell
                 PSCredential credential = null;
                 credential =
                     PromptForCredential(
-                        null,   // caption already written
-                        null,   // message already written
-                        null,
-                        false,
-                        string.Empty);
+                        caption: null,   // caption already written
+                        message: null,   // message already written
+                        userName: null,
+                        targetName: string.Empty);
                 convertedObj = credential;
                 cancelInput = (convertedObj == null);
                 if ((credential != null) && (credential.Password.Length == 0) && listInput)

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
@@ -183,7 +183,7 @@ namespace Microsoft.PowerShell
                 }
 
                 int equal = 0;
-                for(int i =0; i< pwdLength; i++)
+                for(int i = 0; i < pwdLength; i++)
                 {
                     var c1 = Marshal.ReadByte(pwd_ptr + i);
                     var c2 = Marshal.ReadByte(confirmPwd_ptr + i);
@@ -207,4 +207,3 @@ namespace Microsoft.PowerShell
         }
     }
 }
-

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
@@ -153,7 +153,7 @@ namespace Microsoft.PowerShell
                         return null;
                     }
 
-                    if(SecureStringEquals(password, confirmPassword))
+                    if (SecureStringEquals(password, confirmPassword))
                     {
                         break;
                     }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
@@ -196,7 +196,9 @@ namespace Microsoft.PowerShell
                     byte c2 = Marshal.ReadByte(confirmPwd_ptr, i);
                     equal = c1 ^ c2;
                     if (equal != 0)
+                    {
                         return false;
+                    }
                 }
 
                 return true;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
@@ -167,7 +167,7 @@ namespace Microsoft.PowerShell
 
         private static bool SecureStringEquals(SecureString password, SecureString confirmPassword)
         {
-            if(password.Length != confirmPassword.Length)
+            if (password.Length != confirmPassword.Length)
             {
                 return false;
             }
@@ -181,7 +181,7 @@ namespace Microsoft.PowerShell
 
                 int pwdLength = Marshal.ReadInt32(pwd_ptr, -4);
                 int equal = 0;
-                for(int i = 0; i < pwdLength; i++)
+                for (int i = 0; i < pwdLength; i++)
                 {
                     byte c1 = Marshal.ReadByte(pwd_ptr + i);
                     byte c2 = Marshal.ReadByte(confirmPwd_ptr + i);

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
@@ -153,11 +153,11 @@ namespace Microsoft.PowerShell
                         return null;
                     }
 
-                    // If the string is not equal print message and loop.
                     if(SecureStringEquals(password, confirmPassword))
                     {
                         break;
                     }
+
                     WriteToConsole(ConsoleColor.Red, ConsoleColor.Black, passwordMismatch, true);
                 }
                 while (true);
@@ -180,7 +180,7 @@ namespace Microsoft.PowerShell
                 confirmPwd_ptr = Marshal.SecureStringToBSTR(confirmPassword);
                 string confirmPwd = Marshal.PtrToStringBSTR(confirmPwd_ptr);
 
-                return pwd.Equals(confirmPwd);
+                return pwd.Equals(confirmPwd, StringComparison.Ordinal);
             }
             finally
             {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
@@ -167,6 +167,10 @@ namespace Microsoft.PowerShell
 
         private static bool SecureStringEquals(SecureString password, SecureString confirmPassword)
         {
+            if(password.Length != confirmPassword.Length)
+            {
+                return false;
+            }
 
             IntPtr pwd_ptr = IntPtr.Zero;
             IntPtr confirmPwd_ptr = IntPtr.Zero;
@@ -176,21 +180,17 @@ namespace Microsoft.PowerShell
                 confirmPwd_ptr = Marshal.SecureStringToBSTR(confirmPassword);
 
                 int pwdLength = Marshal.ReadInt32(pwd_ptr, -4);
-                int confirmPwdLength = Marshal.ReadInt32(confirmPwd_ptr, -4);
-                if(pwdLength != confirmPwdLength)
-                {
-                    return false;
-                }
-
                 int equal = 0;
                 for(int i = 0; i < pwdLength; i++)
                 {
-                    var c1 = Marshal.ReadByte(pwd_ptr + i);
-                    var c2 = Marshal.ReadByte(confirmPwd_ptr + i);
-                    equal |= c1 ^ c2;
+                    byte c1 = Marshal.ReadByte(pwd_ptr + i);
+                    byte c2 = Marshal.ReadByte(confirmPwd_ptr + i);
+                    equal = c1 ^ c2;
+                    if (equal != 0)
+                        return false;
                 }
 
-                return equal == 0;
+                return true;
             }
             finally
             {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
@@ -6,7 +6,7 @@ using System.Globalization;
 using System.Management.Automation;
 using System.Management.Automation.Internal;
 using System.Security;
-
+using System.Runtime.InteropServices;
 using Microsoft.Win32;
 
 namespace Microsoft.PowerShell
@@ -25,6 +25,7 @@ namespace Microsoft.PowerShell
         /// if so configured.
         /// </summary>
         /// <param name="userName">Name of the user whose creds are to be prompted for. If set to null or empty string, the function will prompt for user name first.</param>
+        /// <param name="reEnterPassword">Promts user to re-enter the password for confirmation</param>
         /// <param name="targetName">Name of the target for which creds are being collected.</param>
         /// <param name="message">Message to be displayed.</param>
         /// <param name="caption">Caption for the message.</param>
@@ -34,11 +35,13 @@ namespace Microsoft.PowerShell
             string caption,
             string message,
             string userName,
+            bool reEnterPassword,
             string targetName)
         {
             return PromptForCredential(caption,
                                          message,
                                          userName,
+                                         reEnterPassword,
                                          targetName,
                                          PSCredentialTypes.Default,
                                          PSCredentialUIOptions.Default);
@@ -48,6 +51,7 @@ namespace Microsoft.PowerShell
         /// Prompt for credentials.
         /// </summary>
         /// <param name="userName">Name of the user whose creds are to be prompted for. If set to null or empty string, the function will prompt for user name first.</param>
+        /// <param name="reEnterPassword">Promts user to re-enter the password for confirmation</param>
         /// <param name="targetName">Name of the target for which creds are being collected.</param>
         /// <param name="message">Message to be displayed.</param>
         /// <param name="caption">Caption for the message.</param>
@@ -59,14 +63,17 @@ namespace Microsoft.PowerShell
             string caption,
             string message,
             string userName,
+            bool reEnterPassword,
             string targetName,
             PSCredentialTypes allowedCredentialTypes,
             PSCredentialUIOptions options)
         {
             PSCredential cred = null;
             SecureString password = null;
+            SecureString confirmPassword = null;
             string userPrompt = null;
             string passwordPrompt = null;
+            string reEnterPasswordPrompt = null;
 
             if (!string.IsNullOrEmpty(caption))
             {
@@ -112,7 +119,50 @@ namespace Microsoft.PowerShell
             {
                 return null;
             }
+            if (reEnterPassword)
+            {
+                reEnterPasswordPrompt = StringUtil.Format(ConsoleHostUserInterfaceSecurityResources.PromptForCredential_ReEnterPassword, userName);
 
+                //
+                // now, prompt to re-enter the password
+                //
+                WriteToConsole(reEnterPasswordPrompt, true);
+                confirmPassword = ReadLineAsSecureString();
+
+                IntPtr pwd_ptr = IntPtr.Zero;
+                IntPtr confirmPwd_ptr = IntPtr.Zero;
+
+                try
+                {
+                    pwd_ptr = Marshal.SecureStringToBSTR(password);
+                    confirmPwd_ptr = Marshal.SecureStringToBSTR(confirmPassword);
+
+                    string pwd = Marshal.PtrToStringBSTR(pwd_ptr);
+                    string confirmPwd = Marshal.PtrToStringBSTR(confirmPwd_ptr);
+
+                    //
+                    // If the string is not equal print error message and returns null
+                    //
+                    if (!(pwd.Equals(confirmPwd)))
+                    {
+                        reEnterPasswordPrompt = StringUtil.Format(ConsoleHostUserInterfaceSecurityResources.PasswordMismatch);
+                        WriteToConsole(reEnterPasswordPrompt, true);
+                        return null;
+                    }
+                }
+                finally
+                {
+                    if (pwd_ptr != IntPtr.Zero)
+                    {
+                        Marshal.ZeroFreeBSTR(pwd_ptr);
+                    }
+
+                    if (confirmPwd_ptr != IntPtr.Zero)
+                    {
+                        Marshal.ZeroFreeBSTR(confirmPwd_ptr);
+                    }
+                }
+            }
             WriteLineToConsole();
 
             cred = new PSCredential(userName, password);

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostUserInterfaceSecurityResources.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostUserInterfaceSecurityResources.resx
@@ -123,7 +123,7 @@
   <data name="PromptForCredential_Password" xml:space="preserve">
     <value>Password for user {0}: </value>
   </data>
-  <data name="PromptForCredential_ReEnterPassword" xml:space="preserve">
+  <data name="PromptForCredential_ReenterPassword" xml:space="preserve">
     <value>Re-Enter Password for user {0}:</value>
   </data>
   <data name="PasswordMismatch" xml:space="preserve">

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostUserInterfaceSecurityResources.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostUserInterfaceSecurityResources.resx
@@ -126,7 +126,7 @@
   <data name="PromptForCredential_ReenterPassword" xml:space="preserve">
     <value>Re-Enter Password for user {0}:</value>
   </data>
-  <data name="PasswordMismatch" xml:space="preserve">
-    <value>Passwords do not match.</value>
+  <data name="PromptForCredential_PasswordMismatch" xml:space="preserve">
+    <value>Passwords do not match. </value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostUserInterfaceSecurityResources.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostUserInterfaceSecurityResources.resx
@@ -123,4 +123,10 @@
   <data name="PromptForCredential_Password" xml:space="preserve">
     <value>Password for user {0}: </value>
   </data>
+  <data name="PromptForCredential_ReEnterPassword" xml:space="preserve">
+    <value>Re-Enter Password for user {0}:</value>
+  </data>
+  <data name="PasswordMismatch" xml:space="preserve">
+    <value>Passwords do not match.</value>
+  </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostUserInterfaceSecurityResources.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostUserInterfaceSecurityResources.resx
@@ -124,9 +124,9 @@
     <value>Password for user {0}: </value>
   </data>
   <data name="PromptForCredential_ReenterPassword" xml:space="preserve">
-    <value>Re-Enter Password for user {0}:</value>
+    <value>Re-enter password for user {0}:</value>
   </data>
   <data name="PromptForCredential_PasswordMismatch" xml:space="preserve">
-    <value>Passwords do not match. </value>
+    <value>Passwords do not match.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
@@ -80,6 +80,19 @@ namespace Microsoft.PowerShell.Commands
         private string _title = UtilsStrings.PromptForCredential_DefaultCaption;
 
         /// <summary>
+        /// Gets and sets the Re-enter Password on the window promt.
+        /// </summary>
+        [Parameter(Mandatory = false, ParameterSetName = messageSet)]
+        public SwitchParameter ReEnterPassword
+        {
+            get { return _reEnterPassword; }
+
+            set { _reEnterPassword = value; }
+        }
+
+        private bool _reEnterPassword;
+
+        /// <summary>
         /// Initializes a new instance of the GetCredentialCommand
         /// class.
         /// </summary>
@@ -100,7 +113,7 @@ namespace Microsoft.PowerShell.Commands
 
             try
             {
-                Credential = this.Host.UI.PromptForCredential(_title, _message, _userName, string.Empty);
+                Credential = this.Host.UI.PromptForCredential(_title, _message, _userName, _reEnterPassword, string.Empty);
             }
             catch (ArgumentException exception)
             {

--- a/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
@@ -80,10 +80,10 @@ namespace Microsoft.PowerShell.Commands
         private string _title = UtilsStrings.PromptForCredential_DefaultCaption;
 
         /// <summary>
-        /// Gets or sets the Re-enter Password on the window prompt.
+        /// Gets or sets the re-enter password on the window prompt.
         /// </summary>
         [Parameter(Mandatory = false, ParameterSetName = messageSet)]
-        public SwitchParameter ReEnterPassword { get; set; }
+        public SwitchParameter ReenterPassword { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the GetCredentialCommand
@@ -106,7 +106,12 @@ namespace Microsoft.PowerShell.Commands
 
             try
             {
-                Credential = this.Host.UI.PromptForCredential(_title, _message, _userName, ReEnterPassword, string.Empty,
+                Credential = this.Host.UI.PromptForCredential(
+                    _title,
+                    _message,
+                    _userName,
+                    ReenterPassword,
+                    string.Empty,
                     PSCredentialTypes.Default,
                     PSCredentialUIOptions.Default);
             }

--- a/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
@@ -80,7 +80,7 @@ namespace Microsoft.PowerShell.Commands
         private string _title = UtilsStrings.PromptForCredential_DefaultCaption;
 
         /// <summary>
-        /// Gets and sets the Re-enter Password on the window prompt.
+        /// Gets or sets the Re-enter Password on the window prompt.
         /// </summary>
         [Parameter(Mandatory = false, ParameterSetName = messageSet)]
         public SwitchParameter ReEnterPassword { get; set; }

--- a/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
@@ -80,10 +80,10 @@ namespace Microsoft.PowerShell.Commands
         private string _title = UtilsStrings.PromptForCredential_DefaultCaption;
 
         /// <summary>
-        /// Gets or sets the re-enter password on the window prompt.
+        /// Gets or sets the confirm password prompt.
         /// </summary>
         [Parameter(ParameterSetName = messageSet)]
-        public SwitchParameter ReenterPassword { get; set; }
+        public SwitchParameter ConfirmPassword { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the GetCredentialCommand
@@ -110,7 +110,7 @@ namespace Microsoft.PowerShell.Commands
                     _title,
                     _message,
                     _userName,
-                    ReenterPassword,
+                    ConfirmPassword,
                     string.Empty,
                     PSCredentialTypes.Default,
                     PSCredentialUIOptions.Default);

--- a/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
@@ -82,7 +82,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Gets or sets the re-enter password on the window prompt.
         /// </summary>
-        [Parameter(Mandatory = false, ParameterSetName = messageSet)]
+        [Parameter(ParameterSetName = messageSet)]
         public SwitchParameter ReenterPassword { get; set; }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
@@ -80,17 +80,10 @@ namespace Microsoft.PowerShell.Commands
         private string _title = UtilsStrings.PromptForCredential_DefaultCaption;
 
         /// <summary>
-        /// Gets and sets the Re-enter Password on the window promt.
+        /// Gets and sets the Re-enter Password on the window prompt.
         /// </summary>
         [Parameter(Mandatory = false, ParameterSetName = messageSet)]
-        public SwitchParameter ReEnterPassword
-        {
-            get { return _reEnterPassword; }
-
-            set { _reEnterPassword = value; }
-        }
-
-        private bool _reEnterPassword;
+        public SwitchParameter ReEnterPassword { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the GetCredentialCommand
@@ -113,7 +106,9 @@ namespace Microsoft.PowerShell.Commands
 
             try
             {
-                Credential = this.Host.UI.PromptForCredential(_title, _message, _userName, _reEnterPassword, string.Empty);
+                Credential = this.Host.UI.PromptForCredential(_title, _message, _userName, ReEnterPassword, string.Empty,
+                    PSCredentialTypes.Default,
+                    PSCredentialUIOptions.Default);
             }
             catch (ArgumentException exception)
             {

--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -54,8 +54,8 @@ namespace System.Management.Automation.Host
         /// The characters typed by the user.
         /// </returns>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLineAsSecureString"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string)"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool,string)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForChoice"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/>
         public abstract string ReadLine();
@@ -92,12 +92,12 @@ namespace System.Management.Automation.Host
         /// </returns>
         /// <remarks>
         /// Note that credentials (a user name and password) should be gathered with
-        /// <see cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string)"/>
-        /// <see cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
+        /// <see cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool, string)"/>
+        /// <see cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
         /// </remarks>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLine"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string)"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool, string)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForChoice"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/>
         public abstract SecureString ReadLineAsSecureString();
@@ -825,8 +825,8 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLine"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLineAsSecureString"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForChoice"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string)"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool, string)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
         public abstract Dictionary<string, PSObject> Prompt(string caption, string message, Collection<FieldDescription> descriptions);
 
         /// <summary>
@@ -848,6 +848,9 @@ namespace System.Management.Automation.Host
         /// Name of the user whose credential is to be prompted for. If set to null or empty
         /// string, the function will prompt for user name first.
         /// </param>
+        /// <param name="reEnterPassword">
+        /// Promts user to re-enter the password for confirmation
+        /// </param>
         /// <param name="targetName">
         /// Name of the target for which the credential is being collected.
         /// </param>
@@ -858,9 +861,9 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLineAsSecureString"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForChoice"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
         public abstract PSCredential PromptForCredential(string caption, string message,
-            string userName, string targetName
+            string userName, bool reEnterPassword, string targetName
         );
 
         /// <summary>
@@ -875,6 +878,9 @@ namespace System.Management.Automation.Host
         /// <param name="userName">
         /// Name of the user whose credential is to be prompted for. If set to null or empty
         /// string, the function will prompt for user name first.
+        /// </param>
+        /// <param name="reEnterPassword">
+        /// Promts user to re-enter the password for confirmation
         /// </param>
         /// <param name="targetName">
         /// Name of the target for which the credential is being collected.
@@ -892,9 +898,9 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLineAsSecureString"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForChoice"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool, string)"/>
         public abstract PSCredential PromptForCredential(string caption, string message,
-            string userName, string targetName, PSCredentialTypes allowedCredentialTypes,
+            string userName, bool reEnterPassword, string targetName, PSCredentialTypes allowedCredentialTypes,
             PSCredentialUIOptions options
         );
 
@@ -920,8 +926,8 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLine"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLineAsSecureString"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string)"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool, string)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
         public abstract int PromptForChoice(string caption, string message, Collection<ChoiceDescription> choices, int defaultChoice);
 
         #endregion Dialog-oriented interaction

--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -888,7 +888,7 @@ namespace System.Management.Automation.Host
         /// Types of credential can be supplied by the user.
         /// </param>
         /// <param name="options">
-        /// Options that control the credential gathering UI behavior
+        /// Options that control the credential gathering UI behavior.
         /// </param>
         /// <returns>
         /// User input credential.
@@ -899,10 +899,9 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForChoice"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string)"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
-        public abstract PSCredential PromptForCredential(string caption, string message,
-            string userName, string targetName, PSCredentialTypes allowedCredentialTypes,
-            PSCredentialUIOptions options
-        );
+        public abstract PSCredential PromptForCredential(string caption, string message, string userName,
+                                                         string targetName, PSCredentialTypes allowedCredentialTypes,
+                                                         PSCredentialUIOptions options);
 
         /// <summary>
         /// Prompt for credential.

--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -922,7 +922,7 @@ namespace System.Management.Automation.Host
         /// Name of the user whose credential is to be prompted for. If set to null or empty
         /// string, the function will prompt for user name first.
         /// </param>
-        /// <param name="reenterPassword">
+        /// <param name="confirmPassword">
         /// Prompts user to re-enter the password for confirmation.
         /// </param>
         /// <param name="targetName">
@@ -947,7 +947,7 @@ namespace System.Management.Automation.Host
             string caption,
             string message,
             string userName,
-            bool reenterPassword,
+            bool confirmPassword,
             string targetName,
             PSCredentialTypes allowedCredentialTypes,
             PSCredentialUIOptions options);

--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -864,9 +864,11 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForChoice"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
-        public abstract PSCredential PromptForCredential(string caption, string message,
-            string userName, string targetName
-        );
+        public abstract PSCredential PromptForCredential(
+            string caption,
+            string message,
+            string userName,
+            string targetName);
 
         /// <summary>
         /// Prompt for credential.
@@ -899,9 +901,13 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForChoice"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string)"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
-        public abstract PSCredential PromptForCredential(string caption, string message, string userName,
-                                                         string targetName, PSCredentialTypes allowedCredentialTypes,
-                                                         PSCredentialUIOptions options);
+        public abstract PSCredential PromptForCredential(
+            string caption,
+            string message,
+            string userName,
+            string targetName,
+            PSCredentialTypes allowedCredentialTypes,
+            PSCredentialUIOptions options);
 
         /// <summary>
         /// Prompt for credential.
@@ -926,7 +932,7 @@ namespace System.Management.Automation.Host
         /// Types of credential can be supplied by the user.
         /// </param>
         /// <param name="options">
-        /// Options that control the credential gathering UI behavior
+        /// Options that control the credential gathering UI behavior.
         /// </param>
         /// <returns>
         /// User input credential.
@@ -937,10 +943,14 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForChoice"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string)"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
-        public abstract PSCredential PromptForCredential(string caption, string message,
-            string userName, bool reenterPassword, string targetName, PSCredentialTypes allowedCredentialTypes,
-            PSCredentialUIOptions options
-        );
+        public abstract PSCredential PromptForCredential(
+            string caption,
+            string message,
+            string userName,
+            bool reenterPassword,
+            string targetName,
+            PSCredentialTypes allowedCredentialTypes,
+            PSCredentialUIOptions options);
 
         /// <summary>
         /// Presents a dialog allowing the user to choose an option from a set of options.

--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -54,7 +54,8 @@ namespace System.Management.Automation.Host
         /// The characters typed by the user.
         /// </returns>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLineAsSecureString"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool,string)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForChoice"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/>
@@ -92,11 +93,13 @@ namespace System.Management.Automation.Host
         /// </returns>
         /// <remarks>
         /// Note that credentials (a user name and password) should be gathered with
-        /// <see cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool, string)"/>
+        /// <see cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string)"/>
+        /// <see cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
         /// <see cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
         /// </remarks>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLine"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool, string)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForChoice"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/>
@@ -825,7 +828,8 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLine"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLineAsSecureString"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForChoice"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool, string)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string,string)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
         public abstract Dictionary<string, PSObject> Prompt(string caption, string message, Collection<FieldDescription> descriptions);
 
@@ -848,9 +852,6 @@ namespace System.Management.Automation.Host
         /// Name of the user whose credential is to be prompted for. If set to null or empty
         /// string, the function will prompt for user name first.
         /// </param>
-        /// <param name="reEnterPassword">
-        /// Promts user to re-enter the password for confirmation
-        /// </param>
         /// <param name="targetName">
         /// Name of the target for which the credential is being collected.
         /// </param>
@@ -861,9 +862,10 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLineAsSecureString"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForChoice"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
         public abstract PSCredential PromptForCredential(string caption, string message,
-            string userName, bool reEnterPassword, string targetName
+            string userName, string targetName
         );
 
         /// <summary>
@@ -878,9 +880,6 @@ namespace System.Management.Automation.Host
         /// <param name="userName">
         /// Name of the user whose credential is to be prompted for. If set to null or empty
         /// string, the function will prompt for user name first.
-        /// </param>
-        /// <param name="reEnterPassword">
-        /// Promts user to re-enter the password for confirmation
         /// </param>
         /// <param name="targetName">
         /// Name of the target for which the credential is being collected.
@@ -898,9 +897,49 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLineAsSecureString"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForChoice"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool, string)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
         public abstract PSCredential PromptForCredential(string caption, string message,
-            string userName, bool reEnterPassword, string targetName, PSCredentialTypes allowedCredentialTypes,
+            string userName, string targetName, PSCredentialTypes allowedCredentialTypes,
+            PSCredentialUIOptions options
+        );
+
+        /// <summary>
+        /// Prompt for credential.
+        /// </summary>
+        /// <param name="caption">
+        /// Caption for the message.
+        /// </param>
+        /// <param name="message">
+        /// Text description for the credential to be prompt.
+        /// </param>
+        /// <param name="userName">
+        /// Name of the user whose credential is to be prompted for. If set to null or empty
+        /// string, the function will prompt for user name first.
+        /// </param>
+        /// <param name="reenterPassword">
+        /// Prompts user to re-enter the password for confirmation.
+        /// </param>
+        /// <param name="targetName">
+        /// Name of the target for which the credential is being collected.
+        /// </param>
+        /// <param name="allowedCredentialTypes">
+        /// Types of credential can be supplied by the user.
+        /// </param>
+        /// <param name="options">
+        /// Options that control the credential gathering UI behavior
+        /// </param>
+        /// <returns>
+        /// User input credential.
+        /// </returns>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLine"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLineAsSecureString"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForChoice"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
+        public abstract PSCredential PromptForCredential(string caption, string message,
+            string userName, bool reenterPassword, string targetName, PSCredentialTypes allowedCredentialTypes,
             PSCredentialUIOptions options
         );
 
@@ -926,7 +965,8 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLine"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLineAsSecureString"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool, string)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string)"/>
+        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, bool, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
         public abstract int PromptForChoice(string caption, string message, Collection<ChoiceDescription> choices, int defaultChoice);
 

--- a/src/System.Management.Automation/engine/hostifaces/internalHostuserInterfacesecurity.cs
+++ b/src/System.Management.Automation/engine/hostifaces/internalHostuserInterfacesecurity.cs
@@ -20,7 +20,7 @@ namespace System.Management.Automation.Internal.Host
                 caption,
                 message,
                 userName,
-                reenterPassword: false,
+                confirmPassword: false,
                 targetName,
                 PSCredentialTypes.Default,
                 PSCredentialUIOptions.Default);
@@ -41,7 +41,7 @@ namespace System.Management.Automation.Internal.Host
                 caption,
                 message,
                 userName,
-                reenterPassword: false,
+                confirmPassword: false,
                 targetName,
                 allowedCredentialTypes,
                 options);
@@ -56,7 +56,7 @@ namespace System.Management.Automation.Internal.Host
             string caption,
             string message,
             string userName,
-            bool reenterPassword,
+            bool confirmPassword,
             string targetName,
             PSCredentialTypes allowedCredentialTypes,
             PSCredentialUIOptions options)
@@ -69,7 +69,7 @@ namespace System.Management.Automation.Internal.Host
             PSCredential result = null;
             try
             {
-                result = _externalUI.PromptForCredential(caption, message, userName, reenterPassword, targetName, allowedCredentialTypes, options);
+                result = _externalUI.PromptForCredential(caption, message, userName, confirmPassword, targetName, allowedCredentialTypes, options);
             }
             catch (PipelineStoppedException)
             {

--- a/src/System.Management.Automation/engine/hostifaces/internalHostuserInterfacesecurity.cs
+++ b/src/System.Management.Automation/engine/hostifaces/internalHostuserInterfacesecurity.cs
@@ -22,10 +22,11 @@ namespace System.Management.Automation.Internal.Host
             string caption,
             string message,
             string userName,
+            bool reEnterPassword,
             string targetName
         )
         {
-            return PromptForCredential(caption, message, userName,
+            return PromptForCredential(caption, message, userName, reEnterPassword,
                                          targetName,
                                          PSCredentialTypes.Default,
                                          PSCredentialUIOptions.Default);
@@ -42,6 +43,7 @@ namespace System.Management.Automation.Internal.Host
             string caption,
             string message,
             string userName,
+            bool reEnterPassword,
             string targetName,
             PSCredentialTypes allowedCredentialTypes,
             PSCredentialUIOptions options
@@ -55,7 +57,7 @@ namespace System.Management.Automation.Internal.Host
             PSCredential result = null;
             try
             {
-                result = _externalUI.PromptForCredential(caption, message, userName, targetName, allowedCredentialTypes, options);
+                result = _externalUI.PromptForCredential(caption, message, userName, reEnterPassword, targetName, allowedCredentialTypes, options);
             }
             catch (PipelineStoppedException)
             {

--- a/src/System.Management.Automation/engine/hostifaces/internalHostuserInterfacesecurity.cs
+++ b/src/System.Management.Automation/engine/hostifaces/internalHostuserInterfacesecurity.cs
@@ -26,14 +26,12 @@ namespace System.Management.Automation.Internal.Host
         /// See base class.
         /// </summary>
         public override PSCredential PromptForCredential
-            (
-            string caption, 
+            (string caption,
             string message,
-            string userName, 
-            string targetName, 
-            PSCredentialTypes allowedCredentialTypes, 
-            PSCredentialUIOptions options
-            )
+            string userName,
+            string targetName,
+            PSCredentialTypes allowedCredentialTypes,
+            PSCredentialUIOptions options)
         {
             return PromptForCredential(caption, message, userName, reenterPassword: false,
                                          targetName, allowedCredentialTypes, options);
@@ -42,19 +40,16 @@ namespace System.Management.Automation.Internal.Host
         /// <summary>
         /// See base class.
         /// </summary>
-
         public override
         PSCredential
         PromptForCredential
-        (
-            string caption,
+            (string caption,
             string message,
             string userName,
             bool reenterPassword,
             string targetName,
             PSCredentialTypes allowedCredentialTypes,
-            PSCredentialUIOptions options
-        )
+            PSCredentialUIOptions options)
         {
             if (_externalUI == null)
             {

--- a/src/System.Management.Automation/engine/hostifaces/internalHostuserInterfacesecurity.cs
+++ b/src/System.Management.Automation/engine/hostifaces/internalHostuserInterfacesecurity.cs
@@ -14,22 +14,29 @@ namespace System.Management.Automation.Internal.Host
         /// <summary>
         /// See base class.
         /// </summary>
-
-        public override
-        PSCredential
-        PromptForCredential
-        (
-            string caption,
-            string message,
-            string userName,
-            bool reEnterPassword,
-            string targetName
-        )
+        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName)
         {
-            return PromptForCredential(caption, message, userName, reEnterPassword,
+            return PromptForCredential(caption, message, userName, reenterPassword: false,
                                          targetName,
                                          PSCredentialTypes.Default,
                                          PSCredentialUIOptions.Default);
+        }
+
+        /// <summary>
+        /// See base class.
+        /// </summary>
+        public override PSCredential PromptForCredential
+            (
+            string caption, 
+            string message,
+            string userName, 
+            string targetName, 
+            PSCredentialTypes allowedCredentialTypes, 
+            PSCredentialUIOptions options
+            )
+        {
+            return PromptForCredential(caption, message, userName, reenterPassword: false,
+                                         targetName, allowedCredentialTypes, options);
         }
 
         /// <summary>
@@ -43,7 +50,7 @@ namespace System.Management.Automation.Internal.Host
             string caption,
             string message,
             string userName,
-            bool reEnterPassword,
+            bool reenterPassword,
             string targetName,
             PSCredentialTypes allowedCredentialTypes,
             PSCredentialUIOptions options
@@ -57,7 +64,7 @@ namespace System.Management.Automation.Internal.Host
             PSCredential result = null;
             try
             {
-                result = _externalUI.PromptForCredential(caption, message, userName, reEnterPassword, targetName, allowedCredentialTypes, options);
+                result = _externalUI.PromptForCredential(caption, message, userName, reenterPassword, targetName, allowedCredentialTypes, options);
             }
             catch (PipelineStoppedException)
             {

--- a/src/System.Management.Automation/engine/hostifaces/internalHostuserInterfacesecurity.cs
+++ b/src/System.Management.Automation/engine/hostifaces/internalHostuserInterfacesecurity.cs
@@ -16,25 +16,35 @@ namespace System.Management.Automation.Internal.Host
         /// </summary>
         public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName)
         {
-            return PromptForCredential(caption, message, userName, reenterPassword: false,
-                                         targetName,
-                                         PSCredentialTypes.Default,
-                                         PSCredentialUIOptions.Default);
+            return PromptForCredential(
+                caption,
+                message,
+                userName,
+                reenterPassword: false,
+                targetName,
+                PSCredentialTypes.Default,
+                PSCredentialUIOptions.Default);
         }
 
         /// <summary>
         /// See base class.
         /// </summary>
-        public override PSCredential PromptForCredential
-            (string caption,
+        public override PSCredential PromptForCredential(
+            string caption,
             string message,
             string userName,
             string targetName,
             PSCredentialTypes allowedCredentialTypes,
             PSCredentialUIOptions options)
         {
-            return PromptForCredential(caption, message, userName, reenterPassword: false,
-                                         targetName, allowedCredentialTypes, options);
+            return PromptForCredential(
+                caption,
+                message,
+                userName,
+                reenterPassword: false,
+                targetName,
+                allowedCredentialTypes,
+                options);
         }
 
         /// <summary>
@@ -42,8 +52,8 @@ namespace System.Management.Automation.Internal.Host
         /// </summary>
         public override
         PSCredential
-        PromptForCredential
-            (string caption,
+        PromptForCredential(
+            string caption,
             string message,
             string userName,
             bool reenterPassword,

--- a/src/System.Management.Automation/engine/remoting/server/ServerRemoteHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRemoteHostUserInterface.cs
@@ -239,8 +239,9 @@ namespace System.Management.Automation.Remoting
         /// </summary>
         public override PSCredential PromptForCredential(string caption, string message, string userName, bool reenterPassword, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
         {
-            return _serverMethodExecutor.ExecuteMethod<PSCredential>(RemoteHostMethodId.PromptForCredential2,
-                    new object[] { caption, message, userName, reenterPassword, targetName, allowedCredentialTypes, options });
+            return _serverMethodExecutor.ExecuteMethod<PSCredential>(
+                RemoteHostMethodId.PromptForCredential2,
+                new object[] { caption, message, userName, reenterPassword, targetName, allowedCredentialTypes, options });
         }
     }
 }

--- a/src/System.Management.Automation/engine/remoting/server/ServerRemoteHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRemoteHostUserInterface.cs
@@ -237,11 +237,11 @@ namespace System.Management.Automation.Remoting
         /// <summary>
         /// Prompt for credential.
         /// </summary>
-        public override PSCredential PromptForCredential(string caption, string message, string userName, bool reenterPassword, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
+        public override PSCredential PromptForCredential(string caption, string message, string userName, bool confirmPassword, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
         {
             return _serverMethodExecutor.ExecuteMethod<PSCredential>(
                 RemoteHostMethodId.PromptForCredential2,
-                new object[] { caption, message, userName, reenterPassword, targetName, allowedCredentialTypes, options });
+                new object[] { caption, message, userName, confirmPassword, targetName, allowedCredentialTypes, options });
         }
     }
 }

--- a/src/System.Management.Automation/engine/remoting/server/ServerRemoteHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRemoteHostUserInterface.cs
@@ -219,7 +219,7 @@ namespace System.Management.Automation.Remoting
         /// <summary>
         /// Prompt for credential.
         /// </summary>
-        public override PSCredential PromptForCredential(string caption, string message, string userName, bool reEnterPassword, string targetName)
+        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName)
         {
             return _serverMethodExecutor.ExecuteMethod<PSCredential>(RemoteHostMethodId.PromptForCredential1,
                     new object[] { caption, message, userName, targetName });
@@ -228,10 +228,19 @@ namespace System.Management.Automation.Remoting
         /// <summary>
         /// Prompt for credential.
         /// </summary>
-        public override PSCredential PromptForCredential(string caption, string message, string userName, bool reEnterPassword, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
+        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
         {
             return _serverMethodExecutor.ExecuteMethod<PSCredential>(RemoteHostMethodId.PromptForCredential2,
                     new object[] { caption, message, userName, targetName, allowedCredentialTypes, options });
+        }
+
+        /// <summary>
+        /// Prompt for credential.
+        /// </summary>
+        public override PSCredential PromptForCredential(string caption, string message, string userName, bool reenterPassword, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
+        {
+            return _serverMethodExecutor.ExecuteMethod<PSCredential>(RemoteHostMethodId.PromptForCredential2,
+                    new object[] { caption, message, userName, reenterPassword, targetName, allowedCredentialTypes, options });
         }
     }
 }

--- a/src/System.Management.Automation/engine/remoting/server/ServerRemoteHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRemoteHostUserInterface.cs
@@ -219,7 +219,7 @@ namespace System.Management.Automation.Remoting
         /// <summary>
         /// Prompt for credential.
         /// </summary>
-        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName)
+        public override PSCredential PromptForCredential(string caption, string message, string userName, bool reEnterPassword, string targetName)
         {
             return _serverMethodExecutor.ExecuteMethod<PSCredential>(RemoteHostMethodId.PromptForCredential1,
                     new object[] { caption, message, userName, targetName });
@@ -228,7 +228,7 @@ namespace System.Management.Automation.Remoting
         /// <summary>
         /// Prompt for credential.
         /// </summary>
-        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
+        public override PSCredential PromptForCredential(string caption, string message, string userName, bool reEnterPassword, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
         {
             return _serverMethodExecutor.ExecuteMethod<PSCredential>(RemoteHostMethodId.PromptForCredential2,
                     new object[] { caption, message, userName, targetName, allowedCredentialTypes, options });

--- a/src/System.Management.Automation/security/CredentialParameter.cs
+++ b/src/System.Management.Automation/security/CredentialParameter.cs
@@ -32,6 +32,7 @@ namespace System.Management.Automation
             PSCredential cred = null;
             string userName = null;
             bool shouldPrompt = false;
+            bool reEnterPassword = false;
 
             if ((engineIntrinsics == null) ||
                (engineIntrinsics.Host == null) ||
@@ -77,6 +78,7 @@ namespace System.Management.Automation
                            caption,
                            prompt,
                            userName,
+                           reEnterPassword,
                            string.Empty);
             }
 

--- a/src/System.Management.Automation/security/CredentialParameter.cs
+++ b/src/System.Management.Automation/security/CredentialParameter.cs
@@ -32,7 +32,7 @@ namespace System.Management.Automation
             PSCredential cred = null;
             string userName = null;
             bool shouldPrompt = false;
-            bool reEnterPassword = false;
+            bool reenterPassword = false;
 
             if ((engineIntrinsics == null) ||
                (engineIntrinsics.Host == null) ||
@@ -75,11 +75,13 @@ namespace System.Management.Automation
                 prompt = CredentialAttributeStrings.CredentialAttribute_Prompt;
 
                 cred = engineIntrinsics.Host.UI.PromptForCredential(
-                           caption,
-                           prompt,
-                           userName,
-                           reEnterPassword,
-                           string.Empty);
+                            caption,
+                            prompt,
+                            userName,
+                            reenterPassword,
+                            string.Empty,
+                            PSCredentialTypes.Default,
+                            PSCredentialUIOptions.Default);
             }
 
             return cred;

--- a/src/System.Management.Automation/security/CredentialParameter.cs
+++ b/src/System.Management.Automation/security/CredentialParameter.cs
@@ -32,7 +32,7 @@ namespace System.Management.Automation
             PSCredential cred = null;
             string userName = null;
             bool shouldPrompt = false;
-            bool reenterPassword = false;
+            bool confirmPassword = false;
 
             if ((engineIntrinsics == null) ||
                (engineIntrinsics.Host == null) ||
@@ -78,7 +78,7 @@ namespace System.Management.Automation
                             caption,
                             prompt,
                             userName,
-                            reenterPassword,
+                            confirmPassword,
                             string.Empty,
                             PSCredentialTypes.Default,
                             PSCredentialUIOptions.Default);

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
@@ -102,16 +102,16 @@ Describe "Get-Credential Test" -Tag "CI" {
         $netcred.UserName | Should -Be "John"
         $netcred.Password | Should -Be "CredTest"
     }
-    It "Get-credential Joe `$reenterPassword set to false"{
-        $cred = $ps.AddScript("Get-Credential Joe -ReenterPassword:`$false").Invoke() | Select-Object -First 1
+    It "Get-credential Joe -ConfirmPassword set to false"{
+        $cred = $ps.AddScript("Get-Credential Joe -ConfirmPassword:`$false").Invoke() | Select-Object -First 1
         $cred | Should -BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()
         $netcred.UserName | Should -Be "Joe"
         $netcred.Password | Should -Be "This is a test"
         $th.ui.Streams.Prompt[-1] | Should -Match "Credential:[^:]+:[^:]+"
     }
-    It "Get-Credential with only `$reenterPassword" {
-        $cred = $ps.AddScript("Get-Credential -ReenterPassword").Invoke() | Select-Object -First 1
+    It "Get-Credential with only -ConfirmPassword" {
+        $cred = $ps.AddScript("Get-Credential -ConfirmPassword").Invoke() | Select-Object -First 1
         $cred | Should -BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()
         $netcred.UserName | Should -Be "John"

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
@@ -102,8 +102,8 @@ Describe "Get-Credential Test" -Tag "CI" {
         $netcred.UserName | Should -Be "John"
         $netcred.Password | Should -Be "CredTest"
     }
-    It "Get-credential Joe `$reenterPassword"{
-        $cred = $ps.AddScript("Get-Credential Joe -ReEnterPassword").Invoke() | Select-Object -First 1
+    It "Get-credential Joe `$reenterPassword set to false"{
+        $cred = $ps.AddScript("Get-Credential Joe -ReenterPassword:`$false").Invoke() | Select-Object -First 1
         $cred | Should -BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()
         $netcred.UserName | Should -Be "Joe"
@@ -111,11 +111,12 @@ Describe "Get-Credential Test" -Tag "CI" {
         $th.ui.Streams.Prompt[-1] | Should -Match "Credential:[^:]+:[^:]+"
     }
     It "Get-Credential with only `$reenterPassword" {
-        $cred = $ps.AddScript("Get-Credential -ReEnterPassword").Invoke() | Select-Object -First 1
+        $cred = $ps.AddScript("Get-Credential -ReenterPassword").Invoke() | Select-Object -First 1
         $cred | Should -BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()
         $netcred.UserName | Should -Be "John"
         $netcred.Password | Should -Be "This is a test"
-        $th.ui.Streams.Prompt[-1] | Should -Match "Credential:[^:]+:[^:]+"
+        $th.ui.Streams.Prompt[-2] | Should -Match "Credential:[^:]+:[^:]+"
+        $th.ui.Streams.Prompt[-1] | Should -Match "Credential@[^@]+@[^@]+"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
@@ -102,4 +102,20 @@ Describe "Get-Credential Test" -Tag "CI" {
         $netcred.UserName | Should -Be "John"
         $netcred.Password | Should -Be "CredTest"
     }
+    It "Get-credential Joe `$reEnterPassword"{
+        $cred = $ps.AddScript("Get-Credential Joe -ReEnterPassword").Invoke() | Select-Object -First 1
+        $cred | Should -BeOfType System.Management.Automation.PSCredential
+        $netcred = $cred.GetNetworkCredential()
+        $netcred.UserName | Should -Be "Joe"
+        $netcred.Password | Should -Be "This is a test"
+        $th.ui.Streams.Prompt[-1] | Should -Match "Credential:[^:]+:[^:]+"
+    }
+    It "Get-Credential with only `$reEnterPassword" {
+        $cred = $ps.AddScript("Get-Credential -ReEnterPassword").Invoke() | Select-Object -First 1
+        $cred | Should -BeOfType System.Management.Automation.PSCredential
+        $netcred = $cred.GetNetworkCredential()
+        $netcred.UserName | Should -Be "John"
+        $netcred.Password | Should -Be "This is a test"
+        $th.ui.Streams.Prompt[-1] | Should -Match "Credential:[^:]+:[^:]+"
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
@@ -102,7 +102,7 @@ Describe "Get-Credential Test" -Tag "CI" {
         $netcred.UserName | Should -Be "John"
         $netcred.Password | Should -Be "CredTest"
     }
-    It "Get-credential Joe `$reEnterPassword"{
+    It "Get-credential Joe `$reenterPassword"{
         $cred = $ps.AddScript("Get-Credential Joe -ReEnterPassword").Invoke() | Select-Object -First 1
         $cred | Should -BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()
@@ -110,7 +110,7 @@ Describe "Get-Credential Test" -Tag "CI" {
         $netcred.Password | Should -Be "This is a test"
         $th.ui.Streams.Prompt[-1] | Should -Match "Credential:[^:]+:[^:]+"
     }
-    It "Get-Credential with only `$reEnterPassword" {
+    It "Get-Credential with only `$reenterPassword" {
         $cred = $ps.AddScript("Get-Credential -ReEnterPassword").Invoke() | Select-Object -First 1
         $cred | Should -BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()

--- a/test/tools/Modules/HelpersHostCS/HelpersHostCS.psm1
+++ b/test/tools/Modules/HelpersHostCS/HelpersHostCS.psm1
@@ -10,6 +10,7 @@ using System.Globalization;
 using System.Collections.ObjectModel;
 using System.Security;
 using System.Collections;
+using System.Runtime.InteropServices;
 
 namespace TestHost
 {
@@ -143,20 +144,82 @@ namespace TestHost
             return PromptedChoice;
         }
 
-        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName)
+        public override PSCredential PromptForCredential(string caption, string message, string userName, bool _reEnterPassword, string targetName)
         {
             Streams.Prompt.Add("Credential:" + caption + ":" + message);
-            SecureString ss = ReadLineAsSecureString();
+            SecureString password = ReadLineAsSecureString();
+            if(_reEnterPassword)
+            {
+                SecureString confirmPassword = ReadLineAsSecureString();
+                IntPtr pwd_ptr = IntPtr.Zero;
+                IntPtr confirmPwd_ptr = IntPtr.Zero;
+                try
+                {
+                    pwd_ptr = Marshal.SecureStringToBSTR(password);
+                    confirmPwd_ptr = Marshal.SecureStringToBSTR(confirmPassword);
+                    string pwd = Marshal.PtrToStringBSTR(pwd_ptr);
+                    string confirmPwd = Marshal.PtrToStringBSTR(confirmPwd_ptr);
+
+                    // If the string is not equal print error message and returns null
+
+                    if(!(pwd.Equals(confirmPwd)))
+                    {
+                        return null;
+                    }
+                }
+                finally
+                {
+                    if (pwd_ptr != IntPtr.Zero)
+                    {
+                        Marshal.ZeroFreeBSTR(pwd_ptr);
+                    }
+                    if (confirmPwd_ptr != IntPtr.Zero)
+                    {
+                        Marshal.ZeroFreeBSTR(confirmPwd_ptr);
+                    }
+                }
+            }
             string userNameToUse = string.IsNullOrEmpty(userName) ? UserNameForCredential : userName;
-            return new PSCredential(userNameToUse, ss);
+            return new PSCredential(userNameToUse, password);
         }
 
-        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
+        public override PSCredential PromptForCredential(string caption, string message, string userName, bool _reEnterPassword, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
         {
             Streams.Prompt.Add("Credential:" + caption + ":" + message);
-            SecureString ss = ReadLineAsSecureString();
+            SecureString password = ReadLineAsSecureString();
+            if(_reEnterPassword)
+            {
+                SecureString confirmPassword = ReadLineAsSecureString();
+                IntPtr pwd_ptr = IntPtr.Zero;
+                IntPtr confirmPwd_ptr = IntPtr.Zero;
+                try
+                {
+                    pwd_ptr = Marshal.SecureStringToBSTR(password);
+                    confirmPwd_ptr = Marshal.SecureStringToBSTR(confirmPassword);
+                    string pwd = Marshal.PtrToStringBSTR(pwd_ptr);
+                    string confirmPwd = Marshal.PtrToStringBSTR(confirmPwd_ptr);
+                    
+                    // If the string is not equal print error message and returns null
+                    
+                    if(!(pwd.Equals(confirmPwd)))
+                    {
+                        return null;
+                    }
+                }
+                finally
+                {
+                    if (pwd_ptr != IntPtr.Zero)
+                    {
+                        Marshal.ZeroFreeBSTR(pwd_ptr);
+                    }
+                    if (confirmPwd_ptr != IntPtr.Zero)
+                    {
+                        Marshal.ZeroFreeBSTR(confirmPwd_ptr);
+                    }
+                }
+            }
             string userNameToUse = string.IsNullOrEmpty(userName) ? UserNameForCredential : userName;
-            return new PSCredential(userNameToUse, ss);
+            return new PSCredential(userNameToUse, password);
         }
 
         public override string ReadLine()

--- a/test/tools/Modules/HelpersHostCS/HelpersHostCS.psm1
+++ b/test/tools/Modules/HelpersHostCS/HelpersHostCS.psm1
@@ -144,50 +144,33 @@ namespace TestHost
             return PromptedChoice;
         }
 
-        public override PSCredential PromptForCredential(string caption, string message, string userName, bool _reEnterPassword, string targetName)
+        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName)
         {
-            Streams.Prompt.Add("Credential:" + caption + ":" + message);
-            SecureString password = ReadLineAsSecureString();
-            if(_reEnterPassword)
-            {
-                SecureString confirmPassword = ReadLineAsSecureString();
-                IntPtr pwd_ptr = IntPtr.Zero;
-                IntPtr confirmPwd_ptr = IntPtr.Zero;
-                try
-                {
-                    pwd_ptr = Marshal.SecureStringToBSTR(password);
-                    confirmPwd_ptr = Marshal.SecureStringToBSTR(confirmPassword);
-                    string pwd = Marshal.PtrToStringBSTR(pwd_ptr);
-                    string confirmPwd = Marshal.PtrToStringBSTR(confirmPwd_ptr);
-
-                    // If the string is not equal print error message and returns null
-
-                    if(!(pwd.Equals(confirmPwd)))
-                    {
-                        return null;
-                    }
-                }
-                finally
-                {
-                    if (pwd_ptr != IntPtr.Zero)
-                    {
-                        Marshal.ZeroFreeBSTR(pwd_ptr);
-                    }
-                    if (confirmPwd_ptr != IntPtr.Zero)
-                    {
-                        Marshal.ZeroFreeBSTR(confirmPwd_ptr);
-                    }
-                }
-            }
-            string userNameToUse = string.IsNullOrEmpty(userName) ? UserNameForCredential : userName;
-            return new PSCredential(userNameToUse, password);
+            return PromptForCredential(caption,
+                                        message,
+                                        userName,
+                                        reenterPassword: false,
+                                        targetName,
+                                        PSCredentialTypes.Default,
+                                        PSCredentialUIOptions.Default);
         }
 
-        public override PSCredential PromptForCredential(string caption, string message, string userName, bool _reEnterPassword, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
+        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
+        {
+            return PromptForCredential(caption,
+                                         message,
+                                         userName,
+                                         reenterPassword: false,
+                                         targetName,
+                                         allowedCredentialTypes,
+                                         options);
+        }
+
+        public override PSCredential PromptForCredential(string caption, string message, string userName, bool reenterPassword, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
         {
             Streams.Prompt.Add("Credential:" + caption + ":" + message);
             SecureString password = ReadLineAsSecureString();
-            if(_reEnterPassword)
+            if(reenterPassword)
             {
                 SecureString confirmPassword = ReadLineAsSecureString();
                 IntPtr pwd_ptr = IntPtr.Zero;

--- a/test/tools/Modules/HelpersHostCS/HelpersHostCS.psm1
+++ b/test/tools/Modules/HelpersHostCS/HelpersHostCS.psm1
@@ -172,34 +172,7 @@ namespace TestHost
             SecureString password = ReadLineAsSecureString();
             if(reenterPassword)
             {
-                SecureString confirmPassword = ReadLineAsSecureString();
-                IntPtr pwd_ptr = IntPtr.Zero;
-                IntPtr confirmPwd_ptr = IntPtr.Zero;
-                try
-                {
-                    pwd_ptr = Marshal.SecureStringToBSTR(password);
-                    confirmPwd_ptr = Marshal.SecureStringToBSTR(confirmPassword);
-                    string pwd = Marshal.PtrToStringBSTR(pwd_ptr);
-                    string confirmPwd = Marshal.PtrToStringBSTR(confirmPwd_ptr);
-                    
-                    // If the string is not equal print error message and returns null
-                    
-                    if(!(pwd.Equals(confirmPwd)))
-                    {
-                        return null;
-                    }
-                }
-                finally
-                {
-                    if (pwd_ptr != IntPtr.Zero)
-                    {
-                        Marshal.ZeroFreeBSTR(pwd_ptr);
-                    }
-                    if (confirmPwd_ptr != IntPtr.Zero)
-                    {
-                        Marshal.ZeroFreeBSTR(confirmPwd_ptr);
-                    }
-                }
+                Streams.Prompt.Add("Credential@" + caption + "@" + message);
             }
             string userNameToUse = string.IsNullOrEmpty(userName) ? UserNameForCredential : userName;
             return new PSCredential(userNameToUse, password);

--- a/test/tools/Modules/HelpersHostCS/HelpersHostCS.psm1
+++ b/test/tools/Modules/HelpersHostCS/HelpersHostCS.psm1
@@ -149,7 +149,7 @@ namespace TestHost
             return PromptForCredential(caption,
                                         message,
                                         userName,
-                                        reenterPassword: false,
+                                        confirmPassword: false,
                                         targetName,
                                         PSCredentialTypes.Default,
                                         PSCredentialUIOptions.Default);
@@ -160,17 +160,17 @@ namespace TestHost
             return PromptForCredential(caption,
                                          message,
                                          userName,
-                                         reenterPassword: false,
+                                         confirmPassword: false,
                                          targetName,
                                          allowedCredentialTypes,
                                          options);
         }
 
-        public override PSCredential PromptForCredential(string caption, string message, string userName, bool reenterPassword, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
+        public override PSCredential PromptForCredential(string caption, string message, string userName, bool confirmPassword, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
         {
             Streams.Prompt.Add("Credential:" + caption + ":" + message);
             SecureString password = ReadLineAsSecureString();
-            if(reenterPassword)
+            if(confirmPassword)
             {
                 Streams.Prompt.Add("Credential@" + caption + "@" + message);
             }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

<!-- Summarize your PR between here and the checklist. -->
 ```Get-Credential``` : Add parameter ```-ReEnterPassword```  to resolve [#10625](https://github.com/PowerShell/PowerShell/issues/10625)

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
By adding ```-ReEnterPassword``` parameter the user will be prompted to re-enter the password and performs a comparison. If comparison fails ```null``` is returned and user is notified about password mismatch.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: <!-- Number/link of that issue here --> [#6034](https://github.com/MicrosoftDocs/PowerShell-Docs/issues/6034)
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
