### PR TITLE
Add null check for args in CommandLineParser

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -700,6 +700,14 @@ namespace Microsoft.PowerShell
                 throw new InvalidOperationException("This instance has already been used. Create a new instance.");
             }
 
+            for (int i = 0; i < args.Length; i++)
+            {
+                if (args[i] is null)
+                {
+                    throw new ArgumentNullException("The 'args' array contains a null element.");
+                }
+            }
+
             // Indicates that we've called this method on this instance, and that when it's done, the state variables
             // will reflect the parse.
             _dirty = true;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -704,7 +704,7 @@ namespace Microsoft.PowerShell
             {
                 if (args[i] is null)
                 {
-                    throw new ArgumentNullException("The 'args' array contains a null element.");
+                    throw new ArgumentNullException(nameof(args), "The specified arguments should not contain null elements.");
                 }
             }
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -704,7 +704,7 @@ namespace Microsoft.PowerShell
             {
                 if (args[i] is null)
                 {
-                    throw new ArgumentNullException(nameof(args), "The specified arguments should not contain null elements.");
+                    throw new ArgumentNullException(nameof(args), CommandLineParameterParserStrings.NullElementInArgs);
                 }
             }
 

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/CommandLineParameterParserStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/CommandLineParameterParserStrings.resx
@@ -219,4 +219,7 @@ Valid formats are:
   <data name="STANotImplemented" xml:space="preserve">
     <value>Parameter -STA is not supported on this platform.</value>
   </data>
+  <data name="NullElementInArgs" xml:space="preserve">
+    <value>The specified arguments should not contain null elements.</value>
+  </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/CommandLineParameterParserStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/CommandLineParameterParserStrings.resx
@@ -220,6 +220,6 @@ Valid formats are:
     <value>Parameter -STA is not supported on this platform.</value>
   </data>
   <data name="NullElementInArgs" xml:space="preserve">
-    <value>The specified arguments should not contain null elements.</value>
+    <value>The specified arguments must not contain null elements.</value>
   </data>
 </root>

--- a/test/xUnit/csharp/test_CommandLineParser.cs
+++ b/test/xUnit/csharp/test_CommandLineParser.cs
@@ -66,6 +66,15 @@ namespace PSTests.Parallel
         }
 
         [Theory]
+        [InlineData("arg1", null, "arg3")]
+        public static void Test_ARGS_With_Null(params string[] commandLine)
+        {
+            var cpp = new CommandLineParameterParser();
+
+            Assert.Throws<System.ArgumentNullException>(() => cpp.Parse(commandLine));
+        }
+
+        [Theory]
         [InlineData("noexistfilename")]
         public static void TestDefaultParameterIsFileName_Not_Exist(params string[] commandLine)
         {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Throw if `args` array contains a null.

## PR Context

https://github.com/PowerShell/PowerShell/pull/13429#issuecomment-673884732

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
