### PR TITLE
Compile += / -= to bind & handle event (de)registration directly

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -6995,6 +6995,13 @@ namespace System.Management.Automation
                 getToolTip = () => string.Join('\n', methodCacheEntry.methodInformationStructures.Select(static m => m.methodDefinition));
             }
 
+            if (member is DotNetAdapter.EventCacheEntry eventCacheEntry)
+            {
+                memberName = eventCacheEntry.events[0].Name;
+                isMethod = false;
+                getToolTip = () => eventCacheEntry.EventDefinition;
+            }
+
             var psMemberInfo = member as PSMemberInfo;
             if (psMemberInfo != null)
             {

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -268,8 +268,8 @@ namespace System.Management.Automation
                 }
 
                 var members = isStatic
-                              ? PSObject.DotNetStaticAdapter.BaseGetMembers<PSMemberInfo>(type)
-                              : PSObject.DotNetInstanceAdapter.GetPropertiesMethodsAndEvents(type, false);
+                    ? PSObject.DotNetStaticAdapter.BaseGetMembers<PSMemberInfo>(type)
+                    : PSObject.DotNetInstanceAdapter.GetPropertiesMethodsAndEvents(type, @static: false);
 
                 if (filterToCall != null)
                 {

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -269,7 +269,7 @@ namespace System.Management.Automation
 
                 var members = isStatic
                               ? PSObject.DotNetStaticAdapter.BaseGetMembers<PSMemberInfo>(type)
-                              : PSObject.DotNetInstanceAdapter.GetPropertiesAndMethods(type, false);
+                              : PSObject.DotNetInstanceAdapter.GetPropertiesMethodsAndEvents(type, false);
 
                 if (filterToCall != null)
                 {

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -2662,8 +2662,15 @@ dir -Recurse `
         It "Test member completion of a static method invocation" {
             $inputStr = '[powershell]::Create().'
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches | Should -HaveCount 33
+            $res.CompletionMatches | Should -HaveCount 34
             $res.CompletionMatches[0].CompletionText | Should -BeExactly "Commands"
+        }
+
+        It "Completes event member names" {
+            $inputStr = '$timer = [System.Timers.Timer]::new(); $timer.El'
+            $results = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
+            $results.CompletionMatches | Should -HaveCount 1
+            $results.CompletionMatches[0].CompletionText | Should -BeExactly 'Elapsed'
         }
 
         It "Test completion with common parameters" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Eventing.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Eventing.Tests.ps1
@@ -2,15 +2,17 @@
 # Licensed under the MIT License.
 
 Describe "Event Subscriber Tests" -Tags "Feature" {
+
     BeforeEach {
         Get-EventSubscriber | Unregister-Event
     }
+
     AfterEach {
         Get-EventSubscriber | Unregister-Event
     }
 
     # can't let this case to work
-    It "Register an event with no action, trigger it and wait for it to be raised." -Pending:$true{
+    It "Register an event with no action, trigger it and wait for it to be raised." -Pending:$true {
         Get-EventSubscriber | Should -BeNullOrEmpty
         $messageData = New-Object psobject
         $job = Start-Job { Start-Sleep -Seconds 5; 1..5 }
@@ -28,7 +30,7 @@ Describe "Event Subscriber Tests" -Tags "Feature" {
     It "Access a global variable from an event action." {
         Get-EventSubscriber | Should -BeNullOrEmpty
         Set-Variable incomingGlobal -Scope global -Value globVarValue
-        $null = Register-EngineEvent -SourceIdentifier foo -Action {Set-Variable -Scope global -Name aglobalvariable -Value $incomingGlobal}
+        $null = Register-EngineEvent -SourceIdentifier foo -Action { Set-Variable -Scope global -Name aglobalvariable -Value $incomingGlobal }
         New-Event foo
         $getvar = Get-Variable aglobalvariable -Scope global
         $getvar.Name | Should -Be aglobalvariable
@@ -40,14 +42,66 @@ Describe "Event Subscriber Tests" -Tags "Feature" {
     It 'Should not throw when having finally block in Powershell.Exiting Action scriptblock' {
         $pwsh = "$PSHOME/pwsh"
         $output = & $pwsh {
-        Register-EngineEvent -SourceIdentifier Powershell.Exiting -Action {
-            try{
-                try{} finally{}
+            Register-EngineEvent -SourceIdentifier Powershell.Exiting -Action {
+                try {
+                    try {} finally {}
+                } catch { Write-Host "Exception" -NoNewline }
             }
-            catch{ Write-Host "Exception" -NoNewline }
-        }
         } | Out-String
 
         $output | Should -Not -BeLike "*Exception*"
+    }
+
+    Context 'Event (De)Registration with += / -=' {
+
+        BeforeAll {
+            $EventScript = { $global:EventTestResult = 120 }
+
+            Add-Type -TypeDefinition @'
+using System;
+public static class _A99_EventTestHelper_91C_ {
+    public static event EventHandler TestEvent;
+    public static void RaiseEvent() => TestEvent?.Invoke(null, null);
+}
+'@
+        }
+
+        BeforeEach {
+            $global:EventTestResult = 0
+        }
+
+        AfterAll {
+            Get-Variable -Name EventTestResult -Scope Global -ErrorAction Ignore | Remove-Variable
+        }
+
+        It 'Registers events with += for an event member' {
+            $ps = [powershell]::Create()
+            $ps.InvocationStateChanged += $EventScript
+
+            $ps.AddScript('2 + 2').Invoke() > $null
+            $global:EventTestResult | Should -Be 120
+        }
+
+        It 'Deregisters events with -= for an event member' {
+            $ps = [powershell]::Create()
+            $ps.InvocationStateChanged += $EventScript
+            $ps.InvocationStateChanged -= $EventScript
+
+            $ps.AddScript('2 + 2').Invoke() > $null
+            $global:EventTestResult | Should -Be 0
+        }
+
+        It 'Correctly registers a static event with +=' {
+            [_A99_EventTestHelper_91C_]::TestEvent += $EventScript
+            [_A99_EventTestHelper_91C_]::RaiseEvent()
+            $global:EventTestResult | Should -Be 120
+        }
+
+        It 'Correctly unregisters a static event with -=' {
+            # Original event should still be registered from above
+            [_A99_EventTestHelper_91C_]::TestEvent -= $EventScript
+            [_A99_EventTestHelper_91C_]::RaiseEvent()
+            $global:EventTestResult | Should -Be 0
+        }
     }
 }


### PR DESCRIPTION
# PR Summary

Permits the following syntax:

```ps1
$scriptblock = { Write-Host 'event triggered' }
$ps = [powershell]::Create()
# Add event handler
$ps.InvocationStateChanged += $scriptblock

# Remove event handler
$ps.InvocationStateChanged -= $scriptblock
```

## Changes

- Expose `PSEvent` static and instance members of classes & enable tab completion for them.
- Add handling in the compiler to bind event (de)registration for `-=` or `+=` only if the LHS is a `MemberExpressionAst`, combined with a runtime check for the LHS value being `PSEvent`.
- Add a new binder type which will map the event member to its add/remove method as appropriate and then offload to `PSInvokeMemberBinder` with that method name.

## PR Context

See #12926 for some additional context, but my thoughts are essentially: events are currently not discoverable and very annoying to work with in PowerShell, sometimes requiring reliance on implementation details.

I do not believe this can be considered a breaking change, since the only place it applies is specifically for event members, which were previously pretty much entirely inaccessible prior to this change.

Resolves #12926 

With respect to tooling, there shouldn't be any breaking points, but event members will be offered in tab completion results with these changes, which may be considered unexpected in some circumstances.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [x] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
