### PR TITLE
Use uint instead of long for PDH constants

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Diagnostics/PdhHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/PdhHelper.cs
@@ -17,92 +17,92 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
 {
     internal static class PdhResults
     {
-        public const long PDH_CSTATUS_VALID_DATA = 0x0L;
-        public const long PDH_CSTATUS_NEW_DATA = 0x1L;
-        public const long PDH_CSTATUS_NO_MACHINE = 0x800007D0L;
-        public const long PDH_CSTATUS_NO_INSTANCE = 0x800007D1L;
-        public const long PDH_MORE_DATA = 0x800007D2L;
-        public const long PDH_CSTATUS_ITEM_NOT_VALIDATED = 0x800007D3L;
-        public const long PDH_RETRY = 0x800007D4L;
-        public const long PDH_NO_DATA = 0x800007D5L;
-        public const long PDH_CALC_NEGATIVE_DENOMINATOR = 0x800007D6L;
-        public const long PDH_CALC_NEGATIVE_TIMEBASE = 0x800007D7L;
-        public const long PDH_CALC_NEGATIVE_VALUE = 0x800007D8L;
-        public const long PDH_DIALOG_CANCELLED = 0x800007D9L;
-        public const long PDH_END_OF_LOG_FILE = 0x800007DAL;
-        public const long PDH_ASYNC_QUERY_TIMEOUT = 0x800007DBL;
-        public const long PDH_CANNOT_SET_DEFAULT_REALTIME_DATASOURCE = 0x800007DCL;
-        public const long PDH_UNABLE_MAP_NAME_FILES = 0x80000BD5L;
-        public const long PDH_PLA_VALIDATION_WARNING = 0x80000BF3L;
-        public const long PDH_CSTATUS_NO_OBJECT = 0xC0000BB8L;
-        public const long PDH_CSTATUS_NO_COUNTER = 0xC0000BB9L;
-        public const long PDH_CSTATUS_INVALID_DATA = 0xC0000BBAL;
-        public const long PDH_MEMORY_ALLOCATION_FAILURE = 0xC0000BBBL;
-        public const long PDH_INVALID_HANDLE = 0xC0000BBCL;
-        public const long PDH_INVALID_ARGUMENT = 0xC0000BBDL;
-        public const long PDH_FUNCTION_NOT_FOUND = 0xC0000BBEL;
-        public const long PDH_CSTATUS_NO_COUNTERNAME = 0xC0000BBFL;
-        public const long PDH_CSTATUS_BAD_COUNTERNAME = 0xC0000BC0L;
-        public const long PDH_INVALID_BUFFER = 0xC0000BC1L;
-        public const long PDH_INSUFFICIENT_BUFFER = 0xC0000BC2L;
-        public const long PDH_CANNOT_CONNECT_MACHINE = 0xC0000BC3L;
-        public const long PDH_INVALID_PATH = 0xC0000BC4L;
-        public const long PDH_INVALID_INSTANCE = 0xC0000BC5L;
-        public const long PDH_INVALID_DATA = 0xC0000BC6L;
-        public const long PDH_NO_DIALOG_DATA = 0xC0000BC7L;
-        public const long PDH_CANNOT_READ_NAME_STRINGS = 0xC0000BC8L;
-        public const long PDH_LOG_FILE_CREATE_ERROR = 0xC0000BC9L;
-        public const long PDH_LOG_FILE_OPEN_ERROR = 0xC0000BCAL;
-        public const long PDH_LOG_TYPE_NOT_FOUND = 0xC0000BCBL;
-        public const long PDH_NO_MORE_DATA = 0xC0000BCCL;
-        public const long PDH_ENTRY_NOT_IN_LOG_FILE = 0xC0000BCDL;
-        public const long PDH_DATA_SOURCE_IS_LOG_FILE = 0xC0000BCEL;
-        public const long PDH_DATA_SOURCE_IS_REAL_TIME = 0xC0000BCFL;
-        public const long PDH_UNABLE_READ_LOG_HEADER = 0xC0000BD0L;
-        public const long PDH_FILE_NOT_FOUND = 0xC0000BD1L;
-        public const long PDH_FILE_ALREADY_EXISTS = 0xC0000BD2L;
-        public const long PDH_NOT_IMPLEMENTED = 0xC0000BD3L;
-        public const long PDH_STRING_NOT_FOUND = 0xC0000BD4L;
-        public const long PDH_UNKNOWN_LOG_FORMAT = 0xC0000BD6L;
-        public const long PDH_UNKNOWN_LOGSVC_COMMAND = 0xC0000BD7L;
-        public const long PDH_LOGSVC_QUERY_NOT_FOUND = 0xC0000BD8L;
-        public const long PDH_LOGSVC_NOT_OPENED = 0xC0000BD9L;
-        public const long PDH_WBEM_ERROR = 0xC0000BDAL;
-        public const long PDH_ACCESS_DENIED = 0xC0000BDBL;
-        public const long PDH_LOG_FILE_TOO_SMALL = 0xC0000BDCL;
-        public const long PDH_INVALID_DATASOURCE = 0xC0000BDDL;
-        public const long PDH_INVALID_SQLDB = 0xC0000BDEL;
-        public const long PDH_NO_COUNTERS = 0xC0000BDFL;
-        public const long PDH_SQL_ALLOC_FAILED = 0xC0000BE0L;
-        public const long PDH_SQL_ALLOCCON_FAILED = 0xC0000BE1L;
-        public const long PDH_SQL_EXEC_DIRECT_FAILED = 0xC0000BE2L;
-        public const long PDH_SQL_FETCH_FAILED = 0xC0000BE3L;
-        public const long PDH_SQL_ROWCOUNT_FAILED = 0xC0000BE4L;
-        public const long PDH_SQL_MORE_RESULTS_FAILED = 0xC0000BE5L;
-        public const long PDH_SQL_CONNECT_FAILED = 0xC0000BE6L;
-        public const long PDH_SQL_BIND_FAILED = 0xC0000BE7L;
-        public const long PDH_CANNOT_CONNECT_WMI_SERVER = 0xC0000BE8L;
-        public const long PDH_PLA_COLLECTION_ALREADY_RUNNING = 0xC0000BE9L;
-        public const long PDH_PLA_ERROR_SCHEDULE_OVERLAP = 0xC0000BEAL;
-        public const long PDH_PLA_COLLECTION_NOT_FOUND = 0xC0000BEBL;
-        public const long PDH_PLA_ERROR_SCHEDULE_ELAPSED = 0xC0000BECL;
-        public const long PDH_PLA_ERROR_NOSTART = 0xC0000BEDL;
-        public const long PDH_PLA_ERROR_ALREADY_EXISTS = 0xC0000BEEL;
-        public const long PDH_PLA_ERROR_TYPE_MISMATCH = 0xC0000BEFL;
-        public const long PDH_PLA_ERROR_FILEPATH = 0xC0000BF0L;
-        public const long PDH_PLA_SERVICE_ERROR = 0xC0000BF1L;
-        public const long PDH_PLA_VALIDATION_ERROR = 0xC0000BF2L;
-        public const long PDH_PLA_ERROR_NAME_TOO_LONG = 0xC0000BF4L;
-        public const long PDH_INVALID_SQL_LOG_FORMAT = 0xC0000BF5L;
-        public const long PDH_COUNTER_ALREADY_IN_QUERY = 0xC0000BF6L;
-        public const long PDH_BINARY_LOG_CORRUPT = 0xC0000BF7L;
-        public const long PDH_LOG_SAMPLE_TOO_SMALL = 0xC0000BF8L;
-        public const long PDH_OS_LATER_VERSION = 0xC0000BF9L;
-        public const long PDH_OS_EARLIER_VERSION = 0xC0000BFAL;
-        public const long PDH_INCORRECT_APPEND_TIME = 0xC0000BFBL;
-        public const long PDH_UNMATCHED_APPEND_COUNTER = 0xC0000BFCL;
-        public const long PDH_SQL_ALTER_DETAIL_FAILED = 0xC0000BFDL;
-        public const long PDH_QUERY_PERF_DATA_TIMEOUT = 0xC0000BFEL;
+        public const uint PDH_CSTATUS_VALID_DATA = 0x0;
+        public const uint PDH_CSTATUS_NEW_DATA = 0x1;
+        public const uint PDH_CSTATUS_NO_MACHINE = 0x800007D0;
+        public const uint PDH_CSTATUS_NO_INSTANCE = 0x800007D1;
+        public const uint PDH_MORE_DATA = 0x800007D2;
+        public const uint PDH_CSTATUS_ITEM_NOT_VALIDATED = 0x800007D3;
+        public const uint PDH_RETRY = 0x800007D4;
+        public const uint PDH_NO_DATA = 0x800007D5;
+        public const uint PDH_CALC_NEGATIVE_DENOMINATOR = 0x800007D6;
+        public const uint PDH_CALC_NEGATIVE_TIMEBASE = 0x800007D7;
+        public const uint PDH_CALC_NEGATIVE_VALUE = 0x800007D8;
+        public const uint PDH_DIALOG_CANCELLED = 0x800007D9;
+        public const uint PDH_END_OF_LOG_FILE = 0x800007DA;
+        public const uint PDH_ASYNC_QUERY_TIMEOUT = 0x800007DB;
+        public const uint PDH_CANNOT_SET_DEFAULT_REALTIME_DATASOURCE = 0x800007DC;
+        public const uint PDH_UNABLE_MAP_NAME_FILES = 0x80000BD5;
+        public const uint PDH_PLA_VALIDATION_WARNING = 0x80000BF3;
+        public const uint PDH_CSTATUS_NO_OBJECT = 0xC0000BB8;
+        public const uint PDH_CSTATUS_NO_COUNTER = 0xC0000BB9;
+        public const uint PDH_CSTATUS_INVALID_DATA = 0xC0000BBA;
+        public const uint PDH_MEMORY_ALLOCATION_FAILURE = 0xC0000BBB;
+        public const uint PDH_INVALID_HANDLE = 0xC0000BBC;
+        public const uint PDH_INVALID_ARGUMENT = 0xC0000BBD;
+        public const uint PDH_FUNCTION_NOT_FOUND = 0xC0000BBE;
+        public const uint PDH_CSTATUS_NO_COUNTERNAME = 0xC0000BBF;
+        public const uint PDH_CSTATUS_BAD_COUNTERNAME = 0xC0000BC0;
+        public const uint PDH_INVALID_BUFFER = 0xC0000BC1;
+        public const uint PDH_INSUFFICIENT_BUFFER = 0xC0000BC2;
+        public const uint PDH_CANNOT_CONNECT_MACHINE = 0xC0000BC3;
+        public const uint PDH_INVALID_PATH = 0xC0000BC4;
+        public const uint PDH_INVALID_INSTANCE = 0xC0000BC5;
+        public const uint PDH_INVALID_DATA = 0xC0000BC6;
+        public const uint PDH_NO_DIALOG_DATA = 0xC0000BC7;
+        public const uint PDH_CANNOT_READ_NAME_STRINGS = 0xC0000BC8;
+        public const uint PDH_LOG_FILE_CREATE_ERROR = 0xC0000BC9;
+        public const uint PDH_LOG_FILE_OPEN_ERROR = 0xC0000BCA;
+        public const uint PDH_LOG_TYPE_NOT_FOUND = 0xC0000BCB;
+        public const uint PDH_NO_MORE_DATA = 0xC0000BCC;
+        public const uint PDH_ENTRY_NOT_IN_LOG_FILE = 0xC0000BCD;
+        public const uint PDH_DATA_SOURCE_IS_LOG_FILE = 0xC0000BCE;
+        public const uint PDH_DATA_SOURCE_IS_REAL_TIME = 0xC0000BCF;
+        public const uint PDH_UNABLE_READ_LOG_HEADER = 0xC0000BD0;
+        public const uint PDH_FILE_NOT_FOUND = 0xC0000BD1;
+        public const uint PDH_FILE_ALREADY_EXISTS = 0xC0000BD2;
+        public const uint PDH_NOT_IMPLEMENTED = 0xC0000BD3;
+        public const uint PDH_STRING_NOT_FOUND = 0xC0000BD4;
+        public const uint PDH_UNKNOWN_LOG_FORMAT = 0xC0000BD6;
+        public const uint PDH_UNKNOWN_LOGSVC_COMMAND = 0xC0000BD7;
+        public const uint PDH_LOGSVC_QUERY_NOT_FOUND = 0xC0000BD8;
+        public const uint PDH_LOGSVC_NOT_OPENED = 0xC0000BD9;
+        public const uint PDH_WBEM_ERROR = 0xC0000BDA;
+        public const uint PDH_ACCESS_DENIED = 0xC0000BDB;
+        public const uint PDH_LOG_FILE_TOO_SMALL = 0xC0000BDC;
+        public const uint PDH_INVALID_DATASOURCE = 0xC0000BDD;
+        public const uint PDH_INVALID_SQLDB = 0xC0000BDE;
+        public const uint PDH_NO_COUNTERS = 0xC0000BDF;
+        public const uint PDH_SQL_ALLOC_FAILED = 0xC0000BE0;
+        public const uint PDH_SQL_ALLOCCON_FAILED = 0xC0000BE1;
+        public const uint PDH_SQL_EXEC_DIRECT_FAILED = 0xC0000BE2;
+        public const uint PDH_SQL_FETCH_FAILED = 0xC0000BE3;
+        public const uint PDH_SQL_ROWCOUNT_FAILED = 0xC0000BE4;
+        public const uint PDH_SQL_MORE_RESULTS_FAILED = 0xC0000BE5;
+        public const uint PDH_SQL_CONNECT_FAILED = 0xC0000BE6;
+        public const uint PDH_SQL_BIND_FAILED = 0xC0000BE7;
+        public const uint PDH_CANNOT_CONNECT_WMI_SERVER = 0xC0000BE8;
+        public const uint PDH_PLA_COLLECTION_ALREADY_RUNNING = 0xC0000BE9;
+        public const uint PDH_PLA_ERROR_SCHEDULE_OVERLAP = 0xC0000BEA;
+        public const uint PDH_PLA_COLLECTION_NOT_FOUND = 0xC0000BEB;
+        public const uint PDH_PLA_ERROR_SCHEDULE_ELAPSED = 0xC0000BEC;
+        public const uint PDH_PLA_ERROR_NOSTART = 0xC0000BED;
+        public const uint PDH_PLA_ERROR_ALREADY_EXISTS = 0xC0000BEE;
+        public const uint PDH_PLA_ERROR_TYPE_MISMATCH = 0xC0000BEF;
+        public const uint PDH_PLA_ERROR_FILEPATH = 0xC0000BF0;
+        public const uint PDH_PLA_SERVICE_ERROR = 0xC0000BF1;
+        public const uint PDH_PLA_VALIDATION_ERROR = 0xC0000BF2;
+        public const uint PDH_PLA_ERROR_NAME_TOO_LONG = 0xC0000BF4;
+        public const uint PDH_INVALID_SQL_LOG_FORMAT = 0xC0000BF5;
+        public const uint PDH_COUNTER_ALREADY_IN_QUERY = 0xC0000BF6;
+        public const uint PDH_BINARY_LOG_CORRUPT = 0xC0000BF7;
+        public const uint PDH_LOG_SAMPLE_TOO_SMALL = 0xC0000BF8;
+        public const uint PDH_OS_LATER_VERSION = 0xC0000BF9;
+        public const uint PDH_OS_EARLIER_VERSION = 0xC0000BFA;
+        public const uint PDH_INCORRECT_APPEND_TIME = 0xC0000BFB;
+        public const uint PDH_UNMATCHED_APPEND_COUNTER = 0xC0000BFC;
+        public const uint PDH_SQL_ALTER_DETAIL_FAILED = 0xC0000BFD;
+        public const uint PDH_QUERY_PERF_DATA_TIMEOUT = 0xC0000BFE;
     }
 
     internal static class PerfDetail
@@ -968,7 +968,7 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
                     }
                     catch (Exception)
                     {
-                        return (uint)PdhResults.PDH_INVALID_PATH;
+                        return PdhResults.PDH_INVALID_PATH;
                     }
                 }
                 else if (regString.ToLowerInvariant() == lowerEngObjectName)
@@ -979,7 +979,7 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
                     }
                     catch (Exception)
                     {
-                        return (uint)PdhResults.PDH_INVALID_PATH;
+                        return PdhResults.PDH_INVALID_PATH;
                     }
                 }
 
@@ -991,7 +991,7 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
 
             if (counterIndex == -1 || objIndex == -1)
             {
-                return (uint)PdhResults.PDH_INVALID_PATH;
+                return PdhResults.PDH_INVALID_PATH;
             }
 
             // Now, call retrieve the localized names of the object and the counter by index:


### PR DESCRIPTION
# PR Summary

Avoid some signed/unsigned conversions.

## PR Context

`PDH_STATUS`error codes can be handled with `UInt32`

https://docs.microsoft.com/en-us/windows/win32/perfctrs/pdh-error-codes

Follow-up: #13141

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [NA] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [NA] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [NA] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [NA] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [NA] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [NA] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
