### PR TITLE
Fix test hooks for `CommandLineParameterParser`

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -246,6 +246,7 @@ namespace Microsoft.PowerShell
             }
         }
 
+#if !UNIX
         internal ProcessWindowStyle? WindowStyle
         {
             get
@@ -254,6 +255,7 @@ namespace Microsoft.PowerShell
                 return _windowStyle;
             }
         }
+#endif
 
         internal bool ShowBanner
         {
@@ -1346,9 +1348,9 @@ namespace Microsoft.PowerShell
         private string? _executionPolicy;
         private string? _settingsFile;
         private string? _workingDirectory;
-        private ProcessWindowStyle? _windowStyle;
 
 #if !UNIX
+        private ProcessWindowStyle? _windowStyle;
         private bool _removeWorkingDirectoryTrailingCharacter = false;
 #endif
     }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -169,7 +169,7 @@ namespace Microsoft.PowerShell
             return maxLength - Path.GetTempPath().Length;
         }
 
-        internal bool? TestHookConsoleInputRedirected;
+        internal bool? InputRedirectedTestHook;
 
         private static readonly string[] s_validParameters = {
             "sta",
@@ -209,6 +209,7 @@ namespace Microsoft.PowerShell
         }
 
         #region Internal properties
+
         internal bool AbortStartup
         {
             get
@@ -242,6 +243,15 @@ namespace Microsoft.PowerShell
             {
                 AssertArgumentsParsed();
                 return _wasCommandEncoded;
+            }
+        }
+
+        internal ProcessWindowStyle? WindowStyle
+        {
+            get
+            {
+                AssertArgumentsParsed();
+                return _windowStyle;
             }
         }
 
@@ -846,9 +856,7 @@ namespace Microsoft.PowerShell
 
                     try
                     {
-                        ProcessWindowStyle style = (ProcessWindowStyle)LanguagePrimitives.ConvertTo(
-                            args[i], typeof(ProcessWindowStyle), CultureInfo.InvariantCulture);
-                        ConsoleControl.SetConsoleMode(style);
+                        _windowStyle = LanguagePrimitives.ConvertTo<ProcessWindowStyle>(args[i]);
                     }
                     catch (PSInvalidCastException e)
                     {
@@ -1234,7 +1242,7 @@ namespace Microsoft.PowerShell
                     return false;
                 }
 
-                if (TestHookConsoleInputRedirected.HasValue ? !TestHookConsoleInputRedirected.Value : !Console.IsInputRedirected)
+                if (InputRedirectedTestHook.HasValue ? !InputRedirectedTestHook.Value : !Console.IsInputRedirected)
                 {
                     SetCommandLineError(CommandLineParameterParserStrings.StdinNotRedirected, showHelp: true);
                     return false;
@@ -1338,6 +1346,7 @@ namespace Microsoft.PowerShell
         private string? _executionPolicy;
         private string? _settingsFile;
         private string? _workingDirectory;
+        private ProcessWindowStyle? _windowStyle;
 
 #if !UNIX
         private bool _removeWorkingDirectoryTrailingCharacter = false;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -271,6 +271,11 @@ namespace Microsoft.PowerShell
         {
             s_cpp.Parse(args);
 
+            if (s_cpp.WindowStyle.HasValue)
+            {
+                ConsoleControl.SetConsoleMode(s_cpp.WindowStyle.Value);
+            }
+
             if (s_cpp.SettingsFile is not null)
             {
                 PowerShellConfig.Instance.SetSystemConfigFilePath(s_cpp.SettingsFile);

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -271,10 +271,12 @@ namespace Microsoft.PowerShell
         {
             s_cpp.Parse(args);
 
+#if !UNIX
             if (s_cpp.WindowStyle.HasValue)
             {
                 ConsoleControl.SetConsoleMode(s_cpp.WindowStyle.Value);
             }
+#endif
 
             if (s_cpp.SettingsFile is not null)
             {

--- a/test/xUnit/csharp/test_CommandLineParser.cs
+++ b/test/xUnit/csharp/test_CommandLineParser.cs
@@ -475,7 +475,7 @@ namespace PSTests.Parallel
         {
             var cpp = new CommandLineParameterParser();
 
-            cpp.TestHookConsoleInputRedirected = false;
+            cpp.InputRedirectedTestHook = false;
 
             cpp.Parse(commandLine);
 
@@ -512,7 +512,7 @@ namespace PSTests.Parallel
         {
             var cpp = new CommandLineParameterParser();
 
-            cpp.TestHookConsoleInputRedirected = true;
+            cpp.InputRedirectedTestHook = true;
 
             cpp.Parse(commandLine);
 
@@ -855,7 +855,7 @@ namespace PSTests.Parallel
         {
             var cpp = new CommandLineParameterParser();
 
-            cpp.TestHookConsoleInputRedirected = true;
+            cpp.InputRedirectedTestHook = true;
 
             cpp.Parse(commandLine);
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

xUnit tests fail when running with `Debug` configuration after #11482. The failed tests are those related to `WindowsStyle_With_Right_Value` because `ConsoleControl.SetConsoleMode` actually gets called during testing but there is [no console window](https://github.com/PowerShell/PowerShell/blob/master/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs#L459), so the assert fails.

This PR moves the call to `ConsoleControl.SetConsoleMode` out of the argument parser.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
