### PR TITLE
Pass -UserScope as required by RunUpdateHelpTests

### DIFF
--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -400,7 +400,7 @@ Describe "Validate Update-Help -SourcePath for all PowerShell modules for user s
         $ProgressPreference = $SavedProgressPreference
     }
 
-    RunSaveHelpTests -Tag "Feature" -useSourcePath -UserScope
+    RunUpdateHelpTests -Tag "Feature" -useSourcePath -UserScope
 }
 
 Describe "Validate 'Save-Help -DestinationPath for one PowerShell modules." -Tags @('CI', 'RequireAdminOnWindows') {

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -175,7 +175,7 @@ function ValidateInstalledHelpContent
     )
 
     [string] $pathProperty = $(if ($UserScope) { 'HelpInstallationPathHome' } else { 'HelpInstallationPath' })
-    [System.Management.Automation.FileInfo[]] $helpFilesInstalled = Get-ChildItem -Path:($testCases[$moduleName]. $pathProperty) -Filter:*help.xml -Recurse
+    [System.IO.FileInfo[]] $helpFilesInstalled = Get-ChildItem -Path:($testCases[$moduleName]. $pathProperty) -Filter:*help.xml -Recurse
 
     [string[]] $expectedHelpFiles = $testCases[$moduleName].HelpFiles
     [string] $junct = "`t"

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -179,7 +179,7 @@ function ValidateInstalledHelpContent
 
     [string[]] $expectedHelpFiles = $testCases[$moduleName].HelpFiles
     [string] $junct = "`t"
-    $helpFilesInstalled.Name -join $junct | Should -Be $expectedHelpFiles -join $junct
+    $helpFilesInstalled.Name -join $junct | Should -Be ($expectedHelpFiles -join $junct)
 
     foreach ($fileName in $expectedHelpFiles)
     {

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -199,7 +199,7 @@ function RunUpdateHelpTests
         if ($powershellCoreModules -contains $moduleName)
         {
 
-            It "Validate Update-Help for module '$moduleName' with scope as '$userscope'" -Skip:(!(Test-CanWriteToPsHome) -and $userscope -eq $false) {
+            It "Validate Update-Help for module '$moduleName' with user scope as '$userscope'" -Skip:(!(Test-CanWriteToPsHome) -and $userscope -eq $false) {
 
                 if($userscope)
                 {

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -431,7 +431,7 @@ Describe "Validate Update-Help -SourcePath for all PowerShell modules for user s
         $ProgressPreference = $SavedProgressPreference
     }
 
-    RunUpdateHelpTests -Tag:Feature -useSourcePath -UserScope
+    RunSaveHelpTests -Tag "Feature" -useSourcePath -UserScope
 }
 
 Describe "Validate 'Save-Help -DestinationPath for one PowerShell modules." -Tags @('CI', 'RequireAdminOnWindows') {
@@ -442,7 +442,7 @@ Describe "Validate 'Save-Help -DestinationPath for one PowerShell modules." -Tag
     AfterAll {
         $ProgressPreference = $SavedProgressPreference
     }
-    RunSaveHelpTests -Tag "Feature"
+    RunSaveHelpTests -Tag "CI"
 }
 
 Describe "Validate 'Save-Help -DestinationPath for all PowerShell modules." -Tags @('Feature', 'RequireAdminOnWindows') {

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -224,7 +224,7 @@ function RunUpdateHelpTests
                     ErrorAction = [System.Management.Automation.ActionPreference]:: Stop
                 }
 
-                $params += $commonParam
+                # $params += $commonParam
 
                 # If the help file is already installed, delete it.
                 [string] $path = $params['Path']

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -210,7 +210,7 @@ function RunUpdateHelpTests
                 $updateScope = @{Scope = 'AllUsers'}
             }
 
-            It "Validate Update-Help for module '$moduleName' in '$updateScope'" -Skip:(!(Test-CanWriteToPsHome) -and $userscope -eq $false) {
+            It ('Validate Update-Help for module ''{0}'' in {1}' -F $moduleName, [PSCustomObject] $updateScope) -Skip:(!(Test-CanWriteToPsHome) -and $userscope -eq $false) {
 
                 $commonParam = @{
                     Include = @("*help.xml")

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -182,7 +182,7 @@ function ValidateInstalledHelpContent
 
     foreach ($fileName in $expectedHelpFiles)
     {
-        $helpFilesInstalled.Name -eq $fileName | Should -Be $fileName
+        [string[]] $helpFilesInstalled.Name -eq $fileName | Should -Be $fileName
     }
 }
 

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -202,6 +202,8 @@ function RunUpdateHelpTests
 
             [hashtable] $params = $null
             [hashtable] $updateScope = $null
+            $testCases[$moduleName]['HelpInstallationPath'] | Should -Not -BeNull
+            $testCases[$moduleName]['HelpInstallationPathHome'] | Should -Not -BeNull
             if($userscope)
             {
                 $params = @{Path = $testCases[$moduleName]['HelpInstallationPathHome']}
@@ -214,6 +216,7 @@ function RunUpdateHelpTests
             }
 
             It ('Validate Update-Help for module ''{0}'' in {1}' -F $moduleName, [PSCustomObject] $updateScope) -Skip:(!(Test-CanWriteToPsHome) -and $userscope -eq $false) {
+                $params['Path']  | Should -Not -BeNull
 
                 [hashtable] $commonParam = @{
                     Filter = @("*help.xml")
@@ -224,7 +227,7 @@ function RunUpdateHelpTests
                 $params += $commonParam
 
                 # If the help file is already installed, delete it.
-                Remove-Item $params['Path']
+                Remove-Item ($params['Path'])
  
                 [hashtable] $UICultureParam = $(if ((Get-UICulture).Name -ne $myUICulture) { @{ UICulture = $myUICulture } } else { @{} })
                 [hashtable] $sourcePathParam = $(if ($useSourcePath) { @{ SourcePath = Join-Path $PSScriptRoot assets } } else { @{} })

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -178,12 +178,11 @@ function ValidateInstalledHelpContent
     [System.IO.FileInfo[]] $helpFilesInstalled = Get-ChildItem -Path:($testCases[$moduleName][$pathProperty]) -Filter:*help.xml -Recurse
 
     [string[]] $expectedHelpFiles = $testCases[$moduleName].HelpFiles
-    [string] $junct = "`t"
-    $helpFilesInstalled.Name -join $junct | Should -Be ($expectedHelpFiles -join $junct)
+    $helpFilesInstalled.Count | Should -Be ($expectedHelpFiles.Count)
 
     foreach ($fileName in $expectedHelpFiles)
     {
-        $helpFilesInstalled -contains $fileName | Should -BeTrue
+        $helpFilesInstalled.Name -eq $fileName | Should -Be $fileName
     }
 }
 

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -174,19 +174,12 @@ function ValidateInstalledHelpContent
         [switch]$UserScope
     )
 
-    if($UserScope)
-    {
-        $params = @{ Path = $testCases[$moduleName].HelpInstallationPathHome }
-    }
-    else
-    {
-        $params = @{ Path = $testCases[$moduleName].HelpInstallationPath }
-    }
+    [string] $pathProperty = $(if ($UserScope) { 'HelpInstallationPathHome' } else { 'HelpInstallationPath' })
+    [System.Management.Automation.FileInfo[]] $helpFilesInstalled = Get-ChildItem $testCases[$moduleName]. $pathProperty *help.xml -Recurse
 
-    $helpFilesInstalled = @(GetFiles @params | ForEach-Object {Split-Path $_ -Leaf})
-
-    $expectedHelpFiles = @($testCases[$moduleName].HelpFiles)
-    $helpFilesInstalled.Count | Should -Be $expectedHelpFiles.Count
+    [string[]] $expectedHelpFiles = $testCases[$moduleName].HelpFiles
+    [string] $junct = "`t"
+    $helpFilesInstalled.Name -join $junct | Should -Be $expectedHelpFiles -join $junct
 
     foreach ($fileName in $expectedHelpFiles)
     {

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -66,7 +66,7 @@ else
         HelpFiles            = "Microsoft.PowerShell.Archive-help.xml"
         HelpInfoFiles        = "Microsoft.PowerShell.Archive_eb74e8da-9ae2-482a-a648-e96550fb8733_HelpInfo.xml"
         CompressedFiles      = "Microsoft.PowerShell.Archive_eb74e8da-9ae2-482a-a648-e96550fb8733_en-US_HelpContent$extension"
-        HelpInstallationPath = Join-Path -Path:$PSHOME -ChildPath:Modules Microsoft.PowerShell.Archive -AdditionalChildPath:$myUICulture
+        HelpInstallationPath = Join-Path -Path:$PSHOME -ChildPath:Modules -AdditionalChildPath:Microsoft.PowerShell.Archive, $myUICulture
     }
 
     "Microsoft.PowerShell.Core" = @{

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -5,7 +5,7 @@ Import-Module HelpersCommon
 
 # Test Settings:
 # This is the list of PowerShell modules for which we test update-help
-$powershellCoreModules = @(
+[string[]] $powershellCoreModules = @(
     "CimCmdlets"
     <#
     This scenario is broken due to issue # https://github.com/PowerShell/platyPS/issues/241
@@ -26,119 +26,126 @@ $powershellCoreModules = @(
 
 # The file extension for the help content on the Download Center.
 # For Linux we use zip, and on Windows we use $extension.
-$extension = ".zip"
+[string] $extension = ".zip"
 
 if ([System.Management.Automation.Platform]::IsWindows)
 {
     $extension = ".cab"
 }
 
+[string] $userHelpRoot = $null
+
 if([System.Management.Automation.Platform]::IsWindows)
 {
-    $userHelpRoot = Join-Path $HOME "Documents/PowerShell/Help/"
+    $userHelpRoot = Join-Path $HOME Documents PowerShell Help
 }
 else
 {
-    $userModulesRoot = [System.Management.Automation.Platform]::SelectProductNameForDirectory([System.Management.Automation.Platform+XDG_Type]::USER_MODULES)
+    [string] $userModulesRoot = [System.Management.Automation.Platform]::SelectProductNameForDirectory([System.Management.Automation.Platform+XDG_Type]::USER_MODULES)
     $userHelpRoot = Join-Path $userModulesRoot -ChildPath ".." -AdditionalChildPath "Help"
 }
 
+# default values for system modules
+[string] $myUICulture = 'en-US'   
+[string] $HelpInstallationPath = Join-Path $PSHOME $myUICulture
+[string] $HelpInstallationPathHome = Join-Path $userHelpRoot $myUICulture
+
 # This is the list of test cases -- each test case represents a PowerShell module.
-$testCases = @{
+[hashtable] $testCases = @{
 
     "CimCmdlets" = @{
         HelpFiles            = "Microsoft.Management.Infrastructure.CimCmdlets.dll-help.xml"
         HelpInfoFiles        = "CimCmdlets_fb6cc51d-c096-4b38-b78d-0fed6277096a_HelpInfo.xml"
         CompressedFiles      = "CimCmdlets_fb6cc51d-c096-4b38-b78d-0fed6277096a_en-US_HelpContent$extension"
-        HelpInstallationPath = "$PSHOME\Modules\CimCmdlets\en-US"
-        HelpInstallationPathHome = "$userHelpRoot\CimCmdlets\en-US"
+        HelpInstallationPath = Join-Path $PSHOME Modules CimCmdlets $myUICulture
+        HelpInstallationPathHome = Join-Path $userHelpRoot CimCmdlets $myUICulture
     }
 
     "Microsoft.PowerShell.Archive" = @{
         HelpFiles            = "Microsoft.PowerShell.Archive-help.xml"
         HelpInfoFiles        = "Microsoft.PowerShell.Archive_eb74e8da-9ae2-482a-a648-e96550fb8733_HelpInfo.xml"
         CompressedFiles      = "Microsoft.PowerShell.Archive_eb74e8da-9ae2-482a-a648-e96550fb8733_en-US_HelpContent$extension"
-        HelpInstallationPath = "$PSHOME\Modules\Microsoft.PowerShell.Archive\en-US"
+        HelpInstallationPath = Join-Path $PSHOME Modules Microsoft.PowerShell.Archive $myUICulture
     }
 
     "Microsoft.PowerShell.Core" = @{
         HelpFiles            = "System.Management.Automation.dll-help.xml"
         HelpInfoFiles        = "Microsoft.PowerShell.Core_00000000-0000-0000-0000-000000000000_HelpInfo.xml"
         CompressedFiles      = "Microsoft.PowerShell.Core_00000000-0000-0000-0000-000000000000_en-US_HelpContent$extension"
-        HelpInstallationPath = "$PSHOME\en-US"
-        HelpInstallationPathHome = "$userHelpRoot\en-US"
+        HelpInstallationPath = $HelpInstallationPath
+        HelpInstallationPathHome = $HelpInstallationPathHome
     }
 
     "Microsoft.PowerShell.Diagnostics" = @{
         HelpFiles            = "Microsoft.PowerShell.Commands.Diagnostics.dll-help.xml"
         HelpInfoFiles        = "Microsoft.PowerShell.Diagnostics_ca046f10-ca64-4740-8ff9-2565dba61a4f_HelpInfo.xml"
         CompressedFiles      = "Microsoft.PowerShell.Diagnostics_ca046f10-ca64-4740-8ff9-2565dba61a4f_en-US_helpcontent$extension"
-        HelpInstallationPath = "$PSHOME\en-US"
-        HelpInstallationPathHome = "$userHelpRoot\en-US"
+        HelpInstallationPath = $HelpInstallationPath
+        HelpInstallationPathHome = $HelpInstallationPathHome
     }
 
     "Microsoft.PowerShell.Host" = @{
         HelpFiles            = "Microsoft.PowerShell.ConsoleHost.dll-help.xml"
         HelpInfoFiles        = "Microsoft.PowerShell.Host_56d66100-99a0-4ffc-a12d-eee9a6718aef_HelpInfo.xml"
         CompressedFiles      = "Microsoft.PowerShell.Host_56d66100-99a0-4ffc-a12d-eee9a6718aef_en-US_helpcontent$extension"
-        HelpInstallationPath = "$PSHOME\en-US"
-        HelpInstallationPathHome = "$userHelpRoot\en-US"
+        HelpInstallationPath = $HelpInstallationPath
+        HelpInstallationPathHome = $HelpInstallationPathHome
     }
 
     "Microsoft.PowerShell.LocalAccounts" = @{
         HelpFiles            = "Microsoft.Powershell.LocalAccounts.dll-help.xml"
         HelpInfoFiles        = "Microsoft.PowerShell.LocalAccounts_8e362604-2c0b-448f-a414-a6a690a644e2_HelpInfo.xml"
         CompressedFiles      = "Microsoft.PowerShell.LocalAccounts_8e362604-2c0b-448f-a414-a6a690a644e2_en-US_HelpContent$extension"
-        HelpInstallationPath = "$PSHOME\Modules\Microsoft.PowerShell.LocalAccounts\en-US"
-        HelpInstallationPathHome = "$userHelpRoot\Microsoft.PowerShell.LocalAccounts\en-US"
+        HelpInstallationPath = Join-Path $PSHOME Modules Microsoft.PowerShell.LocalAccounts $myUICulture
+        HelpInstallationPathHome = Join-Path $userHelpRoot Microsoft.PowerShell.LocalAccounts $myUICulture
     }
 
     "Microsoft.PowerShell.Management" = @{
         HelpFiles            = "Microsoft.PowerShell.Commands.Management.dll-help.xml"
         HelpInfoFiles        = "Microsoft.PowerShell.Management_eefcb906-b326-4e99-9f54-8b4bb6ef3c6d_HelpInfo.xml"
         CompressedFiles      = "Microsoft.PowerShell.Management_eefcb906-b326-4e99-9f54-8b4bb6ef3c6d_en-US_helpcontent$extension"
-        HelpInstallationPath = "$PSHOME\en-US"
-        HelpInstallationPathHome = "$userHelpRoot\en-US"
+        HelpInstallationPath = $HelpInstallationPath
+        HelpInstallationPathHome = $HelpInstallationPathHome
     }
 
     "Microsoft.PowerShell.Security" = @{
         HelpFiles            = "Microsoft.PowerShell.Security.dll-help.xml"
         HelpInfoFiles        = "Microsoft.PowerShell.Security_a94c8c7e-9810-47c0-b8af-65089c13a35a_HelpInfo.xml"
         CompressedFiles      = "Microsoft.PowerShell.Security_a94c8c7e-9810-47c0-b8af-65089c13a35a_en-US_helpcontent$extension"
-        HelpInstallationPath = "$PSHOME\en-US"
-        HelpInstallationPathHome = "$userHelpRoot\en-US"
+        HelpInstallationPath = $HelpInstallationPath
+        HelpInstallationPathHome = $HelpInstallationPathHome
     }
 
     "Microsoft.PowerShell.Utility" = @{
         HelpFiles            = "Microsoft.PowerShell.Commands.Utility.dll-Help.xml", "Microsoft.PowerShell.Utility-help.xml"
         HelpInfoFiles        = "Microsoft.PowerShell.Utility_1da87e53-152b-403e-98dc-74d7b4d63d59_HelpInfo.xml"
         CompressedFiles      = "Microsoft.PowerShell.Utility_1da87e53-152b-403e-98dc-74d7b4d63d59_en-US_helpcontent$extension"
-        HelpInstallationPath = "$PSHOME\en-US"
-        HelpInstallationPathHome = "$userHelpRoot\en-US"
+        HelpInstallationPath = $HelpInstallationPath
+        HelpInstallationPathHome = $HelpInstallationPathHome
     }
 
     "Microsoft.WSMan.Management" = @{
         HelpFiles            = "Microsoft.WSMan.Management.dll-help.xml"
         HelpInfoFiles        = "Microsoft.WsMan.Management_766204A6-330E-4263-A7AB-46C87AFC366C_HelpInfo.xml"
         CompressedFiles      = "Microsoft.WsMan.Management_766204A6-330E-4263-A7AB-46C87AFC366C_en-US_helpcontent$extension"
-        HelpInstallationPath = "$PSHOME\en-US"
-        HelpInstallationPathHome = "$userHelpRoot\en-US"
+        HelpInstallationPath = $HelpInstallationPath
+        HelpInstallationPathHome = $HelpInstallationPathHome
     }
 
     "PackageManagement" = @{
         HelpFiles            = "Microsoft.PowerShell.PackageManagement.dll-help.xml"
         HelpInfoFiles        = "PackageManagement_4ae9fd46-338a-459c-8186-07f910774cb8_HelpInfo.xml"
         CompressedFiles      = "PackageManagement_4ae9fd46-338a-459c-8186-07f910774cb8_en-US_helpcontent$extension"
-        HelpInstallationPath = "$PSHOME\Modules\PackageManagement\en-US"
-        HelpInstallationPathHome = "$userHelpRoot\PackageManagement\en-US"
+        HelpInstallationPath = Join-Path $PSHOME Modules PackageManagement $myUICulture
+        HelpInstallationPathHome = Join-Path $userHelpRoot PackageManagement $myUICulture
     }
 
     "PowershellGet" = @{
         HelpFiles            = "PSGet.psm1-help.xml"
         HelpInfoFiles        = "PowershellGet_1d73a601-4a6c-43c5-ba3f-619b18bbb404_HelpInfo.xml"
         CompressedFiles      = "PowershellGet_1d73a601-4a6c-43c5-ba3f-619b18bbb404_en-US_helpcontent$extension"
-        HelpInstallationPath = "$PSHOME\Modules\PowershellGet\en-US"
-        HelpInstallationPathHome = "$userHelpRoot\PackageManagement\en-US"
+        HelpInstallationPath = Join-Path $PSHOME Modules PowershellGet $myUICulture
+        HelpInstallationPathHome = Join-Path $userHelpRoot PackageManagement $myUICulture
     }
 }
 
@@ -199,6 +206,8 @@ function RunUpdateHelpTests
         if ($powershellCoreModules -contains $moduleName)
         {
 
+            [hashtable] $params = $null
+            [hashtable] $updateScope = $null
             if($userscope)
             {
                 $params = @{Path = $testCases[$moduleName].HelpInstallationPathHome}
@@ -212,7 +221,7 @@ function RunUpdateHelpTests
 
             It ('Validate Update-Help for module ''{0}'' in {1}' -F $moduleName, [PSCustomObject] $updateScope) -Skip:(!(Test-CanWriteToPsHome) -and $userscope -eq $false) {
 
-                $commonParam = @{
+                [hashtable] $commonParam = @{
                     Include = @("*help.xml")
                     Recurse = $true
                     ErrorAction = 'SilentlyContinue'
@@ -224,37 +233,13 @@ function RunUpdateHelpTests
                 Get-ChildItem @params |
                     Remove-Item -Force -ErrorAction SilentlyContinue
 
-                if ((Get-UICulture).Name -ne "en-US")
-                {
-                    if ($useSourcePath)
-                    {
-                        Update-Help -Module $moduleName -Force -UICulture en-US -SourcePath "$PSScriptRoot\assets" @updateScope
-                    }
-                    else
-                    {
-                        Update-Help -Module $moduleName -Force -UICulture en-US @updateScope
-                    }
-                }
-                else
-                {
-                    if ($useSourcePath)
-                    {
-                        Update-Help -Module $moduleName -Force -SourcePath "$PSScriptRoot\assets" @updateScope
-                    }
-                    else
-                    {
-                        Update-Help -Module $moduleName -Force @updateScope
-                    }
-                }
+                [hashtable] $UICultureParam = $(if ((Get-UICulture).Name -ne $myUICulture) { @{ UICulture = $myUICulture } } else { @{} })
+                [hashtable] $sourcePathParam = $(if ($useSourcePath) { @{ SourcePath = Join-Path $PSScriptRoot assets } } else { @{} })
+                Update-Help -Module:$moduleName -Force @UICultureParam @sourcePathParam @updateScope
 
-                if($userscope)
-                {
-                    ValidateInstalledHelpContent -moduleName $moduleName -UserScope
-                }
-                else
-                {
-                    ValidateInstalledHelpContent -moduleName $moduleName
-                }
+                [hashtable] $userScopeParam = $(if ($userscope) { @{ UserScope = $true } } else { @{} })
+                ValidateInstalledHelpContent -moduleName:$moduleName @userScopeParam
+
             }
 
             if ($tag -eq "CI")
@@ -289,9 +274,9 @@ function RunSaveHelpTests
 
                 It "Validate Save-Help for the '$moduleName' module" -Pending:$pending {
 
-                    if ((Get-UICulture).Name -ne "en-US")
+                    if ((Get-UICulture).Name -ne $myUICulture)
                     {
-                        Save-Help -Module $moduleName -Force -UICulture en-US -DestinationPath $saveHelpFolder
+                        Save-Help -Module $moduleName -Force -UICulture $myUICulture -DestinationPath $saveHelpFolder
                     }
                     else
                     {

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -58,7 +58,7 @@ else
         HelpFiles            = "Microsoft.Management.Infrastructure.CimCmdlets.dll-help.xml"
         HelpInfoFiles        = "CimCmdlets_fb6cc51d-c096-4b38-b78d-0fed6277096a_HelpInfo.xml"
         CompressedFiles      = "CimCmdlets_fb6cc51d-c096-4b38-b78d-0fed6277096a_en-US_HelpContent$extension"
-        HelpInstallationPath = Join-Path -Path:$PSHOME ChildPath:Modules -AdditionalChildPath:CimCmdlets, $myUICulture
+        HelpInstallationPath = Join-Path -Path:$PSHOME -ChildPath:Modules -AdditionalChildPath:CimCmdlets, $myUICulture
         HelpInstallationPathHome = Join-Path -Path:$userHelpRoot -ChildPath:CimCmdlets -AdditionalChildPath:$myUICulture
     }
 
@@ -66,7 +66,7 @@ else
         HelpFiles            = "Microsoft.PowerShell.Archive-help.xml"
         HelpInfoFiles        = "Microsoft.PowerShell.Archive_eb74e8da-9ae2-482a-a648-e96550fb8733_HelpInfo.xml"
         CompressedFiles      = "Microsoft.PowerShell.Archive_eb74e8da-9ae2-482a-a648-e96550fb8733_en-US_HelpContent$extension"
-        HelpInstallationPath = Join-Path -Path:$PSHOME ChildPath:Modules Microsoft.PowerShell.Archive -AdditionalChildPath:$myUICulture
+        HelpInstallationPath = Join-Path -Path:$PSHOME -ChildPath:Modules Microsoft.PowerShell.Archive -AdditionalChildPath:$myUICulture
     }
 
     "Microsoft.PowerShell.Core" = @{

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -199,18 +199,18 @@ function RunUpdateHelpTests
         if ($powershellCoreModules -contains $moduleName)
         {
 
-            It "Validate Update-Help for module '$moduleName' with user scope as '$userscope'" -Skip:(!(Test-CanWriteToPsHome) -and $userscope -eq $false) {
+            if($userscope)
+            {
+                $params = @{Path = $testCases[$moduleName].HelpInstallationPathHome}
+                $updateScope = @{Scope = 'CurrentUser'}
+            }
+            else
+            {
+                $params = @{Path = $testCases[$moduleName].HelpInstallationPath}
+                $updateScope = @{Scope = 'AllUsers'}
+            }
 
-                if($userscope)
-                {
-                    $params = @{Path = $testCases[$moduleName].HelpInstallationPathHome}
-                    $updateScope = @{Scope = 'CurrentUser'}
-                }
-                else
-                {
-                    $params = @{Path = $testCases[$moduleName].HelpInstallationPath}
-                    $updateScope = @{Scope = 'AllUsers'}
-                }
+            It "Validate Update-Help for module '$moduleName' in '$updateScope'" -Skip:(!(Test-CanWriteToPsHome) -and $userscope -eq $false) {
 
                 $commonParam = @{
                     Include = @("*help.xml")
@@ -289,7 +289,7 @@ function RunSaveHelpTests
 
                 It "Validate Save-Help for the '$moduleName' module" -Pending:$pending {
 
-                    if ((Get-UICulture).Name -ne "en-Us")
+                    if ((Get-UICulture).Name -ne "en-US")
                     {
                         Save-Help -Module $moduleName -Force -UICulture en-US -DestinationPath $saveHelpFolder
                     }
@@ -347,7 +347,7 @@ Describe "Validate Update-Help from the Web for one PowerShell module." -Tags @(
         $ProgressPreference = $SavedProgressPreference
     }
 
-    RunUpdateHelpTests -Tag:CI
+    RunUpdateHelpTests -Tag "CI"
 }
 
 Describe "Validate Update-Help from the Web for one PowerShell module for user scope." -Tags @('CI', 'RequireAdminOnWindows', 'RequireSudoOnUnix') {
@@ -359,7 +359,7 @@ Describe "Validate Update-Help from the Web for one PowerShell module for user s
         $ProgressPreference = $SavedProgressPreference
     }
 
-    RunUpdateHelpTests -Tag:CI -UserScope
+    RunUpdateHelpTests -Tag "CI" -UserScope
 }
 
 Describe "Validate Update-Help from the Web for all PowerShell modules." -Tags @('Feature', 'RequireAdminOnWindows', 'RequireSudoOnUnix') {
@@ -371,7 +371,7 @@ Describe "Validate Update-Help from the Web for all PowerShell modules." -Tags @
         $ProgressPreference = $SavedProgressPreference
     }
 
-    RunUpdateHelpTests -Tag:Feature
+    RunUpdateHelpTests -Tag "Feature"
 }
 
 Describe "Validate Update-Help from the Web for all PowerShell modules for user scope." -Tags @('Feature', 'RequireAdminOnWindows', 'RequireSudoOnUnix') {
@@ -383,7 +383,7 @@ Describe "Validate Update-Help from the Web for all PowerShell modules for user 
         $ProgressPreference = $SavedProgressPreference
     }
 
-    RunUpdateHelpTests -Tag:Feature -UserScope
+    RunUpdateHelpTests -Tag "Feature" -UserScope
 }
 
 Describe "Validate Update-Help -SourcePath for one PowerShell module." -Tags @('CI', 'RequireAdminOnWindows', 'RequireSudoOnUnix') {
@@ -395,7 +395,7 @@ Describe "Validate Update-Help -SourcePath for one PowerShell module." -Tags @('
         $ProgressPreference = $SavedProgressPreference
     }
 
-    RunUpdateHelpTests -Tag:CI -useSourcePath
+    RunUpdateHelpTests -Tag "CI" -useSourcePath
 }
 
 Describe "Validate Update-Help -SourcePath for one PowerShell module for user scope." -Tags @('CI', 'RequireAdminOnWindows', 'RequireSudoOnUnix') {
@@ -407,7 +407,7 @@ Describe "Validate Update-Help -SourcePath for one PowerShell module for user sc
         $ProgressPreference = $SavedProgressPreference
     }
 
-    RunUpdateHelpTests -Tag:CI -useSourcePath -UserScope
+    RunUpdateHelpTests -Tag "CI" -useSourcePath -UserScope
 }
 
 Describe "Validate Update-Help -SourcePath for all PowerShell modules." -Tags @('Feature', 'RequireAdminOnWindows', 'RequireSudoOnUnix') {
@@ -419,7 +419,7 @@ Describe "Validate Update-Help -SourcePath for all PowerShell modules." -Tags @(
         $ProgressPreference = $SavedProgressPreference
     }
 
-    RunUpdateHelpTests -Tag:Feature -useSourcePath
+    RunUpdateHelpTests -Tag "Feature" -useSourcePath
 }
 
 Describe "Validate Update-Help -SourcePath for all PowerShell modules for user scope." -Tags @('Feature', 'RequireAdminOnWindows', 'RequireSudoOnUnix') {
@@ -442,7 +442,7 @@ Describe "Validate 'Save-Help -DestinationPath for one PowerShell modules." -Tag
     AfterAll {
         $ProgressPreference = $SavedProgressPreference
     }
-    RunSaveHelpTests -Tag:CI
+    RunSaveHelpTests -Tag "Feature"
 }
 
 Describe "Validate 'Save-Help -DestinationPath for all PowerShell modules." -Tags @('Feature', 'RequireAdminOnWindows') {
@@ -453,5 +453,5 @@ Describe "Validate 'Save-Help -DestinationPath for all PowerShell modules." -Tag
     AfterAll {
         $ProgressPreference = $SavedProgressPreference
     }
-    RunSaveHelpTests -Tag:Feature
+    RunSaveHelpTests -Tag "Feature"
 }

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -175,7 +175,7 @@ function ValidateInstalledHelpContent
     )
 
     [string] $pathProperty = $(if ($UserScope) { 'HelpInstallationPathHome' } else { 'HelpInstallationPath' })
-    [System.IO.FileInfo[]] $helpFilesInstalled = Get-ChildItem -Path:($testCases[$moduleName]. $pathProperty) -Filter:*help.xml -Recurse
+    [System.IO.FileInfo[]] $helpFilesInstalled = Get-ChildItem -Path:($testCases[$moduleName][$pathProperty]) -Filter:*help.xml -Recurse
 
     [string[]] $expectedHelpFiles = $testCases[$moduleName].HelpFiles
     [string] $junct = "`t"
@@ -204,12 +204,12 @@ function RunUpdateHelpTests
             [hashtable] $updateScope = $null
             if($userscope)
             {
-                $params = @{Path = $testCases[$moduleName].HelpInstallationPathHome}
+                $params = @{Path = $testCases[$moduleName]['HelpInstallationPathHome']}
                 $updateScope = @{Scope = 'CurrentUser'}
             }
             else
             {
-                $params = @{Path = $testCases[$moduleName].HelpInstallationPath}
+                $params = @{Path = $testCases[$moduleName]['HelpInstallationPath']}
                 $updateScope = @{Scope = 'AllUsers'}
             }
 

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -229,7 +229,7 @@ function RunUpdateHelpTests
                 # If the help file is already installed, delete it.
                 [string] $path = $params['Path']
                 $path | Should -Not -BeNull
-                Remove-Item $path
+                Remove-Item $path -Recurse
  
                 [hashtable] $UICultureParam = $(if ((Get-UICulture).Name -ne $myUICulture) { @{ UICulture = $myUICulture } } else { @{} })
                 [hashtable] $sourcePathParam = $(if ($useSourcePath) { @{ SourcePath = Join-Path $PSScriptRoot assets } } else { @{} })

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -175,7 +175,7 @@ function ValidateInstalledHelpContent
     )
 
     [string] $pathProperty = $(if ($UserScope) { 'HelpInstallationPathHome' } else { 'HelpInstallationPath' })
-    [System.Management.Automation.FileInfo[]] $helpFilesInstalled = Get-ChildItem $testCases[$moduleName]. $pathProperty *help.xml -Recurse
+    [System.Management.Automation.FileInfo[]] $helpFilesInstalled = Get-ChildItem -Path:$testCases[$moduleName]. $pathProperty -Filter:*help.xml -Recurse
 
     [string[]] $expectedHelpFiles = $testCases[$moduleName].HelpFiles
     [string] $junct = "`t"

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -37,18 +37,18 @@ if ([System.Management.Automation.Platform]::IsWindows)
 
 if([System.Management.Automation.Platform]::IsWindows)
 {
-    $userHelpRoot = Join-Path $HOME Documents PowerShell Help
+    $userHelpRoot = Join-Path $HOME Documents PowerShell -AdditionalChildPath:Help
 }
 else
 {
     [string] $userModulesRoot = [System.Management.Automation.Platform]::SelectProductNameForDirectory([System.Management.Automation.Platform+XDG_Type]::USER_MODULES)
-    $userHelpRoot = Join-Path $userModulesRoot -ChildPath ".." -AdditionalChildPath "Help"
+    $userHelpRoot = Join-Path $userModulesRoot .. -AdditionalChildPath:Help
 }
 
 # default values for system modules
 [string] $myUICulture = 'en-US'   
-[string] $HelpInstallationPath = Join-Path $PSHOME $myUICulture
-[string] $HelpInstallationPathHome = Join-Path $userHelpRoot $myUICulture
+[string] $HelpInstallationPath = Join-Path $PSHOME -AdditionalChildPath:$myUICulture
+[string] $HelpInstallationPathHome = Join-Path $userHelpRoot -AdditionalChildPath:$myUICulture
 
 # This is the list of test cases -- each test case represents a PowerShell module.
 [hashtable] $testCases = @{
@@ -57,15 +57,15 @@ else
         HelpFiles            = "Microsoft.Management.Infrastructure.CimCmdlets.dll-help.xml"
         HelpInfoFiles        = "CimCmdlets_fb6cc51d-c096-4b38-b78d-0fed6277096a_HelpInfo.xml"
         CompressedFiles      = "CimCmdlets_fb6cc51d-c096-4b38-b78d-0fed6277096a_en-US_HelpContent$extension"
-        HelpInstallationPath = Join-Path $PSHOME Modules CimCmdlets $myUICulture
-        HelpInstallationPathHome = Join-Path $userHelpRoot CimCmdlets $myUICulture
+        HelpInstallationPath = Join-Path $PSHOME Modules CimCmdlets -AdditionalChildPath:$myUICulture
+        HelpInstallationPathHome = Join-Path $userHelpRoot CimCmdlets -AdditionalChildPath:$myUICulture
     }
 
     "Microsoft.PowerShell.Archive" = @{
         HelpFiles            = "Microsoft.PowerShell.Archive-help.xml"
         HelpInfoFiles        = "Microsoft.PowerShell.Archive_eb74e8da-9ae2-482a-a648-e96550fb8733_HelpInfo.xml"
         CompressedFiles      = "Microsoft.PowerShell.Archive_eb74e8da-9ae2-482a-a648-e96550fb8733_en-US_HelpContent$extension"
-        HelpInstallationPath = Join-Path $PSHOME Modules Microsoft.PowerShell.Archive $myUICulture
+        HelpInstallationPath = Join-Path $PSHOME Modules Microsoft.PowerShell.Archive -AdditionalChildPath:$myUICulture
     }
 
     "Microsoft.PowerShell.Core" = @{
@@ -136,16 +136,16 @@ else
         HelpFiles            = "Microsoft.PowerShell.PackageManagement.dll-help.xml"
         HelpInfoFiles        = "PackageManagement_4ae9fd46-338a-459c-8186-07f910774cb8_HelpInfo.xml"
         CompressedFiles      = "PackageManagement_4ae9fd46-338a-459c-8186-07f910774cb8_en-US_helpcontent$extension"
-        HelpInstallationPath = Join-Path $PSHOME Modules PackageManagement $myUICulture
-        HelpInstallationPathHome = Join-Path $userHelpRoot PackageManagement $myUICulture
+        HelpInstallationPath = Join-Path $PSHOME Modules PackageManagement -AdditionalChildPath:$myUICulture
+        HelpInstallationPathHome = Join-Path $userHelpRoot PackageManagement -AdditionalChildPath:$myUICulture
     }
 
     "PowershellGet" = @{
         HelpFiles            = "PSGet.psm1-help.xml"
         HelpInfoFiles        = "PowershellGet_1d73a601-4a6c-43c5-ba3f-619b18bbb404_HelpInfo.xml"
         CompressedFiles      = "PowershellGet_1d73a601-4a6c-43c5-ba3f-619b18bbb404_en-US_helpcontent$extension"
-        HelpInstallationPath = Join-Path $PSHOME Modules PowershellGet $myUICulture
-        HelpInstallationPathHome = Join-Path $userHelpRoot PackageManagement $myUICulture
+        HelpInstallationPath = Join-Path $PSHOME Modules PowershellGet -AdditionalChildPath:$myUICulture
+        HelpInstallationPathHome = Join-Path $userHelpRoot PackageManagement -AdditionalChildPath:$myUICulture
     }
 }
 
@@ -231,7 +231,7 @@ function RunUpdateHelpTests
 
                 # If the help file is already installed, delete it.
                 Get-ChildItem @params |
-                    Remove-Item -Force -ErrorAction SilentlyContinue
+                    Remove-Item -Force -ErrorAction:SilentlyContinue
 
                 [hashtable] $UICultureParam = $(if ((Get-UICulture).Name -ne $myUICulture) { @{ UICulture = $myUICulture } } else { @{} })
                 [hashtable] $sourcePathParam = $(if ($useSourcePath) { @{ SourcePath = Join-Path $PSScriptRoot assets } } else { @{} })

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -37,18 +37,19 @@ if ([System.Management.Automation.Platform]::IsWindows)
 
 if([System.Management.Automation.Platform]::IsWindows)
 {
-    $userHelpRoot = Join-Path $HOME Documents PowerShell -AdditionalChildPath:Help
+    # To the reader: the explicit parameter names below are required by a brainless code checker.
+    $userHelpRoot = Join-Path -Path:$HOME -ChildPath:Documents -AdditionalChildPath:PowerShell, Help
 }
 else
 {
     [string] $userModulesRoot = [System.Management.Automation.Platform]::SelectProductNameForDirectory([System.Management.Automation.Platform+XDG_Type]::USER_MODULES)
-    $userHelpRoot = Join-Path $userModulesRoot .. -AdditionalChildPath:Help
+    $userHelpRoot = Join-Path -Path:$userModulesRoot -ChildPath:.. -AdditionalChildPath:Help
 }
 
 # default values for system modules
 [string] $myUICulture = 'en-US'   
-[string] $HelpInstallationPath = Join-Path $PSHOME -AdditionalChildPath:$myUICulture
-[string] $HelpInstallationPathHome = Join-Path $userHelpRoot -AdditionalChildPath:$myUICulture
+[string] $HelpInstallationPath = Join-Path $PSHOME $myUICulture
+[string] $HelpInstallationPathHome = Join-Path $userHelpRoot $myUICulture
 
 # This is the list of test cases -- each test case represents a PowerShell module.
 [hashtable] $testCases = @{
@@ -57,15 +58,15 @@ else
         HelpFiles            = "Microsoft.Management.Infrastructure.CimCmdlets.dll-help.xml"
         HelpInfoFiles        = "CimCmdlets_fb6cc51d-c096-4b38-b78d-0fed6277096a_HelpInfo.xml"
         CompressedFiles      = "CimCmdlets_fb6cc51d-c096-4b38-b78d-0fed6277096a_en-US_HelpContent$extension"
-        HelpInstallationPath = Join-Path $PSHOME Modules CimCmdlets -AdditionalChildPath:$myUICulture
-        HelpInstallationPathHome = Join-Path $userHelpRoot CimCmdlets -AdditionalChildPath:$myUICulture
+        HelpInstallationPath = Join-Path -Path:$PSHOME Modules CimCmdlets -AdditionalChildPath:$myUICulture
+        HelpInstallationPathHome = Join-Path -Path:$userHelpRoot ChildPath:CimCmdlets -AdditionalChildPath:$myUICulture
     }
 
     "Microsoft.PowerShell.Archive" = @{
         HelpFiles            = "Microsoft.PowerShell.Archive-help.xml"
         HelpInfoFiles        = "Microsoft.PowerShell.Archive_eb74e8da-9ae2-482a-a648-e96550fb8733_HelpInfo.xml"
         CompressedFiles      = "Microsoft.PowerShell.Archive_eb74e8da-9ae2-482a-a648-e96550fb8733_en-US_HelpContent$extension"
-        HelpInstallationPath = Join-Path $PSHOME Modules Microsoft.PowerShell.Archive -AdditionalChildPath:$myUICulture
+        HelpInstallationPath = Join-Path -Path:$PSHOME ChildPath:Modules Microsoft.PowerShell.Archive -AdditionalChildPath:$myUICulture
     }
 
     "Microsoft.PowerShell.Core" = @{
@@ -96,8 +97,8 @@ else
         HelpFiles            = "Microsoft.Powershell.LocalAccounts.dll-help.xml"
         HelpInfoFiles        = "Microsoft.PowerShell.LocalAccounts_8e362604-2c0b-448f-a414-a6a690a644e2_HelpInfo.xml"
         CompressedFiles      = "Microsoft.PowerShell.LocalAccounts_8e362604-2c0b-448f-a414-a6a690a644e2_en-US_HelpContent$extension"
-        HelpInstallationPath = Join-Path $PSHOME Modules Microsoft.PowerShell.LocalAccounts $myUICulture
-        HelpInstallationPathHome = Join-Path $userHelpRoot Microsoft.PowerShell.LocalAccounts $myUICulture
+        HelpInstallationPath = Join-Path -Path:$PSHOME Modules Microsoft.PowerShell.LocalAccounts $myUICulture
+        HelpInstallationPathHome = Join-Path -Path:$userHelpRoot -ChildPath:Microsoft.PowerShell.LocalAccounts -AdditionalChildPath:$myUICulture
     }
 
     "Microsoft.PowerShell.Management" = @{
@@ -136,16 +137,16 @@ else
         HelpFiles            = "Microsoft.PowerShell.PackageManagement.dll-help.xml"
         HelpInfoFiles        = "PackageManagement_4ae9fd46-338a-459c-8186-07f910774cb8_HelpInfo.xml"
         CompressedFiles      = "PackageManagement_4ae9fd46-338a-459c-8186-07f910774cb8_en-US_helpcontent$extension"
-        HelpInstallationPath = Join-Path $PSHOME Modules PackageManagement -AdditionalChildPath:$myUICulture
-        HelpInstallationPathHome = Join-Path $userHelpRoot PackageManagement -AdditionalChildPath:$myUICulture
+        HelpInstallationPath = Join-Path -Path:$PSHOME Modules PackageManagement -AdditionalChildPath:$myUICulture
+        HelpInstallationPathHome = Join-Path -Path:$userHelpRoot -ChildPath:PackageManagement -AdditionalChildPath:$myUICulture
     }
 
     "PowershellGet" = @{
         HelpFiles            = "PSGet.psm1-help.xml"
         HelpInfoFiles        = "PowershellGet_1d73a601-4a6c-43c5-ba3f-619b18bbb404_HelpInfo.xml"
         CompressedFiles      = "PowershellGet_1d73a601-4a6c-43c5-ba3f-619b18bbb404_en-US_helpcontent$extension"
-        HelpInstallationPath = Join-Path $PSHOME Modules PowershellGet -AdditionalChildPath:$myUICulture
-        HelpInstallationPathHome = Join-Path $userHelpRoot PackageManagement -AdditionalChildPath:$myUICulture
+        HelpInstallationPath = Join-Path -Path:$PSHOME Modules PowershellGet -AdditionalChildPath:$myUICulture
+        HelpInstallationPathHome = Join-Path -Path:$userHelpRoot -ChildPath:PackageManagement -AdditionalChildPath:$myUICulture
     }
 }
 

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -227,7 +227,9 @@ function RunUpdateHelpTests
                 $params += $commonParam
 
                 # If the help file is already installed, delete it.
-                Remove-Item ($params['Path'])
+                [string] $path = $params['Path']
+                $path | Should -Not -BeNull
+                Remove-Item $path
  
                 [hashtable] $UICultureParam = $(if ((Get-UICulture).Name -ne $myUICulture) { @{ UICulture = $myUICulture } } else { @{} })
                 [hashtable] $sourcePathParam = $(if ($useSourcePath) { @{ SourcePath = Join-Path $PSScriptRoot assets } } else { @{} })

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -216,17 +216,16 @@ function RunUpdateHelpTests
             It ('Validate Update-Help for module ''{0}'' in {1}' -F $moduleName, [PSCustomObject] $updateScope) -Skip:(!(Test-CanWriteToPsHome) -and $userscope -eq $false) {
 
                 [hashtable] $commonParam = @{
-                    Include = @("*help.xml")
+                    Filter = @("*help.xml")
                     Recurse = $true
-                    ErrorAction = 'SilentlyContinue'
+                    ErrorAction = [System.Management.Automation.ActionPreference]:: Stop
                 }
 
                 $params += $commonParam
 
                 # If the help file is already installed, delete it.
-                Get-ChildItem @params |
-                    Remove-Item -Force -ErrorAction:SilentlyContinue
-
+                Remove-Item $params['Path']
+ 
                 [hashtable] $UICultureParam = $(if ((Get-UICulture).Name -ne $myUICulture) { @{ UICulture = $myUICulture } } else { @{} })
                 [hashtable] $sourcePathParam = $(if ($useSourcePath) { @{ SourcePath = Join-Path $PSScriptRoot assets } } else { @{} })
                 Update-Help -Module:$moduleName -Force @UICultureParam @sourcePathParam @updateScope

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -137,7 +137,7 @@ else
         HelpFiles            = "Microsoft.PowerShell.PackageManagement.dll-help.xml"
         HelpInfoFiles        = "PackageManagement_4ae9fd46-338a-459c-8186-07f910774cb8_HelpInfo.xml"
         CompressedFiles      = "PackageManagement_4ae9fd46-338a-459c-8186-07f910774cb8_en-US_helpcontent$extension"
-        HelpInstallationPath = Join-Path -Path:$PSHOME Modules PackageManagement -AdditionalChildPath:$myUICulture
+        HelpInstallationPath = Join-Path -Path:$PSHOME -ChildPath:Modules -AdditionalChildPath:PackageManagement, $myUICulture
         HelpInstallationPathHome = Join-Path -Path:$userHelpRoot -ChildPath:PackageManagement -AdditionalChildPath:$myUICulture
     }
 
@@ -145,7 +145,7 @@ else
         HelpFiles            = "PSGet.psm1-help.xml"
         HelpInfoFiles        = "PowershellGet_1d73a601-4a6c-43c5-ba3f-619b18bbb404_HelpInfo.xml"
         CompressedFiles      = "PowershellGet_1d73a601-4a6c-43c5-ba3f-619b18bbb404_en-US_helpcontent$extension"
-        HelpInstallationPath = Join-Path -Path:$PSHOME Modules PowershellGet -AdditionalChildPath:$myUICulture
+        HelpInstallationPath = Join-Path -Path:$PSHOME -ChildPath:Modules -AdditionalChildPath:PowershellGet, $myUICulture
         HelpInstallationPathHome = Join-Path -Path:$userHelpRoot -ChildPath:PackageManagement -AdditionalChildPath:$myUICulture
     }
 }

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -175,7 +175,7 @@ function ValidateInstalledHelpContent
     )
 
     [string] $pathProperty = $(if ($UserScope) { 'HelpInstallationPathHome' } else { 'HelpInstallationPath' })
-    [System.Management.Automation.FileInfo[]] $helpFilesInstalled = Get-ChildItem -Path:$testCases[$moduleName]. $pathProperty -Filter:*help.xml -Recurse
+    [System.Management.Automation.FileInfo[]] $helpFilesInstalled = Get-ChildItem -Path:($testCases[$moduleName]. $pathProperty) -Filter:*help.xml -Recurse
 
     [string[]] $expectedHelpFiles = $testCases[$moduleName].HelpFiles
     [string] $junct = "`t"

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -58,8 +58,8 @@ else
         HelpFiles            = "Microsoft.Management.Infrastructure.CimCmdlets.dll-help.xml"
         HelpInfoFiles        = "CimCmdlets_fb6cc51d-c096-4b38-b78d-0fed6277096a_HelpInfo.xml"
         CompressedFiles      = "CimCmdlets_fb6cc51d-c096-4b38-b78d-0fed6277096a_en-US_HelpContent$extension"
-        HelpInstallationPath = Join-Path -Path:$PSHOME Modules CimCmdlets -AdditionalChildPath:$myUICulture
-        HelpInstallationPathHome = Join-Path -Path:$userHelpRoot ChildPath:CimCmdlets -AdditionalChildPath:$myUICulture
+        HelpInstallationPath = Join-Path -Path:$PSHOME ChildPath:Modules -AdditionalChildPath:CimCmdlets, $myUICulture
+        HelpInstallationPathHome = Join-Path -Path:$userHelpRoot -ChildPath:CimCmdlets -AdditionalChildPath:$myUICulture
     }
 
     "Microsoft.PowerShell.Archive" = @{

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -347,7 +347,7 @@ Describe "Validate Update-Help from the Web for one PowerShell module." -Tags @(
         $ProgressPreference = $SavedProgressPreference
     }
 
-    RunUpdateHelpTests -Tag "CI" -Scope 'AllUsers'
+    RunUpdateHelpTests -Tag:CI
 }
 
 Describe "Validate Update-Help from the Web for one PowerShell module for user scope." -Tags @('CI', 'RequireAdminOnWindows', 'RequireSudoOnUnix') {
@@ -359,7 +359,7 @@ Describe "Validate Update-Help from the Web for one PowerShell module for user s
         $ProgressPreference = $SavedProgressPreference
     }
 
-    RunUpdateHelpTests -Tag "CI" -Scope 'CurrentUser'
+    RunUpdateHelpTests -Tag:CI -UserScope
 }
 
 Describe "Validate Update-Help from the Web for all PowerShell modules." -Tags @('Feature', 'RequireAdminOnWindows', 'RequireSudoOnUnix') {
@@ -371,7 +371,7 @@ Describe "Validate Update-Help from the Web for all PowerShell modules." -Tags @
         $ProgressPreference = $SavedProgressPreference
     }
 
-    RunUpdateHelpTests -Tag "Feature" -Scope 'AllUsers'
+    RunUpdateHelpTests -Tag:Feature
 }
 
 Describe "Validate Update-Help from the Web for all PowerShell modules for user scope." -Tags @('Feature', 'RequireAdminOnWindows', 'RequireSudoOnUnix') {
@@ -383,7 +383,7 @@ Describe "Validate Update-Help from the Web for all PowerShell modules for user 
         $ProgressPreference = $SavedProgressPreference
     }
 
-    RunUpdateHelpTests -Tag "Feature" -Scope 'CurrentUser'
+    RunUpdateHelpTests -Tag:Feature -UserScope
 }
 
 Describe "Validate Update-Help -SourcePath for one PowerShell module." -Tags @('CI', 'RequireAdminOnWindows', 'RequireSudoOnUnix') {
@@ -395,7 +395,7 @@ Describe "Validate Update-Help -SourcePath for one PowerShell module." -Tags @('
         $ProgressPreference = $SavedProgressPreference
     }
 
-    RunUpdateHelpTests -Tag "CI" -useSourcePath -Scope 'AllUsers'
+    RunUpdateHelpTests -Tag:CI -useSourcePath
 }
 
 Describe "Validate Update-Help -SourcePath for one PowerShell module for user scope." -Tags @('CI', 'RequireAdminOnWindows', 'RequireSudoOnUnix') {
@@ -407,7 +407,7 @@ Describe "Validate Update-Help -SourcePath for one PowerShell module for user sc
         $ProgressPreference = $SavedProgressPreference
     }
 
-    RunUpdateHelpTests -Tag "CI" -useSourcePath -Scope 'CurrentUser'
+    RunUpdateHelpTests -Tag:CI -useSourcePath -UserScope
 }
 
 Describe "Validate Update-Help -SourcePath for all PowerShell modules." -Tags @('Feature', 'RequireAdminOnWindows', 'RequireSudoOnUnix') {
@@ -419,7 +419,7 @@ Describe "Validate Update-Help -SourcePath for all PowerShell modules." -Tags @(
         $ProgressPreference = $SavedProgressPreference
     }
 
-    RunUpdateHelpTests -Tag "Feature" -useSourcePath -Scope 'AllUsers'
+    RunUpdateHelpTests -Tag:Feature -useSourcePath
 }
 
 Describe "Validate Update-Help -SourcePath for all PowerShell modules for user scope." -Tags @('Feature', 'RequireAdminOnWindows', 'RequireSudoOnUnix') {
@@ -431,7 +431,7 @@ Describe "Validate Update-Help -SourcePath for all PowerShell modules for user s
         $ProgressPreference = $SavedProgressPreference
     }
 
-    RunUpdateHelpTests -Tag "Feature" -useSourcePath -Scope 'CurrentUser'
+    RunUpdateHelpTests -Tag:Feature -useSourcePath -UserScope
 }
 
 Describe "Validate 'Save-Help -DestinationPath for one PowerShell modules." -Tags @('CI', 'RequireAdminOnWindows') {
@@ -442,7 +442,7 @@ Describe "Validate 'Save-Help -DestinationPath for one PowerShell modules." -Tag
     AfterAll {
         $ProgressPreference = $SavedProgressPreference
     }
-    RunSaveHelpTests -Tag "CI"
+    RunSaveHelpTests -Tag:CI
 }
 
 Describe "Validate 'Save-Help -DestinationPath for all PowerShell modules." -Tags @('Feature', 'RequireAdminOnWindows') {
@@ -453,5 +453,5 @@ Describe "Validate 'Save-Help -DestinationPath for all PowerShell modules." -Tag
     AfterAll {
         $ProgressPreference = $SavedProgressPreference
     }
-    RunSaveHelpTests -Tag "Feature"
+    RunSaveHelpTests -Tag:Feature
 }

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -224,7 +224,7 @@ function RunUpdateHelpTests
                 Get-ChildItem @params |
                     Remove-Item -Force -ErrorAction SilentlyContinue
 
-                if ((Get-UICulture).Name -ne "en-Us")
+                if ((Get-UICulture).Name -ne "en-US")
                 {
                     if ($useSourcePath)
                     {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
The function `RunUpdateHelpTests` does not expect to get ~**Scope**~ but **UserScope**.  I modified the calls accordingly.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
I am lost why passing a **Scope** to a function that accepts **UserScope** would have any good results.  I think the current behaviour is that the tests are skipped because `$userscope -eq $false`, as evidenced by the following [test log entry](https://dev.azure.com/powershell/PowerShell/_build/results?buildId=58204&view=ms.vss-test-web.build-test-results-tab): 

> Validate Update-Help -SourcePath for all PowerShell modules for user scope..Validate Update-Help for module 'Microsoft.PowerShell.Core' with scope as 'False'

… and erroneously marked as passed.


## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [X] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
