### PR TITLE
Avoid unnecessary path resolution for `Get-Acl -LiteralPath`

### DIFF
--- a/src/Microsoft.PowerShell.Security/security/AclCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/AclCommands.cs
@@ -825,7 +825,7 @@ namespace Microsoft.PowerShell.Commands
                     {
                         if (_isLiteralPath)
                         {
-                            pathsToProcess.Add(SessionState.Path.GetUnresolvedProviderPathFromPSPath(p));
+                            pathsToProcess.Add(p);
                         }
                         else
                         {

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/AclCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/AclCmdlets.Tests.ps1
@@ -1,10 +1,64 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 Describe "Acl cmdlets are available and operate properly" -Tag CI {
-    It "Get-Acl returns an ACL object" -Pending:(!$IsWindows) {
+    It "Get-Acl returns an ACL DirectorySecurity object" -Pending:(!$IsWindows) {
         $ACL = Get-Acl $TESTDRIVE
         $ACL | Should -BeOfType System.Security.AccessControl.DirectorySecurity
     }
+
+    It "Get-Acl -LiteralPath HKLM:Software\Classes\*" -Pending:(!$IsWindows) {
+        $ACL = Get-Acl -LiteralPath HKLM:Software\Classes\*
+        $ACL | Should -BeOfType System.Security.AccessControl.RegistrySecurity
+    }
+
+    It "Get-Acl -LiteralPath .\Software\Classes\*" -Pending:(!$IsWindows) {
+        $currentPath = Get-Location
+        Set-Location -LiteralPath HKLM:\
+        $ACL = Get-Acl -LiteralPath .\Software\Classes\*
+        $ACL | Should -BeOfType System.Security.AccessControl.RegistrySecurity
+        $currentPath | Set-Location
+    }
+
+    It "Get-Acl -LiteralPath ." -Pending:(!$IsWindows) {
+        $currentPath = Get-Location
+        Set-Location -LiteralPath $TESTDRIVE
+        $ACL = Get-Acl -LiteralPath .
+        $ACL | Should -BeOfType System.Security.AccessControl.DirectorySecurity
+        $currentPath | Set-Location
+    }
+
+    It "Get-Acl -LiteralPath .." -Pending:(!$IsWindows) {
+        $currentPath = Get-Location
+        Set-Location -LiteralPath $TESTDRIVE
+        $ACL = Get-Acl -LiteralPath ..
+        $ACL | Should -BeOfType System.Security.AccessControl.DirectorySecurity
+        $currentPath | Set-Location
+    }
+
+    It "Get-Acl -Path .\Software\Classes\" -Pending:(!$IsWindows) {
+        $currentPath = Get-Location
+        Set-Location -LiteralPath HKLM:\
+        $ACL = Get-Acl -Path .\Software\Classes\
+        $ACL | Should -BeOfType System.Security.AccessControl.RegistrySecurity
+        $currentPath | Set-Location
+    }
+
+    It "Get-Acl -Path ." -Pending:(!$IsWindows) {
+        $currentPath = Get-Location
+        Set-Location -LiteralPath $TESTDRIVE
+        $ACL = Get-Acl -Path .
+        $ACL | Should -BeOfType System.Security.AccessControl.DirectorySecurity
+        $currentPath | Set-Location
+    }
+
+    It "Get-Acl -Path .." -Pending:(!$IsWindows) {
+        $currentPath = Get-Location
+        Set-Location -LiteralPath $TESTDRIVE
+        $ACL = Get-Acl -Path ..
+        $ACL | Should -BeOfType System.Security.AccessControl.DirectorySecurity
+        $currentPath | Set-Location
+    }
+
     It "Set-Acl can set the ACL of a directory" -Pending {
         Setup -d testdir
         $directory = "$TESTDRIVE/testdir"

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/AclCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/AclCmdlets.Tests.ps1
@@ -3,10 +3,7 @@
 Describe "Acl cmdlets are available and operate properly" -Tag CI {
     Context "Windows ACL test" {
         BeforeAll {
-            if ( !$IsWindows )
-            {
-                return
-            }
+            $PSDefaultParameterValues["It:Skip"] = -not $IsWindows
         }
 
         It "Get-Acl returns an ACL DirectorySecurity object"  {
@@ -78,6 +75,10 @@ Describe "Acl cmdlets are available and operate properly" -Tag CI {
             $newacl = Get-Acl $directory
             $newrule = $newacl.Access | Where-Object { $accessrule.FileSystemRights -eq $_.FileSystemRights -and $accessrule.AccessControlType -eq $_.AccessControlType -and $accessrule.IdentityReference -eq $_.IdentityReference }
             $newrule | Should -Not -BeNullOrEmpty
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues.Remove("It:Skip")
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/AclCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/AclCmdlets.Tests.ps1
@@ -1,74 +1,83 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 Describe "Acl cmdlets are available and operate properly" -Tag CI {
-    It "Get-Acl returns an ACL DirectorySecurity object" -Pending:(!$IsWindows) {
-        $ACL = Get-Acl $TESTDRIVE
-        $ACL | Should -BeOfType System.Security.AccessControl.DirectorySecurity
-    }
+    Context "Windows ACL test" {
+        BeforeAll {
+            if ( !$IsWindows )
+            {
+                return
+            }
+        }
 
-    It "Get-Acl -LiteralPath HKLM:Software\Classes\*" -Pending:(!$IsWindows) {
-        $ACL = Get-Acl -LiteralPath HKLM:Software\Classes\*
-        $ACL | Should -BeOfType System.Security.AccessControl.RegistrySecurity
-    }
+        It "Get-Acl returns an ACL DirectorySecurity object"  {
+            $ACL = Get-Acl $TESTDRIVE
+            $ACL | Should -BeOfType System.Security.AccessControl.DirectorySecurity
+        }
 
-    It "Get-Acl -LiteralPath .\Software\Classes\*" -Pending:(!$IsWindows) {
-        $currentPath = Get-Location
-        Set-Location -LiteralPath HKLM:\
-        $ACL = Get-Acl -LiteralPath .\Software\Classes\*
-        $ACL | Should -BeOfType System.Security.AccessControl.RegistrySecurity
-        $currentPath | Set-Location
-    }
+        It "Get-Acl -LiteralPath HKLM:Software\Classes\*"  {
+            $ACL = Get-Acl -LiteralPath HKLM:Software\Classes\*
+            $ACL | Should -BeOfType System.Security.AccessControl.RegistrySecurity
+        }
 
-    It "Get-Acl -LiteralPath ." -Pending:(!$IsWindows) {
-        $currentPath = Get-Location
-        Set-Location -LiteralPath $TESTDRIVE
-        $ACL = Get-Acl -LiteralPath .
-        $ACL | Should -BeOfType System.Security.AccessControl.DirectorySecurity
-        $currentPath | Set-Location
-    }
+        It "Get-Acl -LiteralPath .\Software\Classes\*"  {
+            $currentPath = Get-Location
+            Set-Location -LiteralPath HKLM:\
+            $ACL = Get-Acl -LiteralPath .\Software\Classes\*
+            $ACL | Should -BeOfType System.Security.AccessControl.RegistrySecurity
+            $currentPath | Set-Location
+        }
 
-    It "Get-Acl -LiteralPath .." -Pending:(!$IsWindows) {
-        $currentPath = Get-Location
-        Set-Location -LiteralPath $TESTDRIVE
-        $ACL = Get-Acl -LiteralPath ..
-        $ACL | Should -BeOfType System.Security.AccessControl.DirectorySecurity
-        $currentPath | Set-Location
-    }
+        It "Get-Acl -LiteralPath ."  {
+            $currentPath = Get-Location
+            Set-Location -LiteralPath $TESTDRIVE
+            $ACL = Get-Acl -LiteralPath .
+            $ACL | Should -BeOfType System.Security.AccessControl.DirectorySecurity
+            $currentPath | Set-Location
+        }
 
-    It "Get-Acl -Path .\Software\Classes\" -Pending:(!$IsWindows) {
-        $currentPath = Get-Location
-        Set-Location -LiteralPath HKLM:\
-        $ACL = Get-Acl -Path .\Software\Classes\
-        $ACL | Should -BeOfType System.Security.AccessControl.RegistrySecurity
-        $currentPath | Set-Location
-    }
+        It "Get-Acl -LiteralPath .."  {
+            $currentPath = Get-Location
+            Set-Location -LiteralPath $TESTDRIVE
+            $ACL = Get-Acl -LiteralPath ..
+            $ACL | Should -BeOfType System.Security.AccessControl.DirectorySecurity
+            $currentPath | Set-Location
+        }
 
-    It "Get-Acl -Path ." -Pending:(!$IsWindows) {
-        $currentPath = Get-Location
-        Set-Location -LiteralPath $TESTDRIVE
-        $ACL = Get-Acl -Path .
-        $ACL | Should -BeOfType System.Security.AccessControl.DirectorySecurity
-        $currentPath | Set-Location
-    }
+        It "Get-Acl -Path .\Software\Classes\"  {
+            $currentPath = Get-Location
+            Set-Location -LiteralPath HKLM:\
+            $ACL = Get-Acl -Path .\Software\Classes\
+            $ACL | Should -BeOfType System.Security.AccessControl.RegistrySecurity
+            $currentPath | Set-Location
+        }
 
-    It "Get-Acl -Path .." -Pending:(!$IsWindows) {
-        $currentPath = Get-Location
-        Set-Location -LiteralPath $TESTDRIVE
-        $ACL = Get-Acl -Path ..
-        $ACL | Should -BeOfType System.Security.AccessControl.DirectorySecurity
-        $currentPath | Set-Location
-    }
+        It "Get-Acl -Path ."  {
+            $currentPath = Get-Location
+            Set-Location -LiteralPath $TESTDRIVE
+            $ACL = Get-Acl -Path .
+            $ACL | Should -BeOfType System.Security.AccessControl.DirectorySecurity
+            $currentPath | Set-Location
+        }
 
-    It "Set-Acl can set the ACL of a directory" -Pending {
-        Setup -d testdir
-        $directory = "$TESTDRIVE/testdir"
-        $acl = Get-Acl $directory
-        $accessRule = [System.Security.AccessControl.FileSystemAccessRule]::New("Everyone","FullControl","ContainerInherit,ObjectInherit","None","Allow")
-        $acl.AddAccessRule($accessRule)
-        { $acl | Set-Acl $directory } | Should -Not -Throw
+        It "Get-Acl -Path .."  {
+            $currentPath = Get-Location
+            Set-Location -LiteralPath $TESTDRIVE
+            $ACL = Get-Acl -Path ..
+            $ACL | Should -BeOfType System.Security.AccessControl.DirectorySecurity
+            $currentPath | Set-Location
+        }
 
-        $newacl = Get-Acl $directory
-        $newrule = $newacl.Access | Where-Object { $accessrule.FileSystemRights -eq $_.FileSystemRights -and $accessrule.AccessControlType -eq $_.AccessControlType -and $accessrule.IdentityReference -eq $_.IdentityReference }
-        $newrule | Should -Not -BeNullOrEmpty
+        It "Set-Acl can set the ACL of a directory" {
+            Setup -d testdir
+            $directory = "$TESTDRIVE/testdir"
+            $acl = Get-Acl $directory
+            $accessRule = [System.Security.AccessControl.FileSystemAccessRule]::New("Everyone","FullControl","ContainerInherit,ObjectInherit","None","Allow")
+            $acl.AddAccessRule($accessRule)
+            { $acl | Set-Acl $directory } | Should -Not -Throw
+
+            $newacl = Get-Acl $directory
+            $newrule = $newacl.Access | Where-Object { $accessrule.FileSystemRights -eq $_.FileSystemRights -and $accessrule.AccessControlType -eq $_.AccessControlType -and $accessrule.IdentityReference -eq $_.IdentityReference }
+            $newrule | Should -Not -BeNullOrEmpty
+        }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix [#11566](https://github.com/PowerShell/PowerShell/issues/11566)
Removes unnecessary path resolution when using `LiteralPath` parameter in `Get-Acl` cmdlet.
Add pester test for Get-Acl cmdlet

<!-- Summarize your PR between here and the checklist. -->

## PR Context
This PR will resolve the bug reported in [#11566](https://github.com/PowerShell/PowerShell/issues/11566). The PR will also reduce the calls made. Adding pester tests to help easier refactoring and to avoid regression. 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
