### PR TITLE
Replace StringCollection with generic List

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Diagnostics/GetCounterCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/GetCounterCommand.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -317,7 +316,7 @@ namespace Microsoft.PowerShell.Commands
         //
         private void ProcessListSetPerMachine(string machine)
         {
-            StringCollection counterSets = new StringCollection();
+            List<string> counterSets = new List<string>();
             uint res = _pdhHelper.EnumObjects(machine, ref counterSets);
             if (res != 0)
             {
@@ -330,7 +329,7 @@ namespace Microsoft.PowerShell.Commands
 
             CultureInfo culture = GetCurrentCulture();
             List<Tuple<char, char>> characterReplacementList = null;
-            StringCollection validPaths = new StringCollection();
+            List<string> validPaths = new List<string>();
 
             _cultureAndSpecialCharacterMap.TryGetValue(culture.Name, out characterReplacementList);
 
@@ -356,8 +355,8 @@ namespace Microsoft.PowerShell.Commands
                         continue;
                     }
 
-                    StringCollection counterSetCounters = new StringCollection();
-                    StringCollection counterSetInstances = new StringCollection();
+                    List<string> counterSetCounters = new List<string>();
+                    List<string> counterSetInstances = new List<string>();
 
                     res = _pdhHelper.EnumObjectItems(machine, counterSet, ref counterSetCounters, ref counterSetInstances);
                     if (res == PdhResults.PDH_ACCESS_DENIED)
@@ -444,7 +443,7 @@ namespace Microsoft.PowerShell.Commands
                 _cultureAndSpecialCharacterMap.TryGetValue(culture.Name, out characterReplacementList);
             }
 
-            StringCollection allExpandedPaths = new StringCollection();
+            List<string> allExpandedPaths = new List<string>();
             foreach (string path in paths)
             {
                 string localizedPath = path;
@@ -468,7 +467,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
 
-                StringCollection expandedPaths;
+                List<string> expandedPaths;
                 res = _pdhHelper.ExpandWildCardPath(localizedPath, out expandedPaths);
                 if (res != 0)
                 {

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/GetEventCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/GetEventCommand.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Eventing.Reader;
 using System.Globalization;
@@ -396,10 +395,10 @@ namespace Microsoft.PowerShell.Commands
         // Other private members and constants
         //
         private ResourceManager _resourceMgr = null;
-        private Dictionary<string, StringCollection> _providersByLogMap = new Dictionary<string, StringCollection>();
+        private Dictionary<string, List<string>> _providersByLogMap = new Dictionary<string, List<string>>();
 
-        private StringCollection _logNamesMatchingWildcard = null;
-        private StringCollection _resolvedPaths = new StringCollection();
+        private List<string> _logNamesMatchingWildcard = null;
+        private List<string> _resolvedPaths = new List<string>();
 
         private List<string> _accumulatedLogNames = new List<string>();
         private List<string> _accumulatedProviderNames = new List<string>();
@@ -771,7 +770,7 @@ namespace Microsoft.PowerShell.Commands
                 //
                 for (int i = 0; i < _path.Length; i++)
                 {
-                    StringCollection resolvedPaths = ValidateAndResolveFilePath(_path[i]);
+                    List<string> resolvedPaths = ValidateAndResolveFilePath(_path[i]);
                     foreach (string resolvedPath in resolvedPaths)
                     {
                         _resolvedPaths.Add(resolvedPath);
@@ -1169,7 +1168,7 @@ namespace Microsoft.PowerShell.Commands
                     {
                         foreach (object elt in (Array)hash[hashkey_path_lc])
                         {
-                            StringCollection resolvedPaths = ValidateAndResolveFilePath(elt.ToString());
+                            List<string> resolvedPaths = ValidateAndResolveFilePath(elt.ToString());
                             foreach (string resolvedPath in resolvedPaths)
                             {
                                 queriedLogsQueryMap.Add(filePrefix + resolvedPath.ToLowerInvariant(),
@@ -1181,7 +1180,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                     else
                     {
-                        StringCollection resolvedPaths = ValidateAndResolveFilePath(hash[hashkey_path_lc].ToString());
+                        List<string> resolvedPaths = ValidateAndResolveFilePath(hash[hashkey_path_lc].ToString());
                         foreach (string resolvedPath in resolvedPaths)
                         {
                             queriedLogsQueryMap.Add(filePrefix + resolvedPath.ToLowerInvariant(),
@@ -1752,9 +1751,9 @@ namespace Microsoft.PowerShell.Commands
         // Writes non-terminating errors for invalid paths
         // and returns an empty collection.
         //
-        private StringCollection ValidateAndResolveFilePath(string path)
+        private List<string> ValidateAndResolveFilePath(string path)
         {
-            StringCollection retColl = new StringCollection();
+            List<string> retColl = new List<string>();
 
             Collection<PathInfo> resolvedPathSubset = null;
             try
@@ -1872,7 +1871,7 @@ namespace Microsoft.PowerShell.Commands
         // and will may produce garbage if the _filterXPath expression provided by the user is invalid.
         // However, we are relying on the EventLog XPath parser to reject the garbage later on.
         //
-        private string AddProviderPredicatesToFilter(StringCollection providers)
+        private string AddProviderPredicatesToFilter(List<string> providers)
         {
             if (providers.Count == 0)
             {
@@ -1910,7 +1909,7 @@ namespace Microsoft.PowerShell.Commands
         // "System/Provider[@Name='a' or @Name='b']"
         // for all provider names specified in the "providers" argument.
         //
-        private string BuildProvidersPredicate(StringCollection providers)
+        private string BuildProvidersPredicate(List<string> providers)
         {
             if (providers.Count == 0)
             {
@@ -2012,7 +2011,7 @@ namespace Microsoft.PowerShell.Commands
 
                         WriteVerbose(string.Format(CultureInfo.InvariantCulture, _resourceMgr.GetString("ProviderLogLink"), providerName, logLink.LogName));
 
-                        StringCollection provColl = new StringCollection();
+                        List<string> provColl = new List<string>();
                         provColl.Add(providerName.ToLowerInvariant());
 
                         _providersByLogMap.Add(logLink.LogName.ToLowerInvariant(), provColl);
@@ -2022,7 +2021,7 @@ namespace Microsoft.PowerShell.Commands
                         //
                         // Log is there: add provider, if needed
                         //
-                        StringCollection coll = _providersByLogMap[logLink.LogName.ToLowerInvariant()];
+                        List<string> coll = _providersByLogMap[logLink.LogName.ToLowerInvariant()];
 
                         if (!coll.Contains(providerName.ToLowerInvariant()))
                         {
@@ -2054,7 +2053,7 @@ namespace Microsoft.PowerShell.Commands
         {
             if (_logNamesMatchingWildcard == null)
             {
-                _logNamesMatchingWildcard = new StringCollection();
+                _logNamesMatchingWildcard = new List<string>();
             }
             else
             {

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/PdhHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/PdhHelper.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
@@ -426,12 +425,12 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
         private Dictionary<string, CounterHandleNInstance> _consumerPathToHandleAndInstanceMap = new Dictionary<string, CounterHandleNInstance>();
 
         /// <summary>
-        /// A helper reading in a Unicode string with embedded NULLs and splitting it into a StringCollection.
+        /// A helper reading in a Unicode string with embedded NULLs and splitting it into a List.
         /// </summary>
         /// <param name="strNative"></param>
         /// <param name="strSize"></param>
         /// <param name="strColl"></param>
-        private void ReadPdhMultiString(ref IntPtr strNative, Int32 strSize, ref StringCollection strColl)
+        private void ReadPdhMultiString(ref IntPtr strNative, Int32 strSize, ref List<string> strColl)
         {
             Debug.Assert(strSize >= 2);
             int offset = 0;
@@ -534,7 +533,7 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
             return res;
         }
 
-        public uint ConnectToDataSource(StringCollection blgFileNames)
+        public uint ConnectToDataSource(List<string> blgFileNames)
         {
             if (blgFileNames.Count == 1)
             {
@@ -609,7 +608,7 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
             return PdhSetQueryTimeRange(_hQuery, ref pTimeInfo);
         }
 
-        public uint EnumBlgFilesMachines(ref StringCollection machineNames)
+        public uint EnumBlgFilesMachines(ref List<string> machineNames)
         {
             IntPtr MachineListTcharSizePtr = new IntPtr(0);
             uint res = PdhHelper.PdhEnumMachinesH(_hDataSource, IntPtr.Zero, ref MachineListTcharSizePtr);
@@ -637,7 +636,7 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
             return res;
         }
 
-        public uint EnumObjects(string machineName, ref StringCollection objectNames)
+        public uint EnumObjects(string machineName, ref List<string> objectNames)
         {
             IntPtr pBufferSize = new IntPtr(0);
             uint res = PdhEnumObjectsH(_hDataSource, machineName, IntPtr.Zero, ref pBufferSize, PerfDetail.PERF_DETAIL_WIZARD, false);
@@ -665,7 +664,7 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
             return res;
         }
 
-        public uint EnumObjectItems(string machineName, string objectName, ref StringCollection counterNames, ref StringCollection instanceNames)
+        public uint EnumObjectItems(string machineName, string objectName, ref List<string> counterNames, ref List<string> instanceNames)
         {
             IntPtr pCounterBufferSize = new IntPtr(0);
             IntPtr pInstanceBufferSize = new IntPtr(0);
@@ -745,11 +744,11 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
             return res;
         }
 
-        public uint GetValidPathsFromFiles(ref StringCollection validPaths)
+        public uint GetValidPathsFromFiles(ref List<string> validPaths)
         {
             Debug.Assert(_hDataSource != null && !_hDataSource.IsInvalid, "Call ConnectToDataSource before GetValidPathsFromFiles");
 
-            StringCollection machineNames = new StringCollection();
+            List<string> machineNames = new List<string>();
             uint res = this.EnumBlgFilesMachines(ref machineNames);
             if (res != 0)
             {
@@ -758,7 +757,7 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
 
             foreach (string machine in machineNames)
             {
-                StringCollection counterSets = new StringCollection();
+                List<string> counterSets = new List<string>();
                 res = this.EnumObjects(machine, ref counterSets);
                 if (res != 0)
                 {
@@ -769,8 +768,8 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
                 {
                     // Console.WriteLine("Counter set " + counterSet);
 
-                    StringCollection counterSetCounters = new StringCollection();
-                    StringCollection counterSetInstances = new StringCollection();
+                    List<string> counterSetCounters = new List<string>();
+                    List<string> counterSetInstances = new List<string>();
 
                     res = this.EnumObjectItems(machine, counterSet, ref counterSetCounters, ref counterSetInstances);
                     if (res != 0)
@@ -1056,9 +1055,9 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
 
         public uint GetValidPaths(string machineName,
                                    string objectName,
-                                   ref StringCollection counters,
-                                   ref StringCollection instances,
-                                   ref StringCollection validPaths)
+                                   ref List<string> counters,
+                                   ref List<string> instances,
+                                   ref List<string> validPaths)
         {
             uint res = 0;
 
@@ -1097,7 +1096,7 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
             return res;
         }
 
-        public uint AddCounters(ref StringCollection validPaths, bool bFlushOldCounters)
+        public uint AddCounters(ref List<string> validPaths, bool bFlushOldCounters)
         {
             Debug.Assert(_hQuery != null && !_hQuery.IsInvalid);
 
@@ -1281,9 +1280,9 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
             return res;
         }
 
-        public uint ExpandWildCardPath(string path, out StringCollection expandedPaths)
+        public uint ExpandWildCardPath(string path, out List<string> expandedPaths)
         {
-            expandedPaths = new StringCollection();
+            expandedPaths = new List<string>();
             IntPtr pcchPathListLength = new IntPtr(0);
 
             uint res = PdhExpandWildCardPathH(_hDataSource,

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ParsePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ParsePathCommand.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Collections.Specialized;
 using System.Management.Automation;
 using System.Management.Automation.Internal;
 
@@ -184,7 +184,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void ProcessRecord()
         {
-            StringCollection pathsToParse = new StringCollection();
+            List<string> pathsToParse = new List<string>();
 
             if (Resolve)
             {

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Management.Automation;
 using System.Management.Automation.Internal;
 
@@ -1117,33 +1116,42 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
             internal static string[] GetProperties(ListViewEntry lve)
             {
-                StringCollection props = new StringCollection();
-                foreach (ListViewField lvf in lve.listViewFieldList)
+                int count = lve.listViewFieldList.Count;
+
+                if (count == 0)
                 {
-                    props.Add(lvf.label ?? lvf.propertyName);
+                    return null;
                 }
 
-                if (props.Count == 0)
-                    return null;
-                string[] retVal = new string[props.Count];
-                props.CopyTo(retVal, 0);
-                return retVal;
+                string[] props = new string[count];
+
+                for (int i = 0; i < count; ++i)
+                {
+                    ListViewField lvf = lve.listViewFieldList[i];
+                    props[i] = lvf.label ?? lvf.propertyName;
+                }
+
+                return props;
             }
 
             internal static string[] GetValues(ListViewEntry lve)
             {
-                StringCollection vals = new StringCollection();
+                int count = lve.listViewFieldList.Count;
 
-                foreach (ListViewField lvf in lve.listViewFieldList)
+                if (count == 0)
                 {
-                    vals.Add(lvf.formatPropertyField.propertyValue);
+                    return null;
                 }
 
-                if (vals.Count == 0)
-                    return null;
-                string[] retVal = new string[vals.Count];
-                vals.CopyTo(retVal, 0);
-                return retVal;
+                string[] vals = new string[count];
+
+                for (int i = 0; i < count; ++i)
+                {
+                    ListViewField lvf = lve.listViewFieldList[i];
+                    vals[i] = lvf.formatPropertyField.propertyValue;
+                }
+
+                return vals;
             }
 
             /// <summary>

--- a/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Collections.Specialized;
 using System.Globalization;
 using System.Management.Automation.Internal;
 using System.Text;
@@ -168,7 +167,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             // error checking on invalid values
 
             // generate the lines using the computed widths
-            StringCollection sc = StringManipulationHelper.GenerateLines(_lo.DisplayCells, _stringBuffer.ToString(),
+            List<string> list = StringManipulationHelper.GenerateLines(_lo.DisplayCells, _stringBuffer.ToString(),
                                         firstLineWidth, followingLinesWidth);
 
             // compute padding
@@ -187,7 +186,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
             // now write the lines on the screen
             bool firstLine = true;
-            foreach (string s in sc)
+            foreach (string s in list)
             {
                 if (firstLine)
                 {
@@ -388,7 +387,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             yield return result;
         }
 
-        internal static StringCollection GenerateLines(DisplayCells displayCells, string val, int firstLineLen, int followingLinesLen)
+        internal static List<string> GenerateLines(DisplayCells displayCells, string val, int firstLineLen, int followingLinesLen)
         {
             if (s_cultureCollection.Contains(CultureInfo.CurrentCulture.TwoLetterISOLanguageName))
             {
@@ -400,9 +399,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             }
         }
 
-        private static StringCollection GenerateLinesWithoutWordWrap(DisplayCells displayCells, string val, int firstLineLen, int followingLinesLen)
+        private static List<string> GenerateLinesWithoutWordWrap(DisplayCells displayCells, string val, int firstLineLen, int followingLinesLen)
         {
-            StringCollection retVal = new StringCollection();
+            List<string> retVal = new List<string>();
 
             if (string.IsNullOrEmpty(val))
             {
@@ -483,7 +482,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         private sealed class SplitLinesAccumulator
         {
-            internal SplitLinesAccumulator(StringCollection retVal, int firstLineLen, int followingLinesLen)
+            internal SplitLinesAccumulator(List<string> retVal, int firstLineLen, int followingLinesLen)
             {
                 _retVal = retVal;
                 _firstLineLen = firstLineLen;
@@ -510,15 +509,15 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 }
             }
 
-            private StringCollection _retVal;
+            private List<string> _retVal;
             private bool _addedFirstLine;
             private int _firstLineLen;
             private int _followingLinesLen;
         }
 
-        private static StringCollection GenerateLinesWithWordWrap(DisplayCells displayCells, string val, int firstLineLen, int followingLinesLen)
+        private static List<string> GenerateLinesWithWordWrap(DisplayCells displayCells, string val, int firstLineLen, int followingLinesLen)
         {
-            StringCollection retVal = new StringCollection();
+            List<string> retVal = new List<string>();
 
             if (string.IsNullOrEmpty(val))
             {

--- a/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
@@ -167,7 +167,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             // error checking on invalid values
 
             // generate the lines using the computed widths
-            List<string> list = StringManipulationHelper.GenerateLines(_lo.DisplayCells, _stringBuffer.ToString(),
+            List<string> lines = StringManipulationHelper.GenerateLines(_lo.DisplayCells, _stringBuffer.ToString(),
                                         firstLineWidth, followingLinesWidth);
 
             // compute padding
@@ -186,7 +186,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
             // now write the lines on the screen
             bool firstLine = true;
-            foreach (string s in list)
+            foreach (string s in lines)
             {
                 if (firstLine)
                 {

--- a/src/System.Management.Automation/FormatAndOutput/common/FormattingObjectsDeserializer.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormattingObjectsDeserializer.cs
@@ -176,7 +176,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 return null;
 
             // copy to string collection, since, a priori, we do not know the length
-            StringCollection temp = new StringCollection ();
+            List<string> temp = new List<string>();
 
             foreach (string s in e)
                 temp.Add (s);

--- a/src/System.Management.Automation/FormatAndOutput/common/ListWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ListWriter.cs
@@ -207,21 +207,21 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             int fieldCellCount = _columnWidth - _propertyLabelsDisplayLength;
 
             // split the lines
-            List<string> list = StringManipulationHelper.GenerateLines(lo.DisplayCells, line, fieldCellCount, fieldCellCount);
+            List<string> lines = StringManipulationHelper.GenerateLines(lo.DisplayCells, line, fieldCellCount, fieldCellCount);
 
             // padding to use in the lines after the first
             string padding = StringUtil.Padding(_propertyLabelsDisplayLength);
 
             // display the string collection
-            for (int k = 0; k < list.Count; k++)
+            for (int k = 0; k < lines.Count; k++)
             {
                 if (k == 0)
                 {
-                    lo.WriteLine(prependString + list[k]);
+                    lo.WriteLine(prependString + lines[k]);
                 }
                 else
                 {
-                    lo.WriteLine(padding + list[k]);
+                    lo.WriteLine(padding + lines[k]);
                 }
             }
         }

--- a/src/System.Management.Automation/FormatAndOutput/common/ListWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ListWriter.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Specialized;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Management.Automation.Internal;
 
@@ -207,21 +207,21 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             int fieldCellCount = _columnWidth - _propertyLabelsDisplayLength;
 
             // split the lines
-            StringCollection sc = StringManipulationHelper.GenerateLines(lo.DisplayCells, line, fieldCellCount, fieldCellCount);
+            List<string> list = StringManipulationHelper.GenerateLines(lo.DisplayCells, line, fieldCellCount, fieldCellCount);
 
             // padding to use in the lines after the first
             string padding = StringUtil.Padding(_propertyLabelsDisplayLength);
 
             // display the string collection
-            for (int k = 0; k < sc.Count; k++)
+            for (int k = 0; k < list.Count; k++)
             {
                 if (k == 0)
                 {
-                    lo.WriteLine(prependString + sc[k]);
+                    lo.WriteLine(prependString + list[k]);
                 }
                 else
                 {
-                    lo.WriteLine(padding + sc[k]);
+                    lo.WriteLine(padding + list[k]);
                 }
             }
         }

--- a/src/System.Management.Automation/FormatAndOutput/common/OutputManager.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/OutputManager.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Management.Automation;
 using System.Management.Automation.Internal;
 
@@ -185,7 +184,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             /// <summary>
             /// Ordered list of ETS type names this object is handling.
             /// </summary>
-            private StringCollection _applicableTypes = new StringCollection();
+            private List<string> _applicableTypes = new List<string>();
         }
 
         /// <summary>

--- a/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
@@ -267,17 +267,20 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 }
 
                 // obtain a set of tokens for each field
-                stringListArray[k] = GenerateMultiLineRowField(values[validColumnArray[k]], _si.columnInfo[validColumnArray[k]].width,
-                    alignment[validColumnArray[k]], ds, addPadding);
+                int pos = validColumnArray[k];
+                List<string> stringList = GenerateMultiLineRowField(
+                    values[pos], _si.columnInfo[pos].width, alignment[pos], ds, addPadding);
+
+                stringListArray[k] = stringList;
 
                 // NOTE: the following padding operations assume that we
                 // pad with a blank (or any character that ALWAYS maps to a single screen cell
                 if (k > 0)
                 {
                     // skipping the first ones, add a separator for concatenation
-                    for (int j = 0; j < stringListArray[k].Count; j++)
+                    for (int j = 0; j < stringList.Count; j++)
                     {
-                        stringListArray[k][j] = StringUtil.Padding(ScreenInfo.separatorCharacterCount) + stringListArray[k][j];
+                        stringList[j] = StringUtil.Padding(ScreenInfo.separatorCharacterCount) + stringList[j];
                     }
                 }
                 else
@@ -285,9 +288,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     // add indentation padding if needed
                     if (_startColumn > 0)
                     {
-                        for (int j = 0; j < stringListArray[k].Count; j++)
+                        for (int j = 0; j < stringList.Count; j++)
                         {
-                            stringListArray[k][j] = StringUtil.Padding(_startColumn) + stringListArray[k][j];
+                            stringList[j] = StringUtil.Padding(_startColumn) + stringList[j];
                         }
                     }
                 }

--- a/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
@@ -256,11 +256,12 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             }
 
             List<string>[] stringListArray = new List<string>[validColumnCount];
+            int length = stringListArray.Length;
             bool addPadding = true;
-            for (int k = 0; k < stringListArray.Length; k++)
+            for (int k = 0; k < length; k++)
             {
                 // for the last column, don't pad it with trailing spaces
-                if (k == stringListArray.Length - 1)
+                if (k == length - 1)
                 {
                     addPadding = false;
                 }
@@ -295,7 +296,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             // now we processed all the rows columns and we need to find the cell that occupies the most
             // rows
             int screenRows = 0;
-            for (int k = 0; k < stringListArray.Length; k++)
+            for (int k = 0; k < length; k++)
             {
                 if (stringListArray[k].Count > screenRows)
                     screenRows = stringListArray[k].Count;
@@ -314,7 +315,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             System.Span<int> lastColWithContent = screenRows <= OutCommandInner.StackAllocThreshold ? stackalloc int[screenRows] : new int[screenRows];
             for (int row = 0; row < screenRows; row++)
             {
-                for (int col = 0; col < stringListArray.Length; col++)
+                for (int col = 0; col < length; col++)
                 {
                     if (stringListArray[col].Count > row)
                     {
@@ -324,12 +325,12 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             }
 
             // add padding for the columns that are shorter
-            for (int col = 0; col < stringListArray.Length; col++)
+            for (int col = 0; col < length; col++)
             {
                 int paddingBlanks = 0;
 
                 // don't pad if last column
-                if (col < stringListArray.Length - 1)
+                if (col < length - 1)
                 {
                     paddingBlanks = _si.columnInfo[validColumnArray[col]].width;
                     if (col > 0)
@@ -366,7 +367,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             {
                 StringBuilder sb = new StringBuilder();
                 // for a given row, walk the columns
-                for (int col = 0; col < stringListArray.Length; col++)
+                for (int col = 0; col < length; col++)
                 {
                     // if the column is the last column with content, we need to trim trailing whitespace, unless there is only one row
                     if (col == lastColWithContent[row] && screenRows > 1)
@@ -387,15 +388,15 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         private List<string> GenerateMultiLineRowField(string val, int k, int alignment, DisplayCells dc, bool addPadding)
         {
-            List<string> lines = StringManipulationHelper.GenerateLines(dc, val,
-                                        _si.columnInfo[k].width, _si.columnInfo[k].width);
+            int width = _si.columnInfo[k].width;
+            List<string> lines = StringManipulationHelper.GenerateLines(dc, val, width, width);
             if (addPadding || alignment == TextAlignment.Right || alignment == TextAlignment.Center)
             {
                 // if length is shorter, do some padding
                 for (int col = 0; col < lines.Count; col++)
                 {
-                    if (dc.Length(lines[col]) < _si.columnInfo[k].width)
-                        lines[col] = GenerateRowField(lines[col], _si.columnInfo[k].width, alignment, dc, addPadding);
+                    if (dc.Length(lines[col]) < width)
+                        lines[col] = GenerateRowField(lines[col], width, alignment, dc, addPadding);
                 }
             }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Management.Automation.Internal;
 using System.Text;
 
@@ -256,7 +255,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 return null;
             }
 
-            StringCollection[] scArray = new StringCollection[validColumnCount];
+            List<string>[] scArray = new List<string>[validColumnCount];
             bool addPadding = true;
             for (int k = 0; k < scArray.Length; k++)
             {
@@ -386,9 +385,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return rows;
         }
 
-        private StringCollection GenerateMultiLineRowField(string val, int k, int alignment, DisplayCells dc, bool addPadding)
+        private List<string> GenerateMultiLineRowField(string val, int k, int alignment, DisplayCells dc, bool addPadding)
         {
-            StringCollection sc = StringManipulationHelper.GenerateLines(dc, val,
+            List<string> sc = StringManipulationHelper.GenerateLines(dc, val,
                                         _si.columnInfo[k].width, _si.columnInfo[k].width);
             if (addPadding || alignment == TextAlignment.Right || alignment == TextAlignment.Center)
             {

--- a/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
@@ -267,7 +267,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 }
 
                 // obtain a set of tokens for each field
-                stringListArray[k] = GenerateMultiLineRowField(values[validColumnArray[k]], validColumnArray[k],
+                stringListArray[k] = GenerateMultiLineRowField(values[validColumnArray[k]], _si.columnInfo[validColumnArray[k]].width,
                     alignment[validColumnArray[k]], ds, addPadding);
 
                 // NOTE: the following padding operations assume that we
@@ -386,9 +386,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return rows;
         }
 
-        private List<string> GenerateMultiLineRowField(string val, int k, int alignment, DisplayCells dc, bool addPadding)
+        private static List<string> GenerateMultiLineRowField(string val, int width, int alignment, DisplayCells dc, bool addPadding)
         {
-            int width = _si.columnInfo[k].width;
             List<string> lines = StringManipulationHelper.GenerateLines(dc, val, width, width);
             if (addPadding || alignment == TextAlignment.Right || alignment == TextAlignment.Center)
             {

--- a/src/System.Management.Automation/FormatAndOutput/out-console/ConsoleLineOutput.cs
+++ b/src/System.Management.Automation/FormatAndOutput/out-console/ConsoleLineOutput.cs
@@ -6,12 +6,12 @@
 //#define TEST_MULTICELL_ON_SINGLE_CELL_LOCALE
 
 using System;
-using System.Collections.Specialized;
 using System.Management.Automation;
 using System.Management.Automation.Internal;
 using System.Management.Automation.Host;
 
 using Dbg = System.Management.Automation.Diagnostics;
+using System.Collections.Generic;
 
 // interfaces for host interaction
 
@@ -550,7 +550,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             /// <summary>
             /// Cached string(s) valid during a sequence of ComputePromptLines()/PromptUser()
             /// </summary>
-            private StringCollection _actualPrompt;
+            private List<string> _actualPrompt;
 
             /// <summary>
             /// Prompt string as passed at initialization.


### PR DESCRIPTION
# PR Summary

* Replace `StringCollection` with `List<string>`.
* Replace `StringCollection` with `string[]` when length is known.
* Rename variables for clarity.
* Refactor `GenerateMultiLineRowField` as static method.
* Cache loop invariant integers.

Changes not made in the following:
`src\System.Management.Automation\engine\LanguagePrimitives.cs`: complex call hierarchy
`src\Microsoft.PowerShell.Commands.Diagnostics\CounterSet.cs`: parameter in public API

## PR Context

Performance using the generic `List<string>` is much better than using the non-generic `StringCollection`.

See https://github.com/PowerShell/PowerShell/pull/13425#issuecomment-673180364 for a benchmark.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [NA] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [NA] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [NA] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [NA] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [NA] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [NA] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
