### PR TITLE
Make the parameter 'args' no-nullable in the public `ConsoleHost` APIs

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -745,8 +745,8 @@ namespace Microsoft.PowerShell
                 }
                 else if (MatchSwitch(switchKey, "login", "l"))
                 {
-                    // This handles -Login on Windows only, where it does nothing.
-                    // On *nix, -Login is handled much earlier to improve startup performance.
+                    // On Windows, '-Login' does nothing.
+                    // On *nix, '-Login' is already handled much earlier to improve startup performance, so we do nothing here.
                 }
                 else if (MatchSwitch(switchKey, "noexit", "noe"))
                 {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleShell.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleShell.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PowerShell
         /// <param name="helpText">Help text for minishell. This is displayed on 'minishell -?'.</param>
         /// <param name="args">Commandline parameters specified by user.</param>
         /// <returns>An integer value which should be used as exit code for the process.</returns>
-        public static int Start(string? bannerText, string? helpText, string?[] args)
+        public static int Start(string? bannerText, string? helpText, string[] args)
         {
             return Start(InitialSessionState.CreateDefault2(), bannerText, helpText, args);
         }
@@ -31,7 +31,7 @@ namespace Microsoft.PowerShell
         /// <param name="helpText">Help text for the shell.</param>
         /// <param name="args">Commandline parameters specified by user.</param>
         /// <returns>An integer value which should be used as exit code for the process.</returns>
-        public static int Start(InitialSessionState initialSessionState, string? bannerText, string? helpText, string?[] args)
+        public static int Start(InitialSessionState initialSessionState, string? bannerText, string? helpText, string[] args)
         {
             if (initialSessionState == null)
             {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ManagedEntrance.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ManagedEntrance.cs
@@ -33,7 +33,7 @@ namespace Microsoft.PowerShell
         /// Length of the passed in argument array.
         /// </param>
         [Obsolete("Callers should now use UnmanagedPSEntry.Start(string[], int)", error: true)]
-        public static int Start(string consoleFilePath, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 2)]string?[] args, int argc)
+        public static int Start(string consoleFilePath, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 2)]string[] args, int argc)
         {
             return Start(args, argc);
         }
@@ -47,7 +47,7 @@ namespace Microsoft.PowerShell
         /// <param name="argc">
         /// Length of the passed in argument array.
         /// </param>
-        public static int Start([MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 1)]string?[] args, int argc)
+        public static int Start([MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 1)]string[] args, int argc)
         {
             if (args == null)
             {

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -2323,6 +2323,8 @@ function CleanupGeneratedSourceCode
         '[System.Management.Automation.Internal.ArchitectureSensitiveAttribute]'
         '[Microsoft.PowerShell.Commands.SelectStringCommand.FileinfoToStringAttribute]'
         '[System.Runtime.CompilerServices.IsReadOnlyAttribute]'
+        '[System.Runtime.CompilerServices.NullableContextAttribute('
+        '[System.Runtime.CompilerServices.NullableAttribute((byte)0)]'
         )
 
     $patternsToReplace = @(
@@ -2355,6 +2357,16 @@ function CleanupGeneratedSourceCode
             ApplyTo = "System.Management.Automation"
             Pattern = "Unable to resolve assembly 'Assembly(Name=System.Security.AccessControl"
             Replacement = "// Unable to resolve assembly 'Assembly(Name=System.Security.AccessControl"
+        },
+        @{
+            ApplyTo = "Microsoft.PowerShell.ConsoleHost"
+            Pattern = "[System.Runtime.CompilerServices.NullableAttribute((byte)2)]"
+            Replacement = "/* [System.Runtime.CompilerServices.NullableAttribute((byte)2)] */"
+        },
+        @{
+            ApplyTo = "Microsoft.PowerShell.ConsoleHost"
+            Pattern = "[System.Runtime.CompilerServices.NullableAttribute((byte)1)]"
+            Replacement = "/* [System.Runtime.CompilerServices.NullableAttribute((byte)1)] */"
         }
     )
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This is a follow-up on #11482
We actually don't expect `args` to contain `null` value in it. For example, the use of `args` in `GetSwitchKey` at [here](https://github.com/PowerShell/PowerShell/blob/master/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs#L592) indicates we are not expecting an element of `args` is `null`, and many other places like `ParseFile`.

/cc @iSazonov Maybe we should validate if `args` contains any `null` elements, maybe that's not necessary given it has been working fine so far, but either way, I'm deferring that to a separate PR.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
