### PR TITLE
Fix tests writing errors to console.

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FileHash.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FileHash.Tests.ps1
@@ -24,14 +24,14 @@ Describe "Get-FileHash" -Tags "CI" {
         }
 
         It "Should write non-terminating error if argument is a folder" {
-            $result = $PSHOME, "${pshome}\pwsh.dll" | Get-FileHash -ErrorVariable errorVariable
+            $result = $PSHOME, "${pshome}\pwsh.dll" | Get-FileHash -ErrorVariable errorVariable -ErrorAction SilentlyContinue
             $result.Count | Should -Be 1
             $errorVariable.FullyQualifiedErrorId | Should -BeExactly "UnauthorizedAccessError,Microsoft.PowerShell.Commands.GetFileHashCommand"
         }
 
         It "Should write non-terminating error if a file is locked" -Skip:(-not $IsWindows) {
             $pagefilePath = (Get-CimInstance -ClassName Win32_PageFileusage).Name
-            $result = $pagefilePath, "${pshome}\pwsh.dll" | Get-FileHash -ErrorVariable errorVariable
+            $result = $pagefilePath, "${pshome}\pwsh.dll" | Get-FileHash -ErrorVariable errorVariable -ErrorAction SilentlyContinue
             $result.Count | Should -Be 1
             $errorVariable.FullyQualifiedErrorId | Should -BeExactly "FileReadError,Microsoft.PowerShell.Commands.GetFileHashCommand"
         }
@@ -89,7 +89,7 @@ Describe "Get-FileHash" -Tags "CI" {
             $newPath = Get-FileHash -Path $testDocumentCopy | Rename-Item -NewName {$_.Hash} -PassThru
             $newPath.FullName | Should -Exist
 
-            Remove-Item -Path $testDocumentCopy -Force
+            Remove-Item -Path $testDocumentCopy -Force -ErrorAction SilentlyContinue
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-RunspaceDebug.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-RunspaceDebug.Tests.ps1
@@ -4,10 +4,10 @@ Describe "Get-RunspaceDebug" -Tags "CI" {
 
     Context "Check return types of RunspaceDebug" {
 
-    It "Should return Microsoft.Powershell.Commands.PSRunspaceDebug as the return type" {
-        $rs = Get-RunspaceDebug
-        $rs | Should -Not -BeNullOrEmpty
-        $rs[0] | Should -BeOfType Microsoft.PowerShell.Commands.PSRunspaceDebug
-    }
+        It "Should return Microsoft.Powershell.Commands.PSRunspaceDebug as the return type" {
+            $rs = Get-RunspaceDebug -ErrorAction SilentlyContinue
+            $rs | Should -Not -BeNullOrEmpty
+            $rs[0] | Should -BeOfType Microsoft.PowerShell.Commands.PSRunspaceDebug
+        }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Issue #12982

This PR fixes some tests that were writing errors to console, as well as checking for an error condition.

## PR Context

I found only three places where this was happening.  The other errors linked in the issue were known 'rooted path' and 'ambiguous parameter set' errors.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
