### PR TITLE
Fix constructing PSModulePath if a sub-path has trailing separator

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -1139,7 +1139,7 @@ namespace System.Management.Automation
                     int position = PathContainsSubstring(result.ToString(), subPathToAdd); // searching in effective 'result' value ensures that possible duplicates in pathsToAdd are handled correctly
                     if (position == -1) // subPathToAdd not found - add it
                     {
-                        if (insertPosition == -1) // append subPathToAdd to the end
+                        if (insertPosition == -1 || insertPosition > basePath.Length) // append subPathToAdd to the end
                         {
                             bool endsWithPathSeparator = false;
                             if (result.Length > 0)
@@ -1223,23 +1223,23 @@ namespace System.Management.Automation
                 // personalModulePath
                 // sharedModulePath
                 // systemModulePath
-                int insertIndex = 0;
-                if (!string.IsNullOrEmpty(personalModulePathToUse))
+                currentProcessModulePath = AddToPath(currentProcessModulePath, personalModulePathToUse, 0);
+                int insertIndex = currentProcessModulePath.IndexOf(Path.PathSeparator, PathContainsSubstring(currentProcessModulePath, personalModulePathToUse));
+                if (insertIndex != -1)
                 {
-                    currentProcessModulePath = AddToPath(currentProcessModulePath, personalModulePathToUse, insertIndex);
-                    insertIndex = PathContainsSubstring(currentProcessModulePath, personalModulePathToUse) + personalModulePathToUse.Length + 1;
+                    // advance past the path separator
+                    insertIndex++;
                 }
 
-                if (!string.IsNullOrEmpty(sharedModulePath))
+                currentProcessModulePath = AddToPath(currentProcessModulePath, sharedModulePath, insertIndex);
+                insertIndex = currentProcessModulePath.IndexOf(Path.PathSeparator, PathContainsSubstring(currentProcessModulePath, sharedModulePath));
+                if (insertIndex != -1)
                 {
-                    currentProcessModulePath = AddToPath(currentProcessModulePath, sharedModulePath, insertIndex);
-                    insertIndex = PathContainsSubstring(currentProcessModulePath, sharedModulePath) + sharedModulePath.Length + 1;
+                    // advance past the path separator
+                    insertIndex++;
                 }
 
-                if (!string.IsNullOrEmpty(systemModulePathToUse))
-                {
-                    currentProcessModulePath = AddToPath(currentProcessModulePath, systemModulePathToUse, insertIndex);
-                }
+                currentProcessModulePath = AddToPath(currentProcessModulePath, systemModulePathToUse, insertIndex);
             }
 
             return currentProcessModulePath;

--- a/test/powershell/engine/Module/ModulePath.Tests.ps1
+++ b/test/powershell/engine/Module/ModulePath.Tests.ps1
@@ -188,10 +188,17 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
         }
     }
 
-    It 'User PSModulePath has trailing separator' -Skip:(!$IsWindows) {
+    It 'User PSModulePath has trailing separator' {
+        if ($IsWindows) {
+            $validation = "*\$env:SystemDrive\*"
+        }
+        else {
+            $validation = "*//*"
+        }
+
         $newUserPath = Join-Path $expectedUserPath ([System.IO.Path]::DirectorySeparatorChar)
         $env:PSModulePath = $env:PSModulePath.Replace($expectedUserPath, $newUserPath).Replace($expectedSharedPath,"")
         $out = & $powershell -noprofile -command '$env:PSModulePath'
-        $out.Split([System.IO.Path]::PathSeparator, [System.StringSplitOptions]::RemoveEmptyEntries) | Should -Not -BeLike "*\$env:SystemDrive\*"
+        $out.Split([System.IO.Path]::PathSeparator, [System.StringSplitOptions]::RemoveEmptyEntries) | Should -Not -BeLike $validation
     }
 }

--- a/test/powershell/engine/Module/ModulePath.Tests.ps1
+++ b/test/powershell/engine/Module/ModulePath.Tests.ps1
@@ -187,4 +187,11 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
             Remove-Item -Path $userConfigPath -Force
         }
     }
+
+    It 'User PSModulePath has trailing separator' -Skip:(!$IsWindows) {
+        $newUserPath = Join-Path $expectedUserPath ([System.IO.Path]::DirectorySeparatorChar)
+        $env:PSModulePath = $env:PSModulePath.Replace($expectedUserPath, $newUserPath).Replace($expectedSharedPath,"")
+        $out = & $powershell -noprofile -command '$env:PSModulePath'
+        $out.Split([System.IO.Path]::PathSeparator, [System.StringSplitOptions]::RemoveEmptyEntries) | Should -Exist
+    }
 }

--- a/test/powershell/engine/Module/ModulePath.Tests.ps1
+++ b/test/powershell/engine/Module/ModulePath.Tests.ps1
@@ -188,7 +188,8 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
         }
     }
 
-    It 'Path with trailing separator' {
+    # Some paths are not pre-created on Linux
+    It 'Path with trailing separator' -Skip:$IsLinux {
         $env:PSModulePath = $env:PSModulePath.Replace($expectedUserPath, $expectedUserPath + [System.IO.Path]::PathSeparator)
         $out = pwsh -noprofile -command '$env:PSModulePath'
         $out.Split([System.IO.Path]::PathSeparator, [System.StringSplitOptions]::RemoveEmptyEntries).ForEach{

--- a/test/powershell/engine/Module/ModulePath.Tests.ps1
+++ b/test/powershell/engine/Module/ModulePath.Tests.ps1
@@ -187,13 +187,4 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
             Remove-Item -Path $userConfigPath -Force
         }
     }
-
-    # Some paths are not pre-created on Linux
-    It 'Path with trailing separator' -Skip:$IsLinux {
-        $env:PSModulePath = $env:PSModulePath.Replace($expectedUserPath, $expectedUserPath + [System.IO.Path]::PathSeparator)
-        $out = pwsh -noprofile -command '$env:PSModulePath'
-        $out.Split([System.IO.Path]::PathSeparator, [System.StringSplitOptions]::RemoveEmptyEntries).ForEach{
-            $_ | Should -Exist
-        }
-    }
 }

--- a/test/powershell/engine/Module/ModulePath.Tests.ps1
+++ b/test/powershell/engine/Module/ModulePath.Tests.ps1
@@ -192,6 +192,6 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
         $newUserPath = Join-Path $expectedUserPath ([System.IO.Path]::DirectorySeparatorChar)
         $env:PSModulePath = $env:PSModulePath.Replace($expectedUserPath, $newUserPath).Replace($expectedSharedPath,"")
         $out = & $powershell -noprofile -command '$env:PSModulePath'
-        $out.Split([System.IO.Path]::PathSeparator, [System.StringSplitOptions]::RemoveEmptyEntries) | Should -Exist
+        $out.Split([System.IO.Path]::PathSeparator, [System.StringSplitOptions]::RemoveEmptyEntries) | Should -Not -BeLike "*\$env:SystemDrive\*"
     }
 }

--- a/test/powershell/engine/Module/ModulePath.Tests.ps1
+++ b/test/powershell/engine/Module/ModulePath.Tests.ps1
@@ -187,4 +187,12 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
             Remove-Item -Path $userConfigPath -Force
         }
     }
+
+    It 'Path with trailing separator' {
+        $env:PSModulePath = $env:PSModulePath.Replace($expectedUserPath, $expectedUserPath + [System.IO.Path]::PathSeparator)
+        $out = pwsh -noprofile -command '$env:PSModulePath'
+        $out.Split([System.IO.Path]::PathSeparator, [System.StringSplitOptions]::RemoveEmptyEntries).ForEach{
+            $_ | Should -Exist
+        }
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

When constructing PSModulePath, the code checks if one of user path, shared path, or $PSHome path is already part of PSModulePath.  The code that does the check trims whitespace and trailing path separator.  So if one of those paths match, but actually has whitespace or trailing separator, then the index doesn't take that into account and subsequent paths are inserted in the wrong location creating an invalid path.

The fix is if one of those paths are found, then find the next index of the path separator and insert at that index.  If there is no path separator after that index, then it just gets appended to the end.

Spent too much time trying to add a test.  The repro requires changing the system environment variable for PSModulePath and a new process to be started so that it's not inherited from an existing PowerShell process.  Validated manually.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/13025

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
