### PR TITLE
Use `is not` syntax and remove unnecessary parentheses

### DIFF
--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimAsyncOperation.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimAsyncOperation.cs
@@ -404,7 +404,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
                 {
                     return null;
                 }
-                else if (!(cimReferenceArray[0] is PSReference))
+                else if (cimReferenceArray[0] is not PSReference)
                 {
                     return null;
                 }

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionProxy.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionProxy.cs
@@ -1055,7 +1055,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
             }
 
             PSObject pso = PSObject.AsPSObject(o);
-            if (!(pso.BaseObject is CimInstance))
+            if (pso.BaseObject is not CimInstance)
             {
                 return;
             }
@@ -2086,7 +2086,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         {
             DebugHelper.WriteLogEx();
 
-            if (!(args.Action is CimWriteResultObject))
+            if (args.Action is not CimWriteResultObject)
             {
                 // allow all other actions
                 return true;
@@ -2240,7 +2240,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         {
             DebugHelper.WriteLogEx();
 
-            if (!(args.Action is CimWriteResultObject))
+            if (args.Action is not CimWriteResultObject)
             {
                 // allow all other actions
                 return true;

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/clientSideQuery.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/clientSideQuery.cs
@@ -405,7 +405,7 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
 
             private object ConvertActualValueToExpectedType(object actualPropertyValue, object expectedPropertyValue)
             {
-                if ((actualPropertyValue is string) && (!(expectedPropertyValue is string)))
+                if ((actualPropertyValue is string) && (expectedPropertyValue is not string))
                 {
                     actualPropertyValue = LanguagePrimitives.ConvertTo(actualPropertyValue, expectedPropertyValue.GetType(), CultureInfo.InvariantCulture);
                 }

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/clientSideQuery.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/clientSideQuery.cs
@@ -405,7 +405,7 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
 
             private object ConvertActualValueToExpectedType(object actualPropertyValue, object expectedPropertyValue)
             {
-                if ((actualPropertyValue is string) && (expectedPropertyValue is not string))
+                if (actualPropertyValue is string && expectedPropertyValue is not string)
                 {
                     actualPropertyValue = LanguagePrimitives.ConvertTo(actualPropertyValue, expectedPropertyValue.GetType(), CultureInfo.InvariantCulture);
                 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -667,7 +667,7 @@ namespace Microsoft.PowerShell.Commands
 
                     // null is not valid value for header.
                     // We silently ignore header if value is null.
-                    if (!(value is null))
+                    if (value is not null)
                     {
                         // add the header value (or overwrite it if already present)
                         WebSession.Headers[key] = value.ToString();

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/TraceExpressionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/TraceExpressionCommand.cs
@@ -525,7 +525,7 @@ namespace Microsoft.PowerShell.Commands
             if (mshobj != null)
             {
                 object baseObject = mshobj.BaseObject;
-                if (!(baseObject is PSCustomObject))
+                if (baseObject is not PSCustomObject)
                 {
                     obj = baseObject;
                 }

--- a/src/Microsoft.PowerShell.ConsoleHost/WindowsTaskbarJumpList/PropertyKey.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/WindowsTaskbarJumpList/PropertyKey.cs
@@ -75,7 +75,7 @@ namespace Microsoft.PowerShell
             if (obj == null)
                 return false;
 
-            if (!(obj is PropertyKey))
+            if (obj is not PropertyKey)
                 return false;
 
             PropertyKey other = (PropertyKey)obj;

--- a/src/Microsoft.PowerShell.ScheduledJob/ScheduledJobDefinition.cs
+++ b/src/Microsoft.PowerShell.ScheduledJob/ScheduledJobDefinition.cs
@@ -938,7 +938,7 @@ namespace Microsoft.PowerShell.ScheduledJob
                     { }
                 }
 
-                if (!(ex is ScheduledJobException))
+                if (ex is not ScheduledJobException)
                 {
                     // Wrap in ScheduledJobException type.
                     string msg = StringUtil.Format(ScheduledJobErrorStrings.ErrorRegisteringDefinitionStore, this.Name);

--- a/src/Microsoft.PowerShell.Security/security/AclCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/AclCommands.cs
@@ -783,7 +783,7 @@ namespace Microsoft.PowerShell.Commands
                     {
                         customDescriptor = PSObject.Base(methodInfo.Invoke());
 
-                        if (!(customDescriptor is FileSystemSecurity))
+                        if (customDescriptor is not FileSystemSecurity)
                         {
                             customDescriptor = new CommonSecurityDescriptor(false, false, customDescriptor.ToString());
                         }

--- a/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
+++ b/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
@@ -1195,7 +1195,7 @@ namespace Microsoft.PowerShell.Commands
                     // If the inner exception is not of that type
                     // then we need to rethrow
                     //
-                    if (!(e.InnerException is CertificateProviderItemNotFoundException))
+                    if (e.InnerException is not CertificateProviderItemNotFoundException)
                     {
                         throw;
                     }

--- a/src/System.Management.Automation/FormatAndOutput/out-console/OutConsole.cs
+++ b/src/System.Management.Automation/FormatAndOutput/out-console/OutConsole.cs
@@ -109,11 +109,10 @@ namespace Microsoft.PowerShell.Commands
                 object inputObjectBase = PSObject.Base(InputObject);
 
                 // Ignore errors and formatting records, as those can't be captured
-                if (
-                    (inputObjectBase != null) &&
-                    (inputObjectBase is not ErrorRecord) &&
-                    (!inputObjectBase.GetType().FullName.StartsWith(
-                        "Microsoft.PowerShell.Commands.Internal.Format", StringComparison.OrdinalIgnoreCase)))
+                if (inputObjectBase != null &&
+                    inputObjectBase is not ErrorRecord &&
+                    !inputObjectBase.GetType().FullName.StartsWith(
+                        "Microsoft.PowerShell.Commands.Internal.Format", StringComparison.OrdinalIgnoreCase))
                 {
                     _outVarResults.Add(InputObject);
                 }

--- a/src/System.Management.Automation/FormatAndOutput/out-console/OutConsole.cs
+++ b/src/System.Management.Automation/FormatAndOutput/out-console/OutConsole.cs
@@ -111,7 +111,7 @@ namespace Microsoft.PowerShell.Commands
                 // Ignore errors and formatting records, as those can't be captured
                 if (
                     (inputObjectBase != null) &&
-                    (!(inputObjectBase is ErrorRecord)) &&
+                    (inputObjectBase is not ErrorRecord) &&
                     (!inputObjectBase.GetType().FullName.StartsWith(
                         "Microsoft.PowerShell.Commands.Internal.Format", StringComparison.OrdinalIgnoreCase)))
                 {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -1805,7 +1805,7 @@ namespace System.Management.Automation
                             }
                         }
                         // Continue trying the filename/commandname completion for scenarios like this: $aa[get-<tab>
-                        else if (!(cursorAst is ErrorExpressionAst && cursorAst.Parent is IndexExpressionAst))
+                        else if (cursorAst is ErrorExpressionAst && cursorAst.Parent is not IndexExpressionAst)
                         {
                             return result;
                         }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -1805,7 +1805,7 @@ namespace System.Management.Automation
                             }
                         }
                         // Continue trying the filename/commandname completion for scenarios like this: $aa[get-<tab>
-                        else if (cursorAst is ErrorExpressionAst && cursorAst.Parent is not IndexExpressionAst)
+                        else if (cursorAst is not ErrorExpressionAst || cursorAst.Parent is not IndexExpressionAst)
                         {
                             return result;
                         }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -1895,7 +1895,7 @@ namespace System.Management.Automation
                             yield return new PSTypeName(pso.TypeNames[0]);
                         }
 
-                        if (!(pso.BaseObject is PSCustomObject))
+                        if (pso.BaseObject is not PSCustomObject)
                         {
                             yield return new PSTypeName(pso.BaseObject.GetType());
                         }
@@ -7140,7 +7140,7 @@ namespace System.Management.Automation
             CommandAst commandAst,
             IDictionary fakeBoundParameters)
         {
-            if (!(commandAst.Parent is PipelineAst pipelineAst))
+            if (commandAst.Parent is not PipelineAst pipelineAst)
             {
                 return null;
             }

--- a/src/System.Management.Automation/engine/CompiledCommandParameter.cs
+++ b/src/System.Management.Automation/engine/CompiledCommandParameter.cs
@@ -69,7 +69,7 @@ namespace System.Management.Automation
                     }
                 }
 
-                if (!(attribute is ArgumentTypeConverterAttribute))
+                if (attribute is not ArgumentTypeConverterAttribute)
                 {
                     ProcessAttribute(runtimeDefinedParameter.Name, attribute, ref validationAttributes, ref argTransformationAttributes, ref aliases);
                 }

--- a/src/System.Management.Automation/engine/EventManager.cs
+++ b/src/System.Management.Automation/engine/EventManager.cs
@@ -2597,7 +2597,7 @@ namespace System.Management.Automation
             catch (Exception e)
             {
                 // Catch-all OK. This is a third-party call-out.
-                if (!(e is PipelineStoppedException))
+                if (e is not PipelineStoppedException)
                 {
                     LogErrorsAndOutput(results, actionState);
                     SetJobState(JobState.Failed);

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -906,7 +906,7 @@ namespace System.Management.Automation
                 formatProvider = CultureInfo.InvariantCulture;
             }
 
-            if (!(formatProvider is CultureInfo culture))
+            if (formatProvider is not CultureInfo culture)
             {
                 throw PSTraceSource.NewArgumentException(nameof(formatProvider));
             }
@@ -936,7 +936,7 @@ namespace System.Management.Automation
 
             if (first is string firstString)
             {
-                if (!(second is string secondString))
+                if (second is not string secondString)
                 {
                     if (!TryConvertTo(second, culture, out secondString))
                     {
@@ -4283,7 +4283,7 @@ namespace System.Management.Automation
 
             public override bool Equals(object other)
             {
-                if (!(other is ConversionTypePair))
+                if (other is not ConversionTypePair)
                     return false;
 
                 var ctp = (ConversionTypePair)other;

--- a/src/System.Management.Automation/engine/Modules/NewModuleManifestCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/NewModuleManifestCommand.cs
@@ -628,7 +628,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 foreach (object spec in moduleSpecs)
                 {
-                    if (!(spec is Hashtable))
+                    if (spec is not Hashtable)
                     {
                         yield return spec.ToString();
                     }

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -953,7 +953,7 @@ namespace System.Management.Automation
 
                 _outVarList = oldValue ?? new ArrayList();
 
-                if (!(_thisCommand is PSScriptCmdlet))
+                if (_thisCommand is not PSScriptCmdlet)
                 {
                     this.OutputPipe.AddVariableList(VariableStreamKind.Output, _outVarList);
                 }
@@ -989,7 +989,7 @@ namespace System.Management.Automation
             // same scope.
             _pipelineVarReference = _state.PSVariable.Get(this.PipelineVariable);
 
-            if (!(_thisCommand is PSScriptCmdlet))
+            if (_thisCommand is not PSScriptCmdlet)
             {
                 this.OutputPipe.SetPipelineVariable(_pipelineVarReference);
             }
@@ -2574,7 +2574,7 @@ namespace System.Management.Automation
                 varList = new ArrayList();
             }
 
-            if (!(_thisCommand is PSScriptCmdlet))
+            if (_thisCommand is not PSScriptCmdlet)
             {
                 this.OutputPipe.AddVariableList(streamKind, varList);
             }

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -183,7 +183,7 @@ namespace System.Management.Automation
 
         internal void SetValueNoConversion(object setValue)
         {
-            if (!(this is PSProperty thisAsProperty))
+            if (this is not PSProperty thisAsProperty)
             {
                 this.Value = setValue;
                 return;
@@ -552,7 +552,7 @@ namespace System.Management.Automation
                     name);
             }
 
-            if (!(member is PSAliasProperty aliasMember))
+            if (member is not PSAliasProperty aliasMember)
             {
                 hasCycle = false;
                 returnedMember = member;

--- a/src/System.Management.Automation/engine/TypeTable.cs
+++ b/src/System.Management.Automation/engine/TypeTable.cs
@@ -2191,7 +2191,7 @@ namespace System.Management.Automation.Runspaces
                     return;
                 }
 
-                if (value is NotePropertyData || value is ScriptPropertyData || value is not CodePropertyData)
+                if (value is not NotePropertyData && value is not ScriptPropertyData && value is not CodePropertyData)
                 {
                     throw PSTraceSource.NewArgumentException("value");
                 }

--- a/src/System.Management.Automation/engine/TypeTable.cs
+++ b/src/System.Management.Automation/engine/TypeTable.cs
@@ -2191,7 +2191,7 @@ namespace System.Management.Automation.Runspaces
                     return;
                 }
 
-                if (!(value is NotePropertyData || value is ScriptPropertyData || value is CodePropertyData))
+                if (value is NotePropertyData || value is ScriptPropertyData || value is not CodePropertyData)
                 {
                     throw PSTraceSource.NewArgumentException("value");
                 }

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -4945,7 +4945,7 @@ namespace System.Management.Automation
         private object DrainAndBlockRemoteOutput()
         {
             // We only do this for remote runspaces.
-            if (!(_runspace is RemoteRunspace)) { return null; }
+            if (_runspace is not RemoteRunspace) { return null; }
 
             try
             {

--- a/src/System.Management.Automation/engine/hostifaces/ConnectionBase.cs
+++ b/src/System.Management.Automation/engine/hostifaces/ConnectionBase.cs
@@ -268,7 +268,7 @@ namespace System.Management.Automation.Runspaces
             // sometimes there are many runspaces created - the callee ensures telemetry is only
             // reported once. Note that if the host implements IHostProvidesTelemetryData, we rely
             // on the host calling ReportStartupTelemetry.
-            if (!(this.Host is IHostProvidesTelemetryData))
+            if (this.Host is not IHostProvidesTelemetryData)
             {
                 TelemetryAPI.ReportStartupTelemetry(null);
             }

--- a/src/System.Management.Automation/engine/hostifaces/ConnectionFactory.cs
+++ b/src/System.Management.Automation/engine/hostifaces/ConnectionFactory.cs
@@ -454,11 +454,11 @@ namespace System.Management.Automation.Runspaces
         public static RunspacePool CreateRunspacePool(int minRunspaces,
             int maxRunspaces, RunspaceConnectionInfo connectionInfo, PSHost host, TypeTable typeTable, PSPrimitiveDictionary applicationArguments)
         {
-            if ((connectionInfo is not WSManConnectionInfo) &&
-                (connectionInfo is not NewProcessConnectionInfo) &&
-                (connectionInfo is not NamedPipeConnectionInfo) &&
-                (connectionInfo is not VMConnectionInfo) &&
-                (connectionInfo is not ContainerConnectionInfo))
+            if (connectionInfo is not WSManConnectionInfo
+                && connectionInfo is not NewProcessConnectionInfo
+                && connectionInfo is not NamedPipeConnectionInfo
+                && connectionInfo is not VMConnectionInfo
+                && connectionInfo is not ContainerConnectionInfo)
             {
                 throw new NotSupportedException();
             }
@@ -539,12 +539,12 @@ namespace System.Management.Automation.Runspaces
         /// <returns></returns>
         public static Runspace CreateRunspace(RunspaceConnectionInfo connectionInfo, PSHost host, TypeTable typeTable, PSPrimitiveDictionary applicationArguments, string name)
         {
-            if ((connectionInfo is not WSManConnectionInfo) &&
-                (connectionInfo is not NewProcessConnectionInfo) &&
-                (connectionInfo is not NamedPipeConnectionInfo) &&
-                (connectionInfo is not SSHConnectionInfo) &&
-                (connectionInfo is not VMConnectionInfo) &&
-                (connectionInfo is not ContainerConnectionInfo))
+            if (connectionInfo is not WSManConnectionInfo
+                && connectionInfo is not NewProcessConnectionInfo
+                && connectionInfo is not NamedPipeConnectionInfo
+                && connectionInfo is not SSHConnectionInfo
+                && connectionInfo is not VMConnectionInfo
+                && connectionInfo is not ContainerConnectionInfo)
             {
                 throw new NotSupportedException();
             }
@@ -606,4 +606,3 @@ namespace System.Management.Automation.Runspaces
         #endregion V3 Extensions
     }
 }
-

--- a/src/System.Management.Automation/engine/hostifaces/ConnectionFactory.cs
+++ b/src/System.Management.Automation/engine/hostifaces/ConnectionFactory.cs
@@ -454,11 +454,11 @@ namespace System.Management.Automation.Runspaces
         public static RunspacePool CreateRunspacePool(int minRunspaces,
             int maxRunspaces, RunspaceConnectionInfo connectionInfo, PSHost host, TypeTable typeTable, PSPrimitiveDictionary applicationArguments)
         {
-            if ((!(connectionInfo is WSManConnectionInfo)) &&
-                (!(connectionInfo is NewProcessConnectionInfo)) &&
-                (!(connectionInfo is NamedPipeConnectionInfo)) &&
-                (!(connectionInfo is VMConnectionInfo)) &&
-                (!(connectionInfo is ContainerConnectionInfo)))
+            if ((connectionInfo is not WSManConnectionInfo) &&
+                (connectionInfo is not NewProcessConnectionInfo) &&
+                (connectionInfo is not NamedPipeConnectionInfo) &&
+                (connectionInfo is not VMConnectionInfo) &&
+                (connectionInfo is not ContainerConnectionInfo))
             {
                 throw new NotSupportedException();
             }
@@ -539,12 +539,12 @@ namespace System.Management.Automation.Runspaces
         /// <returns></returns>
         public static Runspace CreateRunspace(RunspaceConnectionInfo connectionInfo, PSHost host, TypeTable typeTable, PSPrimitiveDictionary applicationArguments, string name)
         {
-            if ((!(connectionInfo is WSManConnectionInfo)) &&
-                (!(connectionInfo is NewProcessConnectionInfo)) &&
-                (!(connectionInfo is NamedPipeConnectionInfo)) &&
-                (!(connectionInfo is SSHConnectionInfo)) &&
-                (!(connectionInfo is VMConnectionInfo)) &&
-                (!(connectionInfo is ContainerConnectionInfo)))
+            if ((connectionInfo is not WSManConnectionInfo) &&
+                (connectionInfo is not NewProcessConnectionInfo) &&
+                (connectionInfo is not NamedPipeConnectionInfo) &&
+                (connectionInfo is not SSHConnectionInfo) &&
+                (connectionInfo is not VMConnectionInfo) &&
+                (connectionInfo is not ContainerConnectionInfo))
             {
                 throw new NotSupportedException();
             }

--- a/src/System.Management.Automation/engine/hostifaces/ConnectionFactory.cs
+++ b/src/System.Management.Automation/engine/hostifaces/ConnectionFactory.cs
@@ -454,11 +454,11 @@ namespace System.Management.Automation.Runspaces
         public static RunspacePool CreateRunspacePool(int minRunspaces,
             int maxRunspaces, RunspaceConnectionInfo connectionInfo, PSHost host, TypeTable typeTable, PSPrimitiveDictionary applicationArguments)
         {
-            if (connectionInfo is not WSManConnectionInfo
-                && connectionInfo is not NewProcessConnectionInfo
-                && connectionInfo is not NamedPipeConnectionInfo
-                && connectionInfo is not VMConnectionInfo
-                && connectionInfo is not ContainerConnectionInfo)
+            if (connectionInfo is not WSManConnectionInfo &&
+                connectionInfo is not NewProcessConnectionInfo &&
+                connectionInfo is not NamedPipeConnectionInfo &&
+                connectionInfo is not VMConnectionInfo &&
+                connectionInfo is not ContainerConnectionInfo)
             {
                 throw new NotSupportedException();
             }
@@ -539,12 +539,12 @@ namespace System.Management.Automation.Runspaces
         /// <returns></returns>
         public static Runspace CreateRunspace(RunspaceConnectionInfo connectionInfo, PSHost host, TypeTable typeTable, PSPrimitiveDictionary applicationArguments, string name)
         {
-            if (connectionInfo is not WSManConnectionInfo
-                && connectionInfo is not NewProcessConnectionInfo
-                && connectionInfo is not NamedPipeConnectionInfo
-                && connectionInfo is not SSHConnectionInfo
-                && connectionInfo is not VMConnectionInfo
-                && connectionInfo is not ContainerConnectionInfo)
+            if (connectionInfo is not WSManConnectionInfo &&
+                connectionInfo is not NewProcessConnectionInfo &&
+                connectionInfo is not NamedPipeConnectionInfo &&
+                connectionInfo is not SSHConnectionInfo &&
+                connectionInfo is not VMConnectionInfo &&
+                connectionInfo is not ContainerConnectionInfo)
             {
                 throw new NotSupportedException();
             }

--- a/src/System.Management.Automation/engine/hostifaces/History.cs
+++ b/src/System.Management.Automation/engine/hostifaces/History.cs
@@ -1459,7 +1459,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     PSObject serializedPipelineState = pipelineState as PSObject;
                     object baseObject = serializedPipelineState.BaseObject;
-                    if (!(baseObject is int))
+                    if (baseObject is not int)
                     {
                         break;
                     }

--- a/src/System.Management.Automation/engine/hostifaces/PSDataCollection.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSDataCollection.cs
@@ -1634,7 +1634,7 @@ namespace System.Management.Automation
                     throw PSTraceSource.NewArgumentNullException(nameof(value), PSDataBufferStrings.ValueNullReference);
                 }
             }
-            else if (!(value is T))
+            else if (value is not T)
             {
                 throw PSTraceSource.NewArgumentException(nameof(value), PSDataBufferStrings.CannotConvertToGenericType,
                                                          value.GetType().FullName,

--- a/src/System.Management.Automation/engine/hostifaces/RunspacePool.cs
+++ b/src/System.Management.Automation/engine/hostifaces/RunspacePool.cs
@@ -638,7 +638,7 @@ namespace System.Management.Automation.Runspaces
             TypeTable typeTable)
         {
             // Disconnect-Connect semantics are currently only supported in WSMan transport.
-            if (!(connectionInfo is WSManConnectionInfo))
+            if (connectionInfo is not WSManConnectionInfo)
             {
                 throw new NotSupportedException();
             }

--- a/src/System.Management.Automation/engine/interpreter/CallInstruction.cs
+++ b/src/System.Management.Automation/engine/interpreter/CallInstruction.cs
@@ -104,7 +104,7 @@ namespace System.Management.Automation.Interpreter
             }
             catch (TargetInvocationException tie)
             {
-                if (!(tie.InnerException is NotSupportedException))
+                if (tie.InnerException is not NotSupportedException)
                 {
                     throw;
                 }

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -3683,7 +3683,7 @@ namespace System.Management.Automation.Language
             var temps = new List<ParameterExpression>();
             var exprs = new List<Expression>();
 
-            if (pipelineAst.Parent is AssignmentStatementAst || pipelineAst.Parent is not ParenExpressionAst)
+            if (pipelineAst.Parent is not AssignmentStatementAst && pipelineAst.Parent is not ParenExpressionAst)
             {
                 // If the parent is an assignment, we've already added a sequence point, don't add another.
                 exprs.Add(UpdatePosition(pipelineAst));

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -3683,7 +3683,7 @@ namespace System.Management.Automation.Language
             var temps = new List<ParameterExpression>();
             var exprs = new List<Expression>();
 
-            if (!(pipelineAst.Parent is AssignmentStatementAst || pipelineAst.Parent is ParenExpressionAst))
+            if (pipelineAst.Parent is AssignmentStatementAst || pipelineAst.Parent is not ParenExpressionAst)
             {
                 // If the parent is an assignment, we've already added a sequence point, don't add another.
                 exprs.Add(UpdatePosition(pipelineAst));

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -2423,7 +2423,7 @@ namespace System.Management.Automation.Language
 
                     UngetToken(rParen);
                     // Don't bother reporting this error if we already reported an empty condition error.
-                    if (!(condition is ErrorStatementAst))
+                    if (condition is not ErrorStatementAst)
                     {
                         ReportIncompleteInput(rParen.Extent,
                             nameof(ParserStrings.MissingEndParenthesisAfterStatement),
@@ -3611,7 +3611,7 @@ namespace System.Management.Automation.Language
                 // so stop parsing the statement and try parsing something else if possible.
 
                 UngetToken(rParen);
-                if (!(condition is ErrorStatementAst))
+                if (condition is not ErrorStatementAst)
                 {
                     ReportIncompleteInput(After(condition),
                         nameof(ParserStrings.MissingEndParenthesisAfterStatement),
@@ -4966,7 +4966,7 @@ namespace System.Management.Automation.Language
                     {
                         htAst = (HashtableAst)aliasAst;
                     }
-                    else if (!(aliasAst is StringConstantExpressionAst))
+                    else if (aliasAst is not StringConstantExpressionAst)
                     {
                         return new ErrorStatementAst(ExtentOf(usingToken, aliasAst), new Ast[] { itemAst, aliasAst });
                     }
@@ -6703,7 +6703,7 @@ namespace System.Management.Automation.Language
                     UngetToken(token);
 
                     // Don't bother reporting this error if we already reported an empty 'IfTrue' operand error.
-                    if (!(ifTrue is ErrorExpressionAst))
+                    if (ifTrue is not ErrorExpressionAst)
                     {
                         componentAsts.Add(ifTrue);
                         ReportIncompleteInput(
@@ -7852,7 +7852,7 @@ namespace System.Management.Automation.Language
 
                 UngetToken(rBracket);
                 // Skip reporting the error if we've already reported a missing index.
-                if (!(indexExpr is ErrorExpressionAst))
+                if (indexExpr is not ErrorExpressionAst)
                 {
                     ReportIncompleteInput(After(indexExpr),
                         nameof(ParserStrings.MissingEndSquareBracket),

--- a/src/System.Management.Automation/engine/parser/SemanticChecks.cs
+++ b/src/System.Management.Automation/engine/parser/SemanticChecks.cs
@@ -761,7 +761,7 @@ namespace System.Management.Automation.Language
                         CheckAssignmentTarget(expr, simpleAssignment, reportError);
                     }
                 }
-                else if (!(ast is ISupportsAssignment))
+                else if (ast is not ISupportsAssignment)
                 {
                     errorAst = ast;
                 }
@@ -907,7 +907,7 @@ namespace System.Management.Automation.Language
         {
             if (convertExpressionAst.Type.TypeName.FullName.Equals(LanguagePrimitives.OrderedAttribute, StringComparison.OrdinalIgnoreCase))
             {
-                if (!(convertExpressionAst.Child is HashtableAst))
+                if (convertExpressionAst.Child is not HashtableAst)
                 {
                     // We allow the ordered attribute only on hashliteral node.
                     // This check covers the following scenario
@@ -1182,7 +1182,7 @@ namespace System.Management.Automation.Language
         private void CheckMemberAccess(MemberExpressionAst ast)
         {
             // If the member access is not constant, it may be considered suspicious
-            if (!(ast.Member is ConstantExpressionAst))
+            if (ast.Member is not ConstantExpressionAst)
             {
                 MarkAstParentsAsSuspicious(ast);
             }

--- a/src/System.Management.Automation/engine/parser/SymbolResolver.cs
+++ b/src/System.Management.Automation/engine/parser/SymbolResolver.cs
@@ -353,7 +353,7 @@ namespace System.Management.Automation.Language
 
         public override AstVisitAction VisitFunctionDefinition(FunctionDefinitionAst functionDefinitionAst)
         {
-            if (!(functionDefinitionAst.Parent is FunctionMemberAst))
+            if (functionDefinitionAst.Parent is not FunctionMemberAst)
             {
                 _symbolTable.EnterScope(functionDefinitionAst.Body, ScopeType.Function);
             }
@@ -736,7 +736,7 @@ namespace System.Management.Automation.Language
 
         public override object VisitFunctionDefinition(FunctionDefinitionAst functionDefinitionAst)
         {
-            if (!(functionDefinitionAst.Parent is FunctionMemberAst))
+            if (functionDefinitionAst.Parent is not FunctionMemberAst)
             {
                 _symbolResolver._symbolTable.LeaveScope();
             }

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -2416,7 +2416,7 @@ namespace System.Management.Automation
                 lhs = convertExpr.Child;
             }
 
-            if (!(lhs is VariableExpressionAst varExpr))
+            if (lhs is not VariableExpressionAst varExpr)
             {
                 return false;
             }

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -2056,7 +2056,7 @@ namespace System.Management.Automation.Language
                     return;
                 }
 
-                if (!(argumentValue is string))
+                if (argumentValue is not string)
                 {
                     ReportError(argumentAst.Extent,
                         nameof(ParserStrings.RequiresInvalidStringArgument),
@@ -2069,7 +2069,7 @@ namespace System.Management.Automation.Language
             }
             else if (PSSnapinToken.StartsWith(parameter.ParameterName, StringComparison.OrdinalIgnoreCase))
             {
-                if (!(argumentValue is string))
+                if (argumentValue is not string)
                 {
                     ReportError(argumentAst.Extent,
                         nameof(ParserStrings.RequiresInvalidStringArgument),
@@ -2219,7 +2219,7 @@ namespace System.Management.Automation.Language
 
         private List<string> HandleRequiresAssemblyArgument(Ast argumentAst, object arg, List<string> requiredAssemblies)
         {
-            if (!(arg is string))
+            if (arg is not string)
             {
                 ReportError(argumentAst.Extent,
                     nameof(ParserStrings.RequiresInvalidStringArgument),
@@ -2242,7 +2242,7 @@ namespace System.Management.Automation.Language
 
         private List<string> HandleRequiresPSEditionArgument(Ast argumentAst, object arg, ref List<string> requiredEditions)
         {
-            if (!(arg is string))
+            if (arg is not string)
             {
                 ReportError(argumentAst.Extent,
                     nameof(ParserStrings.RequiresInvalidStringArgument),

--- a/src/System.Management.Automation/engine/pipeline.cs
+++ b/src/System.Management.Automation/engine/pipeline.cs
@@ -1406,7 +1406,7 @@ namespace System.Management.Automation.Internal
                 // Note that the pipeline could have been stopped asynchronously
                 // before hitting the error, therefore we check whether
                 // firstTerminatingError is PipelineStoppedException.
-                else if ((_firstTerminatingError.SourceException is not PipelineStoppedException)
+                else if (_firstTerminatingError.SourceException is not PipelineStoppedException
                     && command != null && command.Context != null)
                 {
                     Exception ex = e;

--- a/src/System.Management.Automation/engine/pipeline.cs
+++ b/src/System.Management.Automation/engine/pipeline.cs
@@ -1406,7 +1406,7 @@ namespace System.Management.Automation.Internal
                 // Note that the pipeline could have been stopped asynchronously
                 // before hitting the error, therefore we check whether
                 // firstTerminatingError is PipelineStoppedException.
-                else if ((!(_firstTerminatingError.SourceException is PipelineStoppedException))
+                else if ((_firstTerminatingError.SourceException is not PipelineStoppedException)
                     && command != null && command.Context != null)
                 {
                     Exception ex = e;
@@ -1416,7 +1416,7 @@ namespace System.Management.Automation.Internal
                         ex = ex.InnerException;
                     }
 
-                    if (!(ex is PipelineStoppedException))
+                    if (ex is not PipelineStoppedException)
                     {
                         string message = StringUtil.Format(PipelineStrings.SecondFailure,
                             _firstTerminatingError.GetType().Name,

--- a/src/System.Management.Automation/engine/pipeline.cs
+++ b/src/System.Management.Automation/engine/pipeline.cs
@@ -1407,7 +1407,7 @@ namespace System.Management.Automation.Internal
                 // before hitting the error, therefore we check whether
                 // firstTerminatingError is PipelineStoppedException.
                 else if (_firstTerminatingError.SourceException is not PipelineStoppedException
-                    && command != null && command.Context != null)
+                    && command?.Context is not null)
                 {
                     Exception ex = e;
                     while ((ex is TargetInvocationException || ex is CmdletInvocationException)

--- a/src/System.Management.Automation/engine/pipeline.cs
+++ b/src/System.Management.Automation/engine/pipeline.cs
@@ -1407,7 +1407,7 @@ namespace System.Management.Automation.Internal
                 // before hitting the error, therefore we check whether
                 // firstTerminatingError is PipelineStoppedException.
                 else if (_firstTerminatingError.SourceException is not PipelineStoppedException
-                    && command?.Context is not null)
+                    && command?.Context != null)
                 {
                     Exception ex = e;
                     while ((ex is TargetInvocationException || ex is CmdletInvocationException)

--- a/src/System.Management.Automation/engine/remoting/client/Job.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job.cs
@@ -4116,7 +4116,7 @@ namespace System.Management.Automation
         private Pipeline DrainAndBlockRemoteOutput()
         {
             // We only do this for remote runspaces.
-            if (!(_runspace is RemoteRunspace)) { return null; }
+            if (_runspace is not RemoteRunspace) { return null; }
 
             Pipeline runningCmd = _runspace.GetCurrentlyRunningPipeline();
             if (runningCmd != null)

--- a/src/System.Management.Automation/engine/remoting/fanin/InitialSessionStateProvider.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/InitialSessionStateProvider.cs
@@ -1285,7 +1285,7 @@ namespace System.Management.Automation.Remoting
         /// <returns></returns>
         private static bool StringTypeValidationCallback(string key, object obj, PSCmdlet cmdlet, string path)
         {
-            if (!(obj is string))
+            if (obj is not string)
             {
                 cmdlet.WriteVerbose(StringUtil.Format(RemotingErrorIdStrings.DISCTypeMustBeString, key, path));
                 return false;
@@ -1315,7 +1315,7 @@ namespace System.Management.Automation.Remoting
 
         private static bool BooleanTypeValidationCallback(string key, object obj, PSCmdlet cmdlet, string path)
         {
-            if (!(obj is bool))
+            if (obj is not bool)
             {
                 cmdlet.WriteVerbose(StringUtil.Format(RemotingErrorIdStrings.DISCTypeMustBeBoolean, key, path));
                 return false;
@@ -1634,7 +1634,7 @@ namespace System.Management.Automation.Remoting
         {
             foreach (var roleKey in roleDefinitions.Keys)
             {
-                if (!(roleKey is string))
+                if (roleKey is not string)
                 {
                     var invalidOperationEx = new PSInvalidOperationException(
                         string.Format(RemotingErrorIdStrings.InvalidRoleKeyType, roleKey.GetType().FullName));

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -556,7 +556,7 @@ namespace System.Management.Automation.Language
 
         internal static Expression MaybeDebase(DynamicMetaObjectBinder binder, Func<Expression, Expression> generator, DynamicMetaObject target)
         {
-            if (!(target.Value is PSObject))
+            if (target.Value is not PSObject)
             {
                 return generator(target.Expression);
             }
@@ -7135,7 +7135,7 @@ namespace System.Management.Automation.Language
                 {
                     if (parameterType.IsByRef)
                     {
-                        if (!(args[i].Value is PSReference))
+                        if (args[i].Value is not PSReference)
                         {
                             return Compiler.CreateThrow(typeof(object), typeof(MethodException),
                                      new[] { typeof(string), typeof(Exception), typeof(string), typeof(object[]) },

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -729,7 +729,7 @@ namespace System.Management.Automation
                 resourceString => { throw PSTraceSource.NewInvalidOperationException(resourceString); });
             Diagnostics.Assert(pipelineAst != null, "This should be checked by GetSimplePipeline");
 
-            if (!(pipelineAst.PipelineElements[0] is CommandAst))
+            if (pipelineAst.PipelineElements[0] is not CommandAst)
             {
                 throw PSTraceSource.NewInvalidOperationException(AutomationExceptions.CantConvertEmptyPipeline);
             }

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -1917,7 +1917,7 @@ namespace System.Management.Automation
             InterpreterError.UpdateExceptionErrorRecordPosition(rte, extent);
             ErrorRecord errRec = rte.ErrorRecord.WrapException(rte);
 
-            if (!(rte is PipelineStoppedException))
+            if (rte is not PipelineStoppedException)
             {
                 if (outputPipe != null)
                 {

--- a/src/System.Management.Automation/engine/serialization.cs
+++ b/src/System.Management.Automation/engine/serialization.cs
@@ -3372,7 +3372,7 @@ namespace System.Management.Automation
                     hashCodeObject = ((PSObject)hashCodeObject).BaseObject;
                 }
 
-                if (!(hashCodeObject is int))
+                if (hashCodeObject is not int)
                 {
                     return null;
                 }
@@ -3426,7 +3426,7 @@ namespace System.Management.Automation
 
         private PSObject RehydrateCimInstance(PSObject deserializedObject)
         {
-            if (!(deserializedObject.BaseObject is PSCustomObject))
+            if (deserializedObject.BaseObject is not PSCustomObject)
             {
                 return deserializedObject;
             }

--- a/src/System.Management.Automation/help/CommandHelpProvider.cs
+++ b/src/System.Management.Automation/help/CommandHelpProvider.cs
@@ -1178,7 +1178,7 @@ namespace System.Management.Automation
                 return false;
             }
 
-            if (!(helpInfo is BaseCommandHelpInfo))
+            if (helpInfo is not BaseCommandHelpInfo)
                 return false;
 
             if (!Match(helpInfo.Component, helpRequest.Component))

--- a/src/System.Management.Automation/help/HelpSystem.cs
+++ b/src/System.Management.Automation/help/HelpSystem.cs
@@ -372,7 +372,7 @@ namespace System.Management.Automation
                 // Bug Win7 737383: Win7 RTM shows both function and cmdlet help when there is
                 // function and cmdlet with the same name. So, ignoring the ScriptCommandHelpProvider's
                 // results and going to the CommandHelpProvider for further evaluation.
-                if (isHelpInfoFound && (!(helpProvider is ScriptCommandHelpProvider)))
+                if (isHelpInfoFound && (helpProvider is not ScriptCommandHelpProvider))
                 {
                     // once helpInfo found from a provider..no need to traverse other providers.
                     yield break;

--- a/src/System.Management.Automation/help/HelpSystem.cs
+++ b/src/System.Management.Automation/help/HelpSystem.cs
@@ -372,7 +372,7 @@ namespace System.Management.Automation
                 // Bug Win7 737383: Win7 RTM shows both function and cmdlet help when there is
                 // function and cmdlet with the same name. So, ignoring the ScriptCommandHelpProvider's
                 // results and going to the CommandHelpProvider for further evaluation.
-                if (isHelpInfoFound && (helpProvider is not ScriptCommandHelpProvider))
+                if (isHelpInfoFound && helpProvider is not ScriptCommandHelpProvider)
                 {
                     // once helpInfo found from a provider..no need to traverse other providers.
                     yield break;

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -4206,7 +4206,7 @@ namespace Microsoft.PowerShell.Commands
 
         private bool ValidRemoteSessionForScripting(Runspace runspace)
         {
-            if (!(runspace is RemoteRunspace))
+            if (runspace is not RemoteRunspace)
             {
                 return false;
             }


### PR DESCRIPTION
# PR Summary

Instead of the huge changes in #13286, a more modest change using `is not` syntax to remove parentheses.

## PR Context

#13286

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
