### PR TITLE
Allow explicitly specified named parameter to supersede the same one from hashtable splatting

### DIFF
--- a/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
@@ -208,10 +208,26 @@ namespace System.Management.Automation
             }
 
             // Add the passed in arguments to the unboundArguments collection
-
+            Collection<CommandParameterInternal> paramsFromSplatting = null;
             foreach (CommandParameterInternal argument in arguments)
             {
-                UnboundArguments.Add(argument);
+                if (argument.ParameterComesFromSplatting)
+                {
+                    paramsFromSplatting ??= new Collection<CommandParameterInternal>();
+                    paramsFromSplatting.Add(argument);
+                }
+                else
+                {
+                    UnboundArguments.Add(argument);
+                }
+            }
+
+            if (paramsFromSplatting != null)
+            {
+                foreach (CommandParameterInternal argument in paramsFromSplatting)
+                {
+                    UnboundArguments.Add(argument);
+                }
             }
 
             CommandMetadata cmdletMetadata = _commandMetadata;

--- a/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
@@ -1176,17 +1176,6 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Binds the specified parameters to the cmdlet.
-        /// </summary>
-        /// <param name="parameters">
-        /// The parameters to bind.
-        /// </param>
-        internal override Collection<CommandParameterInternal> BindParameters(Collection<CommandParameterInternal> parameters)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <summary>
         /// Binds the specified argument to the specified parameter using the appropriate
         /// parameter binder. If the argument is of type ScriptBlock and the parameter takes
         /// pipeline input, then the ScriptBlock is saved off in the delay-bind ScriptBlock

--- a/src/System.Management.Automation/engine/CommandParameter.cs
+++ b/src/System.Management.Automation/engine/CommandParameter.cs
@@ -29,7 +29,7 @@ namespace System.Management.Automation
         private Parameter _parameter;
         private Argument _argument;
         private bool _spaceAfterParameter;
-        private bool _comesFromSplatting;
+        private bool _fromHashtableSplatting;
 
         internal bool SpaceAfterParameter => _spaceAfterParameter;
 
@@ -39,7 +39,7 @@ namespace System.Management.Automation
 
         internal bool ParameterAndArgumentSpecified => ParameterNameSpecified && ArgumentSpecified;
 
-        internal bool ParameterComesFromSplatting => _comesFromSplatting;
+        internal bool FromHashtableSplatting => _fromHashtableSplatting;
 
         /// <summary>
         /// Gets and sets the string that represents parameter name, which does not include the '-' (dash).
@@ -219,7 +219,7 @@ namespace System.Management.Automation
                 _parameter = new Parameter { ast = parameterAst, parameterName = parameterName, parameterText = parameterText },
                 _argument = new Argument { ast = argumentAst, value = value },
                 _spaceAfterParameter = spaceAfterParameter,
-                _comesFromSplatting = fromSplatting,
+                _fromHashtableSplatting = fromSplatting,
             };
         }
 

--- a/src/System.Management.Automation/engine/CommandParameter.cs
+++ b/src/System.Management.Automation/engine/CommandParameter.cs
@@ -29,14 +29,17 @@ namespace System.Management.Automation
         private Parameter _parameter;
         private Argument _argument;
         private bool _spaceAfterParameter;
+        private bool _comesFromSplatting;
 
-        internal bool SpaceAfterParameter { get { return _spaceAfterParameter; } }
+        internal bool SpaceAfterParameter => _spaceAfterParameter;
 
-        internal bool ParameterNameSpecified { get { return _parameter != null; } }
+        internal bool ParameterNameSpecified => _parameter != null;
 
-        internal bool ArgumentSpecified { get { return _argument != null; } }
+        internal bool ArgumentSpecified => _argument != null;
 
-        internal bool ParameterAndArgumentSpecified { get { return ParameterNameSpecified && ArgumentSpecified; } }
+        internal bool ParameterAndArgumentSpecified => ParameterNameSpecified && ArgumentSpecified;
+
+        internal bool ParameterComesFromSplatting => _comesFromSplatting;
 
         /// <summary>
         /// Gets and sets the string that represents parameter name, which does not include the '-' (dash).
@@ -111,7 +114,7 @@ namespace System.Management.Automation
         /// <summary>
         /// If an argument was specified and is to be splatted, returns true, otherwise false.
         /// </summary>
-        internal bool ArgumentSplatted
+        internal bool ArgumentToBeSplatted
         {
             get { return _argument != null ? _argument.splatted : false; }
         }
@@ -201,19 +204,22 @@ namespace System.Management.Automation
         /// <param name="argumentAst">The ast of the argument value in the script.</param>
         /// <param name="value">The argument value.</param>
         /// <param name="spaceAfterParameter">Used in native commands to correctly handle -foo:bar vs. -foo: bar.</param>
+        /// <param name="fromSplatting">Indicate if this parameter-argument pair comes from splatting.</param>
         internal static CommandParameterInternal CreateParameterWithArgument(
             Ast parameterAst,
             string parameterName,
             string parameterText,
             Ast argumentAst,
             object value,
-            bool spaceAfterParameter)
+            bool spaceAfterParameter,
+            bool fromSplatting = false)
         {
             return new CommandParameterInternal
             {
                 _parameter = new Parameter { ast = parameterAst, parameterName = parameterName, parameterText = parameterText },
                 _argument = new Argument { ast = argumentAst, value = value },
-                _spaceAfterParameter = spaceAfterParameter
+                _spaceAfterParameter = spaceAfterParameter,
+                _comesFromSplatting = fromSplatting,
             };
         }
 

--- a/src/System.Management.Automation/engine/MinishellParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/MinishellParameterBinderController.cs
@@ -38,24 +38,6 @@ namespace System.Management.Automation
         #endregion ctor
 
         /// <summary>
-        /// Override of parent class which should not be used.
-        /// </summary>
-        /// <param name="parameters">
-        /// The parameters to bind.
-        /// </param>
-        /// <remarks>
-        /// For any parameters that do not have a name, they are added to the command
-        /// line arguments for the command
-        /// </remarks>
-        internal override
-        Collection<CommandParameterInternal>
-        BindParameters(Collection<CommandParameterInternal> parameters)
-        {
-            Dbg.Assert(false, "this method should be used");
-            return null;
-        }
-
-        /// <summary>
         /// Value of input format. This property should be read after binding of parameters.
         /// </summary>
         internal NativeCommandIOFormat InputFormat { get; private set; }

--- a/src/System.Management.Automation/engine/ParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/ParameterBinderController.cs
@@ -266,7 +266,7 @@ namespace System.Management.Automation
             Collection<CommandParameterInternal> paramsFromSplatting = null;
             foreach (CommandParameterInternal argument in arguments)
             {
-                if (argument.ParameterComesFromSplatting)
+                if (argument.FromHashtableSplatting)
                 {
                     paramsFromSplatting ??= new Collection<CommandParameterInternal>();
                     paramsFromSplatting.Add(argument);
@@ -601,7 +601,7 @@ namespace System.Management.Automation
                 {
                     string formalParamName = parameter.Parameter.Name;
 
-                    if (argument.ParameterComesFromSplatting)
+                    if (argument.FromHashtableSplatting)
                     {
                         boundExplicitNamedParams ??= new HashSet<string>(
                             BoundParameters.Keys,

--- a/src/System.Management.Automation/engine/ParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/ParameterBinderController.cs
@@ -277,6 +277,8 @@ namespace System.Management.Automation
                 }
             }
 
+            // Move the arguments from hashtable splatting to the end of the unbound args list, so that
+            // the explicitly specified named arguments can supersede those from a hashtable splatting.
             if (paramsFromSplatting != null)
             {
                 foreach (CommandParameterInternal argument in paramsFromSplatting)
@@ -473,7 +475,10 @@ namespace System.Management.Automation
         /// <returns>
         /// The arguments which are still not bound.
         /// </returns>
-        internal abstract Collection<CommandParameterInternal> BindParameters(Collection<CommandParameterInternal> parameters);
+        internal virtual Collection<CommandParameterInternal> BindParameters(Collection<CommandParameterInternal> parameters)
+        {
+            throw new NotImplementedException();
+        }
 
         /// <summary>
         /// Bind the argument to the specified parameter.

--- a/src/System.Management.Automation/engine/hostifaces/PSCommand.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSCommand.cs
@@ -360,6 +360,26 @@ namespace System.Management.Automation
         }
 
         /// <summary>
+        /// Adds a <see cref="CommandParameter"/> instance to the last added command.
+        /// </summary>
+        internal PSCommand AddParameter(CommandParameter parameter)
+        {
+            if (_currentCommand == null)
+            {
+                throw PSTraceSource.NewInvalidOperationException(PSCommandStrings.ParameterRequiresCommand,
+                                                                 new object[] { "PSCommand" });
+            }
+
+            if (_owner != null)
+            {
+                _owner.AssertChangesAreAccepted();
+            }
+
+            _currentCommand.Parameters.Add(parameter);
+            return this;
+        }
+
+        /// <summary>
         /// Adds an argument to the last added command.
         /// For example, to construct a command string "get-process | select-object name"
         ///     <code>

--- a/src/System.Management.Automation/engine/hostifaces/Parameter.cs
+++ b/src/System.Management.Automation/engine/hostifaces/Parameter.cs
@@ -113,7 +113,7 @@ namespace System.Management.Automation.Runspaces
                 ? new CommandParameter(name, internalParameter.ArgumentValue)
                 : name != null
                     ? new CommandParameter(name)
-                    : new CommandParameter(null, internalParameter.ArgumentValue);
+                    : new CommandParameter(name: null, internalParameter.ArgumentValue);
 
             result.FromHashtableSplatting = internalParameter.FromHashtableSplatting;
             return result;

--- a/src/System.Management.Automation/engine/hostifaces/Parameter.cs
+++ b/src/System.Management.Automation/engine/hostifaces/Parameter.cs
@@ -80,9 +80,10 @@ namespace System.Management.Automation.Runspaces
 
         #endregion Public properties
 
-        #region Private Fields
-
-        #endregion Private Fields
+        /// <summary>
+        /// Gets whether the parameter was from splatting a Hashtable.
+        /// </summary>
+        private bool FromHashtableSplatting { get; set; }
 
         #region Conversion from and to CommandParameterInternal
 
@@ -108,17 +109,14 @@ namespace System.Management.Automation.Runspaces
                 Diagnostics.Assert(name.Trim().Length != 1, "Parameter name has to have some non-whitespace characters in it");
             }
 
-            if (internalParameter.ParameterAndArgumentSpecified)
-            {
-                return new CommandParameter(name, internalParameter.ArgumentValue);
-            }
+            CommandParameter result = internalParameter.ParameterAndArgumentSpecified
+                ? new CommandParameter(name, internalParameter.ArgumentValue)
+                : name != null
+                    ? new CommandParameter(name)
+                    : new CommandParameter(null, internalParameter.ArgumentValue);
 
-            if (name != null) // either a switch parameter or first part of parameter+argument
-            {
-                return new CommandParameter(name);
-            }
-            // either a positional argument or second part of parameter+argument
-            return new CommandParameter(null, internalParameter.ArgumentValue);
+            result.FromHashtableSplatting = internalParameter.FromHashtableSplatting;
+            return result;
         }
 
         internal static CommandParameterInternal ToCommandParameterInternal(CommandParameter publicParameter, bool forNativeCommand)
@@ -143,9 +141,12 @@ namespace System.Management.Automation.Runspaces
             {
                 parameterText = forNativeCommand ? name : "-" + name;
                 return CommandParameterInternal.CreateParameterWithArgument(
-                    /*parameterAst*/null, name, parameterText,
-                    /*argumentAst*/null, value,
-                    true);
+                    parameterAst: null,
+                    parameterName: name,
+                    parameterText: parameterText,
+                    argumentAst: null,
+                    value: value,
+                    spaceAfterParameter: true);
             }
 
             // if first character of name is '-', then we try to fake the original token
@@ -184,9 +185,13 @@ namespace System.Management.Automation.Runspaces
 
             // name+value pair
             return CommandParameterInternal.CreateParameterWithArgument(
-                /*parameterAst*/null, parameterName, parameterText,
-                /*argumentAst*/null, value,
-                spaceAfterParameter);
+                parameterAst: null,
+                parameterName,
+                parameterText,
+                argumentAst: null,
+                value,
+                spaceAfterParameter,
+                publicParameter.FromHashtableSplatting);
         }
 
         #endregion
@@ -233,34 +238,6 @@ namespace System.Management.Automation.Runspaces
         }
 
         #endregion
-
-        #region Win Blue Extensions
-
-#if !CORECLR // PSMI Not Supported On CSS
-        internal CimInstance ToCimInstance()
-        {
-            CimInstance c = InternalMISerializer.CreateCimInstance("PS_Parameter");
-            CimProperty nameProperty = InternalMISerializer.CreateCimProperty("Name", this.Name,
-                                                                                Microsoft.Management.Infrastructure.CimType.String);
-            c.CimInstanceProperties.Add(nameProperty);
-            Microsoft.Management.Infrastructure.CimType cimType = CimConverter.GetCimType(this.Value.GetType());
-            CimProperty valueProperty;
-            if (cimType == Microsoft.Management.Infrastructure.CimType.Unknown)
-            {
-                valueProperty = InternalMISerializer.CreateCimProperty("Value", (object)PSMISerializer.Serialize(this.Value),
-                                                                                Microsoft.Management.Infrastructure.CimType.Instance);
-            }
-            else
-            {
-                valueProperty = InternalMISerializer.CreateCimProperty("Value", this.Value, cimType);
-            }
-
-            c.CimInstanceProperties.Add(valueProperty);
-            return c;
-        }
-#endif
-
-        #endregion Win Blue Extensions
     }
 
     /// <summary>

--- a/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
@@ -1267,6 +1267,24 @@ namespace System.Management.Automation
         }
 
         /// <summary>
+        /// Adds a <see cref="CommandParameter"/> instance to the last added command.
+        /// </summary>
+        internal PowerShell AddParameter(CommandParameter parameter)
+        {
+            lock (_syncObject)
+            {
+                if (_psCommand.Commands.Count == 0)
+                {
+                    throw PSTraceSource.NewInvalidOperationException(PowerShellStrings.ParameterRequiresCommand);
+                }
+
+                AssertChangesAreAccepted();
+                _psCommand.AddParameter(parameter);
+                return this;
+            }
+        }
+
+        /// <summary>
         /// Adds a set of parameters to the last added command.
         /// </summary>
         /// <param name="parameters">

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -4241,7 +4241,8 @@ namespace System.Management.Automation.Language
                     Expression.Constant(errorPos.Text),
                     Expression.Constant(arg),
                     Expression.Convert(GetCommandArgumentExpression(arg), typeof(object)),
-                    ExpressionCache.Constant(spaceAfterParameter));
+                    ExpressionCache.Constant(spaceAfterParameter),
+                    ExpressionCache.Constant(false));
             }
 
             return Expression.Call(

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -174,7 +174,7 @@ namespace System.Management.Automation
                     }
                 }
 
-                if (cpi.ArgumentSplatted)
+                if (cpi.ArgumentToBeSplatted)
                 {
                     foreach (var splattedCpi in Splat(cpi.ArgumentValue, cpi.ArgumentAst))
                     {
@@ -338,8 +338,13 @@ namespace System.Management.Automation
                     }
 
                     yield return CommandParameterInternal.CreateParameterWithArgument(
-                        splatAst, parameterName, parameterText,
-                        splatAst, parameterValue, false);
+                        parameterAst: splatAst,
+                        parameterName: parameterName,
+                        parameterText: parameterText,
+                        argumentAst: splatAst,
+                        value: parameterValue,
+                        spaceAfterParameter: false,
+                        fromSplatting: true);
                 }
             }
             else

--- a/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
+++ b/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
@@ -748,7 +748,7 @@ namespace System.Management.Automation
             foreach (var splattedParameter in PipelineOps.Splat(splattedValue, variableAst))
             {
                 CommandParameter publicParameter = CommandParameter.FromCommandParameterInternal(splattedParameter);
-                _powershell.AddParameter(publicParameter.Name, publicParameter.Value);
+                _powershell.AddParameter(publicParameter);
             }
         }
 

--- a/src/System.Management.Automation/engine/scriptparameterbindercontroller.cs
+++ b/src/System.Management.Automation/engine/scriptparameterbindercontroller.cs
@@ -131,17 +131,6 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Binds the specified parameters to the shell function.
-        /// </summary>
-        /// <param name="arguments">
-        /// The arguments to bind.
-        /// </param>
-        internal override Collection<CommandParameterInternal> BindParameters(Collection<CommandParameterInternal> arguments)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <summary>
         /// Takes the remaining arguments that haven't been bound, and binds
         /// them to $args.
         /// </summary>

--- a/src/System.Management.Automation/engine/scriptparameterbindercontroller.cs
+++ b/src/System.Management.Automation/engine/scriptparameterbindercontroller.cs
@@ -77,16 +77,10 @@ namespace System.Management.Automation
         internal void BindCommandLineParameters(Collection<CommandParameterInternal> arguments)
         {
             // Add the passed in arguments to the unboundArguments collection
-
-            foreach (CommandParameterInternal argument in arguments)
-            {
-                UnboundArguments.Add(argument);
-            }
-
+            InitUnboundArguments(arguments);
             ReparseUnboundArguments();
 
-            // To support named parameters you just have un-comment the following line
-            UnboundArguments = BindParameters(UnboundArguments);
+            UnboundArguments = BindNamedParameters(uint.MaxValue, UnboundArguments);
 
             ParameterBindingException parameterBindingError;
             UnboundArguments =
@@ -144,65 +138,7 @@ namespace System.Management.Automation
         /// </param>
         internal override Collection<CommandParameterInternal> BindParameters(Collection<CommandParameterInternal> arguments)
         {
-            Collection<CommandParameterInternal> result = new Collection<CommandParameterInternal>();
-
-            foreach (CommandParameterInternal argument in arguments)
-            {
-                if (!argument.ParameterNameSpecified)
-                {
-                    result.Add(argument);
-                    continue;
-                }
-
-                // We don't want to throw an exception yet because
-                // the parameter might be a positional argument
-
-                MergedCompiledCommandParameter parameter =
-                    BindableParameters.GetMatchingParameter(
-                        argument.ParameterName,
-                        false, true,
-                        new InvocationInfo(this.InvocationInfo.MyCommand, argument.ParameterExtent));
-
-                // If the parameter is not in the specified parameter set,
-                // throw a binding exception
-
-                if (parameter != null)
-                {
-                    // Now check to make sure it hasn't already been
-                    // bound by looking in the boundParameters collection
-
-                    if (BoundParameters.ContainsKey(parameter.Parameter.Name))
-                    {
-                        ParameterBindingException bindingException =
-                            new ParameterBindingException(
-                                ErrorCategory.InvalidArgument,
-                                this.InvocationInfo,
-                                GetParameterErrorExtent(argument),
-                                argument.ParameterName,
-                                null,
-                                null,
-                                ParameterBinderStrings.ParameterAlreadyBound,
-                                nameof(ParameterBinderStrings.ParameterAlreadyBound));
-
-                        throw bindingException;
-                    }
-
-                    BindParameter(uint.MaxValue, argument, parameter, ParameterBindingFlags.ShouldCoerceType);
-                }
-                else if (argument.ParameterName.Equals(Language.Parser.VERBATIM_PARAMETERNAME, StringComparison.Ordinal))
-                {
-                    // We sometimes send a magic parameter from a remote machine with the values referenced via
-                    // a using expression ($using:x).  We then access these values via PSBoundParameters, so
-                    // "bind" them here.
-                    DefaultParameterBinder.CommandLineParameters.SetImplicitUsingParameters(argument.ArgumentValue);
-                }
-                else
-                {
-                    result.Add(argument);
-                }
-            }
-
-            return result;
+            throw new NotImplementedException();
         }
 
         /// <summary>

--- a/test/powershell/engine/ParameterBinding/Splatting.Tests.ps1
+++ b/test/powershell/engine/ParameterBinding/Splatting.Tests.ps1
@@ -1,0 +1,199 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
+
+    BeforeAll {
+        function SimpleTest {
+            param(
+                [Alias('Key')]
+                $Name,
+                $Path
+            )
+
+            "Key: $Name; Path: $Path; Args: $args"
+        }
+    }
+
+    Context "Basic Hashtable Splatting" {
+
+        It "works on cmdlet" {
+            $hash = @{ Verb = "Get"; OutVariable = "zoo" }
+            Get-Verb @hash > $null
+            $zoo | Should -BeOfType 'System.Management.Automation.VerbInfo'
+            $zoo.Verb | Should -BeExactly 'Get'
+        }
+
+        It "works on simple function" {
+            $hash = @{ Name = "Hello"; Blah = "World" }
+            SimpleTest @hash | Should -BeExactly 'Key: Hello; Path: ; Args: -Blah: World'
+
+            $hash = @{ Name = "Hello"; Path = "World" }
+            SimpleTest @hash | Should -BeExactly 'Key: Hello; Path: World; Args: '
+
+            $hash = @{ Name = "Hello" }
+            SimpleTest @hash -Path "Yeah" | Should -BeExactly 'Key: Hello; Path: Yeah; Args: '
+
+            $hash = @{ Key = "Hello" }
+            SimpleTest @hash | Should -BeExactly 'Key: Hello; Path: ; Args: '
+        }
+
+        It "works on ScriptBlock.GetPowerShell" {
+            $hash = @{ Verb = "Get"; OutVariable = "zoo" }
+            $ps = { param($hash) Get-Verb @hash; Get-Variable zoo }.GetPowerShell($hash)
+
+            try {
+                $result = $ps.Invoke()
+                $result[0] | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result[0].Verb | Should -BeExactly 'Get'
+            } finally {
+                $ps.Dispose()
+            }
+        }
+    }
+
+    Context "Explicitly specified named parameter supersedes the same one in Hashtable splatting" {
+
+        It "works with the same parameter name" {
+            $hash = @{ Verb = "Get"; OutVariable = "zoo" }
+            Get-Verb @hash -Verb "Send" > $null
+            $zoo | Should -BeOfType "System.Management.Automation.VerbInfo"
+            $zoo.Verb | Should -BeExactly "Send"
+
+            $ps = { param($hash) Get-Verb @hash -Verb "Send"; Get-Variable zoo }.GetPowerShell($hash)
+            try {
+                $result = $ps.Invoke()
+                $result[0] | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result[0].Verb | Should -BeExactly 'Send'
+            } finally {
+                $ps.Dispose()
+            }
+
+            $hash = @{ Name = "Hello"; Path = "World" }
+            SimpleTest @hash -Path "Yeah" | Should -BeExactly 'Key: Hello; Path: Yeah; Args: '
+
+            $hash = @{ Name = "Hello"; Blah = "World" }
+            SimpleTest @hash -Name "Yeah" | Should -BeExactly 'Key: Yeah; Path: ; Args: -Blah: World'
+        }
+
+        It "works with the same alias name" {
+            $hash = @{ Verb = "Get"; ov = "zoo" }
+            Get-Verb @hash -Verb "Send" -ov "bar" > $null
+            $zoo | Should -BeNullOrEmpty
+            $bar | Should -BeOfType "System.Management.Automation.VerbInfo"
+            $bar.Verb | Should -BeExactly "Send"
+
+            $ps = { param($hash) Get-Verb @hash -Verb "Send" -ov "bar"; Get-Variable bar }.GetPowerShell($hash)
+            try {
+                $result = $ps.Invoke()
+                $result[0] | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result[0].Verb | Should -BeExactly 'Send'
+            } finally {
+                $ps.Dispose()
+            }
+
+            $hash = @{ key = "Hello"; Path = "World" }
+            SimpleTest @hash -Key "Yeah" | Should -BeExactly 'Key: Yeah; Path: World; Args: '
+        }
+
+        It "works with parameter name and alias name mixed" {
+            $hash = @{ Verb = "Get"; OutVariable = "zoo" }
+            Get-Verb @hash -Verb "Send" -ov "bar" > $null
+            $zoo | Should -BeNullOrEmpty
+            $bar | Should -BeOfType "System.Management.Automation.VerbInfo"
+            $bar.Verb | Should -BeExactly "Send"
+
+            $ps = { param($hash) Get-Verb @hash -Verb "Send" -ov "bar"; Get-Variable bar }.GetPowerShell($hash)
+            try {
+                $result = $ps.Invoke()
+                $result[0] | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result[0].Verb | Should -BeExactly 'Send'
+            } finally {
+                $ps.Dispose()
+            }
+
+            $hash = @{ Name = "Hello"; Path = "World" }
+            SimpleTest @hash -Key "Yeah" | Should -BeExactly 'Key: Yeah; Path: World; Args: '
+        }
+
+        It "works with unambiguous prefix and parameter name mixed - prefix explicitly specified" {
+            $hash = @{ Verb = "Get"; OutVariable = "zoo" }
+            Get-Verb @hash -Verb "Send" -outv "bar" > $null
+            $zoo | Should -BeNullOrEmpty
+            $bar | Should -BeOfType "System.Management.Automation.VerbInfo"
+            $bar.Verb | Should -BeExactly "Send"
+
+            $ps = { param($hash) Get-Verb @hash -Verb "Send" -outv "bar"; Get-Variable bar }.GetPowerShell($hash)
+            try {
+                $result = $ps.Invoke()
+                $result[0] | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result[0].Verb | Should -BeExactly 'Send'
+            } finally {
+                $ps.Dispose()
+            }
+
+            $hash = @{ Name = "Hello"; Path = "World" }
+            SimpleTest @hash -n "Yeah" | Should -BeExactly 'Key: Yeah; Path: World; Args: '
+        }
+
+        It "works with unambiguous prefix and parameter name mixed - prefix in splatting hashtable" {
+            $hash = @{ Verb = "Get"; outv = "zoo" }
+            Get-Verb @hash -Verb "Send" -OutVariable "bar" > $null
+            $zoo | Should -BeNullOrEmpty
+            $bar | Should -BeOfType "System.Management.Automation.VerbInfo"
+            $bar.Verb | Should -BeExactly "Send"
+
+            $ps = { param($hash) Get-Verb @hash -Verb "Send" -OutVariable "bar"; Get-Variable bar }.GetPowerShell($hash)
+            try {
+                $result = $ps.Invoke()
+                $result[0] | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result[0].Verb | Should -BeExactly 'Send'
+            } finally {
+                $ps.Dispose()
+            }
+
+            $hash = @{ n = "Hello"; Path = "World" }
+            SimpleTest @hash -Name "Yeah" | Should -BeExactly 'Key: Yeah; Path: World; Args: '
+        }
+
+        It "works with unambiguous prefix and alias name mixed - prefix explicitly specified" {
+            $hash = @{ Verb = "Get"; ov = "zoo" }
+            Get-Verb @hash -Verb "Send" -outv "bar" > $null
+            $zoo | Should -BeNullOrEmpty
+            $bar | Should -BeOfType "System.Management.Automation.VerbInfo"
+            $bar.Verb | Should -BeExactly "Send"
+
+            $ps = { param($hash) Get-Verb @hash -Verb "Send" -outv "bar"; Get-Variable bar }.GetPowerShell($hash)
+            try {
+                $result = $ps.Invoke()
+                $result[0] | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result[0].Verb | Should -BeExactly 'Send'
+            } finally {
+                $ps.Dispose()
+            }
+
+            $hash = @{ key = "Hello"; Path = "World" }
+            SimpleTest @hash -n "Yeah" | Should -BeExactly 'Key: Yeah; Path: World; Args: '
+        }
+
+        It "works with unambiguous prefix and alias name mixed - prefix in splatting hashtable" {
+            $hash = @{ Verb = "Get"; outv = "zoo" }
+            Get-Verb @hash -Verb "Send" -ov "bar" > $null
+            $zoo | Should -BeNullOrEmpty
+            $bar | Should -BeOfType "System.Management.Automation.VerbInfo"
+            $bar.Verb | Should -BeExactly "Send"
+
+            $ps = { param($hash) Get-Verb @hash -Verb "Send" -ov "bar"; Get-Variable bar }.GetPowerShell($hash)
+            try {
+                $result = $ps.Invoke()
+                $result[0] | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result[0].Verb | Should -BeExactly 'Send'
+            } finally {
+                $ps.Dispose()
+            }
+
+            $hash = @{ n = "Hello"; Path = "World" }
+            SimpleTest @hash -key "Yeah" | Should -BeExactly 'Key: Yeah; Path: World; Args: '
+        }
+    }
+}

--- a/test/powershell/engine/ParameterBinding/Splatting.Tests.ps1
+++ b/test/powershell/engine/ParameterBinding/Splatting.Tests.ps1
@@ -20,7 +20,7 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
         It "works on cmdlet" {
             $hash = @{ Verb = "Get"; OutVariable = "zoo" }
             Get-Verb @hash > $null
-            $zoo | Should -BeOfType 'System.Management.Automation.VerbInfo'
+            $zoo | Should -BeOfType System.Management.Automation.VerbInfo
             $zoo.Verb | Should -BeExactly 'Get'
         }
 
@@ -45,7 +45,7 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
 
             try {
                 $result = $ps.Invoke()
-                $result[0] | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result[0] | Should -BeOfType System.Management.Automation.VerbInfo
                 $result[0].Verb | Should -BeExactly 'Get'
             } finally {
                 $ps.Dispose()
@@ -59,9 +59,9 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
                 $sp.Begin($false)
 
                 $result = $sp.Process()
-                $result | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result | Should -BeOfType System.Management.Automation.VerbInfo
                 $result.Verb | Should -BeExactly 'Get'
-                $zoo | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $zoo | Should -BeOfType System.Management.Automation.VerbInfo
                 $zoo.Verb | Should -BeExactly 'Get'
 
                 $sp.End()
@@ -77,19 +77,19 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
             ## Regular use with cmdlet
             $hash = @{ Verb = "Get"; OutVariable = "zoo" }
             Get-Verb @hash -Verb "Send" > $null
-            $zoo | Should -BeOfType "System.Management.Automation.VerbInfo"
+            $zoo | Should -BeOfType System.Management.Automation.VerbInfo
             $zoo.Verb | Should -BeExactly "Send"
 
             $zoo = $null
             Get-Verb -Verb "Send" @hash > $null
-            $zoo | Should -BeOfType "System.Management.Automation.VerbInfo"
+            $zoo | Should -BeOfType System.Management.Automation.VerbInfo
             $zoo.Verb | Should -BeExactly "Send"
 
             ## GetPowerShell
             $ps = { param($hash) Get-Verb @hash -Verb "Send"; Get-Variable zoo }.GetPowerShell($hash)
             try {
                 $result = $ps.Invoke()
-                $result[0] | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result[0] | Should -BeOfType System.Management.Automation.VerbInfo
                 $result[0].Verb | Should -BeExactly 'Send'
             } finally {
                 $ps.Dispose()
@@ -102,9 +102,9 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
                 $sp.Begin($false)
 
                 $result = $sp.Process()
-                $result | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result | Should -BeOfType System.Management.Automation.VerbInfo
                 $result.Verb | Should -BeExactly 'Send'
-                $zoo | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $zoo | Should -BeOfType System.Management.Automation.VerbInfo
                 $zoo.Verb | Should -BeExactly 'Send'
 
                 $sp.End()
@@ -126,14 +126,14 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
             $hash = @{ Verb = "Get"; ov = "zoo" }
             Get-Verb @hash -Verb "Send" -ov "bar" > $null
             $zoo | Should -BeNullOrEmpty
-            $bar | Should -BeOfType "System.Management.Automation.VerbInfo"
+            $bar | Should -BeOfType System.Management.Automation.VerbInfo
             $bar.Verb | Should -BeExactly "Send"
 
             ## GetPowerShell
             $ps = { param($hash) Get-Verb @hash -Verb "Send" -ov "bar"; Get-Variable bar }.GetPowerShell($hash)
             try {
                 $result = $ps.Invoke()
-                $result[0] | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result[0] | Should -BeOfType System.Management.Automation.VerbInfo
                 $result[0].Verb | Should -BeExactly 'Send'
             } finally {
                 $ps.Dispose()
@@ -146,10 +146,10 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
                 $sp.Begin($false)
 
                 $result = $sp.Process()
-                $result | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result | Should -BeOfType System.Management.Automation.VerbInfo
                 $result.Verb | Should -BeExactly 'Send'
                 $zoo | Should -BeNullOrEmpty
-                $bar | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $bar | Should -BeOfType System.Management.Automation.VerbInfo
                 $bar.Verb | Should -BeExactly 'Send'
 
                 $sp.End()
@@ -167,14 +167,14 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
             $hash = @{ Verb = "Get"; OutVariable = "zoo" }
             Get-Verb @hash -Verb "Send" -ov "bar" > $null
             $zoo | Should -BeNullOrEmpty
-            $bar | Should -BeOfType "System.Management.Automation.VerbInfo"
+            $bar | Should -BeOfType System.Management.Automation.VerbInfo
             $bar.Verb | Should -BeExactly "Send"
 
             ## GetPowerShell
             $ps = { param($hash) Get-Verb @hash -Verb "Send" -ov "bar"; Get-Variable bar }.GetPowerShell($hash)
             try {
                 $result = $ps.Invoke()
-                $result[0] | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result[0] | Should -BeOfType System.Management.Automation.VerbInfo
                 $result[0].Verb | Should -BeExactly 'Send'
             } finally {
                 $ps.Dispose()
@@ -187,10 +187,10 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
                 $sp.Begin($false)
 
                 $result = $sp.Process()
-                $result | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result | Should -BeOfType System.Management.Automation.VerbInfo
                 $result.Verb | Should -BeExactly 'Send'
                 $zoo | Should -BeNullOrEmpty
-                $bar | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $bar | Should -BeOfType System.Management.Automation.VerbInfo
                 $bar.Verb | Should -BeExactly 'Send'
 
                 $sp.End()
@@ -208,14 +208,14 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
             $hash = @{ Verb = "Get"; OutVariable = "zoo" }
             Get-Verb @hash -Verb "Send" -outv "bar" > $null
             $zoo | Should -BeNullOrEmpty
-            $bar | Should -BeOfType "System.Management.Automation.VerbInfo"
+            $bar | Should -BeOfType System.Management.Automation.VerbInfo
             $bar.Verb | Should -BeExactly "Send"
 
             ## GetPowerShell
             $ps = { param($hash) Get-Verb @hash -Verb "Send" -outv "bar"; Get-Variable bar }.GetPowerShell($hash)
             try {
                 $result = $ps.Invoke()
-                $result[0] | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result[0] | Should -BeOfType System.Management.Automation.VerbInfo
                 $result[0].Verb | Should -BeExactly 'Send'
             } finally {
                 $ps.Dispose()
@@ -228,10 +228,10 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
                 $sp.Begin($false)
 
                 $result = $sp.Process()
-                $result | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result | Should -BeOfType System.Management.Automation.VerbInfo
                 $result.Verb | Should -BeExactly 'Send'
                 $zoo | Should -BeNullOrEmpty
-                $bar | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $bar | Should -BeOfType System.Management.Automation.VerbInfo
                 $bar.Verb | Should -BeExactly 'Send'
 
                 $sp.End()
@@ -249,14 +249,14 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
             $hash = @{ Verb = "Get"; outv = "zoo" }
             Get-Verb @hash -Verb "Send" -OutVariable "bar" > $null
             $zoo | Should -BeNullOrEmpty
-            $bar | Should -BeOfType "System.Management.Automation.VerbInfo"
+            $bar | Should -BeOfType System.Management.Automation.VerbInfo
             $bar.Verb | Should -BeExactly "Send"
 
             ## GetPowerShell
             $ps = { param($hash) Get-Verb @hash -Verb "Send" -OutVariable "bar"; Get-Variable bar }.GetPowerShell($hash)
             try {
                 $result = $ps.Invoke()
-                $result[0] | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result[0] | Should -BeOfType System.Management.Automation.VerbInfo
                 $result[0].Verb | Should -BeExactly 'Send'
             } finally {
                 $ps.Dispose()
@@ -269,10 +269,10 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
                 $sp.Begin($false)
 
                 $result = $sp.Process()
-                $result | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result | Should -BeOfType System.Management.Automation.VerbInfo
                 $result.Verb | Should -BeExactly 'Send'
                 $zoo | Should -BeNullOrEmpty
-                $bar | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $bar | Should -BeOfType System.Management.Automation.VerbInfo
                 $bar.Verb | Should -BeExactly 'Send'
 
                 $sp.End()
@@ -290,14 +290,14 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
             $hash = @{ Verb = "Get"; ov = "zoo" }
             Get-Verb @hash -Verb "Send" -outv "bar" > $null
             $zoo | Should -BeNullOrEmpty
-            $bar | Should -BeOfType "System.Management.Automation.VerbInfo"
+            $bar | Should -BeOfType System.Management.Automation.VerbInfo
             $bar.Verb | Should -BeExactly "Send"
 
             ## GetPowerShell
             $ps = { param($hash) Get-Verb @hash -Verb "Send" -outv "bar"; Get-Variable bar }.GetPowerShell($hash)
             try {
                 $result = $ps.Invoke()
-                $result[0] | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result[0] | Should -BeOfType System.Management.Automation.VerbInfo
                 $result[0].Verb | Should -BeExactly 'Send'
             } finally {
                 $ps.Dispose()
@@ -310,10 +310,10 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
                 $sp.Begin($false)
 
                 $result = $sp.Process()
-                $result | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result | Should -BeOfType System.Management.Automation.VerbInfo
                 $result.Verb | Should -BeExactly 'Send'
                 $zoo | Should -BeNullOrEmpty
-                $bar | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $bar | Should -BeOfType System.Management.Automation.VerbInfo
                 $bar.Verb | Should -BeExactly 'Send'
 
                 $sp.End()
@@ -331,14 +331,14 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
             $hash = @{ Verb = "Get"; outv = "zoo" }
             Get-Verb @hash -Verb "Send" -ov "bar" > $null
             $zoo | Should -BeNullOrEmpty
-            $bar | Should -BeOfType "System.Management.Automation.VerbInfo"
+            $bar | Should -BeOfType System.Management.Automation.VerbInfo
             $bar.Verb | Should -BeExactly "Send"
 
             ## GetPowerShell
             $ps = { param($hash) Get-Verb @hash -Verb "Send" -ov "bar"; Get-Variable bar }.GetPowerShell($hash)
             try {
                 $result = $ps.Invoke()
-                $result[0] | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result[0] | Should -BeOfType System.Management.Automation.VerbInfo
                 $result[0].Verb | Should -BeExactly 'Send'
             } finally {
                 $ps.Dispose()
@@ -351,10 +351,10 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
                 $sp.Begin($false)
 
                 $result = $sp.Process()
-                $result | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result | Should -BeOfType System.Management.Automation.VerbInfo
                 $result.Verb | Should -BeExactly 'Send'
                 $zoo | Should -BeNullOrEmpty
-                $bar | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $bar | Should -BeOfType System.Management.Automation.VerbInfo
                 $bar.Verb | Should -BeExactly 'Send'
 
                 $sp.End()

--- a/test/powershell/engine/ParameterBinding/Splatting.Tests.ps1
+++ b/test/powershell/engine/ParameterBinding/Splatting.Tests.ps1
@@ -50,16 +50,36 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
                 $ps.Dispose()
             }
         }
+
+        It "works on steppable pipeline" {
+            $hash = @{ Verb = "Get"; OutVariable = "zoo" }
+            $sp = { Get-Verb @hash }.GetSteppablePipeline()
+            try {
+                $sp.Begin($false)
+
+                $result = $sp.Process()
+                $result | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result.Verb | Should -BeExactly 'Get'
+                $zoo | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $zoo.Verb | Should -BeExactly 'Get'
+
+                $sp.End()
+            } finally {
+                $sp.Dispose()
+            }
+        }
     }
 
     Context "Explicitly specified named parameter supersedes the same one in Hashtable splatting" {
 
         It "works with the same parameter name" {
+            ## Regular use with cmdlet
             $hash = @{ Verb = "Get"; OutVariable = "zoo" }
             Get-Verb @hash -Verb "Send" > $null
             $zoo | Should -BeOfType "System.Management.Automation.VerbInfo"
             $zoo.Verb | Should -BeExactly "Send"
 
+            ## GetPowerShell
             $ps = { param($hash) Get-Verb @hash -Verb "Send"; Get-Variable zoo }.GetPowerShell($hash)
             try {
                 $result = $ps.Invoke()
@@ -69,6 +89,24 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
                 $ps.Dispose()
             }
 
+            ## Steppable pipeline
+            $zoo = $null
+            $sp = { Get-Verb @hash -Verb "Send" }.GetSteppablePipeline()
+            try {
+                $sp.Begin($false)
+
+                $result = $sp.Process()
+                $result | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result.Verb | Should -BeExactly 'Send'
+                $zoo | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $zoo.Verb | Should -BeExactly 'Send'
+
+                $sp.End()
+            } finally {
+                $sp.Dispose()
+            }
+
+            ## Regular use with simple function
             $hash = @{ Name = "Hello"; Path = "World" }
             SimpleTest @hash -Path "Yeah" | Should -BeExactly 'Key: Hello; Path: Yeah; Args: '
 
@@ -77,12 +115,14 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
         }
 
         It "works with the same alias name" {
+            ## Regular use with cmdlet
             $hash = @{ Verb = "Get"; ov = "zoo" }
             Get-Verb @hash -Verb "Send" -ov "bar" > $null
             $zoo | Should -BeNullOrEmpty
             $bar | Should -BeOfType "System.Management.Automation.VerbInfo"
             $bar.Verb | Should -BeExactly "Send"
 
+            ## GetPowerShell
             $ps = { param($hash) Get-Verb @hash -Verb "Send" -ov "bar"; Get-Variable bar }.GetPowerShell($hash)
             try {
                 $result = $ps.Invoke()
@@ -92,17 +132,38 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
                 $ps.Dispose()
             }
 
+            ## Steppable pipeline
+            $bar = $null
+            $sp = { Get-Verb @hash -Verb "Send" -ov "bar" }.GetSteppablePipeline()
+            try {
+                $sp.Begin($false)
+
+                $result = $sp.Process()
+                $result | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result.Verb | Should -BeExactly 'Send'
+                $zoo | Should -BeNullOrEmpty
+                $bar | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $bar.Verb | Should -BeExactly 'Send'
+
+                $sp.End()
+            } finally {
+                $sp.Dispose()
+            }
+
+            ## Regular use with simple function
             $hash = @{ key = "Hello"; Path = "World" }
             SimpleTest @hash -Key "Yeah" | Should -BeExactly 'Key: Yeah; Path: World; Args: '
         }
 
         It "works with parameter name and alias name mixed" {
+            ## Regular use with cmdlet
             $hash = @{ Verb = "Get"; OutVariable = "zoo" }
             Get-Verb @hash -Verb "Send" -ov "bar" > $null
             $zoo | Should -BeNullOrEmpty
             $bar | Should -BeOfType "System.Management.Automation.VerbInfo"
             $bar.Verb | Should -BeExactly "Send"
 
+            ## GetPowerShell
             $ps = { param($hash) Get-Verb @hash -Verb "Send" -ov "bar"; Get-Variable bar }.GetPowerShell($hash)
             try {
                 $result = $ps.Invoke()
@@ -112,17 +173,38 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
                 $ps.Dispose()
             }
 
+            ## Steppable pipeline
+            $bar = $null
+            $sp = { Get-Verb @hash -Verb "Send" -ov "bar" }.GetSteppablePipeline()
+            try {
+                $sp.Begin($false)
+
+                $result = $sp.Process()
+                $result | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result.Verb | Should -BeExactly 'Send'
+                $zoo | Should -BeNullOrEmpty
+                $bar | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $bar.Verb | Should -BeExactly 'Send'
+
+                $sp.End()
+            } finally {
+                $sp.Dispose()
+            }
+
+            ## Regular use with simple function
             $hash = @{ Name = "Hello"; Path = "World" }
             SimpleTest @hash -Key "Yeah" | Should -BeExactly 'Key: Yeah; Path: World; Args: '
         }
 
         It "works with unambiguous prefix and parameter name mixed - prefix explicitly specified" {
+            ## Regular use with cmdlet
             $hash = @{ Verb = "Get"; OutVariable = "zoo" }
             Get-Verb @hash -Verb "Send" -outv "bar" > $null
             $zoo | Should -BeNullOrEmpty
             $bar | Should -BeOfType "System.Management.Automation.VerbInfo"
             $bar.Verb | Should -BeExactly "Send"
 
+            ## GetPowerShell
             $ps = { param($hash) Get-Verb @hash -Verb "Send" -outv "bar"; Get-Variable bar }.GetPowerShell($hash)
             try {
                 $result = $ps.Invoke()
@@ -132,17 +214,38 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
                 $ps.Dispose()
             }
 
+            ## Steppable pipeline
+            $bar = $null
+            $sp = { Get-Verb @hash -Verb "Send" -outv "bar" }.GetSteppablePipeline()
+            try {
+                $sp.Begin($false)
+
+                $result = $sp.Process()
+                $result | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result.Verb | Should -BeExactly 'Send'
+                $zoo | Should -BeNullOrEmpty
+                $bar | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $bar.Verb | Should -BeExactly 'Send'
+
+                $sp.End()
+            } finally {
+                $sp.Dispose()
+            }
+
+            ## Regular use with simple function
             $hash = @{ Name = "Hello"; Path = "World" }
             SimpleTest @hash -n "Yeah" | Should -BeExactly 'Key: Yeah; Path: World; Args: '
         }
 
         It "works with unambiguous prefix and parameter name mixed - prefix in splatting hashtable" {
+            ## Regular use with cmdlet
             $hash = @{ Verb = "Get"; outv = "zoo" }
             Get-Verb @hash -Verb "Send" -OutVariable "bar" > $null
             $zoo | Should -BeNullOrEmpty
             $bar | Should -BeOfType "System.Management.Automation.VerbInfo"
             $bar.Verb | Should -BeExactly "Send"
 
+            ## GetPowerShell
             $ps = { param($hash) Get-Verb @hash -Verb "Send" -OutVariable "bar"; Get-Variable bar }.GetPowerShell($hash)
             try {
                 $result = $ps.Invoke()
@@ -152,17 +255,38 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
                 $ps.Dispose()
             }
 
+            ## Steppable pipeline
+            $bar = $null
+            $sp = { Get-Verb @hash -Verb "Send" -OutVariable "bar" }.GetSteppablePipeline()
+            try {
+                $sp.Begin($false)
+
+                $result = $sp.Process()
+                $result | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result.Verb | Should -BeExactly 'Send'
+                $zoo | Should -BeNullOrEmpty
+                $bar | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $bar.Verb | Should -BeExactly 'Send'
+
+                $sp.End()
+            } finally {
+                $sp.Dispose()
+            }
+
+            ## Regular use with simple function
             $hash = @{ n = "Hello"; Path = "World" }
             SimpleTest @hash -Name "Yeah" | Should -BeExactly 'Key: Yeah; Path: World; Args: '
         }
 
         It "works with unambiguous prefix and alias name mixed - prefix explicitly specified" {
+            ## Regular use with cmdlet
             $hash = @{ Verb = "Get"; ov = "zoo" }
             Get-Verb @hash -Verb "Send" -outv "bar" > $null
             $zoo | Should -BeNullOrEmpty
             $bar | Should -BeOfType "System.Management.Automation.VerbInfo"
             $bar.Verb | Should -BeExactly "Send"
 
+            ## GetPowerShell
             $ps = { param($hash) Get-Verb @hash -Verb "Send" -outv "bar"; Get-Variable bar }.GetPowerShell($hash)
             try {
                 $result = $ps.Invoke()
@@ -172,17 +296,38 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
                 $ps.Dispose()
             }
 
+            ## Steppable pipeline
+            $bar = $null
+            $sp = { Get-Verb @hash -Verb "Send" -outv "bar" }.GetSteppablePipeline()
+            try {
+                $sp.Begin($false)
+
+                $result = $sp.Process()
+                $result | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result.Verb | Should -BeExactly 'Send'
+                $zoo | Should -BeNullOrEmpty
+                $bar | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $bar.Verb | Should -BeExactly 'Send'
+
+                $sp.End()
+            } finally {
+                $sp.Dispose()
+            }
+
+            ## Regular use with simple function
             $hash = @{ key = "Hello"; Path = "World" }
             SimpleTest @hash -n "Yeah" | Should -BeExactly 'Key: Yeah; Path: World; Args: '
         }
 
         It "works with unambiguous prefix and alias name mixed - prefix in splatting hashtable" {
+            ## Regular use with cmdlet
             $hash = @{ Verb = "Get"; outv = "zoo" }
             Get-Verb @hash -Verb "Send" -ov "bar" > $null
             $zoo | Should -BeNullOrEmpty
             $bar | Should -BeOfType "System.Management.Automation.VerbInfo"
             $bar.Verb | Should -BeExactly "Send"
 
+            ## GetPowerShell
             $ps = { param($hash) Get-Verb @hash -Verb "Send" -ov "bar"; Get-Variable bar }.GetPowerShell($hash)
             try {
                 $result = $ps.Invoke()
@@ -192,6 +337,25 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
                 $ps.Dispose()
             }
 
+            ## Steppable pipeline
+            $bar = $null
+            $sp = { Get-Verb @hash -Verb "Send" -ov "bar" }.GetSteppablePipeline()
+            try {
+                $sp.Begin($false)
+
+                $result = $sp.Process()
+                $result | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $result.Verb | Should -BeExactly 'Send'
+                $zoo | Should -BeNullOrEmpty
+                $bar | Should -BeOfType 'System.Management.Automation.VerbInfo'
+                $bar.Verb | Should -BeExactly 'Send'
+
+                $sp.End()
+            } finally {
+                $sp.Dispose()
+            }
+
+            ## Regular use with simple function
             $hash = @{ n = "Hello"; Path = "World" }
             SimpleTest @hash -key "Yeah" | Should -BeExactly 'Key: Yeah; Path: World; Args: '
         }

--- a/test/powershell/engine/ParameterBinding/Splatting.Tests.ps1
+++ b/test/powershell/engine/ParameterBinding/Splatting.Tests.ps1
@@ -33,6 +33,7 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
 
             $hash = @{ Name = "Hello" }
             SimpleTest @hash -Path "Yeah" | Should -BeExactly 'Key: Hello; Path: Yeah; Args: '
+            SimpleTest -Path "Yeah" @hash | Should -BeExactly 'Key: Hello; Path: Yeah; Args: '
 
             $hash = @{ Key = "Hello" }
             SimpleTest @hash | Should -BeExactly 'Key: Hello; Path: ; Args: '
@@ -79,6 +80,11 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
             $zoo | Should -BeOfType "System.Management.Automation.VerbInfo"
             $zoo.Verb | Should -BeExactly "Send"
 
+            $zoo = $null
+            Get-Verb -Verb "Send" @hash > $null
+            $zoo | Should -BeOfType "System.Management.Automation.VerbInfo"
+            $zoo.Verb | Should -BeExactly "Send"
+
             ## GetPowerShell
             $ps = { param($hash) Get-Verb @hash -Verb "Send"; Get-Variable zoo }.GetPowerShell($hash)
             try {
@@ -109,6 +115,7 @@ Describe "Hashtable Splatting Parameter Binding Tests" -Tags "CI" {
             ## Regular use with simple function
             $hash = @{ Name = "Hello"; Path = "World" }
             SimpleTest @hash -Path "Yeah" | Should -BeExactly 'Key: Hello; Path: Yeah; Args: '
+            SimpleTest -Path "Yeah" @hash | Should -BeExactly 'Key: Hello; Path: Yeah; Args: '
 
             $hash = @{ Name = "Hello"; Blah = "World" }
             SimpleTest @hash -Name "Yeah" | Should -BeExactly 'Key: Yeah; Path: ; Args: -Blah: World'


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #13114.

Allow explicitly specified named parameter to supersede the same one from hashtable splatting.
The work is done in parameter binder, so that parameters can be resolved to cover a parameter's official name, alias name, and unambiguous partial prefix name.

The changes covers covers Hashtable splatting in 3 scenarios:
1. Cmdlet or advanced script invocation;
2. Simple function invocation;
3. `ScriptBlock.GetPowerShell(...)`, where the script block contains command invocation only and uses Hashtable splatting.

Some code refactoring is done to `ParameterBinderController` to avoid redundant code being duplicated in `CmdletParameterBinderController` and `ScriptParameterBinderController`.

### Breaking Change
This change introduces a minor breaking change to how Hashtable splatting works with **_simple functions_** when it contains key/value pairs that not a named parameters of the function. (**no breaking change to _cmdlet/advanced function_**)

With this change, the named parameters from Hashtable splatting will be moved to the end of the parameter/argument list, so as to late bind them after all explicitly specified named parameters are bound. Parameter binding for simple functions won't throw error when a specified named parameter cannot be found, but stuff the unknown named parameters to the `$args` of the simple function. Since the named parameters from Hashtable splatting are moved to the end of the argument list, the order it appears in `args` will be different, also, other explicitly specified parameters for a simple function gets bound earlier.

For example:
```powershell
function SimpleTest {
    param(
        $Name,
        $Path
    )
    "Name: $Name; Path: $Path; Args: $args"
}

$hash = @{ Name = "Hello"; Blah = "World" }
SimpleTest @hash "MyPath"
```

_Current Behavior_
```none
## 'MyPath' is not bound to `-Path` because it's the third argument in the argument list.
## So it ends up being stuffed into '$args' along with `Blah = "World"`

PS> SimpleTest @hash "MyPath"
Name: Hello; Path: ; Args: -Blah: World MyPath
```
_New Behavior_
```none
## The arguments from @hash are moved to the end of the argument list,
## so `MyPath` becomes the first argument in the list and thus bound to '-Path'

PS> SimpleTest @hash "MyPath"
Name: Hello; Path: MyPath; Args: -Blah: World
```

I think the breaking change is in Bucket 3 `Unlikely Grey Area` because:
1. the current behavior is confusing because how the user explicitly specified arguments after the splatted Hashtable depends on the order of them in the argument list after expanding the Hashtable.
2. it should be rare for user to call a simple function with Hashtable splatting which contains keys that are not parameter names of the function.
3. even if (2) happens, say _the Hashtable is a config with all possible parameters and an user sends the config to functions_, it's very unlikely for `$args` to be used in a real scenario like this.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/6431
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
