### PR TITLE
Enable New-Item creates symlinks to non-existent targets

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
@@ -2114,40 +2114,37 @@ namespace Microsoft.PowerShell.Commands
                 Path = new string[] { string.Empty };
             }
 
-            foreach (string path in Path)
+            try
             {
-                try
-                {
-                    InvokeProvider.Item.New(path, Name, ItemType, Value, CmdletProviderContext);
-                }
-                catch (PSNotSupportedException notSupported)
-                {
-                    WriteError(
-                        new ErrorRecord(
-                            notSupported.ErrorRecord,
-                            notSupported));
-                }
-                catch (DriveNotFoundException driveNotFound)
-                {
-                    WriteError(
-                        new ErrorRecord(
-                            driveNotFound.ErrorRecord,
-                            driveNotFound));
-                }
-                catch (ProviderNotFoundException providerNotFound)
-                {
-                    WriteError(
-                        new ErrorRecord(
-                            providerNotFound.ErrorRecord,
-                            providerNotFound));
-                }
-                catch (ItemNotFoundException pathNotFound)
-                {
-                    WriteError(
-                        new ErrorRecord(
-                            pathNotFound.ErrorRecord,
-                            pathNotFound));
-                }
+                InvokeProvider.Item.New(Path, Name, ItemType, Value, CmdletProviderContext);
+            }
+            catch (PSNotSupportedException notSupported)
+            {
+                WriteError(
+                    new ErrorRecord(
+                        notSupported.ErrorRecord,
+                        notSupported));
+            }
+            catch (DriveNotFoundException driveNotFound)
+            {
+                WriteError(
+                    new ErrorRecord(
+                        driveNotFound.ErrorRecord,
+                        driveNotFound));
+            }
+            catch (ProviderNotFoundException providerNotFound)
+            {
+                WriteError(
+                    new ErrorRecord(
+                        providerNotFound.ErrorRecord,
+                        providerNotFound));
+            }
+            catch (ItemNotFoundException pathNotFound)
+            {
+                WriteError(
+                    new ErrorRecord(
+                        pathNotFound.ErrorRecord,
+                        pathNotFound));
             }
         }
 

--- a/src/System.Management.Automation/engine/ItemCmdletProviderInterfaces.cs
+++ b/src/System.Management.Automation/engine/ItemCmdletProviderInterfaces.cs
@@ -1128,7 +1128,7 @@ namespace System.Management.Automation
         /// If the provider threw an exception.
         /// </exception>
         internal void New(
-            string path,
+            string[] path,
             string name,
             string type,
             object content,
@@ -1140,7 +1140,7 @@ namespace System.Management.Automation
 
             // Parameter validation is done in the session state object
 
-            _sessionState.NewItem(new string[] { path }, name, type, content, context);
+            _sessionState.NewItem(path, name, type, content, context);
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -3505,39 +3505,6 @@ namespace System.Management.Automation
                         }
 
                         targetPath = targetPath?.Replace(StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator);
-
-                        try
-                        {
-                            Collection<string> globbedTarget = Globber.GetGlobbedProviderPathsFromMonadPath(
-                                targetPath,
-                                allowNonexistingPath,
-                                context,
-                                out ProviderInfo targetProvider,
-                                out CmdletProvider targetProviderInstance);
-
-                            if (!string.Equals(targetProvider.Name, "filesystem", StringComparison.OrdinalIgnoreCase))
-                            {
-                                throw PSTraceSource.NewNotSupportedException(SessionStateStrings.MustBeFileSystemPath);
-                            }
-
-                            if (globbedTarget.Count > 1)
-                            {
-                                throw PSTraceSource.NewInvalidOperationException(SessionStateStrings.PathResolvedToMultiple, targetPath);
-                            }
-
-                            if (globbedTarget.Count == 0)
-                            {
-                                throw PSTraceSource.NewInvalidOperationException(SessionStateStrings.PathNotFound, targetPath);
-                            }
-                        }
-                        catch
-                        {
-                            // If Force switch presents we consider the 'content' target path literally otherwise throws.
-                            if (!context.Force)
-                            {
-                                throw;
-                            }
-                        }
                     }
 
                     NewItemPrivate(providerInstance, composedPath, type, targetPath, context);

--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -3459,44 +3459,48 @@ namespace System.Management.Automation
                                 out providerInstance);
                 }
 
-                // Don't support 'New-Item -Type Directory' on the Function provider
-                // if the runspace has ever been in constrained language mode, as the mkdir
-                // function can be abused
-                if (context.ExecutionContext.HasRunspaceEverUsedConstrainedLanguageMode &&
-                    (providerInstance is Microsoft.PowerShell.Commands.FunctionProvider) &&
-                    (string.Equals(type, "Directory", StringComparison.OrdinalIgnoreCase)))
-                {
-                    throw
-                        PSTraceSource.NewNotSupportedException(SessionStateStrings.DriveCmdletProvider_NotSupported);
-                }
-
-                // Symbolic link targets are allowed to not exist on both Windows and Linux
-                bool allowNonexistingPath = false;
-                bool isSymbolicJunctionOrHardLink = false;
-
-                if (type != null)
-                {
-                    WildcardPattern typeEvaluator = WildcardPattern.Get(type + "*", WildcardOptions.IgnoreCase | WildcardOptions.Compiled);
-
-                    allowNonexistingPath = typeEvaluator.IsMatch("symboliclink");
-                    isSymbolicJunctionOrHardLink = allowNonexistingPath || typeEvaluator.IsMatch("junction") || typeEvaluator.IsMatch("hardlink");
-                }
-
                 foreach (string providerPath in providerPaths)
                 {
                     // Compose the globbed container and the name together to get a path
                     // to pass on to the provider.
+
                     string composedPath = providerPath;
                     if (!string.IsNullOrEmpty(name))
                     {
                         composedPath = MakePath(providerInstance, providerPath, name, context);
                     }
 
-                    string targetPath = content?.ToString()?.Replace(StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator);
+                    // Don't support 'New-Item -Type Directory' on the Function provider
+                    // if the runspace has ever been in constrained language mode, as the mkdir
+                    // function can be abused
+                    if (context.ExecutionContext.HasRunspaceEverUsedConstrainedLanguageMode &&
+                        (providerInstance is Microsoft.PowerShell.Commands.FunctionProvider) &&
+                        (string.Equals(type, "Directory", StringComparison.OrdinalIgnoreCase)))
+                    {
+                        throw
+                            PSTraceSource.NewNotSupportedException(SessionStateStrings.DriveCmdletProvider_NotSupported);
+                    }
+
+                    bool isSymbolicJunctionOrHardLink = false;
+                    // Symbolic link targets are allowed to not exist on both Windows and Linux
+                    bool allowNonexistingPath = false;
+
+                    if (type != null)
+                    {
+                        WildcardPattern typeEvaluator = WildcardPattern.Get(type + "*", WildcardOptions.IgnoreCase | WildcardOptions.Compiled);
+
+                        if (typeEvaluator.IsMatch("symboliclink") || typeEvaluator.IsMatch("junction") || typeEvaluator.IsMatch("hardlink"))
+                        {
+                            isSymbolicJunctionOrHardLink = true;
+                            allowNonexistingPath = typeEvaluator.IsMatch("symboliclink");
+                        }
+                    }
 
                     if (isSymbolicJunctionOrHardLink)
                     {
-                        if (string.IsNullOrEmpty(targetPath))
+                        string targetPath;
+
+                        if (content is null || string.IsNullOrEmpty(targetPath = content.ToString()))
                         {
                             throw PSTraceSource.NewArgumentNullException(nameof(content), SessionStateStrings.NewLinkTargetNotSpecified, path);
                         }
@@ -3506,7 +3510,7 @@ namespace System.Management.Automation
                             ProviderInfo targetProvider = null;
                             CmdletProvider targetProviderInstance = null;
 
-                            Collection<string> globbedTarget = Globber.GetGlobbedProviderPathsFromMonadPath(
+                            var globbedTarget = Globber.GetGlobbedProviderPathsFromMonadPath(
                                 targetPath,
                                 allowNonexistingPath,
                                 context,
@@ -3518,9 +3522,21 @@ namespace System.Management.Automation
                                 throw PSTraceSource.NewNotSupportedException(SessionStateStrings.MustBeFileSystemPath);
                             }
 
+                            if (globbedTarget.Count > 1)
+                            {
+                                throw PSTraceSource.NewInvalidOperationException(SessionStateStrings.PathResolvedToMultiple, targetPath);
+                            }
+
                             if (globbedTarget.Count == 0)
                             {
                                 throw PSTraceSource.NewInvalidOperationException(SessionStateStrings.PathNotFound, targetPath);
+                            }
+
+                            // If the original target was a relative path, we want to leave it as relative if it did not require
+                            // globbing to resolve.
+                            if (WildcardPattern.ContainsWildcardCharacters(targetPath))
+                            {
+                                content = globbedTarget[0];
                             }
                         }
                         catch
@@ -3533,7 +3549,7 @@ namespace System.Management.Automation
                         }
                     }
 
-                    NewItemPrivate(providerInstance, composedPath, type, targetPath, context);
+                    NewItemPrivate(providerInstance, composedPath, type, content, context);
                 }
             }
         }
@@ -3569,7 +3585,7 @@ namespace System.Management.Automation
             CmdletProvider providerInstance,
             string path,
             string type,
-            string content,
+            object content,
             CmdletProviderContext context)
         {
             // All parameters should have been validated by caller

--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -3505,36 +3505,47 @@ namespace System.Management.Automation
                             throw PSTraceSource.NewArgumentNullException(nameof(content), SessionStateStrings.NewLinkTargetNotSpecified, path);
                         }
 
-                        ProviderInfo targetProvider = null;
-                        CmdletProvider targetProviderInstance = null;
-
-                        var globbedTarget = Globber.GetGlobbedProviderPathsFromMonadPath(
-                            targetPath,
-                            allowNonexistingPath,
-                            context,
-                            out targetProvider,
-                            out targetProviderInstance);
-
-                        if (!string.Equals(targetProvider.Name, "filesystem", StringComparison.OrdinalIgnoreCase))
+                        try
                         {
-                            throw PSTraceSource.NewNotSupportedException(SessionStateStrings.MustBeFileSystemPath);
+                            ProviderInfo targetProvider = null;
+                            CmdletProvider targetProviderInstance = null;
+
+                            var globbedTarget = Globber.GetGlobbedProviderPathsFromMonadPath(
+                                targetPath,
+                                allowNonexistingPath,
+                                context,
+                                out targetProvider,
+                                out targetProviderInstance);
+
+                            if (!string.Equals(targetProvider.Name, "filesystem", StringComparison.OrdinalIgnoreCase))
+                            {
+                                throw PSTraceSource.NewNotSupportedException(SessionStateStrings.MustBeFileSystemPath);
+                            }
+
+                            if (globbedTarget.Count > 1)
+                            {
+                                throw PSTraceSource.NewInvalidOperationException(SessionStateStrings.PathResolvedToMultiple, targetPath);
+                            }
+
+                            if (globbedTarget.Count == 0)
+                            {
+                                throw PSTraceSource.NewInvalidOperationException(SessionStateStrings.PathNotFound, targetPath);
+                            }
+
+                            // If the original target was a relative path, we want to leave it as relative if it did not require
+                            // globbing to resolve.
+                            if (WildcardPattern.ContainsWildcardCharacters(targetPath))
+                            {
+                                content = globbedTarget[0];
+                            }
                         }
-
-                        if (globbedTarget.Count > 1)
+                        catch
                         {
-                            throw PSTraceSource.NewInvalidOperationException(SessionStateStrings.PathResolvedToMultiple, targetPath);
-                        }
-
-                        if (globbedTarget.Count == 0)
-                        {
-                            throw PSTraceSource.NewInvalidOperationException(SessionStateStrings.PathNotFound, targetPath);
-                        }
-
-                        // If the original target was a relative path, we want to leave it as relative if it did not require
-                        // globbing to resolve.
-                        if (WildcardPattern.ContainsWildcardCharacters(targetPath))
-                        {
-                            content = globbedTarget[0];
+                            // If Force switch presents we consider the 'content' target path literally otherwise throws.
+                            if (!context.Force)
+                            {
+                                throw;
+                            }
                         }
                     }
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -2380,8 +2380,6 @@ namespace Microsoft.PowerShell.Commands
                             }
 
                             GetFileSystemInfo(normalizedTargetPath, out isDirectory);
-
-                            strTargetPath = strTargetPath.Replace(StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator);
                         }
                         else
                         {

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -2380,6 +2380,8 @@ namespace Microsoft.PowerShell.Commands
                             }
 
                             GetFileSystemInfo(normalizedTargetPath, out isDirectory);
+
+                            strTargetPath = strTargetPath.Replace(StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator);
                         }
                         else
                         {

--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -757,20 +757,31 @@ namespace System.Management.Automation
                 }
 
                 PSDriveInfo drive = null;
-                string providerPath = GetProviderPath(path, context, out provider, out drive);
-
-                if (providerPath == null)
+                provider = null;
+                try
                 {
-                    providerInstance = null;
-                    s_tracer.WriteLine("provider returned a null path so return an empty array");
+                    string providerPath = GetProviderPath(path, context, out provider, out drive);
 
-                    s_pathResolutionTracer.WriteLine("Provider '{0}' returned null", provider);
-                    return new Collection<string>();
+                    if (providerPath == null)
+                    {
+                        providerInstance = null;
+                        s_tracer.WriteLine("provider returned a null path so return an empty array");
+
+                        s_pathResolutionTracer.WriteLine("Provider '{0}' returned null", provider);
+                        return new Collection<string>();
+                    }
+
+                    if (drive != null)
+                    {
+                        context.Drive = drive;
+                    }
                 }
-
-                if (drive != null)
+                catch (DriveNotFoundException)
                 {
-                    context.Drive = drive;
+                    if (!allowNonexistingPaths)
+                    {
+                        throw;
+                    }
                 }
 
                 Collection<string> paths = new Collection<string>();

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -330,7 +330,7 @@ Describe "New-Item: symlink with absolute/relative path test" -Tags @('CI', 'Req
         $link = New-Item -Type SymbolicLink globbedAbsoluteLink1 -Target $absolutePath
         (Get-Item $link).Target | Should -BeExactly $absolutePath
 
-        $link = New-Item -Type SymbolicLink globbedRelativeLink1 -Target $fileName
+        $link = New-Item -Type SymbolicLink globbedRelativeLink1 -Target ./$fileName
         (Get-Item $link).Target | Should -BeExactly $fileName
     }
 
@@ -341,7 +341,7 @@ Describe "New-Item: symlink with absolute/relative path test" -Tags @('CI', 'Req
         $link = New-Item -Type SymbolicLink globbedAbsoluteLink2 -Target $absolutePath
         (Get-Item $link).Target | Should -BeExactly $absolutePath
 
-        $link = New-Item -Type SymbolicLink globbedRelativeLink2 -Target $fileName
+        $link = New-Item -Type SymbolicLink globbedRelativeLink2 -Target ./$fileName
         (Get-Item $link).Target | Should -BeExactly $fileName
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -335,6 +335,7 @@ Describe "New-Item: symlink with absolute/relative path test" -Tags @('CI', 'Req
         $fileName = 'file[1].txt'
 
         if (-not $IsWindows) {
+            # Tracking issue https://github.com/PowerShell/PowerShell/issues/13365
             Set-ItResult -Pending -Because "On Unix the Target property is always resolved to an absolute path."
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -331,7 +331,7 @@ Describe "New-Item: symlink with absolute/relative path test" -Tags @('CI', 'Req
         (Get-Item $link).Target | Should -BeExactly $absolutePath
 
         $link = New-Item -Type SymbolicLink globbedRelativeLink1 -Target ./$fileName
-        (Get-Item $link).Target | Should -BeExactly ($fileName -replace '[\\/]', [IO.Path]::DirectorySeparatorChar)
+        (Get-Item $link).Target | Should -BeExactly (./$fileName -replace '[\\/]', [IO.Path]::DirectorySeparatorChar)
     }
 
     It "Can create symlink with absolute/relative nonexistent target as literal path" {
@@ -342,7 +342,7 @@ Describe "New-Item: symlink with absolute/relative path test" -Tags @('CI', 'Req
         (Get-Item $link).Target | Should -BeExactly $absolutePath
 
         $link = New-Item -Type SymbolicLink globbedRelativeLink2 -Target ./$fileName
-        (Get-Item $link).Target | Should -BeExactly ($fileName -replace '[\\/]', [IO.Path]::DirectorySeparatorChar)
+        (Get-Item $link).Target | Should -BeExactly (./$fileName -replace '[\\/]', [IO.Path]::DirectorySeparatorChar)
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -323,27 +323,35 @@ Describe "New-Item: symlink with absolute/relative path test" -Tags @('CI', 'Req
         (Get-Item $link).Target | Should -Be ($target -replace '[\\/]', [IO.Path]::DirectorySeparatorChar)
     }
 
-    It "Can create symlink with absolute/relative existent target as literal path" {
+    It "Can create symlink with absolute existent target as literal path" {
         $fileName = 'file[1].txt'
         $absolutePath = (New-Item -Type File $fileName).FullName
 
         $link = New-Item -Type SymbolicLink globbedAbsoluteLink1 -Target $absolutePath
         (Get-Item $link).Target | Should -BeExactly $absolutePath
+    }
+
+    It "Can create symlink with relative existent target as literal path" {
+        $fileName = 'file[1].txt'
 
         if (-not $IsWindows) {
-            Set-ItResilt -Pending -Because "On Unix the Target property is always resolved to an absolute path."
+            Set-ItResult -Pending -Because "On Unix the Target property is always resolved to an absolute path."
         }
 
         $link = New-Item -Type SymbolicLink globbedRelativeLink1 -Target ./$fileName
         (Get-Item $link).Target | Should -BeExactly ("./$fileName" -replace '[\\/]', [IO.Path]::DirectorySeparatorChar)
     }
 
-    It "Can create symlink with absolute/relative nonexistent target as literal path" {
+    It "Can create symlink with absolute nonexistent target as literal path" {
         $fileName = 'noexist_file[2].txt'
         $absolutePath = Join-Path $pwd $fileName
 
         $link = New-Item -Type SymbolicLink globbedAbsoluteLink2 -Target $absolutePath
         (Get-Item $link).Target | Should -BeExactly $absolutePath
+    }
+
+    It "Can create symlink with relative nonexistent target as literal path" {
+        $fileName = 'noexist_file[2].txt'
 
         $link = New-Item -Type SymbolicLink globbedRelativeLink2 -Target ./$fileName
         (Get-Item $link).Target | Should -BeExactly ("./$fileName" -replace '[\\/]', [IO.Path]::DirectorySeparatorChar)

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -331,7 +331,7 @@ Describe "New-Item: symlink with absolute/relative path test" -Tags @('CI', 'Req
         (Get-Item $link).Target | Should -BeExactly $absolutePath
 
         $link = New-Item -Type SymbolicLink globbedRelativeLink1 -Target ./$fileName
-        (Get-Item $link).Target | Should -BeExactly $fileName
+        (Get-Item $link).Target | Should -BeExactly ($fileName -replace '[\\/]', [IO.Path]::DirectorySeparatorChar)
     }
 
     It "Can create symlink with absolute/relative nonexistent target as literal path" {
@@ -342,7 +342,7 @@ Describe "New-Item: symlink with absolute/relative path test" -Tags @('CI', 'Req
         (Get-Item $link).Target | Should -BeExactly $absolutePath
 
         $link = New-Item -Type SymbolicLink globbedRelativeLink2 -Target ./$fileName
-        (Get-Item $link).Target | Should -BeExactly $fileName
+        (Get-Item $link).Target | Should -BeExactly ($fileName -replace '[\\/]', [IO.Path]::DirectorySeparatorChar)
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -331,7 +331,7 @@ Describe "New-Item: symlink with absolute/relative path test" -Tags @('CI', 'Req
         (Get-Item $link).Target | Should -BeExactly $absolutePath
 
         $link = New-Item -Type SymbolicLink globbedRelativeLink1 -Target ./$fileName
-        (Get-Item $link).Target | Should -BeExactly (./$fileName -replace '[\\/]', [IO.Path]::DirectorySeparatorChar)
+        (Get-Item $link).Target | Should -BeExactly ("./$fileName" -replace '[\\/]', [IO.Path]::DirectorySeparatorChar)
     }
 
     It "Can create symlink with absolute/relative nonexistent target as literal path" {
@@ -342,7 +342,7 @@ Describe "New-Item: symlink with absolute/relative path test" -Tags @('CI', 'Req
         (Get-Item $link).Target | Should -BeExactly $absolutePath
 
         $link = New-Item -Type SymbolicLink globbedRelativeLink2 -Target ./$fileName
-        (Get-Item $link).Target | Should -BeExactly (./$fileName -replace '[\\/]', [IO.Path]::DirectorySeparatorChar)
+        (Get-Item $link).Target | Should -BeExactly ("./$fileName" -replace '[\\/]', [IO.Path]::DirectorySeparatorChar)
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -316,13 +316,34 @@ Describe "New-Item: symlink with absolute/relative path test" -Tags @('CI', 'Req
     It "Can create symlink with relative nonexistent target '<target>'" -TestCases @{ link = $links[0]; target = $targets[0] }, @{ link = $links[1]; target = $targets[1] } {
         param($link, $target)
 
-        $null = New-Item -Type SymbolicLink $link -Target $target -Force
+        $null = New-Item -Type SymbolicLink $link -Target $target
 
         # Make sure the relative target path was recorded as such and uses
         # the platform-appropriate separator.
         (Get-Item $link).Target | Should -Be ($target -replace '[\\/]', [IO.Path]::DirectorySeparatorChar)
+    }
 
-      }
+    It "Can create symlink with absolute/relative existent target as literal path" {
+        $fileName = 'file[1].txt'
+        $absolutePath = (New-Item -Type File $fileName).FullName
+
+        $link = New-Item -Type SymbolicLink globbedAbsoluteLink1 -Target $absolutePath
+        (Get-Item $link).Target | Should -BeExactly $absolutePath
+
+        $link = New-Item -Type SymbolicLink globbedRelativeLink1 -Target $fileName
+        (Get-Item $link).Target | Should -BeExactly $fileName
+    }
+
+    It "Can create symlink with absolute/relative nonexistent target as literal path" {
+        $fileName = 'noexist_file[2].txt'
+        $absolutePath = Join-Path $pwd $fileName
+
+        $link = New-Item -Type SymbolicLink globbedAbsoluteLink2 -Target $absolutePath
+        (Get-Item $link).Target | Should -BeExactly $absolutePath
+
+        $link = New-Item -Type SymbolicLink globbedRelativeLink2 -Target $fileName
+        (Get-Item $link).Target | Should -BeExactly $fileName
+    }
 }
 
 Describe "New-Item with links fails for non elevated user if developer mode not enabled on Windows." -Tags "CI" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -330,6 +330,10 @@ Describe "New-Item: symlink with absolute/relative path test" -Tags @('CI', 'Req
         $link = New-Item -Type SymbolicLink globbedAbsoluteLink1 -Target $absolutePath
         (Get-Item $link).Target | Should -BeExactly $absolutePath
 
+        if (-not $IsWindows) {
+            Set-ItResilt -Pending -Because "On Unix the Target property is always resolved to an absolute path."
+        }
+
         $link = New-Item -Type SymbolicLink globbedRelativeLink1 -Target ./$fileName
         (Get-Item $link).Target | Should -BeExactly ("./$fileName" -replace '[\\/]', [IO.Path]::DirectorySeparatorChar)
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #9067.
Fix #13064.
Fix #13136.

1. Ignore exception if target path can not be resolved (is not exist) and consider it as literal (only first slash is normalized).
2. Create symlink in the case only if -Force switch presents.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
