### PR TITLE
Use read-only auto-implemented properties

### DIFF
--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionProxy.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionProxy.cs
@@ -95,11 +95,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// return value could be null
         /// </remarks>
         /// </summary>
-        internal virtual string ComputerName
-        {
-            get;
-
-        }
+        internal virtual string ComputerName { get; }
 
         /// <summary>
         /// <para>
@@ -109,11 +105,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// return value could be null
         /// </remarks>
         /// </summary>
-        internal virtual CimInstance TargetCimInstance
-        {
-            get;
-
-        }
+        internal virtual CimInstance TargetCimInstance { get; }
     }
     #endregion
 

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionProxy.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionProxy.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         internal virtual string ComputerName
         {
             get;
-            private set;
+
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         internal virtual CimInstance TargetCimInstance
         {
             get;
-            private set;
+
         }
     }
     #endregion

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimCmdletDefinitionContext.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimCmdletDefinitionContext.cs
@@ -26,13 +26,13 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
             _privateData = privateData;
         }
 
-        public string CmdletizationClassName { get; private set; }
+        public string CmdletizationClassName { get; }
 
-        public string CmdletizationClassVersion { get; private set; }
+        public string CmdletizationClassVersion { get; }
 
-        public Version CmdletizationModuleVersion { get; private set; }
+        public Version CmdletizationModuleVersion { get; }
 
-        public bool SupportsShouldProcess { get; private set; }
+        public bool SupportsShouldProcess { get; }
 
         private readonly IDictionary<string, string> _privateData;
 

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimCmdletInvocationContext.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimCmdletInvocationContext.cs
@@ -81,21 +81,21 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
             }
         }
 
-        public CimCmdletDefinitionContext CmdletDefinitionContext { get; private set; }
+        public CimCmdletDefinitionContext CmdletDefinitionContext { get; }
 
-        public InvocationInfo CmdletInvocationInfo { get; private set; }
+        public InvocationInfo CmdletInvocationInfo { get; }
 
-        public MshCommandRuntime.ShouldProcessPossibleOptimization ShouldProcessOptimization { get; private set; }
+        public MshCommandRuntime.ShouldProcessPossibleOptimization ShouldProcessOptimization { get; }
 
-        public ActionPreference ErrorActionPreference { get; private set; }
+        public ActionPreference ErrorActionPreference { get; }
 
-        public ActionPreference WarningActionPreference { get; private set; }
+        public ActionPreference WarningActionPreference { get; }
 
-        public ActionPreference VerboseActionPreference { get; private set; }
+        public ActionPreference VerboseActionPreference { get; }
 
-        public ActionPreference DebugActionPreference { get; private set; }
+        public ActionPreference DebugActionPreference { get; }
 
-        public string NamespaceOverride { get; private set; }
+        public string NamespaceOverride { get; }
 
         public bool IsRunningInBackground
         {

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimJobContext.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimJobContext.cs
@@ -22,11 +22,11 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
             this.TargetObject = targetObject ?? this.ClassName;
         }
 
-        public CimCmdletInvocationContext CmdletInvocationContext { get; private set; }
+        public CimCmdletInvocationContext CmdletInvocationContext { get; }
 
-        public CimSession Session { get; private set; }
+        public CimSession Session { get; }
 
-        public object TargetObject { get; private set; }
+        public object TargetObject { get; }
 
         public string ClassName
         {

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimQuery.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimQuery.cs
@@ -29,7 +29,7 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
 
         internal readonly Dictionary<string, object> queryOptions = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
 
-        internal ClientSideQuery ClientSideQuery { get; private set; }
+        internal ClientSideQuery ClientSideQuery { get; }
 
         internal CimQuery()
         {

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/clientSideQuery.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/clientSideQuery.cs
@@ -55,11 +55,11 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
                 }
             }
 
-            public string PropertyName { get; private set; }
+            public string PropertyName { get; }
 
-            public object PropertyValue { get; private set; }
+            public object PropertyValue { get; }
 
-            public Func<string, string, string> ErrorMessageGenerator { get; private set; }
+            public Func<string, string, string> ErrorMessageGenerator { get; }
 
             private static string GetErrorMessageForNotFound(string queryDescription, string className)
             {

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
@@ -45,12 +45,12 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Name of the computer that is restarting.
         /// </summary>
-        public string ComputerName { get; private set; }
+        public string ComputerName { get; }
 
         /// <summary>
         /// The timeout value specified by the user. It indicates the seconds to wait before timeout.
         /// </summary>
-        public int Timeout { get; private set; }
+        public int Timeout { get; }
 
         /// <summary>
         /// Construct a RestartComputerTimeoutException.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/EnableDisableRunspaceDebugCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/EnableDisableRunspaceDebugCommand.cs
@@ -29,7 +29,7 @@ namespace Microsoft.PowerShell.Commands
         public bool Enabled
         {
             get;
-            private set;
+
         }
 
         /// <summary>
@@ -41,7 +41,7 @@ namespace Microsoft.PowerShell.Commands
         public bool BreakAll
         {
             get;
-            private set;
+
         }
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace Microsoft.PowerShell.Commands
         public string RunspaceName
         {
             get;
-            private set;
+
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace Microsoft.PowerShell.Commands
         public int RunspaceId
         {
             get;
-            private set;
+
         }
 
         #endregion

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/EnableDisableRunspaceDebugCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/EnableDisableRunspaceDebugCommand.cs
@@ -26,11 +26,7 @@ namespace Microsoft.PowerShell.Commands
         /// debugger is currently attached.  The script or command will remain stopped until
         /// a debugger is attached to debug the breakpoint.
         /// </summary>
-        public bool Enabled
-        {
-            get;
-
-        }
+        public bool Enabled { get; }
 
         /// <summary>
         /// When true this property will cause any running command or script in the Runspace
@@ -38,29 +34,17 @@ namespace Microsoft.PowerShell.Commands
         /// script or command will remain stopped until a debugger is attached to debug the
         /// current stop point.
         /// </summary>
-        public bool BreakAll
-        {
-            get;
-
-        }
+        public bool BreakAll { get; }
 
         /// <summary>
         /// Name of runspace for which the options apply.
         /// </summary>
-        public string RunspaceName
-        {
-            get;
-
-        }
+        public string RunspaceName { get; }
 
         /// <summary>
         /// Local Id of runspace for which the options apply.
         /// </summary>
-        public int RunspaceId
-        {
-            get;
-
-        }
+        public int RunspaceId { get; }
 
         #endregion
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandCommandInfo.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandCommandInfo.cs
@@ -116,31 +116,31 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
         /// <summary>
         /// A string representing the definition of the command.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <summary>
         /// A string representing module the command belongs to.
         /// </summary>
-        public string ModuleName { get; private set; }
+        public string ModuleName { get; }
 
         /// <summary>
         /// A reference to the module the command came from.
         /// </summary>
-        public ShowCommandModuleInfo Module { get; private set; }
+        public ShowCommandModuleInfo Module { get; }
 
         /// <summary>
         /// An enumeration of the command types this command belongs to.
         /// </summary>
-        public CommandTypes CommandType { get; private set; }
+        public CommandTypes CommandType { get; }
 
         /// <summary>
         /// A string representing the definition of the command.
         /// </summary>
-        public string Definition { get; private set; }
+        public string Definition { get; }
 
         /// <summary>
         /// A string representing the definition of the command.
         /// </summary>
-        public ICollection<ShowCommandParameterSetInfo> ParameterSets { get; private set; }
+        public ICollection<ShowCommandParameterSetInfo> ParameterSets { get; }
     }
 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandModuleInfo.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandModuleInfo.cs
@@ -46,6 +46,6 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
         /// <summary>
         /// Gets the name of this module.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
     }
 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandParameterInfo.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandParameterInfo.cs
@@ -68,37 +68,37 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
         /// <summary>
         /// Gets the name of the parameter.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <remarks>
         /// True if the parameter is dynamic, or false otherwise.
         /// </remarks>
-        public bool IsMandatory { get; private set; }
+        public bool IsMandatory { get; }
 
         /// <summary>
         /// Gets whether the parameter can take values from the incoming pipeline object.
         /// </summary>
-        public bool ValueFromPipeline { get; private set; }
+        public bool ValueFromPipeline { get; }
 
         /// <summary>
         /// Gets the type of the parameter.
         /// </summary>
-        public ShowCommandParameterType ParameterType { get; private set; }
+        public ShowCommandParameterType ParameterType { get; }
 
         /// <summary>
         /// The possible values of this parameter.
         /// </summary>
-        public IList<string> ValidParamSetValues { get; private set; }
+        public IList<string> ValidParamSetValues { get; }
 
         /// <summary>
         /// Gets whether the parameter has a parameter set.
         /// </summary>
-        public bool HasParameterSet { get; private set; }
+        public bool HasParameterSet { get; }
 
         /// <summary>
         /// Gets the position in which the parameter can be specified on the command line
         /// if not named. If the returned value is int.MinValue then the parameter must be named.
         /// </summary>
-        public int Position { get; private set; }
+        public int Position { get; }
     }
 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandParameterSetInfo.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandParameterSetInfo.cs
@@ -53,16 +53,16 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
         /// <summary>
         /// Gets the name of the parameter set.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <summary>
         /// Gets whether the parameter set is the default parameter set.
         /// </summary>
-        public bool IsDefault { get; private set; }
+        public bool IsDefault { get; }
 
         /// <summary>
         /// Gets the parameter information for the parameters in this parameter set.
         /// </summary>
-        public ICollection<ShowCommandParameterInfo> Parameters { get; private set; }
+        public ICollection<ShowCommandParameterInfo> Parameters { get; }
     }
 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandParameterType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandParameterType.cs
@@ -74,32 +74,32 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
         /// <summary>
         /// The full name of the outermost type.
         /// </summary>
-        public string FullName { get; private set; }
+        public string FullName { get; }
 
         /// <summary>
         /// Whether or not this type is an enum.
         /// </summary>
-        public bool IsEnum { get; private set; }
+        public bool IsEnum { get; }
 
         /// <summary>
         /// Whether or not this type is an dictionary.
         /// </summary>
-        public bool ImplementsDictionary { get; private set; }
+        public bool ImplementsDictionary { get; }
 
         /// <summary>
         /// Whether or not this enum has a flag attribute.
         /// </summary>
-        public bool HasFlagAttribute { get; private set; }
+        public bool HasFlagAttribute { get; }
 
         /// <summary>
         /// Whether or not this type is an array type.
         /// </summary>
-        public bool IsArray { get; private set; }
+        public bool IsArray { get; }
 
         /// <summary>
         /// Gets the inner type, if this corresponds to an array type.
         /// </summary>
-        public ShowCommandParameterType ElementType { get; private set; }
+        public ShowCommandParameterType ElementType { get; }
 
         /// <summary>
         /// Whether or not this type is a string.
@@ -148,6 +148,6 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
         /// <summary>
         /// If this is an enum value, return the list of potential values.
         /// </summary>
-        public ArrayList EnumValues { get; private set; }
+        public ArrayList EnumValues { get; }
     }
 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/UtilityCommon.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/UtilityCommon.cs
@@ -211,12 +211,12 @@ namespace Microsoft.PowerShell.Commands
         /// Gets underlying bytes stored in the collection.
         /// </summary>
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
-        public byte[] Bytes { get; private set; }
+        public byte[] Bytes { get; }
 
         /// <summary>
         /// Gets the path of the file whose contents are wrapped in the ByteCollection.
         /// </summary>
-        public string Path { get; private set; }
+        public string Path { get; }
 
         /// <summary>
         /// Gets the hexadecimal representation of the <see cref="Offset64"/> value.
@@ -226,7 +226,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Gets the type of the input objects used to create the <see cref="ByteCollection"/>.
         /// </summary>
-        public string Label { get; private set; }
+        public string Label { get; }
 
         private const int BytesPerLine = 16;
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -873,7 +873,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// HTTP error response.
         /// </summary>
-        public HttpResponseMessage Response { get; private set; }
+        public HttpResponseMessage Response { get; }
     }
 
     /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/FormObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/FormObject.cs
@@ -13,22 +13,22 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Gets or private sets the Id property.
         /// </summary>
-        public string Id { get; private set; }
+        public string Id { get; }
 
         /// <summary>
         /// Gets or private sets the Method property.
         /// </summary>
-        public string Method { get; private set; }
+        public string Method { get; }
 
         /// <summary>
         /// Gets or private sets the Action property.
         /// </summary>
-        public string Action { get; private set; }
+        public string Action { get; }
 
         /// <summary>
         /// Gets or private sets the Fields property.
         /// </summary>
-        public Dictionary<string, string> Fields { get; private set; }
+        public Dictionary<string, string> Fields { get; }
 
         /// <summary>
         /// Constructor for FormObject.

--- a/src/Microsoft.PowerShell.MarkdownRender/VT100Renderer.cs
+++ b/src/Microsoft.PowerShell.MarkdownRender/VT100Renderer.cs
@@ -41,6 +41,6 @@ namespace Microsoft.PowerShell.MarkdownRender
         /// <summary>
         /// Gets the current escape sequences.
         /// </summary>
-        public VT100EscapeSequences EscapeSequences { get; private set; }
+        public VT100EscapeSequences EscapeSequences { get; }
     }
 }

--- a/src/Microsoft.PowerShell.Security/security/AclCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/AclCommands.cs
@@ -994,10 +994,7 @@ namespace Microsoft.PowerShell.Commands
         /// Parameter '-CentralAccessPolicy' is not supported in OneCore powershell,
         /// because function 'LsaQueryCAPs' is not available in OneCoreUAP and NanoServer.
         /// </summary>
-        private string CentralAccessPolicy
-        {
-            get;
-        }
+        private string CentralAccessPolicy { get; }
 #else
         private string centralAccessPolicy;
 

--- a/src/Microsoft.PowerShell.Security/security/AclCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/AclCommands.cs
@@ -996,7 +996,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         private string CentralAccessPolicy
         {
-            get; set;
+            get;
         }
 #else
         private string centralAccessPolicy;

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData.cs
@@ -672,10 +672,10 @@ namespace System.Management.Automation
     public sealed class FormatViewDefinition
     {
         /// <summary>Name of the formatting view as defined in the formatting file</summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <summary>The control defined by this formatting view can be one of table, list, wide, or custom</summary>
-        public PSControl Control { get; private set; }
+        public PSControl Control { get; }
 
         /// <summary>instance id of the original view this will be used to distinguish two views with the same name and control types</summary>
         internal Guid InstanceId { get; set; }

--- a/src/System.Management.Automation/FormatAndOutput/common/FormattingObjectsDeserializer.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormattingObjectsDeserializer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     /// </summary>
     internal sealed class FormatObjectDeserializer
     {
-        internal TerminatingErrorContext TerminatingErrorContext { get; private set; }
+        internal TerminatingErrorContext TerminatingErrorContext { get; }
 
         /// <summary>
         /// Expansion of TAB character to the following string.

--- a/src/System.Management.Automation/engine/Attributes.cs
+++ b/src/System.Management.Automation/engine/Attributes.cs
@@ -492,7 +492,7 @@ namespace System.Management.Automation
         /// </summary>
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods")]
-        public PSTypeName[] Type { get; private set; }
+        public PSTypeName[] Type { get; }
 
         /// <summary>
         /// Attributes implemented by a provider can use:
@@ -752,7 +752,7 @@ namespace System.Management.Automation
     {
         /// <summary>
         /// </summary>
-        public string PSTypeName { get; private set; }
+        public string PSTypeName { get; }
 
         /// <summary>
         /// Creates a new PSTypeNameAttribute.

--- a/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
@@ -3879,7 +3879,7 @@ namespace System.Management.Automation
         /// Gets or sets the command that this parameter binder controller
         /// will bind parameters to.
         /// </summary>
-        internal Cmdlet Command { get; private set; }
+        internal Cmdlet Command { get; }
 
         #region DefaultParameterBindingStructures
 

--- a/src/System.Management.Automation/engine/ComInterop/InteropServices/ComEventsMethod.cs
+++ b/src/System.Management.Automation/engine/ComInterop/InteropServices/ComEventsMethod.cs
@@ -38,7 +38,7 @@ namespace System.Management.Automation.InteropServices
 
             public Delegate Delegate { get; set; }
 
-            public bool WrapArgs { get; private set; }
+            public bool WrapArgs { get; }
 
             public object? Invoke(object[] args)
             {

--- a/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
@@ -24,10 +24,10 @@ namespace System.Management.Automation
     {
         /// <summary/>
         [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods")]
-        public Type Type { get; private set; }
+        public Type Type { get; }
 
         /// <summary/>
-        public ScriptBlock ScriptBlock { get; private set; }
+        public ScriptBlock ScriptBlock { get; }
 
         /// <param name="type">The type must implement <see cref="IArgumentCompleter"/> and have a default constructor.</param>
         public ArgumentCompleterAttribute(Type type)

--- a/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
@@ -782,12 +782,12 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The command element associated with the exception.
         /// </summary>
-        public CommandElementAst CommandElement { get; private set; }
+        public CommandElementAst CommandElement { get; }
 
         /// <summary>
         /// The ParameterBindingException that this command element caused.
         /// </summary>
-        public ParameterBindingException BindingException { get; private set; }
+        public ParameterBindingException BindingException { get; }
     }
 
     #region "PseudoBindingInfo"

--- a/src/System.Management.Automation/engine/CommandInfo.cs
+++ b/src/System.Management.Automation/engine/CommandInfo.cs
@@ -889,7 +889,7 @@ namespace System.Management.Automation
         /// <summary>
         /// When a type is defined by PowerShell, the ast for that type.
         /// </summary>
-        public TypeDefinitionAst TypeDefinitionAst { get; private set; }
+        public TypeDefinitionAst TypeDefinitionAst { get; }
 
         private bool _typeWasCalculated;
 

--- a/src/System.Management.Automation/engine/CompiledCommandParameter.cs
+++ b/src/System.Management.Automation/engine/CompiledCommandParameter.cs
@@ -193,7 +193,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets the name of the parameter.
         /// </summary>
-        internal string Name { get; private set; }
+        internal string Name { get; }
 
         /// <summary>
         /// The PSTypeName from a PSTypeNameAttribute.
@@ -203,38 +203,38 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets the Type information of the attribute.
         /// </summary>
-        internal Type Type { get; private set; }
+        internal Type Type { get; }
 
         /// <summary>
         /// Gets the Type information of the attribute.
         /// </summary>
-        internal Type DeclaringType { get; private set; }
+        internal Type DeclaringType { get; }
 
         /// <summary>
         /// Gets whether the parameter is a dynamic parameter or not.
         /// </summary>
-        internal bool IsDynamic { get; private set; }
+        internal bool IsDynamic { get; }
 
         /// <summary>
         /// Gets the parameter collection type information.
         /// </summary>
-        internal ParameterCollectionTypeInformation CollectionTypeInformation { get; private set; }
+        internal ParameterCollectionTypeInformation CollectionTypeInformation { get; }
 
         /// <summary>
         /// A collection of the attributes found on the member. The attributes have been compiled into
         /// a format that easier to digest by the metadata processor.
         /// </summary>
-        internal Collection<Attribute> CompiledAttributes { get; private set; }
+        internal Collection<Attribute> CompiledAttributes { get; }
 
         /// <summary>
         /// Gets the collection of data generation attributes on this parameter.
         /// </summary>
-        internal ArgumentTransformationAttribute[] ArgumentTransformationAttributes { get; private set; }
+        internal ArgumentTransformationAttribute[] ArgumentTransformationAttributes { get; }
 
         /// <summary>
         /// Gets the collection of data validation attributes on this parameter.
         /// </summary>
-        internal ValidateArgumentsAttribute[] ValidationAttributes { get; private set; }
+        internal ValidateArgumentsAttribute[] ValidationAttributes { get; }
 
         /// <summary>
         /// Get and private set the obsolete attribute on this parameter.
@@ -299,12 +299,12 @@ namespace System.Management.Automation
         /// <summary>
         /// A dictionary of the parameter sets and the parameter set specific data for this parameter.
         /// </summary>
-        internal Dictionary<string, ParameterSetSpecificMetadata> ParameterSetData { get; private set; }
+        internal Dictionary<string, ParameterSetSpecificMetadata> ParameterSetData { get; }
 
         /// <summary>
         /// The alias names for this parameter.
         /// </summary>
-        internal string[] Aliases { get; private set; }
+        internal string[] Aliases { get; }
 
         /// <summary>
         /// Determines if this parameter takes pipeline input for any of the specified
@@ -675,11 +675,11 @@ namespace System.Management.Automation
         /// <summary>
         /// The collection type of the parameter.
         /// </summary>
-        internal ParameterCollectionType ParameterCollectionType { get; private set; }
+        internal ParameterCollectionType ParameterCollectionType { get; }
 
         /// <summary>
         /// The type of the elements in the collection.
         /// </summary>
-        internal Type ElementType { get; private set; }
+        internal Type ElementType { get; }
     }
 }

--- a/src/System.Management.Automation/engine/DscResourceInfo.cs
+++ b/src/System.Management.Automation/engine/DscResourceInfo.cs
@@ -57,7 +57,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Name of the DSC Resource.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <summary>
         /// Gets or sets resource type name.

--- a/src/System.Management.Automation/engine/EventManager.cs
+++ b/src/System.Management.Automation/engine/EventManager.cs
@@ -2011,7 +2011,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets whether the event should be unregistered.
         /// </summary>
-        internal bool AutoUnregister { get; private set; }
+        internal bool AutoUnregister { get; }
 
         /// <summary>
         /// Indicate how many new should be added to the action queue.

--- a/src/System.Management.Automation/engine/MergedCommandParameterMetadata.cs
+++ b/src/System.Management.Automation/engine/MergedCommandParameterMetadata.cs
@@ -657,12 +657,12 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets the compiled command parameter for the association.
         /// </summary>
-        internal CompiledCommandParameter Parameter { get; private set; }
+        internal CompiledCommandParameter Parameter { get; }
 
         /// <summary>
         /// Gets the type of binder that the compiled command parameter should be bound with.
         /// </summary>
-        internal ParameterBinderAssociation BinderAssociation { get; private set; }
+        internal ParameterBinderAssociation BinderAssociation { get; }
 
         public override string ToString()
         {

--- a/src/System.Management.Automation/engine/PSClassInfo.cs
+++ b/src/System.Management.Automation/engine/PSClassInfo.cs
@@ -23,7 +23,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Name of the class.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <summary>
         /// Collection of members of the class.
@@ -72,16 +72,16 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets or sets name of the member.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <summary>
         /// Gets or sets type of the member.
         /// </summary>
-        public string TypeName { get; private set; }
+        public string TypeName { get; }
 
         /// <summary>
         /// Default value of the Field.
         /// </summary>
-        public string DefaultValue { get; private set; }
+        public string DefaultValue { get; }
     }
 }

--- a/src/System.Management.Automation/engine/ParameterBinderBase.cs
+++ b/src/System.Management.Automation/engine/ParameterBinderBase.cs
@@ -1985,7 +1985,7 @@ namespace System.Management.Automation
 
         private static readonly IDictionary s_emptyUsingParameters = new ReadOnlyDictionary<object, object>(new Dictionary<object, object>());
 
-        public List<string> BoundPositionally { get; private set; }
+        public List<string> BoundPositionally { get; }
 
         internal IDictionary ImplicitUsingParameters { get; set; }
     }

--- a/src/System.Management.Automation/engine/ParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/ParameterBinderController.cs
@@ -56,7 +56,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets the parameter binder for the command.
         /// </summary>
-        internal ParameterBinderBase DefaultParameterBinder { get; private set; }
+        internal ParameterBinderBase DefaultParameterBinder { get; }
 
         /// <summary>
         /// The invocation information about the code being run.

--- a/src/System.Management.Automation/engine/ParameterSetInfo.cs
+++ b/src/System.Management.Automation/engine/ParameterSetInfo.cs
@@ -72,12 +72,12 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets the name of the parameter set.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <summary>
         /// Gets whether the parameter set is the default parameter set.
         /// </summary>
-        public bool IsDefault { get; private set; }
+        public bool IsDefault { get; }
 
         /// <summary>
         /// Gets the parameter information for the parameters in this parameter set.

--- a/src/System.Management.Automation/engine/ScriptInfo.cs
+++ b/src/System.Management.Automation/engine/ScriptInfo.cs
@@ -68,7 +68,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets the ScriptBlock that represents the implementation of the script.
         /// </summary>
-        public ScriptBlock ScriptBlock { get; private set; }
+        public ScriptBlock ScriptBlock { get; }
 
         // Path
 

--- a/src/System.Management.Automation/engine/Subsystem/SubsystemInfo.cs
+++ b/src/System.Management.Automation/engine/Subsystem/SubsystemInfo.cs
@@ -20,12 +20,12 @@ namespace System.Management.Automation.Subsystem
         /// <summary>
         /// The kind of a concrete subsystem.
         /// </summary>
-        public SubsystemKind Kind { get; private set; }
+        public SubsystemKind Kind { get; }
 
         /// <summary>
         /// The type of a concrete subsystem.
         /// </summary>
-        public Type SubsystemType { get; private set; }
+        public Type SubsystemType { get; }
 
         /// <summary>
         /// Indicate whether the subsystem allows to unregister an implementation.

--- a/src/System.Management.Automation/engine/TypeTable.cs
+++ b/src/System.Management.Automation/engine/TypeTable.cs
@@ -1936,18 +1936,18 @@ namespace System.Management.Automation.Runspaces
             this.TypeName = type.FullName;
         }
 
-        internal bool fromTypesXmlFile { get; private set; }
+        internal bool fromTypesXmlFile { get; }
 
         /// <summary>
         /// Get the TypeName.
         /// </summary>
-        public string TypeName { get; private set; }
+        public string TypeName { get; }
 
         /// <summary>
         /// Get the members of this TypeData instance.
         /// The Key of the dictionary is the member's name, and the Value is a TypeMemberData instance.
         /// </summary>
-        public Dictionary<string, TypeMemberData> Members { get; private set; }
+        public Dictionary<string, TypeMemberData> Members { get; }
 
         /// <summary>
         /// The type converter.
@@ -1966,7 +1966,7 @@ namespace System.Management.Automation.Runspaces
 
         #region StandardMember
 
-        internal Dictionary<string, TypeMemberData> StandardMembers { get; private set; }
+        internal Dictionary<string, TypeMemberData> StandardMembers { get; }
 
         /// <summary>
         /// The serializationMethod.
@@ -2725,7 +2725,7 @@ namespace System.Management.Automation.Runspaces
         /// <summary>
         /// The referenced properties.
         /// </summary>
-        public Collection<string> ReferencedProperties { get; private set; }
+        public Collection<string> ReferencedProperties { get; }
 
         /// <summary>
         /// The PropertySet name.
@@ -2777,7 +2777,7 @@ namespace System.Management.Automation.Runspaces
         /// <summary>
         /// The members of the MemberSet.
         /// </summary>
-        public Collection<TypeMemberData> Members { get; private set; }
+        public Collection<TypeMemberData> Members { get; }
 
         /// <summary>
         /// Set true if the member is supposed to be hidden.

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -2035,7 +2035,7 @@ namespace System.Management.Automation
         internal string ErrorId
         {
             get;
-            private set;
+
         }
 
         internal ImplicitRemotingBatchingNotSupportedException(string errorId) : base(

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -2032,11 +2032,7 @@ namespace System.Management.Automation
 
     internal class ImplicitRemotingBatchingNotSupportedException : Exception
     {
-        internal string ErrorId
-        {
-            get;
-
-        }
+        internal string ErrorId { get; }
 
         internal ImplicitRemotingBatchingNotSupportedException(string errorId) : base(
             ParserStrings.ImplicitRemotingPipelineBatchingNotSupported)

--- a/src/System.Management.Automation/engine/debugger/Breakpoint.cs
+++ b/src/System.Management.Automation/engine/debugger/Breakpoint.cs
@@ -20,7 +20,7 @@ namespace System.Management.Automation
         /// <summary>
         /// The action to take when the breakpoint is hit.
         /// </summary>
-        public ScriptBlock Action { get; private set; }
+        public ScriptBlock Action { get; }
 
         /// <summary>
         /// Gets whether this breakpoint is enabled.
@@ -40,7 +40,7 @@ namespace System.Management.Automation
         /// <summary>
         /// This breakpoint's Id.
         /// </summary>
-        public int Id { get; private set; }
+        public int Id { get; }
 
         /// <summary>
         /// True if breakpoint is set on a script, false if the breakpoint is not scoped.
@@ -53,7 +53,7 @@ namespace System.Management.Automation
         /// <summary>
         /// The script this breakpoint is on, or null if the breakpoint is not scoped.
         /// </summary>
-        public string Script { get; private set; }
+        public string Script { get; }
 
         #endregion properties
 
@@ -191,9 +191,9 @@ namespace System.Management.Automation
         /// <summary>
         /// Which command this breakpoint is on.
         /// </summary>
-        public string Command { get; private set; }
+        public string Command { get; }
 
-        internal WildcardPattern CommandPattern { get; private set; }
+        internal WildcardPattern CommandPattern { get; }
 
         /// <summary>
         /// Gets a string representation of this breakpoint.
@@ -312,12 +312,12 @@ namespace System.Management.Automation
         /// <summary>
         /// The access mode to trigger this variable breakpoint on.
         /// </summary>
-        public VariableAccessMode AccessMode { get; private set; }
+        public VariableAccessMode AccessMode { get; }
 
         /// <summary>
         /// Which variable this breakpoint is on.
         /// </summary>
-        public string Variable { get; private set; }
+        public string Variable { get; }
 
         /// <summary>
         /// Gets the string representation of this breakpoint.
@@ -415,12 +415,12 @@ namespace System.Management.Automation
         /// <summary>
         /// Which column this breakpoint is on.
         /// </summary>
-        public int Column { get; private set; }
+        public int Column { get; }
 
         /// <summary>
         /// Which line this breakpoint is on.
         /// </summary>
-        public int Line { get; private set; }
+        public int Line { get; }
 
         /// <summary>
         /// Gets a string representation of this breakpoint.

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -178,29 +178,17 @@ namespace System.Management.Automation
         /// <summary>
         /// Job to be started.
         /// </summary>
-        public Job Job
-        {
-            get;
-
-        }
+        public Job Job { get; }
 
         /// <summary>
         /// Job debugger.
         /// </summary>
-        public Debugger Debugger
-        {
-            get;
-
-        }
+        public Debugger Debugger { get; }
 
         /// <summary>
         /// Job is run asynchronously.
         /// </summary>
-        public bool IsAsync
-        {
-            get;
-
-        }
+        public bool IsAsync { get; }
 
         /// <summary>
         /// Constructor.
@@ -226,11 +214,7 @@ namespace System.Management.Automation
     public sealed class StartRunspaceDebugProcessingEventArgs : EventArgs
     {
         /// <summary> The runspace to process </summary>
-        public Runspace Runspace
-        {
-            get;
-
-        }
+        public Runspace Runspace { get; }
 
         /// <summary>
         /// When set to true this will cause PowerShell to process this runspace debug session through its
@@ -262,11 +246,7 @@ namespace System.Management.Automation
         /// <summary>
         /// The runspace where internal debug processing has ended.
         /// </summary>
-        public Runspace Runspace
-        {
-            get;
-
-        }
+        public Runspace Runspace { get; }
 
         /// <summary>
         /// Constructor.
@@ -4196,11 +4176,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Type of runspace being monitored for debugging.
         /// </summary>
-        public PSMonitorRunspaceType RunspaceType
-        {
-            get;
-
-        }
+        public PSMonitorRunspaceType RunspaceType { get; }
 
         /// <summary>
         /// Unique parent debugger identifier for monitored runspace.
@@ -5018,11 +4994,7 @@ namespace System.Management.Automation
         /// True if debugger evaluated command.  Otherwise evaluation was
         /// performed by PowerShell.
         /// </summary>
-        public bool EvaluatedByDebugger
-        {
-            get;
-
-        }
+        public bool EvaluatedByDebugger { get; }
 
         #endregion
 

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -95,7 +95,7 @@ namespace System.Management.Automation
         /// Note there may be more than one breakpoint on the same object (line, variable, command). A single event is
         /// raised for all these breakpoints.
         /// </remarks>
-        public ReadOnlyCollection<Breakpoint> Breakpoints { get; private set; }
+        public ReadOnlyCollection<Breakpoint> Breakpoints { get; }
 
         /// <summary>
         /// This property must be set in the event handler to indicate the debugger what it should do next.
@@ -155,17 +155,17 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets the breakpoint that was updated.
         /// </summary>
-        public Breakpoint Breakpoint { get; private set; }
+        public Breakpoint Breakpoint { get; }
 
         /// <summary>
         /// Gets the type of update.
         /// </summary>
-        public BreakpointUpdateType UpdateType { get; private set; }
+        public BreakpointUpdateType UpdateType { get; }
 
         /// <summary>
         /// Gets the current breakpoint count.
         /// </summary>
-        public int BreakpointCount { get; private set; }
+        public int BreakpointCount { get; }
     };
 
     #region PSJobStartEventArgs
@@ -181,7 +181,7 @@ namespace System.Management.Automation
         public Job Job
         {
             get;
-            private set;
+
         }
 
         /// <summary>
@@ -190,7 +190,7 @@ namespace System.Management.Automation
         public Debugger Debugger
         {
             get;
-            private set;
+
         }
 
         /// <summary>
@@ -199,7 +199,7 @@ namespace System.Management.Automation
         public bool IsAsync
         {
             get;
-            private set;
+
         }
 
         /// <summary>
@@ -229,7 +229,7 @@ namespace System.Management.Automation
         public Runspace Runspace
         {
             get;
-            private set;
+
         }
 
         /// <summary>
@@ -265,7 +265,7 @@ namespace System.Management.Automation
         public Runspace Runspace
         {
             get;
-            private set;
+
         }
 
         /// <summary>
@@ -4199,7 +4199,7 @@ namespace System.Management.Automation
         public PSMonitorRunspaceType RunspaceType
         {
             get;
-            private set;
+
         }
 
         /// <summary>
@@ -5021,7 +5021,7 @@ namespace System.Management.Automation
         public bool EvaluatedByDebugger
         {
             get;
-            private set;
+
         }
 
         #endregion
@@ -5488,18 +5488,18 @@ namespace System.Management.Automation
         /// <summary>
         /// InvocationInfo of the command currently being executed.
         /// </summary>
-        public InvocationInfo InvocationInfo { get; private set; }
+        public InvocationInfo InvocationInfo { get; }
 
         /// <summary>
         /// If not empty, indicates that the execution was suspended because one or more breakpoints
         /// were hit. Otherwise, the execution was suspended as part of a step operation.
         /// </summary>
-        public Breakpoint[] Breakpoints { get; private set; }
+        public Breakpoint[] Breakpoints { get; }
 
         /// <summary>
         /// Gets the object that triggered the current dynamic breakpoint.
         /// </summary>
-        public object Trigger { get; private set; }
+        public object Trigger { get; }
     }
 
     #endregion
@@ -5567,13 +5567,13 @@ namespace System.Management.Automation
         /// <summary>
         /// The InvocationInfo of the command.
         /// </summary>
-        public InvocationInfo InvocationInfo { get; private set; }
+        public InvocationInfo InvocationInfo { get; }
 
         /// <summary>
         /// The position information for the current position in the frame.  Null if the frame is not
         /// associated with a script.
         /// </summary>
-        public IScriptExtent Position { get; private set; }
+        public IScriptExtent Position { get; }
 
         /// <summary>
         /// The name of the function associated with this frame.
@@ -5765,12 +5765,12 @@ namespace System.Management.Automation.Internal
         /// <summary>
         /// Created Runspace.
         /// </summary>
-        public Runspace Runspace { get; private set; }
+        public Runspace Runspace { get; }
 
         /// <summary>
         /// Type of runspace for monitoring.
         /// </summary>
-        public PSMonitorRunspaceType RunspaceType { get; private set; }
+        public PSMonitorRunspaceType RunspaceType { get; }
 
         /// <summary>
         /// Nested debugger wrapper for runspace debugger.
@@ -5876,7 +5876,7 @@ namespace System.Management.Automation.Internal
         /// <summary>
         /// PowerShell command to run.  Can be null.
         /// </summary>
-        public PowerShell Command { get; private set; }
+        public PowerShell Command { get; }
 
         /// <summary>
         /// Unique parent debugger identifier.

--- a/src/System.Management.Automation/engine/hostifaces/Connection.cs
+++ b/src/System.Management.Automation/engine/hostifaces/Connection.cs
@@ -758,11 +758,7 @@ namespace System.Management.Automation.Runspaces
         /// <summary>
         /// Gets the Runspace Id.
         /// </summary>
-        public int Id
-        {
-            get;
-
-        }
+        public int Id { get; }
 
         /// <summary>
         /// Returns protocol version that the remote server uses for PS remoting.

--- a/src/System.Management.Automation/engine/hostifaces/Connection.cs
+++ b/src/System.Management.Automation/engine/hostifaces/Connection.cs
@@ -761,7 +761,7 @@ namespace System.Management.Automation.Runspaces
         public int Id
         {
             get;
-            private set;
+
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -1052,7 +1052,7 @@ namespace System.Management.Automation.Host
         internal List<TranscriptionOption> Transcripts
         {
             get;
-            private set;
+
         }
 
         internal TranscriptionOption SystemTranscript { get; set; }
@@ -1093,12 +1093,12 @@ namespace System.Management.Automation.Host
         /// <summary>
         /// Any output to log for this transcript.
         /// </summary>
-        internal List<string> OutputToLog { get; private set; }
+        internal List<string> OutputToLog { get; }
 
         /// <summary>
         /// Any output currently being logged for this transcript.
         /// </summary>
-        internal List<string> OutputBeingLogged { get; private set; }
+        internal List<string> OutputBeingLogged { get; }
 
         /// <summary>
         /// Whether to include time stamp / command separators in

--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -1049,11 +1049,7 @@ namespace System.Management.Automation.Host
             PromptText = "PS>";
         }
 
-        internal List<TranscriptionOption> Transcripts
-        {
-            get;
-
-        }
+        internal List<TranscriptionOption> Transcripts { get; }
 
         internal TranscriptionOption SystemTranscript { get; set; }
         internal string CommandBeingIgnored { get; set; }

--- a/src/System.Management.Automation/engine/interpreter/LightLambda.cs
+++ b/src/System.Management.Automation/engine/interpreter/LightLambda.cs
@@ -32,7 +32,7 @@ namespace System.Management.Automation.Interpreter
 {
     internal sealed class LightLambdaCompileEventArgs : EventArgs
     {
-        public Delegate Compiled { get; private set; }
+        public Delegate Compiled { get; }
 
         internal LightLambdaCompileEventArgs(Delegate compiled)
         {

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -190,7 +190,7 @@ namespace System.Management.Automation
             this.RequestingCommandProcessor = requestingCommand.Context.CurrentCommandProcessor;
         }
 
-        public CommandProcessorBase RequestingCommandProcessor { get; private set; }
+        public CommandProcessorBase RequestingCommandProcessor { get; }
     }
 
     #endregion Flow Control Exceptions
@@ -1727,12 +1727,12 @@ namespace System.Management.Automation
 
         internal char LowerBound
         {
-            get; private set;
+            get;
         }
 
         internal char UpperBound
         {
-            get; private set;
+            get;
         }
 
         public char Current

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -1725,15 +1725,9 @@ namespace System.Management.Automation
             get { return Current; }
         }
 
-        internal char LowerBound
-        {
-            get;
-        }
+        internal char LowerBound { get; }
 
-        internal char UpperBound
-        {
-            get;
-        }
+        internal char UpperBound { get; }
 
         public char Current
         {

--- a/src/System.Management.Automation/engine/parser/AstVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/AstVisitor.cs
@@ -239,7 +239,7 @@ namespace System.Management.Automation.Language
             this.Root = root;
         }
 
-        private Ast Root { get; set; }
+        private Ast Root { get; }
 
         internal AstVisitAction CheckParent(Ast ast)
         {

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -2206,11 +2206,11 @@ namespace System.Management.Automation.Language
                 this.ContinueLabel = continueLabel;
             }
 
-            internal string Label { get; private set; }
+            internal string Label { get; }
 
-            internal LabelTarget ContinueLabel { get; private set; }
+            internal LabelTarget ContinueLabel { get; }
 
-            internal LabelTarget BreakLabel { get; private set; }
+            internal LabelTarget BreakLabel { get; }
         }
 
         private LabelTarget _returnTarget;

--- a/src/System.Management.Automation/engine/parser/TypeResolver.cs
+++ b/src/System.Management.Automation/engine/parser/TypeResolver.cs
@@ -53,9 +53,9 @@ namespace System.Management.Automation.Language
         /// </summary>
         internal class AmbiguousTypeException : InvalidCastException
         {
-            public string[] Candidates { private set; get; }
+            public string[] Candidates { get; }
 
-            public TypeName TypeName { private set; get; }
+            public TypeName TypeName { get; }
 
             public AmbiguousTypeException(TypeName typeName, IEnumerable<string> candidates)
             {

--- a/src/System.Management.Automation/engine/parser/VariableAnalysis.cs
+++ b/src/System.Management.Automation/engine/parser/VariableAnalysis.cs
@@ -31,7 +31,7 @@ namespace System.Management.Automation.Language
         public bool Automatic { get; set; }
         public bool PreferenceVariable { get; set; }
         public bool Assigned { get; set; }
-        public List<Ast> AssociatedAsts { get; private set; }
+        public List<Ast> AssociatedAsts { get; }
     }
 
     internal class FindAllVariablesVisitor : AstVisitor
@@ -340,11 +340,11 @@ namespace System.Management.Automation.Language
                 this.ContinueTarget = continueTarget;
             }
 
-            internal string Label { get; private set; }
+            internal string Label { get; }
 
-            internal Block BreakTarget { get; private set; }
+            internal Block BreakTarget { get; }
 
-            internal Block ContinueTarget { get; private set; }
+            internal Block ContinueTarget { get; }
         }
 
         private class Block

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -104,7 +104,7 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The extent in the source this ast represents.
         /// </summary>
-        public IScriptExtent Extent { get; private set; }
+        public IScriptExtent Extent { get; }
 
         /// <summary>
         /// The parent tree for this node.
@@ -504,7 +504,7 @@ namespace System.Management.Automation.Language
         /// Indicate the kind of the ErrorStatement. e.g. Kind == Switch means that this error statment is generated
         /// when parsing a switch statement.
         /// </summary>
-        public Token Kind { get; private set; }
+        public Token Kind { get; }
 
         /// <summary>
         /// The flags specified and their value. The value is null if it's not specified.
@@ -514,24 +514,24 @@ namespace System.Management.Automation.Language
         /// TODO, Changing this to an IDictionary because ReadOnlyDictionary is available only in .NET 4.5
         /// This is a temporary workaround and will be fixed later. Tracked by Win8: 354135
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
-        public Dictionary<string, Tuple<Token, Ast>> Flags { get; private set; }
+        public Dictionary<string, Tuple<Token, Ast>> Flags { get; }
 
         /// <summary>
         /// The conditions specified.
         /// </summary>
-        public ReadOnlyCollection<Ast> Conditions { get; private set; }
+        public ReadOnlyCollection<Ast> Conditions { get; }
 
         /// <summary>
         /// The bodies specified.
         /// </summary>
-        public ReadOnlyCollection<Ast> Bodies { get; private set; }
+        public ReadOnlyCollection<Ast> Bodies { get; }
 
         /// <summary>
         /// Sometimes a valid ast is parsed successfully within the extent that this error statement represents.  Those
         /// asts are contained in this collection.  This collection may contain other error asts.  This collection may
         /// be null when no asts were successfully constructed within the extent of this error ast.
         /// </summary>
-        public ReadOnlyCollection<Ast> NestedAst { get; private set; }
+        public ReadOnlyCollection<Ast> NestedAst { get; }
 
         /// <summary>
         /// Copy the ErrorStatementAst instance.
@@ -648,7 +648,7 @@ namespace System.Management.Automation.Language
         /// asts are contained in this collection.  This collection may contain other error asts.  This collection may
         /// be null when no asts were successfully constructed within the extent of this error ast.
         /// </summary>
-        public ReadOnlyCollection<Ast> NestedAst { get; private set; }
+        public ReadOnlyCollection<Ast> NestedAst { get; }
 
         /// <summary>
         /// Copy the ErrorExpressionAst instance.
@@ -1064,7 +1064,7 @@ namespace System.Management.Automation.Language
         /// The asts for attributes (such as [DscLocalConfigurationManager()]) used before the scriptblock.
         /// This property is never null.
         /// </summary>
-        public ReadOnlyCollection<AttributeAst> Attributes { get; private set; }
+        public ReadOnlyCollection<AttributeAst> Attributes { get; }
 
         /// <summary>
         /// The asts for any using statements.  This property is never null.
@@ -1077,28 +1077,28 @@ namespace System.Management.Automation.Language
         /// The ast representing the parameters for a script block, or null if no param block was specified.
         /// </summary>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Param")]
-        public ParamBlockAst ParamBlock { get; private set; }
+        public ParamBlockAst ParamBlock { get; }
 
         /// <summary>
         /// The ast representing the begin block for a script block, or null if no begin block was specified.
         /// </summary>
-        public NamedBlockAst BeginBlock { get; private set; }
+        public NamedBlockAst BeginBlock { get; }
 
         /// <summary>
         /// The ast representing the process block for a script block, or null if no process block was specified.
         /// </summary>
-        public NamedBlockAst ProcessBlock { get; private set; }
+        public NamedBlockAst ProcessBlock { get; }
 
         /// <summary>
         /// The ast representing the end block for a script block, or null if no end block was specified.
         /// </summary>
-        public NamedBlockAst EndBlock { get; private set; }
+        public NamedBlockAst EndBlock { get; }
 
         /// <summary>
         /// The ast representing the dynamicparam block for a script block, or null if no dynamicparam block was specified.
         /// </summary>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Param")]
-        public NamedBlockAst DynamicParamBlock { get; private set; }
+        public NamedBlockAst DynamicParamBlock { get; }
 
         /// <summary>
         /// All of the parsed information from any #requires in the script, or null if #requires was not used.
@@ -1649,12 +1649,12 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The asts for attributes (such as [cmdletbinding()]) used before the param keyword.
         /// </summary>
-        public ReadOnlyCollection<AttributeAst> Attributes { get; private set; }
+        public ReadOnlyCollection<AttributeAst> Attributes { get; }
 
         /// <summary>
         /// The asts for the parameters of the param statement.
         /// </summary>
-        public ReadOnlyCollection<ParameterAst> Parameters { get; private set; }
+        public ReadOnlyCollection<ParameterAst> Parameters { get; }
 
         /// <summary>
         /// Copy the ParamBlockAst instance.
@@ -1808,7 +1808,7 @@ namespace System.Management.Automation.Language
         /// For a function/filter that did not explicitly name the end/process block (which is quite common),
         /// this property will return true.
         /// </summary>
-        public bool Unnamed { get; private set; }
+        public bool Unnamed { get; }
 
         /// <summary>
         /// The kind of block, always one of:
@@ -1819,18 +1819,18 @@ namespace System.Management.Automation.Language
         /// <item><see cref="TokenKind.Dynamicparam"/></item>
         /// </list>
         /// </summary>
-        public TokenKind BlockKind { get; private set; }
+        public TokenKind BlockKind { get; }
 
         /// <summary>
         /// The asts for all of the statements represented by this statement block.  This property is never null.
         /// </summary>
-        public ReadOnlyCollection<StatementAst> Statements { get; private set; }
+        public ReadOnlyCollection<StatementAst> Statements { get; }
 
         /// <summary>
         /// The asts for all of the trap statements specified by this statement block, or null if no trap statements were
         /// specified in this block.
         /// </summary>
-        public ReadOnlyCollection<TrapStatementAst> Traps { get; private set; }
+        public ReadOnlyCollection<TrapStatementAst> Traps { get; }
 
         /// <summary>
         /// Copy the NamedBlockAst instance.
@@ -1856,9 +1856,9 @@ namespace System.Management.Automation.Language
         }
 
         // Used by the debugger for command breakpoints
-        internal IScriptExtent OpenCurlyExtent { get; private set; }
+        internal IScriptExtent OpenCurlyExtent { get; }
 
-        internal IScriptExtent CloseCurlyExtent { get; private set; }
+        internal IScriptExtent CloseCurlyExtent { get; }
 
         #region Visitors
 
@@ -1925,18 +1925,18 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The named argument specified by this ast, is never null or empty.
         /// </summary>
-        public string ArgumentName { get; private set; }
+        public string ArgumentName { get; }
 
         /// <summary>
         /// The ast of the value of the argument specified by this ast.  This property is never null.
         /// </summary>
-        public ExpressionAst Argument { get; private set; }
+        public ExpressionAst Argument { get; }
 
         /// <summary>
         /// If the source omitted an expression, this returns true, otherwise false.  This allows a caller to distinguish
         /// the difference between <c>[Parameter(Mandatory)]</c> and <c>[Parameter(Mandatory=$true)]</c>
         /// </summary>
-        public bool ExpressionOmitted { get; private set; }
+        public bool ExpressionOmitted { get; }
 
         /// <summary>
         /// Copy the NamedAttributeArgumentAst instance.
@@ -1995,7 +1995,7 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The type name for the attribute.  This property is never null.
         /// </summary>
-        public ITypeName TypeName { get; private set; }
+        public ITypeName TypeName { get; }
 
         internal abstract Attribute GetAttribute();
     }
@@ -2051,12 +2051,12 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The asts for the attribute arguments specified positionally.
         /// </summary>
-        public ReadOnlyCollection<ExpressionAst> PositionalArguments { get; private set; }
+        public ReadOnlyCollection<ExpressionAst> PositionalArguments { get; }
 
         /// <summary>
         /// The asts for the named attribute arguments.
         /// </summary>
-        public ReadOnlyCollection<NamedAttributeArgumentAst> NamedArguments { get; private set; }
+        public ReadOnlyCollection<NamedAttributeArgumentAst> NamedArguments { get; }
 
         /// <summary>
         /// Copy the AttributeAst instance.
@@ -2223,17 +2223,17 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The asts for any attributes or type constraints specified on the parameter.
         /// </summary>
-        public ReadOnlyCollection<AttributeBaseAst> Attributes { get; private set; }
+        public ReadOnlyCollection<AttributeBaseAst> Attributes { get; }
 
         /// <summary>
         /// The variable path for the parameter.  This property is never null.
         /// </summary>
-        public VariableExpressionAst Name { get; private set; }
+        public VariableExpressionAst Name { get; }
 
         /// <summary>
         /// The ast for the default value of the parameter, or null if no default value was specified.
         /// </summary>
-        public ExpressionAst DefaultValue { get; private set; }
+        public ExpressionAst DefaultValue { get; }
 
         /// <summary>
         /// Returns the type of the parameter.  If the parameter is constrained to be a specific type, that type is returned,
@@ -2411,13 +2411,13 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The asts for all of the statements represented by this statement block.  This property is never null.
         /// </summary>
-        public ReadOnlyCollection<StatementAst> Statements { get; private set; }
+        public ReadOnlyCollection<StatementAst> Statements { get; }
 
         /// <summary>
         /// The asts for all of the trap statements specified by this statement block, or null if no trap statements were
         /// specified in this block.
         /// </summary>
-        public ReadOnlyCollection<TrapStatementAst> Traps { get; private set; }
+        public ReadOnlyCollection<TrapStatementAst> Traps { get; }
 
         /// <summary>
         /// Copy the StatementBlockAst instance.
@@ -2583,27 +2583,27 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The name of the type.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <summary>
         /// The asts for the custom attributes specified on the type.  This property is never null.
         /// </summary>
-        public ReadOnlyCollection<AttributeAst> Attributes { get; private set; }
+        public ReadOnlyCollection<AttributeAst> Attributes { get; }
 
         /// <summary>
         /// The asts for the base types. This property is never null.
         /// </summary>
-        public ReadOnlyCollection<TypeConstraintAst> BaseTypes { get; private set; }
+        public ReadOnlyCollection<TypeConstraintAst> BaseTypes { get; }
 
         /// <summary>
         /// The asts for the members of the type.  This property is never null.
         /// </summary>
-        public ReadOnlyCollection<MemberAst> Members { get; private set; }
+        public ReadOnlyCollection<MemberAst> Members { get; }
 
         /// <summary>
         /// The type attributes (like class or interface) of the type.
         /// </summary>
-        public TypeAttributes TypeAttributes { get; private set; }
+        public TypeAttributes TypeAttributes { get; }
 
         /// <summary>
         /// Returns true if the type defines an enum.
@@ -2862,24 +2862,24 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The kind of using statement.
         /// </summary>
-        public UsingStatementKind UsingStatementKind { get; private set; }
+        public UsingStatementKind UsingStatementKind { get; }
 
         /// <summary>
         /// When <see cref="Alias"/> is null or <see cref="ModuleSpecification"/> is null, the item being used, otherwise the alias name.
         /// </summary>
-        public StringConstantExpressionAst Name { get; private set; }
+        public StringConstantExpressionAst Name { get; }
 
         /// <summary>
         /// The name of the item being aliased.
         /// This property is mutually exclusive with <see cref="ModuleSpecification"/> property.
         /// </summary>
-        public StringConstantExpressionAst Alias { get; private set; }
+        public StringConstantExpressionAst Alias { get; }
 
         /// <summary>
         /// Hashtable that can be converted to <see cref="Microsoft.PowerShell.Commands.ModuleSpecification"/>. Only for 'using module' case, otherwise null.
         /// This property is mutually exclusive with <see cref="Alias"/> property.
         /// </summary>
-        public HashtableAst ModuleSpecification { get; private set; }
+        public HashtableAst ModuleSpecification { get; }
 
         /// <summary>
         /// ModuleInfo about used module. Only for 'using module' case, otherwise null.
@@ -3071,22 +3071,22 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The ast for the type of the property.  This property may be null if no type was specified.
         /// </summary>
-        public TypeConstraintAst PropertyType { get; private set; }
+        public TypeConstraintAst PropertyType { get; }
 
         /// <summary>
         /// The custom attributes of the property.  This property is never null.
         /// </summary>
-        public ReadOnlyCollection<AttributeAst> Attributes { get; private set; }
+        public ReadOnlyCollection<AttributeAst> Attributes { get; }
 
         /// <summary>
         /// The attributes (like public or static) of the property.
         /// </summary>
-        public PropertyAttributes PropertyAttributes { get; private set; }
+        public PropertyAttributes PropertyAttributes { get; }
 
         /// <summary>
         /// The ast for the initial value of the property.  This property may be null if no initial value was specified.
         /// </summary>
-        public ExpressionAst InitialValue { get; private set; }
+        public ExpressionAst InitialValue { get; }
 
         /// <summary>
         /// Return true if the property is public.
@@ -3254,12 +3254,12 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The attributes specified on the method.  This property is never null.
         /// </summary>
-        public ReadOnlyCollection<AttributeAst> Attributes { get; private set; }
+        public ReadOnlyCollection<AttributeAst> Attributes { get; }
 
         /// <summary>
         /// The ast representing the return type for the method.  This property may be null if no return type was specified.
         /// </summary>
-        public TypeConstraintAst ReturnType { get; private set; }
+        public TypeConstraintAst ReturnType { get; }
 
         /// <summary>
         /// The parameters specified immediately after the function name.  This property is never null.
@@ -3277,7 +3277,7 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// Method attribute flags.
         /// </summary>
-        public MethodAttributes MethodAttributes { get; private set; }
+        public MethodAttributes MethodAttributes { get; }
 
         /// <summary>
         /// Returns true if the method is public.
@@ -3486,9 +3486,9 @@ namespace System.Management.Automation.Language
             get { return DefiningType.Name; }
         }
 
-        internal TypeDefinitionAst DefiningType { get; private set; }
+        internal TypeDefinitionAst DefiningType { get; }
 
-        internal SpecialMemberFunctionType Type { get; private set; }
+        internal SpecialMemberFunctionType Type { get; }
 
         internal override string GetTooltip()
         {
@@ -3539,7 +3539,7 @@ namespace System.Management.Automation.Language
 
         public ReadOnlyCollection<ParameterAst> Parameters { get { return null; } }
 
-        public ScriptBlockAst Body { get; private set; }
+        public ScriptBlockAst Body { get; }
 
         public PowerShell GetPowerShell(ExecutionContext context, Dictionary<string, object> variables, bool isTrustedInput,
             bool filterNonUsingVariables, bool? createLocalScope, params object[] args)
@@ -3639,17 +3639,17 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// If true, the filter keyword was used.
         /// </summary>
-        public bool IsFilter { get; private set; }
+        public bool IsFilter { get; }
 
         /// <summary>
         /// If true, the workflow keyword was used.
         /// </summary>
-        public bool IsWorkflow { get; private set; }
+        public bool IsWorkflow { get; }
 
         /// <summary>
         /// The name of the function or filter.  This property is never null or empty.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <summary>
         /// The parameters specified immediately after the function name, or null if no parameters were specified.
@@ -3660,12 +3660,12 @@ namespace System.Management.Automation.Language
         /// In this example, the parameters specified after the function name must be empty or the script is not valid.
         /// </para>
         /// </summary>
-        public ReadOnlyCollection<ParameterAst> Parameters { get; private set; }
+        public ReadOnlyCollection<ParameterAst> Parameters { get; }
 
         /// <summary>
         /// The body of the function.  This property is never null.
         /// </summary>
-        public ScriptBlockAst Body { get; private set; }
+        public ScriptBlockAst Body { get; }
 
         internal IScriptExtent NameExtent { get; private set; }
 
@@ -3920,12 +3920,12 @@ namespace System.Management.Automation.Language
         /// executed.  This property is never null and always has at least 1 value.
         /// </summary>
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
-        public ReadOnlyCollection<IfClause> Clauses { get; private set; }
+        public ReadOnlyCollection<IfClause> Clauses { get; }
 
         /// <summary>
         /// The ast for the else clause, or null if no else clause is specified.
         /// </summary>
-        public StatementBlockAst ElseClause { get; private set; }
+        public StatementBlockAst ElseClause { get; }
 
         /// <summary>
         /// Copy the IfStatementAst instance.
@@ -4033,17 +4033,17 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The name of the variable this data statement sets, or null if no variable name was specified.
         /// </summary>
-        public string Variable { get; private set; }
+        public string Variable { get; }
 
         /// <summary>
         /// The asts naming the commands allowed to execute in this data statement.
         /// </summary>
-        public ReadOnlyCollection<ExpressionAst> CommandsAllowed { get; private set; }
+        public ReadOnlyCollection<ExpressionAst> CommandsAllowed { get; }
 
         /// <summary>
         /// The ast for the body of the data statement.  This property is never null.
         /// </summary>
-        public StatementBlockAst Body { get; private set; }
+        public StatementBlockAst Body { get; }
 
         /// <summary>
         /// Copy the DataStatementAst instance.
@@ -4055,7 +4055,7 @@ namespace System.Management.Automation.Language
             return new DataStatementAst(this.Extent, this.Variable, newCommandsAllowed, newBody);
         }
 
-        internal bool HasNonConstantAllowedCommand { get; private set; }
+        internal bool HasNonConstantAllowedCommand { get; }
 
         #region Visitors
 
@@ -4118,13 +4118,13 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The label name if specified, otherwise null.
         /// </summary>
-        public string Label { get; private set; }
+        public string Label { get; }
 
         /// <summary>
         /// The ast for the condition that is tested on each iteration of the loop, or the condition tested on a switch.
         /// This property may be null if the statement is a <see cref="ForStatementAst"/>, otherwise it is never null.
         /// </summary>
-        public PipelineBaseAst Condition { get; private set; }
+        public PipelineBaseAst Condition { get; }
     }
 
     /// <summary>
@@ -4158,7 +4158,7 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The body of a loop statement.  This property is never null.
         /// </summary>
-        public StatementBlockAst Body { get; private set; }
+        public StatementBlockAst Body { get; }
     }
 
     /// <summary>
@@ -4253,17 +4253,17 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The name of the variable set for each item as the loop iterates.  This property is never null.
         /// </summary>
-        public VariableExpressionAst Variable { get; private set; }
+        public VariableExpressionAst Variable { get; }
 
         /// <summary>
         /// The limit to be obeyed during parallel processing, if any.
         /// </summary>
-        public ExpressionAst ThrottleLimit { get; private set; }
+        public ExpressionAst ThrottleLimit { get; }
 
         /// <summary>
         /// The flags, if any specified on the foreach statement.
         /// </summary>
-        public ForEachFlags Flags { get; private set; }
+        public ForEachFlags Flags { get; }
 
         /// <summary>
         /// Copy the ForEachStatementAst instance.
@@ -4349,12 +4349,12 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The ast for the initialization expression of a for statement, or null if none was specified.
         /// </summary>
-        public PipelineBaseAst Initializer { get; private set; }
+        public PipelineBaseAst Initializer { get; }
 
         /// <summary>
         /// The ast for the iteration expression of a for statement, or null if none was specified.
         /// </summary>
-        public PipelineBaseAst Iterator { get; private set; }
+        public PipelineBaseAst Iterator { get; }
 
         /// <summary>
         /// Copy the ForStatementAst instance.
@@ -4664,19 +4664,19 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The flags, if any specified on the switch statement.
         /// </summary>
-        public SwitchFlags Flags { get; private set; }
+        public SwitchFlags Flags { get; }
 
         /// <summary>
         /// A possibly empty collection of conditions and statement blocks representing the cases of the switch statement.
         /// If the collection is empty, the default clause is not null.
         /// </summary>
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
-        public ReadOnlyCollection<SwitchClause> Clauses { get; private set; }
+        public ReadOnlyCollection<SwitchClause> Clauses { get; }
 
         /// <summary>
         /// The ast for the default of the switch statement, or null if no default block was specified.
         /// </summary>
-        public StatementBlockAst Default { get; private set; }
+        public StatementBlockAst Default { get; }
 
         /// <summary>
         /// Copy the SwitchStatementAst instance.
@@ -4784,7 +4784,7 @@ namespace System.Management.Automation.Language
         /// A possibly empty collection of types caught by this catch block.  If the collection is empty, the catch handler
         /// catches all exceptions.
         /// </summary>
-        public ReadOnlyCollection<TypeConstraintAst> CatchTypes { get; private set; }
+        public ReadOnlyCollection<TypeConstraintAst> CatchTypes { get; }
 
         /// <summary>
         /// Returns true if this handler handles any kind of exception.
@@ -4795,7 +4795,7 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The body of the catch block.  This property is never null.
         /// </summary>
-        public StatementBlockAst Body { get; private set; }
+        public StatementBlockAst Body { get; }
 
         /// <summary>
         /// Copy the CatchClauseAst instance.
@@ -4897,18 +4897,18 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The body of the try statement.  This property is never null.
         /// </summary>
-        public StatementBlockAst Body { get; private set; }
+        public StatementBlockAst Body { get; }
 
         /// <summary>
         /// A collection of catch clauses, which is empty if there are no catches.
         /// </summary>
-        public ReadOnlyCollection<CatchClauseAst> CatchClauses { get; private set; }
+        public ReadOnlyCollection<CatchClauseAst> CatchClauses { get; }
 
         /// <summary>
         /// The ast for the finally block, or null if no finally block was specified, in which case <see cref="CatchClauses"/>
         /// is a non-null, non-empty collection.
         /// </summary>
-        public StatementBlockAst Finally { get; private set; }
+        public StatementBlockAst Finally { get; }
 
         /// <summary>
         /// Copy the TryStatementAst instance.
@@ -4991,12 +4991,12 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The ast for the type trapped by this trap block, or null if no type was specified.
         /// </summary>
-        public TypeConstraintAst TrapType { get; private set; }
+        public TypeConstraintAst TrapType { get; }
 
         /// <summary>
         /// The body for the trap block.  This property is never null.
         /// </summary>
-        public StatementBlockAst Body { get; private set; }
+        public StatementBlockAst Body { get; }
 
         /// <summary>
         /// Copy the TrapStatementAst instance.
@@ -5060,7 +5060,7 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The expression or label to break to, or null if no label was specified.
         /// </summary>
-        public ExpressionAst Label { get; private set; }
+        public ExpressionAst Label { get; }
 
         /// <summary>
         /// Copy the BreakStatementAst instance.
@@ -5117,7 +5117,7 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The expression or label to continue to, or null if no label was specified.
         /// </summary>
-        public ExpressionAst Label { get; private set; }
+        public ExpressionAst Label { get; }
 
         /// <summary>
         /// Copy the ContinueStatementAst instance.
@@ -5174,7 +5174,7 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The pipeline specified in the return statement, or null if none was specified.
         /// </summary>
-        public PipelineBaseAst Pipeline { get; private set; }
+        public PipelineBaseAst Pipeline { get; }
 
         /// <summary>
         /// Copy the ReturnStatementAst instance.
@@ -5231,7 +5231,7 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The pipeline specified in the exit statement, or null if none was specified.
         /// </summary>
-        public PipelineBaseAst Pipeline { get; private set; }
+        public PipelineBaseAst Pipeline { get; }
 
         /// <summary>
         /// Copy the ExitStatementAst instance.
@@ -5288,7 +5288,7 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The pipeline specified in the throw statement, or null if none was specified.
         /// </summary>
-        public PipelineBaseAst Pipeline { get; private set; }
+        public PipelineBaseAst Pipeline { get; }
 
         /// <summary>
         /// If the throw statement is a rethrow.  In PowerShell, a throw statement need not throw anything.  Such
@@ -5591,7 +5591,7 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// A non-null, non-empty collection of commands that represent the pipeline.
         /// </summary>
-        public ReadOnlyCollection<CommandBaseAst> PipelineElements { get; private set; }
+        public ReadOnlyCollection<CommandBaseAst> PipelineElements { get; }
 
         /// <summary>
         /// Indicates that this pipeline should be run in the background.
@@ -5728,19 +5728,19 @@ namespace System.Management.Automation.Language
         /// The name of the parameter.  This value does not include a leading dash, and in the case that an argument
         /// is specified, no trailing colon is included either.  This property is never null or empty.
         /// </summary>
-        public string ParameterName { get; private set; }
+        public string ParameterName { get; }
 
         /// <summary>
         /// The ast for the argument if specified (e.g. -Path:-abc, then the argument is the ast for '-ast'), otherwise null
         /// if no argument was specified.
         /// </summary>
-        public ExpressionAst Argument { get; private set; }
+        public ExpressionAst Argument { get; }
 
         /// <summary>
         /// The error position to use when parameter binding fails.  This extent does not include the argument if one was
         /// specified, which means this extent is often the same as <see cref="Ast.Extent"/>.
         /// </summary>
-        public IScriptExtent ErrorPosition { get; private set; }
+        public IScriptExtent ErrorPosition { get; }
 
         /// <summary>
         /// Copy the CommandParameterAst instance.
@@ -5809,7 +5809,7 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The possibly empty collection of redirections for this command.
         /// </summary>
-        public ReadOnlyCollection<RedirectionAst> Redirections { get; private set; }
+        public ReadOnlyCollection<RedirectionAst> Redirections { get; }
     }
 
     /// <summary>
@@ -5857,13 +5857,13 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// A non-empty collection of command elements.  This property is never null.
         /// </summary>
-        public ReadOnlyCollection<CommandElementAst> CommandElements { get; private set; }
+        public ReadOnlyCollection<CommandElementAst> CommandElements { get; }
 
         /// <summary>
         /// The invocation operator (either <see cref="TokenKind.Dot"/> or <see cref="TokenKind.Ampersand"/>) if one was specified,
         /// otherwise the value is <see cref="TokenKind.Unknown"/>.
         /// </summary>
-        public TokenKind InvocationOperator { get; private set; }
+        public TokenKind InvocationOperator { get; }
 
         /// <summary>
         /// <para>Returns the name of the command invoked by this ast.</para>
@@ -5972,7 +5972,7 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The ast for the expression that is or starts a pipeline.  This property is never null.
         /// </summary>
-        public ExpressionAst Expression { get; private set; }
+        public ExpressionAst Expression { get; }
 
         /// <summary>
         /// Copy the CommandExpressionAst instance.
@@ -6035,7 +6035,7 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The stream to read objects from.  Objects are either merged with another stream, or written to a file.
         /// </summary>
-        public RedirectionStream FromStream { get; private set; }
+        public RedirectionStream FromStream { get; }
     }
 
     /// <summary>
@@ -6101,7 +6101,7 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The stream that results will be written to.
         /// </summary>
-        public RedirectionStream ToStream { get; private set; }
+        public RedirectionStream ToStream { get; }
 
         /// <summary>
         /// Copy the MergingRedirectionAst instance.
@@ -6166,12 +6166,12 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The ast for the location to redirect to.
         /// </summary>
-        public ExpressionAst Location { get; private set; }
+        public ExpressionAst Location { get; }
 
         /// <summary>
         /// True if the file is appended, false otherwise.
         /// </summary>
-        public bool Append { get; private set; }
+        public bool Append { get; }
 
         /// <summary>
         /// Copy the FileRedirectionAst instance.
@@ -6262,22 +6262,22 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The ast for the location being assigned.  This property is never null.
         /// </summary>
-        public ExpressionAst Left { get; private set; }
+        public ExpressionAst Left { get; }
 
         /// <summary>
         /// The operator for token assignment (such as =, +=, -=, etc.).  The value is always some assignment operator.
         /// </summary>
-        public TokenKind Operator { get; private set; }
+        public TokenKind Operator { get; }
 
         /// <summary>
         /// The ast for the value to assign.  This property is never null.
         /// </summary>
-        public StatementAst Right { get; private set; }
+        public StatementAst Right { get; }
 
         /// <summary>
         /// The position to report at runtime if there is an error during assignment.  This property is never null.
         /// </summary>
-        public IScriptExtent ErrorPosition { get; private set; }
+        public IScriptExtent ErrorPosition { get; }
 
         /// <summary>
         /// Copy the AssignmentStatementAst instance.
@@ -6396,19 +6396,19 @@ namespace System.Management.Automation.Language
         /// This ast represents configuration body script block.
         /// This property is never null.
         /// </summary>
-        public ScriptBlockExpressionAst Body { get; private set; }
+        public ScriptBlockExpressionAst Body { get; }
 
         /// <summary>
         /// The configuration type.
         /// </summary>
-        public ConfigurationType ConfigurationType { get; private set; }
+        public ConfigurationType ConfigurationType { get; }
 
         /// <summary>
         /// The name of the configuration instance,
         /// For example, Instance name of 'configuration test { ...... }' is 'test'
         /// This property is never null.
         /// </summary>
-        public ExpressionAst InstanceName { get; private set; }
+        public ExpressionAst InstanceName { get; }
 
         /// <summary>
         /// Duplicates the <see cref="ConfigurationDefinitionAst"/>, allowing it to be composed into other ASTs.
@@ -6872,7 +6872,7 @@ namespace System.Management.Automation.Language
         ///
         /// This property is never null and never empty.
         /// </summary>
-        public ReadOnlyCollection<CommandElementAst> CommandElements { get; private set; }
+        public ReadOnlyCollection<CommandElementAst> CommandElements { get; }
 
         /// <summary>
         /// Duplicates the <see cref="DynamicKeywordStatementAst"/>, allowing it to be composed into other ASTs.
@@ -7381,22 +7381,22 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The operator token kind.  The value returned is always a binary operator.
         /// </summary>
-        public TokenKind Operator { get; private set; }
+        public TokenKind Operator { get; }
 
         /// <summary>
         /// The ast for the left hand side of the binary expression.  The property is never null.
         /// </summary>
-        public ExpressionAst Left { get; private set; }
+        public ExpressionAst Left { get; }
 
         /// <summary>
         /// The ast for the right hand side of the binary expression.  The property is never null.
         /// </summary>
-        public ExpressionAst Right { get; private set; }
+        public ExpressionAst Right { get; }
 
         /// <summary>
         /// The position to report an error if an error occurs at runtime.  The property is never null.
         /// </summary>
-        public IScriptExtent ErrorPosition { get; private set; }
+        public IScriptExtent ErrorPosition { get; }
 
         /// <summary>
         /// Copy the BinaryExpressionAst instance.
@@ -7491,12 +7491,12 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The operator token for the unary expression.  The value returned is always a unary operator.
         /// </summary>
-        public TokenKind TokenKind { get; private set; }
+        public TokenKind TokenKind { get; }
 
         /// <summary>
         /// The child expression the unary operator is applied to.  The property is never null.
         /// </summary>
-        public ExpressionAst Child { get; private set; }
+        public ExpressionAst Child { get; }
 
         /// <summary>
         /// Copy the UnaryExpressionAst instance.
@@ -7573,12 +7573,12 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The scriptblockexpression that has a keyword applied to it. This property is nerver null.
         /// </summary>
-        public StatementBlockAst Body { get; private set; }
+        public StatementBlockAst Body { get; }
 
         /// <summary>
         /// The keyword name.
         /// </summary>
-        public Token Kind { get; private set; }
+        public Token Kind { get; }
 
         /// <summary>
         /// Copy the BlockStatementAst instance.
@@ -7643,12 +7643,12 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The expression that has an attribute or type constraint applied to it.  This property is never null.
         /// </summary>
-        public ExpressionAst Child { get; private set; }
+        public ExpressionAst Child { get; }
 
         /// <summary>
         /// The attribute or type constraint for this expression.  This property is never null.
         /// </summary>
-        public AttributeBaseAst Attribute { get; private set; }
+        public AttributeBaseAst Attribute { get; }
 
         /// <summary>
         /// Copy the AttributedExpressionAst instance.
@@ -7888,17 +7888,17 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The expression that produces the value to retrieve the member from.  This property is never null.
         /// </summary>
-        public ExpressionAst Expression { get; private set; }
+        public ExpressionAst Expression { get; }
 
         /// <summary>
         /// The name of the member to retrieve.  This property is never null.
         /// </summary>
-        public CommandElementAst Member { get; private set; }
+        public CommandElementAst Member { get; }
 
         /// <summary>
         /// True if the member to return is static, false if the member is an instance member.
         /// </summary>
-        public bool Static { get; private set; }
+        public bool Static { get; }
 
         /// <summary>
         /// Gets a value indicating true if the operator used is ?. or ?[].
@@ -7999,7 +7999,7 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The non-empty collection of arguments to pass when invoking the method, or null if no arguments were specified.
         /// </summary>
-        public ReadOnlyCollection<ExpressionAst> Arguments { get; private set; }
+        public ReadOnlyCollection<ExpressionAst> Arguments { get; }
 
         /// <summary>
         /// Copy the InvokeMemberExpressionAst instance.
@@ -8562,12 +8562,12 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The typename that specifies the generic class.
         /// </summary>
-        public ITypeName TypeName { get; private set; }
+        public ITypeName TypeName { get; }
 
         /// <summary>
         /// The generic arguments for this typename.
         /// </summary>
-        public ReadOnlyCollection<ITypeName> GenericArguments { get; private set; }
+        public ReadOnlyCollection<ITypeName> GenericArguments { get; }
 
         /// <summary>
         /// The extent of the typename.
@@ -8843,12 +8843,12 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The element type of the array.
         /// </summary>
-        public ITypeName ElementType { get; private set; }
+        public ITypeName ElementType { get; }
 
         /// <summary>
         /// The rank of the array.
         /// </summary>
-        public int Rank { get; private set; }
+        public int Rank { get; }
 
         /// <summary>
         /// The extent of the typename.
@@ -9065,7 +9065,7 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The name of the type.  This property is never null.
         /// </summary>
-        public ITypeName TypeName { get; private set; }
+        public ITypeName TypeName { get; }
 
         /// <summary>
         /// Copy the TypeExpressionAst instance.
@@ -9158,13 +9158,13 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The name of the variable.  This property is never null.
         /// </summary>
-        public VariablePath VariablePath { get; private set; }
+        public VariablePath VariablePath { get; }
 
         /// <summary>
         /// True if splatting syntax was used, false otherwise.
         /// </summary>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
-        public bool Splatted { get; private set; }
+        public bool Splatted { get; }
 
         /// <summary>
         /// Check if the variable is one of $true, $false and $null.
@@ -9351,7 +9351,7 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The value of the constant.  This property is null only if the expression represents the null constant.
         /// </summary>
-        public object Value { get; private set; }
+        public object Value { get; }
 
         /// <summary>
         /// Copy the ConstantExpressionAst instance.
@@ -9458,7 +9458,7 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The type of string.
         /// </summary>
-        public StringConstantType StringConstantType { get; private set; }
+        public StringConstantType StringConstantType { get; }
 
         /// <summary>
         /// The value of the string, not including the quotes used.
@@ -9609,18 +9609,18 @@ namespace System.Management.Automation.Language
         /// The value of string, not including the quote characters and without any variables replaced.
         /// This property is never null.
         /// </summary>
-        public string Value { get; private set; }
+        public string Value { get; }
 
         /// <summary>
         /// The type of string.
         /// </summary>
-        public StringConstantType StringConstantType { get; private set; }
+        public StringConstantType StringConstantType { get; }
 
         /// <summary>
         /// A non-empty collection of expressions contained within the string.  The nested expressions are always either
         /// instances of <see cref="VariableExpressionAst"/> or <see cref="SubExpressionAst"/>.
         /// </summary>
-        public ReadOnlyCollection<ExpressionAst> NestedExpressions { get; private set; }
+        public ReadOnlyCollection<ExpressionAst> NestedExpressions { get; }
 
         /// <summary>
         /// Copy the ExpandableStringExpressionAst instance.
@@ -9642,7 +9642,7 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The format expression needed to execute this ast.  It is generated by the scanner, it is not provided by clients.
         /// </summary>
-        internal string FormatExpression { get; private set; }
+        internal string FormatExpression { get; }
 
         #region Visitors
 
@@ -9700,7 +9700,7 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The ast for the scriptblock that this ast represent.  This property is never null.
         /// </summary>
-        public ScriptBlockAst ScriptBlock { get; private set; }
+        public ScriptBlockAst ScriptBlock { get; }
 
         /// <summary>
         /// Copy the ScriptBlockExpressionAst instance.
@@ -9772,7 +9772,7 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The non-empty collection of asts of the elements of the array.
         /// </summary>
-        public ReadOnlyCollection<ExpressionAst> Elements { get; private set; }
+        public ReadOnlyCollection<ExpressionAst> Elements { get; }
 
         /// <summary>
         /// Copy the ArrayLiteralAst instance.
@@ -9855,7 +9855,7 @@ namespace System.Management.Automation.Language
         /// The pairs of key names and asts for values used to construct the hash table.
         /// </summary>
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
-        public ReadOnlyCollection<KeyValuePair> KeyValuePairs { get; private set; }
+        public ReadOnlyCollection<KeyValuePair> KeyValuePairs { get; }
 
         /// <summary>
         /// Copy the HashtableAst instance.
@@ -9946,7 +9946,7 @@ namespace System.Management.Automation.Language
         /// The expression/statements represented by this sub-expression.
         /// </summary>
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
-        public StatementBlockAst SubExpression { get; private set; }
+        public StatementBlockAst SubExpression { get; }
 
         /// <summary>
         /// Copy the ArrayExpressionAst instance.
@@ -10012,7 +10012,7 @@ namespace System.Management.Automation.Language
         /// The pipeline (which is frequently but not always an expression) for this parenthesized expression.
         /// This property is never null.
         /// </summary>
-        public PipelineBaseAst Pipeline { get; private set; }
+        public PipelineBaseAst Pipeline { get; }
 
         /// <summary>
         /// Copy the ParenExpressionAst instance.
@@ -10078,7 +10078,7 @@ namespace System.Management.Automation.Language
         /// The expression/statements represented by this sub-expression.  This property is never null.
         /// </summary>
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
-        public StatementBlockAst SubExpression { get; private set; }
+        public StatementBlockAst SubExpression { get; }
 
         /// <summary>
         /// Copy the SubExpressionAst instance.
@@ -10139,7 +10139,7 @@ namespace System.Management.Automation.Language
         /// The expression represented by this using expression.  This property is never null.
         /// </summary>
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
-        public ExpressionAst SubExpression { get; private set; }
+        public ExpressionAst SubExpression { get; }
 
         // Used from code gen to get the value from a well known location.
         internal int RuntimeUsingIndex
@@ -10301,17 +10301,17 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// Return the ast for the expression being indexed.  This value is never null.
         /// </summary>
-        public ExpressionAst Target { get; private set; }
+        public ExpressionAst Target { get; }
 
         /// <summary>
         /// Return the ast for the index expression.  This value is never null.
         /// </summary>
-        public ExpressionAst Index { get; private set; }
+        public ExpressionAst Index { get; }
 
         /// <summary>
         /// Gets a value indicating whether ?[] operator is being used.
         /// </summary>
-        public bool NullConditional { get; private set; }
+        public bool NullConditional { get; }
 
         /// <summary>
         /// Copy the IndexExpressionAst instance.

--- a/src/System.Management.Automation/engine/parser/token.cs
+++ b/src/System.Management.Automation/engine/parser/token.cs
@@ -1349,7 +1349,7 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The full details of the variable path.
         /// </summary>
-        public VariablePath VariablePath { get; private set; }
+        public VariablePath VariablePath { get; }
 
         internal override string ToDebugString(int indent)
         {
@@ -1503,12 +1503,12 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The stream being redirected.
         /// </summary>
-        public RedirectionStream FromStream { get; private set; }
+        public RedirectionStream FromStream { get; }
 
         /// <summary>
         /// The stream being written to.
         /// </summary>
-        public RedirectionStream ToStream { get; private set; }
+        public RedirectionStream ToStream { get; }
     }
 
     /// <summary>
@@ -1526,12 +1526,12 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// The stream being redirected.
         /// </summary>
-        public RedirectionStream FromStream { get; private set; }
+        public RedirectionStream FromStream { get; }
 
         /// <summary>
         /// True if the redirection should append the file rather than create a new file.
         /// </summary>
-        public bool Append { get; private set; }
+        public bool Append { get; }
     }
 
     internal class UnscannedSubExprToken : StringLiteralToken
@@ -1542,6 +1542,6 @@ namespace System.Management.Automation.Language
             this.SkippedCharOffsets = skippedCharOffsets;
         }
 
-        internal BitArray SkippedCharOffsets { get; private set; }
+        internal BitArray SkippedCharOffsets { get; }
     }
 }

--- a/src/System.Management.Automation/engine/remoting/client/Job.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job.cs
@@ -371,7 +371,7 @@ namespace System.Management.Automation
             InstanceId = instanceId;
         }
 
-        internal int Id { get; private set; }
+        internal int Id { get; }
 
         internal Guid InstanceId { get; private set; }
     }
@@ -4521,7 +4521,7 @@ namespace System.Management.Automation
         internal bool ProcessingOutput
         {
             get;
-            private set;
+
         }
 
         internal OutputProcessingStateEventArgs(bool processingOutput)

--- a/src/System.Management.Automation/engine/remoting/client/Job.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job.cs
@@ -4518,11 +4518,7 @@ namespace System.Management.Automation
 
     internal class OutputProcessingStateEventArgs : EventArgs
     {
-        internal bool ProcessingOutput
-        {
-            get;
-
-        }
+        internal bool ProcessingOutput { get; }
 
         internal OutputProcessingStateEventArgs(bool processingOutput)
         {

--- a/src/System.Management.Automation/engine/remoting/commands/EnterPSHostProcessCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/EnterPSHostProcessCommand.cs
@@ -750,7 +750,7 @@ namespace Microsoft.PowerShell.Commands
         public string ProcessName
         {
             get;
-            private set;
+
         }
 
         /// <summary>
@@ -759,7 +759,7 @@ namespace Microsoft.PowerShell.Commands
         public int ProcessId
         {
             get;
-            private set;
+
         }
 
         /// <summary>
@@ -768,7 +768,7 @@ namespace Microsoft.PowerShell.Commands
         public string AppDomainName
         {
             get;
-            private set;
+
         }
 
         /// <summary>
@@ -777,7 +777,7 @@ namespace Microsoft.PowerShell.Commands
         public string MainWindowTitle
         {
             get;
-            private set;
+
         }
 
         #endregion

--- a/src/System.Management.Automation/engine/remoting/commands/EnterPSHostProcessCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/EnterPSHostProcessCommand.cs
@@ -747,38 +747,22 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Name of process.
         /// </summary>
-        public string ProcessName
-        {
-            get;
-
-        }
+        public string ProcessName { get; }
 
         /// <summary>
         /// Id of process.
         /// </summary>
-        public int ProcessId
-        {
-            get;
-
-        }
+        public int ProcessId { get; }
 
         /// <summary>
         /// Name of PowerShell AppDomain in process.
         /// </summary>
-        public string AppDomainName
-        {
-            get;
-
-        }
+        public string AppDomainName { get; }
 
         /// <summary>
         /// Main window title of the process.
         /// </summary>
-        public string MainWindowTitle
-        {
-            get;
-
-        }
+        public string MainWindowTitle { get; }
 
         #endregion
 

--- a/src/System.Management.Automation/engine/remoting/common/RemoteSessionNamedPipe.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RemoteSessionNamedPipe.cs
@@ -301,20 +301,12 @@ namespace System.Management.Automation.Remoting
         /// Exception reason for listener end event.  Can be null
         /// which indicates listener thread end is not due to an error.
         /// </summary>
-        public Exception Reason
-        {
-
-            get;
-        }
+        public Exception Reason { get; }
 
         /// <summary>
         /// True if listener should be restarted after ending.
         /// </summary>
-        public bool RestartListener
-        {
-
-            get;
-        }
+        public bool RestartListener { get; }
 
         #endregion
 

--- a/src/System.Management.Automation/engine/remoting/common/RemoteSessionNamedPipe.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RemoteSessionNamedPipe.cs
@@ -303,7 +303,7 @@ namespace System.Management.Automation.Remoting
         /// </summary>
         public Exception Reason
         {
-            private set;
+
             get;
         }
 
@@ -312,7 +312,7 @@ namespace System.Management.Automation.Remoting
         /// </summary>
         public bool RestartListener
         {
-            private set;
+
             get;
         }
 

--- a/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemoteDebuggingCapability.cs
+++ b/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemoteDebuggingCapability.cs
@@ -17,7 +17,7 @@ namespace System.Management.Automation.Remoting
     {
         private readonly HashSet<string> _supportedCommands = new HashSet<string>();
 
-        internal Version PSVersion { get; private set; }
+        internal Version PSVersion { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RemoteDebuggingCapability"/> class.

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -340,7 +340,7 @@ namespace System.Management.Automation
 
         internal bool HasLogged { get; set; }
         internal bool SkipLogging { get; set; }
-        internal bool IsFilter { get; private set; }
+        internal bool IsFilter { get; }
 
         internal bool IsProductCode
         {

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -858,7 +858,7 @@ namespace System.Management.Automation
             this.FromStream = from;
         }
 
-        internal RedirectionStream FromStream { get; private set; }
+        internal RedirectionStream FromStream { get; }
 
         internal abstract void Bind(PipelineProcessor pipelineProcessor, CommandProcessorBase commandProcessor, ExecutionContext context);
 
@@ -1039,9 +1039,9 @@ namespace System.Management.Automation
                                  File);
         }
 
-        internal string File { get; private set; }
+        internal string File { get; }
 
-        internal bool Appending { get; private set; }
+        internal bool Appending { get; }
 
         private PipelineProcessor PipelineProcessor { get; set; }
 

--- a/src/System.Management.Automation/engine/scriptparameterbinder.cs
+++ b/src/System.Management.Automation/engine/scriptparameterbinder.cs
@@ -161,7 +161,7 @@ namespace System.Management.Automation
         /// <summary>
         /// The script that is being bound to.
         /// </summary>
-        internal ScriptBlock Script { get; private set; }
+        internal ScriptBlock Script { get; }
 
         internal SessionStateScope LocalScope { get; set; }
 

--- a/src/System.Management.Automation/engine/scriptparameterbindercontroller.cs
+++ b/src/System.Management.Automation/engine/scriptparameterbindercontroller.cs
@@ -63,7 +63,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Holds the set of parameters that were not bound to any argument (i.e $args)
         /// </summary>
-        internal List<object> DollarArgs { get; private set; }
+        internal List<object> DollarArgs { get; }
 
         /// <summary>
         /// Binds the command line parameters for shell functions/filters/scripts/scriptblocks.

--- a/src/System.Management.Automation/utils/Telemetry.cs
+++ b/src/System.Management.Automation/utils/Telemetry.cs
@@ -79,13 +79,13 @@ namespace Microsoft.PowerShell.Telemetry
         private const string _telemetryFailure = "TELEMETRY_FAILURE";
 
         // Telemetry client to be reused when we start sending more telemetry
-        private static TelemetryClient s_telemetryClient { get; set; }
+        private static TelemetryClient s_telemetryClient { get; }
 
         // the unique identifier for the user, when we start we
-        private static string s_uniqueUserIdentifier { get; set; }
+        private static string s_uniqueUserIdentifier { get; }
 
         // the session identifier
-        private static string s_sessionId { get; set; }
+        private static string s_sessionId { get; }
 
         // private semaphore to determine whether we sent the startup telemetry event
         private static int s_startupEventSent = 0;

--- a/src/System.Management.Automation/utils/tracing/EtwActivity.cs
+++ b/src/System.Management.Automation/utils/tracing/EtwActivity.cs
@@ -63,19 +63,11 @@ namespace System.Management.Automation.Tracing
         }
 
         /// <summary> Gets whether the event is successfully written </summary>
-        public bool Success
-        {
-            get;
-
-        }
+        public bool Success { get; }
 
         /// <summary> Gets payload in the event </summary>
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
-        public object[] Payload
-        {
-            get;
-
-        }
+        public object[] Payload { get; }
 
         /// <summary>
         /// Creates a new instance of EtwEventArgs class.

--- a/src/System.Management.Automation/utils/tracing/EtwActivity.cs
+++ b/src/System.Management.Automation/utils/tracing/EtwActivity.cs
@@ -66,7 +66,7 @@ namespace System.Management.Automation.Tracing
         public bool Success
         {
             get;
-            private set;
+
         }
 
         /// <summary> Gets payload in the event </summary>
@@ -74,7 +74,7 @@ namespace System.Management.Automation.Tracing
         public object[] Payload
         {
             get;
-            private set;
+
         }
 
         /// <summary>

--- a/test/xUnit/Asserts/PriorityAttribute.cs
+++ b/test/xUnit/Asserts/PriorityAttribute.cs
@@ -11,5 +11,5 @@ public class TestPriorityAttribute : Attribute
         Priority = priority;
     }
 
-    public int Priority { get; private set; }
+    public int Priority { get; }
 }


### PR DESCRIPTION
# PR Summary

Fix RCS1170: Use read-only auto-implemented property

This PR made changes to ComInterop, so a corresponding PR was merged in dotnet/runtime#44677.


## PR Context

<https://github.com/JosefPihrt/Roslynator/blob/master/docs/analyzers/RCS1170.md>

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [NA] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [NA] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [NA] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [NA] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [NA] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [NA] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
