### PR TITLE
Fix Test-XUnitTestResults function

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -1478,7 +1478,7 @@ function Test-XUnitTestResults
         throw "Cannot convert $TestResultsFile to xml : $($_.message)"
     }
 
-    $failedTests = $results.assemblies.assembly.collection.test  | Where-Object result -eq "fail"
+    $failedTests = $results.assemblies.assembly.collection.test | Where-Object result -eq "fail"
 
     if(-not $failedTests)
     {

--- a/build.psm1
+++ b/build.psm1
@@ -1478,7 +1478,7 @@ function Test-XUnitTestResults
         throw "Cannot convert $TestResultsFile to xml : $($_.message)"
     }
 
-    $failedTests = $results.assemblies.assembly.collection | Where-Object failed -GT 0
+    $failedTests = $results.assemblies.assembly.collection.test  | Where-Object result -eq "fail"
 
     if(-not $failedTests)
     {
@@ -1487,10 +1487,10 @@ function Test-XUnitTestResults
 
     foreach($failure in $failedTests)
     {
-        $description = $failure.test.type
-        $name = $failure.test.method
-        $message = $failure.test.failure.message.'#cdata-section'
-        $StackTrace = $failure.test.failure.'stack-trace'.'#cdata-section'
+        $description = $failure.type
+        $name = $failure.method
+        $message = $failure.failure.message
+        $StackTrace = $failure.failure.'stack-trace'
 
         Write-Log -isError -message ("Description: " + $description)
         Write-Log -isError -message ("Name:        " + $name)
@@ -1498,9 +1498,10 @@ function Test-XUnitTestResults
         Write-Log -isError -message $message
         Write-Log -isError -message "stack-trace:"
         Write-Log -isError -message $StackTrace
+        Write-Log -isError -message " "
     }
 
-    throw "$($failedTests.failed) tests failed"
+    throw "$($results.assemblies.assembly.failed) tests failed"
 }
 
 #


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix Test-XUnitTestResults function to correctly parse xUnit results if fail results present.

I attached a file with xUnit results so that reviewers can manually test the function
[xUnitTestResults.zip](https://github.com/PowerShell/PowerShell/files/4973567/xUnitTestResults.zip)



## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
