### PR TITLE
Remove `ComEnumerator` as COM objects using IEnumerator is now supported in .NET 5

### DIFF
--- a/src/System.Management.Automation/engine/COM/ComUtil.cs
+++ b/src/System.Management.Automation/engine/COM/ComUtil.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections;
 using System.Collections.ObjectModel;
 using System.Management.Automation.ComInterop;
 using System.Runtime.InteropServices;
@@ -363,55 +362,6 @@ namespace System.Management.Automation
             }
 
             return returnValue;
-        }
-    }
-
-    /// <summary>
-    /// Defines an enumerator that represent a COM collection object.
-    /// </summary>
-    internal class ComEnumerator : IEnumerator
-    {
-        private COM.IEnumVARIANT _enumVariant;
-        private object[] _element;
-
-        private ComEnumerator(COM.IEnumVARIANT enumVariant)
-        {
-            _enumVariant = enumVariant;
-            _element = new object[1];
-        }
-
-        public object Current
-        {
-            get { return _element[0]; }
-        }
-
-        public bool MoveNext()
-        {
-            _element[0] = null;
-            int result = _enumVariant.Next(1, _element, IntPtr.Zero);
-            return result == 0;
-        }
-
-        public void Reset()
-        {
-            _element[0] = null;
-            _enumVariant.Reset();
-        }
-
-        /// <summary>
-        /// Try to create an enumerator for a COM object.
-        /// </summary>
-        /// <returns>
-        /// A 'ComEnumerator' instance, or null if we cannot create an enumerator for the COM object.
-        /// </returns>
-        internal static ComEnumerator Create(object comObject)
-        {
-            if (comObject == null || !comObject.GetType().IsCOMObject) { return null; }
-
-            // The passed-in COM object could already be a IEnumVARIANT interface.
-            // e.g. user call '_NewEnum()' on a COM collection interface.
-            var enumVariant = comObject as COM.IEnumVARIANT;
-            return enumVariant != null ? new ComEnumerator(enumVariant) : null;
         }
     }
 }

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -3311,17 +3311,7 @@ namespace System.Management.Automation
             {
             }
 
-            // We use ComEnumerator to enumerate COM collections because the following code doesn't work in .NET Core
-            //   IEnumerator enumerator = targetValue as IEnumerator;
-            //   if (enumerator != null)
-            //   {
-            //       enumerable.MoveNext();
-            //       ...
-            //   }
-            // The call to 'MoveNext()' throws exception because COM is not fully supported in .NET Core.
-            // See https://github.com/dotnet/runtime/issues/21690 for more information.
-            // When COM support is fully back to .NET Core, we need to change back to directly use the type cast.
-            return ComEnumerator.Create(targetValue) ?? NonEnumerableObjectEnumerator.Create(obj);
+            return targetValue as IEnumerator ?? NonEnumerableObjectEnumerator.Create(obj);
         }
 
         internal static IEnumerator GetGenericEnumerator<T>(IEnumerable<T> enumerable)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #12881

.NET 5 now [support COM objects using `IEnumerator` (`IEnumVARIANT`)](https://github.com/dotnet/runtime/pull/37326) (the fix is in .NET 5 preview 7), so in our code, the `ComEnumerator`, that handles `IEnumVARIANT` can be removed.

The `ComEnumerator` was introduced in #4553 3 years ago to make PowerShell able to enumerate COM object.
The support for COM objects that use `IEnumerable` was back in .NET 3.1, so #11795 reverted some of our changes.
This is a follow-up PR, to remove the remaining `ComEnumerator` code since now .NET 5 finally supports COM objects that use `IEnumerator`.

No new test is needed.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
