### PR TITLE
Create warnings when UTF7 is specified as an encoding

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -606,7 +606,20 @@ namespace Microsoft.PowerShell.Commands
         [ArgumentToEncodingTransformationAttribute]
         [ArgumentEncodingCompletionsAttribute]
         [ValidateNotNullOrEmpty]
-        public Encoding Encoding { get; set; } = ClrFacade.GetDefaultEncoding();
+        public Encoding Encoding
+        {
+            get
+            {
+                return _encoding;
+            }
+            set
+            {
+                EncodingConversion.WarnIfObsolete(this, value);
+                _encoding = value;
+            }
+        }
+
+        private Encoding _encoding = ClrFacade.GetDefaultEncoding();
 
         /// <summary>
         /// Avoid writing out duplicate warning messages when there are one or more unspecified names.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -9,7 +9,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Management.Automation;
-using System.Management.Automation.Internal;
 using System.Text;
 
 using Dbg = System.Management.Automation.Diagnostics;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Management.Automation;
+using System.Management.Automation.Internal;
 using System.Text;
 
 using Dbg = System.Management.Automation.Diagnostics;
@@ -217,7 +218,20 @@ namespace Microsoft.PowerShell.Commands
         [ArgumentToEncodingTransformationAttribute]
         [ArgumentEncodingCompletionsAttribute]
         [ValidateNotNullOrEmpty]
-        public Encoding Encoding { get; set; } = ClrFacade.GetDefaultEncoding();
+        public Encoding Encoding
+        {
+            get
+            {
+                return _encoding;
+            }
+            set
+            {
+                EncodingConversion.WarnIfObsolete(this, value);
+                _encoding = value;
+            }
+        }
+
+        private Encoding _encoding = ClrFacade.GetDefaultEncoding();
 
         /// <summary>
         /// Gets or sets property that sets append parameter.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -223,6 +223,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 return _encoding;
             }
+
             set
             {
                 EncodingConversion.WarnIfObsolete(this, value);
@@ -611,6 +612,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 return _encoding;
             }
+
             set
             {
                 EncodingConversion.WarnIfObsolete(this, value);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-hex/Format-Hex.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-hex/Format-Hex.cs
@@ -71,7 +71,20 @@ namespace Microsoft.PowerShell.Commands
         [ArgumentToEncodingTransformationAttribute()]
         [ArgumentEncodingCompletionsAttribute]
         [ValidateNotNullOrEmpty]
-        public Encoding Encoding { get; set; } = ClrFacade.GetDefaultEncoding();
+        public Encoding Encoding
+        {
+            get
+            {
+                return _encoding;
+            }
+            set
+            {
+                EncodingConversion.WarnIfObsolete(this, value);
+                _encoding = value;
+            }
+        }
+
+        private Encoding _encoding = ClrFacade.GetDefaultEncoding();
 
         /// <summary>
         /// Gets or sets count of bytes to read from the input stream.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-file/Out-File.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-file/Out-File.cs
@@ -84,6 +84,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 return _encoding;
             }
+
             set
             {
                 EncodingConversion.WarnIfObsolete(this, value);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-file/Out-File.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-file/Out-File.cs
@@ -78,7 +78,20 @@ namespace Microsoft.PowerShell.Commands
         [ArgumentToEncodingTransformationAttribute()]
         [ArgumentEncodingCompletionsAttribute]
         [ValidateNotNullOrEmpty]
-        public Encoding Encoding { get; set; } = ClrFacade.GetDefaultEncoding();
+        public Encoding Encoding
+        {
+            get
+            {
+                return _encoding;
+            }
+            set
+            {
+                EncodingConversion.WarnIfObsolete(this, value);
+                _encoding = value;
+            }
+        }
+
+        private Encoding _encoding = ClrFacade.GetDefaultEncoding();
 
         /// <summary>
         /// Property that sets append parameter.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
@@ -82,6 +82,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 return _encoding;
             }
+
             set
             {
                 EncodingConversion.WarnIfObsolete(this, value);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
@@ -76,7 +76,20 @@ namespace Microsoft.PowerShell.Commands
         [ArgumentToEncodingTransformationAttribute()]
         [ArgumentEncodingCompletionsAttribute]
         [ValidateNotNullOrEmpty]
-        public Encoding Encoding { get; set; } = ClrFacade.GetDefaultEncoding();
+        public Encoding Encoding
+        {
+            get
+            {
+                return _encoding;
+            }
+            set
+            {
+                EncodingConversion.WarnIfObsolete(this, value);
+                _encoding = value;
+            }
+        }
+
+        private Encoding _encoding = ClrFacade.GetDefaultEncoding();
 
         #endregion Parameters
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -1349,7 +1349,20 @@ namespace Microsoft.PowerShell.Commands
         [ArgumentToEncodingTransformationAttribute()]
         [ArgumentEncodingCompletionsAttribute]
         [ValidateNotNullOrEmpty]
-        public Encoding Encoding { get; set; } = ClrFacade.GetDefaultEncoding();
+        public Encoding Encoding
+        {
+            get
+            {
+                return _encoding;
+            }
+            set
+            {
+                EncodingConversion.WarnIfObsolete(this, value);
+                _encoding = value;
+            }
+        }
+
+        private Encoding _encoding = ClrFacade.GetDefaultEncoding();
 
         /// <summary>
         /// Gets or sets the number of context lines to collect. If set to a

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -1355,6 +1355,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 return _encoding;
             }
+
             set
             {
                 EncodingConversion.WarnIfObsolete(this, value);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Send-MailMessage.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Send-MailMessage.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Management.Automation;
+using System.Management.Automation.Internal;
 using System.Net.Mail;
 using System.Text;
 
@@ -63,7 +64,20 @@ namespace Microsoft.PowerShell.Commands
         [ValidateNotNullOrEmpty]
         [ArgumentEncodingCompletionsAttribute]
         [ArgumentToEncodingTransformationAttribute]
-        public Encoding Encoding { get; set; } = Encoding.ASCII;
+        public Encoding Encoding
+        {
+            get
+            {
+                return _encoding;
+            }
+            set
+            {
+                EncodingConversion.WarnIfObsolete(this, value);
+                _encoding = value;
+            }
+        }
+
+        private Encoding _encoding = Encoding.ASCII;
 
         /// <summary>
         /// Gets or sets the address collection that contains the

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Send-MailMessage.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Send-MailMessage.cs
@@ -69,6 +69,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 return _encoding;
             }
+
             set
             {
                 EncodingConversion.WarnIfObsolete(this, value);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Send-MailMessage.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Send-MailMessage.cs
@@ -5,7 +5,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Management.Automation;
-using System.Management.Automation.Internal;
 using System.Net.Mail;
 using System.Text;
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/XmlCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/XmlCommands.cs
@@ -120,6 +120,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 return _encoding;
             }
+
             set
             {
                 EncodingConversion.WarnIfObsolete(this, value);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/XmlCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/XmlCommands.cs
@@ -114,7 +114,20 @@ namespace Microsoft.PowerShell.Commands
         [ArgumentToEncodingTransformationAttribute()]
         [ArgumentEncodingCompletionsAttribute]
         [ValidateNotNullOrEmpty]
-        public Encoding Encoding { get; set; } = ClrFacade.GetDefaultEncoding();
+        public Encoding Encoding
+        {
+            get
+            {
+                return _encoding;
+            }
+            set
+            {
+                EncodingConversion.WarnIfObsolete(this, value);
+                _encoding = value;
+            }
+        }
+
+        private Encoding _encoding = ClrFacade.GetDefaultEncoding();
 
         #endregion Command Line Parameters
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -6744,7 +6744,7 @@ namespace Microsoft.PowerShell.Commands
         /// </returns>
         public object GetContentReaderDynamicParameters(string path)
         {
-            return new FileSystemContentReaderDynamicParameters();
+            return new FileSystemContentReaderDynamicParameters(this);
         }
 
         /// <summary>
@@ -6878,7 +6878,7 @@ namespace Microsoft.PowerShell.Commands
         /// </returns>
         public object GetContentWriterDynamicParameters(string path)
         {
-            return new FileSystemContentWriterDynamicParameters();
+            return new FileSystemContentWriterDynamicParameters(this);
         }
 
         /// <summary>
@@ -7593,6 +7593,13 @@ namespace Microsoft.PowerShell.Commands
     /// </summary>
     public class FileSystemContentDynamicParametersBase
     {
+        internal FileSystemContentDynamicParametersBase(FileSystemProvider provider)
+        {
+            _provider = provider;
+        }
+
+        private FileSystemProvider _provider;
+
         /// <summary>
         /// Gets or sets the encoding method used when
         /// reading data from the file.
@@ -7610,6 +7617,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
+                if (value == System.Text.Encoding.UTF7)
+                {
+                    _provider.WriteWarning(PathUtilsStrings.Utf7EncodingObsolete);
+                }
                 _encoding = value;
                 // If an encoding was explicitly set, be sure to capture that.
                 WasStreamTypeSpecified = true;
@@ -7659,6 +7670,8 @@ namespace Microsoft.PowerShell.Commands
     /// </summary>
     public class FileSystemContentWriterDynamicParameters : FileSystemContentDynamicParametersBase
     {
+        internal FileSystemContentWriterDynamicParameters(FileSystemProvider provider) : base(provider) { }
+
         /// <summary>
         /// False to add a newline to the end of the output string, true if not.
         /// </summary>
@@ -7684,6 +7697,8 @@ namespace Microsoft.PowerShell.Commands
     /// </summary>
     public class FileSystemContentReaderDynamicParameters : FileSystemContentDynamicParametersBase
     {
+        internal FileSystemContentReaderDynamicParameters(FileSystemProvider provider) : base (provider) { }
+
         /// <summary>
         /// Gets or sets the delimiter to use when reading the file.  Custom delimiters
         /// may not be used when the file is opened with a "Byte" encoding.

--- a/src/System.Management.Automation/resources/PathUtilsStrings.resx
+++ b/src/System.Management.Automation/resources/PathUtilsStrings.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Utf7EncodingObsolete" xml:space="preserve">
+    <value>Encoding 'UTF-7' is obsolete, please use UTF-8.</value>
+  </data>
   <data name="UtilityFileExistsNoClobber" xml:space="preserve">
     <value>File {0} already exists and {1} was specified.</value>
   </data>

--- a/src/System.Management.Automation/utils/EncodingUtils.cs
+++ b/src/System.Management.Automation/utils/EncodingUtils.cs
@@ -63,6 +63,12 @@ namespace System.Management.Automation
             Encoding foundEncoding;
             if (encodingMap.TryGetValue(encoding, out foundEncoding))
             {
+                // Write a warning if using utf7 as it is obsolete in .NET5
+                if ( String.Compare(encoding, Utf7, StringComparison.OrdinalIgnoreCase) ==  0 )
+                {
+                    cmdlet.WriteWarning(PathUtilsStrings.Utf7EncodingObsolete);
+                }
+
                 return foundEncoding;
             }
 
@@ -81,7 +87,19 @@ namespace System.Management.Automation
 
             return null;
         }
+
+        /// <summary>
+        /// Warn if the encoding has been designated as obsolete
+        /// </summary>
+        internal static void WarnIfObsolete(Cmdlet cmdlet, Encoding encoding)
+        {
+            if (encoding == System.Text.Encoding.UTF7)
+            {
+                cmdlet.WriteWarning(PathUtilsStrings.Utf7EncodingObsolete);
+            }
+        }
     }
+
 
     /// <summary>
     /// To make it easier to specify -Encoding parameter, we add an ArgumentTransformationAttribute here.

--- a/src/System.Management.Automation/utils/EncodingUtils.cs
+++ b/src/System.Management.Automation/utils/EncodingUtils.cs
@@ -64,7 +64,7 @@ namespace System.Management.Automation
             if (encodingMap.TryGetValue(encoding, out foundEncoding))
             {
                 // Write a warning if using utf7 as it is obsolete in .NET5
-                if ( String.Compare(encoding, Utf7, StringComparison.OrdinalIgnoreCase) ==  0 )
+                if (string.Compare(encoding, Utf7, StringComparison.OrdinalIgnoreCase) == 0)
                 {
                     cmdlet.WriteWarning(PathUtilsStrings.Utf7EncodingObsolete);
                 }
@@ -89,8 +89,10 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Warn if the encoding has been designated as obsolete
+        /// Warn if the encoding has been designated as obsolete.
         /// </summary>
+        /// <param name="cmdlet">A cmdlet instance which is used to emit the warning.</param>
+        /// <param name="encoding">The encoding to check for obsolescence.</param>
         internal static void WarnIfObsolete(Cmdlet cmdlet, Encoding encoding)
         {
             if (encoding == System.Text.Encoding.UTF7)
@@ -99,7 +101,6 @@ namespace System.Management.Automation
             }
         }
     }
-
 
     /// <summary>
     /// To make it easier to specify -Encoding parameter, we add an ArgumentTransformationAttribute here.


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This addresses #13358 to emit a warning when UTF7 is specified as an encoding. This is due to it's obsolescence in .NET5

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [X] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/6509
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
