### PR TITLE
Avoid using long for disposed flag

### DIFF
--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimAsyncOperation.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimAsyncOperation.cs
@@ -442,9 +442,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         {
             get
             {
-                // Ensure the read of _disposed doesn't move up before the write in the Dispose method.
-                Interlocked.MemoryBarrier();
-
                 return this._disposed == 1;
             }
         }

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimAsyncOperation.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimAsyncOperation.cs
@@ -33,7 +33,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         {
             this.moreActionEvent = new ManualResetEventSlim(false);
             this.actionQueue = new ConcurrentQueue<CimBaseAction>();
-            this._disposed = 0;
             this.operationCount = 0;
         }
 
@@ -53,7 +52,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// <param name="actionArgs">Event argument.</param>
         protected void NewCmdletActionHandler(object cimSession, CmdletActionEventArgs actionArgs)
         {
-            DebugHelper.WriteLogEx("Disposed {0}, action type = {1}", 0, this._disposed, actionArgs.Action);
+            DebugHelper.WriteLogEx("Disposed {0}, action type = {1}", 0, this.Disposed, actionArgs.Action);
 
             if (this.Disposed)
             {
@@ -443,11 +442,11 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         {
             get
             {
-                return Interlocked.Read(ref this._disposed) == 1;
+                return Interlocked.CompareExchange(ref this._disposed, 0, 0) == 1;
             }
         }
 
-        private long _disposed;
+        private int _disposed;
 
         /// <summary>
         /// <para>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimAsyncOperation.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimAsyncOperation.cs
@@ -442,7 +442,8 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         {
             get
             {
-                return Interlocked.CompareExchange(ref this._disposed, 0, 0) == 1;
+                Interlocked.MemoryBarrier();
+                return this._disposed == 1;
             }
         }
 

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimAsyncOperation.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimAsyncOperation.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         {
             this.moreActionEvent = new ManualResetEventSlim(false);
             this.actionQueue = new ConcurrentQueue<CimBaseAction>();
+            this._disposed = 0;
             this.operationCount = 0;
         }
 

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimAsyncOperation.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimAsyncOperation.cs
@@ -442,7 +442,9 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         {
             get
             {
+                // Ensure the read of _disposed doesn't move up before the write in the Dispose method.
                 Interlocked.MemoryBarrier();
+
                 return this._disposed == 1;
             }
         }


### PR DESCRIPTION
# PR Summary

Avoid unecessary `Int64` for disposed flag in `CimAsyncOperation.cs`

## PR Context

The original intent appears to be to allow use of `Interlocked.Read(Int64)`. However this is implemented in the BCL with `Interlocked.CompareExchange(ref location, 0, 0)`. We can use that pattern with an `Int32`.

<https://stackoverflow.com/a/24893231>

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
