### PR TITLE
Fix: Process.Parent property is null on Linux if the process name contains a space

### DIFF
--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -976,13 +976,13 @@ namespace System.Management.Automation
                 try
                 {
                     var stat = System.IO.File.ReadAllText(path);
-                    var parts = stat.Split(' ', 5);
-                    if (parts.Length < 5)
+                    var parts = stat.Substring(stat.LastIndexOf(')')).Split(' ', 4);
+                    if (parts.Length < 4)
                     {
                         return invalidPid;
                     }
 
-                    return Int32.Parse(parts[3]);
+                    return Int32.Parse(parts[2]);
                 }
                 catch (Exception)
                 {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
@@ -130,6 +130,12 @@ Describe "Process Parent property" -Tags "CI" {
         & $powershellexe -noprofile -command '(Get-Process -Id $PID).Parent' | Should -Not -BeNullOrEmpty
     }
 
+    It "Has Parent process property in linux" -Pending:$IsLinux {
+        # Added new test to check for bug as described in issue #12908
+        $powershellexe = (Get-Process -Id $PID).mainmodule.filename
+        & $powershellexe -noprofile -command '(Get-Process -Name "$((Get-Process -Id $PID).Name)").Parent' | Should -Not -BeNullOrEmpty
+    }
+
     It "Has valid parent process ID property" -Pending {
         # Bug. See https://github.com/PowerShell/PowerShell/issues/12908
         $powershellexe = (Get-Process -Id $PID).mainmodule.filename

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
@@ -133,8 +133,13 @@ Describe "Process Parent property" -Tags "CI" {
     It "Has Parent process property in linux" -Skip:(-not $IsLinux) {
         # Added new test to check for bug as described in issue https://github.com/PowerShell/PowerShell/issue/12908
             $powershellexe = (Get-Process -Name "$((Get-Process -Id $PID).Name)").mainmodule.filename
-            & $powershellexe -noprofile -command '(Get-Process -Name "$((Get-Process -Id $PID).Name)").Parent' | Should -Not -BeNullOrEmpty
-        }
+            & $powershellexe -noprofile -command "echo '#!/bin/bash' > 't ( e ( s ) t )'"
+            & $powershellexe -noprofile -command "echo './src/powershell-unix/bin/Debug/net5.0/linux-x64/publish/pwsh' >> 't ( e ( s ) t )'"
+            & $powershellexe -noprofile -command "chmod +x './t ( e ( s ) t )'"
+            & $powershellexe -noprofile -command "Import-Module ./build.psm1"
+            & $powershellexe -noprofile -command "Start-PSBuild"
+            & $powershellexe -noprofile -command "./'t ( e ( s ) t )'"
+            & $powershellexe -noprofile -command '(Get-Process -Name "t ( e ( s ) t )").Parent' | Should -Not -BeNullOrEmpty
     }
 
     It "Has valid parent process ID property" -Pending {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
@@ -132,7 +132,7 @@ Describe "Process Parent property" -Tags "CI" {
 
     It "Has Parent process property in linux" -Pending:$IsLinux {
         # Added new test to check for bug as described in issue #12908
-        $powershellexe = (Get-Process -Id $PID).mainmodule.filename
+        $powershellexe = (Get-Process -Name "$((Get-Process -Id $PID).Name)").mainmodule.filename
         & $powershellexe -noprofile -command '(Get-Process -Name "$((Get-Process -Id $PID).Name)").Parent' | Should -Not -BeNullOrEmpty
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
@@ -132,14 +132,10 @@ Describe "Process Parent property" -Tags "CI" {
 
     It "Has Parent process property in linux" -Skip:(-not $IsLinux) {
         # Added new test to check for bug as described in issue https://github.com/PowerShell/PowerShell/issue/12908
-            $powershellexe = (Get-Process -Name "$((Get-Process -Id $PID).Name)").mainmodule.filename
-            & $powershellexe -noprofile -command "echo '#!/bin/bash' > 't ( e ( s ) t )'"
-            & $powershellexe -noprofile -command "echo './src/powershell-unix/bin/Debug/net5.0/linux-x64/publish/pwsh' >> 't ( e ( s ) t )'"
-            & $powershellexe -noprofile -command "chmod +x './t ( e ( s ) t )'"
-            & $powershellexe -noprofile -command "Import-Module ./build.psm1"
-            & $powershellexe -noprofile -command "Start-PSBuild"
-            & $powershellexe -noprofile -command "./'t ( e ( s ) t )'"
-            & $powershellexe -noprofile -command '(Get-Process -Name "t ( e ( s ) t )").Parent' | Should -Not -BeNullOrEmpty
+        $powershellexe = (Get-Process -Name "$((Get-Process -Id $PID).Name)").mainmodule.filename
+        & $powershellexe -noprofile -command "Set-Content -Path .\'t ( e ( s ) t ).txt' -Value '#!/bin/bash`r`n./$PSHOME/pwsh`r`nchmod +x ./ " + "'t ( e ( s ) t )\'"
+        & $powershellexe -noprofile -command "./'t ( e ( s ) t )'"
+        & $powershellexe -noprofile -command '(Get-Process -Name "t ( e ( s ) t )").Parent' | Should -Not -BeNullOrEmpty
     }
 
     It "Has valid parent process ID property" -Pending {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
@@ -130,10 +130,12 @@ Describe "Process Parent property" -Tags "CI" {
         & $powershellexe -noprofile -command '(Get-Process -Id $PID).Parent' | Should -Not -BeNullOrEmpty
     }
 
-    It "Has Parent process property in linux" -Pending:$IsLinux {
+    It "Has Parent process property in linux" {
         # Added new test to check for bug as described in issue #12908
-        $powershellexe = (Get-Process -Name "$((Get-Process -Id $PID).Name)").mainmodule.filename
-        & $powershellexe -noprofile -command '(Get-Process -Name "$((Get-Process -Id $PID).Name)").Parent' | Should -Not -BeNullOrEmpty
+        if( $IsLinux ) {
+            $powershellexe = (Get-Process -Name "$((Get-Process -Id $PID).Name)").mainmodule.filename
+            & $powershellexe -noprofile -command '(Get-Process -Name "$((Get-Process -Id $PID).Name)").Parent' | Should -Not -BeNullOrEmpty
+        }
     }
 
     It "Has valid parent process ID property" -Pending {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
@@ -130,9 +130,8 @@ Describe "Process Parent property" -Tags "CI" {
         & $powershellexe -noprofile -command '(Get-Process -Id $PID).Parent' | Should -Not -BeNullOrEmpty
     }
 
-    It "Has Parent process property in linux" {
-        # Added new test to check for bug as described in issue #12908
-        if( $IsLinux ) {
+    It "Has Parent process property in linux" -Skip:(-not $IsLinux) {
+        # Added new test to check for bug as described in issue https://github.com/PowerShell/PowerShell/issue/12908
             $powershellexe = (Get-Process -Name "$((Get-Process -Id $PID).Name)").mainmodule.filename
             & $powershellexe -noprofile -command '(Get-Process -Name "$((Get-Process -Id $PID).Name)").Parent' | Should -Not -BeNullOrEmpty
         }
@@ -144,4 +143,3 @@ Describe "Process Parent property" -Tags "CI" {
         & $powershellexe -noprofile -command '(Get-Process -Id $PID).Parent.Id' | Should -Be $PID
     }
 }
-


### PR DESCRIPTION
# PR Summary

<!-- Summarize your PR between here and the checklist. -->
Changed code in CorePsPlatform.cs so that process names with spaces in them can be handled.
## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
Fix for #12908 
This was caused by the inconsistency in the index position after split, which has been fixed here by only considering the substring which stats after the last closing parenthesis ')' and hence it will always have a consistent index for process ID after split()ing.
Note: first ever PR, please be lenient with my documentation. I'm open to suggestions for any changes.
## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
