### PR TITLE
Fix Azure File Copy break in AzDevOps

### DIFF
--- a/tools/releaseBuild/azureDevOps/WindowsBuild.yml
+++ b/tools/releaseBuild/azureDevOps/WindowsBuild.yml
@@ -247,7 +247,7 @@ jobs:
   dependsOn: BuildJob
   condition: succeeded()
   pool:
-    name: Package ES CodeHub Lab E
+    name: Package ES Standard Build
   strategy:
     matrix:
       release-anycpu:

--- a/tools/releaseBuild/azureDevOps/WindowsBuild.yml
+++ b/tools/releaseBuild/azureDevOps/WindowsBuild.yml
@@ -332,7 +332,7 @@ jobs:
     continueOnError: true
     condition: and(succeeded(), eq(variables['Build.Reason'], 'Manual'))
 
-  - task: AzureFileCopy@3
+  - task: AzureFileCopy@4
     displayName: 'upload signed msi to Azure - x64'
     inputs:
       SourcePath: '$(Build.StagingDirectory)\signedPackages\PowerShell-$(Version)-win-x64.msi'
@@ -352,7 +352,7 @@ jobs:
     displayName: '[create script] upload signed msi - x86'
     continueOnError: true
 
-  - task: AzureFileCopy@3
+  - task: AzureFileCopy@4
     displayName: 'upload signed msi to Azure - x86'
     inputs:
       SourcePath: '$(Build.StagingDirectory)\signedPackages\PowerShell-$(Version)-win-x86.msi'
@@ -372,7 +372,7 @@ jobs:
     displayName: '[Create script] upload signed zip - x64'
     continueOnError: true
 
-  - task: AzureFileCopy@3
+  - task: AzureFileCopy@4
     displayName: 'upload signed zip to Azure - x64'
     inputs:
       SourcePath: '$(System.ArtifactsDirectory)\signed\PowerShell-$(Version)-win-x64.zip'
@@ -392,7 +392,7 @@ jobs:
     displayName: '[create script] upload signed zip - x86'
     continueOnError: true
 
-  - task: AzureFileCopy@3
+  - task: AzureFileCopy@4
     displayName: 'upload signed zip to Azure - x86'
     inputs:
       SourcePath: '$(System.ArtifactsDirectory)\signed\PowerShell-$(Version)-win-x86.zip'
@@ -412,7 +412,7 @@ jobs:
     displayName: '[create script] upload signed zip - arm'
     continueOnError: true
 
-  - task: AzureFileCopy@3
+  - task: AzureFileCopy@4
     displayName: 'upload signed zip to Azure - arm'
     inputs:
       SourcePath: '$(System.ArtifactsDirectory)\signed\PowerShell-$(Version)-win-arm32.zip'
@@ -432,7 +432,7 @@ jobs:
     displayName: '[create script] upload signed zip - arm64'
     continueOnError: true
 
-  - task: AzureFileCopy@3
+  - task: AzureFileCopy@4
     displayName: 'upload signed zip to Azure - arm64'
     inputs:
       SourcePath: '$(System.ArtifactsDirectory)\signed\PowerShell-$(Version)-win-arm64.zip'
@@ -452,7 +452,7 @@ jobs:
     displayName: '[create script] upload signed zip - fxdependent'
     continueOnError: true
 
-  - task: AzureFileCopy@3
+  - task: AzureFileCopy@4
     displayName: 'upload signed zip to Azure - fxdependent'
     inputs:
       SourcePath: '$(System.ArtifactsDirectory)\signed\PowerShell-$(Version)-win-fxdependent.zip'

--- a/tools/releaseBuild/azureDevOps/templates/compliance.yml
+++ b/tools/releaseBuild/azureDevOps/templates/compliance.yml
@@ -7,7 +7,7 @@ jobs:
   dependsOn:
     ${{ parameters.parentJobs }}
   pool:
-    name: Package ES CodeHub Lab E
+    name: Package ES Standard Build
 
   # APIScan can take a long time
   timeoutInMinutes: 180

--- a/tools/releaseBuild/azureDevOps/templates/json.yml
+++ b/tools/releaseBuild/azureDevOps/templates/json.yml
@@ -20,7 +20,7 @@ jobs:
       ReleaseTagVar: $(ReleaseTagVar)
       CreateJson: yes
 
-  - task: AzureFileCopy@3
+  - task: AzureFileCopy@4
     displayName: 'upload daily-build-info JSON file to Azure - ${{ parameters.architecture }}'
     inputs:
       SourcePath: '$(BuildInfoPath)'

--- a/tools/releaseBuild/azureDevOps/templates/linux.yml
+++ b/tools/releaseBuild/azureDevOps/templates/linux.yml
@@ -49,7 +49,7 @@ jobs:
   displayName: ${{ parameters.uploadDisplayName }} ${{ parameters.buildName }}
   dependsOn: build_${{ parameters.buildName }}
   condition: succeeded()
-  pool: Package ES CodeHub Lab E
+  pool: Package ES Standard Build
   variables:
     buildName: ${{ parameters.buildName }}
   steps:

--- a/tools/releaseBuild/azureDevOps/templates/linux.yml
+++ b/tools/releaseBuild/azureDevOps/templates/linux.yml
@@ -109,7 +109,7 @@ jobs:
       binVersionOverride: $(SigningVersionOverride)
     condition: and(and(succeeded(), eq(variables['SHOULD_SIGN'], 'true')),eq(variables['buildName'], 'RPM'))
 
-  - task: AzureFileCopy@3
+  - task: AzureFileCopy@4
     displayName: 'Upload to Azure - DEB and tar.gz'
     inputs:
       SourcePath: '$(System.ArtifactsDirectory)\finished\release'
@@ -122,7 +122,7 @@ jobs:
     parameters:
       artifactPath: $(System.ArtifactsDirectory)\finished\release
 
-  - task: AzureFileCopy@3
+  - task: AzureFileCopy@4
     displayName: 'Upload to Azure - RPM - Unsigned'
     inputs:
       SourcePath: '$(System.ArtifactsDirectory)\rpm\release'
@@ -132,7 +132,7 @@ jobs:
       ContainerName: '$(AzureVersion)'
     condition: and(and(succeeded(), ne(variables['SHOULD_SIGN'], 'true')),eq(variables['buildName'], 'RPM'))
 
-  - task: AzureFileCopy@3
+  - task: AzureFileCopy@4
     displayName: 'Upload to Azure - RPM - Signed'
     inputs:
       SourcePath: '$(Build.StagingDirectory)\signedPackages'

--- a/tools/releaseBuild/azureDevOps/templates/mac-package-signing.yml
+++ b/tools/releaseBuild/azureDevOps/templates/mac-package-signing.yml
@@ -4,7 +4,7 @@ jobs:
   dependsOn: build_macOS
   condition: succeeded()
   pool:
-    name: Package ES CodeHub Lab E
+    name: Package ES Standard Build
   variables:
     BuildConfiguration: release
     BuildPlatform: any cpu

--- a/tools/releaseBuild/azureDevOps/templates/mac-package-signing.yml
+++ b/tools/releaseBuild/azureDevOps/templates/mac-package-signing.yml
@@ -97,7 +97,7 @@ jobs:
     displayName: 'Create unsigned folder to upload'
     condition: and(succeeded(), ne(variables['SHOULD_SIGN'], 'true'))
 
-  - task: AzureFileCopy@3
+  - task: AzureFileCopy@4
     displayName: 'AzureBlob File Copy - unsigned'
     inputs:
       SourcePath: '$(Build.StagingDirectory)\macos-unsigned'
@@ -107,7 +107,7 @@ jobs:
       ContainerName: '$(AzureVersion)'
     condition: and(succeeded(), ne(variables['SHOULD_SIGN'], 'true'))
 
-  - task: AzureFileCopy@3
+  - task: AzureFileCopy@4
     displayName: 'AzureBlob File Copy - signed'
     inputs:
       SourcePath: '$(System.ArtifactsDirectory)\azureMacOs'

--- a/tools/releaseBuild/azureDevOps/templates/nuget.yml
+++ b/tools/releaseBuild/azureDevOps/templates/nuget.yml
@@ -160,7 +160,7 @@ jobs:
       Get-ChildItem "$(System.ArtifactsDirectory)\signed\globaltool" -Recurse
     displayName: Move global tool packages to subfolder and capture
 
-  - task: AzureFileCopy@3
+  - task: AzureFileCopy@4
     displayName: 'Upload NuGet packages to Azure'
     inputs:
       SourcePath: '$(System.ArtifactsDirectory)\signed\'
@@ -170,7 +170,7 @@ jobs:
       ContainerName: '$(AzureVersion)-nuget'
     condition: and(succeeded(), eq(variables['SHOULD_SIGN'], 'true'))
 
-  - task: AzureFileCopy@3
+  - task: AzureFileCopy@4
     displayName: 'Upload global tool packages to Azure'
     inputs:
       sourcePath: '$(System.ArtifactsDirectory)\signed\globaltool'

--- a/tools/releaseBuild/azureDevOps/templates/upload.yml
+++ b/tools/releaseBuild/azureDevOps/templates/upload.yml
@@ -12,7 +12,7 @@ steps:
     artifactFilter: PowerShell-${{ parameters.version }}-win-${{ parameters.architecture }}.msi
     condition: and(succeeded(), eq('${{ parameters.msi }}', 'yes'))
 
-- task: AzureFileCopy@3
+- task: AzureFileCopy@4
   displayName: 'upload signed msi to Azure - ${{ parameters.architecture }}'
   inputs:
     SourcePath: '$(Build.StagingDirectory)\signedPackages\PowerShell-${{ parameters.version }}-win-${{ parameters.architecture }}.msi'
@@ -28,7 +28,7 @@ steps:
     artifactPath: $(System.ArtifactsDirectory)\signed
     artifactFilter: PowerShell-${{ parameters.version }}-win-${{ parameters.architecture }}.zip
 
-- task: AzureFileCopy@3
+- task: AzureFileCopy@4
   displayName: 'upload signed zip to Azure - ${{ parameters.architecture }}'
   inputs:
     SourcePath: '$(System.ArtifactsDirectory)\signed\PowerShell-${{ parameters.version }}-win-${{ parameters.architecture }}.zip'
@@ -56,7 +56,7 @@ steps:
     artifactFilter: PowerShell-${{ parameters.version }}-win-${{ parameters.architecture }}.msix
     condition: and(succeeded(), eq('${{ parameters.msix }}', 'yes'))
 
-- task: AzureFileCopy@3
+- task: AzureFileCopy@4
   displayName: 'upload signed msix to Azure - ${{ parameters.architecture }}'
   inputs:
     SourcePath: '$(Build.StagingDirectory)\signedPackages\PowerShell-${{ parameters.version }}-win-${{ parameters.architecture }}.msix'

--- a/tools/releaseBuild/azureDevOps/templates/upload.yml
+++ b/tools/releaseBuild/azureDevOps/templates/upload.yml
@@ -20,6 +20,7 @@ steps:
     Destination: AzureBlob
     storage: '$(StorageAccount)'
     ContainerName: '$(AzureVersion)'
+    resourceGroup: '$(StorageResourceGroup)'
   condition: and(succeeded(), eq('${{ parameters.msi }}', 'yes'))
 
 - template: upload-final-results.yml
@@ -35,6 +36,7 @@ steps:
     Destination: AzureBlob
     storage: '$(StorageAccount)'
     ContainerName: '$(AzureVersion)'
+    resourceGroup: '$(StorageResourceGroup)'
   condition: succeeded()
 
 # Disable upload task as the symbols package is not currently used and we want to avoid publishing this in releases
@@ -62,4 +64,5 @@ steps:
     Destination: AzureBlob
     storage: '$(StorageAccount)'
     ContainerName: '$(AzureVersion)-private'
+    resourceGroup: '$(StorageResourceGroup)'
   condition: and(succeeded(), eq('${{ parameters.msix }}', 'yes'), eq(variables['SHOULD_SIGN'], 'true'))

--- a/tools/releaseBuild/azureDevOps/templates/upload.yml
+++ b/tools/releaseBuild/azureDevOps/templates/upload.yml
@@ -40,7 +40,7 @@ steps:
   condition: succeeded()
 
 # Disable upload task as the symbols package is not currently used and we want to avoid publishing this in releases
-#- task: AzureFileCopy@3
+#- task: AzureFileCopy@4
 #  displayName: 'upload pbd zip to Azure - ${{ parameters.architecture }}'
 #  inputs:
 #    SourcePath: '$(System.ArtifactsDirectory)\signed\PowerShell-Symbols-${{ parameters.version }}-win-${{ parameters.architecture }}.zip'

--- a/tools/releaseBuild/azureDevOps/templates/windows-package-signing.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-package-signing.yml
@@ -8,7 +8,7 @@ jobs:
     ${{ parameters.parentJobs }}
   condition: succeeded()
   pool:
-    name: Package ES CodeHub Lab E
+    name: Package ES Standard Build
   variables:
     BuildConfiguration: release
     BuildPlatform: any cpu


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix Azure File Copy break in AzDevOps

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
