### PR TITLE
Expand numberOfPowershellRefAssemblies list capacity

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -670,11 +670,9 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         private static IEnumerable<PortableExecutableReference> InitDefaultRefAssemblies()
         {
-            // Define number of reference assemblies distributed with PowerShell.
-            // This number is accurate as of PowerShell v7.1.0-preview.3 built with .NET v5.0.100-preview.5.20278.13
-            const int numberOfPowershellRefAssemblies = 152;
+            const int maxPowershellRefAssemblies = 160;
 
-            const int capacity = numberOfPowershellRefAssemblies + 1;
+            const int capacity = maxPowershellRefAssemblies + 1;
             var defaultRefAssemblies = new List<PortableExecutableReference>(capacity);
 
             foreach (string file in Directory.EnumerateFiles(s_netcoreAppRefFolder, "*.dll", SearchOption.TopDirectoryOnly))
@@ -684,6 +682,11 @@ namespace Microsoft.PowerShell.Commands
 
             // Add System.Management.Automation.dll
             defaultRefAssemblies.Add(MetadataReference.CreateFromFile(typeof(PSObject).Assembly.Location));
+
+            // We want to avoid reallocating the internal array, so we assert if the list capacity has increased.
+            Diagnostics.Assert(
+                defaultRefAssemblies.Capacity <= capacity,
+                $"defaultRefAssemblies was resized because of insufficient initial capacity! A capacity of {defaultRefAssemblies.Count} is required.");
 
             return defaultRefAssemblies;
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -670,6 +670,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         private static IEnumerable<PortableExecutableReference> InitDefaultRefAssemblies()
         {
+            // Define number of reference assemblies distributed with PowerShell.
             const int maxPowershellRefAssemblies = 160;
 
             const int capacity = maxPowershellRefAssemblies + 1;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -671,8 +671,8 @@ namespace Microsoft.PowerShell.Commands
         private static IEnumerable<PortableExecutableReference> InitDefaultRefAssemblies()
         {
             // Define number of reference assemblies distributed with PowerShell.
-            // This number is accurate as of PowerShell v7.1.0-preview.1 built with .NET v5.0.100-preview.1.20155.7
-            const int numberOfPowershellRefAssemblies = 151;
+            // This number is accurate as of PowerShell v7.1.0-preview.3 built with .NET v5.0.100-preview.5.20278.13
+            const int numberOfPowershellRefAssemblies = 152;
 
             const int capacity = numberOfPowershellRefAssemblies + 1;
             var defaultRefAssemblies = new List<PortableExecutableReference>(capacity);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -685,11 +685,6 @@ namespace Microsoft.PowerShell.Commands
             // Add System.Management.Automation.dll
             defaultRefAssemblies.Add(MetadataReference.CreateFromFile(typeof(PSObject).Assembly.Location));
 
-            // We want to avoid reallocating the internal array, so we assert if the list capacity has increased.
-            Diagnostics.Assert(
-                defaultRefAssemblies.Capacity <= capacity,
-                $"defaultRefAssemblies was resized because of insufficient initial capacity! A capacity of {defaultRefAssemblies.Count} is required.");
-
             return defaultRefAssemblies;
         }
 


### PR DESCRIPTION
# PR Summary

* Increase the list capacity because .NET v5.0.100-preview.5.20278.13 has an extra assembly
* Remove assert added in #12520

## PR Context

HEAD of master has been broken since 99da109 (#12772), when .NET was updated to 5.0.100-preview.5.20278.13

https://github.com/PowerShell/PowerShell/issues/12815#issuecomment-636132717

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
