### PR TITLE
Reinstate Test-Connection tests

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -46,10 +46,10 @@ Describe "Test-Connection" -tags "CI" {
         $UnreachableAddress = "10.11.12.13"
         # this resolves to an actual IP rather than 127.0.0.1
         # this can also include both IPv4 and IPv6, so select InterNetwork rather than InterNetworkV6
-        $hostAddress = [System.Net.Dns]::GetHostEntry($hostName).AddressList |
-            Where-Object { $_.AddressFamily -eq "InterNetwork" } |
-            Select-Object -First 1 |
-            ForEach-Object { $_.IPAddressToString }
+        #$hostAddress = [System.Net.Dns]::GetHostEntry($hostName).AddressList |
+        #    Where-Object { $_.AddressFamily -eq "InterNetwork" } |
+        #    Select-Object -First 1 |
+        #    ForEach-Object { $_.IPAddressToString }
         # under some environments, we can't round trip this and retrieve the real name from the address
         # in this case we will simply use the hostname
         $jobContinues = Start-Job { Test-Connection $using:targetAddress -Repeat }
@@ -112,9 +112,9 @@ Describe "Test-Connection" -tags "CI" {
         }
 
         It "Force IPv4 with implicit PingOptions" {
-            $result = Test-Connection $hostAddress -Count 1 -IPv4
+            $result = Test-Connection $testAddress -Count 1 -IPv4
 
-            $result[0].Address | Should -BeExactly $hostAddress
+            $result[0].Address | Should -BeExactly $testAddress
             $result[0].Reply.Options.Ttl | Should -BeLessOrEqual 128
             if ($IsWindows) {
                 $result[0].Reply.Options.DontFragment | Should -BeFalse
@@ -124,13 +124,13 @@ Describe "Test-Connection" -tags "CI" {
         # In VSTS, address is 0.0.0.0
         # This test is marked as PENDING as .NET Core does not return correct PingOptions from ping request
         It "Force IPv4 with explicit PingOptions" -Pending {
-            $result1 = Test-Connection $hostAddress -Count 1 -IPv4 -MaxHops 10 -DontFragment
+            $result1 = Test-Connection $testAddress -Count 1 -IPv4 -MaxHops 10 -DontFragment
 
             # explicitly go to google dns. this test will pass even if the destination is unreachable
             # it's more about breaking out of the loop
             $result2 = Test-Connection 8.8.8.8 -Count 1 -IPv4 -MaxHops 1 -DontFragment
 
-            $result1.Address | Should -BeExactly $hostAddress
+            $result1.Address | Should -BeExactly $testAddress
             $result1.Reply.Options.Ttl | Should -BeLessOrEqual 128
 
             if (!$IsWindows) {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -44,6 +44,12 @@ Describe "Test-Connection" -tags "CI" {
         $targetAddress = "127.0.0.1"
         $targetAddressIPv6 = "::1"
         $UnreachableAddress = "10.11.12.13"
+        # this resolves to an actual IP rather than 127.0.0.1
+        # this can also include both IPv4 and IPv6, so select InterNetwork rather than InterNetworkV6
+        $realAddress = [System.Net.Dns]::GetHostEntry($hostName).AddressList |
+            Where-Object { $_.AddressFamily -eq "InterNetwork" } |
+            Select-Object -First 1 |
+            ForEach-Object { $_.IPAddressToString }
         # under some environments, we can't round trip this and retrieve the real name from the address
         # in this case we will simply use the hostname
         $jobContinues = Start-Job { Test-Connection $using:targetAddress -Repeat }
@@ -105,10 +111,10 @@ Describe "Test-Connection" -tags "CI" {
             $error[0].Exception.InnerException.ErrorCode | Should -Be $code
         }
 
-        It "Force IPv4 with implicit PingOptions" -Pending {
+        It "Force IPv4 with implicit PingOptions" {
             $result = Test-Connection $testAddress -Count 1 -IPv4
 
-            $result[0].Address | Should -BeExactly $testAddress
+            $result[0].Address | Should -BeExactly $realAddress
             $result[0].Reply.Options.Ttl | Should -BeLessOrEqual 128
             if ($IsWindows) {
                 $result[0].Reply.Options.DontFragment | Should -BeFalse
@@ -116,14 +122,15 @@ Describe "Test-Connection" -tags "CI" {
         }
 
         # In VSTS, address is 0.0.0.0
+        # This test is marked as PENDING as .NET Core does not return correct PingOptions from ping request
         It "Force IPv4 with explicit PingOptions" -Pending {
-            $result1 = Test-Connection $testAddress -Count 1 -IPv4 -MaxHops 10 -DontFragment
+            $result1 = Test-Connection $realAddress -Count 1 -IPv4 -MaxHops 10 -DontFragment
 
             # explicitly go to google dns. this test will pass even if the destination is unreachable
             # it's more about breaking out of the loop
             $result2 = Test-Connection 8.8.8.8 -Count 1 -IPv4 -MaxHops 1 -DontFragment
 
-            $result1.Address | Should -BeExactly $testAddress
+            $result1.Address | Should -BeExactly $realAddress
             $result1.Reply.Options.Ttl | Should -BeLessOrEqual 128
 
             if (!$IsWindows) {
@@ -259,11 +266,11 @@ Describe "Test-Connection" -tags "CI" {
     Context "MTUSizeDetect" {
         # We skip the MtuSize detection tests when in containers, as the environments throw raw exceptions
         # instead of returning a PacketTooBig response cleanly.
-        It "MTUSizeDetect works" -Pending:($true -or $env:__INCONTAINER -eq 1) {
-            $result = Test-Connection $testAddress -MtuSize
+        It "MTUSizeDetect works" -Pending:($env:__INCONTAINER -eq 1) {
+            $result = Test-Connection $hostName -MtuSize
 
             $result | Should -BeOfType Microsoft.PowerShell.Commands.TestConnectionCommand+PingMtuStatus
-            $result.Destination | Should -BeExactly $testAddress
+            $result.Destination | Should -BeExactly $hostName
             $result.Status | Should -BeExactly "Success"
             $result.MtuSize | Should -BeGreaterThan 0
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -44,12 +44,7 @@ Describe "Test-Connection" -tags "CI" {
         $targetAddress = "127.0.0.1"
         $targetAddressIPv6 = "::1"
         $UnreachableAddress = "10.11.12.13"
-        # this resolves to an actual IP rather than 127.0.0.1
-        # this can also include both IPv4 and IPv6, so select InterNetwork rather than InterNetworkV6
-        #$hostAddress = [System.Net.Dns]::GetHostEntry($hostName).AddressList |
-        #    Where-Object { $_.AddressFamily -eq "InterNetwork" } |
-        #    Select-Object -First 1 |
-        #    ForEach-Object { $_.IPAddressToString }
+
         # under some environments, we can't round trip this and retrieve the real name from the address
         # in this case we will simply use the hostname
         $jobContinues = Start-Job { Test-Connection $using:targetAddress -Repeat }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -267,10 +267,10 @@ Describe "Test-Connection" -tags "CI" {
         # We skip the MtuSize detection tests when in containers, as the environments throw raw exceptions
         # instead of returning a PacketTooBig response cleanly.
         It "MTUSizeDetect works" -Pending:($env:__INCONTAINER -eq 1) {
-            $result = Test-Connection $hostName -MtuSize
+            $result = Test-Connection $testAddress -MtuSize
 
             $result | Should -BeOfType Microsoft.PowerShell.Commands.TestConnectionCommand+PingMtuStatus
-            $result.Destination | Should -BeExactly $hostName
+            $result.Destination | Should -BeExactly $testAddress
             $result.Status | Should -BeExactly "Success"
             $result.MtuSize | Should -BeGreaterThan 0
         }
@@ -289,7 +289,7 @@ Describe "Test-Connection" -tags "CI" {
             $result = Test-Connection $testAddress -TraceRoute -IPv4
 
             $result[0] | Should -BeOfType Microsoft.PowerShell.Commands.TestConnectionCommand+TraceStatus
-            $result[0].Source | Should -BeExactly $hostName
+            $result[0].Source | Should -BeExactly $testAddress
             $result[0].TargetAddress | Should -BeExactly $testAddress
             $result[0].Target | Should -BeExactly $testAddress
             $result[0].Hop | Should -Be 1

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -46,7 +46,7 @@ Describe "Test-Connection" -tags "CI" {
         $UnreachableAddress = "10.11.12.13"
         # this resolves to an actual IP rather than 127.0.0.1
         # this can also include both IPv4 and IPv6, so select InterNetwork rather than InterNetworkV6
-        $realAddress = [System.Net.Dns]::GetHostEntry($hostName).AddressList |
+        $hostAddress = [System.Net.Dns]::GetHostEntry($hostName).AddressList |
             Where-Object { $_.AddressFamily -eq "InterNetwork" } |
             Select-Object -First 1 |
             ForEach-Object { $_.IPAddressToString }
@@ -112,9 +112,9 @@ Describe "Test-Connection" -tags "CI" {
         }
 
         It "Force IPv4 with implicit PingOptions" {
-            $result = Test-Connection $testAddress -Count 1 -IPv4
+            $result = Test-Connection $hostAddress -Count 1 -IPv4
 
-            $result[0].Address | Should -BeExactly $realAddress
+            $result[0].Address | Should -BeExactly $hostAddress
             $result[0].Reply.Options.Ttl | Should -BeLessOrEqual 128
             if ($IsWindows) {
                 $result[0].Reply.Options.DontFragment | Should -BeFalse
@@ -124,13 +124,13 @@ Describe "Test-Connection" -tags "CI" {
         # In VSTS, address is 0.0.0.0
         # This test is marked as PENDING as .NET Core does not return correct PingOptions from ping request
         It "Force IPv4 with explicit PingOptions" -Pending {
-            $result1 = Test-Connection $realAddress -Count 1 -IPv4 -MaxHops 10 -DontFragment
+            $result1 = Test-Connection $hostAddress -Count 1 -IPv4 -MaxHops 10 -DontFragment
 
             # explicitly go to google dns. this test will pass even if the destination is unreachable
             # it's more about breaking out of the loop
             $result2 = Test-Connection 8.8.8.8 -Count 1 -IPv4 -MaxHops 1 -DontFragment
 
-            $result1.Address | Should -BeExactly $realAddress
+            $result1.Address | Should -BeExactly $hostAddress
             $result1.Reply.Options.Ttl | Should -BeLessOrEqual 128
 
             if (!$IsWindows) {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes https://github.com/PowerShell/PowerShell/issues/13309.

Reverts some of the changes in https://github.com/PowerShell/PowerShell/pull/12943.

The `Test-Connection` tests first failed in CI due to a dependency on CI system DNS resolution. We tried to address that in #12943 but recently hit a failure where the new form of the tests using the gateway address also failed consistently across builds.

Given that the DNS issue was resolved, this changes the tests that have been failing back to using the hostname.

There's also a test that didn't work with DNS, was working with the gateway address, but is not working now. That test is now marked as pending.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
