### PR TITLE
Add StringUtil.Format overload to avoid unnecessary allocations

### DIFF
--- a/src/System.Management.Automation/utils/StringUtil.cs
+++ b/src/System.Management.Automation/utils/StringUtil.cs
@@ -17,6 +17,9 @@ namespace System.Management.Automation.Internal
         internal static string Format(string format, object arg0, object arg1)
             => string.Format(Globalization.CultureInfo.CurrentCulture, format, arg0, arg1);
 
+        internal static string Format(string format, object arg0, object arg1, object arg2)
+            => string.Format(Globalization.CultureInfo.CurrentCulture, format, arg0, arg1, arg2);
+
         internal static string Format(string format, params object[] args)
             => string.Format(Globalization.CultureInfo.CurrentCulture, format, args);
 

--- a/src/System.Management.Automation/utils/StringUtil.cs
+++ b/src/System.Management.Automation/utils/StringUtil.cs
@@ -11,26 +11,14 @@ namespace System.Management.Automation.Internal
     internal static
     class StringUtil
     {
-        internal static
-        string
-        Format(string formatSpec, object o)
-        {
-            return string.Format(System.Globalization.CultureInfo.CurrentCulture, formatSpec, o);
-        }
+        internal static string Format(string format, object arg0)
+            => string.Format(Globalization.CultureInfo.CurrentCulture, format, arg0);
 
-        internal static
-        string
-        Format(string formatSpec, object o1, object o2)
-        {
-            return string.Format(System.Globalization.CultureInfo.CurrentCulture, formatSpec, o1, o2);
-        }
+        internal static string Format(string format, object arg0, object arg1)
+            => string.Format(Globalization.CultureInfo.CurrentCulture, format, arg0, arg1);
 
-        internal static
-        string
-        Format(string formatSpec, params object[] o)
-        {
-            return string.Format(System.Globalization.CultureInfo.CurrentCulture, formatSpec, o);
-        }
+        internal static string Format(string format, params object[] args)
+            => string.Format(Globalization.CultureInfo.CurrentCulture, format, args);
 
         internal static
         string


### PR DESCRIPTION
# PR Summary

* Rename method parameters so that their names correspond to `string.Format`
* Add `StringUtil.Format` overload to avoid unnecessary boxing allocations

## PR Context

See also: https://github.com/dotnet/runtime/issues/14484

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [NA] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [NA] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [NA] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [NA] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [NA] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [NA] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
