### PR TITLE
Use HashSet instead of Hashtable with null values

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataQuery.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataQuery.cs
@@ -588,7 +588,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <returns></returns>
         internal static AppliesTo GetAllApplicableTypes(TypeInfoDataBase db, AppliesTo appliesTo)
         {
-            Hashtable allTypes = new Hashtable(StringComparer.OrdinalIgnoreCase);
+            var allTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             foreach (TypeOrGroupReference r in appliesTo.referenceList)
             {
@@ -596,8 +596,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 TypeReference tr = r as TypeReference;
                 if (tr != null)
                 {
-                    if (!allTypes.ContainsKey(tr.name))
-                        allTypes.Add(tr.name, null);
+                    if (!allTypes.Contains(tr.name))
+                        allTypes.Add(tr.name);
                 }
                 else
                 {
@@ -616,16 +616,16 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     // we found the group, go over it
                     foreach (TypeReference x in tgd.typeReferenceList)
                     {
-                        if (!allTypes.ContainsKey(x.name))
-                            allTypes.Add(x.name, null);
+                        if (!allTypes.Contains(x.name))
+                            allTypes.Add(x.name);
                     }
                 }
             }
 
             AppliesTo retVal = new AppliesTo();
-            foreach (DictionaryEntry x in allTypes)
+            foreach (string x in allTypes)
             {
-                retVal.AddAppliesToType(x.Key as string);
+                retVal.AddAppliesToType(x);
             }
 
             return retVal;

--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/Mshexpression.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/Mshexpression.cs
@@ -231,19 +231,19 @@ namespace Microsoft.PowerShell.Commands
                 }
             }
 
-            Hashtable hash = new Hashtable();
+            var set = new HashSet<string>();
 
             // build the list of unique values: remove the possible duplicates
             // from property set expansion
             foreach (PSMemberInfo m in temporaryMemberList)
             {
-                if (!hash.ContainsKey(m.Name))
+                if (!set.Contains(m.Name))
                 {
                     PSPropertyExpression ex = new PSPropertyExpression(m.Name);
 
                     ex._isResolved = true;
                     retVal.Add(ex);
-                    hash.Add(m.Name, null);
+                    set.Add(m.Name);
                 }
             }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/Mshexpression.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/Mshexpression.cs
@@ -231,19 +231,19 @@ namespace Microsoft.PowerShell.Commands
                 }
             }
 
-            var set = new HashSet<string>();
+            var allMembers = new HashSet<string>();
 
             // build the list of unique values: remove the possible duplicates
             // from property set expansion
             foreach (PSMemberInfo m in temporaryMemberList)
             {
-                if (!set.Contains(m.Name))
+                if (!allMembers.Contains(m.Name))
                 {
                     PSPropertyExpression ex = new PSPropertyExpression(m.Name);
 
                     ex._isResolved = true;
                     retVal.Add(ex);
-                    set.Add(m.Name);
+                    allMembers.Add(m.Name);
                 }
             }
 

--- a/src/System.Management.Automation/help/AliasHelpProvider.cs
+++ b/src/System.Management.Automation/help/AliasHelpProvider.cs
@@ -141,7 +141,7 @@ namespace System.Management.Automation
             {
                 string target = helpRequest.Target;
                 string pattern = target;
-                Hashtable hashtable = new Hashtable(StringComparer.OrdinalIgnoreCase);
+                var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
                 if (!WildcardPattern.ContainsWildcardCharacters(target))
                 {
@@ -169,12 +169,12 @@ namespace System.Management.Automation
                                 continue;
                             }
 
-                            if (hashtable.ContainsKey(name))
+                            if (set.Contains(name))
                             {
                                 continue;
                             }
 
-                            hashtable.Add(name, null);
+                            set.Add(name);
 
                             yield return helpInfo;
                         }
@@ -216,12 +216,12 @@ namespace System.Management.Automation
                                 continue;
                             }
 
-                            if (hashtable.ContainsKey(name))
+                            if (set.Contains(name))
                             {
                                 continue;
                             }
 
-                            hashtable.Add(name, null);
+                            set.Add(name);
 
                             yield return helpInfo;
                         }
@@ -243,12 +243,12 @@ namespace System.Management.Automation
 
                         HelpInfo helpInfo = AliasHelpInfo.GetHelpInfo(alias);
 
-                        if (hashtable.ContainsKey(name))
+                        if (set.Contains(name))
                         {
                             continue;
                         }
 
-                        hashtable.Add(name, null);
+                        set.Add(name);
 
                         yield return helpInfo;
                     }

--- a/src/System.Management.Automation/help/AliasHelpProvider.cs
+++ b/src/System.Management.Automation/help/AliasHelpProvider.cs
@@ -141,7 +141,7 @@ namespace System.Management.Automation
             {
                 string target = helpRequest.Target;
                 string pattern = target;
-                var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                var allAliases = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
                 if (!WildcardPattern.ContainsWildcardCharacters(target))
                 {
@@ -169,12 +169,12 @@ namespace System.Management.Automation
                                 continue;
                             }
 
-                            if (set.Contains(name))
+                            if (allAliases.Contains(name))
                             {
                                 continue;
                             }
 
-                            set.Add(name);
+                            allAliases.Add(name);
 
                             yield return helpInfo;
                         }
@@ -216,12 +216,12 @@ namespace System.Management.Automation
                                 continue;
                             }
 
-                            if (set.Contains(name))
+                            if (allAliases.Contains(name))
                             {
                                 continue;
                             }
 
-                            set.Add(name);
+                            allAliases.Add(name);
 
                             yield return helpInfo;
                         }
@@ -243,12 +243,12 @@ namespace System.Management.Automation
 
                         HelpInfo helpInfo = AliasHelpInfo.GetHelpInfo(alias);
 
-                        if (set.Contains(name))
+                        if (allAliases.Contains(name))
                         {
                             continue;
                         }
 
-                        set.Add(name);
+                        allAliases.Add(name);
 
                         yield return helpInfo;
                     }

--- a/src/System.Management.Automation/help/CommandHelpProvider.cs
+++ b/src/System.Management.Automation/help/CommandHelpProvider.cs
@@ -427,7 +427,7 @@ namespace System.Management.Automation
             int countHelpInfosFound = 0;
             string target = helpRequest.Target;
             // this is for avoiding duplicate result from help output.
-            Hashtable hashtable = new Hashtable(StringComparer.OrdinalIgnoreCase);
+            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             CommandSearcher searcher = GetCommandSearcherForExactMatch(target, _context);
 
@@ -453,7 +453,7 @@ namespace System.Management.Automation
                         throw new PSInvalidOperationException(HelpErrors.CircularDependencyInHelpForwarding);
                     }
 
-                    if (hashtable.ContainsKey(helpName))
+                    if (set.Contains(helpName))
                         continue;
 
                     if (!Match(helpInfo, helpRequest, current))
@@ -462,7 +462,7 @@ namespace System.Management.Automation
                     }
 
                     countHelpInfosFound++;
-                    hashtable.Add(helpName, null);
+                    set.Add(helpName);
                     yield return helpInfo;
 
                     if ((countHelpInfosFound >= helpRequest.MaxResults) && (helpRequest.MaxResults > 0))
@@ -1053,8 +1053,8 @@ namespace System.Management.Automation
 
             int countOfHelpInfoObjectsFound = 0;
             // this is for avoiding duplicate result from help output.
-            Hashtable hashtable = new Hashtable(StringComparer.OrdinalIgnoreCase);
-            Hashtable hiddenCommands = new Hashtable(StringComparer.OrdinalIgnoreCase);
+            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var hiddenCommands = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (string pattern in patternList)
             {
                 CommandSearcher searcher = GetCommandSearcherForSearch(pattern, _context);
@@ -1077,15 +1077,15 @@ namespace System.Management.Automation
                         {
                             // this command is not visible to the user (from CommandOrigin) so
                             // dont show help topic for it.
-                            if (!hiddenCommands.ContainsKey(helpName))
+                            if (!hiddenCommands.Contains(helpName))
                             {
-                                hiddenCommands.Add(helpName, null);
+                                hiddenCommands.Add(helpName);
                             }
 
                             continue;
                         }
 
-                        if (hashtable.ContainsKey(helpName))
+                        if (set.Contains(helpName))
                             continue;
 
                         // filter out the helpInfo object depending on user request
@@ -1100,7 +1100,7 @@ namespace System.Management.Automation
                             continue;
                         }
 
-                        hashtable.Add(helpName, null);
+                        set.Add(helpName);
                         countOfHelpInfoObjectsFound++;
                         yield return helpInfo;
 
@@ -1130,10 +1130,10 @@ namespace System.Management.Automation
 
                         if (helpInfo != null && !string.IsNullOrEmpty(helpName))
                         {
-                            if (hashtable.ContainsKey(helpName))
+                            if (set.Contains(helpName))
                                 continue;
 
-                            if (hiddenCommands.ContainsKey(helpName))
+                            if (hiddenCommands.Contains(helpName))
                                 continue;
 
                             // filter out the helpInfo object depending on user request
@@ -1148,7 +1148,7 @@ namespace System.Management.Automation
                                 continue;
                             }
 
-                            hashtable.Add(helpName, null);
+                            set.Add(helpName);
                             countOfHelpInfoObjectsFound++;
                             yield return helpInfo;
 

--- a/src/System.Management.Automation/help/CommandHelpProvider.cs
+++ b/src/System.Management.Automation/help/CommandHelpProvider.cs
@@ -427,7 +427,7 @@ namespace System.Management.Automation
             int countHelpInfosFound = 0;
             string target = helpRequest.Target;
             // this is for avoiding duplicate result from help output.
-            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var allHelpNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             CommandSearcher searcher = GetCommandSearcherForExactMatch(target, _context);
 
@@ -453,7 +453,7 @@ namespace System.Management.Automation
                         throw new PSInvalidOperationException(HelpErrors.CircularDependencyInHelpForwarding);
                     }
 
-                    if (set.Contains(helpName))
+                    if (allHelpNames.Contains(helpName))
                         continue;
 
                     if (!Match(helpInfo, helpRequest, current))
@@ -462,7 +462,7 @@ namespace System.Management.Automation
                     }
 
                     countHelpInfosFound++;
-                    set.Add(helpName);
+                    allHelpNames.Add(helpName);
                     yield return helpInfo;
 
                     if ((countHelpInfosFound >= helpRequest.MaxResults) && (helpRequest.MaxResults > 0))


### PR DESCRIPTION
# PR Summary

* Replace use non-generic `Hashtable`
* `Dictionary` not used as we don't store values.

## PR Context

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
