### PR TITLE
Add SupportsWildcardsAttribute to parameters

### DIFF
--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/GetCimClassCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/GetCimClassCommand.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         [Parameter(
             Position = 0,
             ValueFromPipelineByPropertyName = true)]
+        [SupportsWildcards]
         public string ClassName
         {
             get { return className; }
@@ -158,6 +159,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// </para>
         /// </summary>
         [Parameter(ValueFromPipelineByPropertyName = true)]
+        [SupportsWildcards]
         public string MethodName
         {
             get { return methodName; }
@@ -192,6 +194,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// </para>
         /// </summary>
         [Parameter(ValueFromPipelineByPropertyName = true)]
+        [SupportsWildcards]
         public string QualifierName
         {
             get { return qualifierName; }

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/GetCimSessionCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/GetCimSessionCommand.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         [Parameter(Position = 0,
             ValueFromPipelineByPropertyName = true,
             ParameterSetName = ComputerNameSet)]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] ComputerName
         {
@@ -120,6 +121,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         [Parameter(Mandatory = true,
             ValueFromPipelineByPropertyName = true,
             ParameterSetName = NameSet)]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] Name
         {

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/RemoveCimSessionCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/RemoveCimSessionCommand.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
             Position = 0,
             ValueFromPipelineByPropertyName = true,
             ParameterSetName = ComputerNameSet)]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] ComputerName
         {
@@ -147,6 +148,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
             Mandatory = true,
             ValueFromPipelineByPropertyName = true,
             ParameterSetName = NameSet)]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] Name
         {

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/GetCounterCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/GetCounterCommand.cs
@@ -45,6 +45,7 @@ namespace Microsoft.PowerShell.Commands
                 ValueFromPipelineByPropertyName = false,
                 HelpMessageBaseName = "GetEventResources")]
         [AllowEmptyCollection]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays",
                             Scope = "member",
                             Target = "Microsoft.PowerShell.Commands.GetCounterCommand.ListSet",
@@ -69,6 +70,7 @@ namespace Microsoft.PowerShell.Commands
                 ValueFromPipelineByPropertyName = true,
                 HelpMessageBaseName = "GetEventResources")]
         [AllowEmptyCollection]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays",
                             Scope = "member",
                             Target = "Microsoft.PowerShell.Commands.GetCounterCommand.ListSet",

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/GetEventCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/GetEventCommand.cs
@@ -39,6 +39,7 @@ namespace Microsoft.PowerShell.Commands
                 HelpMessageBaseName = "GetEventResources",
                 HelpMessageResourceId = "ListLogParamHelp")]
         [AllowEmptyCollection]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays",
                             Scope = "member",
                             Target = "Microsoft.PowerShell.Commands.GetEvent.ListLog",
@@ -63,6 +64,7 @@ namespace Microsoft.PowerShell.Commands
                 ValueFromPipelineByPropertyName = true,
                 HelpMessageBaseName = "GetEventResources",
                 HelpMessageResourceId = "GetLogParamHelp")]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays",
                             Scope = "member",
                             Target = "Microsoft.PowerShell.Commands.GetEvent.LogName",
@@ -88,7 +90,7 @@ namespace Microsoft.PowerShell.Commands
                 HelpMessageBaseName = "GetEventResources",
                 HelpMessageResourceId = "ListProviderParamHelp")]
         [AllowEmptyCollection]
-
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays",
                             Scope = "member",
                             Target = "Microsoft.PowerShell.Commands.GetEvent.ListProvider",
@@ -113,7 +115,7 @@ namespace Microsoft.PowerShell.Commands
                 ValueFromPipelineByPropertyName = true,
                 HelpMessageBaseName = "GetEventResources",
                 HelpMessageResourceId = "GetProviderParamHelp")]
-
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays",
                             Scope = "member",
                             Target = "Microsoft.PowerShell.Commands.GetEvent.ProviderName",
@@ -140,6 +142,7 @@ namespace Microsoft.PowerShell.Commands
                 HelpMessageResourceId = "PathParamHelp")]
 
         [Alias("PSPath")]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays",
                             Scope = "member",
                             Target = "Microsoft.PowerShell.Commands.GetEvent.Path",

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/ImportCounterCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/ImportCounterCommand.cs
@@ -44,7 +44,7 @@ namespace Microsoft.PowerShell.Commands
                 ValueFromPipelineByPropertyName = true,
                 HelpMessageBaseName = "GetEventResources")]
         [Alias("PSPath")]
-
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays",
                             Scope = "member",
                             Target = "Microsoft.PowerShell.Commands.GetCounterCommand.ListSet",
@@ -72,6 +72,7 @@ namespace Microsoft.PowerShell.Commands
                 ValueFromPipelineByPropertyName = false,
                 HelpMessageBaseName = "GetEventResources")]
         [AllowEmptyCollection]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays",
                             Scope = "member",
                             Target = "Microsoft.PowerShell.Commands.GetCounterCommand.ListSet",
@@ -128,6 +129,7 @@ namespace Microsoft.PowerShell.Commands
                 ValueFromPipeline = false,
                 HelpMessageBaseName = "GetEventResources")]
         [AllowEmptyCollection]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays",
                             Scope = "member",
                             Target = "Microsoft.PowerShell.Commands.GetCounterCommand.ListSet",

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
@@ -25,6 +25,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Position = 0, Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         [Alias("PSPath")]
+        [SupportsWildcards]
         public string[] Path { get; set; }
 
         /// <summary>
@@ -33,6 +34,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Position = 1, Mandatory = true, ValueFromPipelineByPropertyName = true)]
         [AllowNull]
         [AllowEmptyString]
+        [SupportsWildcards]
         public string ChildPath { get; set; }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ContentCommandBase.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ContentCommandBase.cs
@@ -24,6 +24,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Position = 0, ParameterSetName = "Path",
                    Mandatory = true, ValueFromPipelineByPropertyName = true)]
+        [SupportsWildcards]
         public string[] Path { get; set; }
 
         /// <summary>
@@ -47,6 +48,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the filter property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string Filter
         {
             get { return base.Filter; }
@@ -58,6 +60,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the include property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string[] Include
         {
             get { return base.Include; }
@@ -69,6 +72,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the exclude property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string[] Exclude
         {
             get { return base.Exclude; }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ControlPanelItemCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ControlPanelItemCommand.cs
@@ -699,6 +699,7 @@ $result
         /// </summary>
         [Parameter(Position = 0, Mandatory = true, ParameterSetName = RegularNameParameterSet, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] Name
         {
@@ -712,6 +713,7 @@ $result
         /// </summary>
         [Parameter(Mandatory = true, ParameterSetName = CanonicalNameParameterSet)]
         [AllowNull]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] CanonicalName
         {

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Eventlog.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Eventlog.cs
@@ -43,6 +43,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Position = 0, Mandatory = true, ParameterSetName = "LogName")]
         [Alias("LN")]
+        [SupportsWildcards]
         public string LogName { get; set; }
 
         /// <summary>
@@ -104,6 +105,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(ParameterSetName = "LogName")]
         [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] UserName
         {
@@ -188,6 +190,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = "LogName")]
         [ValidateNotNullOrEmpty()]
         [Alias("ABO")]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] Source
         {
@@ -209,6 +212,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = "LogName")]
         [ValidateNotNullOrEmpty()]
         [Alias("MSG")]
+        [SupportsWildcards]
         public string Message
         {
             get

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetChildrenCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetChildrenCommand.cs
@@ -35,6 +35,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Position = 0, ParameterSetName = childrenSet,
                    ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+        [SupportsWildcards]
         public string[] Path
         {
             get
@@ -72,6 +73,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the filter property.
         /// </summary>
         [Parameter(Position = 1)]
+        [SupportsWildcards]
         public override string Filter
         {
             get
@@ -89,6 +91,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the include property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string[] Include
         {
             get
@@ -106,6 +109,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the exclude property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string[] Exclude
         {
             get
@@ -188,6 +192,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the names switch.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public SwitchParameter Name
         {
             get

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetComputerInfoCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetComputerInfoCommand.cs
@@ -117,6 +117,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Position = 0,
                    ValueFromPipeline = true,
                    ValueFromPipelineByPropertyName = true)]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] Property { get; set; }
         #endregion Parameters

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Hotfix.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Hotfix.cs
@@ -39,6 +39,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(ParameterSetName = "Description")]
         [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] Description { get; set; }
 

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
@@ -647,6 +647,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Position = 0, ParameterSetName = PathParameterSet,
                    ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+        [SupportsWildcards]
         public string Path
         {
             get => _path;
@@ -821,6 +822,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Position = 0, ParameterSetName = PathParameterSet,
                    ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+        [SupportsWildcards]
         public string Path
         {
             get => _path;
@@ -1495,6 +1497,7 @@ namespace Microsoft.PowerShell.Commands
                    Mandatory = true, ValueFromPipelineByPropertyName = true)]
         [AllowNull]
         [AllowEmptyCollection]
+        [SupportsWildcards]
         public string[] Name
         {
             get => _names;
@@ -1677,6 +1680,7 @@ namespace Microsoft.PowerShell.Commands
         /// </remarks>
         [Parameter(Position = 0, ParameterSetName = NameParameterSet, ValueFromPipelineByPropertyName = true)]
         [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
         public string[] Name
         {
             get => _name;
@@ -1854,6 +1858,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Position = 0, ParameterSetName = PathParameterSet,
                    Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+        [SupportsWildcards]
         public string[] Path
         {
             get => _paths;
@@ -1880,6 +1885,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the filter property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string Filter
         {
             get => base.Filter;
@@ -1890,6 +1896,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the include property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string[] Include
         {
             get => base.Include;
@@ -1900,6 +1907,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the exclude property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string[] Exclude
         {
             get => base.Exclude;
@@ -2174,6 +2182,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Position = 0, ParameterSetName = PathParameterSet,
                    Mandatory = true, ValueFromPipelineByPropertyName = true)]
+        [SupportsWildcards]
         public string[] Path
         {
             get => _paths;
@@ -2237,6 +2246,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the filter property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string Filter
         {
             get => base.Filter;
@@ -2247,6 +2257,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the include property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string[] Include
         {
             get => base.Include;
@@ -2257,6 +2268,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the exclude property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string[] Exclude
         {
             get => base.Exclude;
@@ -2377,6 +2389,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Position = 0, ParameterSetName = PathParameterSet,
                    Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+        [SupportsWildcards]
         public string[] Path
         {
             get => _paths;
@@ -2403,6 +2416,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the filter property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string Filter
         {
             get => base.Filter;
@@ -2413,6 +2427,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the include property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string[] Include
         {
             get => base.Include;
@@ -2423,6 +2438,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the exclude property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string[] Exclude
         {
             get => base.Exclude;
@@ -2805,6 +2821,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Position = 0, ParameterSetName = PathParameterSet,
                    Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+        [SupportsWildcards]
         public string[] Path
         {
             get => _paths;
@@ -2856,6 +2873,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the filter property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string Filter
         {
             get => base.Filter;
@@ -2866,6 +2884,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the include property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string[] Include
         {
             get => base.Include;
@@ -2876,6 +2895,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the exclude property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string[] Exclude
         {
             get => base.Exclude;
@@ -3180,6 +3200,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the path property.
         /// </summary>
         [Parameter(Position = 0, Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true, ParameterSetName = ByPathParameterSet)]
+        [SupportsWildcards]
         public string Path
         {
             get => _path;
@@ -3522,6 +3543,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Position = 0, ParameterSetName = PathParameterSet,
                    Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+        [SupportsWildcards]
         public string[] Path
         {
             get => _paths;
@@ -3587,6 +3609,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the filter property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string Filter
         {
             get => base.Filter;
@@ -3597,6 +3620,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the include property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string[] Include
         {
             get => base.Include;
@@ -3607,6 +3631,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the exclude property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string[] Exclude
         {
             get => base.Exclude;
@@ -3781,6 +3806,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Position = 0, ParameterSetName = PathParameterSet,
                    Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+        [SupportsWildcards]
         public string[] Path
         {
             get => _paths;
@@ -3826,6 +3852,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the filter property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string Filter
         {
             get => base.Filter;
@@ -3836,6 +3863,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the include property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string[] Include
         {
             get => base.Include;
@@ -3846,6 +3874,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the exclude property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string[] Exclude
         {
             get => base.Exclude;
@@ -3970,6 +3999,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Position = 0, ParameterSetName = PathParameterSet,
                    Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+        [SupportsWildcards]
         public string[] Path
         {
             get => _paths;
@@ -3996,6 +4026,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the filter property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string Filter
         {
             get => base.Filter;
@@ -4006,6 +4037,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the include property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string[] Include
         {
             get => base.Include;
@@ -4016,6 +4048,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the exclude property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string[] Exclude
         {
             get => base.Exclude;
@@ -4135,6 +4168,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Position = 0, ValueFromPipelineByPropertyName = true)]
         [ValidateNotNullOrEmpty()]
+        [SupportsWildcards]
         public string[] PSProvider
         {
             get => _provider;

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ParsePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ParsePathCommand.cs
@@ -78,6 +78,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Position = 0, ParameterSetName = qualifierSet, Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         [Parameter(Position = 0, ParameterSetName = noQualifierSet, Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         [Parameter(Position = 0, ParameterSetName = isAbsoluteSet, Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+        [SupportsWildcards]
         public string[] Path { get; set; }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/PingPathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/PingPathCommand.cs
@@ -46,6 +46,7 @@ namespace Microsoft.PowerShell.Commands
         [AllowNull]
         [AllowEmptyCollection]
         [AllowEmptyString]
+        [SupportsWildcards]
         public string[] Path
         {
             get { return _paths; }
@@ -77,6 +78,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the filter property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string Filter
         {
             get { return base.Filter; }
@@ -88,6 +90,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the include property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string[] Include
         {
             get { return base.Include; }
@@ -99,6 +102,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the exclude property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string[] Exclude
         {
             get { return base.Exclude; }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -478,6 +478,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Position = 0, ParameterSetName = NameWithUserNameParameterSet, ValueFromPipelineByPropertyName = true)]
         [Alias("ProcessName")]
         [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
         public string[] Name
         {
             get { return processNames; }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/PropertyCommandBase.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/PropertyCommandBase.cs
@@ -19,6 +19,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the filter parameter.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string Filter
         {
             get
@@ -36,6 +37,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the include property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string[] Include
         {
             get
@@ -53,6 +55,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the exclude property.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public override string[] Exclude
         {
             get

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ResolvePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ResolvePathCommand.cs
@@ -24,6 +24,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Position = 0, ParameterSetName = "Path",
                    Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+        [SupportsWildcards]
         public string[] Path
         {
             get

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
@@ -196,6 +196,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets/sets an array of display names for services.
         /// </summary>
         [Parameter(ParameterSetName = "DisplayName", Mandatory = true)]
+        [SupportsWildcards]
         public string[] DisplayName
         {
             get
@@ -220,6 +221,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
         public string[] Include
         {
             get
@@ -243,6 +245,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
         public string[] Exclude
         {
             get
@@ -584,6 +587,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Position = 0, ParameterSetName = "Default", ValueFromPipelineByPropertyName = true, ValueFromPipeline = true)]
         [ValidateNotNullOrEmpty()]
         [Alias("ServiceName")]
+        [SupportsWildcards]
         public string[] Name
         {
             get
@@ -610,6 +614,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         [Alias("SDO", "ServicesDependedOn")]
+        [SupportsWildcards]
         public SwitchParameter RequiredServices { get; set; }
 
         #endregion Parameters
@@ -779,6 +784,7 @@ namespace Microsoft.PowerShell.Commands
         /// </remarks>
         [Parameter(Position = 0, ParameterSetName = "Default", Mandatory = true, ValueFromPipelineByPropertyName = true, ValueFromPipeline = true)]
         [Alias("ServiceName")]
+        [SupportsWildcards]
         public string[] Name
         {
             get

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TimeZoneCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TimeZoneCommands.cs
@@ -40,6 +40,7 @@ namespace Microsoft.PowerShell.Commands
         /// A list of the local time zone names that the cmdlet should look up.
         /// </summary>
         [Parameter(Position = 0, ValueFromPipeline = true, ParameterSetName = "Name")]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] Name { get; set; }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -270,6 +270,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Mandatory = true, ParameterSetName = FromAssemblyNameParameterSetName)]
         [Alias("AN")]
         [ValidateTrustedData]
+        [SupportsWildcards]
         public string[] AssemblyName { get; set; }
 
         private bool _loadAssembly = false;
@@ -310,6 +311,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = FromPathParameterSetName)]
         [Parameter(ParameterSetName = FromLiteralPathParameterSetName)]
         [Alias("OA")]
+        [SupportsWildcards]
         public string OutputAssembly
         {
             get

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ExportAliasCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ExportAliasCommand.cs
@@ -39,6 +39,7 @@ namespace Microsoft.PowerShell.Commands
         /// The Path of the file to export the aliases to.
         /// </summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ByPath")]
+        [SupportsWildcards]
         public string Path
         {
             get { return _path; }
@@ -77,6 +78,7 @@ namespace Microsoft.PowerShell.Commands
         /// The Name parameter for the command.
         /// </summary>
         [Parameter(Position = 1, ValueFromPipelineByPropertyName = true)]
+        [SupportsWildcards]
         public string[] Name
         {
             get { return _names; }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
@@ -30,6 +30,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
         [Parameter(Position = 0)]
         public string[] TypeName
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-hex/Format-Hex.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-hex/Format-Hex.cs
@@ -48,6 +48,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "Path")]
         [ValidateNotNullOrEmpty()]
+        [SupportsWildcards]
         public string[] Path { get; set; }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-object/Format-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-object/Format-Object.cs
@@ -30,6 +30,7 @@ namespace Microsoft.PowerShell.Commands
         /// will be determined using property sets, etc.
         /// </summary>
         [Parameter(Position = 0)]
+        [SupportsWildcards]
         public object[] Property
         {
             get { return _props; }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-wide/Format-Wide.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-wide/Format-Wide.cs
@@ -31,6 +31,7 @@ namespace Microsoft.PowerShell.Commands
         /// The parameter is optional, since the defaults will be determined using property sets, etc.
         /// </summary>
         [Parameter(Position = 0)]
+        [SupportsWildcards]
         public object Property
         {
             get { return _prop; }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetAliasCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetAliasCommand.cs
@@ -24,6 +24,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(ParameterSetName = "Default", Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         [ValidateNotNullOrEmpty()]
+        [SupportsWildcards]
         public string[] Name
         {
             get { return _names; }
@@ -37,6 +38,7 @@ namespace Microsoft.PowerShell.Commands
         /// The Exclude parameter for the command.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public string[] Exclude
         {
             get { return _excludes; }
@@ -58,6 +60,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(ParameterSetName = "Definition")]
         [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] Definition { get; set; }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
@@ -24,6 +24,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// <value></value>
         [Parameter(Mandatory = true, ParameterSetName = PathParameterSet, Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+        [SupportsWildcards]
         public string[] Path
         {
             get

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetVerbCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetVerbCommand.cs
@@ -20,6 +20,7 @@ namespace Microsoft.PowerShell.Commands
         /// Optional Verb filter.
         /// </summary>
         [Parameter(ValueFromPipeline = true, ValueFromPipelineByPropertyName = true, Position = 0)]
+        [SupportsWildcards]
         public string[] Verb
         {
             get; set;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
@@ -343,6 +343,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Position = 2)]
         [Alias("Name")]
+        [SupportsWildcards]
         public string[] CommandName
         {
             get

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImportAliasCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImportAliasCommand.cs
@@ -30,6 +30,7 @@ namespace Microsoft.PowerShell.Commands
         /// The path from which to import the aliases.
         /// </summary>
         [Parameter(Position = 0, Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true, ParameterSetName = "ByPath")]
+        [SupportsWildcards]
         public string Path { get; set; }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImportPowerShellDataFile.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImportPowerShellDataFile.cs
@@ -22,6 +22,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ByPath")]
         [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] Path { get; set; }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -1203,6 +1203,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Position = 1, Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = ParameterSetFile)]
         [Parameter(Position = 1, Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = ParameterSetFileRaw)]
         [FileinfoToString]
+        [SupportsWildcards]
         public string[] Path { get; set; }
 
         /// <summary>
@@ -1278,6 +1279,7 @@ namespace Microsoft.PowerShell.Commands
         /// <exception cref="WildcardPatternException">Invalid wildcard pattern was specified.</exception>
         [Parameter]
         [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
         public string[] Include
         {
             get => _includeStrings;
@@ -1305,6 +1307,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
         public string[] Exclude
         {
             get => _excludeStrings;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
@@ -242,6 +242,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// <value></value>
         [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
         [Parameter(Position = 0)]
         public PSPropertyExpression[] Property { get; set; } = null;
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/OrderObjectBase.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/OrderObjectBase.cs
@@ -123,6 +123,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or Sets the Properties that would be used for Grouping, Sorting and Comparison.
         /// </summary>
         [Parameter(Position = 0)]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public object[] Property { get; set; }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -83,6 +83,7 @@ namespace Microsoft.PowerShell.Commands
         /// <value></value>
         [Parameter(Position = 0, ParameterSetName = "DefaultParameter")]
         [Parameter(Position = 0, ParameterSetName = "SkipLastParameter")]
+        [SupportsWildcards]
         public object[] Property { get; set; }
 
         /// <summary>
@@ -90,6 +91,7 @@ namespace Microsoft.PowerShell.Commands
         /// <value></value>
         [Parameter(ParameterSetName = "DefaultParameter")]
         [Parameter(ParameterSetName = "SkipLastParameter")]
+        [SupportsWildcards]
         public string[] ExcludeProperty { get; set; } = null;
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Set-PSBreakpoint.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Set-PSBreakpoint.cs
@@ -42,6 +42,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Alias("C")]
         [Parameter(ParameterSetName = CommandParameterSetName, Mandatory = true)]
+        [SupportsWildcards]
         public string[] Command { get; set; }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowMarkdownCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowMarkdownCommand.cs
@@ -40,6 +40,7 @@ namespace Microsoft.PowerShell.Commands
         [ValidateNotNullOrEmpty]
         [Parameter(Position = 0, Mandatory = true,
                    ValueFromPipelineByPropertyName = true, ParameterSetName = "Path")]
+        [SupportsWildcards]
         public string[] Path { get; set; }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Tee-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Tee-Object.cs
@@ -32,6 +32,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "File")]
         [Alias("Path")]
+        [SupportsWildcards]
         public string FilePath
         {
             get { return _fileName; }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/UnblockFile.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/UnblockFile.cs
@@ -33,6 +33,7 @@ namespace Microsoft.PowerShell.Commands
         /// The path of the file to unblock.
         /// </summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ByPath")]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] Path
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Update-TypeData.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Update-TypeData.cs
@@ -1281,6 +1281,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
         [Parameter(Position = 0, ValueFromPipeline = true)]
         public string[] TypeName { get; set; }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
@@ -251,6 +251,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         [ValidateNotNullOrEmpty()]
+        [SupportsWildcards]
         public string[] Name
         {
             get
@@ -294,6 +295,7 @@ namespace Microsoft.PowerShell.Commands
         /// The Include parameter for all the variable commands.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public string[] Include
         {
             get
@@ -311,6 +313,7 @@ namespace Microsoft.PowerShell.Commands
         /// The Exclude parameter for all the variable commands.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public string[] Exclude
         {
             get
@@ -592,6 +595,7 @@ namespace Microsoft.PowerShell.Commands
         /// The Include parameter for all the variable commands.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public string[] Include
         {
             get
@@ -609,6 +613,7 @@ namespace Microsoft.PowerShell.Commands
         /// The Exclude parameter for all the variable commands.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public string[] Exclude
         {
             get
@@ -1194,12 +1199,14 @@ namespace Microsoft.PowerShell.Commands
         /// Name of the PSVariable(s) to set.
         /// </summary>
         [Parameter(Position = 0, ValueFromPipelineByPropertyName = true, Mandatory = true)]
+        [SupportsWildcards]
         public string[] Name { get; set; }
 
         /// <summary>
         /// The Include parameter for all the variable commands.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public string[] Include
         {
             get
@@ -1217,6 +1224,7 @@ namespace Microsoft.PowerShell.Commands
         /// The Exclude parameter for all the variable commands.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public string[] Exclude
         {
             get

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/XmlCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/XmlCommands.cs
@@ -812,6 +812,7 @@ namespace Microsoft.PowerShell.Commands
                    ValueFromPipelineByPropertyName = true,
                    ParameterSetName = "Path")]
         [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
         public string[] Path { get; set; }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/GetTracerCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/GetTracerCommand.cs
@@ -21,6 +21,7 @@ namespace Microsoft.PowerShell.Commands
         /// <value></value>
         [Parameter(Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         [ValidateNotNullOrEmpty()]
+        [SupportsWildcards]
         public string[] Name
         {
             get

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/SetTracerCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/SetTracerCommand.cs
@@ -21,6 +21,7 @@ namespace Microsoft.PowerShell.Commands
         /// operation will take place on.
         /// </summary>
         [Parameter(Position = 0, Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+        [SupportsWildcards]
         public string[] Name
         {
             get { return base.NameInternal; }

--- a/src/Microsoft.PowerShell.LocalAccounts/LocalAccounts/Commands/GetLocalUserCommand.cs
+++ b/src/Microsoft.PowerShell.LocalAccounts/LocalAccounts/Commands/GetLocalUserCommand.cs
@@ -39,6 +39,7 @@ namespace Microsoft.PowerShell.Commands
                    ValueFromPipelineByPropertyName = true,
                    ParameterSetName = "Default")]
         [ValidateNotNull]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] Name
         {

--- a/src/Microsoft.PowerShell.Security/security/AclCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/AclCommands.cs
@@ -31,6 +31,7 @@ namespace Microsoft.PowerShell.Commands
         /// property allows for provider-specific filtering of results.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public string Filter
         {
             get
@@ -49,6 +50,7 @@ namespace Microsoft.PowerShell.Commands
         /// specifies the items on which the command will act.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public string[] Include
         {
             get
@@ -67,6 +69,7 @@ namespace Microsoft.PowerShell.Commands
         /// specifies the items on which the command will not act.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public string[] Exclude
         {
             get
@@ -643,6 +646,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true, ParameterSetName = "ByPath")]
         [ValidateNotNullOrEmpty()]
+        [SupportsWildcards]
         public string[] Path
         {
             get
@@ -911,6 +915,7 @@ namespace Microsoft.PowerShell.Commands
         /// security descriptor.
         /// </summary>
         [Parameter(Position = 0, Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = "ByPath")]
+        [SupportsWildcards]
         public string[] Path
         {
             get

--- a/src/Microsoft.PowerShell.Security/security/SignatureCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/SignatureCommands.cs
@@ -31,6 +31,7 @@ namespace Microsoft.PowerShell.Commands
         /// digital signature.
         /// </summary>
         [Parameter(Position = 0, Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true, ParameterSetName = "ByPath")]
+        [SupportsWildcards]
         public string[] FilePath
         {
             get

--- a/src/Microsoft.WSMan.Management/CredSSP.cs
+++ b/src/Microsoft.WSMan.Management/CredSSP.cs
@@ -405,6 +405,7 @@ namespace Microsoft.WSMan.Management
         /// </summary>
         [Parameter(Position = 1)]
         [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] DelegateComputer
         {

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommand.cs
@@ -721,6 +721,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// will be determined using property sets, etc.
         /// </summary>
         [Parameter(Position = 0)]
+        [SupportsWildcards]
         public object[] Property { get; set; }
 
         #endregion

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -38,6 +38,7 @@ namespace Microsoft.PowerShell.Commands
             ValueFromPipelineByPropertyName = true,
             ParameterSetName = "AllCommandSet")]
         [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
         public string[] Name
         {
             get
@@ -71,6 +72,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the verb parameter to the cmdlet.
         /// </summary>
         [Parameter(ValueFromPipelineByPropertyName = true, ParameterSetName = "CmdletSet")]
+        [SupportsWildcards]
         public string[] Verb
         {
             get
@@ -97,6 +99,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(ValueFromPipelineByPropertyName = true, ParameterSetName = "CmdletSet")]
         [ArgumentCompleter(typeof(NounArgumentCompleter))]
+        [SupportsWildcards]
         public string[] Noun
         {
             get
@@ -278,6 +281,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
         public string[] ParameterName
         {
             get { return _parameterNames; }
@@ -305,6 +309,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
         public PSTypeName[] ParameterType
         {
             get

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -195,6 +195,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = ForEachObjectCommand.PropertyAndMethodSet)]
         [ValidateTrustedData]
         [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
         public string MemberName
         {
             get
@@ -1394,6 +1395,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Position = 1, ParameterSetName = "CaseSensitiveNotInSet")]
         [Parameter(Position = 1, ParameterSetName = "IsSet")]
         [Parameter(Position = 1, ParameterSetName = "IsNotSet")]
+        [SupportsWildcards]
         public object Value
         {
             get

--- a/src/System.Management.Automation/engine/Modules/ExportModuleMemberCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ExportModuleMemberCommand.cs
@@ -25,6 +25,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(ValueFromPipeline = true, ValueFromPipelineByPropertyName = true, Position = 0)]
         [AllowEmptyCollection]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public string[] Function
         {
@@ -54,6 +55,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(ValueFromPipelineByPropertyName = true)]
         [AllowEmptyCollection]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public string[] Cmdlet
         {
@@ -83,6 +85,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(ValueFromPipelineByPropertyName = true)]
         [ValidateNotNull]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public string[] Variable
         {
@@ -112,6 +115,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(ValueFromPipelineByPropertyName = true)]
         [ValidateNotNull]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public string[] Alias
         {

--- a/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
@@ -47,6 +47,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = ParameterSet_AvailableInPsrpSession, ValueFromPipeline = true, Position = 0)]
         [Parameter(ParameterSetName = ParameterSet_AvailableInCimSession, ValueFromPipeline = true, Position = 0)]
         [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays",
             Justification = "Cmdlets use arrays for parameters.")]
         public string[] Name { get; set; }

--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -88,6 +88,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = ParameterSet_ViaCimSession, Mandatory = true, ValueFromPipeline = true, Position = 0)]
         [Parameter(ParameterSetName = ParameterSet_ViaWinCompat, Mandatory = true, ValueFromPipeline = true, Position = 0)]
         [ValidateTrustedData]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public string[] Name { set; get; } = Array.Empty<string>();
 
@@ -114,6 +115,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         [ValidateNotNull]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public string[] Function
         {
@@ -141,6 +143,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         [ValidateNotNull]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public string[] Cmdlet
         {
@@ -169,6 +172,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         [ValidateNotNull]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public string[] Variable
         {
@@ -196,6 +200,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         [ValidateNotNull]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public string[] Alias
         {

--- a/src/System.Management.Automation/engine/Modules/NewModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/NewModuleCommand.cs
@@ -57,6 +57,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         [ValidateNotNull]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public string[] Function
         {

--- a/src/System.Management.Automation/engine/Modules/NewModuleManifestCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/NewModuleManifestCommand.cs
@@ -337,6 +337,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         [AllowEmptyCollection]
+        [SupportsWildcards]
         public string[] FunctionsToExport
         {
             get { return _exportedFunctions; }
@@ -351,6 +352,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         [AllowEmptyCollection]
+        [SupportsWildcards]
         public string[] AliasesToExport
         {
             get { return _exportedAliases; }
@@ -365,6 +367,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         [AllowEmptyCollection]
+        [SupportsWildcards]
         public string[] VariablesToExport
         {
             get { return _exportedVariables; }
@@ -379,6 +382,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         [AllowEmptyCollection]
+        [SupportsWildcards]
         public string[] CmdletsToExport
         {
             get { return _exportedCmdlets; }
@@ -393,6 +397,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         [AllowEmptyCollection]
+        [SupportsWildcards]
         public string[] DscResourcesToExport
         {
             get { return _dscResourcesToExport; }

--- a/src/System.Management.Automation/engine/Modules/RemoveModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/RemoveModuleCommand.cs
@@ -29,6 +29,7 @@ namespace Microsoft.PowerShell.Commands
         /// This parameter specifies the current pipeline object.
         /// </summary>
         [Parameter(Mandatory = true, ParameterSetName = "name", ValueFromPipeline = true, Position = 0)]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public string[] Name
         {

--- a/src/System.Management.Automation/engine/Modules/TestModuleManifestCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/TestModuleManifestCommand.cs
@@ -41,6 +41,7 @@ namespace Microsoft.PowerShell.Commands
         /// The output path for the generated file...
         /// </summary>
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0, ValueFromPipelineByPropertyName = true)]
+        [SupportsWildcards]
         public string Path
         {
             get { return _path; }

--- a/src/System.Management.Automation/engine/hostifaces/History.cs
+++ b/src/System.Management.Automation/engine/hostifaces/History.cs
@@ -1625,6 +1625,7 @@ namespace Microsoft.PowerShell.Commands
 
         [Parameter(ParameterSetName = "CommandLineParameter", HelpMessage = "Specifies the name of a command in the session history")]
         [ValidateNotNullOrEmpty()]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] CommandLine
         {

--- a/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
@@ -2536,6 +2536,7 @@ else
         /// </summary>
         [Parameter(Mandatory = true, Position = 0, ValueFromPipelineByPropertyName = true)]
         [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
         public string Name { get; set; }
 
         /// <summary>
@@ -2819,6 +2820,7 @@ $args[0] | ForEach-Object {{
         /// </summary>
         [Parameter(Position = 0, Mandatory = false)]
         [ValidateNotNullOrEmpty()]
+        [SupportsWildcards]
         public string[] Name { get; set; }
 
         /// <summary>
@@ -4194,6 +4196,7 @@ $_ | Enable-PSSessionConfiguration -force $args[0] -sddl $args[1] -isSDDLSpecifi
         /// </summary>
         [Parameter(Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
         public string[] Name { get; set; }
 
         private Collection<string> _shellsToEnable = new Collection<string>();
@@ -4481,6 +4484,7 @@ $_ | Disable-PSSessionConfiguration -force $args[0] -whatif:$args[1] -confirm:$a
         /// </summary>
         [Parameter(Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
         public string[] Name { get; set; }
 
         private Collection<string> _shellsToDisable = new Collection<string>();

--- a/src/System.Management.Automation/engine/remoting/commands/NewPSSessionConfigurationFile.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/NewPSSessionConfigurationFile.cs
@@ -388,6 +388,7 @@ namespace Microsoft.PowerShell.Commands
         /// A list of visible aliases.
         /// </summary>
         [Parameter()]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] VisibleAliases
         {
@@ -408,6 +409,7 @@ namespace Microsoft.PowerShell.Commands
         /// A list of visible cmdlets.
         /// </summary>
         [Parameter()]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public object[] VisibleCmdlets
         {
@@ -428,6 +430,7 @@ namespace Microsoft.PowerShell.Commands
         /// A list of visible functions.
         /// </summary>
         [Parameter()]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public object[] VisibleFunctions
         {
@@ -448,6 +451,7 @@ namespace Microsoft.PowerShell.Commands
         /// A list of visible external commands (scripts and applications)
         /// </summary>
         [Parameter()]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] VisibleExternalCommands
         {
@@ -468,6 +472,7 @@ namespace Microsoft.PowerShell.Commands
         /// A list of providers.
         /// </summary>
         [Parameter()]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] VisibleProviders
         {
@@ -1277,6 +1282,7 @@ namespace Microsoft.PowerShell.Commands
         /// A list of visible aliases.
         /// </summary>
         [Parameter()]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] VisibleAliases
         {
@@ -1297,6 +1303,7 @@ namespace Microsoft.PowerShell.Commands
         /// A list of visible cmdlets.
         /// </summary>
         [Parameter()]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public object[] VisibleCmdlets
         {
@@ -1317,6 +1324,7 @@ namespace Microsoft.PowerShell.Commands
         /// A list of visible functions.
         /// </summary>
         [Parameter()]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public object[] VisibleFunctions
         {
@@ -1337,6 +1345,7 @@ namespace Microsoft.PowerShell.Commands
         /// A list of visible external commands (scripts and applications)
         /// </summary>
         [Parameter()]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] VisibleExternalCommands
         {
@@ -1357,6 +1366,7 @@ namespace Microsoft.PowerShell.Commands
         /// A list of providers.
         /// </summary>
         [Parameter()]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] VisibleProviders
         {

--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -2508,6 +2508,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true,
                    ParameterSetName = PSRunspaceCmdlet.NameParameterSet)]
         [ValidateNotNullOrEmpty()]
+        [SupportsWildcards]
         public virtual string[] Name
         {
             get

--- a/src/System.Management.Automation/engine/remoting/commands/ReceiveJob.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/ReceiveJob.cs
@@ -104,6 +104,7 @@ namespace Microsoft.PowerShell.Commands
         [Alias("Cn")]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
         public string[] ComputerName
         {
             get

--- a/src/System.Management.Automation/engine/remoting/commands/RemoveJob.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/RemoveJob.cs
@@ -608,6 +608,7 @@ namespace Microsoft.PowerShell.Commands
                   Mandatory = true,
                   ParameterSetName = JobCmdletBase.NameParameterSet)]
         [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
         public string[] Name
         {
             get
@@ -705,6 +706,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ValueFromPipelineByPropertyName = true,
             ParameterSetName = RemoveJobCommand.CommandParameterSet)]
         [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
         public virtual string[] Command
         {
             get

--- a/src/System.Management.Automation/engine/remoting/commands/TestPSSessionConfigurationFile.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/TestPSSessionConfigurationFile.cs
@@ -26,6 +26,7 @@ namespace Microsoft.PowerShell.Commands
         /// The output path for the generated file...
         /// </summary>
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0, ValueFromPipelineByPropertyName = true)]
+        [SupportsWildcards]
         public string Path
         {
             get { return _path; }

--- a/src/System.Management.Automation/help/HelpCommands.cs
+++ b/src/System.Management.Automation/help/HelpCommands.cs
@@ -51,12 +51,14 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Position = 0, ValueFromPipelineByPropertyName = true)]
         [ValidateNotNullOrEmpty()]
+        [SupportsWildcards]
         public string Name { get; set; } = string.Empty;
 
         /// <summary>
         /// Path to provider location that user is curious about.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public string Path { get; set; }
 
         /// <summary>
@@ -157,24 +159,28 @@ namespace Microsoft.PowerShell.Commands
         /// Support WildCard strings as supported by WildcardPattern class.
         /// </remarks>
         [Parameter(ParameterSetName = "Parameters", Mandatory = true)]
+        [SupportsWildcards]
         public string[] Parameter { get; set; }
 
         /// <summary>
         /// Gets and sets list of Component's to search on.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public string[] Component { get; set; }
 
         /// <summary>
         /// Gets and sets list of Functionality's to search on.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public string[] Functionality { get; set; }
 
         /// <summary>
         /// Gets and sets list of Role's to search on.
         /// </summary>
         [Parameter]
+        [SupportsWildcards]
         public string[] Role { get; set; }
 
         /// <summary>

--- a/src/System.Management.Automation/help/SaveHelpCommand.cs
+++ b/src/System.Management.Automation/help/SaveHelpCommand.cs
@@ -89,6 +89,7 @@ namespace Microsoft.PowerShell.Commands
         [Alias("Name")]
         [ValidateNotNull]
         [ArgumentToModuleTransformationAttribute()]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public PSModuleInfo[] Module { get; set; }
 

--- a/src/System.Management.Automation/help/UpdateHelpCommand.cs
+++ b/src/System.Management.Automation/help/UpdateHelpCommand.cs
@@ -43,6 +43,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Position = 0, ParameterSetName = LiteralPathParameterSetName, ValueFromPipelineByPropertyName = true)]
         [Alias("Name")]
         [ValidateNotNull]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] Module
         {

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -7786,6 +7786,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         [ValidateNotNullOrEmpty()]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] Stream { get; set; }
 #endif
@@ -7802,6 +7803,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         [ValidateNotNullOrEmpty()]
+        [SupportsWildcards]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] Stream { get; set; }
 #endif


### PR DESCRIPTION
# PR Summary

This PR is the second-half of #4716 to add `[SupportsWildcards]` attribute to all parameters that support wildcards.

## PR Context

The `[SupportsWildcards]` attribute is queried by the help system to inform the user if wildcards are supported. The list of parameters was generated by @sdwheeler.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
