### PR TITLE
Use `is not` syntax part 2

### DIFF
--- a/src/Microsoft.Management.UI.Internal/ManagementList/Common/Utilities.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/Common/Utilities.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Management.UI.Internal
 
             foreach (object item in items)
             {
-                if (!(item is T))
+                if (item is not T)
                 {
                     return false;
                 }

--- a/src/Microsoft.Management.UI.Internal/ShowCommand/Controls/ParameterSetControl.xaml.cs
+++ b/src/Microsoft.Management.UI.Internal/ShowCommand/Controls/ParameterSetControl.xaml.cs
@@ -357,7 +357,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
         /// <param name="uiControl">Will adding UIControl.</param>
         private void AddControlToMainGrid(UIElement uiControl)
         {
-            if (this.firstFocusableElement == null && !(uiControl is Label))
+            if (this.firstFocusableElement == null && uiControl is not Label)
             {
                 this.firstFocusableElement = uiControl;
             }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetContentCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetContentCommand.cs
@@ -142,7 +142,7 @@ namespace Microsoft.PowerShell.Commands
                         holder.Reader != null,
                         "All holders should have a reader assigned");
 
-                    if (_tailSpecified && !(holder.Reader is FileSystemContentReaderWriter))
+                    if (_tailSpecified && holder.Reader is not FileSystemContentReaderWriter)
                     {
                         string errMsg = SessionStateStrings.GetContent_TailNotSupported;
                         ErrorRecord error = new ErrorRecord(new InvalidOperationException(errMsg), "TailNotSupported", ErrorCategory.InvalidOperation, Tail);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1897,7 +1897,7 @@ namespace Microsoft.PowerShell.Commands
             // Treat Strings and other single values as a StringContent.
             // If enumeration is false, also treat IEnumerables as StringContents.
             // String implements IEnumerable so the explicit check is required.
-            if (enumerate == false || fieldValue is string || !(fieldValue is IEnumerable))
+            if (enumerate == false || fieldValue is string || fieldValue is not IEnumerable)
             {
                 formData.Add(GetMultipartStringContent(fieldName: fieldName, fieldValue: fieldValue));
                 return;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/TraceListenerCommandBase.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/TraceListenerCommandBase.cs
@@ -419,7 +419,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     TraceListener listenerToRemove = source.Listeners[index];
 
-                    if (fileListenersOnly && !(listenerToRemove is TextWriterTraceListener))
+                    if (fileListenersOnly && listenerToRemove is not TextWriterTraceListener)
                     {
                         // Since we only want to remove file listeners, skip any that
                         // aren't file listeners

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -1868,7 +1868,7 @@ namespace Microsoft.PowerShell
 
                 // If we're not going to continue, then get the exit code out of the runspace and
                 // and indicate that it should be returned...
-                if (!_noExit && !(this.Runspace is RemoteRunspace))
+                if (!_noExit && this.Runspace is not RemoteRunspace)
                 {
                     this.Runspace.ExecutionContext.ScriptCommandProcessorShouldRethrowExit = true;
                 }

--- a/src/System.Management.Automation/DscSupport/CimDSCParser.cs
+++ b/src/System.Management.Automation/DscSupport/CimDSCParser.cs
@@ -73,8 +73,9 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
                     MemberInfo[] memberInfo = targetType.GetMember(property.Name, BindingFlags.Public | BindingFlags.Instance);
 
                     // verify property exists in corresponding class type
-                    if (memberInfo == null || memberInfo.Length > 1 ||
-                        (memberInfo[0] is not PropertyInfo && memberInfo[0] is not FieldInfo))
+                    if (memberInfo == null
+                        || memberInfo.Length > 1
+                        || (memberInfo[0] is not PropertyInfo && memberInfo[0] is not FieldInfo))
                     {
                         errorMessage = string.Format(CultureInfo.CurrentCulture, ParserStrings.PropertyNotDeclaredInPSClass, new object[] { property.Name, className });
                         var invalidOperationException = new InvalidOperationException(errorMessage);

--- a/src/System.Management.Automation/DscSupport/CimDSCParser.cs
+++ b/src/System.Management.Automation/DscSupport/CimDSCParser.cs
@@ -73,7 +73,8 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
                     MemberInfo[] memberInfo = targetType.GetMember(property.Name, BindingFlags.Public | BindingFlags.Instance);
 
                     // verify property exists in corresponding class type
-                    if (memberInfo == null || memberInfo.Length > 1 || !(memberInfo[0] is PropertyInfo || memberInfo[0] is FieldInfo))
+                    if (memberInfo == null || memberInfo.Length > 1 ||
+                        (memberInfo[0] is not PropertyInfo && memberInfo[0] is not FieldInfo))
                     {
                         errorMessage = string.Format(CultureInfo.CurrentCulture, ParserStrings.PropertyNotDeclaredInPSClass, new object[] { property.Name, className });
                         var invalidOperationException = new InvalidOperationException(errorMessage);

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader_Views.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader_Views.cs
@@ -170,7 +170,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                         return false;
                     }
 
-                    if (!(view.mainControl is ComplexControlBody) && !(view.mainControl is ListControlBody))
+                    if (view.mainControl is not ComplexControlBody && view.mainControl is not ListControlBody)
                     {
                         // Error at XPath {0} in file {1}: Out Of Band views can only have CustomControl or ListControl.
                         ReportError(StringUtil.Format(FormatAndOutXmlLoadingStrings.InvalidControlForOutOfBandView, ComputeCurrentXPath(), FilePath));

--- a/src/System.Management.Automation/cimSupport/cmdletization/xml/cmdlets-over-objects.xmlSerializer.autogen.cs
+++ b/src/System.Management.Automation/cimSupport/cmdletization/xml/cmdlets-over-objects.xmlSerializer.autogen.cs
@@ -2071,22 +2071,22 @@ namespace Microsoft.PowerShell.Cmdletization.Xml
                         {
                             if (ci == Microsoft.PowerShell.Cmdletization.Xml.ItemsChoiceType.@RegularQuery && ((object)(ai) != null))
                             {
-                                if (((object)ai) != null && !(ai is global::Microsoft.PowerShell.Cmdletization.Xml.WildcardablePropertyQuery)) throw CreateMismatchChoiceException(@"Microsoft.PowerShell.Cmdletization.Xml.WildcardablePropertyQuery", @"ItemsElementName", @"Microsoft.PowerShell.Cmdletization.Xml.ItemsChoiceType.@RegularQuery");
+                                if (((object)ai) != null && ai is not global::Microsoft.PowerShell.Cmdletization.Xml.WildcardablePropertyQuery) throw CreateMismatchChoiceException(@"Microsoft.PowerShell.Cmdletization.Xml.WildcardablePropertyQuery", @"ItemsElementName", @"Microsoft.PowerShell.Cmdletization.Xml.ItemsChoiceType.@RegularQuery");
                                 Write13_WildcardablePropertyQuery(@"RegularQuery", @"http://schemas.microsoft.com/cmdlets-over-objects/2009/11", ((global::Microsoft.PowerShell.Cmdletization.Xml.WildcardablePropertyQuery)ai), false, false);
                             }
                             else if (ci == Microsoft.PowerShell.Cmdletization.Xml.ItemsChoiceType.@ExcludeQuery && ((object)(ai) != null))
                             {
-                                if (((object)ai) != null && !(ai is global::Microsoft.PowerShell.Cmdletization.Xml.WildcardablePropertyQuery)) throw CreateMismatchChoiceException(@"Microsoft.PowerShell.Cmdletization.Xml.WildcardablePropertyQuery", @"ItemsElementName", @"Microsoft.PowerShell.Cmdletization.Xml.ItemsChoiceType.@ExcludeQuery");
+                                if (((object)ai) != null && ai is not global::Microsoft.PowerShell.Cmdletization.Xml.WildcardablePropertyQuery) throw CreateMismatchChoiceException(@"Microsoft.PowerShell.Cmdletization.Xml.WildcardablePropertyQuery", @"ItemsElementName", @"Microsoft.PowerShell.Cmdletization.Xml.ItemsChoiceType.@ExcludeQuery");
                                 Write13_WildcardablePropertyQuery(@"ExcludeQuery", @"http://schemas.microsoft.com/cmdlets-over-objects/2009/11", ((global::Microsoft.PowerShell.Cmdletization.Xml.WildcardablePropertyQuery)ai), false, false);
                             }
                             else if (ci == Microsoft.PowerShell.Cmdletization.Xml.ItemsChoiceType.@MaxValueQuery && ((object)(ai) != null))
                             {
-                                if (((object)ai) != null && !(ai is global::Microsoft.PowerShell.Cmdletization.Xml.PropertyQuery)) throw CreateMismatchChoiceException(@"Microsoft.PowerShell.Cmdletization.Xml.PropertyQuery", @"ItemsElementName", @"Microsoft.PowerShell.Cmdletization.Xml.ItemsChoiceType.@MaxValueQuery");
+                                if (((object)ai) != null && ai is not global::Microsoft.PowerShell.Cmdletization.Xml.PropertyQuery) throw CreateMismatchChoiceException(@"Microsoft.PowerShell.Cmdletization.Xml.PropertyQuery", @"ItemsElementName", @"Microsoft.PowerShell.Cmdletization.Xml.ItemsChoiceType.@MaxValueQuery");
                                 Write14_PropertyQuery(@"MaxValueQuery", @"http://schemas.microsoft.com/cmdlets-over-objects/2009/11", ((global::Microsoft.PowerShell.Cmdletization.Xml.PropertyQuery)ai), false, false);
                             }
                             else if (ci == Microsoft.PowerShell.Cmdletization.Xml.ItemsChoiceType.@MinValueQuery && ((object)(ai) != null))
                             {
-                                if (((object)ai) != null && !(ai is global::Microsoft.PowerShell.Cmdletization.Xml.PropertyQuery)) throw CreateMismatchChoiceException(@"Microsoft.PowerShell.Cmdletization.Xml.PropertyQuery", @"ItemsElementName", @"Microsoft.PowerShell.Cmdletization.Xml.ItemsChoiceType.@MinValueQuery");
+                                if (((object)ai) != null && ai is not global::Microsoft.PowerShell.Cmdletization.Xml.PropertyQuery) throw CreateMismatchChoiceException(@"Microsoft.PowerShell.Cmdletization.Xml.PropertyQuery", @"ItemsElementName", @"Microsoft.PowerShell.Cmdletization.Xml.ItemsChoiceType.@MinValueQuery");
                                 Write14_PropertyQuery(@"MinValueQuery", @"http://schemas.microsoft.com/cmdlets-over-objects/2009/11", ((global::Microsoft.PowerShell.Cmdletization.Xml.PropertyQuery)ai), false, false);
                             }
                             else if ((object)(ai) != null)

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -627,7 +627,7 @@ namespace System.Management.Automation
                                 completionContext.ReplacementLength = replacementLength = 0;
                                 result = GetResultForAttributeArgument(completionContext, ref replacementIndex, ref replacementLength);
                             }
-                            else if (lastAst is HashtableAst hashTableAst && !(lastAst.Parent is DynamicKeywordStatementAst) && CheckForPendingAssignment(hashTableAst))
+                            else if (lastAst is HashtableAst hashTableAst && lastAst.Parent is not DynamicKeywordStatementAst && CheckForPendingAssignment(hashTableAst))
                             {
                                 // Handle scenarios such as 'gci | Format-Table @{Label=<tab>' if incomplete parsing of the assignment.
                                 return null;

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -5050,7 +5050,7 @@ namespace System.Management.Automation
                     memberName = memberNameAst.Value + "*";
                 }
             }
-            else if (!(lastAst is ErrorExpressionAst) && targetExpr == null)
+            else if (lastAst is not ErrorExpressionAst && targetExpr == null)
             {
                 // I don't think we can complete anything interesting
                 return results;
@@ -6567,7 +6567,7 @@ namespace System.Management.Automation
             object value;
             if (SafeExprEvaluator.TrySafeEval(targetExpr, context.ExecutionContext, out value) && value != null)
             {
-                if (targetExpr is ArrayExpressionAst && !(value is object[]))
+                if (targetExpr is ArrayExpressionAst && value is not object[])
                 {
                     // When the array contains only one element, the evaluation result would be that element. We wrap it into an array
                     value = new[] { value };

--- a/src/System.Management.Automation/engine/CommandProcessor.cs
+++ b/src/System.Management.Automation/engine/CommandProcessor.cs
@@ -319,7 +319,7 @@ namespace System.Management.Automation
                     // NOTICE-2004/06/08-JonN 959638
                     using (commandRuntime.AllowThisCommandToWrite(true))
                     {
-                        if (Context._debuggingMode > 0 && !(Command is PSScriptCmdlet))
+                        if (Context._debuggingMode > 0 && Command is not PSScriptCmdlet)
                         {
                             Context.Debugger.CheckCommand(this.Command.MyInvocation);
                         }

--- a/src/System.Management.Automation/engine/CommandProcessorBase.cs
+++ b/src/System.Management.Automation/engine/CommandProcessorBase.cs
@@ -517,7 +517,7 @@ namespace System.Management.Automation
                         {
                             SetCurrentScopeToExecutionScope();
 
-                            if (Context._debuggingMode > 0 && !(Command is PSScriptCmdlet))
+                            if (Context._debuggingMode > 0 && Command is not PSScriptCmdlet)
                             {
                                 Context.Debugger.CheckCommand(this.Command.MyInvocation);
                             }
@@ -896,7 +896,7 @@ namespace System.Management.Automation
 
                 // An explicit throw is written to $error as an ErrorRecord, so we
                 // skip adding what is more or less a duplicate.
-                if (!(e is PipelineStoppedException) && !e.WasThrownFromThrowStatement)
+                if (e is not PipelineStoppedException && !e.WasThrownFromThrowStatement)
                     commandRuntime.AppendErrorToVariables(e);
             }
             // Upstream cmdlets see only that execution stopped

--- a/src/System.Management.Automation/engine/ExecutionContext.cs
+++ b/src/System.Management.Automation/engine/ExecutionContext.cs
@@ -875,7 +875,7 @@ namespace System.Management.Automation
         internal void AppendDollarError(object obj)
         {
             ErrorRecord objAsErrorRecord = obj as ErrorRecord;
-            if (objAsErrorRecord == null && !(obj is Exception))
+            if (objAsErrorRecord == null && obj is not Exception)
             {
                 Diagnostics.Assert(false, "Object to append was neither an ErrorRecord nor an Exception in ExecutionContext.AppendDollarError");
                 return;

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -1320,7 +1320,9 @@ namespace Microsoft.PowerShell.Commands
                         }
                     }
 
-                    if (ArgumentList != null && !(current is CmdletInfo || current is IScriptCommandInfo))
+                    if (ArgumentList != null &&
+                        current is not CmdletInfo &&
+                        current is not IScriptCommandInfo)
                     {
                         // If current is not a cmdlet or script, we need to throw a terminating error.
                         ThrowTerminatingError(

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -1320,9 +1320,9 @@ namespace Microsoft.PowerShell.Commands
                         }
                     }
 
-                    if (ArgumentList != null &&
-                        current is not CmdletInfo &&
-                        current is not IScriptCommandInfo)
+                    if (ArgumentList != null
+                        && current is not CmdletInfo
+                        && current is not IScriptCommandInfo)
                     {
                         // If current is not a cmdlet or script, we need to throw a terminating error.
                         ThrowTerminatingError(

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -1035,7 +1035,7 @@ namespace Microsoft.PowerShell.Commands
                     _propertyOrMethodName,
                     possibleMatches));
             }
-            else if (methods.Count == 0 || !(methods[0] is PSMethodInfo))
+            else if (methods.Count == 0 || methods[0] is not PSMethodInfo)
             {
                 // write error record: method no found
                 WriteError(GenerateNameParameterError(

--- a/src/System.Management.Automation/engine/MinishellParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/MinishellParameterBinderController.cs
@@ -99,7 +99,7 @@ namespace System.Management.Automation
                         // Value of -Command parameter must be scriptblock
                         var scriptBlockArgument = parameters[i];
                         var argumentValue = PSObject.Base(scriptBlockArgument.ArgumentValue);
-                        if (!scriptBlockArgument.ArgumentSpecified || !(argumentValue is ScriptBlock))
+                        if (!scriptBlockArgument.ArgumentSpecified || argumentValue is not ScriptBlock)
                         {
                             throw NewParameterBindingException(null, ErrorCategory.InvalidArgument, CommandParameter,
                                                                typeof(ScriptBlock), argumentValue.GetType(),

--- a/src/System.Management.Automation/engine/Modules/PSModuleInfo.cs
+++ b/src/System.Management.Automation/engine/Modules/PSModuleInfo.cs
@@ -1360,7 +1360,7 @@ namespace System.Management.Automation
                 try
                 {
                     // Only copy simple mutable variables...
-                    if (v.Options == ScopedItemOptions.None && !(v is NullVariable))
+                    if (v.Options == ScopedItemOptions.None && v is not NullVariable)
                     {
                         PSVariable newVar = new PSVariable(v.Name, v.Value, v.Options, v.Description);
                         // The variable is already defined/set in the scope, and that means the attributes

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -2384,7 +2384,10 @@ namespace System.Management.Automation
             // PipelineStoppedException should not get added to $Error
             // 2008/06/25 - narrieta: ExistNestedPromptException should not be added to $error either
             // 2019/10/18 - StopUpstreamCommandsException should not be added either
-            if (e is not HaltCommandException && e is not PipelineStoppedException && e is not ExitNestedPromptException && e is not StopUpstreamCommandsException)
+            if (e is not HaltCommandException &&
+                e is not PipelineStoppedException &&
+                e is not ExitNestedPromptException &&
+                e is not StopUpstreamCommandsException)
             {
                 try
                 {

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -2384,7 +2384,7 @@ namespace System.Management.Automation
             // PipelineStoppedException should not get added to $Error
             // 2008/06/25 - narrieta: ExistNestedPromptException should not be added to $error either
             // 2019/10/18 - StopUpstreamCommandsException should not be added either
-            if (!(e is HaltCommandException) && !(e is PipelineStoppedException) && !(e is ExitNestedPromptException) && !(e is StopUpstreamCommandsException))
+            if (e is not HaltCommandException && e is not PipelineStoppedException && e is not ExitNestedPromptException && e is not StopUpstreamCommandsException)
             {
                 try
                 {

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -2384,10 +2384,10 @@ namespace System.Management.Automation
             // PipelineStoppedException should not get added to $Error
             // 2008/06/25 - narrieta: ExistNestedPromptException should not be added to $error either
             // 2019/10/18 - StopUpstreamCommandsException should not be added either
-            if (e is not HaltCommandException &&
-                e is not PipelineStoppedException &&
-                e is not ExitNestedPromptException &&
-                e is not StopUpstreamCommandsException)
+            if (e is not HaltCommandException
+                && e is not PipelineStoppedException
+                && e is not ExitNestedPromptException
+                && e is not StopUpstreamCommandsException)
             {
                 try
                 {

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -2150,7 +2150,7 @@ namespace System.Management.Automation
             private bool MustDeferIDMOP()
             {
                 var baseObject = PSObject.Base(Value);
-                return baseObject is IDynamicMetaObjectProvider && !(baseObject is PSObject);
+                return baseObject is IDynamicMetaObjectProvider && baseObject is not PSObject;
             }
 
             private DynamicMetaObject DeferForIDMOP(DynamicMetaObjectBinder binder, params DynamicMetaObject[] args)

--- a/src/System.Management.Automation/engine/Pipe.cs
+++ b/src/System.Management.Automation/engine/Pipe.cs
@@ -510,7 +510,7 @@ namespace System.Management.Automation.Internal
                 // If our object came from GetEnumerator (and hence is not IEnumerator), then we need to dispose
                 // Otherwise, we don't own the object, so don't dispose.
                 var disposable = ie as IDisposable;
-                if (disposable != null && !(objects is IEnumerator))
+                if (disposable != null && objects is not IEnumerator)
                 {
                     disposable.Dispose();
                 }

--- a/src/System.Management.Automation/engine/ScopedItemSearcher.cs
+++ b/src/System.Management.Automation/engine/ScopedItemSearcher.cs
@@ -274,7 +274,7 @@ namespace System.Management.Automation
             VariablePath name,
             out PSVariable variable)
         {
-            Diagnostics.Assert(!(name is FunctionLookupPath),
+            Diagnostics.Assert(name is not FunctionLookupPath,
                 "name was scanned incorrect if we get here and it is a FunctionLookupPath");
 
             bool result = true;
@@ -328,7 +328,7 @@ namespace System.Management.Automation
             VariablePath name,
             out AliasInfo alias)
         {
-            Diagnostics.Assert(!(name is FunctionLookupPath),
+            Diagnostics.Assert(name is not FunctionLookupPath,
                 "name was scanned incorrect if we get here and it is a FunctionLookupPath");
 
             bool result = true;
@@ -470,7 +470,7 @@ namespace System.Management.Automation
             VariablePath name,
             out PSDriveInfo drive)
         {
-            Diagnostics.Assert(!(name is FunctionLookupPath),
+            Diagnostics.Assert(name is not FunctionLookupPath,
                 "name was scanned incorrect if we get here and it is a FunctionLookupPath");
 
             bool result = true;

--- a/src/System.Management.Automation/engine/hostifaces/Connection.cs
+++ b/src/System.Management.Automation/engine/hostifaces/Connection.cs
@@ -943,7 +943,7 @@ namespace System.Management.Automation.Runspaces
                         case PipelineState.Completed:
                         case PipelineState.Stopped:
                         case PipelineState.Failed:
-                            if (this.InNestedPrompt || !(this is RemoteRunspace) && this.Debugger.InBreakpoint)
+                            if (this.InNestedPrompt || this is not RemoteRunspace && this.Debugger.InBreakpoint)
                             {
                                 this.RunspaceAvailability = RunspaceAvailability.AvailableForNestedCommand;
                             }

--- a/src/System.Management.Automation/engine/hostifaces/Connection.cs
+++ b/src/System.Management.Automation/engine/hostifaces/Connection.cs
@@ -943,7 +943,8 @@ namespace System.Management.Automation.Runspaces
                         case PipelineState.Completed:
                         case PipelineState.Stopped:
                         case PipelineState.Failed:
-                            if (this.InNestedPrompt || this is not RemoteRunspace && this.Debugger.InBreakpoint)
+                            if (this.InNestedPrompt ||
+                                (this is not RemoteRunspace && this.Debugger.InBreakpoint))
                             {
                                 this.RunspaceAvailability = RunspaceAvailability.AvailableForNestedCommand;
                             }

--- a/src/System.Management.Automation/engine/hostifaces/Connection.cs
+++ b/src/System.Management.Automation/engine/hostifaces/Connection.cs
@@ -650,7 +650,7 @@ namespace System.Management.Automation.Runspaces
         {
             get
             {
-                return !(this is LocalRunspace || ConnectionInfo == null);
+                return this is not LocalRunspace && ConnectionInfo != null;
             }
         }
 

--- a/src/System.Management.Automation/engine/hostifaces/Connection.cs
+++ b/src/System.Management.Automation/engine/hostifaces/Connection.cs
@@ -943,8 +943,8 @@ namespace System.Management.Automation.Runspaces
                         case PipelineState.Completed:
                         case PipelineState.Stopped:
                         case PipelineState.Failed:
-                            if (this.InNestedPrompt ||
-                                (this is not RemoteRunspace && this.Debugger.InBreakpoint))
+                            if (this.InNestedPrompt
+                                || (this is not RemoteRunspace && this.Debugger.InBreakpoint))
                             {
                                 this.RunspaceAvailability = RunspaceAvailability.AvailableForNestedCommand;
                             }

--- a/src/System.Management.Automation/engine/hostifaces/InternalHost.cs
+++ b/src/System.Management.Automation/engine/hostifaces/InternalHost.cs
@@ -39,7 +39,7 @@ namespace System.Management.Automation.Internal.Host
         internal InternalHost(PSHost externalHost, ExecutionContext executionContext)
         {
             Dbg.Assert(externalHost != null, "must supply an PSHost");
-            Dbg.Assert(!(externalHost is InternalHost), "try to create an InternalHost from another InternalHost");
+            Dbg.Assert(externalHost is not InternalHost, "try to create an InternalHost from another InternalHost");
 
             Dbg.Assert(executionContext != null, "must supply an ExecutionContext");
 

--- a/src/System.Management.Automation/engine/hostifaces/LocalConnection.cs
+++ b/src/System.Management.Automation/engine/hostifaces/LocalConnection.cs
@@ -987,7 +987,7 @@ namespace System.Management.Automation.Runspaces
                 foreach (Job job in this.JobRepository.Jobs)
                 {
                     // Only stop or disconnect PowerShell jobs.
-                    if (job is PSRemotingJob == false)
+                    if (job is not PSRemotingJob)
                     {
                         continue;
                     }

--- a/src/System.Management.Automation/engine/hostifaces/pipelinebase.cs
+++ b/src/System.Management.Automation/engine/hostifaces/pipelinebase.cs
@@ -491,9 +491,9 @@ namespace System.Management.Automation.Runspaces
                     throw e;
                 }
 
-                if (syncCall &&
-                    InputStream is not PSDataCollectionStream<PSObject> &&
-                    InputStream is not PSDataCollectionStream<object>)
+                if (syncCall
+                    && InputStream is not PSDataCollectionStream<PSObject>
+                    && InputStream is not PSDataCollectionStream<object>)
                 {
                     // Method is called from synchronous invoke.
                     if (input != null)

--- a/src/System.Management.Automation/engine/hostifaces/pipelinebase.cs
+++ b/src/System.Management.Automation/engine/hostifaces/pipelinebase.cs
@@ -491,7 +491,9 @@ namespace System.Management.Automation.Runspaces
                     throw e;
                 }
 
-                if (syncCall && !(InputStream is PSDataCollectionStream<PSObject> || InputStream is PSDataCollectionStream<object>))
+                if (syncCall &&
+                    InputStream is not PSDataCollectionStream<PSObject> &&
+                    InputStream is not PSDataCollectionStream<object>)
                 {
                     // Method is called from synchronous invoke.
                     if (input != null)

--- a/src/System.Management.Automation/engine/interpreter/CallInstruction.cs
+++ b/src/System.Management.Automation/engine/interpreter/CallInstruction.cs
@@ -178,7 +178,7 @@ namespace System.Management.Automation.Interpreter
 
         private static bool ShouldCache(MethodInfo info)
         {
-            return !(info is DynamicMethod);
+            return info is not DynamicMethod;
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/parser/AstVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/AstVisitor.cs
@@ -386,7 +386,7 @@ namespace System.Management.Automation.Language
             Type type = ast.TypeName.GetReflectionType();
             if (type != null)
             {
-                Diagnostics.Assert(!(type is TypeBuilder), "ReflectionType can never be TypeBuilder");
+                Diagnostics.Assert(type is not TypeBuilder, "ReflectionType can never be TypeBuilder");
             }
 
             return AstVisitAction.Continue;

--- a/src/System.Management.Automation/engine/parser/ConstantValues.cs
+++ b/src/System.Management.Automation/engine/parser/ConstantValues.cs
@@ -261,7 +261,7 @@ namespace System.Management.Automation.Language
 
         public object VisitMemberExpression(MemberExpressionAst memberExpressionAst)
         {
-            if (!memberExpressionAst.Static || !(memberExpressionAst.Expression is TypeExpressionAst))
+            if (!memberExpressionAst.Static || memberExpressionAst.Expression is not TypeExpressionAst)
             {
                 return false;
             }

--- a/src/System.Management.Automation/engine/parser/DebugViewWriter.cs
+++ b/src/System.Management.Automation/engine/parser/DebugViewWriter.cs
@@ -470,7 +470,7 @@ namespace System.Management.Automation.Language {
         private static bool IsSimpleExpression(Expression node) {
             var binary = node as BinaryExpression;
             if (binary != null) {
-                return !(binary.Left is BinaryExpression || binary.Right is BinaryExpression);
+                return binary.Left is not BinaryExpression && binary.Right is not BinaryExpression;
             }
 
             return false;

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -4923,8 +4923,8 @@ namespace System.Management.Automation.Language
                 return new ErrorStatementAst(ExtentOf(usingToken, itemToken.Extent));
             }
 
-            if (itemAst is not StringConstantExpressionAst &&
-                (kind != UsingStatementKind.Module || itemAst is not HashtableAst))
+            if (itemAst is not StringConstantExpressionAst
+                && (kind != UsingStatementKind.Module || itemAst is not HashtableAst))
             {
                 ReportError(ExtentFromFirstOf(itemAst, itemToken),
                     nameof(ParserStrings.InvalidValueForUsingItemName),

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -1973,7 +1973,7 @@ namespace System.Management.Automation.Language
                     }
                     else if ((token.TokenFlags & TokenFlags.Keyword) != 0)
                     {
-                        foreach (var attr in attributes.Where(attr => !(attr is AttributeAst)))
+                        foreach (var attr in attributes.Where(attr => attr is not AttributeAst))
                         {
                             ReportError(attr.Extent,
                                 nameof(ParserStrings.TypeNotAllowedBeforeStatement),
@@ -4923,7 +4923,7 @@ namespace System.Management.Automation.Language
                 return new ErrorStatementAst(ExtentOf(usingToken, itemToken.Extent));
             }
 
-            if (!(itemAst is StringConstantExpressionAst) && (kind != UsingStatementKind.Module || !(itemAst is HashtableAst)))
+            if (itemAst is not StringConstantExpressionAst && (kind != UsingStatementKind.Module || itemAst is not HashtableAst))
             {
                 ReportError(ExtentFromFirstOf(itemAst, itemToken),
                     nameof(ParserStrings.InvalidValueForUsingItemName),

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -4923,7 +4923,8 @@ namespace System.Management.Automation.Language
                 return new ErrorStatementAst(ExtentOf(usingToken, itemToken.Extent));
             }
 
-            if (itemAst is not StringConstantExpressionAst && (kind != UsingStatementKind.Module || itemAst is not HashtableAst))
+            if (itemAst is not StringConstantExpressionAst &&
+                (kind != UsingStatementKind.Module || itemAst is not HashtableAst))
             {
                 ReportError(ExtentFromFirstOf(itemAst, itemToken),
                     nameof(ParserStrings.InvalidValueForUsingItemName),

--- a/src/System.Management.Automation/engine/parser/SemanticChecks.cs
+++ b/src/System.Management.Automation/engine/parser/SemanticChecks.cs
@@ -197,7 +197,8 @@ namespace System.Management.Automation.Language
                         var members = attributeType.GetMember(name, MemberTypes.Field | MemberTypes.Property,
                             BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance |
                             BindingFlags.FlattenHierarchy);
-                        if (members.Length != 1 || !(members[0] is PropertyInfo || members[0] is FieldInfo))
+                        if (members.Length != 1 ||
+                            (members[0] is not PropertyInfo && members[0] is not FieldInfo))
                         {
                             _parser.ReportError(namedArg.Extent,
                                 nameof(ParserStrings.PropertyNotFoundForAttribute),

--- a/src/System.Management.Automation/engine/parser/SemanticChecks.cs
+++ b/src/System.Management.Automation/engine/parser/SemanticChecks.cs
@@ -348,7 +348,7 @@ namespace System.Management.Automation.Language
         {
             int count = 0;
             ITypeName type = typeName;
-            while ((type is TypeName) == false)
+            while (type is not TypeName)
             {
                 count++;
                 if (count > 200)

--- a/src/System.Management.Automation/engine/parser/SemanticChecks.cs
+++ b/src/System.Management.Automation/engine/parser/SemanticChecks.cs
@@ -197,8 +197,8 @@ namespace System.Management.Automation.Language
                         var members = attributeType.GetMember(name, MemberTypes.Field | MemberTypes.Property,
                             BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance |
                             BindingFlags.FlattenHierarchy);
-                        if (members.Length != 1 ||
-                            (members[0] is not PropertyInfo && members[0] is not FieldInfo))
+                        if (members.Length != 1
+                            || (members[0] is not PropertyInfo && members[0] is not FieldInfo))
                         {
                             _parser.ReportError(namedArg.Extent,
                                 nameof(ParserStrings.PropertyNotFoundForAttribute),
@@ -1027,9 +1027,9 @@ namespace System.Management.Automation.Language
             }
 
             var memberExpr = exprAst as MemberExpressionAst;
-            if (memberExpr != null &&
-                memberExpr is not InvokeMemberExpressionAst &&
-                memberExpr.Member is StringConstantExpressionAst)
+            if (memberExpr != null
+                && memberExpr is not InvokeMemberExpressionAst
+                && memberExpr.Member is StringConstantExpressionAst)
             {
                 return CheckUsingExpression(memberExpr.Expression);
             }
@@ -1050,9 +1050,9 @@ namespace System.Management.Automation.Language
 
         public override AstVisitAction VisitVariableExpression(VariableExpressionAst variableExpressionAst)
         {
-            if (variableExpressionAst.Splatted &&
-                variableExpressionAst.Parent is not CommandAst &&
-                variableExpressionAst.Parent is not UsingExpressionAst)
+            if (variableExpressionAst.Splatted
+                && variableExpressionAst.Parent is not CommandAst
+                && variableExpressionAst.Parent is not UsingExpressionAst)
             {
                 if (variableExpressionAst.Parent is ArrayLiteralAst && variableExpressionAst.Parent.Parent is CommandAst)
                 {
@@ -1219,9 +1219,9 @@ namespace System.Management.Automation.Language
         public override AstVisitAction VisitScriptBlock(ScriptBlockAst scriptBlockAst)
         {
             _scopeStack.Push(scriptBlockAst);
-            if (scriptBlockAst.Parent == null ||
-                scriptBlockAst.Parent is ScriptBlockExpressionAst ||
-                scriptBlockAst.Parent.Parent is not FunctionMemberAst)
+            if (scriptBlockAst.Parent == null
+                || scriptBlockAst.Parent is ScriptBlockExpressionAst
+                || scriptBlockAst.Parent.Parent is not FunctionMemberAst)
             {
                 _memberScopeStack.Push(null);
             }
@@ -1453,9 +1453,9 @@ namespace System.Management.Automation.Language
             var scriptBlockAst = ast as ScriptBlockAst;
             if (scriptBlockAst != null)
             {
-                if (scriptBlockAst.Parent == null ||
-                    scriptBlockAst.Parent is ScriptBlockExpressionAst ||
-                    scriptBlockAst.Parent.Parent is not FunctionMemberAst)
+                if (scriptBlockAst.Parent == null
+                    || scriptBlockAst.Parent is ScriptBlockExpressionAst
+                    || scriptBlockAst.Parent.Parent is not FunctionMemberAst)
                 {
                     _memberScopeStack.Pop();
                 }

--- a/src/System.Management.Automation/engine/parser/SemanticChecks.cs
+++ b/src/System.Management.Automation/engine/parser/SemanticChecks.cs
@@ -1026,7 +1026,7 @@ namespace System.Management.Automation.Language
             }
 
             var memberExpr = exprAst as MemberExpressionAst;
-            if (memberExpr != null && !(memberExpr is InvokeMemberExpressionAst) && (memberExpr.Member is StringConstantExpressionAst))
+            if (memberExpr != null && memberExpr is not InvokeMemberExpressionAst && (memberExpr.Member is StringConstantExpressionAst))
             {
                 return CheckUsingExpression(memberExpr.Expression);
             }
@@ -1047,7 +1047,7 @@ namespace System.Management.Automation.Language
 
         public override AstVisitAction VisitVariableExpression(VariableExpressionAst variableExpressionAst)
         {
-            if (variableExpressionAst.Splatted && !(variableExpressionAst.Parent is CommandAst) && !(variableExpressionAst.Parent is UsingExpressionAst))
+            if (variableExpressionAst.Splatted && variableExpressionAst.Parent is not CommandAst && variableExpressionAst.Parent is not UsingExpressionAst)
             {
                 if (variableExpressionAst.Parent is ArrayLiteralAst && variableExpressionAst.Parent.Parent is CommandAst)
                 {
@@ -1214,7 +1214,7 @@ namespace System.Management.Automation.Language
         public override AstVisitAction VisitScriptBlock(ScriptBlockAst scriptBlockAst)
         {
             _scopeStack.Push(scriptBlockAst);
-            if (scriptBlockAst.Parent == null || scriptBlockAst.Parent is ScriptBlockExpressionAst || !(scriptBlockAst.Parent.Parent is FunctionMemberAst))
+            if (scriptBlockAst.Parent == null || scriptBlockAst.Parent is ScriptBlockExpressionAst || scriptBlockAst.Parent.Parent is not FunctionMemberAst)
             {
                 _memberScopeStack.Push(null);
             }
@@ -1446,7 +1446,7 @@ namespace System.Management.Automation.Language
             var scriptBlockAst = ast as ScriptBlockAst;
             if (scriptBlockAst != null)
             {
-                if (scriptBlockAst.Parent == null || scriptBlockAst.Parent is ScriptBlockExpressionAst || !(scriptBlockAst.Parent.Parent is FunctionMemberAst))
+                if (scriptBlockAst.Parent == null || scriptBlockAst.Parent is ScriptBlockExpressionAst || scriptBlockAst.Parent.Parent is not FunctionMemberAst)
                 {
                     _memberScopeStack.Pop();
                 }

--- a/src/System.Management.Automation/engine/parser/SemanticChecks.cs
+++ b/src/System.Management.Automation/engine/parser/SemanticChecks.cs
@@ -1027,7 +1027,9 @@ namespace System.Management.Automation.Language
             }
 
             var memberExpr = exprAst as MemberExpressionAst;
-            if (memberExpr != null && memberExpr is not InvokeMemberExpressionAst && (memberExpr.Member is StringConstantExpressionAst))
+            if (memberExpr != null &&
+                memberExpr is not InvokeMemberExpressionAst &&
+                memberExpr.Member is StringConstantExpressionAst)
             {
                 return CheckUsingExpression(memberExpr.Expression);
             }
@@ -1048,7 +1050,9 @@ namespace System.Management.Automation.Language
 
         public override AstVisitAction VisitVariableExpression(VariableExpressionAst variableExpressionAst)
         {
-            if (variableExpressionAst.Splatted && variableExpressionAst.Parent is not CommandAst && variableExpressionAst.Parent is not UsingExpressionAst)
+            if (variableExpressionAst.Splatted &&
+                variableExpressionAst.Parent is not CommandAst &&
+                variableExpressionAst.Parent is not UsingExpressionAst)
             {
                 if (variableExpressionAst.Parent is ArrayLiteralAst && variableExpressionAst.Parent.Parent is CommandAst)
                 {
@@ -1215,7 +1219,9 @@ namespace System.Management.Automation.Language
         public override AstVisitAction VisitScriptBlock(ScriptBlockAst scriptBlockAst)
         {
             _scopeStack.Push(scriptBlockAst);
-            if (scriptBlockAst.Parent == null || scriptBlockAst.Parent is ScriptBlockExpressionAst || scriptBlockAst.Parent.Parent is not FunctionMemberAst)
+            if (scriptBlockAst.Parent == null ||
+                scriptBlockAst.Parent is ScriptBlockExpressionAst ||
+                scriptBlockAst.Parent.Parent is not FunctionMemberAst)
             {
                 _memberScopeStack.Push(null);
             }
@@ -1447,7 +1453,9 @@ namespace System.Management.Automation.Language
             var scriptBlockAst = ast as ScriptBlockAst;
             if (scriptBlockAst != null)
             {
-                if (scriptBlockAst.Parent == null || scriptBlockAst.Parent is ScriptBlockExpressionAst || scriptBlockAst.Parent.Parent is not FunctionMemberAst)
+                if (scriptBlockAst.Parent == null ||
+                    scriptBlockAst.Parent is ScriptBlockExpressionAst ||
+                    scriptBlockAst.Parent.Parent is not FunctionMemberAst)
                 {
                     _memberScopeStack.Pop();
                 }

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -369,7 +369,7 @@ namespace System.Management.Automation.Language
                 // Nested function isn't really a member of the type so stop looking
                 // Anonymous script blocks are though
                 var functionDefinitionAst = ast as FunctionDefinitionAst;
-                if (functionDefinitionAst != null && !(functionDefinitionAst.Parent is FunctionMemberAst))
+                if (functionDefinitionAst != null && functionDefinitionAst.Parent is not FunctionMemberAst)
                     break;
                 ast = ast.Parent;
             }
@@ -1581,7 +1581,7 @@ namespace System.Management.Automation.Language
             }
 
             // Make sure all statements are pipelines.
-            if (EndBlock.Statements.Any(ast => !(ast is PipelineAst)))
+            if (EndBlock.Statements.Any(ast => ast is not PipelineAst))
             {
                 errorId = "CanOnlyConvertOnePipeline";
                 errorMsg = AutomationExceptions.CanOnlyConvertOnePipeline;
@@ -4019,7 +4019,7 @@ namespace System.Management.Automation.Language
             {
                 this.CommandsAllowed = new ReadOnlyCollection<ExpressionAst>(commandsAllowed.ToArray());
                 SetParents(CommandsAllowed);
-                this.HasNonConstantAllowedCommand = CommandsAllowed.Any(ast => !(ast is StringConstantExpressionAst));
+                this.HasNonConstantAllowedCommand = CommandsAllowed.Any(ast => ast is not StringConstantExpressionAst);
             }
             else
             {

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -2110,7 +2110,7 @@ namespace System.Management.Automation.Language
                     return;
                 }
 
-                if (argumentValue is string || !(argumentValue is IEnumerable))
+                if (argumentValue is string || argumentValue is not IEnumerable)
                 {
                     requiredEditions = HandleRequiresPSEditionArgument(argumentAst, argumentValue, ref requiredEditions);
                 }
@@ -2165,7 +2165,7 @@ namespace System.Management.Automation.Language
             }
             else if (assemblyToken.StartsWith(parameter.ParameterName, StringComparison.OrdinalIgnoreCase))
             {
-                if (argumentValue is string || !(argumentValue is IEnumerable))
+                if (argumentValue is string || argumentValue is not IEnumerable)
                 {
                     requiredAssemblies = HandleRequiresAssemblyArgument(argumentAst, argumentValue, requiredAssemblies);
                 }

--- a/src/System.Management.Automation/engine/remoting/client/Job.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job.cs
@@ -3382,9 +3382,10 @@ namespace System.Management.Automation
                                 fullyQualifiedErrorId, ErrorCategory.OpenError,
                                 null, null, null, null, null, errorDetails, null);
             }
-            else if ((pipeline.PipelineStateInfo.State == PipelineState.Failed) ||
-                     ((pipeline.PipelineStateInfo.State == PipelineState.Stopped) &&
-                      (pipeline.PipelineStateInfo.Reason != null && pipeline.PipelineStateInfo.Reason is not PipelineStoppedException)))
+            else if (pipeline.PipelineStateInfo.State == PipelineState.Failed
+                || (pipeline.PipelineStateInfo.State == PipelineState.Stopped
+                    && pipeline.PipelineStateInfo.Reason != null
+                    && pipeline.PipelineStateInfo.Reason is not PipelineStoppedException))
             {
                 // Pipeline stopped state is also an error condition if the associated exception is not 'PipelineStoppedException'.
                 object targetObject = runspace.ConnectionInfo.ComputerName;

--- a/src/System.Management.Automation/engine/remoting/client/Job.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job.cs
@@ -3384,7 +3384,7 @@ namespace System.Management.Automation
             }
             else if ((pipeline.PipelineStateInfo.State == PipelineState.Failed) ||
                      ((pipeline.PipelineStateInfo.State == PipelineState.Stopped) &&
-                      (pipeline.PipelineStateInfo.Reason != null && !(pipeline.PipelineStateInfo.Reason is PipelineStoppedException))))
+                      (pipeline.PipelineStateInfo.Reason != null && pipeline.PipelineStateInfo.Reason is not PipelineStoppedException)))
             {
                 // Pipeline stopped state is also an error condition if the associated exception is not 'PipelineStoppedException'.
                 object targetObject = runspace.ConnectionInfo.ComputerName;

--- a/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
+++ b/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
@@ -156,8 +156,8 @@ namespace System.Management.Automation
         {
             // The RemoteRunspace object can only be constructed this way with a RunspacePool that
             // is in the disconnected state.
-            if ((runspacePool.RunspacePoolStateInfo.State != RunspacePoolState.Disconnected) ||
-                 runspacePool.ConnectionInfo is not WSManConnectionInfo)
+            if (runspacePool.RunspacePoolStateInfo.State != RunspacePoolState.Disconnected
+                || runspacePool.ConnectionInfo is not WSManConnectionInfo)
             {
                 throw PSTraceSource.NewInvalidOperationException(RunspaceStrings.InvalidRunspacePool);
             }

--- a/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
+++ b/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
@@ -157,7 +157,7 @@ namespace System.Management.Automation
             // The RemoteRunspace object can only be constructed this way with a RunspacePool that
             // is in the disconnected state.
             if ((runspacePool.RunspacePoolStateInfo.State != RunspacePoolState.Disconnected) ||
-                 !(runspacePool.ConnectionInfo is WSManConnectionInfo))
+                 runspacePool.ConnectionInfo is not WSManConnectionInfo)
             {
                 throw PSTraceSource.NewInvalidOperationException(RunspaceStrings.InvalidRunspacePool);
             }

--- a/src/System.Management.Automation/engine/remoting/commands/ReceiveJob.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/ReceiveJob.cs
@@ -768,7 +768,7 @@ namespace Microsoft.PowerShell.Commands
             // There is a bug in V2 that only remoting jobs work
             // with Receive-Job. This is being fixed
 
-            if (!(job is Job2) && job.UsesResultsCollection)
+            if (job is not Job2 && job.UsesResultsCollection)
             {
                 // extract results and handle them
                 Collection<PSStreamObject> results = ReadAll<PSStreamObject>(job.Results);

--- a/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemoteHostEncoder.cs
+++ b/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemoteHostEncoder.cs
@@ -744,7 +744,7 @@ namespace System.Management.Automation.Remoting
         /// </summary>
         private static T SafelyGetBaseObject<T>(PSObject psObject)
         {
-            if (psObject == null || psObject.BaseObject == null || !(psObject.BaseObject is T))
+            if (psObject == null || psObject.BaseObject == null || psObject.BaseObject is not T)
             {
                 throw RemoteHostExceptions.NewDecodingFailedException();
             }
@@ -771,7 +771,7 @@ namespace System.Management.Automation.Remoting
         private static T SafelyGetPropertyValue<T>(PSObject psObject, string key)
         {
             PSPropertyInfo propertyInfo = psObject.Properties[key];
-            if (propertyInfo == null || propertyInfo.Value == null || !(propertyInfo.Value is T))
+            if (propertyInfo == null || propertyInfo.Value == null || propertyInfo.Value is not T)
             {
                 throw RemoteHostExceptions.NewDecodingFailedException();
             }

--- a/src/System.Management.Automation/engine/remoting/fanin/InitialSessionStateProvider.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/InitialSessionStateProvider.cs
@@ -1326,7 +1326,7 @@ namespace System.Management.Automation.Remoting
 
         private static bool IntegerTypeValidationCallback(string key, object obj, PSCmdlet cmdlet, string path)
         {
-            if (!(obj is int) && !(obj is long))
+            if (obj is not int && obj is not long)
             {
                 cmdlet.WriteVerbose(StringUtil.Format(RemotingErrorIdStrings.DISCTypeMustBeInteger, key, path));
                 return false;

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -1722,7 +1722,8 @@ namespace System.Management.Automation.Language
                 {
                     var members = attributeType.GetMember(name, MemberTypes.Field | MemberTypes.Property,
                         BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
-                    if (members.Length != 1 || !(members[0] is PropertyInfo || members[0] is FieldInfo))
+                    if (members.Length != 1 ||
+                        (members[0] is not PropertyInfo && members[0] is not FieldInfo))
                     {
                         return target.ThrowRuntimeError(args, BindingRestrictions.Empty, "PropertyNotFoundForType",
                                                         ParserStrings.PropertyNotFoundForType, Expression.Constant(name),

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -737,7 +737,11 @@ namespace System.Management.Automation.Language
                 return null;
             }
 
-            if (obj is not PSObject && obj is not IEnumerable && obj is not IEnumerator && obj is not DataTable && !Marshal.IsComObject(obj))
+            if (obj is not PSObject &&
+                obj is not IEnumerable &&
+                obj is not IEnumerator &&
+                obj is not DataTable &&
+                !Marshal.IsComObject(obj))
             {
                 return null;
             }
@@ -4674,7 +4678,9 @@ namespace System.Management.Automation.Language
                 }
             }
 
-            if (paramLength == 2 && setterParams[0].ParameterType == typeof(int) && target.Value is not IDictionary)
+            if (paramLength == 2 &&
+                setterParams[0].ParameterType == typeof(int) &&
+                target.Value is not IDictionary)
             {
                 // PowerShell supports negative indexing for some types (specifically, those with a single
                 // int parameter to the indexer, and also have either a Length or Count property.)  For

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -737,11 +737,11 @@ namespace System.Management.Automation.Language
                 return null;
             }
 
-            if (obj is not PSObject &&
-                obj is not IEnumerable &&
-                obj is not IEnumerator &&
-                obj is not DataTable &&
-                !Marshal.IsComObject(obj))
+            if (obj is not PSObject
+                && obj is not IEnumerable
+                && obj is not IEnumerator
+                && obj is not DataTable
+                && !Marshal.IsComObject(obj))
             {
                 return null;
             }
@@ -1726,8 +1726,8 @@ namespace System.Management.Automation.Language
                 {
                     var members = attributeType.GetMember(name, MemberTypes.Field | MemberTypes.Property,
                         BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
-                    if (members.Length != 1 ||
-                        (members[0] is not PropertyInfo && members[0] is not FieldInfo))
+                    if (members.Length != 1
+                        || (members[0] is not PropertyInfo && members[0] is not FieldInfo))
                     {
                         return target.ThrowRuntimeError(args, BindingRestrictions.Empty, "PropertyNotFoundForType",
                                                         ParserStrings.PropertyNotFoundForType, Expression.Constant(name),
@@ -4678,9 +4678,9 @@ namespace System.Management.Automation.Language
                 }
             }
 
-            if (paramLength == 2 &&
-                setterParams[0].ParameterType == typeof(int) &&
-                target.Value is not IDictionary)
+            if (paramLength == 2
+                && setterParams[0].ParameterType == typeof(int)
+                && target.Value is not IDictionary)
             {
                 // PowerShell supports negative indexing for some types (specifically, those with a single
                 // int parameter to the indexer, and also have either a Length or Count property.)  For

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -737,7 +737,7 @@ namespace System.Management.Automation.Language
                 return null;
             }
 
-            if (!(obj is PSObject) && !(obj is IEnumerable) && !(obj is IEnumerator) && !(obj is DataTable) && !Marshal.IsComObject(obj))
+            if (obj is not PSObject && obj is not IEnumerable && obj is not IEnumerator && obj is not DataTable && !Marshal.IsComObject(obj))
             {
                 return null;
             }
@@ -885,7 +885,7 @@ namespace System.Management.Automation.Language
                     restrictions)).WriteToDebugLog(this);
             }
 
-            bool needsToDispose = !(PSObject.Base(target.Value) is IEnumerator);
+            bool needsToDispose = PSObject.Base(target.Value) is not IEnumerator;
             return (new DynamicMetaObject(
                 Expression.Call(CachedReflectionInfo.EnumerableOps_WriteEnumerableToPipe,
                                 enumerable.Expression,
@@ -2011,7 +2011,7 @@ namespace System.Management.Automation.Language
 
         private static object ObjectRule(CallSite site, object obj)
         {
-            if (!(obj is ValueType) && !(obj is PSObject)) { return obj; }
+            if (obj is not ValueType && obj is not PSObject) { return obj; }
 
             return ((CallSite<Func<CallSite, object, object>>)site).Update(site, obj);
         }
@@ -3836,7 +3836,7 @@ namespace System.Management.Automation.Language
             var baseObject = PSObject.Base(argument.Value);
 
             // Source value cannot be null or AutomationNull, and it cannot be a pure PSObject.
-            if (baseObject != null && !(baseObject is PSObject))
+            if (baseObject != null && baseObject is not PSObject)
             {
                 Type fromType = baseObject.GetType();
                 ConversionRank rank = ConversionRank.None;
@@ -4673,7 +4673,7 @@ namespace System.Management.Automation.Language
                 }
             }
 
-            if (paramLength == 2 && setterParams[0].ParameterType == typeof(int) && !(target.Value is IDictionary))
+            if (paramLength == 2 && setterParams[0].ParameterType == typeof(int) && target.Value is not IDictionary)
             {
                 // PowerShell supports negative indexing for some types (specifically, those with a single
                 // int parameter to the indexer, and also have either a Length or Count property.)  For

--- a/src/System.Management.Automation/help/MamlUtil.cs
+++ b/src/System.Management.Automation/help/MamlUtil.cs
@@ -206,7 +206,7 @@ namespace System.Management.Automation
                     return propertyInfo;
                 }
 
-                if (propertyInfo == null || !(propertyInfo.Value is PSObject))
+                if (propertyInfo == null || propertyInfo.Value is not PSObject)
                 {
                     return null;
                 }
@@ -317,7 +317,7 @@ namespace System.Management.Automation
                 }
 
                 // If we are not on the last path element, let's make sure we can extend the path.
-                if (propertyInfo.Value == null || !(propertyInfo.Value is PSObject))
+                if (propertyInfo.Value == null || propertyInfo.Value is not PSObject)
                 {
                     propertyInfo.Value = new PSObject();
                 }

--- a/src/System.Management.Automation/utils/PowerShellExecutionHelper.cs
+++ b/src/System.Management.Automation/utils/PowerShellExecutionHelper.cs
@@ -189,7 +189,7 @@ namespace System.Management.Automation
                 if (pso != null)
                 {
                     object baseObject = pso.BaseObject;
-                    if (baseObject != null && !(baseObject is PSCustomObject))
+                    if (baseObject != null && baseObject is not PSCustomObject)
                         result = baseObject.ToString();
                     else
                         result = pso.ToString();


### PR DESCRIPTION
# PR Summary

* More `!(foo is T)` -> `foo is not T`
* Convert boolean logic to DNF form

## PR Context

Follow-up #13323

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [NA] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [NA] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [NA] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [NA] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [NA] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [NA] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
