### PR TITLE
Enable the upload of ETW traces to CLR CAP in Windows daily build

### DIFF
--- a/.vsts-ci/windows-daily.yml
+++ b/.vsts-ci/windows-daily.yml
@@ -147,7 +147,7 @@ stages:
 
     - pwsh: |
         Import-Module .\build.psm1
-        $xUnitTestResultsFile = "$(System.ArtifactsDirectory)\xunit\xUnitTestResults.xml"
+        $xUnitTestResultsFile = '$(System.ArtifactsDirectory)\xunit\xUnitTestResults.xml'
         Test-XUnitTestResults -TestResultsFile $xUnitTestResultsFile
       displayName: Verify xUnit Test Results
       condition: succeededOrFailed()
@@ -156,9 +156,10 @@ stages:
         $capDataDir = '$(CapDataDir)'
         $capModuleFile = '$(CapUtilDir)\CAPService.psm1'
 
+        Write-Host 'IngressToken: $(CapIngressToken)'
         if ((Test-Path $capModuleFile) -and (Test-Path $capDataDir)) {
             Import-Module $capModuleFile
-            Stop-TraceCollection -DataDir $capDataDir -RepoRoot $pwd
+            Stop-TraceCollection -DataDir $capDataDir -RepoRoot $pwd -IngressToken '$(CapIngressToken)'
         }
       displayName: 'Upload CLR Trace'
       condition: always()

--- a/.vsts-ci/windows-daily.yml
+++ b/.vsts-ci/windows-daily.yml
@@ -48,6 +48,8 @@ stages:
 
 - stage: TestWin
   displayName: Test for Windows
+  variables:
+  - group: CLR-CAP
   jobs:
   - job: win_test
     pool:

--- a/.vsts-ci/windows-daily.yml
+++ b/.vsts-ci/windows-daily.yml
@@ -158,7 +158,6 @@ stages:
         $capDataDir = '$(CapDataDir)'
         $capModuleFile = '$(CapUtilDir)\CAPService.psm1'
 
-        Write-Host 'IngressToken: $(CapIngressToken)'
         if ((Test-Path $capModuleFile) -and (Test-Path $capDataDir)) {
             Import-Module $capModuleFile
             Stop-TraceCollection -DataDir $capDataDir -RepoRoot $pwd -IngressToken '$(CapIngressToken)'


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

A variable group was created that contains the variable `CapIngressToken`, which stores the ingress token used for the upload.
Update the `windows-daily.yml` file to provide the ingress token when calling `Stop-TraceCollection`, so the upload can happen.

Here is the build that validated the changes in this PR:
https://dev.azure.com/powershell/PowerShell/_build/results?buildId=54570&view=results

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
