### PR TITLE
WIP: Try to manage quotes in strings when calling native executables

### DIFF
--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -126,6 +126,9 @@ namespace System.Management.Automation
                 new ExperimentalFeature(
                     name: "PSSubsystemPluginModel",
                     description: "A plugin model for registering and un-registering PowerShell subsystems"),
+                new ExperimentalFeature(
+                    name: "PSEscapeDoubleQuotedStringForNativeExecutables",
+                    description: "Alternative approach for escaping quotes when calling a native executable"),
             };
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);
 

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -130,7 +130,14 @@ namespace System.Management.Automation
                             stringConstantType = StringConstantType.DoubleQuoted;
                         }
 
-                        AppendOneNativeArgument(Context, argValue, arrayLiteralAst, sawVerbatimArgumentMarker, stringConstantType);
+                        string valueString = parameter.ArgumentValue as string;
+                        if ( valueString != null && stringConstantType == StringConstantType.DoubleQuoted && valueString.Contains("\"")) {
+                            AppendOneNativeArgument(Context, valueString.Replace("\"","\\\""), arrayLiteralAst, sawVerbatimArgumentMarker, stringConstantType);
+                        }
+                        else {
+                            AppendOneNativeArgument(Context, argValue, arrayLiteralAst, sawVerbatimArgumentMarker, stringConstantType);
+                        }
+
                     }
                 }
             }

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -133,12 +133,19 @@ namespace System.Management.Automation
                         // We need to search the string for a double quote.
                         // If the double quote is not preceded by a "\", we need to add one
                         string valueString = argValue as string;
-                        if ( ExperimentalFeature.IsEnabled("PSEscapeDoubleQuotedStringForNativeExecutables") && ! string.IsNullOrEmpty(valueString) && valueString.IndexOf('"') > 1)
+                        if ( ExperimentalFeature.IsEnabled("PSEscapeDoubleQuotedStringForNativeExecutables") && ! string.IsNullOrEmpty(valueString) && valueString.IndexOf('"') >= 0)
                         {
                             StringBuilder parameterValue = new StringBuilder(valueString);
-                            for(int i = 1; i < parameterValue.Length; i++)
+                            for(int i = valueString.Length-1; i >= 0; i--)
                             {
-                                if ( parameterValue[i] == '"' && parameterValue[i-1] != '\\')
+                                if (i == 0)
+                                {
+                                    if ( valueString[0] == '"' )
+                                    {
+                                        parameterValue.Insert(0,'\\');
+                                    }
+                                }
+                                else if ( parameterValue[i] == '"' && parameterValue[i-1] != '\\')
                                 {
                                     parameterValue.Insert(i, '\\');
                                 }

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -122,14 +122,6 @@ namespace System.Management.Automation
                                 break;
                         }
 
-                        // Prior to PSNativePSPathResolution experimental feature, a single quote worked the same as a double quote
-                        // so if the feature is not enabled, we treat any quotes as double quotes.  When this feature is no longer
-                        // experimental, this code here needs to be removed.
-                        if (!ExperimentalFeature.IsEnabled("PSNativePSPathResolution") && stringConstantType == StringConstantType.SingleQuoted)
-                        {
-                            stringConstantType = StringConstantType.DoubleQuoted;
-                        }
-
                         // We need to search the string for a double quote.
                         // If the double quote is not preceded by a "\", we need to add one
                         string valueString = argValue as string;

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -133,30 +133,28 @@ namespace System.Management.Automation
                         // We need to search the string for a double quote.
                         // If the double quote is not preceded by a "\", we need to add one
                         string valueString = argValue as string;
-                        if ( ExperimentalFeature.IsEnabled("PSEscapeDoubleQuotedStringForNativeExecutables") && ! string.IsNullOrEmpty(valueString) && valueString.IndexOf('"') >= 0)
+                        if ( ExperimentalFeature.IsEnabled("PSEscapeDoubleQuotedStringForNativeExecutables") && !string.IsNullOrEmpty(valueString) && valueString.IndexOf('"') >= 0)
                         {
                             StringBuilder parameterValue = new StringBuilder(valueString);
-                            for(int i = valueString.Length-1; i >= 0; i--)
+                            for(int i = valueString.Length - 1; i >= 0; i--)
                             {
                                 if (i == 0)
                                 {
-                                    if ( valueString[0] == '"' )
+                                    if (valueString[0] == '"')
                                     {
                                         parameterValue.Insert(0,'\\');
                                     }
                                 }
-                                else if ( parameterValue[i] == '"' && parameterValue[i-1] != '\\')
+                                else if (parameterValue[i] == '"' && parameterValue[i - 1] != '\\')
                                 {
                                     parameterValue.Insert(i, '\\');
                                 }
-
                             }
 
                             argValue = parameterValue.ToString();
                         }
 
                         AppendOneNativeArgument(Context, argValue, arrayLiteralAst, sawVerbatimArgumentMarker, stringConstantType);
-
                     }
                 }
             }

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1157,7 +1157,26 @@ namespace System.Management.Automation
                 startInfo.CreateNoWindow = mpc.NonInteractive;
             }
 
-            startInfo.Arguments = NativeParameterBinderController.Arguments;
+            if (ExperimentalFeature.IsEnabled("PSEscapeDoubleQuotedStringForNativeExecutables"))
+            {
+                    foreach(var p in arguments)
+                    {
+                        if (p.ParameterExtent.Text != "")
+                        {
+                            startInfo.ArgumentList.Add(p.ParameterExtent.Text);
+                        }
+                        string argValue = p.ArgumentValue as string;
+                        if (argValue != null && ! string.IsNullOrEmpty(argValue))
+                        {
+                            startInfo.ArgumentList.Add(argValue);
+                        }
+                    }
+
+            }
+            else
+            {
+                startInfo.Arguments = NativeParameterBinderController.Arguments;
+            }
 
             ExecutionContext context = this.Command.Context;
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR attempts to manage the scenario where multiple quotes and strings with spaces are sent to the Native Command Processor. The current behavior of our native executable has the following results:

```powershell
PS> testexe -echoargs 'one "two three" four' 
Arg 0 is <one two>
Arg 1 is <three four>
```

which is somewhat surprising. This PR changes the behavior to:

```powershell
PS> testexe -echoargs 'one "two three" four'                                                                                   
Arg 0 is <one "two three" four>
```

somewhat _more_ pathological is the following:

```powershell
testexe -echoargs ' "this is" "a test" '  
Arg 0 is < this>
Arg 1 is <is a>
Arg 2 is <test >
```

with my change:

```powershell
testexe -echoargs ' "this is" "a test" '      
Arg 0 is < "this is" "a test" >
```

This PR represents a breaking change

## PR Context

see [issue 1995](https://github.com/PowerShell/PowerShell/issues/1995)

The implementation is somewhat straightforward, it inspects the string argument looking for `"` and prepends the _native_ escape `\` character to the `"`. If there is already a `\` in front of the `"` no change is made. 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [x] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [x] Experimental feature name(s): **PSEscapeDoubleQuotedStringForNativeExecutables**
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [x] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
