### PR TITLE
Fix error message from new symbolic link missing target

### DIFF
--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -3500,14 +3500,14 @@ namespace System.Management.Automation
                     {
                         if (content == null)
                         {
-                            throw PSTraceSource.NewArgumentNullException(SessionStateStrings.NewItemValueNotSpecified, path);
+                            throw PSTraceSource.NewArgumentNullException(nameof(content), SessionStateStrings.NewItemValueNotSpecified, path);
                         }
 
                         string targetPath = content.ToString();
 
                         if (string.IsNullOrEmpty(targetPath))
                         {
-                            throw PSTraceSource.NewArgumentNullException(SessionStateStrings.PathNotFound, targetPath);
+                            throw PSTraceSource.NewArgumentNullException(nameof(targetPath), SessionStateStrings.PathNotFound, targetPath);
                         }
 
                         ProviderInfo targetProvider = null;

--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -3502,7 +3502,7 @@ namespace System.Management.Automation
 
                         if (content == null || string.IsNullOrEmpty(targetPath = content.ToString()))
                         {
-                            throw PSTraceSource.NewArgumentNullException(nameof(content), SessionStateStrings.NewItemValueNotSpecified, path);
+                            throw PSTraceSource.NewArgumentNullException(nameof(content), SessionStateStrings.NewLinkTargetNotSpecified, path);
                         }
 
                         ProviderInfo targetProvider = null;

--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -3498,16 +3498,12 @@ namespace System.Management.Automation
 
                     if (isSymbolicJunctionOrHardLink)
                     {
-                        if (content == null)
+
+                        string targetPath;
+
+                        if (null == content || string.IsNullOrEmpty(targetPath = content.ToString()))
                         {
                             throw PSTraceSource.NewArgumentNullException(nameof(content), SessionStateStrings.NewItemValueNotSpecified, path);
-                        }
-
-                        string targetPath = content.ToString();
-
-                        if (string.IsNullOrEmpty(targetPath))
-                        {
-                            throw PSTraceSource.NewArgumentNullException(nameof(targetPath), SessionStateStrings.PathNotFound, targetPath);
                         }
 
                         ProviderInfo targetProvider = null;

--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -3498,10 +3498,9 @@ namespace System.Management.Automation
 
                     if (isSymbolicJunctionOrHardLink)
                     {
-
                         string targetPath;
 
-                        if (null == content || string.IsNullOrEmpty(targetPath = content.ToString()))
+                        if (content == null || string.IsNullOrEmpty(targetPath = content.ToString()))
                         {
                             throw PSTraceSource.NewArgumentNullException(nameof(content), SessionStateStrings.NewItemValueNotSpecified, path);
                         }

--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -3500,7 +3500,7 @@ namespace System.Management.Automation
                     {
                         string targetPath;
 
-                        if (content == null || string.IsNullOrEmpty(targetPath = content.ToString()))
+                        if (content is null || string.IsNullOrEmpty(targetPath = content.ToString()))
                         {
                             throw PSTraceSource.NewArgumentNullException(nameof(content), SessionStateStrings.NewLinkTargetNotSpecified, path);
                         }
@@ -4946,4 +4946,3 @@ namespace System.Management.Automation
 }
 
 #pragma warning restore 56500
-

--- a/src/System.Management.Automation/resources/SessionStateStrings.resx
+++ b/src/System.Management.Automation/resources/SessionStateStrings.resx
@@ -663,8 +663,8 @@
   <data name="RemoveDriveRoot" xml:space="preserve">
     <value>Cannot remove the drive root in this way. Use "Remove-PSDrive" to remove this drive.</value>
   </data>
-  <data name="NewItemValueNotSpecified" xml:space="preserve">
-    <value>Item '{0}' cannot be created because the value was not specified.</value>
+  <data name="NewLinkTargetNotSpecified" xml:space="preserve">
+    <value>Link '{0}' cannot be created because Target was not specified.</value>
   </data>
   <data name="DollarNullDescription" xml:space="preserve">
     <value>References to the null variable always return the null value. Assignments have no effect.</value>

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -185,6 +185,11 @@ Describe "New-Item" -Tags "CI" {
             Pop-Location
         }
     }
+
+    It "Should display an error message when a symbolic link target is not specified" {
+        New-Item -Name $testfile -Path $tmpDirectory -ItemType SymbolicLink | Should -Throw -ErrorId 'ArgumentNull,Microsoft.PowerShell.Commands.NewItemCommand'
+        $ERROR | Select-Object -First 1 | Foreach-Object Exception | Foreach-Object Message | Should -Contain 'value'
+    }
 }
 
 # More precisely these tests require SeCreateSymbolicLinkPrivilege.

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -187,7 +187,7 @@ Describe "New-Item" -Tags "CI" {
     }
 
     It "Should display an error message when a symbolic link target is not specified" {
-        New-Item -Name $testfile -Path $tmpDirectory -ItemType SymbolicLink | Should -Throw -ErrorId 'ArgumentNull,Microsoft.PowerShell.Commands.NewItemCommand'
+        { New-Item -Name $testfile -Path $tmpDirectory -ItemType SymbolicLink } | Should -Throw -ErrorId 'ArgumentNull,Microsoft.PowerShell.Commands.NewItemCommand'
         $ERROR | Select-Object -First 1 | Foreach-Object Exception | Foreach-Object Message | Should -Contain 'value'
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -187,8 +187,10 @@ Describe "New-Item" -Tags "CI" {
     }
 
     It "Should display an error message when a symbolic link target is not specified" {
-        { New-Item -Name $testfile -Path $tmpDirectory -ItemType SymbolicLink } | Should -Throw -ErrorId 'ArgumentNull,Microsoft.PowerShell.Commands.NewItemCommand'
-        $ERROR | Select-Object -First 1 | Foreach-Object Exception | Foreach-Object Message | Should -Contain 'value'
+        { New-Item -Name:$testfile -Path:$tmpDirectory -ItemType:SymbolicLink } | Should -Throw -ErrorId 'ArgumentNull,Microsoft.PowerShell.Commands.NewItemCommand'
+        $Error | Select-Object -First:1 | Foreach-Object Exception | Foreach-Object ParamName | Should -Be 'content'
+        { New-Item -Name:$testfile -Path:$tmpDirectory -ItemType:SymbolicLink -Value:{} } | Should -Throw -ErrorId 'ArgumentNull,Microsoft.PowerShell.Commands.NewItemCommand'
+        $Error | Select-Object -First:2 | Foreach-Object Exception | Foreach-Object ParamName | Should -Be 'content'
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -188,9 +188,9 @@ Describe "New-Item" -Tags "CI" {
 
     It "Should display an error message when a symbolic link target is not specified" {
         { New-Item -Name $testfile -Path $tmpDirectory -ItemType SymbolicLink } | Should -Throw -ErrorId 'ArgumentNull,Microsoft.PowerShell.Commands.NewItemCommand'
-        $Error[0].Exception.ParamName | Should -BeExactly 'Content'
+        $Error[0].Exception.ParamName | Should -BeExactly 'content'
         { New-Item -Name $testfile -Path $tmpDirectory -ItemType:SymbolicLink -Value {} } | Should -Throw -ErrorId 'ArgumentNull,Microsoft.PowerShell.Commands.NewItemCommand'
-         $Error[0].Exception.ParamName | Should -BeExactly 'Content'
+         $Error[0].Exception.ParamName | Should -BeExactly 'content'
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -190,7 +190,7 @@ Describe "New-Item" -Tags "CI" {
         { New-Item -Name:$testfile -Path:$tmpDirectory -ItemType:SymbolicLink } | Should -Throw -ErrorId 'ArgumentNull,Microsoft.PowerShell.Commands.NewItemCommand'
         $Error | Select-Object -First:1 | Foreach-Object Exception | Foreach-Object ParamName | Should -Be 'content'
         { New-Item -Name:$testfile -Path:$tmpDirectory -ItemType:SymbolicLink -Value:{} } | Should -Throw -ErrorId 'ArgumentNull,Microsoft.PowerShell.Commands.NewItemCommand'
-        $Error | Select-Object -First:2 | Foreach-Object Exception | Foreach-Object ParamName | Should -Be 'content'
+        $Error | Select-Object -First:1 | Foreach-Object Exception | Foreach-Object ParamName | Should -Be 'content'
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -187,10 +187,10 @@ Describe "New-Item" -Tags "CI" {
     }
 
     It "Should display an error message when a symbolic link target is not specified" {
-        { New-Item -Name:$testfile -Path:$tmpDirectory -ItemType:SymbolicLink } | Should -Throw -ErrorId 'ArgumentNull,Microsoft.PowerShell.Commands.NewItemCommand'
-        $Error | Select-Object -First:1 | Foreach-Object Exception | Foreach-Object ParamName | Should -Be 'content'
-        { New-Item -Name:$testfile -Path:$tmpDirectory -ItemType:SymbolicLink -Value:{} } | Should -Throw -ErrorId 'ArgumentNull,Microsoft.PowerShell.Commands.NewItemCommand'
-        $Error | Select-Object -First:1 | Foreach-Object Exception | Foreach-Object ParamName | Should -Be 'content'
+        { New-Item -Name $testfile -Path $tmpDirectory -ItemType SymbolicLink } | Should -Throw -ErrorId 'ArgumentNull,Microsoft.PowerShell.Commands.NewItemCommand'
+        $Error[0].Exception.ParamName | Should -BeExactly 'Content'
+        { New-Item -Name $testfile -Path $tmpDirectory -ItemType:SymbolicLink -Value {} } | Should -Throw -ErrorId 'ArgumentNull,Microsoft.PowerShell.Commands.NewItemCommand'
+         $Error[0].Exception.ParamName | Should -BeExactly 'Content'
     }
 }
 
@@ -386,4 +386,3 @@ Describe "New-Item -Force allows to create an item even if the directories in th
         $FullyQualifiedFile | Should -Exist
     }
 }
-


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
Fixes #13073 (well, at least descreases its morbidity).

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
When the target value was not given and `New-Item` throws an exception, use the custom message format intended to be used.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
