### PR TITLE
Handle when the ICO file isn't present

### DIFF
--- a/tools/install-powershell.ps1
+++ b/tools/install-powershell.ps1
@@ -425,7 +425,7 @@ try {
     if ($IsWinEnv -and $Daily.IsPresent) {
         if (-not (Test-Path "~/.rcedit/rcedit-x64.exe")) {
             Write-Verbose "Install RCEdit for modifying exe resources" -Verbose
-            $rceditUrl = "https://github.com/electron/rcedit/releases/download/v1.0.0/rcedit-x64.exe"
+            $rceditUrl = "https://github.com/electron/rcedit/releases/download/v1.1.1/rcedit-x64.exe"
             $null = New-Item -Path "~/.rcedit" -Type Directory -Force -ErrorAction SilentlyContinue
             Invoke-WebRequest -OutFile "~/.rcedit/rcedit-x64.exe" -Uri $rceditUrl
         }

--- a/tools/install-powershell.ps1
+++ b/tools/install-powershell.ps1
@@ -423,18 +423,29 @@ try {
 
     # Edit icon to disambiguate daily builds.
     if ($IsWinEnv -and $Daily.IsPresent) {
-        if (-not (Test-Path "~/.rcedit/rcedit-x64.exe")) {
-            Write-Verbose "Install RCEdit for modifying exe resources" -Verbose
-            $rceditUrl = "https://github.com/electron/rcedit/releases/download/v1.1.1/rcedit-x64.exe"
-            $null = New-Item -Path "~/.rcedit" -Type Directory -Force -ErrorAction SilentlyContinue
-            Invoke-WebRequest -OutFile "~/.rcedit/rcedit-x64.exe" -Uri $rceditUrl
+        $skipRunning = $false
+        
+        # Test if a few paths DO NOT exist and handle them accordingly.
+        switch ($false) {
+            (Test-Path "$Destination\pwsh.exe") {
+                throw "$Destination\pwsh.exe not found. Please review the contents of the daily package."
+            }
+            (Test-Path "$Destination\assets\Powershell_avatar.ico") {
+                Write-Warning "ICO file ($Destination\assets\Powershell_avatar.ico) not found. Skipping running rcedit."
+                $skipRunning = $true
+                break
+            }
+            (Test-Path "~/.rcedit/rcedit-x64.exe") {
+                Write-Verbose "Install RCEdit for modifying exe resources" -Verbose
+                $rceditUrl = "https://github.com/electron/rcedit/releases/download/v1.1.1/rcedit-x64.exe"
+                $null = New-Item -Path "~/.rcedit" -Type Directory -Force -ErrorAction SilentlyContinue
+                Invoke-WebRequest -OutFile "~/.rcedit/rcedit-x64.exe" -Uri $rceditUrl
+            }
         }
 
         Write-Verbose "Change icon to disambiguate it from a released installation" -Verbose
-        if (Test-Path "$Destination\assets\Powershell_avatar.ico") {
+        if (-not $skipRunning) {
             & "~/.rcedit/rcedit-x64.exe" "$Destination\pwsh.exe" --set-icon "$Destination\assets\Powershell_avatar.ico"
-        } else {
-            Write-Error "ICO file ($Destination\assets\Powershell_avatar.ico) not found. Skipping running rcedit."
         }
     }
 

--- a/tools/install-powershell.ps1
+++ b/tools/install-powershell.ps1
@@ -423,8 +423,7 @@ try {
 
     # Edit icon to disambiguate daily builds.
     if ($IsWinEnv -and $Daily.IsPresent) {
-        $rceditPath = "~/.rcedit/rcedit-x64.exe"
-        if (-not (Test-Path $rceditPath)) {
+        if (-not (Test-Path "~/.rcedit/rcedit-x64.exe")) {
             Write-Verbose "Install RCEdit for modifying exe resources" -Verbose
             $rceditUrl = "https://github.com/electron/rcedit/releases/download/v1.1.1/rcedit-x64.exe"
             $null = New-Item -Path "~/.rcedit" -Type Directory -Force -ErrorAction SilentlyContinue
@@ -432,12 +431,10 @@ try {
         }
 
         Write-Verbose "Change icon to disambiguate it from a released installation" -Verbose
-        try {
-            $rceditArgs = @("$Destination\pwsh.exe", "--set-icon", "$Destination\assets\Powershell_avatar.ico")
-            Write-Verbose "rcedit args: $rceditArgs" -Verbose
-            & $rceditPath @rceditArgs
-        } catch {
-            Write-Warning "rcedit-x64.exe exited with non-zero exit code. The icon may not have been updated."
+        if (Test-Path "$Destination\assets\Powershell_avatar.ico") {
+            & "~/.rcedit/rcedit-x64.exe" "$Destination\pwsh.exe" --set-icon "$Destination\assets\Powershell_avatar.ico"
+        } else {
+            Write-Error "ICO file ($Destination\assets\Powershell_avatar.ico) not found. Skipping running rcedit."
         }
     }
 

--- a/tools/install-powershell.ps1
+++ b/tools/install-powershell.ps1
@@ -431,7 +431,11 @@ try {
         }
 
         Write-Verbose "Change icon to disambiguate it from a released installation" -Verbose
-        & "~/.rcedit/rcedit-x64.exe" "$Destination\pwsh.exe" --set-icon "$Destination\assets\Powershell_avatar.ico"
+        try {
+            & "~/.rcedit/rcedit-x64.exe" "$Destination\pwsh.exe" --set-icon "$Destination\assets\Powershell_avatar.ico"
+        } catch {
+            Write-Warning "rcedit-x64.exe exited with non-zero exit code. The icon may not have been updated."
+        }
     }
 
     ## Change the mode of 'pwsh' to 'rwxr-xr-x' to allow execution

--- a/tools/install-powershell.ps1
+++ b/tools/install-powershell.ps1
@@ -433,9 +433,9 @@ try {
 
         Write-Verbose "Change icon to disambiguate it from a released installation" -Verbose
         try {
-            $rceditArgs = @("'$Destination\pwsh.exe'", "--set-icon", "'$Destination\assets\Powershell_avatar.ico'")
+            $rceditArgs = @("$Destination\pwsh.exe", "--set-icon", "$Destination\assets\Powershell_avatar.ico")
             Write-Verbose "rcedit args: $rceditArgs" -Verbose
-            & $rceditPath $rceditArgs
+            & $rceditPath @rceditArgs
         } catch {
             Write-Warning "rcedit-x64.exe exited with non-zero exit code. The icon may not have been updated."
         }

--- a/tools/install-powershell.ps1
+++ b/tools/install-powershell.ps1
@@ -433,9 +433,9 @@ try {
 
         Write-Verbose "Change icon to disambiguate it from a released installation" -Verbose
         try {
-            $rceditArgs = @("$Destination\pwsh.exe", "--set-icon", "$Destination\assets\Powershell_avatar.ico")
+            $rceditArgs = @("'$Destination\pwsh.exe'", "--set-icon", "'$Destination\assets\Powershell_avatar.ico'")
             Write-Verbose "rcedit args: $rceditArgs" -Verbose
-            & $rceditPath $rceditArgs
+            & $rceditPath @rceditArgs
         } catch {
             Write-Warning "rcedit-x64.exe exited with non-zero exit code. The icon may not have been updated."
         }

--- a/tools/install-powershell.ps1
+++ b/tools/install-powershell.ps1
@@ -423,7 +423,8 @@ try {
 
     # Edit icon to disambiguate daily builds.
     if ($IsWinEnv -and $Daily.IsPresent) {
-        if (-not (Test-Path "~/.rcedit/rcedit-x64.exe")) {
+        $rceditPath = "~/.rcedit/rcedit-x64.exe"
+        if (-not (Test-Path $rceditPath)) {
             Write-Verbose "Install RCEdit for modifying exe resources" -Verbose
             $rceditUrl = "https://github.com/electron/rcedit/releases/download/v1.1.1/rcedit-x64.exe"
             $null = New-Item -Path "~/.rcedit" -Type Directory -Force -ErrorAction SilentlyContinue
@@ -432,7 +433,9 @@ try {
 
         Write-Verbose "Change icon to disambiguate it from a released installation" -Verbose
         try {
-            & "~/.rcedit/rcedit-x64.exe" "$Destination\pwsh.exe" --set-icon "$Destination\assets\Powershell_avatar.ico"
+            $rceditArgs = @("$Destination\pwsh.exe", "--set-icon" "$Destination\assets\Powershell_avatar.ico")
+            Write-Verbose "rcedit args: $rceditArgs"
+            & $rceditPath $rceditArgs
         } catch {
             Write-Warning "rcedit-x64.exe exited with non-zero exit code. The icon may not have been updated."
         }

--- a/tools/install-powershell.ps1
+++ b/tools/install-powershell.ps1
@@ -433,7 +433,7 @@ try {
 
         Write-Verbose "Change icon to disambiguate it from a released installation" -Verbose
         try {
-            $rceditArgs = @("$Destination\pwsh.exe", "--set-icon" "$Destination\assets\Powershell_avatar.ico")
+            $rceditArgs = @("$Destination\pwsh.exe", "--set-icon", "$Destination\assets\Powershell_avatar.ico")
             Write-Verbose "rcedit args: $rceditArgs"
             & $rceditPath $rceditArgs
         } catch {

--- a/tools/install-powershell.ps1
+++ b/tools/install-powershell.ps1
@@ -434,7 +434,7 @@ try {
         Write-Verbose "Change icon to disambiguate it from a released installation" -Verbose
         try {
             $rceditArgs = @("$Destination\pwsh.exe", "--set-icon", "$Destination\assets\Powershell_avatar.ico")
-            Write-Verbose "rcedit args: $rceditArgs"
+            Write-Verbose "rcedit args: $rceditArgs" -Verbose
             & $rceditPath $rceditArgs
         } catch {
             Write-Warning "rcedit-x64.exe exited with non-zero exit code. The icon may not have been updated."

--- a/tools/install-powershell.ps1
+++ b/tools/install-powershell.ps1
@@ -435,7 +435,7 @@ try {
         try {
             $rceditArgs = @("'$Destination\pwsh.exe'", "--set-icon", "'$Destination\assets\Powershell_avatar.ico'")
             Write-Verbose "rcedit args: $rceditArgs" -Verbose
-            & $rceditPath @rceditArgs
+            & $rceditPath $rceditArgs
         } catch {
             Write-Warning "rcedit-x64.exe exited with non-zero exit code. The icon may not have been updated."
         }

--- a/tools/install-powershell.ps1
+++ b/tools/install-powershell.ps1
@@ -443,8 +443,8 @@ try {
             }
         }
 
-        Write-Verbose "Change icon to disambiguate it from a released installation" -Verbose
         if (-not $skipRunning) {
+            Write-Verbose "Change icon to disambiguate it from a released installation" -Verbose
             & "~/.rcedit/rcedit-x64.exe" "$Destination\pwsh.exe" --set-icon "$Destination\assets\Powershell_avatar.ico"
         }
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

* Bump rcedit version used
* Check if ICO file exists before running rcedit

## PR Context

rcedit is failing to set icons in CI scenarios because the ICO doesn't exist in the package.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
