### PR TITLE
Change `Read-Host -MaskInput` to use existing SecureString path, but return as plain text

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ReadConsoleCmdlet.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ReadConsoleCmdlet.cs
@@ -132,7 +132,7 @@ namespace Microsoft.PowerShell.Commands
                 FieldDescription fd = new FieldDescription(promptString);
                 if (AsSecureString || MaskInput)
                 {
-                    fd.SetParameterType(typeof(System.Security.SecureString));
+                    fd.SetParameterType(typeof(SecureString));
                 }
                 else
                 {
@@ -149,9 +149,9 @@ namespace Microsoft.PowerShell.Commands
                 {
                     foreach (PSObject o in result.Values)
                     {
-                        if (MaskInput && o.BaseObject is System.Security.SecureString)
+                        if (MaskInput && o.BaseObject is SecureString)
                         {
-                            WriteObject(Utils.GetStringFromSecureString((System.Security.SecureString)o.BaseObject));
+                            WriteObject(Utils.GetStringFromSecureString((SecureString)o.BaseObject));
                         }
                         else
                         {
@@ -174,7 +174,7 @@ namespace Microsoft.PowerShell.Commands
 
                 if (MaskInput)
                 {
-                    WriteObject(Utils.GetStringFromSecureString((System.Security.SecureString)result));
+                    WriteObject(Utils.GetStringFromSecureString((SecureString)result));
                 }
                 else
                 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ReadConsoleCmdlet.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ReadConsoleCmdlet.cs
@@ -149,7 +149,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     foreach (PSObject o in result.Values)
                     {
-                        if (MaskInput && o.BaseObject is SecureString secureString)
+                        if (MaskInput && o?.BaseObject is SecureString secureString)
                         {
                             WriteObject(Utils.GetStringFromSecureString(secureString));
                         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ReadConsoleCmdlet.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ReadConsoleCmdlet.cs
@@ -149,9 +149,9 @@ namespace Microsoft.PowerShell.Commands
                 {
                     foreach (PSObject o in result.Values)
                     {
-                        if (MaskInput && o.BaseObject is SecureString)
+                        if (MaskInput && o.BaseObject is SecureString secureString)
                         {
-                            WriteObject(Utils.GetStringFromSecureString((SecureString)o.BaseObject));
+                            WriteObject(Utils.GetStringFromSecureString(secureString));
                         }
                         else
                         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ReadConsoleCmdlet.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ReadConsoleCmdlet.cs
@@ -130,7 +130,7 @@ namespace Microsoft.PowerShell.Commands
                 }
 
                 FieldDescription fd = new FieldDescription(promptString);
-                if (AsSecureString)
+                if (AsSecureString || MaskInput)
                 {
                     fd.SetParameterType(typeof(System.Security.SecureString));
                 }
@@ -149,27 +149,37 @@ namespace Microsoft.PowerShell.Commands
                 {
                     foreach (PSObject o in result.Values)
                     {
-                        WriteObject(o);
+                        if (MaskInput && o.BaseObject is System.Security.SecureString)
+                        {
+                            WriteObject(Utils.GetStringFromSecureString((System.Security.SecureString)o.BaseObject));
+                        }
+                        else
+                        {
+                            WriteObject(o);
+                        }
                     }
                 }
             }
             else
             {
                 object result;
-                if (AsSecureString)
+                if (AsSecureString || MaskInput)
                 {
                     result = Host.UI.ReadLineAsSecureString();
-                }
-                else if (MaskInput)
-                {
-                    result = Host.UI.ReadLineMaskedAsString();
                 }
                 else
                 {
                     result = Host.UI.ReadLine();
                 }
 
-                WriteObject(result);
+                if (MaskInput)
+                {
+                    WriteObject(Utils.GetStringFromSecureString((System.Security.SecureString)result));
+                }
+                else
+                {
+                    WriteObject(result);
+                }
             }
         }
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -113,17 +113,6 @@ namespace Microsoft.PowerShell
         }
 
         /// <summary>
-        /// Null implementation of ReadLineMaskedAsString.
-        /// </summary>
-        /// <returns>
-        /// It throws an exception.
-        /// </returns>
-        public override string ReadLineMaskedAsString()
-        {
-            throw new PSNotImplementedException();
-        }
-
-        /// <summary>
         /// ReadLineAsSecureString.
         /// </summary>
         /// <returns></returns>

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -182,39 +182,6 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// See base class.
         /// </summary>
-        /// <returns>
-        /// The characters typed by the user.
-        /// </returns>
-        /// <exception cref="HostException">
-        /// If obtaining a handle to the active screen buffer failed
-        ///    OR
-        ///    Win32's setting input buffer mode to disregard window and mouse input failed.
-        ///    OR
-        ///    Win32's ReadConsole failed.
-        /// </exception>
-        /// <exception cref="PipelineStoppedException">
-        /// If Ctrl-C is entered by user.
-        /// </exception>
-        public override string ReadLineMaskedAsString()
-        {
-            HandleThrowOnReadAndPrompt();
-
-            // we lock here so that multiple threads won't interleave the various reads and writes here.
-            object result = null;
-            lock (_instanceLock)
-            {
-                result = ReadLineSafe(false, PrintToken);
-            }
-
-            StringBuilder resultSb = result as StringBuilder;
-            Dbg.Assert(resultSb != null, "ReadLineMaskedAsString did not return a stringBuilder");
-
-            return resultSb.ToString();
-        }
-
-        /// <summary>
-        /// See base class.
-        /// </summary>
         /// <returns></returns>
         /// <exception cref="HostException">
         /// If obtaining a handle to the active screen buffer failed

--- a/src/System.Management.Automation/engine/hostifaces/InternalHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/InternalHostUserInterface.cs
@@ -123,47 +123,6 @@ namespace System.Management.Automation.Internal.Host
         /// <summary>
         /// See base class.
         /// </summary>
-        /// <returns>
-        /// The characters typed by the user.
-        /// </returns>
-        /// <exception cref="HostException">
-        /// If the UI property of the external host is null, possibly because the PSHostUserInterface is not
-        /// implemented by the external host.
-        /// </exception>
-        public override
-        string
-        ReadLineMaskedAsString()
-        {
-            if (_externalUI == null)
-            {
-                ThrowNotInteractive();
-            }
-
-            string result = null;
-
-            try
-            {
-                result = _externalUI.ReadLineMaskedAsString();
-            }
-            catch (PipelineStoppedException)
-            {
-                // PipelineStoppedException is thrown by host when it wants
-                // to stop the pipeline.
-                LocalPipeline lpl = (LocalPipeline)((RunspaceBase)_parent.Context.CurrentRunspace).GetCurrentlyRunningPipeline();
-                if (lpl == null)
-                {
-                    throw;
-                }
-
-                lpl.Stopper.Stop();
-            }
-
-            return result;
-        }
-
-        /// <summary>
-        /// See base class.
-        /// </summary>
         /// <exception cref="HostException">
         /// if the UI property of the external host is null, possibly because the PSHostUserInterface is not
         /// implemented by the external host.

--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -62,29 +62,6 @@ namespace System.Management.Automation.Host
         public abstract string ReadLine();
 
         /// <summary>
-        /// Same as ReadLine except that the input is not echoed to the user while it is collected
-        /// or is echoed in some obfuscated way, such as showing a dot for each character.
-        /// </summary>
-        /// <returns>
-        /// The characters typed by the user.
-        /// </returns>
-        /// <remarks>
-        /// Note that credentials (a user name and password) should be gathered with
-        /// <see cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string)"/>
-        /// <see cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
-        /// </remarks>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLine"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string)"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForCredential(string, string, string, string, System.Management.Automation.PSCredentialTypes, System.Management.Automation.PSCredentialUIOptions)"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForChoice"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/>
-        public virtual string ReadLineMaskedAsString()
-        {
-            // Default implementation of the function to maintain backwards compatibility of the base class.
-            throw new PSNotImplementedException();
-        }
-
-        /// <summary>
         /// Same as ReadLine, except that the result is a SecureString, and that the input is not echoed to the user while it is
         /// collected (or is echoed in some obfuscated way, such as showing a dot for each character).
         /// </summary>

--- a/src/System.Management.Automation/engine/remoting/server/ServerRemoteHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRemoteHostUserInterface.cs
@@ -198,17 +198,6 @@ namespace System.Management.Automation.Remoting
         }
 
         /// <summary>
-        /// Read line as string masked.
-        /// </summary>
-        /// <returns>
-        /// Not implemented. It throws an exception.
-        /// </returns>
-        public override string ReadLineMaskedAsString()
-        {
-            throw new PSNotImplementedException();
-        }
-
-        /// <summary>
         /// Read line as secure string.
         /// </summary>
         public override SecureString ReadLineAsSecureString()

--- a/test/tools/Modules/HelpersHostCS/HelpersHostCS.psm1
+++ b/test/tools/Modules/HelpersHostCS/HelpersHostCS.psm1
@@ -183,11 +183,6 @@ namespace TestHost
             return ReadLineData;
         }
 
-        public override string ReadLineMaskedAsString()
-        {
-            return ReadLineData;
-        }
-
         public override SecureString ReadLineAsSecureString()
         {
             SecureString ss = new SecureString();


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

https://github.com/PowerShell/PowerShell/pull/10908 introduced a new `-MaskInput` switch to enable hiding the input while still returning a string.  It did this by introducing a new method `ReadLineMaskedAsString()`, however, this was not necessary and would not be supported by remoting as it required hosts to implement it.  It also did not support use of `-MaskInput` with `-Prompt`.

The change here is to revert most of the changes in that PR to instead use existing `ReadLineAsSecureString()` method which would already be implemented by different hosts and convert to a string if `-MaskInput` is used.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/13011

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed] https://github.com/MicrosoftDocs/PowerShell-Docs/issues/5021(https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
