### PR TITLE
Reformat StringUtil

### DIFF
--- a/src/System.Management.Automation/utils/StringUtil.cs
+++ b/src/System.Management.Automation/utils/StringUtil.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Globalization;
 using System.Management.Automation.Host;
 using System.Threading;
 
@@ -8,24 +9,21 @@ using Dbg = System.Management.Automation.Diagnostics;
 
 namespace System.Management.Automation.Internal
 {
-    internal static
-    class StringUtil
+    internal static class StringUtil
     {
         internal static string Format(string format, object arg0)
-            => string.Format(Globalization.CultureInfo.CurrentCulture, format, arg0);
+            => string.Format(CultureInfo.CurrentCulture, format, arg0);
 
         internal static string Format(string format, object arg0, object arg1)
-            => string.Format(Globalization.CultureInfo.CurrentCulture, format, arg0, arg1);
+            => string.Format(CultureInfo.CurrentCulture, format, arg0, arg1);
 
         internal static string Format(string format, object arg0, object arg1, object arg2)
-            => string.Format(Globalization.CultureInfo.CurrentCulture, format, arg0, arg1, arg2);
+            => string.Format(CultureInfo.CurrentCulture, format, arg0, arg1, arg2);
 
         internal static string Format(string format, params object[] args)
-            => string.Format(Globalization.CultureInfo.CurrentCulture, format, args);
+            => string.Format(CultureInfo.CurrentCulture, format, args);
 
-        internal static
-        string
-        TruncateToBufferCellWidth(PSHostRawUserInterface rawUI, string toTruncate, int maxWidthInBufferCells)
+        internal static string TruncateToBufferCellWidth(PSHostRawUserInterface rawUI, string toTruncate, int maxWidthInBufferCells)
         {
             Dbg.Assert(rawUI != null, "need a reference");
             Dbg.Assert(maxWidthInBufferCells >= 0, "maxWidthInBufferCells must be positive");
@@ -58,19 +56,19 @@ namespace System.Management.Automation.Internal
         // Typical padding is at most a screen's width, any more than that and we won't bother caching.
         private const int IndentCacheMax = 120;
 
-        private static readonly string[] IndentCache = new string[IndentCacheMax];
+        private static readonly string[] s_indentCache = new string[IndentCacheMax];
 
         internal static string Padding(int countOfSpaces)
         {
             if (countOfSpaces >= IndentCacheMax)
                 return new string(' ', countOfSpaces);
 
-            var result = IndentCache[countOfSpaces];
+            var result = s_indentCache[countOfSpaces];
 
             if (result == null)
             {
-                Interlocked.CompareExchange(ref IndentCache[countOfSpaces], new string(' ', countOfSpaces), null);
-                result = IndentCache[countOfSpaces];
+                Interlocked.CompareExchange(ref s_indentCache[countOfSpaces], new string(' ', countOfSpaces), null);
+                result = s_indentCache[countOfSpaces];
             }
 
             return result;
@@ -78,23 +76,22 @@ namespace System.Management.Automation.Internal
 
         private const int DashCacheMax = 120;
 
-        private static readonly string[] DashCache = new string[DashCacheMax];
+        private static readonly string[] s_dashCache = new string[DashCacheMax];
 
         internal static string DashPadding(int count)
         {
             if (count >= DashCacheMax)
                 return new string('-', count);
 
-            var result = DashCache[count];
+            var result = s_dashCache[count];
 
             if (result == null)
             {
-                Interlocked.CompareExchange(ref DashCache[count], new string('-', count), null);
-                result = DashCache[count];
+                Interlocked.CompareExchange(ref s_dashCache[count], new string('-', count), null);
+                result = s_dashCache[count];
             }
 
             return result;
         }
     }
 }
-


### PR DESCRIPTION
# PR Summary

* Add `using System.Globalization`
* Class declaration keywords all on same line.
* Use correct naming convention for static readonly member (`s_indentCache` instead of `IndentCache`)
* Remove double blank line at EOF.

## PR Context

Follow-up: #13408

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [NA] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [NA] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [NA] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [NA] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [NA] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [NA] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
