### PR TITLE
Update Linux daily CI to run in a single agent & collect traces

### DIFF
--- a/.vsts-ci/linux-daily.yml
+++ b/.vsts-ci/linux-daily.yml
@@ -24,12 +24,13 @@ pr:
     include:
     - '*'
     exclude:
+    - tools/releaseBuild/*
+    - tools/releaseBuild/azureDevOps/templates/*
     - /.vsts-ci/misc-analysis.yml
     - /.github/ISSUE_TEMPLATE/*
     - /.dependabot/config.yml
 
 variables:
-  GIT_CONFIG_PARAMETERS: "'core.autocrlf=false'"
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   POWERSHELL_TELEMETRY_OPTOUT: 1
   # Avoid expensive initialization of dotnet cli, see: https://donovanbrown.com/post/Stop-wasting-time-during-NET-Core-builds
@@ -41,23 +42,27 @@ resources:
   clean: true
 
 stages:
-- stage: BuildWin
-  displayName: Build for Windows
+- stage: BuildLinux
+  displayName: Build for Linux
   jobs:
   - template: templates/ci-build.yml
+    parameters:
+      pool: ubuntu-16.04
+      jobName: linux_build
+      displayName: linux Build
 
-- stage: TestWin
-  displayName: Test for Windows
+- stage: TestLinux
+  displayName: Test for Linux
   jobs:
-  - job: win_test
+  - job: linux_test
     pool:
-      vmImage: vs2017-win2016
-    displayName: Windows Test
+      vmImage: ubuntu-16.04
+    displayName: Linux Test
 
     steps:
     - pwsh: |
         Get-ChildItem -Path env:
-      displayName: 'Capture Environment'
+      displayName: Capture Environment
       condition: succeededOrFailed()
 
     - task: DownloadBuildArtifacts@0
@@ -75,46 +80,28 @@ stages:
       continueOnError: true
 
     - pwsh: |
-        $capRootDir = Join-Path ([System.IO.Path]::GetTempPath()) "CAP"
-        $capUtilDir = Join-Path $capRootDir "Utils"
-
-        if (Test-Path $capRootDir) { Remove-Item $capRootDir -Recurse -Force }
-        New-Item $capUtilDir -ItemType Directory > $null
-
-        $capZipFile = Join-Path $capRootDir "cap.zip"
-        Invoke-WebRequest -Uri https://pscoretestdata.blob.core.windows.net/dotnet-cap/windows.zip -OutFile $capZipFile
-        Unblock-File -Path $capZipFile
-        Expand-Archive -Path $capZipFile -DestinationPath $capUtilDir -Force
-
-        Write-Host "=== Capture CAP Util Directory ==="
-        Get-ChildItem $capUtilDir -Recurse
-
-        Write-Host "##vso[task.setvariable variable=CapRootDir]$capRootDir"
-        Write-Host "##vso[task.setvariable variable=CapUtilDir]$capUtilDir"
-      displayName: 'Download CAP package'
-      condition: succeededOrFailed()
-
-    # must be run frow Windows PowerShell
-    - powershell: |
         Import-Module .\tools\ci.psm1
-        Invoke-CIInstall
+        Invoke-CIInstall -SkipUser
       displayName: Bootstrap
       condition: succeededOrFailed()
 
     - pwsh: |
         Import-Module .\build.psm1
         Restore-PSOptions -PSOptionsPath '$(System.ArtifactsDirectory)\build\psoptions.json'
-        $path = Split-Path -Parent (Get-PSOutput -Options (Get-PSOptions))
-        $rootPath = Split-Path -Path $path
+        $output = (Get-PSOptions).Output
+        $rootPath = Split-Path (Split-Path $output)
         Expand-Archive -Path '$(System.ArtifactsDirectory)\build\build.zip' -DestinationPath $rootPath -Force
-      displayName: 'Unzip Build'
-      condition: succeeded()
 
-    - pwsh: |
-        Import-Module $(CapUtilDir)\CAPService.psm1
-        $dataDir = Start-TraceCollection -RootDir $(CapRootDir)
-        Write-Host "##vso[task.setvariable variable=CapDataDir]$dataDir"
-      displayName: 'Start CLR Trace Collection'
+        ## Fix permissions
+        Get-ChildItem $rootPath -Recurse | ForEach-Object {
+            if ($_ -is [System.IO.DirectoryInfo]) {
+                chmod +rwx $_.FullName
+            } else {
+                chmod +rw $_.FullName
+            }
+        }
+        chmod a+x $output
+      displayName: 'Unzip Build and Fix Permissions'
       condition: succeeded()
 
     - pwsh: |
@@ -152,19 +139,16 @@ stages:
       displayName: Verify xUnit Test Results
       condition: succeededOrFailed()
 
-    - pwsh: |
-        $capDataDir = '$(CapDataDir)'
-        $capModuleFile = '$(CapUtilDir)\CAPService.psm1'
-
-        if ((Test-Path $capModuleFile) -and (Test-Path $capDataDir)) {
-            Import-Module $capModuleFile
-            Stop-TraceCollection -DataDir $capDataDir -RepoRoot $pwd
-        }
-      displayName: 'Upload CLR Trace'
-      condition: always()
-
-- stage: PackagingWin
-  displayName: Packaging for Windows
+- stage: CodeCovTestPackage
+  displayName: CodeCoverage and Test Packages
+  dependsOn: [] # by specifying an empty array, this stage doesn't depend on the stage before it
   jobs:
-  # Unlike daily builds, we do not upload nuget package to MyGet so we do not wait on tests to finish.
-  - template: templates/windows-packaging.yml
+  - job: CodeCovTestPackage
+    displayName: CodeCoverage and Test Packages
+    pool:
+      vmImage: ubuntu-16.04
+    steps:
+    - pwsh: |
+        Import-Module .\tools\ci.psm1
+        New-CodeCoverageAndTestPackage
+      displayName: CodeCoverage and Test Package

--- a/.vsts-ci/linux-daily.yml
+++ b/.vsts-ci/linux-daily.yml
@@ -101,6 +101,9 @@ stages:
             }
         }
         chmod a+x $output
+
+        Write-Host "=== Capture Unzipped Directory ==="
+        Get-ChildItem $rootPath -Recurse
       displayName: 'Unzip Build and Fix Permissions'
       condition: succeeded()
 

--- a/.vsts-ci/windows-daily.yml
+++ b/.vsts-ci/windows-daily.yml
@@ -89,8 +89,8 @@ stages:
           Write-Host "=== Capture CAP Util Directory ==="
           Get-ChildItem $capUtilDir -Recurse
 
-          Send-VstsCommand "vso[task.setvariable variable=CapRootDir]$capRootDir"
-          Send-VstsCommand "vso[task.setvariable variable=CapUtilDir]$capUtilDir"
+          Write-Host "##vso[task.setvariable variable=CapRootDir]$capRootDir"
+          Write-Host "##vso[task.setvariable variable=CapUtilDir]$capUtilDir"
         displayName: 'Download CAP package'
         condition: succeededOrFailed()
 
@@ -113,7 +113,7 @@ stages:
       - pwsh: |
           Import-Module $(CapUtilDir)\CAPService.psm1
           $dataDir = Start-TraceCollection -RootDir $(CapRootDir)
-          Send-VstsCommand "vso[task.setvariable variable=CapDataDir]$dataDir"
+          Write-Host "##vso[task.setvariable variable=CapDataDir]$dataDir"
         displayName: 'Start CLR Trace Collection'
         condition: succeeded()
 

--- a/.vsts-ci/windows-daily.yml
+++ b/.vsts-ci/windows-daily.yml
@@ -74,6 +74,26 @@ stages:
         displayName: 'Capture Artifacts Directory'
         continueOnError: true
 
+      - pwsh: |
+          $capRootDir = Join-Path ([System.IO.Path]::GetTempPath()) "CAP"
+          $capUtilDir = Join-Path $capRootDir "Utils"
+
+          if (Test-Path $capRootDir) { Remove-Item $capRootDir -Recurse -Force }
+          New-Item $capUtilDir -ItemType Directory > $null
+
+          $capZipFile = Join-Path $capRootDir "cap.zip"
+          Invoke-WebRequest -Uri https://pscoretestdata.blob.core.windows.net/dotnet-cap/windows.zip -OutFile $capZipFile
+          Unblock-File -Path $capZipFile
+          Expand-Archive -Path $capZipFile -DestinationPath $capUtilDir -Force
+
+          Write-Host "=== Capture CAP Util Directory ==="
+          Get-ChildItem $capUtilDir -Recurse
+
+          Send-VstsCommand "vso[task.setvariable variable=CapRootDir]$capRootDir"
+          Send-VstsCommand "vso[task.setvariable variable=CapUtilDir]$capUtilDir"
+        displayName: 'Download CAP package'
+        condition: succeededOrFailed()
+
       # must be run frow Windows PowerShell
       - powershell: |
           Import-Module .\tools\ci.psm1
@@ -88,6 +108,13 @@ stages:
           $rootPath = Split-Path -Path $path
           Expand-Archive -Path '$(System.ArtifactsDirectory)\build\build.zip' -DestinationPath $rootPath -Force
         displayName: 'Unzip Build'
+        condition: succeeded()
+
+      - pwsh: |
+          Import-Module $(CapUtilDir)\CAPService.psm1
+          $dataDir = Start-TraceCollection -RootDir $(CapRootDir)
+          Send-VstsCommand "vso[task.setvariable variable=CapDataDir]$dataDir"
+        displayName: 'Start CLR Trace Collection'
         condition: succeeded()
 
       - pwsh: |
@@ -124,6 +151,17 @@ stages:
           Test-XUnitTestResults -TestResultsFile $xUnitTestResultsFile
         displayName: Verify xUnit Test Results
         condition: succeededOrFailed()
+
+      - pwsh: |
+          $capDataDir = '$(CapDataDir)'
+          $capModuleFile = '$(CapUtilDir)\CAPService.psm1'
+
+          if ((Test-Path $capModuleFile) -and (Test-Path $capDataDir)) {
+              Import-Module $capModuleFile
+              Stop-TraceCollection -DataDir $capDataDir -RepoRoot $pwd
+          }
+        displayName: 'Upload CLR Trace'
+        condition: always()
 
 - stage: PackagingWin
   displayName: Packaging for Windows


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- Update Linux daily build to run tests in a single agent
- Collect CLR traces in Windows daily build
   - Download the CAP utility package from https://pscoretestdata.blob.core.windows.net/dotnet-cap/windows.zip
   - Start trace collection before test run
   - Stop trace collection after test run

Build using `linux-daily.yml`: https://dev.azure.com/powershell/PowerShell/_build/results?buildId=54399&view=results
Build using `windows-daily.yml`: https://dev.azure.com/powershell/PowerShell/_build/results?buildId=54125&view=results

Trace collection in Linux daily build is not included in this PR. I got some issues installing `perfcollect` in the CI environment.
I will submit a separate PR after resolving the issues.

## Background

This is to implement CLR Customer Assistance Program (CAP):

> The CLR CAP was created with two goals in mind: proactively help partner teams resolve CLR related issues and help the our team gain better insights into how the CLR is performing on first party services. The CLR CAP is 100% based on the collection and analysis of events in CLR (ETW in Windows for .NET Frameworks and EventPipe technology for .NET Core runtime).

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
