### PR TITLE
Remove positional assignment of QUALIFIER for SPLIT-PATH

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ParsePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ParsePathCommand.cs
@@ -107,7 +107,7 @@ namespace Microsoft.PowerShell.Commands
         /// The qualifier is the drive or provider that is qualifying
         /// the MSH path.
         /// </value>
-        [Parameter(ValueFromPipelineByPropertyName = true, ParameterSetName = qualifierSet, Mandatory = false)]
+        [Parameter(ValueFromPipelineByPropertyName = true, ParameterSetName = qualifierSet)]
         public SwitchParameter Qualifier { get; set; }
 
         /// <summary>
@@ -476,4 +476,3 @@ namespace Microsoft.PowerShell.Commands
         }
     }
 }
-

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ParsePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ParsePathCommand.cs
@@ -107,7 +107,7 @@ namespace Microsoft.PowerShell.Commands
         /// The qualifier is the drive or provider that is qualifying
         /// the MSH path.
         /// </value>
-        [Parameter(Position = 1, ValueFromPipelineByPropertyName = true, ParameterSetName = qualifierSet, Mandatory = false)]
+        [Parameter(ValueFromPipelineByPropertyName = true, ParameterSetName = qualifierSet, Mandatory = false)]
         public SwitchParameter Qualifier { get; set; }
 
         /// <summary>

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
@@ -30,7 +30,7 @@ Describe "Split-Path" -Tags "CI" {
     }
 
     It "Should error given positional parameter #2" {
-	{ Split-Path env: $NULL } | Should -Throw
+	    { Split-Path env: $NULL } | Should -Throw
     }
 
     It "Should return the path when the noqualifier switch is used" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
@@ -30,7 +30,7 @@ Describe "Split-Path" -Tags "CI" {
     }
 
     It "Should error given positional parameter #2" {
-	    { Split-Path env: $NULL } | Should -Throw
+	    { Split-Path env: $NULL } | Should -Throw  -ErrorId 'PositionalParameterNotFound,Microsoft.PowerShell.Commands.SplitPathCommand'
     }
 
     It "Should return the path when the noqualifier switch is used" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
@@ -29,6 +29,10 @@ Describe "Split-Path" -Tags "CI" {
 	{ Split-Path -Qualifier -ErrorAction Stop abcdef } | Should -Throw
     }
 
+    It "Should error given positional parameter #2" {
+	{ Split-Path env: $NULL } | Should -Throw
+    }
+
     It "Should return the path when the noqualifier switch is used" {
 	Split-Path env:PATH -NoQualifier | Should -BeExactly "PATH"
     }


### PR DESCRIPTION


<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
The syntax ``SPLIT-PATH C: -QUALIFIER`` should be required to pass QUALIFIER.
## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
The syntax ``SPLIT-PATH C: $NULL`` is confusing and should not be supported.  
## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [X] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [X] Issue filed: #12959
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
