### PR TITLE
Add Fluent Design Icon asset for PowerShell 7 usage

### DIFF
--- a/assets/ps_fluent_design_384.svg
+++ b/assets/ps_fluent_design_384.svg
@@ -1,0 +1,56 @@
+<svg width="384" height="240" viewBox="0 0 384 240" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0)">
+<mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="2" y="0" width="380" height="240">
+<rect width="355.113" height="241.732" rx="25" transform="matrix(1 0 -0.119498 0.992834 28.8866 0)" fill="white"/>
+</mask>
+<g mask="url(#mask0)">
+<rect width="355.113" height="241.732" rx="25" transform="matrix(1 0 -0.119498 0.992834 28.8866 0)" fill="url(#paint0_linear)"/>
+<g filter="url(#filter0_d)">
+<rect width="40.209" height="120.304" rx="15" transform="matrix(-0.636514 -0.69116 0.797679 -0.693014 79.2652 203.762)" fill="#E9E9E9"/>
+</g>
+<g filter="url(#filter1_d)">
+<rect width="39.9772" height="120.328" rx="15" transform="matrix(0.795812 -0.695168 0.63463 0.692878 67.1067 64.3472)" fill="#EFEFEF"/>
+</g>
+<g filter="url(#filter2_d)">
+<rect width="39.586" height="121.952" rx="10" transform="matrix(0.116569 -0.99283 1 -4.22614e-08 192.099 200.583)" fill="#EFEFEF"/>
+</g>
+</g>
+</g>
+<defs>
+<filter id="filter0_d" x="-40.1238" y="13.6796" width="309.149" height="299.001" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dy="15"/>
+<feGaussianBlur stdDeviation="50"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+</filter>
+<filter id="filter1_d" x="-26.7054" y="-42.3455" width="295.802" height="298.967" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dy="15"/>
+<feGaussianBlur stdDeviation="50"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.75 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+</filter>
+<filter id="filter2_d" x="93.1961" y="76.2808" width="324.372" height="239.302" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dy="15"/>
+<feGaussianBlur stdDeviation="50"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+</filter>
+<linearGradient id="paint0_linear" x1="0" y1="0" x2="327.506" y2="274.653" gradientUnits="userSpaceOnUse">
+<stop stop-color="#2E466A"/>
+<stop offset="0.53125" stop-color="#1C2C40"/>
+<stop offset="1" stop-color="#00040A"/>
+</linearGradient>
+<clipPath id="clip0">
+<rect width="384" height="240" fill="white"/>
+</clipPath>
+</defs>
+</svg>


### PR DESCRIPTION
# PR Summary

Add a modern PowerShell icon with [Fluent Design](https://www.microsoft.com/design/fluent/) guidelines and inspired by the [community](https://twitter.com/Steve_MSFT/status/1279220914412851200). Retains the same design ethos and color palette, with a subtle new fluent approach. PR contains static svg asset.

## PR Context

#### Asset Details

``assets/ps_fluent_design_384.svg``

##### Aspect Ratios

Example Bounding Box Usage: ``512x512 or larger HiDPI 1:1``
Icon Proportions: ``384x240 8:5``
Fun Fact: Icon is proportionally skewed at a 7-degree angle

##### Color Palletes

Grayscale: ``#FFFFFF, #000000``
Gradient: ``[#2E466A 0%, #1C2C40 ~50%, #00040A 100%]`` 45 degrees top-left
Layout and color placement tested for Pinned Start Menu Tile, List Tile, Taskbar, rpm/deb Installer, MacOS Launchpad and Dock

#### Next Steps

Compile static assets in different sizes for dev/test in preview builds.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None: Static Assets only
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.