### PR TITLE
Autofix RCS1036: Remove redundant empty line

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Diagnostics/PdhHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/PdhHelper.cs
@@ -431,7 +431,6 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
         /// <param name="strNative"></param>
         /// <param name="strSize"></param>
         /// <param name="strColl"></param>
-
         private void ReadPdhMultiString(ref IntPtr strNative, Int32 strSize, ref StringCollection strColl)
         {
             Debug.Assert(strSize >= 2);

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
@@ -1272,7 +1272,6 @@ $result
     /// workgroup computer. Use this command to rename domain workstations and local
     /// machines only. It cannot be used to rename Domain Controllers.
     /// </summary>
-
     [Cmdlet(VerbsCommon.Rename, "Computer", SupportsShouldProcess = true,
         HelpUri = "https://go.microsoft.com/fwlink/?LinkID=2097054", RemotingCapability = RemotingCapability.SupportedByCommand)]
     public class RenameComputerCommand : PSCmdlet

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -545,7 +545,6 @@ namespace Microsoft.PowerShell.Commands
         ///<summary>
         /// To display the modules of a process.
         ///</summary>
-
         [Parameter(ParameterSetName = NameParameterSet)]
         [Parameter(ParameterSetName = IdParameterSet)]
         [Parameter(ParameterSetName = InputObjectParameterSet)]

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConsoleColorCmdlet.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConsoleColorCmdlet.cs
@@ -10,7 +10,6 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// Base class for a variety of commandlets that take color parameters.
     /// </summary>
-
     public
     class ConsoleColorCmdlet : PSCmdlet
     {
@@ -26,7 +25,6 @@ namespace Microsoft.PowerShell.Commands
         /// The -ForegroundColor parameter.
         /// </summary>
         /// <value></value>
-
         [Parameter]
         public
         ConsoleColor
@@ -60,7 +58,6 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// </summary>
         /// <value></value>
-
         [Parameter]
         public
         ConsoleColor

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertTo-Html.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertTo-Html.cs
@@ -18,7 +18,6 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// Class comment.
     /// </summary>
-
     [Cmdlet(VerbsData.ConvertTo, "Html", DefaultParameterSetName = "Page",
         HelpUri = "https://go.microsoft.com/fwlink/?LinkID=2096595", RemotingCapability = RemotingCapability.None)]
     public sealed

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -43,7 +43,6 @@ namespace Microsoft.PowerShell.Commands
         /// Abstract Property - Input Object which is written in Csv format.
         /// Derived as Different Attributes.In ConvertTo-CSV, This is a positional parameter. Export-CSV not a Positional behaviour.
         /// </summary>
-
         public abstract PSObject InputObject { get; set; }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
@@ -1104,7 +1104,6 @@ namespace System.Management.Automation
         /// <param name="property">Name of property. Pass null for item.</param>
         /// <param name="source">Object to be written.</param>
         /// <param name="entry">Serialization information about source.</param>
-
         private void WriteOnePrimitiveKnownType(
             XmlWriter writer, string property, object source, TypeSerializationInfo entry)
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHostCmdlet.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHostCmdlet.cs
@@ -10,7 +10,6 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// Writes the PSHost object to the success stream.
     /// </summary>
-
     [Cmdlet(VerbsCommon.Get, "Host", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=2097110", RemotingCapability = RemotingCapability.None)]
     [OutputType(typeof(System.Management.Automation.Host.PSHost))]
     public

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
@@ -198,7 +198,6 @@ namespace Microsoft.PowerShell.Commands
         /// to maintain two sets of MeasureInfo and constantly checking
         /// what mode we're in.
         /// </summary>
-
         [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses")]
         private class Statistics
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ReadConsoleCmdlet.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ReadConsoleCmdlet.cs
@@ -16,7 +16,6 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// Retrieves input from the host virtual console and writes it to the pipeline output.
     /// </summary>
-
     [Cmdlet(VerbsCommunications.Read, "Host", DefaultParameterSetName = "AsString", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=2096610")]
     [OutputType(typeof(string), typeof(SecureString))]
     public sealed class ReadHostCommand : PSCmdlet
@@ -24,7 +23,6 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Constructs a new instance.
         /// </summary>
-
         public
         ReadHostCommand()
         {
@@ -36,7 +34,6 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// The objects to display on the host before collecting input.
         /// </summary>
-
         [Parameter(Position = 0, ValueFromRemainingArguments = true)]
         [AllowNull]
         public

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
@@ -14,7 +14,6 @@ namespace Microsoft.PowerShell.Commands
     /// Base class for all variable commands.
     /// Because -Scope is defined in VariableCommandBase, all derived commands must implement -Scope.
     /// </summary>
-
     public abstract class VariableCommandBase : PSCmdlet
     {
         #region Parameters

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -667,7 +667,6 @@ namespace Microsoft.PowerShell
         /// <param name="args">
         /// The command line parameters to be processed.
         /// </param>
-
         internal void Parse(string[] args)
         {
             Dbg.Assert(!_dirty, "This instance has already been used. Create a new instance.");

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
@@ -44,7 +44,6 @@ namespace Microsoft.PowerShell
     /// Class ConsoleControl is used to wrap the various win32 console APIs 1:1 (i.e. at a low level, without attempting to be a
     /// "true" object-oriented library.
     /// </summary>
-
     internal static class ConsoleControl
     {
 #if !UNIX
@@ -481,7 +480,6 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// Types of control ConsoleBreakSignals received by break Win32Handler delegates.
         /// </summary>
-
         internal enum ConsoleBreakSignal : uint
         {
             // These correspond to the CRTL_XXX_EVENT #defines in public/sdk/inc/wincon.h
@@ -511,7 +509,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="HostException">
         /// If Win32's SetConsoleCtrlHandler fails
         /// </exception>
-
         internal static void AddBreakHandler(BreakHandler handlerDelegate)
         {
             bool result = NativeMethods.SetConsoleCtrlHandler(handlerDelegate, true);
@@ -532,7 +529,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="HostException">
         /// If Win32's SetConsoleCtrlHandler fails
         /// </exception>
-
         internal static void RemoveBreakHandler()
         {
             bool result = NativeMethods.SetConsoleCtrlHandler(null, false);
@@ -657,7 +653,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="HostException">
         /// If Win32's GetConsoleMode fails
         /// </exception>
-
         internal static ConsoleModes GetMode(ConsoleHandle consoleHandle)
         {
             Dbg.Assert(!consoleHandle.IsInvalid, "consoleHandle is not valid");
@@ -690,7 +685,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="HostException">
         /// If Win32's SetConsoleMode fails
         /// </exception>
-
         internal static void SetMode(ConsoleHandle consoleHandle, ConsoleModes mode)
         {
             Dbg.Assert(!consoleHandle.IsInvalid, "consoleHandle is not valid");
@@ -740,7 +734,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="HostException">
         /// If Win32's ReadConsole fails
         /// </exception>
-
         internal static string ReadConsole(
             ConsoleHandle consoleHandle,
             int initialContentLength,
@@ -813,7 +806,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="HostException">
         /// If Win32's ReadConsoleInput fails
         /// </exception>
-
         internal static int ReadConsoleInput(ConsoleHandle consoleHandle, ref INPUT_RECORD[] buffer)
         {
             Dbg.Assert(!consoleHandle.IsInvalid, "ConsoleHandle is not valid");
@@ -853,7 +845,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="HostException">
         /// If Win32's PeekConsoleInput fails
         /// </exception>
-
         internal static int PeekConsoleInput
         (
             ConsoleHandle consoleHandle,
@@ -895,7 +886,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="HostException">
         /// If Win32's GetNumberOfConsoleInputEvents fails
         /// </exception>
-
         internal static int GetNumberOfConsoleInputEvents(ConsoleHandle consoleHandle)
         {
             Dbg.Assert(!consoleHandle.IsInvalid, "ConsoleHandle is not valid");
@@ -989,7 +979,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="HostException">
         /// If Win32's SetConsoleScreenBufferSize fails
         /// </exception>
-
         internal static void SetConsoleScreenBufferSize(ConsoleHandle consoleHandle, Size newSize)
         {
             Dbg.Assert(!consoleHandle.IsInvalid, "ConsoleHandle is not valid");
@@ -1078,7 +1067,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="ArgumentException">
         /// If it is illegal to write <paramref name="contents"/> to the output buffer
         /// </exception>
-
         internal static void WriteConsoleOutput(ConsoleHandle consoleHandle, Coordinates origin, BufferCell[,] contents)
         {
             Dbg.Assert(!consoleHandle.IsInvalid, "ConsoleHandle is not valid");
@@ -1705,7 +1693,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="HostException">
         /// If there is not enough memory to complete calls to Win32's ReadConsoleOutput
         /// </exception>
-
         internal static void ReadConsoleOutput
         (
             ConsoleHandle consoleHandle,
@@ -2379,7 +2366,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="HostException">
         /// If Win32's ScrollConsoleScreenBuffer fails
         /// </exception>
-
         internal static void ScrollConsoleScreenBuffer
         (
             ConsoleHandle consoleHandle,
@@ -2430,7 +2416,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="HostException">
         /// If Win32's SetConsoleWindowInfo fails
         /// </exception>
-
         internal static void SetConsoleWindowInfo(ConsoleHandle consoleHandle, bool absolute, SMALL_RECT windowInfo)
         {
             Dbg.Assert(!consoleHandle.IsInvalid, "ConsoleHandle is not valid");
@@ -2460,7 +2445,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="HostException">
         /// If Win32's GetLargestConsoleWindowSize fails
         /// </exception>
-
         internal static Size GetLargestConsoleWindowSize(ConsoleHandle consoleHandle)
         {
             Dbg.Assert(!consoleHandle.IsInvalid, "ConsoleHandle is not valid");
@@ -2490,7 +2474,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="HostException">
         /// If Win32's GetConsoleTitle fails
         /// </exception>
-
         internal static string GetConsoleWindowTitle()
         {
             const int MaxWindowTitleLength = 1024;
@@ -2522,7 +2505,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="HostException">
         /// If Win32's SetConsoleTitle fails
         /// </exception>
-
         internal static void SetConsoleWindowTitle(string consoleTitle)
         {
             bool result = NativeMethods.SetConsoleTitle(consoleTitle);
@@ -2643,7 +2625,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="HostException">
         /// if the Win32's SetConsoleTextAttribute fails
         /// </exception>
-
         internal static void SetConsoleTextAttribute(ConsoleHandle consoleHandle, WORD attribute)
         {
             Dbg.Assert(!consoleHandle.IsInvalid, "ConsoleHandle is not valid");
@@ -2849,7 +2830,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="HostException">
         /// If Win32's SetConsoleCursorPosition fails
         /// </exception>
-
         internal static void SetConsoleCursorPosition(ConsoleHandle consoleHandle, Coordinates cursorPosition)
         {
             Dbg.Assert(!consoleHandle.IsInvalid, "ConsoleHandle is not valid");
@@ -2884,7 +2864,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="HostException">
         /// If Win32's GetConsoleCursorInfo fails
         /// </exception>
-
         internal static CONSOLE_CURSOR_INFO GetConsoleCursorInfo(ConsoleHandle consoleHandle)
         {
             Dbg.Assert(!consoleHandle.IsInvalid, "ConsoleHandle is not valid");
@@ -2939,7 +2918,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="HostException">
         /// If Win32's SetConsoleCursorInfo fails
         /// </exception>
-
         internal static void SetConsoleCursorInfo(ConsoleHandle consoleHandle, CONSOLE_CURSOR_INFO cursorInfo)
         {
             Dbg.Assert(!consoleHandle.IsInvalid, "ConsoleHandle is not valid");
@@ -3002,7 +2980,6 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// Class to hold the Native Methods used in this file enclosing class.
         /// </summary>
-
         internal static class NativeMethods
         {
             internal static readonly IntPtr INVALID_HANDLE_VALUE = new IntPtr(-1);  // WinBase.h

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -389,7 +389,6 @@ namespace Microsoft.PowerShell
         /// executing instance is stopped.
         ///
         ///</param>
-
         private static void SpinUpBreakHandlerThread(bool shouldEndSession)
         {
             ConsoleHost host = ConsoleHost.SingletonInstance;
@@ -521,7 +520,6 @@ namespace Microsoft.PowerShell
         /// </summary>
         /// <value></value>
         /// <exception/>
-
         public override string Name
         {
             get
@@ -538,7 +536,6 @@ namespace Microsoft.PowerShell
         /// </summary>
         /// <value></value>
         /// <exception/>
-
         public override System.Version Version
         {
             get
@@ -553,7 +550,6 @@ namespace Microsoft.PowerShell
         /// </summary>
         /// <value></value>
         /// <exception/>
-
         public override System.Guid InstanceId { get; } = Guid.NewGuid();
 
         /// <summary>
@@ -1609,7 +1605,6 @@ namespace Microsoft.PowerShell
         /// Opens and Initializes the Host's sole Runspace.  Processes the startup scripts and runs any command passed on the
         /// command line.
         /// </summary>
-
         private void DoCreateRunspace(string initialCommand, bool skipProfiles, bool staMode, string configurationName, Collection<CommandParameter> initialCommandArgs)
         {
             Dbg.Assert(_runspaceRef == null, "runspace should be null");
@@ -1997,7 +1992,6 @@ namespace Microsoft.PowerShell
         /// </summary>
         /// <param name="str"></param>
         /// <returns></returns>
-
         internal static string EscapeSingleQuotes(string str)
         {
             // worst case we have to escape every character, so capacity is twice as large as input length
@@ -2335,7 +2329,6 @@ namespace Microsoft.PowerShell
             /// <exception cref="InvalidOperationException">
             ///  when there is no instanceStack.Count == 0
             /// </exception>
-
             internal static bool ExitCurrentLoop()
             {
                 if (s_instanceStack.Count == 0)

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostRawUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostRawUserInterface.cs
@@ -22,7 +22,6 @@ namespace Microsoft.PowerShell
     /// <summary>
     /// Implementation of RawConsole for powershell.
     /// </summary>
-
     internal sealed
     class ConsoleHostRawUserInterface : System.Management.Automation.Host.PSHostRawUserInterface
     {
@@ -31,7 +30,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="HostException">
         /// If obtaining the buffer's foreground and background color failed
         /// </exception>
-
         internal
         ConsoleHostRawUserInterface(ConsoleHostUserInterface mshConsole) : base()
         {
@@ -78,7 +76,6 @@ namespace Microsoft.PowerShell
         ///    OR
         ///    Win32's SetConsoleTextAttribute
         /// </exception>
-
         public override
         ConsoleColor
         ForegroundColor
@@ -129,7 +126,6 @@ namespace Microsoft.PowerShell
         ///    OR
         ///    Win32's SetConsoleTextAttribute
         /// </exception>
-
         public override
         ConsoleColor
         BackgroundColor
@@ -222,7 +218,6 @@ namespace Microsoft.PowerShell
         ///    OR
         ///    Win32's SetConsoleCursorInfo failed
         /// </exception>
-
         public override
         int
         CursorSize
@@ -278,7 +273,6 @@ namespace Microsoft.PowerShell
         ///    OR
         ///    Win32's SetConsoleWindowInfo failed
         /// </exception>
-
         public override
         Coordinates
         WindowPosition
@@ -345,7 +339,6 @@ namespace Microsoft.PowerShell
         ///    OR
         ///    Win32's SetConsoleScreenBufferSize failed
         /// </exception>
-
         public override
         Size
         BufferSize
@@ -398,7 +391,6 @@ namespace Microsoft.PowerShell
         ///    OR
         ///    Win32's SetConsoleWindowInfo failed
         /// </exception>
-
         public override
         Size
         WindowSize
@@ -519,7 +511,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="HostException">
         /// If obtaining information about the buffer failed
         /// </exception>
-
         public override
         Size
         MaxWindowSize
@@ -543,7 +534,6 @@ namespace Microsoft.PowerShell
         ///    OR
         ///    Win32's GetLargestConsoleWindowSize failed
         /// </exception>
-
         public override
         Size
         MaxPhysicalWindowSize
@@ -602,7 +592,6 @@ namespace Microsoft.PowerShell
         ///    OR
         ///    Win32's ReadConsoleInput failed
         /// </exception>
-
         public override
         KeyInfo
         ReadKey(ReadKeyOptions options)
@@ -730,7 +719,6 @@ namespace Microsoft.PowerShell
         ///    OR
         ///    Win32's FlushConsoleInputBuffer failed
         /// </exception>
-
         public override
         void
         FlushInputBuffer()
@@ -752,7 +740,6 @@ namespace Microsoft.PowerShell
         ///    OR
         ///    Win32's PeekConsoleInput failed
         /// </exception>
-
         public override
         bool
         KeyAvailable
@@ -873,7 +860,6 @@ namespace Microsoft.PowerShell
         ///    OR
         ///    there is not enough memory to complete calls to Win32's WriteConsoleOutput
         /// </exception>
-
         public override
         void
         SetBufferContents(Coordinates origin, BufferCell[,] contents)
@@ -1084,7 +1070,6 @@ namespace Microsoft.PowerShell
         ///    OR
         ///    there is not enough memory to complete calls to Win32's ReadConsoleOutput
         /// </exception>
-
         public override
         BufferCell[,] GetBufferContents(Rectangle region)
         {
@@ -1208,7 +1193,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="HostException">
         /// If Win32's WideCharToMultiByte fails
         /// </exception>
-
         public override
         int LengthInBufferCells(string s)
         {
@@ -1224,7 +1208,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="HostException">
         /// If Win32's WideCharToMultiByte fails
         /// </exception>
-
         public override
         int LengthInBufferCells(string s, int offset)
         {
@@ -1244,7 +1227,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="HostException">
         /// If Win32's WideCharToMultiByte fails
         /// </exception>
-
         public override
         int LengthInBufferCells(char c)
         {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -54,7 +54,6 @@ namespace Microsoft.PowerShell
         /// </summary>
         /// <param name="parent"></param>
         /// <exception/>
-
         internal ConsoleHostUserInterface(ConsoleHost parent)
         {
             Dbg.Assert(parent != null, "parent may not be null");
@@ -93,7 +92,6 @@ namespace Microsoft.PowerShell
         /// </summary>
         /// <value></value>
         /// <exception/>
-
         public override PSHostRawUserInterface RawUI
         {
             get
@@ -131,7 +129,6 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// True if command completion is currently running.
         /// </summary>
-
         internal bool IsCommandCompletionRunning
         {
             get
@@ -144,13 +141,11 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// True if the Read* functions should read from the stdin stream instead of from the win32 console.
         /// </summary>
-
         internal bool ReadFromStdin { get; set; }
 
         /// <summary>
         /// True if the host shouldn't write out prompts.
         /// </summary>
-
         internal bool NoPrompt { get; set; }
 
         #region Line-oriented interaction
@@ -168,7 +163,6 @@ namespace Microsoft.PowerShell
         ///    OR
         ///    Win32's SetConsoleCursorPosition failed
         /// </exception>
-
         public override string ReadLine()
         {
             HandleThrowOnReadAndPrompt();
@@ -193,7 +187,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="PipelineStoppedException">
         /// If Ctrl-C is entered by user
         /// </exception>
-
         public override SecureString ReadLineAsSecureString()
         {
             HandleThrowOnReadAndPrompt();
@@ -245,7 +238,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="PipelineStoppedException">
         /// If Ctrl-C is entered by user
         /// </exception>
-
         private object ReadLineSafe(bool isSecureString, char? printToken)
         {
             // Don't lock (instanceLock) in here -- the caller needs to do that...
@@ -439,7 +431,6 @@ namespace Microsoft.PowerShell
         ///    OR
         ///    Win32's SetConsoleCursorPosition failed
         /// </exception>
-
         private void WritePrintToken(
             string printToken,
             ref Coordinates originalCursorPosition)
@@ -476,7 +467,6 @@ namespace Microsoft.PowerShell
         ///    OR
         ///    Win32's SetConsoleCursorPosition failed
         /// </exception>
-
         private void WriteBackSpace(Coordinates originalCursorPosition)
         {
             Coordinates cursorPosition = _rawui.CursorPosition;
@@ -678,7 +668,6 @@ namespace Microsoft.PowerShell
         ///    OR
         ///    Win32's WriteConsole fails
         /// </exception>
-
         public override void Write(string value)
         {
             WriteImpl(value, newLine: false);
@@ -749,7 +738,6 @@ namespace Microsoft.PowerShell
         ///    OR
         ///    Win32's WriteConsole fails
         /// </exception>
-
         public override void Write(ConsoleColor foregroundColor, ConsoleColor backgroundColor, string value)
         {
             Write(foregroundColor, backgroundColor, value, newLine: false);
@@ -861,7 +849,6 @@ namespace Microsoft.PowerShell
         /// A list of strings representing the text broken into "lines" each of which are guaranteed not to exceed
         /// maxWidthInBufferCells.
         /// </returns>
-
         internal List<string> WrapText(string text, int maxWidthInBufferCells)
         {
             List<string> result = new List<string>();
@@ -953,7 +940,6 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// Struct used by WrapText.
         /// </summary>
-
         [Flags]
         internal enum WordFlags
         {
@@ -988,7 +974,6 @@ namespace Microsoft.PowerShell
         /// This can be made faster by, instead of creating little strings for each word, creating indices of the start and end
         /// range of a word.  That would reduce the string allocations.
         /// </remarks>
-
         internal List<Word> ChopTextIntoWords(string text, int maxWidthInBufferCells)
         {
             List<Word> result = new List<Word>();
@@ -1096,7 +1081,6 @@ namespace Microsoft.PowerShell
         /// <param name="result">
         /// The list into which the words will be added.
         /// </param>
-
         internal void AddWord(string text, int startIndex, int endIndex,
             int maxWidthInBufferCells, bool isWhitespace, ref List<Word> result)
         {
@@ -1235,7 +1219,6 @@ namespace Microsoft.PowerShell
         ///    OR
         ///    Win32's WriteConsole fails
         /// </exception>
-
         public override void WriteVerboseLine(string message)
         {
             // don't lock here as WriteLine is already protected.
@@ -1273,7 +1256,6 @@ namespace Microsoft.PowerShell
         ///    OR
         ///    Win32's WriteConsole fails
         /// </exception>
-
         public override void WriteWarningLine(string message)
         {
             // don't lock here as WriteLine is already protected.
@@ -1297,7 +1279,6 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// Invoked by CommandBase.WriteProgress to display a progress record.
         /// </summary>
-
         public override void WriteProgress(Int64 sourceId, ProgressRecord record)
         {
             if (record == null)
@@ -1436,7 +1417,6 @@ namespace Microsoft.PowerShell
         ///    OR
         ///    Win32's SetConsoleCursorPosition failed
         /// </exception>
-
         internal string ReadLine(bool endOnTab, string initialContent, out ReadLineResult result, bool calledFromPipeline, bool transcribeResult)
         {
             result = ReadLineResult.endedOnEnter;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceProgress.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceProgress.cs
@@ -16,7 +16,6 @@ namespace Microsoft.PowerShell
         /// Called at the end of a prompt loop to take down any progress display that might have appeared and purge any
         /// outstanding progress activity state.
         /// </summary>
-
         internal
         void
         ResetProgress()
@@ -55,7 +54,6 @@ namespace Microsoft.PowerShell
         /// Invoked by ConsoleHostUserInterface.WriteProgress to update the set of outstanding activities for which
         /// ProgressRecords have been received.
         /// </summary>
-
         private
         void
         HandleIncomingProgressRecord(Int64 sourceId, ProgressRecord record)
@@ -101,7 +99,6 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// TimerCallback for '_progPaneUpdateTimer' to update 'progPaneUpdateFlag'
         /// </summary>
-
         private
         void
         ProgressPaneUpdateTimerElapsed(object sender)

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfacePrompt.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfacePrompt.cs
@@ -87,7 +87,6 @@ namespace Microsoft.PowerShell
         /// If the converting the user input to the prompt field type fails unless it is caused by
         ///     OverflowException or FormatException
         /// </exception>
-
         public override
         Dictionary<string, PSObject>
         Prompt(string caption, string message, Collection<FieldDescription> descriptions)
@@ -475,7 +474,6 @@ namespace Microsoft.PowerShell
         /// <param name="desc"></param>
         /// <param name="inputDone"></param>
         /// <returns></returns>
-
         private string PromptCommandMode(string input, FieldDescription desc, out bool inputDone)
         {
             Dbg.Assert(input != null && input.StartsWith(PromptCommandPrefix, StringComparison.OrdinalIgnoreCase),

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfacePromptForChoice.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfacePromptForChoice.cs
@@ -39,7 +39,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="PromptingException">
         ///  when prompt is canceled by, for example, Ctrl-c.
         /// </exception>
-
         public override int PromptForChoice(string caption, string message, Collection<ChoiceDescription> choices, int defaultChoice)
         {
             HandleThrowOnReadAndPrompt();

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
@@ -29,7 +29,6 @@ namespace Microsoft.PowerShell
         /// <param name="message">Message to be displayed.</param>
         /// <param name="caption">Caption for the message.</param>
         /// <returns>PSCredential object.</returns>
-
         public override PSCredential PromptForCredential(
             string caption,
             string message,
@@ -54,7 +53,6 @@ namespace Microsoft.PowerShell
         /// <param name="allowedCredentialTypes">What type of creds can be supplied by the user.</param>
         /// <param name="options">Options that control the cred gathering UI behavior.</param>
         /// <returns>PSCredential object, or null if input was cancelled (or if reading from stdin and stdin at EOF).</returns>
-
         public override PSCredential PromptForCredential(
             string caption,
             string message,

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleShell.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleShell.cs
@@ -11,7 +11,6 @@ namespace Microsoft.PowerShell
     /// This class provides an entry point which is called by minishell's main
     /// to transfer control to Msh console host implementation.
     /// </summary>
-
     public static class ConsoleShell
     {
         /// <summary>Entry point in to ConsoleShell. This method is called by main of minishell.</summary>

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/Executor.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/Executor.cs
@@ -24,7 +24,6 @@ namespace Microsoft.PowerShell
     /// The class' instance methods manage a single pipeline.  The class' static methods track the outstanding instances to
     /// ensure that only one instance is 'active' (and therefore cancellable) at a time.
     /// </summary>
-
     internal class Executor
     {
         [Flags]
@@ -527,7 +526,6 @@ namespace Microsoft.PowerShell
         /// The Nullable`bool representation of the first result object returned, or null if an exception was thrown or no
         /// objects were returned by the command.
         /// </returns>
-
         internal bool? ExecuteCommandAndGetResultAsBool(string command)
         {
             Exception unused = null;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/PendingProgress.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/PendingProgress.cs
@@ -24,7 +24,6 @@ namespace Microsoft.PowerShell
     /// This class uses lots of nearly identical helper functions to recursively traverse the tree. If I weren't so pressed
     /// for time, I would see if generic methods could be used to collapse the number of traversers.
     /// </summary>
-
     internal
     class PendingProgress
     {
@@ -42,7 +41,6 @@ namespace Microsoft.PowerShell
         /// The ProgressRecord received that will either update the status of an activity which we are already tracking, or
         /// represent a new activity that we need to track.
         /// </param>
-
         internal
         void
         Update(Int64 sourceId, ProgressRecord record)
@@ -179,7 +177,6 @@ namespace Microsoft.PowerShell
         /// <param name="indexToRemove">
         /// Index into the list of the node to be removed.
         /// </param>
-
         private
         void
         RemoveNode(ArrayList nodes, int indexToRemove)
@@ -255,7 +252,6 @@ namespace Microsoft.PowerShell
         /// <param name="nodeToAdd">
         /// Node to be added.
         /// </param>
-
         private
         void
         AddNode(ArrayList nodes, ProgressNode nodeToAdd)
@@ -356,7 +352,6 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// Convenience overload.
         /// </summary>
-
         private
         ProgressNode
         FindNodeById(Int64 sourceId, int activityId)
@@ -427,7 +422,6 @@ namespace Microsoft.PowerShell
         /// <returns>
         /// The found node, or null if no suitable node was located.
         /// </returns>
-
         private
         ProgressNode
         FindNodeById(Int64 sourceId, int activityId, out ArrayList listWhereFound, out int indexWhereFound)
@@ -465,7 +459,6 @@ namespace Microsoft.PowerShell
         /// <returns>
         /// The found node, or null if no suitable node was located.
         /// </returns>
-
         private
         ProgressNode
         FindOldestNodeOfGivenStyle(ArrayList nodes, int oldestSoFar, ProgressNode.RenderStyle style)
@@ -530,7 +523,6 @@ namespace Microsoft.PowerShell
         ///
         /// All nodes are aged every time a new ProgressRecord is received.
         /// </summary>
-
         private
         void
         AgeNodesAndResetStyle()
@@ -561,7 +553,6 @@ namespace Microsoft.PowerShell
         /// <returns>
         /// An array of strings containing the textual representation of the outstanding progress activities.
         /// </returns>
-
         internal
         string[]
         Render(int maxWidth, int maxHeight, PSHostRawUserInterface rawUI)
@@ -631,7 +622,6 @@ namespace Microsoft.PowerShell
         /// <param name="rawUI">
         /// The PSHostRawUserInterface used to gauge string widths in the rendering.
         /// </param>
-
         private
         void
         RenderHelper(ArrayList strings, ArrayList nodes, int indentation, int maxWidth, PSHostRawUserInterface rawUI)
@@ -708,7 +698,6 @@ namespace Microsoft.PowerShell
         /// </returns>
         /// <param name="maxWidth">
         /// </param>
-
         private int TallyHeight(PSHostRawUserInterface rawUi, int maxHeight, int maxWidth)
         {
             HeightTallyer ht = new HeightTallyer(rawUi, maxHeight, maxWidth);
@@ -724,7 +713,6 @@ namespace Microsoft.PowerShell
         /// <param name="nodes"></param>
         /// <param name="style"></param>
         /// <returns></returns>
-
         private
         bool
         AllNodesHaveGivenStyle(ArrayList nodes, ProgressNode.RenderStyle style)
@@ -759,7 +747,6 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// Debugging code. NodeVisitor that counts up the number of nodes in the tree.
         /// </summary>
-
         private
         class
         CountingNodeVisitor : NodeVisitor
@@ -783,7 +770,6 @@ namespace Microsoft.PowerShell
         /// <returns>
         /// The number of nodes in the tree.
         /// </returns>
-
         private
         int
         CountNodes()
@@ -823,7 +809,6 @@ namespace Microsoft.PowerShell
         /// false to indicate that all of the nodes are compressed to a given level, but that the rendering still can't fit
         /// within the constraint.
         /// </returns>
-
         private
         bool
         CompressToFitHelper(
@@ -894,7 +879,6 @@ namespace Microsoft.PowerShell
         /// The number of nodes that were made invisible during the compression.
         ///
         ///</returns>
-
         private
         int
         CompressToFit(PSHostRawUserInterface rawUi, int maxHeight, int maxWidth)
@@ -983,7 +967,6 @@ namespace Microsoft.PowerShell
             /// <returns>
             /// true to continue visiting nodes, false if not.
             /// </returns>
-
             internal abstract
             bool
             Visit(ProgressNode node, ArrayList listWhereFound, int indexWhereFound);

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressNode.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressNode.cs
@@ -15,7 +15,6 @@ namespace Microsoft.PowerShell
     /// ProgressNode is an augmentation of the ProgressRecord type that adds extra fields for the purposes of tracking
     /// outstanding activities received by the host, and rendering them in the console.
     /// </summary>
-
     internal
     class
     ProgressNode : ProgressRecord
@@ -23,7 +22,6 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// Indicates the various layouts for rendering a particular node.  Each style is progressively less terse.
         /// </summary>
-
         internal
         enum
         RenderStyle
@@ -47,7 +45,6 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// Constructs an instance from a ProgressRecord.
         /// </summary>
-
         internal
         ProgressNode(Int64 sourceId, ProgressRecord record)
             :
@@ -80,7 +77,6 @@ namespace Microsoft.PowerShell
         /// <param name="rawUI">
         /// The PSHostRawUserInterface used to gauge string widths in the rendering.
         /// </param>
-
         internal
         void
         Render(ArrayList strCollection, int indentation, int maxWidth, PSHostRawUserInterface rawUI)
@@ -130,7 +126,6 @@ namespace Microsoft.PowerShell
         /// <param name="isFullPlus">
         /// Indicate if the full StatusDescription and CurrentOperation should be displayed.
         /// </param>
-
         private
         void
         RenderFull(ArrayList strCollection, int indentation, int maxWidth, PSHostRawUserInterface rawUI, bool isFullPlus)
@@ -240,7 +235,6 @@ namespace Microsoft.PowerShell
         /// <param name="rawUI">
         /// The PSHostRawUserInterface used to gauge string widths in the rendering.
         /// </param>
-
         private
         void
         RenderCompact(ArrayList strCollection, int indentation, int maxWidth, PSHostRawUserInterface rawUI)
@@ -309,7 +303,6 @@ namespace Microsoft.PowerShell
         /// <param name="rawUI">
         /// The PSHostRawUserInterface used to gauge string widths in the rendering.
         /// </param>
-
         private
         void
         RenderMinimal(ArrayList strCollection, int indentation, int maxWidth, PSHostRawUserInterface rawUI)
@@ -347,7 +340,6 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// The nodes that have this node as their parent.
         /// </summary>
-
         internal
         ArrayList
         Children;
@@ -362,7 +354,6 @@ namespace Microsoft.PowerShell
         /// space. The rendering of nodes can be progressively "compressed" into a more terse format, or not rendered at all in
         /// order to fit as many nodes as possible in the available space. The oldest nodes are compressed or skipped first.
         /// </summary>
-
         internal
         int
         Age;
@@ -370,7 +361,6 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// The style in which this node should be rendered.
         /// </summary>
-
         internal
         RenderStyle
         Style = RenderStyle.FullPlus;
@@ -378,7 +368,6 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// Identifies the source of the progress record.
         /// </summary>
-
         internal
         Int64
         SourceId;
@@ -387,7 +376,6 @@ namespace Microsoft.PowerShell
         /// The number of vertical BufferCells that are required to render the node in its current style.
         /// </summary>
         /// <value></value>
-
         internal int LinesRequiredMethod(PSHostRawUserInterface rawUi, int maxWidth)
         {
             Dbg.Assert(this.RecordType != ProgressRecordType.Completed, "should never render completed records");
@@ -421,7 +409,6 @@ namespace Microsoft.PowerShell
         /// The number of vertical BufferCells that are required to render the node in the Full style.
         /// </summary>
         /// <value></value>
-
         private int LinesRequiredInFullStyleMethod(PSHostRawUserInterface rawUi, int maxWidth, bool isFullPlus)
         {
             // Since the fields of this instance could have been changed, we compute this on-the-fly.
@@ -479,7 +466,6 @@ namespace Microsoft.PowerShell
         /// The number of vertical BufferCells that are required to render the node in the Compact style.
         /// </summary>
         /// <value></value>
-
         private
         int
         LinesRequiredInCompactStyle

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressPane.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressPane.cs
@@ -13,7 +13,6 @@ namespace Microsoft.PowerShell
     /// progress updates are shown.
     ///
     ///</summary>
-
     internal
     class ProgressPane
     {
@@ -23,7 +22,6 @@ namespace Microsoft.PowerShell
         /// <param name="ui">
         /// An implementation of the PSHostRawUserInterface with which the pane will be shown and hidden.
         /// </param>
-
         internal
         ProgressPane(ConsoleHostUserInterface ui)
         {
@@ -39,7 +37,6 @@ namespace Microsoft.PowerShell
         /// true if the pane is visible, false if not.
         ///
         ///</value>
-
         internal
         bool
         IsShowing
@@ -54,7 +51,6 @@ namespace Microsoft.PowerShell
         /// Shows the pane in the screen buffer.  Saves off the content of the region of the buffer that will be overwritten so
         /// that it can be restored again.
         /// </summary>
-
         internal
         void
         Show()
@@ -140,7 +136,6 @@ namespace Microsoft.PowerShell
         /// Hides the pane by restoring the saved contents of the region of the buffer that the pane occupies.  If the pane is
         /// not showing, then does nothing.
         /// </summary>
-
         internal
         void
         Hide()
@@ -164,7 +159,6 @@ namespace Microsoft.PowerShell
         /// <param name="pendingProgress">
         /// A PendingProgress instance that represents the outstanding activities that should be shown.
         /// </param>
-
         internal
         void
         Show(PendingProgress pendingProgress)

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/Serialization.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/Serialization.cs
@@ -14,26 +14,22 @@ namespace Microsoft.PowerShell
     /// Wraps Hitesh's xml serializer in such a way that it will select the proper serializer based on the data
     /// format.
     /// </summary>
-
     internal class Serialization
     {
         /// <summary>
         /// Describes the format of the data streamed between minishells, e.g. the allowed arguments to the minishell
         /// -outputformat and -inputformat command line parameters.
         /// </summary>
-
         internal enum DataFormat
         {
             /// <summary>
             /// Text format -- i.e. stream text just as out-default would display it.
             /// </summary>
-
             Text = 0,
 
             /// <summary>
             /// XML-serialized format.
             /// </summary>
-
             XML = 1,
 
             /// <summary>

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/StartTranscriptCmdlet.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/StartTranscriptCmdlet.cs
@@ -12,7 +12,6 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// Implements the start-transcript cmdlet.
     /// </summary>
-
     [Cmdlet(VerbsLifecycle.Start, "Transcript", SupportsShouldProcess = true, DefaultParameterSetName = "ByPath", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=2096485")]
     [OutputType(typeof(string))]
     public sealed class StartTranscriptCommand : PSCmdlet
@@ -23,7 +22,6 @@ namespace Microsoft.PowerShell.Commands
         /// Documents/PowerShell_transcript.YYYYMMDDmmss.txt.
         /// </summary>
         /// <value></value>
-
         [Parameter(Position = 0, ParameterSetName = "ByPath")]
         [ValidateNotNullOrEmpty]
         public string Path
@@ -77,7 +75,6 @@ namespace Microsoft.PowerShell.Commands
         /// Describes the current state of the activity.
         /// </summary>
         /// <value></value>
-
         [Parameter]
         public SwitchParameter Append
         {
@@ -99,7 +96,6 @@ namespace Microsoft.PowerShell.Commands
         /// <remarks>
         /// The read-only attribute will not be replaced when the transcript is done.
         /// </remarks>
-
         [Parameter()]
         public SwitchParameter Force
         {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/StopTranscriptCmdlet.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/StopTranscriptCmdlet.cs
@@ -10,7 +10,6 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// Implements the stop-transcript cmdlet.
     /// </summary>
-
     [Cmdlet(VerbsLifecycle.Stop, "Transcript", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=2096798")]
     [OutputType(typeof(string))]
     public sealed class StopTranscriptCommand : PSCmdlet
@@ -18,7 +17,6 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Starts the transcription.
         /// </summary>
-
         protected override
         void
         BeginProcessing()

--- a/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
+++ b/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
@@ -469,7 +469,6 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Native IntPtr store handle.
         /// </summary>
-
         public IntPtr StoreHandle
         {
             get
@@ -503,7 +502,6 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// True if a real store is open.
         /// </summary>
-
         public bool Valid
         {
             get
@@ -701,7 +699,6 @@ namespace Microsoft.PowerShell.Commands
         ///     path is null or empty.
         ///     destination is null or empty.
         /// </exception>
-
         protected override void RemoveItem(
                                 string path,
                                 bool recurse)
@@ -808,7 +805,6 @@ namespace Microsoft.PowerShell.Commands
         ///     path is null or empty.
         ///     destination is null or empty.
         /// </exception>
-
         protected override void MoveItem(
                                 string path,
                                 string destination)
@@ -1620,7 +1616,6 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// <param name="pProvInfo">Key prov info.</param>
         /// <returns>No return.</returns>
-
         [SuppressMessage("Microsoft.Usage", "CA1806:DoNotIgnoreMethodResults", MessageId = "System.Management.Automation.Security.NativeMethods.NCryptSetProperty(System.IntPtr,System.String,System.Void*,System.Int32,System.Int32)")]
         [SuppressMessage("Microsoft.Usage", "CA1806:DoNotIgnoreMethodResults", MessageId = "System.Management.Automation.Security.NativeMethods.NCryptFreeObject(System.IntPtr)")]
         private void DoDeleteKey(IntPtr pProvInfo)
@@ -1749,7 +1744,6 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="fDeleteKey">Boolean to specify whether or not to delete private key.</param>
         /// <param name = "sourcePath">Source path.</param>
         /// <returns>No return.</returns>
-
         private void RemoveCertStore(string storeName, bool fDeleteKey, string sourcePath)
         {
             // if recurse is true, remove every cert in the store
@@ -1847,7 +1841,6 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="fMachine">Machine context or user.</param>
         /// <param name = "sourcePath">Source path.</param>
         /// <returns>No return.</returns>
-
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1806:DoNotIgnoreMethodResults")]
         private void DoRemove(X509Certificate2 cert, bool fDeleteKey, bool fMachine, string sourcePath)
         {
@@ -3085,7 +3078,6 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Constructor of an EnhancedKeyUsageRepresentation.
         /// </summary>
-
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Oid")]
 
         public EnhancedKeyUsageRepresentation(string inputFriendlyName, string inputOid)
@@ -3154,14 +3146,12 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// Class for SendAsTrustedIssuer.
     /// </summary>
-
     [SuppressMessage("Microsoft.Design", "CA1053:StaticHolderTypesShouldNotHaveConstructors")]
     public sealed class SendAsTrustedIssuerProperty
     {
         /// <summary>
         /// Get property of SendAsTrustedIssuer.
         /// </summary>
-
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public static bool ReadSendAsTrustedIssuerProperty(X509Certificate2 cert)
         {
@@ -3197,7 +3187,6 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Set property of SendAsTrustedIssuer.
         /// </summary>
-
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public static void WriteSendAsTrustedIssuerProperty(X509Certificate2 cert, string certPath, bool addProperty)
         {
@@ -3311,7 +3300,6 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// Class for ekulist.
     /// </summary>
-
     public sealed class EnhancedKeyUsageProperty
     {
         private List<EnhancedKeyUsageRepresentation> _ekuList = new List<EnhancedKeyUsageRepresentation>();
@@ -3355,7 +3343,6 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// Class for DNSNameList.
     /// </summary>
-
     public sealed class DnsNameProperty
     {
         private List<DnsNameRepresentation> _dnsList = new List<DnsNameRepresentation>();

--- a/src/Microsoft.WSMan.Management/CredSSP.cs
+++ b/src/Microsoft.WSMan.Management/CredSSP.cs
@@ -97,7 +97,6 @@ namespace Microsoft.WSMan.Management
     /// the server, hence allowing the user to perform management operations that
     /// access a second hop.
     /// </summary>
-
     [Cmdlet(VerbsLifecycle.Disable, "WSManCredSSP", HelpUri = "https://go.microsoft.com/fwlink/?LinkId=2096628")]
     [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Cred")]
     [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "SSP")]

--- a/src/Microsoft.WSMan.Management/Interop.cs
+++ b/src/Microsoft.WSMan.Management/Interop.cs
@@ -23,7 +23,6 @@ namespace Microsoft.WSMan.Management
 
     #region WsManEnumFlags
     /// <summary><para>_WSManEnumFlags enumeration.</para></summary>
-
     [SuppressMessage("Microsoft.Design", "CA1027:MarkEnumsWithFlags")]
     [TypeLibType((short)0)]
     public enum WSManEnumFlags
@@ -926,7 +925,6 @@ namespace Microsoft.WSMan.Management
         /// <param name="parameters"></param>
         /// <param name="flags"></param>
         /// <returns></returns>
-
         [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "URI")]
         [SuppressMessage("Microsoft.Design", "CA1054:UriParametersShouldNotBeStrings", MessageId = "0#")]
         [DispId(5)]

--- a/src/Microsoft.WSMan.Management/InvokeWSManAction.cs
+++ b/src/Microsoft.WSMan.Management/InvokeWSManAction.cs
@@ -23,7 +23,6 @@ namespace Microsoft.WSMan.Management
     /// Invoke-WSManAction -Action StartService -ResourceURI wmicimv2/Win32_Service
     /// -SelectorSet {Name=Spooler}
     /// </summary>
-
     [Cmdlet(VerbsLifecycle.Invoke, "WSManAction", DefaultParameterSetName = "URI", HelpUri = "https://go.microsoft.com/fwlink/?LinkId=2096843")]
     public class InvokeWSManActionCommand : AuthenticatingWSManCommand, IDisposable
     {

--- a/src/Microsoft.WSMan.Management/NewWSManSession.cs
+++ b/src/Microsoft.WSMan.Management/NewWSManSession.cs
@@ -25,7 +25,6 @@ namespace Microsoft.WSMan.Management
     /// Invoke-WSManAction
     /// Connect-WSMan.
     /// </summary>
-
     [Cmdlet(VerbsCommon.New, "WSManSessionOption", HelpUri = "https://go.microsoft.com/fwlink/?LinkId=2096845")]
     public class NewWSManSessionOptionCommand : PSCmdlet
     {

--- a/src/Microsoft.WSMan.Management/PingWSMan.cs
+++ b/src/Microsoft.WSMan.Management/PingWSMan.cs
@@ -22,7 +22,6 @@ namespace Microsoft.WSMan.Management
     /// Issues an operation against the remote machine to ensure that the wsman
     /// service is running.
     /// </summary>
-
     [Cmdlet(VerbsDiagnostic.Test, "WSMan", HelpUri = "https://go.microsoft.com/fwlink/?LinkId=2097114")]
     public class TestWSManCommand : AuthenticatingWSManCommand, IDisposable
     {

--- a/src/Microsoft.WSMan.Management/WSManConnections.cs
+++ b/src/Microsoft.WSMan.Management/WSManConnections.cs
@@ -288,7 +288,6 @@ namespace Microsoft.WSMan.Management
     /// is the local computer. Type the fully qualified domain name, NETBIOS name or
     /// IP address to indicate the remote host(s)
     /// </summary>
-
     [Cmdlet(VerbsCommunications.Disconnect, "WSMan", HelpUri = "https://go.microsoft.com/fwlink/?LinkId=2096839")]
     public class DisconnectWSManCommand : PSCmdlet, IDisposable
     {

--- a/src/Microsoft.WSMan.Management/WSManInstance.cs
+++ b/src/Microsoft.WSMan.Management/WSManInstance.cs
@@ -28,7 +28,6 @@ namespace Microsoft.WSMan.Management
     /// Invoke-WSManAction -Action StartService -ResourceURI wmicimv2/Win32_Service
     /// -SelectorSet {Name=Spooler}
     /// </summary>
-
     [Cmdlet(VerbsCommon.Get, "WSManInstance", DefaultParameterSetName = "GetInstance", HelpUri = "https://go.microsoft.com/fwlink/?LinkId=2096627")]
     public class GetWSManInstanceCommand : AuthenticatingWSManCommand, IDisposable
     {
@@ -102,7 +101,6 @@ namespace Microsoft.WSMan.Management
         /// remote machine. The format of this string is:
         /// transport://server:port/Prefix.
         /// </summary>
-
         [Parameter(
                   ParameterSetName = "GetInstance")]
         [Parameter(
@@ -143,7 +141,6 @@ namespace Microsoft.WSMan.Management
         /// Switch indicates list all instances of a management resource. Equivalent to
         /// WSManagement Enumerate.
         /// </summary>
-
         [Parameter(Mandatory = true,
                   ParameterSetName = "Enumerate")]
         public SwitchParameter Enumerate
@@ -181,7 +178,6 @@ namespace Microsoft.WSMan.Management
         /// Specifies a section inside the instance that is to be updated or retrieved
         /// for the given operation.
         /// </summary>
-
         [Parameter(ParameterSetName = "GetInstance")]
         [ValidateNotNullOrEmpty]
         public string Fragment
@@ -242,7 +238,6 @@ namespace Microsoft.WSMan.Management
         /// associated instances. This can only be used when specifying the Dialect as
         /// Association.
         /// </summary>
-
         [Parameter(ParameterSetName = "Enumerate")]
         public SwitchParameter Associations
         {
@@ -754,7 +749,6 @@ namespace Microsoft.WSMan.Management
         /// request. These are similar to switches used in command line shells in that
         /// they are service-specific.
         /// </summary>
-
         [Parameter]
         [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
         [Alias("os")]
@@ -788,7 +782,6 @@ namespace Microsoft.WSMan.Management
         /// The following is the definition of the input parameter "ResourceURI".
         /// URI of the resource class/instance representation.
         /// </summary>
-
         [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "URI")]
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Resourceuri")]
 
@@ -1077,7 +1070,6 @@ namespace Microsoft.WSMan.Management
         /// request. These are similar to switches used in command line shells in that
         /// they are service-specific.
         /// </summary>
-
         [Parameter]
         [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
         [Alias("os")]
@@ -1111,7 +1103,6 @@ namespace Microsoft.WSMan.Management
         /// The following is the definition of the input parameter "ResourceURI".
         /// URI of the resource class/instance representation.
         /// </summary>
-
         [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "URI")]
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Resourceuri")]
 
@@ -1275,7 +1266,6 @@ namespace Microsoft.WSMan.Management
     /// Creates an instance of a management resource identified by the resource URI
     /// using specified ValueSet or input File.
     /// </summary>
-
     [Cmdlet(VerbsCommon.New, "WSManInstance", DefaultParameterSetName = "ComputerName", HelpUri = "https://go.microsoft.com/fwlink/?LinkId=2096933")]
     public class NewWSManInstanceCommand : AuthenticatingWSManCommand, IDisposable
     {

--- a/src/Microsoft.WSMan.Runtime/WSManSessionOption.cs
+++ b/src/Microsoft.WSMan.Runtime/WSManSessionOption.cs
@@ -23,7 +23,6 @@ namespace Microsoft.WSMan.Management
     /// <summary>
     /// Session option class.
     /// </summary>
-
     public sealed class SessionOption
     {
         /// <summary>

--- a/src/System.Management.Automation/engine/ComInterop/ComMethodDesc.cs
+++ b/src/System.Management.Automation/engine/ComInterop/ComMethodDesc.cs
@@ -31,7 +31,6 @@ namespace System.Management.Automation.ComInterop
         internal ComMethodDesc(ITypeInfo typeInfo, FUNCDESC funcDesc)
             : this(funcDesc.memid)
         {
-
             InvokeKind = funcDesc.invkind;
 
             string[] rgNames = new string[1 + funcDesc.cParams];

--- a/src/System.Management.Automation/engine/ComInterop/ComTypeDesc.cs
+++ b/src/System.Management.Automation/engine/ComInterop/ComTypeDesc.cs
@@ -25,7 +25,6 @@ namespace System.Management.Automation.ComInterop
             TypeLib = typeLibDesc;
         }
 
-
         internal static ComTypeDesc FromITypeInfo(ITypeInfo typeInfo, TYPEATTR typeAttr)
         {
             switch (typeAttr.typekind)

--- a/src/System.Management.Automation/engine/ComInterop/IDispatchComObject.cs
+++ b/src/System.Management.Automation/engine/ComInterop/IDispatchComObject.cs
@@ -73,7 +73,6 @@ namespace System.Management.Automation.ComInterop
     /// just find and invoke the multicast delegate corresponding to the invoked
     /// dispid.
     ///  </summary>
-
     internal sealed class IDispatchComObject : ComObject, IDynamicMetaObjectProvider
     {
         private ComTypeDesc _comTypeDesc;

--- a/src/System.Management.Automation/engine/ComInterop/UnknownArgBuilder.cs
+++ b/src/System.Management.Automation/engine/ComInterop/UnknownArgBuilder.cs
@@ -48,7 +48,6 @@ namespace System.Management.Automation.ComInterop
             );
         }
 
-
         internal override Expression UnmarshalFromRef(Expression value)
         {
             // value == IntPtr.Zero ? null : Marshal.GetObjectForIUnknown(value);

--- a/src/System.Management.Automation/engine/ComInterop/VarEnumSelector.cs
+++ b/src/System.Management.Automation/engine/ComInterop/VarEnumSelector.cs
@@ -245,7 +245,6 @@ namespace System.Management.Automation.ComInterop
                 typeNames += typeName;
             }
 
-
             throw Error.AmbiguousConversion(argumentType.Name, typeNames);
         }
 

--- a/src/System.Management.Automation/engine/CommandBase.cs
+++ b/src/System.Management.Automation/engine/CommandBase.cs
@@ -543,7 +543,6 @@ namespace System.Management.Automation
         }
 
         /// <Content contentref="System.Management.Automation.VariableIntrinsics.GetValue" />
-
         public object GetVariableValue(string name, object defaultValue)
         {
             using (PSTransactionManager.GetEngineProtectionScope())

--- a/src/System.Management.Automation/engine/InformationRecord.cs
+++ b/src/System.Management.Automation/engine/InformationRecord.cs
@@ -14,7 +14,6 @@ namespace System.Management.Automation
     /// which, according to host or user preference, forwards that information on to the host for rendering to the user.
     /// </remarks>
     /// <seealso cref="System.Management.Automation.Cmdlet.WriteInformation(object, string[])"/>
-
     [DataContract()]
     public class InformationRecord
     {

--- a/src/System.Management.Automation/engine/ProgressRecord.cs
+++ b/src/System.Management.Automation/engine/ProgressRecord.cs
@@ -15,7 +15,6 @@ namespace System.Management.Automation
     /// which, according to user preference, forwards that information on to the host for rendering to the user.
     /// </remarks>
     /// <seealso cref="System.Management.Automation.Cmdlet.WriteProgress(ProgressRecord)"/>
-
     [DataContract()]
     public
     class ProgressRecord
@@ -35,7 +34,6 @@ namespace System.Management.Automation
         /// <param name="statusDescription">
         /// A description of the status of the activity.
         /// </param>
-
         public
         ProgressRecord(int activityId, string activity, string statusDescription)
         {
@@ -81,7 +79,6 @@ namespace System.Management.Automation
         /// Gets the Id of the activity to which this record corresponds.  Used as a 'key' for the
         /// linking of subordinate activities.
         /// </summary>
-
         public
         int
         ActivityId
@@ -107,7 +104,6 @@ namespace System.Management.Automation
         /// shell so that a script can set that variable, and have all subsequent calls to WriteProgress (the API) be
         /// subordinate to the "current parent id".-->
         /// </remarks>
-
         public
         int
         ParentActivityId
@@ -135,7 +131,6 @@ namespace System.Management.Automation
         /// States the overall intent of whats being accomplished, such as "Recursively removing item c:\temp." Typically
         /// displayed in conjunction with a progress bar.
         /// </remarks>
-
         public
         string
         Activity
@@ -159,7 +154,6 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets and sets the current status of the operation, e.g., "35 of 50 items Copied." or "95% completed." or "100 files purged."
         /// </summary>
-
         public
         string
         StatusDescription
@@ -185,7 +179,6 @@ namespace System.Management.Automation
         /// below its associated progress bar, e.g., "deleting file foo.bar"
         /// Set to null or empty in the case a sub-activity will be used to show the current operation.
         /// </summary>
-
         public
         string
         CurrentOperation
@@ -207,7 +200,6 @@ namespace System.Management.Automation
         /// Gets and sets the estimate of the percentage of total work for the activity that is completed.  Typically displayed as a progress bar.
         /// Set to a negative value to indicate that the percentage completed should not be displayed.
         /// </summary>
-
         public
         int
         PercentComplete
@@ -241,7 +233,6 @@ namespace System.Management.Automation
         ///<remarks>
         /// A value less than 0 means "don't display a time remaining."
         /// </remarks>
-
         public
         int
         SecondsRemaining
@@ -262,7 +253,6 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets and sets the type of record represented by this instance.
         /// </summary>
-
         public
         ProgressRecordType
         RecordType
@@ -291,7 +281,6 @@ namespace System.Management.Automation
         /// a, b, c, d, e, f, and g are the values of ParentActivityId, ActivityId, Activity, StatusDescription,
         /// CurrentOperation, PercentComplete, SecondsRemaining and RecordType properties.
         /// </returns>
-
         public override
         string
         ToString()
@@ -520,7 +509,6 @@ namespace System.Management.Automation
     /// <summary>
     /// Defines two types of progress record that refer to the beginning (or middle) and end of an operation.
     /// </summary>
-
     public
     enum ProgressRecordType
     {
@@ -539,7 +527,6 @@ namespace System.Management.Automation
         /// Finally, when the host receives a 'completed' record
         /// for that activity, it will remove the progress indicator.
         /// </remarks>
-
         Processing,
 
         /// <summary>
@@ -550,7 +537,6 @@ namespace System.Management.Automation
         /// ProgressRecordType.Completed exactly once, in the last call
         /// to WriteProgress.
         /// </remarks>
-
         Completed
     }
 }

--- a/src/System.Management.Automation/engine/ScopedItemSearcher.cs
+++ b/src/System.Management.Automation/engine/ScopedItemSearcher.cs
@@ -111,7 +111,6 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets the current scoped item.
         /// </summary>
-
         T IEnumerator<T>.Current
         {
             get

--- a/src/System.Management.Automation/engine/SessionState.cs
+++ b/src/System.Management.Automation/engine/SessionState.cs
@@ -18,7 +18,6 @@ namespace System.Management.Automation
     /// <summary>
     /// Holds the state of a Monad Shell session.
     /// </summary>
-
     [SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling", Justification = "This is a bridge class between internal classes and a public interface. It requires this much coupling.")]
     internal sealed partial class SessionStateInternal
     {

--- a/src/System.Management.Automation/engine/SessionStateScope.cs
+++ b/src/System.Management.Automation/engine/SessionStateScope.cs
@@ -1852,7 +1852,6 @@ namespace System.Management.Automation
         /// table. The entries in this table are automatically propagated
         /// to new scopes.
         /// </summary>
-
         private readonly Dictionary<string, List<CmdletInfo>> _allScopeCmdlets = new Dictionary<string, List<CmdletInfo>>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>

--- a/src/System.Management.Automation/engine/hostifaces/ChoiceDescription.cs
+++ b/src/System.Management.Automation/engine/hostifaces/ChoiceDescription.cs
@@ -9,7 +9,6 @@ namespace System.Management.Automation.Host
     /// Provides a description of a choice for use by <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForChoice"/>.
     /// <!--Used by the Msh engine to describe cmdlet parameters.-->
     /// </summary>
-
     public sealed
     class ChoiceDescription
     {
@@ -29,7 +28,6 @@ namespace System.Management.Automation.Host
         /// <exception cref="System.Management.Automation.PSArgumentException">
         /// <paramref name="label"/> is null or empty.
         /// </exception>
-
         public
         ChoiceDescription(string label)
         {
@@ -59,7 +57,6 @@ namespace System.Management.Automation.Host
         /// <exception cref="System.Management.Automation.PSArgumentNullException">
         /// <paramref name="helpMessage"/> is null.
         /// </exception>
-
         public
         ChoiceDescription(string label, string helpMessage)
         {
@@ -92,7 +89,6 @@ namespace System.Management.Automation.Host
         ///
         /// For examples, a choice named "Yes to All" might have "Yes to &amp;All" as it's label.
         /// </remarks>
-
         public
         string
         Label
@@ -115,7 +111,6 @@ namespace System.Management.Automation.Host
         /// This should be a few sentences to describe the field, suitable for presentation as a tool tip.
         /// Avoid placing including formatting characters such as newline and tab.
         /// </remarks>
-
         public
         string
         HelpMessage

--- a/src/System.Management.Automation/engine/hostifaces/DefaultHost.cs
+++ b/src/System.Management.Automation/engine/hostifaces/DefaultHost.cs
@@ -14,7 +14,6 @@ namespace Microsoft.PowerShell
     /// This is the default host implementing PSHost offering minimal host capabilities.
     /// Runspace is the primary user of this class.
     /// </summary>
-
     internal class DefaultHost : PSHost
     {
         #region ctor
@@ -25,7 +24,6 @@ namespace Microsoft.PowerShell
         /// <param name="currentCulture">Current culture for this host.</param>
         /// <param name="currentUICulture">Current UI culture for this host.</param>
         /// <exception/>
-
         internal DefaultHost(CultureInfo currentCulture, CultureInfo currentUICulture)
         {
             CurrentCulture = currentCulture;
@@ -70,7 +68,6 @@ namespace Microsoft.PowerShell
         /// </summary>
         /// <value></value>
         /// <exception/>
-
         public override
         void
         SetShouldExit(int exitCode)
@@ -85,7 +82,6 @@ namespace Microsoft.PowerShell
         /// <exception cref="NotSupportedException">
         /// On calling this method
         /// </exception>
-
         public override
         void
         EnterNestedPrompt()
@@ -112,7 +108,6 @@ namespace Microsoft.PowerShell
         /// </summary>
         /// <value></value>
         /// <exception/>
-
         public override
         void
         NotifyBeginApplication()
@@ -125,7 +120,6 @@ namespace Microsoft.PowerShell
         /// </summary>
         /// <value></value>
         /// <exception/>
-
         public override
         void
         NotifyEndApplication()

--- a/src/System.Management.Automation/engine/hostifaces/FieldDescription.cs
+++ b/src/System.Management.Automation/engine/hostifaces/FieldDescription.cs
@@ -22,7 +22,6 @@ namespace System.Management.Automation.Host
     /// It is permitted to subclass <see cref="System.Management.Automation.Host.FieldDescription"/>
     /// but there is no established scenario for doing this, nor has it been tested.
     /// </remarks>
-
     public class
     FieldDescription
     {
@@ -35,7 +34,6 @@ namespace System.Management.Automation.Host
         /// <exception cref="System.Management.Automation.PSArgumentException">
         /// <paramref name="name"/> is null or empty.
         /// </exception>
-
         public
         FieldDescription(string name)
         {
@@ -69,7 +67,6 @@ namespace System.Management.Automation.Host
         /// <exception cref="System.Management.Automation.PSArgumentNullException">
         /// If <paramref name="parameterType"/> is null.
         /// </exception>
-
         public
         void
         SetParameterType(System.Type parameterType)
@@ -96,7 +93,6 @@ namespace System.Management.Automation.Host
         /// <!--The value of ParameterTypeName is the string value returned.
         /// by System.Type.Name.-->
         /// </remarks>
-
         public
         string
         ParameterTypeName
@@ -123,7 +119,6 @@ namespace System.Management.Automation.Host
         /// <!--The value of ParameterTypeName is the string value returned.
         /// by System.Type.Name.-->
         /// </remarks>
-
         public
         string
         ParameterTypeFullName
@@ -151,7 +146,6 @@ namespace System.Management.Automation.Host
         /// If not already set by a call to <see cref="System.Management.Automation.Host.FieldDescription.SetParameterType"/>,
         /// <see cref="System.String"/> will be used as the type.
         /// </remarks>
-
         public
         string
         ParameterAssemblyFullName
@@ -189,7 +183,6 @@ namespace System.Management.Automation.Host
         ///
         /// If no label is set, then the empty string is returned.
         /// </remarks>
-
         public
         string
         Label
@@ -222,7 +215,6 @@ namespace System.Management.Automation.Host
         /// This should be a few sentences to describe the field, suitable for presentation as a tool tip.
         /// Avoid placing including formatting characters such as newline and tab.
         /// </remarks>
-
         public
         string
         HelpMessage
@@ -248,7 +240,6 @@ namespace System.Management.Automation.Host
         /// <summary>
         /// Gets and sets whether a value must be supplied for this field.
         /// </summary>
-
         public
         bool
         IsMandatory
@@ -274,7 +265,6 @@ namespace System.Management.Automation.Host
         /// can make use of the object in its presentation of the fields prompt.
         ///
         ///</remarks>
-
         public
         PSObject
         DefaultValue
@@ -297,7 +287,6 @@ namespace System.Management.Automation.Host
         /// is being called from the MSH engine, this will contain the set of prompting attributes that are attached to a
         /// cmdlet parameter declaration.
         /// </summary>
-
         public
         Collection<Attribute>
         Attributes
@@ -312,7 +301,6 @@ namespace System.Management.Automation.Host
         /// <exception cref="System.Management.Automation.PSArgumentException">
         /// If <paramref name="nameOfType"/> is null.
         /// </exception>
-
         internal
         void
         SetParameterTypeName(string nameOfType)
@@ -332,7 +320,6 @@ namespace System.Management.Automation.Host
         /// <exception cref="System.Management.Automation.PSArgumentException">
         /// If <paramref name="fullNameOfType"/> is null.
         /// </exception>
-
         internal
         void
         SetParameterTypeFullName(string fullNameOfType)
@@ -352,7 +339,6 @@ namespace System.Management.Automation.Host
         /// <exception cref="System.Management.Automation.PSArgumentException">
         /// If <paramref name="fullNameOfAssembly"/> is null.
         /// </exception>
-
         internal
         void
         SetParameterAssemblyFullName(string fullNameOfAssembly)

--- a/src/System.Management.Automation/engine/hostifaces/History.cs
+++ b/src/System.Management.Automation/engine/hostifaces/History.cs
@@ -109,7 +109,6 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Cleared status of an entry.
         /// </summary>
-
         internal bool Cleared { get; set; } = false;
 
         /// <summary>
@@ -167,7 +166,6 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Constructs history store.
         /// </summary>
-
         internal History(ExecutionContext context)
         {
             // Create history size variable. Add ValidateRangeAttribute to
@@ -586,7 +584,6 @@ namespace Microsoft.PowerShell.Commands
         /// gets the total number of entries added
         ///</summary>
         ///<returns>count of total entries added.</returns>
-
         internal int Buffercapacity()
         {
             return _capacity;
@@ -1586,7 +1583,6 @@ namespace Microsoft.PowerShell.Commands
     ///<summary>
     /// This Class implements the Clear History cmdlet
     ///</summary>
-
     [Cmdlet(VerbsCommon.Clear, "History", SupportsShouldProcess = true, DefaultParameterSetName = "IDParameter", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=2096691")]
     public class ClearHistoryCommand : PSCmdlet
     {
@@ -1616,13 +1612,11 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Id of a history entry.
         /// </summary>
-
         private int[] _id;
 
         /// <summary>
         /// Command line name of an entry in the session history.
         /// </summary>
-
         [Parameter(ParameterSetName = "CommandLineParameter", HelpMessage = "Specifies the name of a command in the session history")]
         [ValidateNotNullOrEmpty()]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
@@ -1642,7 +1636,6 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Commandline parameter.
         /// </summary>
-
         private string[] _commandline = null;
 
         ///<summary>
@@ -1677,7 +1670,6 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Specifies whether new entries to be cleared or the default old ones.
         /// </summary>
-
         [Parameter(Mandatory = false, HelpMessage = "Specifies whether new entries to be cleared or the default old ones.")]
         public SwitchParameter Newest
         {
@@ -1695,7 +1687,6 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Switch parameter on the history entries.
         /// </summary>
-
         private SwitchParameter _newest;
 
         #endregion Command Line Parameters
@@ -1703,7 +1694,6 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Overriding Begin Processing.
         /// </summary>
-
         protected override void BeginProcessing()
         {
             _history = ((LocalRunspace)Context.CurrentRunspace).History;
@@ -1712,7 +1702,6 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Overriding Process Record.
         /// </summary>
-
         protected override void ProcessRecord()
         {
             // case statement to identify the parameter set
@@ -1915,7 +1904,6 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="newest" >Order of the entries.</param>
         /// <returns>Nothing.</returns>
         /// </summary>
-
         private void ClearHistoryEntries(long id, int count, string cmdline, SwitchParameter newest)
         {
             // if cmdline is null,use default parameter set notion.

--- a/src/System.Management.Automation/engine/hostifaces/InternalHostRawUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/InternalHostRawUserInterface.cs
@@ -78,7 +78,6 @@ namespace System.Management.Automation.Internal.Host
         /// if the RawUI property of the external host is null, possibly because the PSHostRawUserInterface is not
         ///  implemented by the external host
         /// </exception>
-
         public override
         ConsoleColor
         BackgroundColor
@@ -114,7 +113,6 @@ namespace System.Management.Automation.Internal.Host
         /// if the RawUI property of the external host is null, possibly because the PSHostRawUserInterface is not
         ///  implemented by the external host
         /// </exception>
-
         public override
         Coordinates
         CursorPosition
@@ -150,7 +148,6 @@ namespace System.Management.Automation.Internal.Host
         /// if the RawUI property of the external host is null, possibly because the PSHostRawUserInterface is not
         ///  implemented by the external host
         /// </exception>
-
         public override
         Coordinates
         WindowPosition
@@ -186,7 +183,6 @@ namespace System.Management.Automation.Internal.Host
         /// if the RawUI property of the external host is null, possibly because the PSHostRawUserInterface is not
         ///  implemented by the external host
         /// </exception>
-
         public override
         int
         CursorSize
@@ -222,7 +218,6 @@ namespace System.Management.Automation.Internal.Host
         /// if the RawUI property of the external host is null, possibly because the PSHostRawUserInterface is not
         ///  implemented by the external host
         /// </exception>
-
         public override
         Size
         BufferSize
@@ -258,7 +253,6 @@ namespace System.Management.Automation.Internal.Host
         /// if the RawUI property of the external host is null, possibly because the PSHostRawUserInterface is not
         ///  implemented by the external host
         /// </exception>
-
         public override
         Size
         WindowSize
@@ -294,7 +288,6 @@ namespace System.Management.Automation.Internal.Host
         /// if the RawUI property of the external host is null, possibly because the PSHostRawUserInterface is not
         ///  implemented by the external host
         /// </exception>
-
         public override
         Size
         MaxWindowSize
@@ -320,7 +313,6 @@ namespace System.Management.Automation.Internal.Host
         /// if the RawUI property of the external host is null, possibly because the PSHostRawUserInterface is not
         ///  implemented by the external host
         /// </exception>
-
         public override
         Size
         MaxPhysicalWindowSize
@@ -348,7 +340,6 @@ namespace System.Management.Automation.Internal.Host
         /// if the RawUI property of the external host is null, possibly because the PSHostRawUserInterface is not
         ///  implemented by the external host
         /// </exception>
-
         public override
         KeyInfo
         ReadKey(ReadKeyOptions options)
@@ -386,7 +377,6 @@ namespace System.Management.Automation.Internal.Host
         /// if the RawUI property of the external host is null, possibly because the PSHostRawUserInterface is not
         ///  implemented by the external host
         /// </exception>
-
         public override
         void
         FlushInputBuffer()
@@ -407,7 +397,6 @@ namespace System.Management.Automation.Internal.Host
         /// if the RawUI property of the external host is null, possibly because the PSHostRawUserInterface is not
         ///  implemented by the external host
         /// </exception>
-
         public override
         bool
         KeyAvailable
@@ -433,7 +422,6 @@ namespace System.Management.Automation.Internal.Host
         /// if the RawUI property of the external host is null, possibly because the PSHostRawUserInterface is not
         ///  implemented by the external host
         /// </exception>
-
         public override
         string
         WindowTitle
@@ -495,7 +483,6 @@ namespace System.Management.Automation.Internal.Host
         /// if the RawUI property of the external host is null, possibly because the PSHostRawUserInterface is not
         ///  implemented by the external host
         /// </exception>
-
         public override
         void
         SetBufferContents(Rectangle r, BufferCell fill)
@@ -517,7 +504,6 @@ namespace System.Management.Automation.Internal.Host
         /// if the RawUI property of the external host is null, possibly because the PSHostRawUserInterface is not
         ///  implemented by the external host
         /// </exception>
-
         public override
         BufferCell[,]
         GetBufferContents(Rectangle r)
@@ -545,7 +531,6 @@ namespace System.Management.Automation.Internal.Host
         /// if the RawUI property of the external host is null, possibly because the PSHostRawUserInterface is not
         ///  implemented by the external host
         /// </exception>
-
         public override
         void
         ScrollBufferContents

--- a/src/System.Management.Automation/engine/hostifaces/InternalHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/InternalHostUserInterface.cs
@@ -67,7 +67,6 @@ namespace System.Management.Automation.Internal.Host
         /// </summary>
         /// <value></value>
         /// <exception/>
-
         public override
         System.Management.Automation.Host.PSHostRawUserInterface
         RawUI
@@ -127,7 +126,6 @@ namespace System.Management.Automation.Internal.Host
         /// if the UI property of the external host is null, possibly because the PSHostUserInterface is not
         /// implemented by the external host.
         /// </exception>
-
         public override
         SecureString
         ReadLineAsSecureString()
@@ -168,7 +166,6 @@ namespace System.Management.Automation.Internal.Host
         /// if <paramref name="value"/> is not null and the UI property of the external host is null,
         ///     possibly because the PSHostUserInterface is not implemented by the external host
         /// </exception>
-
         public override
         void
         Write(string value)
@@ -199,7 +196,6 @@ namespace System.Management.Automation.Internal.Host
         /// if <paramref name="value"/> is not null and the UI property of the external host is null,
         ///     possibly because the PSHostUserInterface is not implemented by the external host
         /// </exception>
-
         public override
         void
         Write(ConsoleColor foregroundColor, ConsoleColor backgroundColor, string value)
@@ -226,7 +222,6 @@ namespace System.Management.Automation.Internal.Host
         /// if the UI property of the external host is null, possibly because the PSHostUserInterface is not
         ///     implemented by the external host
         /// </exception>
-
         public override
         void
         WriteLine()
@@ -248,7 +243,6 @@ namespace System.Management.Automation.Internal.Host
         /// if <paramref name="value"/> is not null and the UI property of the external host is null,
         ///     possibly because the PSHostUserInterface is not implemented by the external host
         /// </exception>
-
         public override
         void
         WriteLine(string value)
@@ -296,7 +290,6 @@ namespace System.Management.Automation.Internal.Host
         /// if <paramref name="value"/> is not null and the UI property of the external host is null,
         ///     possibly because the PSHostUserInterface is not implemented by the external host
         /// </exception>
-
         public override
         void
         WriteLine(ConsoleColor foregroundColor, ConsoleColor backgroundColor, string value)
@@ -321,7 +314,6 @@ namespace System.Management.Automation.Internal.Host
         /// if <paramref name="message"/> is not null and the UI property of the external host is null,
         ///     possibly because the PSHostUserInterface is not implemented by the external host
         /// </exception>
-
         public override
         void
         WriteDebugLine(string message)
@@ -369,7 +361,6 @@ namespace System.Management.Automation.Internal.Host
         /// <exception cref="ArgumentException">
         /// If the debug preference is not a valid ActionPreference value.
         /// </exception>
-
         internal
         void
         WriteDebugLine(string message, ref ActionPreference preference)
@@ -469,7 +460,6 @@ namespace System.Management.Automation.Internal.Host
         /// Preference setting which determines the behaviour.  This is by-ref and will be modified based upon what the user
         /// types. (e.g. YesToAll will change Inquire => NotifyContinue)
         /// </param>
-
         private
         bool
         DebugShouldContinue(string message, ref ActionPreference actionPreference)
@@ -539,7 +529,6 @@ namespace System.Management.Automation.Internal.Host
         /// if <paramref name="record"/> is not null and the UI property of the external host is null,
         ///     possibly because the PSHostUserInterface is not implemented by the external host
         /// </exception>
-
         public override
         void
         WriteProgress(Int64 sourceId, ProgressRecord record)
@@ -570,7 +559,6 @@ namespace System.Management.Automation.Internal.Host
         /// if <paramref name="message"/> is not null and the UI property of the external host is null,
         ///     possibly because the PSHostUserInterface is not implemented by the external host
         /// </exception>
-
         public override
         void
         WriteVerboseLine(string message)
@@ -616,7 +604,6 @@ namespace System.Management.Automation.Internal.Host
         /// if <paramref name="message"/> is not null and the UI property of the external host is null,
         ///     possibly because the PSHostUserInterface is not implemented by the external host
         /// </exception>
-
         public override void WriteWarningLine(string message)
         {
             if (message == null)
@@ -725,7 +712,6 @@ namespace System.Management.Automation.Internal.Host
         /// if the UI property of the external host is null,
         ///     possibly because the PSHostUserInterface is not implemented by the external host
         /// </exception>
-
         public override
         Dictionary<string, PSObject>
         Prompt(string caption, string message, Collection<FieldDescription> descriptions)
@@ -779,7 +765,6 @@ namespace System.Management.Automation.Internal.Host
         /// if the UI property of the external host is null,
         ///     possibly because the PSHostUserInterface is not implemented by the external host
         /// </exception>
-
         public override
         int
         PromptForChoice(string caption, string message, Collection<ChoiceDescription> choices, int defaultChoice)

--- a/src/System.Management.Automation/engine/hostifaces/MshHost.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHost.cs
@@ -34,7 +34,6 @@ namespace System.Management.Automation.Host
     /// <seealso cref="System.Management.Automation.Runspaces.Runspace"/>
     /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface"/>
     /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface"/>
-
     public abstract class PSHost
     {
         /// <summary>
@@ -47,7 +46,6 @@ namespace System.Management.Automation.Host
         /// <summary>
         /// Protected constructor which does nothing.  Provided per .Net design guidelines section 4.3.1.
         /// </summary>
-
         protected PSHost()
         {
             // do nothing
@@ -70,7 +68,6 @@ namespace System.Management.Automation.Host
         ///         if ($Host.Name -ieq "ConsoleHost") { write-host "I'm running in the Console Host" }
         ///     </MSH>
         /// </example>
-
         public abstract string Name
         {
             get;
@@ -87,7 +84,6 @@ namespace System.Management.Automation.Host
         /// <value>
         /// The version number of the hosting application.
         /// </value>
-
         public abstract System.Version Version
         {
             get;
@@ -97,7 +93,6 @@ namespace System.Management.Automation.Host
         /// Gets a GUID that uniquely identifies this instance of the host.  The value should remain invariant for the lifetime of
         /// this instance.
         /// </summary>
-
         public abstract System.Guid InstanceId
         {
             get;
@@ -118,7 +113,6 @@ namespace System.Management.Automation.Host
         /// implementation of PSHostUserInterface for this application. As an alternative,
         /// for simple scenarios, just returning null is sufficient.
         /// </remarks>
-
         public abstract System.Management.Automation.Host.PSHostUserInterface UI
         {
             get;
@@ -134,7 +128,6 @@ namespace System.Management.Automation.Host
         /// The runspace will set the thread current culture to this value each time it starts a pipeline. Thus, cmdlets are
         /// encouraged to use Thread.CurrentThread.CurrentCulture.
         /// </remarks>
-
         public abstract System.Globalization.CultureInfo CurrentCulture
         {
             get;
@@ -148,7 +141,6 @@ namespace System.Management.Automation.Host
         /// <value>
         /// A CultureInfo object representing the host's current UI culture.  Returning null is not allowed.
         /// </value>
-
         public abstract System.Globalization.CultureInfo CurrentUICulture
         {
             get;
@@ -167,7 +159,6 @@ namespace System.Management.Automation.Host
         /// The exit code accompanying the exit keyword. Typically, after exiting a runspace, a host will also terminate. The
         /// exitCode parameter can be used to set the host's process exit code.
         /// </param>
-
         public abstract void SetShouldExit(int exitCode);
 
         /// <summary>
@@ -188,7 +179,6 @@ namespace System.Management.Automation.Host
         /// evaluates other commands.  It does not create a truly new engine instance with new session state.-->
         /// </remarks>
         /// <seealso cref="System.Management.Automation.Host.PSHost.ExitNestedPrompt"/>
-
         public abstract void EnterNestedPrompt();
 
         /// <summary>
@@ -204,7 +194,6 @@ namespace System.Management.Automation.Host
         /// If the UI Property returns a null, the engine should not call this method.
         /// </remarks>
         /// <seealso cref="EnterNestedPrompt"/>
-
         public abstract void ExitNestedPrompt();
 
         /// <summary>
@@ -230,7 +219,6 @@ namespace System.Management.Automation.Host
         /// change will not be visible to the host if the host is in another process.  Therefore, the implementation of
         /// get for this property should always return a unique instance.
         /// </remarks>
-
         public virtual PSObject PrivateData
         {
             get
@@ -270,14 +258,12 @@ namespace System.Management.Automation.Host
         /// NotifyBeginApplication.
         /// </remarks>
         /// <seealso cref="System.Management.Automation.Host.PSHost.NotifyEndApplication"/>
-
         public abstract void NotifyBeginApplication();
 
         /// <summary>
         /// Called by the engine to notify the host that the execution of a legacy command has completed.
         /// </summary>
         /// <seealso cref="System.Management.Automation.Host.PSHost.NotifyBeginApplication"/>
-
         public abstract void NotifyEndApplication();
 
         /// <summary>

--- a/src/System.Management.Automation/engine/hostifaces/MshHostRawUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostRawUserInterface.cs
@@ -15,7 +15,6 @@ namespace System.Management.Automation.Host
     /// <summary>
     /// Represents an (x,y) coordinate pair.
     /// </summary>
-
     public
     struct Coordinates
     {
@@ -68,7 +67,6 @@ namespace System.Management.Automation.Host
         /// <returns>
         /// "a,b" where a and b are the values of the X and Y properties.
         /// </returns>
-
         public override
         string
         ToString()
@@ -86,7 +84,6 @@ namespace System.Management.Automation.Host
         /// True if <paramref name="objB"/> is Coordinates and its X and Y values are the same as those of this instance,
         /// false if not.
         /// </returns>
-
         public override
         bool
         Equals(object obj)
@@ -107,7 +104,6 @@ namespace System.Management.Automation.Host
         /// <returns>
         /// Hash code for this instance.
         /// </returns>
-
         public override
         int
         GetHashCode()
@@ -173,7 +169,6 @@ namespace System.Management.Automation.Host
         /// <returns>
         /// true if the respective X and Y values are the same, false otherwise.
         /// </returns>
-
         public static
         bool
         operator ==(Coordinates first, Coordinates second)
@@ -195,7 +190,6 @@ namespace System.Management.Automation.Host
         /// <returns>
         /// true if any of the respective either X or Y field is not the same, false otherwise.
         /// </returns>
-
         public static
         bool
         operator !=(Coordinates first, Coordinates second)
@@ -207,7 +201,6 @@ namespace System.Management.Automation.Host
     /// <summary>
     /// Represents a width and height pair.
     /// </summary>
-
     public
     struct Size
     {
@@ -260,7 +253,6 @@ namespace System.Management.Automation.Host
         /// <returns>
         /// "a,b" where a and b are the values of the Width and Height properties.
         /// </returns>
-
         public override
         string
         ToString()
@@ -278,7 +270,6 @@ namespace System.Management.Automation.Host
         /// True if <paramref name="obj"/> is Size and its Width and Height values are the same as those of this instance,
         /// false if not.
         /// </returns>
-
         public override
         bool
         Equals(object obj)
@@ -302,7 +293,6 @@ namespace System.Management.Automation.Host
         /// consider Width the high-order part of a 64-bit in, and
         /// Height the lower order half.  Then use the int64.GetHashCode.-->
         /// </returns>
-
         public override
         int
         GetHashCode()
@@ -368,7 +358,6 @@ namespace System.Management.Automation.Host
         /// <returns>
         /// true if the respective Width and Height fields are the same, false otherwise.
         /// </returns>
-
         public static
         bool
         operator ==(Size first, Size second)
@@ -390,7 +379,6 @@ namespace System.Management.Automation.Host
         /// <returns>
         /// true if any of the respective Width and Height fields are not the same, false otherwise.
         /// </returns>
-
         public static
         bool
         operator !=(Size first, Size second)
@@ -403,7 +391,6 @@ namespace System.Management.Automation.Host
     /// Governs the behavior of <see cref="System.Management.Automation.Host.PSHostRawUserInterface.ReadKey()"/>
     /// and <see cref="System.Management.Automation.Host.PSHostRawUserInterface.ReadKey(System.Management.Automation.Host.ReadKeyOptions)"/>
     /// </summary>
-
     [Flags]
     public
     enum
@@ -412,32 +399,27 @@ namespace System.Management.Automation.Host
         /// <summary>
         /// Allow Ctrl-C to be processed as a keystroke, as opposed to causing a break event.
         /// </summary>
-
         AllowCtrlC = 0x0001,
 
         /// <summary>
         /// Do not display the character for the key in the window when pressed.
         /// </summary>
-
         NoEcho = 0x0002,
 
         /// <summary>
         /// Include key down events.  Either one of IncludeKeyDown and IncludeKeyUp or both must be specified.
         /// </summary>
-
         IncludeKeyDown = 0x0004,
 
         /// <summary>
         /// Include key up events.  Either one of IncludeKeyDown and IncludeKeyUp or both must be specified.
         /// </summary>
-
         IncludeKeyUp = 0x0008
     }
 
     /// <summary>
     /// Defines the states of Control Key.
     /// </summary>
-
     [Flags]
     public
     enum ControlKeyStates
@@ -445,62 +427,52 @@ namespace System.Management.Automation.Host
         /// <summary>
         /// The right alt key is pressed.
         /// </summary>
-
         RightAltPressed = 0x0001,
 
         /// <summary>
         /// The left alt key is pressed.
         /// </summary>
-
         LeftAltPressed = 0x0002,
 
         /// <summary>
         /// The right ctrl key is pressed.
         /// </summary>
-
         RightCtrlPressed = 0x0004,
 
         /// <summary>
         /// The left ctrl key is pressed.
         /// </summary>
-
         LeftCtrlPressed = 0x0008,
 
         /// <summary>
         /// The shift key is pressed.
         /// </summary>
-
         ShiftPressed = 0x0010,
 
         /// <summary>
         /// The numlock light is on.
         /// </summary>
-
         NumLockOn = 0x0020,
 
         /// <summary>
         /// The scrolllock light is on.
         /// </summary>
-
         ScrollLockOn = 0x0040,
 
         /// <summary>
         /// The capslock light is on.
         /// </summary>
-
         CapsLockOn = 0x0080,
 
         /// <summary>
         /// The key is enhanced.
         /// </summary>
-
         EnhancedKey = 0x0100
     }
 
     /// <summary>
     /// Represents information of a keystroke.
     /// </summary>
-
     public
     struct KeyInfo
     {
@@ -516,7 +488,6 @@ namespace System.Management.Automation.Host
         /// <summary>
         /// Gets and set device-independent key.
         /// </summary>
-
         public int VirtualKeyCode
         {
             get { return virtualKeyCode; }
@@ -527,7 +498,6 @@ namespace System.Management.Automation.Host
         /// <summary>
         /// Gets and set unicode Character of the key.
         /// </summary>
-
         public char Character
         {
             get { return character; }
@@ -538,7 +508,6 @@ namespace System.Management.Automation.Host
         /// <summary>
         /// State of the control keys.
         /// </summary>
-
         public ControlKeyStates ControlKeyState
         {
             get { return controlKeyState; }
@@ -549,7 +518,6 @@ namespace System.Management.Automation.Host
         /// <summary>
         /// Gets and set the status of whether this instance is generated by a key pressed or released.
         /// </summary>
-
         public bool KeyDown
         {
             get { return keyDown; }
@@ -573,7 +541,6 @@ namespace System.Management.Automation.Host
         /// <param name="keyDown">
         /// Whether the key is pressed or released
         /// </param>
-
         public
         KeyInfo
         (
@@ -595,7 +562,6 @@ namespace System.Management.Automation.Host
         /// <returns>
         /// "a,b,c,d" where a, b, c, and d are the values of the VirtualKeyCode, Character, ControlKeyState, and KeyDown properties.
         /// </returns>
-
         public override
         string
         ToString()
@@ -612,7 +578,6 @@ namespace System.Management.Automation.Host
         /// True if <paramref name="obj"/> is KeyInfo and its VirtualKeyCode, Character, ControlKeyState, and KeyDown values are the
         /// same as those of this instance, false if not.
         /// </returns>
-
         public override
         bool
         Equals(object obj)
@@ -637,7 +602,6 @@ namespace System.Management.Automation.Host
         ///                VirtualKeyCode the lower-order nibbles of a 32-bit int,
         ///       Then use the UInt32.GetHashCode.-->
         /// </returns>
-
         public override
         int
         GetHashCode()
@@ -672,7 +636,6 @@ namespace System.Management.Automation.Host
         /// are the same, false otherwise.
         /// </returns>
         /// <exception/>
-
         public static
         bool
         operator ==(KeyInfo first, KeyInfo second)
@@ -697,7 +660,6 @@ namespace System.Management.Automation.Host
         /// are the different, false otherwise.
         /// </returns>
         /// <exception/>
-
         public static
         bool
         operator !=(KeyInfo first, KeyInfo second)
@@ -711,7 +673,6 @@ namespace System.Management.Automation.Host
     /// <!--We use this structure instead of System.Drawing.Rectangle because S.D.R
     /// is way overkill and would bring in another assembly.-->
     /// </summary>
-
     public
     struct Rectangle
     {
@@ -727,7 +688,6 @@ namespace System.Management.Automation.Host
         /// <summary>
         /// Gets and sets the left side of the rectangle.
         /// </summary>
-
         public int Left
         {
             get { return left; }
@@ -738,7 +698,6 @@ namespace System.Management.Automation.Host
         /// <summary>
         /// Gets and sets the top of the rectangle.
         /// </summary>
-
         public int Top
         {
             get { return top; }
@@ -749,7 +708,6 @@ namespace System.Management.Automation.Host
         /// <summary>
         /// Gets and sets the right side of the rectangle.
         /// </summary>
-
         public int Right
         {
             get { return right; }
@@ -760,7 +718,6 @@ namespace System.Management.Automation.Host
         /// <summary>
         /// Gets and sets the bottom of the rectangle.
         /// </summary>
-
         public int Bottom
         {
             get { return bottom; }
@@ -787,7 +744,6 @@ namespace System.Management.Automation.Host
         /// <paramref name="right"/> is less than <paramref name="left"/>;
         /// <paramref name="bottom"/> is less than <paramref name="top"/>
         /// </exception>
-
         public
         Rectangle(int left, int top, int right, int bottom)
         {
@@ -824,7 +780,6 @@ namespace System.Management.Automation.Host
         /// The Coordinates of the lower right corner of the Rectangle
         /// </param>
         /// <exception/>
-
         public
         Rectangle(Coordinates upperLeft, Coordinates lowerRight)
             : this(upperLeft.X, upperLeft.Y, lowerRight.X, lowerRight.Y)
@@ -837,7 +792,6 @@ namespace System.Management.Automation.Host
         /// <returns>
         /// "a,b ; c,d" where a, b, c, and d are values of the Left, Top, Right, and Bottom properties.
         /// </returns>
-
         public override
         string
         ToString()
@@ -855,7 +809,6 @@ namespace System.Management.Automation.Host
         /// True if <paramref name="obj"/> is Rectangle and its Left, Top, Right, and Bottom values are the same as those of this instance,
         /// false if not.
         /// </returns>
-
         public override
         bool
         Equals(object obj)
@@ -879,7 +832,6 @@ namespace System.Management.Automation.Host
         ///                (Left XOR Right) the lower order half.  Then use the int64.GetHashCode.-->
         /// </returns>
         /// <exception/>
-
         public override
         int
         GetHashCode()
@@ -948,7 +900,6 @@ namespace System.Management.Automation.Host
         /// <returns>
         /// true if the respective Top, Left, Bottom, and Right fields are the same, false otherwise.
         /// </returns>
-
         public static
         bool
         operator ==(Rectangle first, Rectangle second)
@@ -972,7 +923,6 @@ namespace System.Management.Automation.Host
         /// true if any of the respective Top, Left, Bottom, and Right fields are not the same, false otherwise.
         /// </returns>
         /// <exception/>
-
         public static
         bool
         operator !=(Rectangle first, Rectangle second)
@@ -984,7 +934,6 @@ namespace System.Management.Automation.Host
     /// <summary>
     /// Represents a character, a foregroundColor color, and background color.
     /// </summary>
-
     public
     struct BufferCell
     {
@@ -1000,7 +949,6 @@ namespace System.Management.Automation.Host
         /// <summary>
         /// Gets and sets the character value.
         /// </summary>
-
         public char Character
         {
             get { return character; }
@@ -1014,7 +962,6 @@ namespace System.Management.Automation.Host
         /// <summary>
         /// Gets and sets the foreground color.
         /// </summary>
-
         public ConsoleColor ForegroundColor
         {
             get { return foregroundColor; }
@@ -1025,7 +972,6 @@ namespace System.Management.Automation.Host
         /// <summary>
         /// Gets and sets the background color.
         /// </summary>
-
         public ConsoleColor BackgroundColor
         {
             get { return backgroundColor; }
@@ -1036,7 +982,6 @@ namespace System.Management.Automation.Host
         /// <summary>
         /// Gets and sets the type value.
         /// </summary>
-
         public BufferCellType BufferCellType
         {
             get { return bufferCellType; }
@@ -1060,7 +1005,6 @@ namespace System.Management.Automation.Host
         /// <param name="bufferCellType">
         /// The type of this BufferCell object
         /// </param>
-
         public
         BufferCell(char character, ConsoleColor foreground, ConsoleColor background, BufferCellType bufferCellType)
         {
@@ -1076,7 +1020,6 @@ namespace System.Management.Automation.Host
         /// <returns>
         /// "'a' b c d" where a, b, c, and d are the values of the Character, ForegroundColor, BackgroundColor, and Type properties.
         /// </returns>
-
         public override
         string
         ToString()
@@ -1094,7 +1037,6 @@ namespace System.Management.Automation.Host
         /// True if <paramref name="obj"/> is BufferCell and its Character, ForegroundColor, BackgroundColor, and BufferCellType values
         /// are the same as those of this instance, false if not.
         /// </returns>
-
         public override
         bool
         Equals(object obj)
@@ -1118,7 +1060,6 @@ namespace System.Management.Automation.Host
         /// Hash code for this instance.
         ///
         ///</returns>
-
         public override
         int
         GetHashCode()
@@ -1148,7 +1089,6 @@ namespace System.Management.Automation.Host
         /// <returns>
         /// true if the respective Character, ForegroundColor, BackgroundColor, and BufferCellType values are the same, false otherwise.
         /// </returns>
-
         public static
         bool
         operator ==(BufferCell first, BufferCell second)
@@ -1174,7 +1114,6 @@ namespace System.Management.Automation.Host
         /// true if any of the respective Character, ForegroundColor, BackgroundColor, and BufferCellType values are not the same,
         /// false otherwise.
         /// </returns>
-
         public static
         bool
         operator !=(BufferCell first, BufferCell second)
@@ -1189,26 +1128,22 @@ namespace System.Management.Automation.Host
     /// Defines three types of BufferCells to accommodate for hosts that use up to two cells
     /// to display a character in some languages such as Chinese and Japanese.
     /// </summary>
-
     public enum
     BufferCellType
     {
         /// <summary>
         /// Character occupies one BufferCell.
         /// </summary>
-
         Complete,
 
         /// <summary>
         /// Character occupies two BufferCells and this is the leading one.
         /// </summary>
-
         Leading,
 
         /// <summary>
         /// Preceded by a Leading BufferCell.
         /// </summary>
-
         Trailing
     }
 
@@ -1227,14 +1162,12 @@ namespace System.Management.Automation.Host
     /// </remarks>
     /// <seealso cref="System.Management.Automation.Host.PSHost"/>
     /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface"/>
-
     public abstract
     class PSHostRawUserInterface
     {
         /// <summary>
         /// Protected constructor which does nothing.  Provided per .Net design guidelines section 4.3.1.
         /// </summary>
-
         protected
         PSHostRawUserInterface()
         {
@@ -1250,7 +1183,6 @@ namespace System.Management.Automation.Host
         /// other properties that take structs (e.g. -Position, -Size), I anticipate that the more common use-case for color
         /// is to just change the foreground color.-->
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.BackgroundColor"/>
-
         public abstract
         ConsoleColor
         ForegroundColor
@@ -1264,7 +1196,6 @@ namespace System.Management.Automation.Host
         /// the screen buffer can have a separate background color.
         /// </summary>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.ForegroundColor"/>
-
         public abstract
         ConsoleColor
         BackgroundColor
@@ -1288,7 +1219,6 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.MaxWindowSize"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.SetBufferContents(Rectangle, BufferCell)"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.SetBufferContents(Coordinates, BufferCell[,])"/>
-
         public abstract
         Coordinates
         CursorPosition
@@ -1305,7 +1235,6 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.WindowSize"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.CursorPosition"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.MaxWindowSize"/>
-
         public abstract
         Coordinates
         WindowPosition
@@ -1318,7 +1247,6 @@ namespace System.Management.Automation.Host
         /// Gets or sets the cursor size as a percentage 0..100.
         /// </summary>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.CursorPosition"/>
-
         public abstract
         int
         CursorSize
@@ -1335,7 +1263,6 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.CursorPosition"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.MaxWindowSize"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.WindowPosition"/>
-
         public abstract
         Size
         BufferSize
@@ -1353,7 +1280,6 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.CursorPosition"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.MaxWindowSize"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.WindowPosition"/>
-
         public abstract
         Size
         WindowSize
@@ -1378,7 +1304,6 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.CursorPosition"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.WindowSize"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.WindowPosition"/>
-
         public abstract
         Size
         MaxWindowSize
@@ -1400,7 +1325,6 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.CursorPosition"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.WindowSize"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.WindowPosition"/>
-
         public abstract
         Size
         MaxPhysicalWindowSize
@@ -1424,7 +1348,6 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.FlushInputBuffer"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.KeyAvailable"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.WindowPosition"/>
-
         public
         KeyInfo
         ReadKey()
@@ -1457,7 +1380,6 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.ReadKey(System.Management.Automation.Host.ReadKeyOptions)"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.FlushInputBuffer"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.KeyAvailable"/>
-
         public abstract
         KeyInfo
         ReadKey(ReadKeyOptions options);
@@ -1468,7 +1390,6 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.ReadKey()"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.ReadKey(System.Management.Automation.Host.ReadKeyOptions)"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.KeyAvailable"/>
-
         public abstract
         void
         FlushInputBuffer();
@@ -1482,7 +1403,6 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.ReadKey()"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.ReadKey(ReadKeyOptions)"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.FlushInputBuffer"/>
-
         public abstract
         bool
         KeyAvailable
@@ -1493,7 +1413,6 @@ namespace System.Management.Automation.Host
         /// <summary>
         /// Gets or sets the titlebar text of the current view window.
         /// </summary>
-
         public abstract
         string
         WindowTitle
@@ -1521,7 +1440,6 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.SetBufferContents(Rectangle, BufferCell)"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.GetBufferContents"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.ScrollBufferContents"/>
-
         public abstract
         void
         SetBufferContents(Coordinates origin, BufferCell[,] contents);
@@ -1566,7 +1484,6 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.SetBufferContents(Coordinates, BufferCell[,])"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.GetBufferContents"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.ScrollBufferContents"/>
-
         public abstract
         void
         SetBufferContents(Rectangle rectangle, BufferCell fill);
@@ -1605,7 +1522,6 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.SetBufferContents(Rectangle, BufferCell)"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.SetBufferContents(Coordinates, BufferCell[,])"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.ScrollBufferContents"/>
-
         public abstract
         BufferCell[,]
         GetBufferContents(Rectangle rectangle);
@@ -1636,7 +1552,6 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.SetBufferContents(Rectangle, BufferCell)"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.SetBufferContents(Coordinates, BufferCell[,])"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.GetBufferContents"/>
-
         public abstract
         void
         ScrollBufferContents
@@ -1670,7 +1585,6 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.SetBufferContents(Coordinates, BufferCell[,])"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.GetBufferContents"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.ScrollBufferContents"/>
-
         public virtual
         int
         LengthInBufferCells
@@ -1710,7 +1624,6 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.SetBufferContents(Coordinates, BufferCell[,])"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.GetBufferContents"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.ScrollBufferContents"/>
-
         public virtual
         int
         LengthInBufferCells
@@ -1743,7 +1656,6 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.SetBufferContents(Coordinates, BufferCell[,])"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.GetBufferContents"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.ScrollBufferContents"/>
-
         public virtual
         int
         LengthInBufferCells
@@ -1912,7 +1824,6 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.SetBufferContents(Coordinates, BufferCell[,])"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.GetBufferContents"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.ScrollBufferContents"/>
-
         public
         BufferCell[,]
         NewBufferCellArray(int width, int height, BufferCell contents)
@@ -1994,7 +1905,6 @@ namespace System.Management.Automation.Host
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.SetBufferContents(Coordinates, BufferCell[,])"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.GetBufferContents"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface.ScrollBufferContents"/>
-
         public
         BufferCell[,]
         NewBufferCellArray(Size size, BufferCell contents)

--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -23,7 +23,6 @@ namespace System.Management.Automation.Host
     /// </summary>
     /// <seealso cref="System.Management.Automation.Host.PSHost"/>
     /// <seealso cref="System.Management.Automation.Host.PSHostRawUserInterface"/>
-
     public abstract class PSHostUserInterface
     {
         /// <summary>

--- a/src/System.Management.Automation/engine/hostifaces/RunspaceInit.cs
+++ b/src/System.Management.Automation/engine/hostifaces/RunspaceInit.cs
@@ -9,7 +9,6 @@ namespace System.Management.Automation.Runspaces
     /// <summary>
     /// Runspace class for local runspace.
     /// </summary>
-
     internal sealed partial
     class LocalRunspace : RunspaceBase
     {

--- a/src/System.Management.Automation/engine/hostifaces/internalHostuserInterfacesecurity.cs
+++ b/src/System.Management.Automation/engine/hostifaces/internalHostuserInterfacesecurity.cs
@@ -14,7 +14,6 @@ namespace System.Management.Automation.Internal.Host
         /// <summary>
         /// See base class.
         /// </summary>
-
         public override
         PSCredential
         PromptForCredential
@@ -34,7 +33,6 @@ namespace System.Management.Automation.Internal.Host
         /// <summary>
         /// See base class.
         /// </summary>
-
         public override
         PSCredential
         PromptForCredential

--- a/src/System.Management.Automation/engine/remoting/client/Job.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job.cs
@@ -2316,7 +2316,6 @@ namespace System.Management.Automation
         /// <summary>
         /// Checks the status of remote command execution.
         /// </summary>
-
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         private void SetStatusMessage()
         {

--- a/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemoteSessionCapability.cs
+++ b/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemoteSessionCapability.cs
@@ -174,7 +174,6 @@ namespace System.Management.Automation.Remoting
         /// <summary>
         /// Data.
         /// </summary>
-
         #region DO NOT REMOVE OR RENAME THESE FIELDS - it will break remoting compatibility with Windows PowerShell
 
         private Dictionary<HostDefaultDataId, object> data;

--- a/src/System.Management.Automation/engine/remoting/server/serverremotesessionstatemachine.cs
+++ b/src/System.Management.Automation/engine/remoting/server/serverremotesessionstatemachine.cs
@@ -346,7 +346,6 @@ namespace System.Management.Automation.Remoting
         /// If the parameter <paramref name="fsmEventArg"/> is not NegotiationReceived event or it does not hold the
         /// client negotiation packet.
         /// </exception>
-
         private void DoNegotiationReceived(object sender, RemoteSessionStateMachineEventArgs fsmEventArg)
         {
             using (s_trace.TraceEventHandlers())
@@ -386,7 +385,6 @@ namespace System.Management.Automation.Remoting
         /// <exception cref="ArgumentNullException">
         /// If the parameter <paramref name="fsmEventArg"/> is null.
         /// </exception>
-
         private void DoNegotiationSending(object sender, RemoteSessionStateMachineEventArgs fsmEventArg)
         {
             if (fsmEventArg == null)
@@ -413,7 +411,6 @@ namespace System.Management.Automation.Remoting
         /// <exception cref="ArgumentNullException">
         /// If the parameter <paramref name="fsmEventArg"/> is null.
         /// </exception>
-
         private void DoNegotiationCompleted(object sender, RemoteSessionStateMachineEventArgs fsmEventArg)
         {
             using (s_trace.TraceEventHandlers())
@@ -441,7 +438,6 @@ namespace System.Management.Automation.Remoting
         /// <exception cref="ArgumentNullException">
         /// If the parameter <paramref name="fsmEventArg"/> is null.
         /// </exception>
-
         private void DoEstablished(object sender, RemoteSessionStateMachineEventArgs fsmEventArg)
         {
             using (s_trace.TraceEventHandlers())

--- a/src/System.Management.Automation/namespaces/CoreCommandContext.cs
+++ b/src/System.Management.Automation/namespaces/CoreCommandContext.cs
@@ -250,7 +250,6 @@ namespace System.Management.Automation
         /// <exception cref="ArgumentNullException">
         /// If <paramref name="contextToCopyFrom"/> is null.
         /// </exception>
-
         internal CmdletProviderContext(
             CmdletProviderContext contextToCopyFrom)
         {

--- a/src/System.Management.Automation/utils/HostInterfacesExceptions.cs
+++ b/src/System.Management.Automation/utils/HostInterfacesExceptions.cs
@@ -10,7 +10,6 @@ namespace System.Management.Automation.Host
     /// Defines the exception thrown when the Host cannot complete an operation
     /// such as checking whether there is any input available.
     /// </summary>
-
     [Serializable]
     public
     class HostException : RuntimeException
@@ -19,7 +18,6 @@ namespace System.Management.Automation.Host
         /// <summary>
         /// Initializes a new instance of the HostException class.
         /// </summary>
-
         public
         HostException() : base(
             StringUtil.Format(HostInterfaceExceptionsStrings.DefaultCtorMessageTemplate, typeof(HostException).FullName))
@@ -33,7 +31,6 @@ namespace System.Management.Automation.Host
         /// <param name="message">
         /// The error message that explains the reason for the exception.
         /// </param>
-
         public
         HostException(string message) : base(message)
         {
@@ -52,7 +49,6 @@ namespace System.Management.Automation.Host
         /// parameter is not a null reference, the current exception is raised in a catch
         /// block that handles the inner exception.
         /// </param>
-
         public
         HostException(string message, Exception innerException)
             : base(message, innerException)
@@ -82,7 +78,6 @@ namespace System.Management.Automation.Host
         /// <remarks>
         /// Intentionally public, third-party hosts can call this
         /// </remarks>
-
         public
         HostException(string message, Exception innerException, string errorId, ErrorCategory errorCategory) :
             base(message, innerException)
@@ -101,7 +96,6 @@ namespace System.Management.Automation.Host
         /// <param name="context">
         /// The contextual information about the source or destination.
         /// </param>
-
         protected
         HostException(SerializationInfo info, StreamingContext context)
             : base(info, context)
@@ -121,7 +115,6 @@ namespace System.Management.Automation.Host
     /// <summary>
     /// Defines the exception thrown when an error occurs from prompting for a command parameter.
     /// </summary>
-
     [Serializable]
     public
     class PromptingException : HostException
@@ -130,7 +123,6 @@ namespace System.Management.Automation.Host
         /// <summary>
         /// Initializes a new instance of the PromptingException class.
         /// </summary>
-
         public
         PromptingException() : base(StringUtil.Format(HostInterfaceExceptionsStrings.DefaultCtorMessageTemplate, typeof(PromptingException).FullName))
         {
@@ -143,7 +135,6 @@ namespace System.Management.Automation.Host
         /// <param name="message">
         /// The error message that explains the reason for the exception.
         /// </param>
-
         public
         PromptingException(string message) : base(message)
         {
@@ -162,7 +153,6 @@ namespace System.Management.Automation.Host
         /// parameter is not a null reference, the current exception is raised in a catch
         /// block that handles the inner exception.
         /// </param>
-
         public
         PromptingException(string message, Exception innerException)
             : base(message, innerException)
@@ -192,7 +182,6 @@ namespace System.Management.Automation.Host
         /// <remarks>
         /// Intentionally public, third-party hosts can call this
         /// </remarks>
-
         public
         PromptingException(string message, Exception innerException, string errorId, ErrorCategory errorCategory) :
             base(message, innerException, errorId, errorCategory)
@@ -209,7 +198,6 @@ namespace System.Management.Automation.Host
         /// <param name="context">
         /// The contextual information about the source or destination.
         /// </param>
-
         protected
         PromptingException(SerializationInfo info, StreamingContext context)
             : base(info, context)


### PR DESCRIPTION
# PR Summary

Fixes SA1506: A documentation header line must not be followed by a blank line.

## PR Context

Changes split from #13334

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [NA] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [NA] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [NA] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [NA] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [NA] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [NA] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
