### PR TITLE
WIP: Allow self-referential generic type parameters in interface list

### DIFF
--- a/src/System.Management.Automation/engine/parser/PSType.cs
+++ b/src/System.Management.Automation/engine/parser/PSType.cs
@@ -282,18 +282,21 @@ namespace System.Management.Automation.Language
             private Type ResolveConcreteInterfaceTypeArguments(ITypeName typeName, TypeBuilder parameter)
             {
                 var typeArgs = new List<Type>();
-                if(typeName.IsGeneric && typeName is GenericTypeName genericName)
+                if (typeName.IsGeneric && typeName is GenericTypeName genericName)
                 {
-                    foreach(var typeArg in genericName.GenericArguments)
+                    foreach (var typeArg in genericName.GenericArguments)
                     {
                         typeArgs.Add(ResolveConcreteInterfaceTypeArguments(typeArg, parameter));
                     }
+
                     return genericName.TypeName.GetReflectionType().MakeGenericType(typeArgs.ToArray());
                 }
-                if(parameter.FullName == typeName.FullName)
+
+                if (parameter.FullName == typeName.FullName)
                 {
                     return parameter;
                 }
+
                 return typeName.GetReflectionType();
             }
         }
@@ -329,10 +332,11 @@ namespace System.Management.Automation.Language
                 var baseClass = this.GetBaseTypes(parser, typeDefinitionAst, out interfaces);
 
                 _typeBuilder = module.DefineType(typeName, Reflection.TypeAttributes.Class | Reflection.TypeAttributes.Public, baseClass, null);
-                foreach(var interfaceExpression in interfaces)
+                foreach (var interfaceExpression in interfaces)
                 {
                     _typeBuilder.AddInterfaceImplementation(interfaceExpression.ResolveConcreteInterfaceType(_typeBuilder));
                 }
+
                 _staticHelpersTypeBuilder = module.DefineType(string.Format(CultureInfo.InvariantCulture, "{0}_<staticHelpers>", typeName), Reflection.TypeAttributes.Class);
                 DefineCustomAttributes(_typeBuilder, typeDefinitionAst.Attributes, _parser, AttributeTargets.Class);
                 _typeDefinitionAst.Type = _typeBuilder;
@@ -351,7 +355,7 @@ namespace System.Management.Automation.Language
             /// <param name="parser"></param>
             /// <param name="typeDefinitionAst"></param>
             /// <param name="interfaces">Return declared interfaces.</param>
-            /// <returns></returns>
+            /// <returns>The base type</returns>
             private Type GetBaseTypes(Parser parser, TypeDefinitionAst typeDefinitionAst, out List<InterfaceExpression> interfaces)
             {
                 // Define base types and report errors.
@@ -361,14 +365,14 @@ namespace System.Management.Automation.Language
                 bool TryGetInterface(TypeConstraintAst ast, out InterfaceExpression interfaceExpression)
                 {
                     interfaceExpression = new InterfaceExpression(ast);
-                    if(ast.TypeName.IsGeneric && ast.TypeName is GenericTypeName genericTypeName)
+                    if (ast.TypeName.IsGeneric && ast.TypeName is GenericTypeName genericTypeName)
                     {
-                        if(genericTypeName.TypeName.GetReflectionType().IsInterface)
+                        if (genericTypeName.TypeName.GetReflectionType().IsInterface)
                         {
                             return true;
                         }
                     }
-                    else if(ast.TypeName.GetReflectionType()?.IsInterface ?? false)
+                    else if (ast.TypeName.GetReflectionType()?.IsInterface ?? false)
                     {
                         return true;
                     }
@@ -395,7 +399,7 @@ namespace System.Management.Automation.Language
                     }
                     else
                     {
-                        if(TryGetInterface(firstBaseTypeAst, out InterfaceExpression interfaceExpression))
+                        if (TryGetInterface(firstBaseTypeAst, out InterfaceExpression interfaceExpression))
                         {
                             // First Ast can represent interface as well as BaseClass.
                             interfaces.Add(interfaceExpression);
@@ -505,8 +509,10 @@ namespace System.Management.Automation.Language
                     foreach (var interfaceType in _typeBuilder.GetInterfaces())
                     {
                         var typeDefinition = interfaceType;
-                        if(interfaceType.IsGenericType && interfaceType.GenericTypeArguments.Contains(_typeBuilder))
+                        if (interfaceType.IsGenericType && interfaceType.GenericTypeArguments.Contains(_typeBuilder))
+                        {
                             typeDefinition = interfaceType.GetGenericTypeDefinition();
+                        }
 
                         foreach (var parentInterface in typeDefinition.GetInterfaces())
                         {
@@ -525,7 +531,7 @@ namespace System.Management.Automation.Language
                     }
                 }
 
-                return _interfaceProperties.TryGetValue(name, out Type returnType) && (returnType == type || (returnType.IsGenericParameter));
+                return _interfaceProperties.TryGetValue(name, out Type returnType) && (returnType == type || returnType.IsGenericParameter);
             }
 
             public void DefineMembers()

--- a/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
+++ b/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
@@ -87,6 +87,11 @@ Describe 'Classes inheritance syntax' -Tags "CI" {
         { [A]::b = "bla" } | Should -Throw -ErrorId 'ExceptionWhenSetting'
     }
 
+    It 'can implement generic interfaces referencing itself as a type parameter' {
+        $C1 = Invoke-Expression 'class ComparableClass : IComparable[ComparableClass] { [int]$Value; [int]CompareTo([ComparableClass]$obj){ return $this.Value.CompareTo($obj.Value) } } [ComparableClass]'
+        $C1.ImplementedInterfaces[0].TypeParameter | Should -Be $C1
+    }
+
     Context "Inheritance from abstract .NET classes" {
         BeforeAll {
             class TestHost : System.Management.Automation.Host.PSHost


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

Delay type parameter-binding of unclosed  (self-referential) type references in generic interface declarations

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

We currently support implementing typed generic interfaces, but only if the type parameters can be resolved in the defining scope prior to defining the new type.

This makes the following implementation impossible in PowerShell:

        class SortableThing : IComparable, IComparable[SortableThing]
        {
            [int]Value

            [int]
            CompareTo([SortableThing]$obj)
            {
                return $this.Value.CompareTo($obj.Value)
            }

            [int]
            CompareTo($obj)
            {
                if($obj -isnot [SortableThing]){
                    throw [ArgumentException]::new()
                }
                return $this.CompareTo([SortableThing]$obj)
            }
        }

To this end, the following changes have been made to the DefineTypeHelper in PSType:

 - For declared interfaces, `GetBaseTypes` now outputs a list of late-binding `InterfaceExpression`'s rather than a list of `Type` instances describing concrete interfaces
 - We add the interfaces to the new type _after_ defining the type builder, allowing us to resolve self-referential type parameters against the still-unclosed-type instead of throwing `TypeNotFound`

At some point we will need to re-think how we resolve generic type arguments, perhaps refactor `GenericTypeName` completely to natively support late binding against unclosed types, but I'll leave that an exercise for the future for now.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [X] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
