### PR TITLE
Use correct isError parameter with Write-Log

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -3173,7 +3173,7 @@ function New-TestPackage
     else
     {
         $null = New-Item -Path $Destination -ItemType Directory -Force
-        Write-Verbose -message "Creating destination folder: $Destination"
+        Write-Verbose -Message "Creating destination folder: $Destination"
     }
 
     $rootFolder = $env:TEMP

--- a/build.psm1
+++ b/build.psm1
@@ -3194,12 +3194,12 @@ function New-TestPackage
     $null = Publish-PSTestTools -runtime $Runtime
     $powerShellTestRoot =  Join-Path $PSScriptRoot 'test'
     Copy-Item $powerShellTestRoot -Recurse -Destination $packageRoot -Force
-    Write-Verbose -message "Copied test directory"
+    Write-Verbose -Message "Copied test directory"
 
     # Copy assests folder to package root for wix related tests.
     $assetsPath = Join-Path $PSScriptRoot 'assets'
     Copy-Item $assetsPath -Recurse -Destination $packageRoot -Force
-    Write-Verbose -message "Copied assests directory"
+    Write-Verbose -Message "Copied assests directory"
 
     # Create expected folder structure for resx files in package root.
     $srcRootForResx = New-Item -Path "$packageRoot/src" -Force -ItemType Directory
@@ -3215,7 +3215,7 @@ function New-TestPackage
         $assemblyPart = $assemblyPart.TrimStart([io.path]::DirectorySeparatorChar)
         $resxDestPath = Join-Path $srcRootForResx $assemblyPart
         $null = New-Item -Path $resxDestPath -Force -ItemType Directory
-        Write-Verbose -message "Created resx directory : $resxDestPath"
+        Write-Verbose -Message "Created resx directory : $resxDestPath"
         Copy-Item -Path "$directoryFullName\*" -Recurse $resxDestPath -Force
     }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

It looks like the wrong parameter was being used with `Write-Log` causing difficulties when logging errors.
<!-- Summarize your PR between here and the checklist. -->

## PR Context

Created from #11592
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
