### PR TITLE
Change `Add-Type -OutputType` to not support `ConsoleApplication` and `WindowsApplication`

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -551,7 +551,21 @@ namespace Microsoft.PowerShell.Commands
             {
                 ThrowTerminatingError(
                     new ErrorRecord(
-                        new PSNotSupportedException(AddTypeStrings.CannotDefineNewType), "CannotDefineNewType", ErrorCategory.PermissionDenied, null));
+                        new PSNotSupportedException(AddTypeStrings.CannotDefineNewType),
+                        nameof(AddTypeStrings.CannotDefineNewType),
+                        ErrorCategory.PermissionDenied,
+                        targetObject: null));
+            }
+
+            // 'ConsoleApplication' and 'WindowsApplication' types are currently not working in .NET Core
+            if (OutputType != OutputAssemblyType.Library)
+            {
+                ThrowTerminatingError(
+                    new ErrorRecord(
+                        new PSNotSupportedException(AddTypeStrings.AssemblyTypeNotSupported),
+                        nameof(AddTypeStrings.AssemblyTypeNotSupported),
+                        ErrorCategory.NotImplemented,
+                        targetObject: OutputType));
             }
         }
 
@@ -890,12 +904,9 @@ namespace Microsoft.PowerShell.Commands
             {
                 case OutputAssemblyType.Library:
                     return OutputKind.DynamicallyLinkedLibrary;
-                case OutputAssemblyType.ConsoleApplication:
-                    return OutputKind.ConsoleApplication;
-                case OutputAssemblyType.WindowsApplication:
-                    return OutputKind.WindowsApplication;
+
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(outputType));
+                    throw PSTraceSource.NewNotSupportedException();
             }
         }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/AddTypeStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/AddTypeStrings.resx
@@ -165,4 +165,7 @@
   <data name="ReferenceAssemblyIgnored" xml:space="preserve">
     <value>The specified reference assembly '{0}' is unnecessary and ignored.</value>
   </data>
+  <data name="AssemblyTypeNotSupported" xml:space="preserve">
+    <value>Both the assembly types 'ConsoleApplication' and 'WindowsApplication' are not currently supported.</value>
+  </data>
 </root>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Type.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Type.Tests.ps1
@@ -246,4 +246,12 @@ public class AttributeTest$guid : PSCmdlet
         param ($assemblyName, $errorid)
         { Add-Type -AssemblyName $assemblyName } | Should -Throw -ErrorId $errorid
     }
+
+    It "Throw terminating error when '-OutputType' is '<outputType>'" -TestCases @(
+        @{ outputType = 'ConsoleApplication' }
+        @{ outputType = 'WindowsApplication' }
+    ) {
+        param($outputType)
+        { Add-Type -TypeDefinition "Hello" -OutputType $outputType } | Should -Throw -ErrorId 'AssemblyTypeNotSupported,Microsoft.PowerShell.Commands.AddTypeCommand'
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Related issue: https://github.com/PowerShell/PowerShell/issues/13344
The output assembly type `ConsoleApplication` and `WindowsApplication` doesn't work with `Add-Type` today.
Per the conclusion of the powershell committee, this PR changes `Add-Type -OutputType` to throw terminating error when either `ConsoleApplication` or `WindowsApplication` is used.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/6499
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
