### PR TITLE
Remove experimental flag from `PSNullConditionalOperators` feature

### DIFF
--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -115,9 +115,6 @@ namespace System.Management.Automation
                     description: "Provide unix permission information for files and directories"),
 #endif
                 new ExperimentalFeature(
-                    name: "PSNullConditionalOperators",
-                    description: "Support the null conditional member access operators in PowerShell language"),
-                new ExperimentalFeature(
                     name: "PSCultureInvariantReplaceOperator",
                     description: "Use culture invariant to-string convertor for lval in replace operator"),
                 new ExperimentalFeature(

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -4243,7 +4243,7 @@ namespace System.Management.Automation.Language
                 return NewToken(TokenKind.LBracket);
             }
 
-            if (ExperimentalFeature.IsEnabled("PSNullConditionalOperators") && c == '?')
+            if (c == '?')
             {
                 _tokenStart = _currentIndex;
                 SkipChar();

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -3,7 +3,6 @@
 Describe "TabCompletion" -Tags CI {
     BeforeAll {
         $separator = [System.IO.Path]::DirectorySeparatorChar
-        $nullConditionalFeatureDisabled = -not $EnabledExperimentalFeatures.Contains('PSNullConditionalOperators')
     }
 
     It 'Should complete Command' {
@@ -34,12 +33,12 @@ Describe "TabCompletion" -Tags CI {
         $res.CompletionMatches[0].CompletionText | Should -BeExactly 'ToString('
     }
 
-    It 'Should complete dotnet method with null conditional operator' -Skip:$nullConditionalFeatureDisabled {
+    It 'Should complete dotnet method with null conditional operator' {
         $res = TabExpansion2 -inputScript '(1)?.ToSt' -cursorColumn '(1)?.ToSt'.Length
         $res.CompletionMatches[0].CompletionText | Should -BeExactly 'ToString('
     }
 
-    It 'Should complete dotnet method with null conditional operator without first letter' -Skip:$nullConditionalFeatureDisabled {
+    It 'Should complete dotnet method with null conditional operator without first letter' {
         $res = TabExpansion2 -inputScript '(1)?.' -cursorColumn '(1)?.'.Length
         $res.CompletionMatches[0].CompletionText | Should -BeExactly 'CompareTo('
     }

--- a/test/powershell/Language/Parser/Parsing.Tests.ps1
+++ b/test/powershell/Language/Parser/Parsing.Tests.ps1
@@ -279,37 +279,18 @@ Describe 'null coalescing statement parsing' -Tag "CI" {
 }
 
 Describe 'null conditional member access statement parsing' -Tag 'CI' {
-    BeforeAll {
-        $skipTest = -not $EnabledExperimentalFeatures.Contains('PSNullConditionalOperators')
+    ShouldBeParseError '[datetime]?::now' ExpectedValueExpression, UnexpectedToken 11, 11
+    ShouldBeParseError '$x ?.name' ExpectedValueExpression, UnexpectedToken 4, 4
+    ShouldBeParseError 'Get-Date ?.ToString()' ExpectedExpression 20
+    ShouldBeParseError '${x}?.' MissingPropertyName 6
+    ShouldBeParseError '${x}?.name = "value"' InvalidLeftHandSide 0
 
-        if ($skipTest) {
-            Write-Verbose "Test Suite Skipped. The test suite requires the experimental feature 'PSNullConditionalOperators' to be enabled." -Verbose
-            $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
-            $PSDefaultParameterValues["it:skip"] = $true
-        }
-    }
-
-    AfterAll {
-        if ($skipTest) {
-            $global:PSDefaultParameterValues = $originalDefaultParameterValues
-        }
-    }
-
-    # We need to add this check as parsing on script block is done before an `It` is called.
-    if (-not $skipTest) {
-        ShouldBeParseError '[datetime]?::now' ExpectedValueExpression, UnexpectedToken 11, 11
-        ShouldBeParseError '$x ?.name' ExpectedValueExpression, UnexpectedToken 4, 4
-        ShouldBeParseError 'Get-Date ?.ToString()' ExpectedExpression 20
-        ShouldBeParseError '${x}?.' MissingPropertyName 6
-        ShouldBeParseError '${x}?.name = "value"' InvalidLeftHandSide 0
-
-        ShouldBeParseError '[datetime]?[0]' MissingTypename, ExpectedValueExpression, UnexpectedToken 12, 11, 11
-        ShouldBeParseError '${x} ?[1]' MissingTypename, ExpectedValueExpression, UnexpectedToken 7, 6, 6
-        ShouldBeParseError '${x}?[]' MissingArrayIndexExpression 6
-        ShouldBeParseError '${x}?[-]' MissingExpressionAfterOperator 7
-        ShouldBeParseError '${x}?[             ]' MissingArrayIndexExpression 6
-        ShouldBeParseError '${x}?[0] = 1' InvalidLeftHandSide 0
-    }
+    ShouldBeParseError '[datetime]?[0]' MissingTypename, ExpectedValueExpression, UnexpectedToken 12, 11, 11
+    ShouldBeParseError '${x} ?[1]' MissingTypename, ExpectedValueExpression, UnexpectedToken 7, 6, 6
+    ShouldBeParseError '${x}?[]' MissingArrayIndexExpression 6
+    ShouldBeParseError '${x}?[-]' MissingExpressionAfterOperator 7
+    ShouldBeParseError '${x}?[             ]' MissingArrayIndexExpression 6
+    ShouldBeParseError '${x}?[0] = 1' InvalidLeftHandSide 0
 }
 
 Describe 'splatting parsing' -Tags "CI" {

--- a/test/tools/TestMetadata.json
+++ b/test/tools/TestMetadata.json
@@ -1,10 +1,6 @@
 {
   "ExperimentalFeatures": {
     "ExpTest.FeatureOne": [ "test/powershell/engine/ExperimentalFeature/ExperimentalFeature.Basic.Tests.ps1" ],
-    "PSNullConditionalOperators": [
-      "test/powershell/Language/Operators/NullConditional.Tests.ps1",
-      "test/powershell/Language/Parser/Parsing.Tests.ps1",
-      "test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1" ],
     "PSCultureInvariantReplaceOperator": [ "test/powershell/Language/Operators/ReplaceOperator.Tests.ps1" ],
     "Microsoft.PowerShell.Utility.PSManageBreakpointsInRunspace": [ "test/powershell/Modules/Microsoft.PowerShell.Utility/RunspaceBreakpointManagement.Tests.ps1" ]
   }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

As per the recommendation of the committee removing the experimental flag from `PSNullConditionalOperators` feature

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
