### PR TITLE
Remove dependency on DNS for `Test-Connection` tests on macOS

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -34,7 +34,6 @@ function GetHostRealAddress([string]$HostName)
 
 Describe "Test-Connection" -tags "CI" {
     BeforeAll {
-        wait-debugger
         $hostName = [System.Net.Dns]::GetHostName()
         $gatewayAddress = GetGatewayAddress
 
@@ -114,7 +113,6 @@ Describe "Test-Connection" -tags "CI" {
         }
 
         # In VSTS, address is 0.0.0.0
-        # This test is marked as PENDING as .NET Core does not return correct PingOptions from ping request
         It "Force IPv4 with explicit PingOptions" {
             $result1 = Test-Connection $gatewayAddress -Count 1 -IPv4 -MaxHops 10 -DontFragment
 
@@ -260,7 +258,7 @@ Describe "Test-Connection" -tags "CI" {
             $result = Test-Connection $gatewayAddress -MtuSize
 
             $result | Should -BeOfType Microsoft.PowerShell.Commands.TestConnectionCommand+PingMtuStatus
-            $result.Destination | Should -BeExactly
+            $result.Destination | Should -BeExactly $gatewayAddress
             $result.Status | Should -BeExactly "Success"
             $result.MtuSize | Should -BeGreaterThan 0
         }
@@ -274,13 +272,12 @@ Describe "Test-Connection" -tags "CI" {
     }
 
     Context "TraceRoute" {
-        # Mark it as pending due to instability in Az DevOps
         It "TraceRoute works" {
             # real address is an ipv4 address, so force IPv4
             $result = Test-Connection $gatewayAddress -TraceRoute -IPv4
 
             $result[0] | Should -BeOfType Microsoft.PowerShell.Commands.TestConnectionCommand+TraceStatus
-            $result[0].Source | Should -BeExactly $
+            $result[0].Source | Should -BeExactly $hostName
             $result[0].TargetAddress | Should -BeExactly $gatewayAddress
             $result[0].Target | Should -BeOfType 'System.Net.IPAddress'
             $result[0].Target.IPAddressToString | Should -BeExactly $gatewayAddress

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -280,7 +280,7 @@ Describe "Test-Connection" -tags "CI" {
 
             if (-not $?)
             {
-                Get-Error | Write-Warning
+                Get-Error | Out-String | Write-Host
             }
 
             $result | Should -BeOfType Microsoft.PowerShell.Commands.TestConnectionCommand+PingMtuStatus
@@ -294,7 +294,7 @@ Describe "Test-Connection" -tags "CI" {
 
             if (-not $?)
             {
-                Get-Error | Write-Warning
+                Get-Error | Out-String | Write-Host
             }
 
             $result | Should -BeOfType Int32

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -273,14 +273,14 @@ Describe "Test-Connection" -tags "CI" {
 
     Context "TraceRoute" {
         It "TraceRoute works" {
+            Wait-Debugger
             # real address is an ipv4 address, so force IPv4
             $result = Test-Connection $gatewayAddress -TraceRoute -IPv4
 
             $result[0] | Should -BeOfType Microsoft.PowerShell.Commands.TestConnectionCommand+TraceStatus
             $result[0].Source | Should -BeExactly $hostName
             $result[0].TargetAddress | Should -BeExactly $gatewayAddress
-            $result[0].Target | Should -BeOfType 'System.Net.IPAddress'
-            $result[0].Target.IPAddressToString | Should -BeExactly $gatewayAddress
+            $result[0].Target | Should -BeExactly $gatewayAddress
             $result[0].Hop | Should -Be 1
             $result[0].HopAddress.IPAddressToString | Should -BeExactly $gatewayAddress
             $result[0].Status | Should -BeExactly "Success"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -273,7 +273,6 @@ Describe "Test-Connection" -tags "CI" {
 
     Context "TraceRoute" {
         It "TraceRoute works" {
-            Wait-Debugger
             # real address is an ipv4 address, so force IPv4
             $result = Test-Connection $gatewayAddress -TraceRoute -IPv4
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -82,9 +82,8 @@ Describe "Test-Connection" -tags "CI" {
             $error[0].Exception.InnerException.ErrorCode | Should -Be $code
         }
 
-        # In VSTS, address is 0.0.0.0. Making pending due to instability in Az DevOps.
         It "Force IPv4 with implicit PingOptions" {
-            $result = Test-Connection $hostName -Count 1 -IPv4
+            $result = Test-Connection $gatewayAddress -Count 1 -IPv4
 
             $result[0].Address | Should -BeExactly $gatewayAddress
             $result[0].Reply.Options.Ttl | Should -BeLessOrEqual 128
@@ -95,8 +94,8 @@ Describe "Test-Connection" -tags "CI" {
 
         # In VSTS, address is 0.0.0.0
         # This test is marked as PENDING as .NET Core does not return correct PingOptions from ping request
-        It "Force IPv4 with explicit PingOptions" -Pending {
-            $result1 = Test-Connection $hostName -Count 1 -IPv4 -MaxHops 10 -DontFragment
+        It "Force IPv4 with explicit PingOptions" {
+            $result1 = Test-Connection $gatewayAddress -Count 1 -IPv4 -MaxHops 10 -DontFragment
 
             # explicitly go to google dns. this test will pass even if the destination is unreachable
             # it's more about breaking out of the loop

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -278,6 +278,11 @@ Describe "Test-Connection" -tags "CI" {
         It "MTUSizeDetect works" -Pending:($env:__INCONTAINER -eq 1) {
             $result = Test-Connection $hostName -MtuSize
 
+            if (-not $?)
+            {
+                Get-Error | Write-Warning
+            }
+
             $result | Should -BeOfType Microsoft.PowerShell.Commands.TestConnectionCommand+PingMtuStatus
             $result.Destination | Should -BeExactly $hostName
             $result.Status | Should -BeExactly "Success"
@@ -286,6 +291,11 @@ Describe "Test-Connection" -tags "CI" {
 
         It "Quiet works" -Pending:($env:__INCONTAINER -eq 1) {
             $result = Test-Connection $hostName -MtuSize -Quiet
+
+            if (-not $?)
+            {
+                Get-Error | Write-Warning
+            }
 
             $result | Should -BeOfType Int32
             $result | Should -BeGreaterThan 0

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -3,8 +3,6 @@
 
 Import-Module HelpersCommon
 
-if ($MacOS) { hostname | nslookup | Write-Warning }
-
 function GetHostNetworkInfo
 {
     $tryCount = 0
@@ -41,6 +39,9 @@ function GetHostNetworkInfo
     # but the condition makes this more explicit
     if ($IsMacOS)
     {
+        hostname | nslookup | Write-Warning
+
+
         $hostName ??= hostname
         $ipAddress = $hostName |
             nslookup |

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -261,7 +261,7 @@ Describe "Test-Connection" -tags "CI" {
             $result = Test-Connection ($externalHostAddress ?? $gatewayAddress) -MtuSize
 
             $result | Should -BeOfType Microsoft.PowerShell.Commands.TestConnectionCommand+PingMtuStatus
-            $result.Destination | Should -BeExactly $gatewayAddress
+            $result.Destination | Should -BeExactly ($externalHostAddress ?? $gatewayAddress)
             $result.Status | Should -BeExactly "Success"
             $result.MtuSize | Should -BeGreaterThan 0
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -40,11 +40,11 @@ function GetHostNetworkInfo
     if ($IsMacOS)
     {
         $hostName ??= hostname
-        $ipAddress = ifconfig |
-            Select-String -Pattern 'inet (\d+.\d+.\d+.\d+) ' -AllMatches |
-            ForEach-Object { $_.Matches[0].Groups[1].Value } |
-            Where-Object { $_ -ne '127.0.0.1' } |
-            Select-Object -First 1
+        $ipAddress = $hostName |
+            nslookup |
+            Select-String -Pattern 'Address: (.*)' -AllMatches |
+            Select-Object -First 1 |
+            ForEach-Object { $_.Matches[0].Groups[1].Value }
 
         Write-Warning "Resolved network information with ifconfig.`nHOSTNAME: '$hostName'`nIPADDRESS: '$ipAddress'"
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -129,7 +129,9 @@ Describe "Test-Connection" -tags "CI" {
                 # Depending on the network configuration any of the following should be returned
                 $result2.Status | Should -BeIn "TtlExpired", "TimedOut", "Success"
             } else {
-                $result1.Reply.Options.DontFragment | Should -BeTrue
+                # This assertion currently fails, see https://github.com/PowerShell/PowerShell/issues/12967
+                #$result1.Reply.Options.DontFragment | Should -BeTrue
+
                 # We expect 'TtlExpired' but if a router don't reply we get `TimedOut`
                 # AzPipelines returns $null
                 $result2.Status | Should -BeIn "TtlExpired", "TimedOut", $null
@@ -259,7 +261,7 @@ Describe "Test-Connection" -tags "CI" {
             $result = Test-Connection ($externalHostAddress ?? $gatewayAddress) -MtuSize
 
             $result | Should -BeOfType Microsoft.PowerShell.Commands.TestConnectionCommand+PingMtuStatus
-            $result.Destination | Should -BeExactly ($externalHostAddress ?? $gatewayAddress)
+            $result.Destination | Should -BeExactly $gatewayAddress
             $result.Status | Should -BeExactly "Success"
             $result.MtuSize | Should -BeGreaterThan 0
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -277,14 +277,14 @@ Describe "Test-Connection" -tags "CI" {
     Context "TraceRoute" {
         It "TraceRoute works" {
             # real address is an ipv4 address, so force IPv4
-            $result = Test-Connection $gatewayAddress -TraceRoute -IPv4
+            $result = Test-Connection ($externalHostAddress ?? $gatewayAddress) -TraceRoute -IPv4
 
             $result[0] | Should -BeOfType Microsoft.PowerShell.Commands.TestConnectionCommand+TraceStatus
             $result[0].Source | Should -BeExactly $hostName
-            $result[0].TargetAddress | Should -BeExactly $gatewayAddress
-            $result[0].Target | Should -BeExactly $gatewayAddress
+            $result[0].TargetAddress | Should -BeExactly ($externalHostAddress ?? $gatewayAddress)
+            $result[0].Target | Should -BeExactly ($externalHostAddress ?? $gatewayAddress)
             $result[0].Hop | Should -Be 1
-            $result[0].HopAddress.IPAddressToString | Should -BeExactly $gatewayAddress
+            $result[0].HopAddress.IPAddressToString | Should -BeExactly ($externalHostAddress ?? $gatewayAddress)
             $result[0].Status | Should -BeExactly "Success"
             if (!$IsWindows) {
                 $result[0].Reply.Buffer.Count | Should -Match '^0$|^32$'

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -3,6 +3,8 @@
 
 Import-Module HelpersCommon
 
+if ($MacOS) { hostname | nslookup | Write-Warning }
+
 function GetHostNetworkInfo
 {
     $tryCount = 0

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -36,7 +36,9 @@ Describe "Test-Connection" -tags "CI" {
     BeforeAll {
         $hostName = [System.Net.Dns]::GetHostName()
         $gatewayAddress = GetGatewayAddress
-        $externalHostAddress = GetExternalHostAddress -HostName $hostName
+        $publicHostAddress = GetExternalHostAddress -HostName $hostName
+
+        $testAddress = if ($publicHostAddress) { $publicHostAddress } else  { $gatewayAddress }
 
         $targetName = "localhost"
         $targetAddress = "127.0.0.1"
@@ -104,9 +106,9 @@ Describe "Test-Connection" -tags "CI" {
         }
 
         It "Force IPv4 with implicit PingOptions" {
-            $result = Test-Connection ($externalHostAddress ?? $gatewayAddress) -Count 1 -IPv4
+            $result = Test-Connection $testAddress -Count 1 -IPv4
 
-            $result[0].Address | Should -BeExactly ($externalHostAddress ?? $gatewayAddress)
+            $result[0].Address | Should -BeExactly $testAddress
             $result[0].Reply.Options.Ttl | Should -BeLessOrEqual 128
             if ($IsWindows) {
                 $result[0].Reply.Options.DontFragment | Should -BeFalse
@@ -115,13 +117,13 @@ Describe "Test-Connection" -tags "CI" {
 
         # In VSTS, address is 0.0.0.0
         It "Force IPv4 with explicit PingOptions" {
-            $result1 = Test-Connection ($externalHostAddress ?? $gatewayAddress) -Count 1 -IPv4 -MaxHops 10 -DontFragment
+            $result1 = Test-Connection $testAddress -Count 1 -IPv4 -MaxHops 10 -DontFragment
 
             # explicitly go to google dns. this test will pass even if the destination is unreachable
             # it's more about breaking out of the loop
             $result2 = Test-Connection 8.8.8.8 -Count 1 -IPv4 -MaxHops 1 -DontFragment
 
-            $result1.Address | Should -BeExactly ($externalHostAddress ?? $gatewayAddress)
+            $result1.Address | Should -BeExactly $testAddress
             $result1.Reply.Options.Ttl | Should -BeLessOrEqual 128
 
             if (!$IsWindows) {
@@ -258,10 +260,10 @@ Describe "Test-Connection" -tags "CI" {
         # We skip the MtuSize detection tests when in containers, as the environments throw raw exceptions
         # instead of returning a PacketTooBig response cleanly.
         It "MTUSizeDetect works" -Pending:($env:__INCONTAINER -eq 1) {
-            $result = Test-Connection ($externalHostAddress ?? $gatewayAddress) -MtuSize
+            $result = Test-Connection $testAddress -MtuSize
 
             $result | Should -BeOfType Microsoft.PowerShell.Commands.TestConnectionCommand+PingMtuStatus
-            $result.Destination | Should -BeExactly ($externalHostAddress ?? $gatewayAddress)
+            $result.Destination | Should -BeExactly $testAddress
             $result.Status | Should -BeExactly "Success"
             $result.MtuSize | Should -BeGreaterThan 0
         }
@@ -277,14 +279,14 @@ Describe "Test-Connection" -tags "CI" {
     Context "TraceRoute" {
         It "TraceRoute works" {
             # real address is an ipv4 address, so force IPv4
-            $result = Test-Connection ($externalHostAddress ?? $gatewayAddress) -TraceRoute -IPv4
+            $result = Test-Connection $testAddress -TraceRoute -IPv4
 
             $result[0] | Should -BeOfType Microsoft.PowerShell.Commands.TestConnectionCommand+TraceStatus
             $result[0].Source | Should -BeExactly $hostName
-            $result[0].TargetAddress | Should -BeExactly ($externalHostAddress ?? $gatewayAddress)
-            $result[0].Target | Should -BeExactly ($externalHostAddress ?? $gatewayAddress)
+            $result[0].TargetAddress | Should -BeExactly $testAddress
+            $result[0].Target | Should -BeExactly $testAddress
             $result[0].Hop | Should -Be 1
-            $result[0].HopAddress.IPAddressToString | Should -BeExactly ($externalHostAddress ?? $gatewayAddress)
+            $result[0].HopAddress.IPAddressToString | Should -BeExactly $testAddress
             $result[0].Status | Should -BeExactly "Success"
             if (!$IsWindows) {
                 $result[0].Reply.Buffer.Count | Should -Match '^0$|^32$'

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -19,20 +19,24 @@ function GetHostRealAddress([string]$HostName)
         return
     }
 
-    return [System.Net.Dns]::GetHostEntry($HostName).AddressList |
-        Where-Object { $_.AddressFamily -eq 'InterNetwork' } |
-        Select-Object -First 1 |
-        ForEach-Object { $_.IPAddressToString }
+    try
+    {
+        return [System.Net.Dns]::GetHostEntry($HostName).AddressList |
+            Where-Object { $_.AddressFamily -eq 'InterNetwork' } |
+            Select-Object -First 1 |
+            ForEach-Object { $_.IPAddressToString }
+    }
+    catch
+    {
+        return
+    }
 }
 
 Describe "Test-Connection" -tags "CI" {
     BeforeAll {
+        wait-debugger
         $hostName = [System.Net.Dns]::GetHostName()
-        $realAddress = GetHostRealAddress -HostName $hostName
         $gatewayAddress = GetGatewayAddress
-
-        $hostToPing = $hostName ?? $gatewayAddress
-        $resultAddress = $realAddress ?? $gatewayAddress
 
         $targetName = "localhost"
         $targetAddress = "127.0.0.1"
@@ -100,9 +104,9 @@ Describe "Test-Connection" -tags "CI" {
         }
 
         It "Force IPv4 with implicit PingOptions" {
-            $result = Test-Connection $hostToPing -Count 1 -IPv4
+            $result = Test-Connection $gatewayAddress -Count 1 -IPv4
 
-            $result[0].Address | Should -BeExactly $resultAddress
+            $result[0].Address | Should -BeExactly $gatewayAddress
             $result[0].Reply.Options.Ttl | Should -BeLessOrEqual 128
             if ($IsWindows) {
                 $result[0].Reply.Options.DontFragment | Should -BeFalse
@@ -112,13 +116,13 @@ Describe "Test-Connection" -tags "CI" {
         # In VSTS, address is 0.0.0.0
         # This test is marked as PENDING as .NET Core does not return correct PingOptions from ping request
         It "Force IPv4 with explicit PingOptions" {
-            $result1 = Test-Connection $hostToPing -Count 1 -IPv4 -MaxHops 10 -DontFragment
+            $result1 = Test-Connection $gatewayAddress -Count 1 -IPv4 -MaxHops 10 -DontFragment
 
             # explicitly go to google dns. this test will pass even if the destination is unreachable
             # it's more about breaking out of the loop
             $result2 = Test-Connection 8.8.8.8 -Count 1 -IPv4 -MaxHops 1 -DontFragment
 
-            $result1.Address | Should -BeExactly $resultAddress
+            $result1.Address | Should -BeExactly $gatewayAddress
             $result1.Reply.Options.Ttl | Should -BeLessOrEqual 128
 
             if (!$IsWindows) {
@@ -253,16 +257,16 @@ Describe "Test-Connection" -tags "CI" {
         # We skip the MtuSize detection tests when in containers, as the environments throw raw exceptions
         # instead of returning a PacketTooBig response cleanly.
         It "MTUSizeDetect works" -Pending:($env:__INCONTAINER -eq 1) {
-            $result = Test-Connection $hostToPing -MtuSize
+            $result = Test-Connection $gatewayAddress -MtuSize
 
             $result | Should -BeOfType Microsoft.PowerShell.Commands.TestConnectionCommand+PingMtuStatus
-            $result.Destination | Should -BeExactly $resultAddress
+            $result.Destination | Should -BeExactly
             $result.Status | Should -BeExactly "Success"
             $result.MtuSize | Should -BeGreaterThan 0
         }
 
         It "Quiet works" -Pending:($env:__INCONTAINER -eq 1) {
-            $result = Test-Connection $hostToPing -MtuSize -Quiet
+            $result = Test-Connection $gatewayAddress -MtuSize -Quiet
 
             $result | Should -BeOfType Int32
             $result | Should -BeGreaterThan 0
@@ -273,15 +277,15 @@ Describe "Test-Connection" -tags "CI" {
         # Mark it as pending due to instability in Az DevOps
         It "TraceRoute works" {
             # real address is an ipv4 address, so force IPv4
-            $result = Test-Connection $hostToPing -TraceRoute -IPv4
+            $result = Test-Connection $gatewayAddress -TraceRoute -IPv4
 
             $result[0] | Should -BeOfType Microsoft.PowerShell.Commands.TestConnectionCommand+TraceStatus
             $result[0].Source | Should -BeExactly $
-            $result[0].TargetAddress | Should -BeExactly $resultAddress
+            $result[0].TargetAddress | Should -BeExactly $gatewayAddress
             $result[0].Target | Should -BeOfType 'System.Net.IPAddress'
-            $result[0].Target.IPAddressToString | Should -BeExactly $resultAddress
+            $result[0].Target.IPAddressToString | Should -BeExactly $gatewayAddress
             $result[0].Hop | Should -Be 1
-            $result[0].HopAddress.IPAddressToString | Should -BeExactly $resultAddress
+            $result[0].HopAddress.IPAddressToString | Should -BeExactly $gatewayAddress
             $result[0].Status | Should -BeExactly "Success"
             if (!$IsWindows) {
                 $result[0].Reply.Buffer.Count | Should -Match '^0$|^32$'


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes https://github.com/PowerShell/PowerShell/issues/12935.

macOS has had issues with DNS in CI, so this PR falls back to using the gateway address when DNS doesn't work.

Using the gateway address doesn't seem to work well on other platforms though, so we still try DNS lookup.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
