### PR TITLE
Enable skipped tests

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Clipboard.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Clipboard.Tests.ps1
@@ -13,7 +13,7 @@ Describe 'Clipboard cmdlet tests' -Tag CI {
         }
 
         AfterAll {
-            $PSDefaultParameterValues = $defaultParamValues
+            $global:PSDefaultParameterValues = $defaultParamValues
         }
 
         It 'Get-Clipboard returns what is in Set-Clipboard' {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystemProviderExtended.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystemProviderExtended.Tests.ps1
@@ -1,8 +1,13 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI" {
+Describe "FileSystem Provider Extended Tests for Get-ChildItem cmdlet" -Tags "CI" {
     BeforeAll {
+        $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
+        if ($IsLinux) {
+            $PSDefaultParameterValues["it:skip"] = $true
+        }
+
         $restoreLocation = Get-Location
 
         $DirSep = [IO.Path]::DirectorySeparatorChar
@@ -36,6 +41,8 @@ Describe "Extended FileSystem Provider Tests for Get-ChildItem cmdlet" -Tags "CI
     }
 
     AfterAll {
+        $global:PSDefaultParameterValues = $originalDefaultParameterValues
+
         #restore the previous location
         Set-Location -Path $restoreLocation
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
@@ -130,7 +130,8 @@ Describe "Process Parent property" -Tags "CI" {
         & $powershellexe -noprofile -command '(Get-Process -Id $PID).Parent' | Should -Not -BeNullOrEmpty
     }
 
-    It "Has valid parent process ID property" {
+    It "Has valid parent process ID property" -Pending {
+        # Bug. See https://github.com/PowerShell/PowerShell/issues/12908
         $powershellexe = (Get-Process -Id $PID).mainmodule.filename
         & $powershellexe -noprofile -command '(Get-Process -Id $PID).Parent.Id' | Should -Be $PID
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
@@ -71,6 +71,8 @@ Describe "Get-Process" -Tags "CI" {
     }
 
     It "Test for process property = Name" {
+        $msg = Get-Process -Id $PID | fl * | Out-String
+        Write-Warning ">>> $PID; $msg"
         (Get-Process -Id $PID).Name | Should -BeExactly "pwsh"
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
@@ -70,9 +70,8 @@ Describe "Get-Process" -Tags "CI" {
         { (Get-Process -Id $idleProcessPid).Name } | Should -Not -Throw
     }
 
-    It "Test for process property = Name" {
-        $msg = Get-Process -Id $PID | fl * | Out-String
-        Write-Warning ">>> $PID; $msg"
+    It "Test for process property = Name" -Pending {
+        # Bug in .Net 5.0 Preview4. See https://github.com/PowerShell/PowerShell/pull/12894
         (Get-Process -Id $PID).Name | Should -BeExactly "pwsh"
     }
 
@@ -125,7 +124,8 @@ Describe "Get-Process Formatting" -Tags "Feature" {
 }
 
 Describe "Process Parent property" -Tags "CI" {
-    It "Has Parent process property" {
+    It "Has Parent process property" -Pending {
+        # Bug in .Net 5.0 Preview4. See https://github.com/PowerShell/PowerShell/pull/12894
         $powershellexe = (Get-Process -Id $PID).mainmodule.filename
         & $powershellexe -noprofile -command '(Get-Process -Id $PID).Parent' | Should -Not -BeNullOrEmpty
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- Replace `$PSDefaultParameterValues` with `$global:PSDefaultParameterValues` to correctly restore skipping settings.
- Skip FileSystem Provider Extended tests on Linux because Hidden flag is not supported on Linux in .Net 5 Preview. The tests should be fixed in follow PR.
- Pending two Linux tests because of .Net 5.0 Preview bug dotnet/runtime#33673.
(PowerShell process name is `ConsoleHost mai` instead of `pwsh`)
- (Tracking issue #12908) Pending one Linux test because of PowerShell bug manifested due to mentioned .Net bug
https://github.com/PowerShell/PowerShell/blob/5ef69e88bc2a6e500349a8eec8d13bb27e143e3e/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs#L972-L985
Since a process names contains a space ( `ConsoleHost mai`) the split returns additional extra element and we get wrong value with `parts[3]`.

## PR Context

I discovered that CIs skip silently many tests which run after the Clipboard tests. 

I have more general concern - I saw that tests was skipped on Linux but not on Windows and MacOS and I don't understand how this can be. My concern is that there is a bug. I hope MSFT can investigate this.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
