### PR TITLE
Optimize Get-ChildItem -Recurse -Name

### DIFF
--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -2380,9 +2380,7 @@ namespace System.Management.Automation
                         // Since the path contained glob characters or we are recursing and the
                         // path is a container, do the name enumeration manually
 
-                        // TODO: after we get support the depth in .Net API we will be able use DoGetChildNamesFast()
-                        if (depth == uint.MaxValue &&
-                            providerInstance is Microsoft.PowerShell.Commands.FileSystemProvider fileSystemProvider)
+                        if (providerInstance is Microsoft.PowerShell.Commands.FileSystemProvider fileSystemProvider)
                         {
                             string newProviderPath =
                                 MakePath(
@@ -2490,9 +2488,7 @@ namespace System.Management.Automation
                     // The path did not contain glob characters but recurse was specified
                     // so do the enumeration manually
 
-                    // TODO: after we get support the depth in .Net API we will be able use DoGetChildNamesFast()
-                    if (depth == uint.MaxValue &&
-                        providerInstance is Microsoft.PowerShell.Commands.FileSystemProvider fileSystemProvider)
+                    if (providerInstance is Microsoft.PowerShell.Commands.FileSystemProvider fileSystemProvider)
                     {
                         string newProviderPath =
                             MakePath(

--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -2380,7 +2380,9 @@ namespace System.Management.Automation
                         // Since the path contained glob characters or we are recursing and the
                         // path is a container, do the name enumeration manually
 
-                        if (providerInstance is Microsoft.PowerShell.Commands.FileSystemProvider fileSystemProvider)
+                        // TODO: after we get support the depth in .Net API we will be able use DoGetChildNamesFast()
+                        if (depth == uint.MaxValue &&
+                            providerInstance is Microsoft.PowerShell.Commands.FileSystemProvider fileSystemProvider)
                         {
                             string newProviderPath =
                                 MakePath(
@@ -2488,7 +2490,9 @@ namespace System.Management.Automation
                     // The path did not contain glob characters but recurse was specified
                     // so do the enumeration manually
 
-                    if (providerInstance is Microsoft.PowerShell.Commands.FileSystemProvider fileSystemProvider)
+                    // TODO: after we get support the depth in .Net API we will be able use DoGetChildNamesFast()
+                    if (depth == uint.MaxValue &&
+                        providerInstance is Microsoft.PowerShell.Commands.FileSystemProvider fileSystemProvider)
                     {
                         string newProviderPath =
                             MakePath(

--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -2380,16 +2380,38 @@ namespace System.Management.Automation
                         // Since the path contained glob characters or we are recursing and the
                         // path is a container, do the name enumeration manually
 
-                        DoGetChildNamesManually(
-                            providerInstance,
-                            providerPath,
-                            string.Empty,
-                            returnContainers,
-                            includeMatcher,
-                            excludeMatcher,
-                            context,
-                            recurse,
-                            depth);
+                        if (providerInstance is Microsoft.PowerShell.Commands.FileSystemProvider fileSystemProvider)
+                        {
+                            string newProviderPath =
+                                MakePath(
+                                    providerInstance,
+                                    providerPath,
+                                    string.Empty,
+                                    context);
+
+                            fileSystemProvider.DoGetChildNamesFast(
+                                providerInstance,
+                                newProviderPath,
+                                returnContainers,
+                                includeMatcher,
+                                excludeMatcher,
+                                context,
+                                recurse,
+                                depth);
+                        }
+                        else
+                        {
+                            DoGetChildNamesManually(
+                                providerInstance,
+                                providerPath,
+                                string.Empty,
+                                returnContainers,
+                                includeMatcher,
+                                excludeMatcher,
+                                context,
+                                recurse,
+                                depth);
+                        }
                     }
                     else
                     {
@@ -2466,16 +2488,38 @@ namespace System.Management.Automation
                     // The path did not contain glob characters but recurse was specified
                     // so do the enumeration manually
 
-                    DoGetChildNamesManually(
-                        providerInstance,
-                        providerPath,
-                        string.Empty,
-                        returnContainers,
-                        includeMatcher,
-                        excludeMatcher,
-                        context,
-                        recurse,
-                        depth);
+                    if (providerInstance is Microsoft.PowerShell.Commands.FileSystemProvider fileSystemProvider)
+                    {
+                        string newProviderPath =
+                            MakePath(
+                                providerInstance,
+                                providerPath,
+                                string.Empty,
+                                context);
+
+                        fileSystemProvider.DoGetChildNamesFast(
+                            providerInstance,
+                            newProviderPath,
+                            returnContainers,
+                            includeMatcher,
+                            excludeMatcher,
+                            context,
+                            recurse,
+                            depth);
+                    }
+                    else
+                    {
+                        DoGetChildNamesManually(
+                            providerInstance,
+                            providerPath,
+                            string.Empty,
+                            returnContainers,
+                            includeMatcher,
+                            excludeMatcher,
+                            context,
+                            recurse,
+                            depth);
+                    }
                 }
                 else
                 {

--- a/src/System.Management.Automation/namespaces/FileSystemProviderEnumerable.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProviderEnumerable.cs
@@ -1,0 +1,89 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Enumeration;
+using System.Threading;
+
+namespace Microsoft.PowerShell.Commands
+{
+    /// <summary>
+    /// Enumerable that allows utilizing custom filter predicates and tranform delegates.
+    /// </summary>
+    internal class FileSystemProviderEnumerable<TResult> : IEnumerable<TResult>
+    {
+        private DelegateEnumerator? _enumerator;
+        private readonly FindTransform _transform;
+        private readonly EnumerationOptions _options;
+        private readonly string _directory;
+
+        /// <summary>
+        /// Enumerable that allows utilizing custom filter predicates and tranform delegates.
+        /// </summary>
+        internal FileSystemProviderEnumerable(string directory, FindTransform transform, EnumerationOptions? options = null)
+        {
+            _directory = directory ?? throw new ArgumentNullException(nameof(directory));
+            _transform = transform ?? throw new ArgumentNullException(nameof(transform));
+            _options = options ?? new EnumerationOptions();
+
+            // We need to create the enumerator up front to ensure that we throw I/O exceptions for
+            // the root directory on creation of the enumerable.
+            _enumerator = new DelegateEnumerator(this);
+        }
+
+        internal FindPredicate? ShouldIncludePredicate { get; set; }
+
+        internal FindPredicate? ShouldRecursePredicate { get; set; }
+
+        internal FindPredicate? ShouldOnPredicate { get; set; }
+
+        internal OnDirectoryFinishedDelegate? OnDirectoryFinishedAction { get; set; }
+
+        public IEnumerator<TResult> GetEnumerator()
+        {
+            return Interlocked.Exchange(ref _enumerator, null) ?? new DelegateEnumerator(this);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        /// <summary>
+        /// Delegate for filtering out find results.
+        /// </summary>
+        internal delegate bool FindPredicate(ref FileSystemEntry entry);
+
+        /// <summary>
+        /// Delegate for calling whenever the end of a directory is reached.
+        /// </summary>
+        /// <param name="directory">The path of the directory that finished.</param>
+        internal delegate void OnDirectoryFinishedDelegate(ReadOnlySpan<char> directory);
+
+        /// <summary>
+        /// Delegate for transforming raw find data into a result.
+        /// </summary>
+        internal delegate TResult FindTransform(ref FileSystemEntry entry);
+
+        private sealed class DelegateEnumerator : FileSystemEnumerator<TResult>
+        {
+            private readonly FileSystemProviderEnumerable<TResult> _enumerable;
+
+            internal DelegateEnumerator(FileSystemProviderEnumerable<TResult> enumerable)
+                : base(enumerable._directory, enumerable._options)
+            {
+                _enumerable = enumerable;
+            }
+
+            protected override TResult TransformEntry(ref FileSystemEntry entry) => _enumerable._transform(ref entry);
+            protected override bool ShouldRecurseIntoEntry(ref FileSystemEntry entry)
+                => _enumerable.ShouldRecursePredicate?.Invoke(ref entry) ?? true;
+            protected override bool ShouldIncludeEntry(ref FileSystemEntry entry)
+                => _enumerable.ShouldIncludePredicate?.Invoke(ref entry) ?? true;
+            protected override void OnDirectoryFinished(ReadOnlySpan<char> directory)
+                => _enumerable.OnDirectoryFinishedAction?.Invoke(directory);
+        }
+    }
+}

--- a/src/System.Management.Automation/namespaces/FileSystemProviderEnumerable.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProviderEnumerable.cs
@@ -39,8 +39,6 @@ namespace Microsoft.PowerShell.Commands
 
         internal FindPredicate? ShouldRecursePredicate { get; set; }
 
-        internal OnDirectoryFinishedDelegate? OnDirectoryFinishedAction { get; set; }
-
         internal ContinueOnErrorPredicate? ShouldContinueOnErrorPredicate { get; set; }
 
         public IEnumerator<TResult> GetEnumerator()
@@ -87,8 +85,6 @@ namespace Microsoft.PowerShell.Commands
                 => _enumerable.ShouldRecursePredicate?.Invoke(ref entry) ?? true;
             protected override bool ShouldIncludeEntry(ref FileSystemEntry entry)
                 => _enumerable.ShouldIncludePredicate?.Invoke(ref entry) ?? true;
-            protected override void OnDirectoryFinished(ReadOnlySpan<char> directory)
-                => _enumerable.OnDirectoryFinishedAction?.Invoke(directory);
             protected override bool ContinueOnError(int error)
                 // Here _enumerable can be still null because base constructor can throw 'access denied' before we assign _enumerable.
                 => _enumerable?.ShouldContinueOnErrorPredicate?.Invoke(error) ?? false;

--- a/src/System.Management.Automation/namespaces/FileSystemProviderEnumerable.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProviderEnumerable.cs
@@ -81,10 +81,13 @@ namespace Microsoft.PowerShell.Commands
             }
 
             protected override TResult TransformEntry(ref FileSystemEntry entry) => _enumerable._transform(ref entry);
+
             protected override bool ShouldRecurseIntoEntry(ref FileSystemEntry entry)
                 => _enumerable.ShouldRecursePredicate?.Invoke(ref entry) ?? true;
+
             protected override bool ShouldIncludeEntry(ref FileSystemEntry entry)
                 => _enumerable.ShouldIncludePredicate?.Invoke(ref entry) ?? true;
+
             protected override bool ContinueOnError(int error)
                 // Here _enumerable can be still null because base constructor can throw 'access denied' before we assign _enumerable.
                 => _enumerable?.ShouldContinueOnErrorPredicate?.Invoke(error) ?? false;

--- a/src/System.Management.Automation/namespaces/FileSystemProviderEnumerable.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProviderEnumerable.cs
@@ -14,16 +14,20 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// Enumerable that allows utilizing custom filter predicates and tranform delegates.
     /// </summary>
+    /// <typeparam name="TResult">The type of a result.</typeparam>
     internal class FileSystemProviderEnumerable<TResult> : IEnumerable<TResult>
     {
-        private DelegateEnumerator? _enumerator;
         private readonly FindTransform _transform;
         private readonly EnumerationOptions _options;
         private readonly string _directory;
+        private DelegateEnumerator? _enumerator;
 
         /// <summary>
         /// Enumerable that allows utilizing custom filter predicates and tranform delegates.
         /// </summary>
+        /// <param name="directory">The path of the starting directory.</param>
+        /// <param name="transform">The delegate to transform internal data to a result.</param>
+        /// <param name="options">The enumeration options.</param>
         internal FileSystemProviderEnumerable(string directory, FindTransform transform, EnumerationOptions? options = null)
         {
             _directory = directory ?? throw new ArgumentNullException(nameof(directory));
@@ -51,6 +55,8 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Delegate for filtering out find results.
         /// </summary>
+        /// <param name="entry">A lower level view of System.IO.FileSystemInfo for fitering.</param>
+        /// <return>If true include the entry to result.</return>
         internal delegate bool FindPredicate(ref FileSystemEntry entry);
 
         /// <summary>
@@ -63,11 +69,14 @@ namespace Microsoft.PowerShell.Commands
         /// Delegate for calling whenever on I/O error.
         /// </summary>
         /// <param name="error">I/O error code.</param>
+        /// <return>If true continue the enumeration. If false throw.</return>
         internal delegate bool ContinueOnErrorPredicate(int error);
 
         /// <summary>
         /// Delegate for transforming raw find data into a result.
         /// </summary>
+        /// <param name="entry">A lower level view of System.IO.FileSystemInfo for transforming to TResult.</param>
+        /// <return>Result of the transformation of TResult type.</return>
         internal delegate TResult FindTransform(ref FileSystemEntry entry);
 
         private sealed class DelegateEnumerator : FileSystemEnumerator<TResult>

--- a/src/System.Management.Automation/namespaces/FileSystemProviderEnumerable.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProviderEnumerable.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/System.Management.Automation/namespaces/FileSystemProviderEnumerable.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProviderEnumerable.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.Commands
         /// Delegate for filtering out find results.
         /// </summary>
         /// <param name="entry">A lower level view of System.IO.FileSystemInfo for fitering.</param>
-        /// <return>If true include the entry to result.</return>
+        /// <returns>If true include the entry to result.</returns>
         internal delegate bool FindPredicate(ref FileSystemEntry entry);
 
         /// <summary>
@@ -69,14 +69,14 @@ namespace Microsoft.PowerShell.Commands
         /// Delegate for calling whenever on I/O error.
         /// </summary>
         /// <param name="error">I/O error code.</param>
-        /// <return>If true continue the enumeration. If false throw.</return>
+        /// <returns>If true continue the enumeration. If false throw.</returns>
         internal delegate bool ContinueOnErrorPredicate(int error);
 
         /// <summary>
         /// Delegate for transforming raw find data into a result.
         /// </summary>
         /// <param name="entry">A lower level view of System.IO.FileSystemInfo for transforming to TResult.</param>
-        /// <return>Result of the transformation of TResult type.</return>
+        /// <returns>Result of the transformation of TResult type.</returns>
         internal delegate TResult FindTransform(ref FileSystemEntry entry);
 
         private sealed class DelegateEnumerator : FileSystemEnumerator<TResult>

--- a/src/System.Management.Automation/namespaces/FileSystemProviderEnumerable.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProviderEnumerable.cs
@@ -23,7 +23,8 @@ namespace Microsoft.PowerShell.Commands
         private DelegateEnumerator? _enumerator;
 
         /// <summary>
-        /// Enumerable that allows utilizing custom filter predicates and tranform delegates.
+        /// Initializes a new instance of the FileSystemProviderEnumerable
+        /// that allows utilizing custom filter predicates and tranform delegates.
         /// </summary>
         /// <param name="directory">The path of the starting directory.</param>
         /// <param name="transform">The delegate to transform internal data to a result.</param>

--- a/src/System.Management.Automation/namespaces/FileSystemProviderEnumerable.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProviderEnumerable.cs
@@ -24,8 +24,8 @@ namespace Microsoft.PowerShell.Commands
         private DelegateEnumerator? _enumerator;
 
         /// <summary>
-        /// Initializes a new instance of the FileSystemProviderEnumerable
-        /// that allows utilizing custom filter predicates and tranform delegates.
+        /// Initializes a new instance of the <see cref="FileSystemProviderEnumerable{TResult}"/> class.
+        /// The class allows utilizing custom filter predicates and tranform delegates.
         /// </summary>
         /// <param name="directory">The path of the starting directory.</param>
         /// <param name="transform">The delegate to transform internal data to a result.</param>
@@ -100,7 +100,7 @@ namespace Microsoft.PowerShell.Commands
                 => _enumerable.ShouldIncludePredicate?.Invoke(ref entry) ?? true;
 
             protected override bool ContinueOnError(int error)
-                // Here _enumerable can be still null because base constructor can throw 'access denied' before we assign _enumerable.
+                //// Here _enumerable can be still null because base constructor can throw 'access denied' before we assign _enumerable.
                 => _enumerable?.ShouldContinueOnErrorPredicate?.Invoke(error) ?? false;
         }
     }

--- a/src/System.Management.Automation/namespaces/FileSystemProviderEnumerableFactory.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProviderEnumerableFactory.cs
@@ -79,8 +79,8 @@ namespace Microsoft.PowerShell.Commands
             }
 
             bool FileSystemEntryFilter(ref FileSystemEntry entry)
-                {
-                    if (errorCode != 0)
+            {
+                if (errorCode != 0)
                 {
                     // While enumerating we can get an error.
                     // In the case ShouldContinueOnErrorPredicate sets the error code.

--- a/src/System.Management.Automation/namespaces/FileSystemProviderEnumerableFactory.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProviderEnumerableFactory.cs
@@ -104,7 +104,9 @@ namespace Microsoft.PowerShell.Commands
                     return false;
                 }
 
-                bool isIncludeMatch = includeMatcher == null || includeMatcher.Count == 0 ? true :
+                bool isIncludeMatch =
+                    includeMatcher == null ||
+                    includeMatcher.Count == 0 ||
                     SessionStateUtilities.MatchesAnyWildcardPattern(
                         entry.FileName.ToString(),
                         includeMatcher,
@@ -112,7 +114,9 @@ namespace Microsoft.PowerShell.Commands
 
                 if (isIncludeMatch)
                 {
-                    return excludeMatcher == null || excludeMatcher.Count == 0 ? true :
+                    return
+                        excludeMatcher == null ||
+                        excludeMatcher.Count == 0 ||
                         !SessionStateUtilities.MatchesAnyWildcardPattern(
                             entry.FileName.ToString(),
                             excludeMatcher,

--- a/src/System.Management.Automation/namespaces/FileSystemProviderEnumerableFactory.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProviderEnumerableFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -62,7 +63,7 @@ namespace Microsoft.PowerShell.Commands
                 if (errorCode != 0)
                 {
                     // While enumerating we can get an error.
-                    // In the case ShouldContinueOnErrorPredicate set the error code.
+                    // In the case ShouldContinueOnErrorPredicate sets the error code.
                     // The error can be either 'access denied' or 'path not found'.
                     Exception? exc = System.Runtime.InteropServices.Marshal.GetExceptionForHR(GetHRForWin32Error(errorCode));
                     errorCode = 0;

--- a/src/System.Management.Automation/namespaces/FileSystemProviderEnumerableFactory.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProviderEnumerableFactory.cs
@@ -52,7 +52,6 @@ namespace Microsoft.PowerShell.Commands
             FlagsExpression<FileAttributes>? switchEvaluator,
             bool filterHidden,
             InodeTracker? tracker,  // tracker will be non-null only if the user invoked the -FollowSymLinks and -Recurse switch parameters.
-            uint depth,
             CmdletProviderContext context,
             EnumerationOptions options)
         {
@@ -134,7 +133,7 @@ namespace Microsoft.PowerShell.Commands
                 ShouldRecursePredicate = (ref FileSystemEntry entry) =>
                     {
                         // Making sure to obey the StopProcessing.
-                        if (context.Stopping || depth <= 0)
+                        if (context.Stopping)
                         {
                             return false;
                         }
@@ -182,14 +181,6 @@ namespace Microsoft.PowerShell.Commands
                         // So we save the error code to process it later (in FileSystemEntryFilter() method) and suppress throw.
                         errorCode = error;
                         return true;
-                    },
-
-                OnDirectoryFinishedAction = (ReadOnlySpan<char> directory) =>
-                    {
-                        if (depth > 0)
-                        {
-                            depth--;
-                        }
                     }
             };
         }
@@ -290,7 +281,6 @@ namespace Microsoft.PowerShell.Commands
                         switchEvaluator,
                         filterHidden,
                         tracker,
-                        depth,
                         context,
                         new System.IO.EnumerationOptions { RecurseSubdirectories = recurse, MatchType = MatchType.Win32, AttributesToSkip = 0, IgnoreInaccessible = false }))
                 {

--- a/src/System.Management.Automation/namespaces/FileSystemProviderEnumerableFactory.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProviderEnumerableFactory.cs
@@ -1,0 +1,272 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file ref the project root for more information.
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.IO.Enumeration;
+using System.Management.Automation;
+using System.Management.Automation.Provider;
+
+namespace Microsoft.PowerShell.Commands
+{
+    public sealed partial class FileSystemProvider : NavigationCmdletProvider,
+                                                    IContentCmdletProvider,
+                                                    IPropertyCmdletProvider,
+                                                    ISecurityDescriptorCmdletProvider,
+                                                    ICmdletProviderSupportsHelp
+    {
+        private static bool MatchesPattern(string expression, ReadOnlySpan<char> name, EnumerationOptions options)
+        {
+            bool ignoreCase = (options.MatchCasing == MatchCasing.PlatformDefault && !Platform.IsWindows)
+                || options.MatchCasing == MatchCasing.CaseInsensitive;
+
+            return options.MatchType switch
+            {
+                MatchType.Simple => FileSystemName.MatchesSimpleExpression(expression.AsSpan(), name, ignoreCase),
+                MatchType.Win32 => FileSystemName.MatchesWin32Expression(expression.AsSpan(), name, ignoreCase),
+                _ => throw new ArgumentOutOfRangeException(nameof(options)),
+            };
+        }
+
+        private static IEnumerable<string> GetNames(
+            CmdletProvider providerInstance,
+            string directory,
+            string expression,
+            ReturnContainers returnContainers,
+            Collection<WildcardPattern>? includeMatcher,
+            Collection<WildcardPattern>? excludeMatcher,
+            FlagsExpression<FileAttributes>? evaluator,
+            FlagsExpression<FileAttributes>? switchEvaluator,
+            bool filterHidden,
+            InodeTracker? tracker,  // tracker will be non-null only if the user invoked the -FollowSymLinks and -Recurse switch parameters.
+            uint depth,
+            CmdletProviderContext context,
+            EnumerationOptions options)
+        {
+            bool FileSystemEntryFilter(ref FileSystemEntry entry)
+            {
+                if ((returnContainers == ReturnContainers.ReturnAllContainers) && entry.Attributes.HasFlag(FileAttributes.Directory))
+                {
+                    return true;
+                }
+
+                bool attributeFilter = true;
+
+                if (evaluator != null)
+                {
+                    // from expressions
+                    attributeFilter = evaluator.Evaluate(entry.Attributes);
+                }
+
+                if (switchEvaluator != null)
+                {
+                    // from switch parameters
+                    attributeFilter = attributeFilter && switchEvaluator.Evaluate(entry.Attributes);
+                }
+
+                bool hidden = entry.Attributes.HasFlag(FileAttributes.Hidden);
+
+                // if "Hidden" is explicitly specified anywhere in the attribute filter, then override
+                // default hidden attribute filter.
+                if (!(attributeFilter && (filterHidden || context.Force || !hidden) && MatchesPattern(expression, entry.FileName, options)))
+                {
+                    return false;
+                }
+
+                bool isIncludeMatch = includeMatcher == null || includeMatcher.Count == 0 ? true :
+                    SessionStateUtilities.MatchesAnyWildcardPattern(
+                        entry.FileName.ToString(),
+                        includeMatcher,
+                        true);
+
+                if (isIncludeMatch)
+                {
+                    return excludeMatcher == null || excludeMatcher.Count == 0 ? true :
+                        !SessionStateUtilities.MatchesAnyWildcardPattern(
+                            entry.FileName.ToString(),
+                            excludeMatcher,
+                            false);
+                }
+
+                return false;
+            }
+
+            // Here transformation lambda returns relative path based on OriginalRootDirectory
+            return new FileSystemProviderEnumerable<string>(
+                directory,
+                (ref FileSystemEntry entry) => entry.OriginalRootDirectory.Length > entry.Directory.Length ? entry.FileName.ToString() : Path.Join(entry.Directory.Slice(entry.OriginalRootDirectory.Length), entry.FileName),
+                options)
+            {
+                ShouldIncludePredicate = FileSystemEntryFilter,
+
+                ShouldRecursePredicate = (ref FileSystemEntry entry) =>
+                    {
+                        // Making sure to obey the StopProcessing.
+                        if (context.Stopping || depth <= 0)
+                        {
+                            return false;
+                        }
+
+                        bool hidden = false;
+                        if (!context.Force)
+                        {
+                            hidden = entry.Attributes.HasFlag(FileAttributes.Hidden);
+                        }
+
+                        // if "Hidden" is explicitly specified anywhere in the attribute filter, then override
+                        // default hidden attribute filter.
+                        if (context.Force || !hidden || filterHidden)
+                        {
+                            // We only want to recurse into symlinks if
+                            //  a) the user has asked to with the -FollowSymLinks switch parameter and
+                            //  b) the directory pointed to by the symlink has not already been visited,
+                            //     preventing symlink loops.
+                            //  c) it is not a reparse point with a target (not OneDrive or an AppX link).
+                            if (tracker == null)
+                            {
+                                if (entry.Attributes.HasFlag(FileAttributes.ReparsePoint) && InternalSymbolicLinkLinkCodeMethods.IsReparsePointWithTarget(entry.ToFileSystemInfo()))
+                                {
+                                    return false;
+                                }
+                            }
+                            else if (!tracker.TryVisitPath(entry.ToFullPath()))
+                            {
+                                providerInstance.WriteWarning(
+                                    System.Management.Automation.Internal.StringUtil.Format(
+                                        FileSystemProviderStrings.AlreadyListedDirectory,
+                                        entry.ToFullPath()));
+                                return false;
+                            }
+
+                            //depth--;
+
+                            return true;
+                        }
+
+                        return false;
+                    },
+
+                OnDirectoryFinishedAction = (ReadOnlySpan<char> directory) =>
+                    {
+                        if (depth > 0)
+                        {
+                            depth--;
+                        }
+                    }
+            };
+        }
+
+        /// <summary>
+        /// Gets the child names of the item at the specified path by
+        /// manually recursing through all the containers instead of
+        /// allowing the provider to do the recursion.
+        /// </summary>
+        /// <param name="providerInstance">
+        /// The provider instance to use.
+        /// </param>
+        /// <param name="newProviderPath">
+        /// The path to the item if it was specified on the command line.
+        /// </param>
+        /// <param name="recurse">
+        /// If true all names in the subtree should be returned.
+        /// </param>
+        /// <param name="depth">
+        /// Current depth of recursion; special case uint.MaxValue performs full recursion.
+        /// </param>
+        /// <param name="returnContainers">
+        /// Determines if all containers should be returned or only those containers that match the
+        /// filter(s).
+        /// </param>
+        /// <param name="includeMatcher">
+        /// A set of filters that the names must match to be returned.
+        /// </param>
+        /// <param name="excludeMatcher">
+        /// A set of filters that the names cannot match to be returned.
+        /// </param>
+        /// <param name="context">
+        /// The context which the core command is running.
+        /// </param>
+        internal void DoGetChildNamesFast(
+            CmdletProvider providerInstance,
+            string newProviderPath,
+            ReturnContainers returnContainers,
+            Collection<WildcardPattern>? includeMatcher,
+            Collection<WildcardPattern>? excludeMatcher,
+            CmdletProviderContext context,
+            bool recurse,
+            uint depth)
+        {
+            if (newProviderPath == null)
+            {
+                throw new ArgumentNullException(nameof(newProviderPath), nameof(DoGetChildNamesFast));
+            }
+
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context), nameof(DoGetChildNamesFast));
+            }
+
+            CmdletProviderContext childNamesContext =
+                new CmdletProviderContext(context);
+
+            try
+            {
+                FlagsExpression<FileAttributes>? evaluator = null;
+                FlagsExpression<FileAttributes>? switchEvaluator = null;
+                InodeTracker? tracker = null;
+
+                if (DynamicParameters is GetChildDynamicParameters fspDynamicParam)
+                {
+                    evaluator = fspDynamicParam.Attributes;
+                    switchEvaluator = FormatAttributeSwitchParameters();
+
+                    if (recurse && fspDynamicParam.FollowSymlink)
+                    {
+                        tracker = new InodeTracker(newProviderPath);
+                    }
+                }
+
+                bool filterHidden = false;
+
+                if (evaluator != null)
+                {
+                    // "Hidden" is specified somewhere in the expression
+                    filterHidden = evaluator.ExistsInExpression(FileAttributes.Hidden);
+                }
+
+                if (switchEvaluator != null)
+                {
+                    // "Hidden" is specified somewhere in the parameters
+                    filterHidden = filterHidden || switchEvaluator.ExistsInExpression(FileAttributes.Hidden);
+                }
+
+                foreach (var result in
+                    GetNames(
+                        this,
+                        newProviderPath,
+                        Filter ?? "*",
+                        returnContainers,
+                        includeMatcher,
+                        excludeMatcher,
+                        evaluator,
+                        switchEvaluator,
+                        filterHidden,
+                        tracker,
+                        depth,
+                        childNamesContext,
+                        new System.IO.EnumerationOptions { RecurseSubdirectories = recurse, MatchType = MatchType.Win32, AttributesToSkip = 0, IgnoreInaccessible = false }))
+                {
+                    context.WriteObject(result);
+                }
+            }
+            finally
+            {
+                childNamesContext.RemoveStopReferral();
+            }
+        }
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystemProviderExtended.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystemProviderExtended.Tests.ps1
@@ -12,7 +12,7 @@ Describe "FileSystem Provider Extended Tests for Get-ChildItem cmdlet" -Tags "CI
 
         $DirSep = [IO.Path]::DirectorySeparatorChar
 
-        $rootDir = Join-Path "TestDrive:" "TestDir"
+        $rootDir = Join-Path $TestPath "TestDir"
         New-Item -Path $rootDir -ItemType Directory > $null
 
         Set-Location $rootDir

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystemProviderExtended.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystemProviderExtended.Tests.ps1
@@ -246,18 +246,12 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
     Context 'Validate Get-ChildItem -Path -Recurse -Name' {
         It "Get-ChildItem -Path -Recurse -Name" {
             $result = Get-ChildItem -Path $rootDir -Recurse -Name
-            $msg = $result -join "`n"
-            Write-Warning $msg
-            $msg = Get-ChildItem -Path $rootDir -Recurse -Force | Out-String
-            Write-Warning $msg
             $result.Count | Should -Be 8
             $result[0] | Should -BeOfType System.String
         }
 
         It "Get-ChildItem -Path -Recurse -Name -Hidden" {
             $result = Get-ChildItem -Path $rootDir -Recurse -Name -Hidden
-            $msg = $result -join "`n"
-            Write-Warning $msg
             $result.Count | Should -Be 4
             $result | Should -BeOfType System.String
             $result.Where({ $_ -eq ".filehidden1.doc" }) | Should -BeOfType System.String
@@ -340,6 +334,8 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
 
         It "Get-ChildItem -Path -Depth 2 -Name -Force" {
             $result = Get-ChildItem -Path $rootDir -Depth 2 -Name -Force
+            $msg = $result -join "`n"
+            Write-Warning $msg
             $result.Count | Should -Be 13
             $result[0] | Should -BeOfType System.String
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Addresses #9119

Intention is to improve performance without changing current behavior. Later we can more easily fix already known bugs/inconsistencies and add new features.

Performance win is up to 50%.
Allocations are dramatically reduces if filtering is used (now no allocations are for discarded  paths).

- Use new .Net Runtime path (folder/file) enumerator in PowerShell file system provider.
- Refactor existing code to one method.
- Add more tests (mainly for hidden file attribute)

Today the .Net API does not support:
- `Depth` ([tracking issue](https://github.com/dotnet/runtime/issues/43748)) and we use a workaround in the case.
- ContinueOnError predicate and we use copy-pasted and bit enhanced code from .Net.

## PR Context

Current implementation is a generic (common for all providers) enumerating code which is very expensive. New implementation uses new .Net API for file enumerating. The API is very fast and efficient, especially if filtering is used.

The follow intention is to use this approach later for `dir -recurse` too and then fix known bugs and add new features.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
