### PR TITLE
Change `$ErrorActionPreference` to not affect stderr output

### DIFF
--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -123,6 +123,9 @@ namespace System.Management.Automation
                 new ExperimentalFeature(
                     name: "PSNativePSPathResolution",
                     description: "Convert PSPath to filesystem path, if possible, for native commands"),
+                new ExperimentalFeature(
+                    name: "PSNotApplyErrorActionToStderr",
+                    description: "Don't have $ErrorActionPreference affect stderr output"),
             };
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);
 

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -2856,35 +2856,36 @@ namespace System.Management.Automation
                 preference = ActionPreference.Continue;
             }
 
-            switch (preference)
+            if (!isNativeError)
             {
-                case ActionPreference.Stop:
-                    ActionPreferenceStopException e =
-                        new ActionPreferenceStopException(
-                            MyInvocation,
-                            errorRecord,
-                            StringUtil.Format(CommandBaseStrings.ErrorPreferenceStop,
-                                              "ErrorActionPreference",
-                                              errorRecord.ToString()));
-                    throw ManageException(e);
+                switch (preference)
+                {
+                    case ActionPreference.Stop:
+                        ActionPreferenceStopException e =
+                            new ActionPreferenceStopException(
+                                MyInvocation,
+                                errorRecord,
+                                StringUtil.Format(CommandBaseStrings.ErrorPreferenceStop,
+                                                "ErrorActionPreference",
+                                                errorRecord.ToString()));
+                        throw ManageException(e);
 
-                case ActionPreference.Inquire:
-                    // ignore return value
-                    // this will throw if the user chooses not to continue
-                    lastErrorContinueStatus = InquireHelper(
-                        RuntimeException.RetrieveMessage(errorRecord),
-                        null,
-                        true,  // allowYesToAll
-                        false, // allowNoToAll
-                        true,  // replaceNoWithHalt
-                        false  // hasSecurityImpact
-                    );
-                    break;
+                    case ActionPreference.Inquire:
+                        // ignore return value
+                        // this will throw if the user chooses not to continue
+                        lastErrorContinueStatus = InquireHelper(
+                            RuntimeException.RetrieveMessage(errorRecord),
+                            null,
+                            true,  // allowYesToAll
+                            false, // allowNoToAll
+                            true,  // replaceNoWithHalt
+                            false  // hasSecurityImpact
+                        );
+                        break;
+                }
+
+                AppendErrorToVariables(errorRecord);
             }
-
-            // 2005/01/20 Do not write the object to $error if
-            // ManageException has already done so
-            AppendErrorToVariables(errorRecord);
 
             // Add this note property and set its value to true for F&O
             // to decide whether to call WriteErrorLine or WriteLine.

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -2856,7 +2856,7 @@ namespace System.Management.Automation
                 preference = ActionPreference.Continue;
             }
 
-            if (!isNativeError)
+            if (!(ExperimentalFeature.IsEnabled("PSNotApplyErrorActionToStderr") && isNativeError))
             {
                 switch (preference)
                 {

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -2831,33 +2831,33 @@ namespace System.Management.Automation
                 this.PipelineProcessor.LogExecutionError(_thisCommand.MyInvocation, errorRecord);
             }
 
-            ActionPreference preference = ErrorAction;
-            if (actionPreference.HasValue)
-            {
-                preference = actionPreference.Value;
-            }
-
-            // No trace of the error in the 'Ignore' case
-            if (ActionPreference.Ignore == preference)
-            {
-                return; // do not write or record to output pipe
-            }
-
-            // 2004/05/26-JonN
-            // The object is not written in the SilentlyContinue case
-            if (ActionPreference.SilentlyContinue == preference)
-            {
-                AppendErrorToVariables(errorRecord);
-                return; // do not write to output pipe
-            }
-
-            if (ContinueStatus.YesToAll == lastErrorContinueStatus)
-            {
-                preference = ActionPreference.Continue;
-            }
-
             if (!(ExperimentalFeature.IsEnabled("PSNotApplyErrorActionToStderr") && isNativeError))
             {
+                ActionPreference preference = ErrorAction;
+                if (actionPreference.HasValue)
+                {
+                    preference = actionPreference.Value;
+                }
+
+                // No trace of the error in the 'Ignore' case
+                if (ActionPreference.Ignore == preference)
+                {
+                    return; // do not write or record to output pipe
+                }
+
+                // 2004/05/26-JonN
+                // The object is not written in the SilentlyContinue case
+                if (ActionPreference.SilentlyContinue == preference)
+                {
+                    AppendErrorToVariables(errorRecord);
+                    return; // do not write to output pipe
+                }
+
+                if (ContinueStatus.YesToAll == lastErrorContinueStatus)
+                {
+                    preference = ActionPreference.Continue;
+                }
+
                 switch (preference)
                 {
                     case ActionPreference.Stop:

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -100,19 +100,6 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             { & $powershell -outp blah -comm { $input } } | Should -Throw -ErrorId "IncorrectValueForFormatParameter"
         }
 
-        It "Verify Validate Dollar Error Populated should throw exception" {
-            $origEA = $ErrorActionPreference
-            $ErrorActionPreference = "Stop"
-            $a = 1,2,3
-            $e = {
-                $a | & $powershell -noprofile -command { wgwg-wrwrhqwrhrh35h3h3}
-            } | Should -Throw -ErrorId "CommandNotFoundException" -PassThru
-
-            $e.ToString() | Should -Match "wgwg-wrwrhqwrhrh35h3h3"
-
-            $ErrorActionPreference = $origEA
-        }
-
         It "Verify Validate Output Format As Text Explicitly Child Single Shell does not throw" {
             {
                 "blahblah" | & $powershell -noprofile -out text -com { $input }

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -142,7 +142,7 @@ Describe "Native Command Processor" -tags "Feature" {
     }
 
     It '$ErrorActionPreference does not apply to redirected stderr output' -Skip:(!$EnabledExperimentalFeatures.Contains('PSNotApplyErrorActionToStderr')) {
-        pwsh -noprofile -command '$ErrorActionPreference = ''Stop''; testexe -stderr stop 2>$null; ''hello''' | Should -BeExactly 'hello'
+        pwsh -noprofile -command '$ErrorActionPreference = ''Stop''; testexe -stderr stop 2>$null; ''hello''; $error' | Should -BeExactly 'hello'
     }
 }
 

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -140,6 +140,10 @@ Describe "Native Command Processor" -tags "Feature" {
             [Console]::OutputEncoding = $originalOutputEncoding
         }
     }
+
+    It '$ErrorActionPreference does not apply to redirected stderr output' {
+        pwsh -noprofile -command "`$ErrorActionPreference = 'Stop'; testexe -stderr stop 2>`$null; 'hello'" | Should -BeExactly 'hello'
+    }
 }
 
 Describe "Open a text file with NativeCommandProcessor" -tags @("Feature", "RequireAdminOnWindows") {

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -142,7 +142,7 @@ Describe "Native Command Processor" -tags "Feature" {
     }
 
     It '$ErrorActionPreference does not apply to redirected stderr output' -Skip:(!$EnabledExperimentalFeatures.Contains('PSNotApplyErrorActionToStderr')) {
-        pwsh -noprofile -command '$ErrorActionPreference = "Stop"; testexe -stderr stop 2>$null; "hello"' | Should -BeExactly 'hello'
+        pwsh -noprofile -command '$ErrorActionPreference = ''Stop''; testexe -stderr stop 2>$null; ''hello''' | Should -BeExactly 'hello'
     }
 }
 

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -141,7 +141,7 @@ Describe "Native Command Processor" -tags "Feature" {
         }
     }
 
-    It '$ErrorActionPreference does not apply to redirected stderr output' {
+    It '$ErrorActionPreference does not apply to redirected stderr output' -Skip:(!$EnabledExperimentalFeatures.Contains('PSNotApplyErrorActionToStderr')) {
         pwsh -noprofile -command "`$ErrorActionPreference = 'Stop'; testexe -stderr stop 2>`$null; 'hello'" | Should -BeExactly 'hello'
     }
 }

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -142,7 +142,7 @@ Describe "Native Command Processor" -tags "Feature" {
     }
 
     It '$ErrorActionPreference does not apply to redirected stderr output' -Skip:(!$EnabledExperimentalFeatures.Contains('PSNotApplyErrorActionToStderr')) {
-        pwsh -noprofile -command "`$ErrorActionPreference = 'Stop'; testexe -stderr stop 2>`$null; 'hello'" | Should -BeExactly 'hello'
+        pwsh -noprofile -command '$ErrorActionPreference = "Stop"; testexe -stderr stop 2>$null; "hello"' | Should -BeExactly 'hello'
     }
 }
 

--- a/test/powershell/Language/Scripting/NativeExecution/NativeStreams.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeStreams.Tests.ps1
@@ -21,8 +21,7 @@ Describe "Native streams behavior with PowerShell" -Tags 'CI' {
 
         # this check should be the first one, because $error is a global shared variable
         It 'should not add records to $error variable' {
-            # we are keeping existing Windows PS v5.1 behavior for $error variable
-            $error.Count | Should -Be 9
+            $error.Count | Should -Be 0
         }
 
         It 'uses ErrorRecord object to return stderr output' {

--- a/test/tools/TestExe/TestExe.cs
+++ b/test/tools/TestExe/TestExe.cs
@@ -24,6 +24,9 @@ namespace TestExe
                         // Used to test functionality depending on $LASTEXITCODE, like &&/|| operators
                         Console.WriteLine(args[1]);
                         return int.Parse(args[1]);
+                    case "-stderr":
+                        Console.Error.WriteLine(args[1]);
+                        break;
                     default:
                         Console.WriteLine("Unknown test {0}", args[0]);
                         break;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Based on @PowerShell/powershell-committee discussion, we agreed that stderr should not be treated as an `ErrorRecord` as many native commands use that as an alternate stream from stdout and it does not signify an error (like verbose or progress information).  Stderr output is still wrapped as ErrorRecords, but the runtime no longer applies `$ErrorActionPreference` if the ErrorRecord comes from a native command.  The diff makes the change look bigger than it is, but it's simply wrapping existing code that applies `$ErrorActionPreference` and writing to `$Error` to not apply if the ErrorRecord is simply wrapping stderr.

Updated `TestExe` to have a switch to write output to stderr.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/3996

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [x] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [x] Experimental feature name(s): `PSNotApplyErrorActionToStderr`
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/6466
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
