### PR TITLE
Add missing dispose for CancellationTokenSource

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimChildJobBase.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimChildJobBase.cs
@@ -1087,6 +1087,7 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
                 }
 
                 _cimSensitiveValueConverter.Dispose();
+                _cancellationTokenSource.Dispose();
             }
         }
     }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -838,6 +838,7 @@ namespace Microsoft.PowerShell.Commands
                 if (disposing)
                 {
                     _sender?.Dispose();
+                    _dnsLookupCancel.Dispose();
                 }
 
                 _disposed = true;


### PR DESCRIPTION
`Dispose()` call was missing on CancellationTokenSource in CimChildJobBase and TestConnectionCommand.

