### PR TITLE
Ensure assemblies listed `FileList` are not loaded

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -4379,7 +4379,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     try
                     {
-                        string fixedFileName = FixupFileName(moduleBase, s, extension, importingModule);
+                        string fixedFileName = FixupFileName(moduleBase, s, extension, importingModule, skipLoading: true);
                         var dir = Path.GetDirectoryName(fixedFileName);
 
                         if (string.Equals(psHome, dir, StringComparison.OrdinalIgnoreCase) ||
@@ -4537,9 +4537,9 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// A utility routine to fix up a file name so it's rooted and has an extension.
         /// </summary>
-        internal string FixupFileName(string moduleBase, string name, string extension, bool isImportingModule)
+        internal string FixupFileName(string moduleBase, string name, string extension, bool isImportingModule, bool skipLoading = false)
         {
-            return FixupFileName(moduleBase, name, extension, isImportingModule, pathIsResolved: out _);
+            return FixupFileName(moduleBase, name, extension, isImportingModule, pathIsResolved: out _, skipLoading);
         }
 
         /// <summary>
@@ -4554,10 +4554,11 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="extension">The extension to use in case the given name has no extension.</param>
         /// <param name="isImportingModule">Indicate if we are loading a module.</param>
         /// <param name="pathIsResolved">Indicate if the returned path is fully resolved.</param>
+        /// <param name="skipLoading">Indicate if the resolved module should be loaded.</param>
         /// <returns>
         /// The resolved file path. Or, the combined path of <paramref name="moduleBase"/> and <paramref name="name"/> when the file path cannot be resolved.
         /// </returns>
-        internal string FixupFileName(string moduleBase, string name, string extension, bool isImportingModule, out bool pathIsResolved)
+        internal string FixupFileName(string moduleBase, string name, string extension, bool isImportingModule, out bool pathIsResolved, bool skipLoading = false)
         {
             pathIsResolved = false;
             string originalName = name;
@@ -4585,7 +4586,7 @@ namespace Microsoft.PowerShell.Commands
             // Return the path if successfully resolved.
             if (resolvedPath != null)
             {
-                if (isImportingModule && resolvedPath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                if (isImportingModule && resolvedPath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) && !skipLoading)
                 {
                     // If we are fixing up an assembly file path and we are actually loading the module, then we load the resolved assembly file here.
                     // This is because we process type/format ps1xml files before 'RootModule' and 'NestedModules' entries during the module loading.

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -384,6 +384,10 @@ Describe "Module with FileList" -Tag "CI" {
         New-ModuleManifest -Path "$testdrive\Modules\FileListLoadTest\FileListLoadTest.psd1" -FileList @("FileListLoadTest.dll")
     }
 
+    AfterAll {
+        $env:PSModulePath = $originalPSModulePath
+    }
+
     It "Assemblies in FileList are not loaded" {
         Import-Module FileListLoadTest
         $asms = [System.AppDomain]::CurrentDomain.GetAssemblies().Location

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -361,3 +361,32 @@ Describe "Import-Module -Force behaviour" -Tag "CI" {
         { Test-Two } | Should -Throw -ErrorId 'CommandNotFoundException'
     }
 }
+
+Describe "Module with FileList" -Tag "CI" {
+    BeforeAll {
+        $src = @"
+            using System;
+            namespace ModuleCmdlets
+            {
+                public class FileListLoad
+                {
+                }
+            }
+"@
+
+        $originalPSModulePath = $env:PSModulePath
+        New-Item -ItemType Directory -Path "$testdrive\Modules\FileListLoadTest\" -Force > $null
+
+        $asmPath = "$TESTDRIVE\Modules\FileListLoadTest\FileListLoadTest.dll"
+        Add-Type -TypeDefinition $src -OutputAssembly $asmPath
+
+        $env:PSModulePath += [System.IO.Path]::PathSeparator + "$testdrive\Modules"
+        New-ModuleManifest -Path "$testdrive\Modules\FileListLoadTest\FileListLoadTest.psd1" -FileList @("FileListLoadTest.dll")
+    }
+
+    It "Assemblies in FileList are not loaded" {
+        Import-Module FileListLoadTest
+        $asms = [System.AppDomain]::CurrentDomain.GetAssemblies().Location
+        $asmPath | Should -Not -BeIn $asms
+    }
+}


### PR DESCRIPTION
Fixes #12821 

# PR Summary

Assemblies listed in `FileList` of the `psd1` should not be loaded when the module is loaded. This change fixes the regression introduced in `6.2.0-preview.2`

## PR Context

Regression was introduced as a side effect of https://github.com/PowerShell/PowerShell/pull/8073

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
