### PR TITLE
WIP: Change default prompt to improve readability of UNC paths

### DIFF
--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4764,7 +4764,7 @@ end {
         }
 
         internal const string DefaultPromptFunctionText = @"
-""PS $($executionContext.SessionState.Path.CurrentLocation)$('>' * ($nestedPromptLevel + 1)) "";
+""PS $($ExecutionContext.SessionState.Path.CurrentLocation.Drive ? $ExecutionContext.SessionState.Path.CurrentLocation : $ExecutionContext.SessionState.Path.CurrentLocation.ProviderPath)$('>' * ($nestedPromptLevel + 1)) "";
 # .Link
 # https://go.microsoft.com/fwlink/?LinkID=225750
 # .ExternalHelp System.Management.Automation.dll-help.xml

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -4480,7 +4480,7 @@ namespace System.Management.Automation
                 DebuggerStrings.NestedRunspaceDebuggerPromptProcessName,
                 @"$($PID)",
                 @"""");
-            string locationPart = @"""PS $($executionContext.SessionState.Path.CurrentLocation)> """;
+            string locationPart = @"""PS $($ExecutionContext.SessionState.Path.CurrentLocation.Drive ? $ExecutionContext.SessionState.Path.CurrentLocation : $ExecutionContext.SessionState.Path.CurrentLocation.ProviderPath)> """;
             string promptScript = "'[DBG]: '" + " + " + processPart + " + " + "' [" + CodeGeneration.EscapeSingleQuotedStringContent(_runspace.Name) + "]: '" + " + " + locationPart;
 
             // Get the command prompt from the wrapped debugger.

--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -1414,7 +1414,8 @@ namespace System.Management.Automation.PSTasks
         {
             // Nested debugged runspace prompt should look like:
             // [DBG]: [JobName]: PS C:\>>
-            string promptScript = "'[DBG]: '" + " + " + "'[" + CodeGeneration.EscapeSingleQuotedStringContent(_jobName) + "]: '" + " + " + @"""PS $($executionContext.SessionState.Path.CurrentLocation)>> """;
+            string locationPart = @"""PS $($ExecutionContext.SessionState.Path.CurrentLocation.Drive ? $ExecutionContext.SessionState.Path.CurrentLocation : $ExecutionContext.SessionState.Path.CurrentLocation.ProviderPath)>> """;
+            string promptScript = "'[DBG]: '" + " + " + "'[" + CodeGeneration.EscapeSingleQuotedStringContent(_jobName) + "]: '" + " + " + locationPart;
             PSCommand promptCommand = new PSCommand();
             promptCommand.AddScript(promptScript);
             _wrappedDebugger.ProcessCommand(promptCommand, output);

--- a/src/System.Management.Automation/engine/remoting/client/Job.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job.cs
@@ -4157,7 +4157,8 @@ namespace System.Management.Automation
         {
             // Nested debugged runspace prompt should look like:
             // [DBG]: [JobName]: PS C:\>>
-            string promptScript = "'[DBG]: '" + " + " + "'[" + CodeGeneration.EscapeSingleQuotedStringContent(_jobName) + "]: '" + " + " + @"""PS $($executionContext.SessionState.Path.CurrentLocation)>> """;
+            string locationPart = @"""PS $($ExecutionContext.SessionState.Path.CurrentLocation.Drive ? $ExecutionContext.SessionState.Path.CurrentLocation : $ExecutionContext.SessionState.Path.CurrentLocation.ProviderPath)>> """;
+            string promptScript = "'[DBG]: '" + " + " + "'[" + CodeGeneration.EscapeSingleQuotedStringContent(_jobName) + "]: '" + " + " + locationPart;
             PSCommand promptCommand = new PSCommand();
             promptCommand.AddScript(promptScript);
             _wrappedDebugger.ProcessCommand(promptCommand, output);

--- a/src/System.Management.Automation/engine/remoting/commands/EnterPSHostProcessCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/EnterPSHostProcessCommand.cs
@@ -297,7 +297,7 @@ namespace Microsoft.PowerShell.Commands
             string promptFn = StringUtil.Format(RemotingErrorIdStrings.EnterPSHostProcessPrompt,
                 @"function global:prompt { """,
                 @"$($PID)",
-                @"PS $($executionContext.SessionState.Path.CurrentLocation)> "" }"
+                @"PS $($ExecutionContext.SessionState.Path.CurrentLocation.Drive ? $ExecutionContext.SessionState.Path.CurrentLocation : $ExecutionContext.SessionState.Path.CurrentLocation.ProviderPath)> "" }"
             );
 
             // Set prompt in pushed named pipe runspace.

--- a/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
@@ -1167,7 +1167,7 @@ namespace Microsoft.PowerShell.Commands
                 string promptFn = StringUtil.Format(RemotingErrorIdStrings.EnterVMSessionPrompt,
                     @"function global:prompt { """,
                     targetName,
-                    @"PS $($executionContext.SessionState.Path.CurrentLocation)> "" }");
+                    @"PS $($ExecutionContext.SessionState.Path.CurrentLocation.Drive ? $ExecutionContext.SessionState.Path.CurrentLocation : $ExecutionContext.SessionState.Path.CurrentLocation.ProviderPath)> "" }");
 
                 // Set prompt in pushed named pipe runspace.
                 using (System.Management.Automation.PowerShell ps = System.Management.Automation.PowerShell.Create())

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -890,7 +890,7 @@ namespace StackTest {
         It "Job Debug: Path '<Path>' is displayed correctly" -TestCases $allOsTestCases {
             param ($Path)
             $output = InvokePromptTest -OutputIndex -2 -CommandLine "-noprofile -nologo -noexit -c ""Set-Location $Path;`$j = Start-Job -ScriptBlock {Wait-Debugger; {}}; `
-                while(`$j.State -ne 'AtBreakpoint' -and (`$count++ -lt 11)) {Start-Sleep -Milliseconds 50}; Debug-Job `$j;"""
+                while(`$j.State -ne 'AtBreakpoint' -and (`$count++ -lt 11)) {Start-Sleep -Milliseconds 250}; Debug-Job `$j;"""
 
             $output | Should -Be "[DBG]: [Job2]: PS $Path>> "
         }
@@ -898,7 +898,7 @@ namespace StackTest {
         It "(Windows) Job Debug: Path '<Path>' is displayed correctly" -Skip:(-not $IsWindows) -TestCases $winTestCases {
             param ($Path)
             $output = InvokePromptTest -OutputIndex -2 -CommandLine "-noprofile -nologo -noexit -c ""Set-Location $Path;`$j = Start-Job -ScriptBlock {Wait-Debugger; {}}; `
-                while(`$j.State -ne 'AtBreakpoint' -and (`$count++ -lt 11)) {Start-Sleep -Milliseconds 50}; Debug-Job `$j;"""
+                while(`$j.State -ne 'AtBreakpoint' -and (`$count++ -lt 11)) {Start-Sleep -Milliseconds 250}; Debug-Job `$j;"""
 
                 $output | Should -Be "[DBG]: [Job2]: PS $Path>> "
         }
@@ -906,15 +906,16 @@ namespace StackTest {
         It "PSTask Debug: Path '<Path>' is displayed correctly" -TestCases $allOsTestCases {
             param ($Path)
             $output = InvokePromptTestPSTask -CommandLine "-noprofile -nologo -c ""Set-Location $Path;`$null = 1 | Foreach-Object -Parallel {Wait-Debugger; {}} -AsJob; `
-                while($null -ne (`$rd=Get-RunspaceDebug | Where-Object Enabled -eq true) -and (`$count++ -lt 11)) {Start-Sleep -Milliseconds 50}; `
+                while($null -ne (`$rd=Get-RunspaceDebug | Where-Object Enabled -eq true) -and (`$count++ -lt 11)) {Start-Sleep -Milliseconds 250}; `
                 `$rd = Get-RunspaceDebug | Where-Object Enabled -eq true; Debug-Runspace -Id `$rd.RunspaceId"""
 
             $output[1] | Should -Be "[DBG]: [Process:$($output[0])]: [PSTask:1]: PS $Path>> "
         }
+
         It "(Windows) PSTask Debug: Path '<Path>' is displayed correctly" -Skip:(-not $IsWindows) -TestCases $winTestCases {
             param ($Path)
             $output = InvokePromptTestPSTask -CommandLine "-noprofile -nologo -c ""Set-Location $Path;`$null = 1 | Foreach-Object -Parallel {Wait-Debugger; {}} -AsJob; `
-                while($null -ne (`$rd=Get-RunspaceDebug | Where-Object Enabled -eq true) -and (`$count++ -lt 11)) {Start-Sleep -Milliseconds 5000}; `
+                while($null -ne (`$rd=Get-RunspaceDebug | Where-Object Enabled -eq true) -and (`$count++ -lt 11)) {Start-Sleep -Milliseconds 250}; `
                 `$rd = Get-RunspaceDebug | Where-Object Enabled -eq true; Debug-Runspace -Id `$rd.RunspaceId"""
 
             $output[1] | Should -Be "[DBG]: [Process:$($output[0])]: [PSTask:1]: PS $Path>> "

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -820,6 +820,99 @@ namespace StackTest {
             $LASTEXITCODE | Should -Be $ExitCodeBadCommandLineParameter
         }
     }
+
+    Context "Console prompt tests" {
+
+        It "Alias PSDrive is displayed correctly"  {
+
+            $si = NewProcessStartInfo "-noprofile -nologo -noexit -c ""Set-Location Alias:""" -RedirectStdIn
+            $process = RunPowerShell $si
+            $process.StandardInput.WriteLine("`n")
+            $process.StandardOutput.ReadLine() | Should -Be "PS Alias:\> "
+            $process.StandardInput.Close()
+            EnsureChildHasExited $process
+        }
+
+        It "Cert PSDrive is displayed correctly" -Skip:(-not $IsWindows) {
+
+            $si = NewProcessStartInfo "-noprofile -nologo -noexit -c ""Set-Location Cert:""" -RedirectStdIn
+            $process = RunPowerShell $si
+            $process.StandardInput.WriteLine("`n")
+            $process.StandardOutput.ReadLine() | Should -Be "PS Cert:\> "
+            $process.StandardInput.Close()
+            EnsureChildHasExited $process
+        }
+
+        It "Environment PSDrive is displayed correctly" {
+
+            $si = NewProcessStartInfo "-noprofile -nologo -noexit -c ""Set-Location Env:""" -RedirectStdIn
+            $process = RunPowerShell $si
+            $process.StandardInput.WriteLine("`n")
+            $process.StandardOutput.ReadLine() | Should -Be "PS Env:\> "
+            $process.StandardInput.Close()
+            EnsureChildHasExited $process
+        }
+
+        It "Function PSDrive is displayed correctly" {
+
+            $si = NewProcessStartInfo "-noprofile -nologo -noexit -c ""Set-Location Function:""" -RedirectStdIn
+            $process = RunPowerShell $si
+            $process.StandardInput.WriteLine("`n")
+            $process.StandardOutput.ReadLine() | Should -Be "PS Function:\> "
+            $process.StandardInput.Close()
+            EnsureChildHasExited $process
+        }
+
+        It "Registry PSDrive is displayed correctly" -Skip:(-not $IsWindows) {
+
+            $si = NewProcessStartInfo "-noprofile -nologo -noexit -c ""Set-Location HKLM:""" -RedirectStdIn
+            $process = RunPowerShell $si
+            $process.StandardInput.WriteLine("`n")
+            $process.StandardOutput.ReadLine() | Should -Be "PS HKLM:\> "
+            $process.StandardInput.Close()
+            EnsureChildHasExited $process
+        }
+
+        It "Temp PSDrive is displayed correctly" {
+
+            $si = NewProcessStartInfo "-noprofile -nologo -noexit -c ""Set-Location Temp:""" -RedirectStdIn
+            $process = RunPowerShell $si
+            $process.StandardInput.WriteLine("`n")
+            $process.StandardOutput.ReadLine() | Should -Be "PS Temp:\> "
+            $process.StandardInput.Close()
+            EnsureChildHasExited $process
+        }
+
+        It "UNC Path is displayed correctly" -Skip:(-not $IsWindows) {
+
+            $si = NewProcessStartInfo "-noprofile -nologo -noexit -c ""Set-Location \\localhost\c$""" -RedirectStdIn
+            $process = RunPowerShell $si
+            $process.StandardInput.WriteLine("`n")
+            $process.StandardOutput.ReadLine() | Should -Be "PS \\localhost\c$> "
+            $process.StandardInput.Close()
+            EnsureChildHasExited $process
+        }
+
+        It "Variable PSDrive is displayed correctly" {
+
+            $si = NewProcessStartInfo "-noprofile -nologo -noexit -c ""Set-Location Variable:""" -RedirectStdIn
+            $process = RunPowerShell $si
+            $process.StandardInput.WriteLine("`n")
+            $process.StandardOutput.ReadLine() | Should -Be "PS Variable:\> "
+            $process.StandardInput.Close()
+            EnsureChildHasExited $process
+        }
+
+        It "WSMan PSDrive is displayed correctly" -Skip:(-not $IsWindows) {
+
+            $si = NewProcessStartInfo "-noprofile -nologo -noexit -c ""Set-Location WSMan:""" -RedirectStdIn
+            $process = RunPowerShell $si
+            $process.StandardInput.WriteLine("`n")
+            $process.StandardOutput.ReadLine() | Should -Be "PS WSMan:\> "
+            $process.StandardInput.Close()
+            EnsureChildHasExited $process
+        }
+    }
 }
 
 Describe "WindowStyle argument" -Tag Feature {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This changes the default prompt to use `ProviderPath` instead of `CurrentLocation` when a given location does not have a PS Drive. The original discussion in #12544 was regarding UNC paths, but I felt it was appropriate to address it as a whole, instead of only for the `FileSystem` provider.

I've added tests for the prompt, but so far it only covers the codepath in `InitialSessionState.cs`, and I could probably use some pointers on getting coverage of the remaining codepaths.

I'm also unsure if this is considered a breaking change, it is clearly something the user can change at will, and I don't think applications or scripts can reasonably depend on them, on the other hand it can change the display of third party modules like `sqlps`.

I can't find documentation specifically describing paths like `PS Microsoft.Powershell.Core\FileSystem::\\share\path>` currently so I think no new documentation is required, except for release notes of course.

## PR Context

This implements the enhancement requested in #12544

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
- **Testing - New and feature**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.