### PR TITLE
Fix accessor order

### DIFF
--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimCommandBase.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimCommandBase.cs
@@ -727,6 +727,11 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// </summary>
         internal CimAsyncOperation AsyncOperation
         {
+            get
+            {
+                return this.operation;
+            }
+
             set
             {
                 lock (this.myLock)
@@ -734,11 +739,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
                     Debug.Assert(this.operation == null, "Caller should verify that operation is null");
                     this.operation = value;
                 }
-            }
-
-            get
-            {
-                return this.operation;
             }
         }
 

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimRegisterCimIndication.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimRegisterCimIndication.cs
@@ -309,8 +309,8 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// <param name="cmdlet"></param>
         internal Cmdlet Cmdlet
         {
-            set;
             get;
+            set;
         }
 
         /// <summary>
@@ -318,8 +318,8 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// </summary>
         internal string TargetComputerName
         {
-            set;
             get;
+            set;
         }
 
         #endregion

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionProxy.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionProxy.cs
@@ -540,16 +540,16 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// </summary>
         public UInt32 OperationTimeout
         {
+            get
+            {
+                return (UInt32)this.options.Timeout.TotalSeconds;
+            }
+
             set
             {
                 DebugHelper.WriteLogEx("OperationTimeout {0},", 0, value);
 
                 this.options.Timeout = TimeSpan.FromSeconds((double)value);
-            }
-
-            get
-            {
-                return (UInt32)this.options.Timeout.TotalSeconds;
             }
         }
 
@@ -558,16 +558,16 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// </summary>
         public Uri ResourceUri
         {
+            get
+            {
+                return this.options.ResourceUri;
+            }
+
             set
             {
                 DebugHelper.WriteLogEx("ResourceUri {0},", 0, value);
 
                 this.options.ResourceUri = value;
-            }
-
-            get
-            {
-                return this.options.ResourceUri;
             }
         }
 
@@ -1595,16 +1595,16 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// </summary>
         private IDisposable CancelOperation
         {
+            get
+            {
+                return this._cancelOperation;
+            }
+
             set
             {
                 DebugHelper.WriteLogEx();
                 this._cancelOperation = value;
                 Interlocked.Exchange(ref this._cancelOperationDisposed, 0);
-            }
-
-            get
-            {
-                return this._cancelOperation;
             }
         }
 
@@ -1627,14 +1627,14 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// </summary>
         internal XOperationContextBase ContextObject
         {
-            set
-            {
-                this.contextObject = value;
-            }
-
             get
             {
                 return this.contextObject;
+            }
+
+            set
+            {
+                this.contextObject = value;
             }
         }
 
@@ -1651,14 +1651,14 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// </summary>
         internal IObjectPreProcess ObjectPreProcess
         {
-            set
-            {
-                this.objectPreprocess = value;
-            }
-
             get
             {
                 return this.objectPreprocess;
+            }
+
+            set
+            {
+                this.objectPreprocess = value;
             }
         }
 

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/SetCimInstanceCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/SetCimInstanceCommand.cs
@@ -279,14 +279,14 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         [ValidateNotNull]
         public SwitchParameter PassThru
         {
-            set
-            {
-                this.passThru = value;
-            }
-
             get
             {
                 return this.passThru;
+            }
+
+            set
+            {
+                this.passThru = value;
             }
         }
 

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetContentCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetContentCommand.cs
@@ -59,13 +59,13 @@ namespace Microsoft.PowerShell.Commands
         [Alias("Last")]
         public int Tail
         {
+            get { return _backCount; }
+
             set
             {
                 _backCount = value;
                 _tailSpecified = true;
             }
-
-            get { return _backCount; }
         }
 
         private int _backCount = -1;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddMember.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddMember.cs
@@ -37,9 +37,9 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Mandatory = true, ValueFromPipeline = true, ParameterSetName = NotePropertyMultiMemberSet)]
         public PSObject InputObject
         {
-            set { _inputObject = value; }
-
             get { return _inputObject; }
+
+            set { _inputObject = value; }
         }
 
         private PSMemberTypes _memberType;
@@ -50,9 +50,9 @@ namespace Microsoft.PowerShell.Commands
         [Alias("Type")]
         public PSMemberTypes MemberType
         {
-            set { _memberType = value; }
-
             get { return _memberType; }
+
+            set { _memberType = value; }
         }
 
         private string _memberName;
@@ -62,9 +62,9 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Mandatory = true, Position = 1, ParameterSetName = "MemberSet")]
         public string Name
         {
-            set { _memberName = value; }
-
             get { return _memberName; }
+
+            set { _memberName = value; }
         }
 
         private object _value1 = s_notSpecified;
@@ -74,9 +74,9 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Position = 2, ParameterSetName = "MemberSet")]
         public object Value
         {
-            set { _value1 = value; }
-
             get { return _value1; }
+
+            set { _value1 = value; }
         }
 
         private object _value2 = s_notSpecified;
@@ -86,9 +86,9 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Position = 3, ParameterSetName = "MemberSet")]
         public object SecondValue
         {
-            set { _value2 = value; }
-
             get { return _value2; }
+
+            set { _value2 = value; }
         }
 
         private string _typeName;
@@ -102,9 +102,9 @@ namespace Microsoft.PowerShell.Commands
         [ValidateNotNullOrEmpty]
         public string TypeName
         {
-            set { _typeName = value; }
-
             get { return _typeName; }
+
+            set { _typeName = value; }
         }
 
         private bool _force;
@@ -116,9 +116,9 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = NotePropertyMultiMemberSet)]
         public SwitchParameter Force
         {
-            set { _force = value; }
-
             get { return _force; }
+
+            set { _force = value; }
         }
 
         private bool _passThru /* = false */;
@@ -132,9 +132,9 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = NotePropertyMultiMemberSet)]
         public SwitchParameter PassThru
         {
-            set { _passThru = value; }
-
             get { return _passThru; }
+
+            set { _passThru = value; }
         }
 
         #region Simplifying NoteProperty Declaration
@@ -152,9 +152,9 @@ namespace Microsoft.PowerShell.Commands
         [ValidateNotNullOrEmpty]
         public string NotePropertyName
         {
-            set { _notePropertyName = value; }
-
             get { return _notePropertyName; }
+
+            set { _notePropertyName = value; }
         }
 
         private object _notePropertyValue;
@@ -165,9 +165,9 @@ namespace Microsoft.PowerShell.Commands
         [AllowNull]
         public object NotePropertyValue
         {
-            set { _notePropertyValue = value; }
-
             get { return _notePropertyValue; }
+
+            set { _notePropertyValue = value; }
         }
 
         // Use IDictionary to support both Hashtable and OrderedHashtable

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutGridViewCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutGridViewCommand.cs
@@ -88,7 +88,7 @@ namespace Microsoft.PowerShell.Commands
         /// and if it should be possible to select multiple or single list items.
         /// </summary>
         [Parameter(ParameterSetName = "OutputMode")]
-        public OutputModeOption OutputMode { set; get; }
+        public OutputModeOption OutputMode { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the selected items should be written to the pipeline.
@@ -97,9 +97,9 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = "PassThru")]
         public SwitchParameter PassThru
         {
-            set { this.OutputMode = value.IsPresent ? OutputModeOption.Multiple : OutputModeOption.None; }
-
             get { return OutputMode == OutputModeOption.Multiple ? new SwitchParameter(true) : new SwitchParameter(false); }
+
+            set { this.OutputMode = value.IsPresent ? OutputModeOption.Multiple : OutputModeOption.None; }
         }
 
         #endregion Input Parameters

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetMember.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetMember.cs
@@ -65,21 +65,21 @@ namespace Microsoft.PowerShell.Commands
         /// The object to retrieve properties from.
         /// </summary>
         [Parameter(ValueFromPipeline = true)]
-        public PSObject InputObject { set; get; }
+        public PSObject InputObject { get; set; }
 
         /// <summary>
         /// The member names to be retrieved.
         /// </summary>
         [Parameter(Position = 0)]
         [ValidateNotNullOrEmpty]
-        public string[] Name { set; get; } = new string[] { "*" };
+        public string[] Name { get; set; } = new string[] { "*" };
 
         /// <summary>
         /// The member types to be retrieved.
         /// </summary>
         [Parameter]
         [Alias("Type")]
-        public PSMemberTypes MemberType { set; get; } = PSMemberTypes.All;
+        public PSMemberTypes MemberType { get; set; } = PSMemberTypes.All;
 
         /// <summary>
         /// View from which the members are retrieved.
@@ -94,9 +94,9 @@ namespace Microsoft.PowerShell.Commands
         [Parameter]
         public SwitchParameter Static
         {
-            set { _staticParameter = value; }
-
             get { return _staticParameter; }
+
+            set { _staticParameter = value; }
         }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetUnique.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetUnique.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// <value></value>
         [Parameter(ValueFromPipeline = true)]
-        public PSObject InputObject { set; get; } = AutomationNull.Value;
+        public PSObject InputObject { get; set; } = AutomationNull.Value;
 
         /// <summary>
         /// This parameter specifies that objects should be converted to

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
@@ -257,9 +257,9 @@ namespace Microsoft.PowerShell.Commands
         [ValidateNotNullOrEmpty]
         public new string Prefix
         {
-            set { base.Prefix = value; }
-
             get { return base.Prefix; }
+
+            set { base.Prefix = value; }
         }
 
         /// <summary>
@@ -521,7 +521,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// This parameter specified a prefix used to modify names of imported commands.
         /// </summary>
-        internal string Prefix { set; get; } = string.Empty;
+        internal string Prefix { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the certificate with which to sign the format file and psm1 file.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
@@ -234,7 +234,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// <value></value>
         [Parameter(ValueFromPipeline = true)]
-        public PSObject InputObject { set; get; } = AutomationNull.Value;
+        public PSObject InputObject { get; set; } = AutomationNull.Value;
 
         /// <summary>
         /// Properties to be examined.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/OrderObjectBase.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/OrderObjectBase.cs
@@ -117,7 +117,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// </summary>
         [Parameter(ValueFromPipeline = true)]
-        public PSObject InputObject { set; get; } = AutomationNull.Value;
+        public PSObject InputObject { get; set; } = AutomationNull.Value;
 
         /// <summary>
         /// Gets or Sets the Properties that would be used for Grouping, Sorting and Comparison.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -76,7 +76,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// <value></value>
         [Parameter(ValueFromPipeline = true)]
-        public PSObject InputObject { set; get; } = AutomationNull.Value;
+        public PSObject InputObject { get; set; } = AutomationNull.Value;
 
         /// <summary>
         /// </summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/TimeExpressionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/TimeExpressionCommand.cs
@@ -25,13 +25,13 @@ namespace Microsoft.PowerShell.Commands
         /// This parameter specifies the current pipeline object.
         /// </summary>
         [Parameter(ValueFromPipeline = true)]
-        public PSObject InputObject { set; get; } = AutomationNull.Value;
+        public PSObject InputObject { get; set; } = AutomationNull.Value;
 
         /// <summary>
         /// The script block to apply.
         /// </summary>
         [Parameter(Position = 0, Mandatory = true)]
-        public ScriptBlock Expression { set; get; }
+        public ScriptBlock Expression { get; set; }
 
         #endregion
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Update-Data.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Update-Data.cs
@@ -24,14 +24,14 @@ namespace Microsoft.PowerShell.Commands
             ParameterSetName = FileParameterSet)]
         [Alias("PSPath", "Path")]
         [ValidateNotNull]
-        public string[] AppendPath { set; get; } = Array.Empty<string>();
+        public string[] AppendPath { get; set; } = Array.Empty<string>();
 
         /// <summary>
         /// Files to prepend to the existing set.
         /// </summary>
         [Parameter(ParameterSetName = FileParameterSet)]
         [ValidateNotNull]
-        public string[] PrependPath { set; get; } = Array.Empty<string>();
+        public string[] PrependPath { get; set; } = Array.Empty<string>();
 
         private static void ReportWrongExtension(string file, string errorId, PSCmdlet cmdlet)
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Update-TypeData.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Update-TypeData.cs
@@ -50,13 +50,13 @@ namespace Microsoft.PowerShell.Commands
                      System.Management.Automation.Runspaces.TypeData.CodeMethod, IgnoreCase = true)]
         public PSMemberTypes MemberType
         {
+            get { return _memberType; }
+
             set
             {
                 _memberType = value;
                 _isMemberTypeSet = true;
             }
-
-            get { return _memberType; }
         }
 
         private string _memberName;
@@ -67,9 +67,9 @@ namespace Microsoft.PowerShell.Commands
         [ValidateNotNullOrEmpty]
         public string MemberName
         {
-            set { _memberName = value; }
-
             get { return _memberName; }
+
+            set { _memberName = value; }
         }
 
         private object _value1 = s_notSpecified;
@@ -80,9 +80,9 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = DynamicTypeSet)]
         public object Value
         {
-            set { _value1 = value; }
-
             get { return _value1; }
+
+            set { _value1 = value; }
         }
 
         private object _value2;
@@ -94,9 +94,9 @@ namespace Microsoft.PowerShell.Commands
         [ValidateNotNull]
         public object SecondValue
         {
-            set { _value2 = value; }
-
             get { return _value2; }
+
+            set { _value2 = value; }
         }
 
         private Type _typeConverter;
@@ -107,9 +107,9 @@ namespace Microsoft.PowerShell.Commands
         [ValidateNotNull]
         public Type TypeConverter
         {
-            set { _typeConverter = value; }
-
             get { return _typeConverter; }
+
+            set { _typeConverter = value; }
         }
 
         private Type _typeAdapter;
@@ -120,9 +120,9 @@ namespace Microsoft.PowerShell.Commands
         [ValidateNotNull]
         public Type TypeAdapter
         {
-            set { _typeAdapter = value; }
-
             get { return _typeAdapter; }
+
+            set { _typeAdapter = value; }
         }
 
         /// <summary>
@@ -132,9 +132,9 @@ namespace Microsoft.PowerShell.Commands
         [ValidateNotNullOrEmpty]
         public string SerializationMethod
         {
-            set { _serializationMethod = value; }
-
             get { return _serializationMethod; }
+
+            set { _serializationMethod = value; }
         }
 
         /// <summary>
@@ -144,9 +144,9 @@ namespace Microsoft.PowerShell.Commands
         [ValidateNotNull]
         public Type TargetTypeForDeserialization
         {
-            set { _targetTypeForDeserialization = value; }
-
             get { return _targetTypeForDeserialization; }
+
+            set { _targetTypeForDeserialization = value; }
         }
 
         /// <summary>
@@ -157,9 +157,9 @@ namespace Microsoft.PowerShell.Commands
         [ValidateRange(0, int.MaxValue)]
         public int SerializationDepth
         {
-            set { _serializationDepth = value; }
-
             get { return _serializationDepth; }
+
+            set { _serializationDepth = value; }
         }
 
         /// <summary>
@@ -169,9 +169,9 @@ namespace Microsoft.PowerShell.Commands
         [ValidateNotNullOrEmpty]
         public string DefaultDisplayProperty
         {
-            set { _defaultDisplayProperty = value; }
-
             get { return _defaultDisplayProperty; }
+
+            set { _defaultDisplayProperty = value; }
         }
 
         /// <summary>
@@ -181,9 +181,9 @@ namespace Microsoft.PowerShell.Commands
         [ValidateNotNull]
         public bool? InheritPropertySerializationSet
         {
-            set { _inheritPropertySerializationSet = value; }
-
             get { return _inheritPropertySerializationSet; }
+
+            set { _inheritPropertySerializationSet = value; }
         }
 
         /// <summary>
@@ -193,9 +193,9 @@ namespace Microsoft.PowerShell.Commands
         [ValidateNotNullOrEmpty]
         public string StringSerializationSource
         {
-            set { _stringSerializationSource = value; }
-
             get { return _stringSerializationSource; }
+
+            set { _stringSerializationSource = value; }
         }
 
         /// <summary>
@@ -206,9 +206,9 @@ namespace Microsoft.PowerShell.Commands
         [ValidateNotNullOrEmpty]
         public string[] DefaultDisplayPropertySet
         {
-            set { _defaultDisplayPropertySet = value; }
-
             get { return _defaultDisplayPropertySet; }
+
+            set { _defaultDisplayPropertySet = value; }
         }
 
         /// <summary>
@@ -219,9 +219,9 @@ namespace Microsoft.PowerShell.Commands
         [ValidateNotNullOrEmpty]
         public string[] DefaultKeyPropertySet
         {
-            set { _defaultKeyPropertySet = value; }
-
             get { return _defaultKeyPropertySet; }
+
+            set { _defaultKeyPropertySet = value; }
         }
 
         /// <summary>
@@ -232,9 +232,9 @@ namespace Microsoft.PowerShell.Commands
         [ValidateNotNullOrEmpty]
         public string[] PropertySerializationSet
         {
-            set { _propertySerializationSet = value; }
-
             get { return _propertySerializationSet; }
+
+            set { _propertySerializationSet = value; }
         }
 
         // These members are represented as NoteProperty in types.ps1xml
@@ -261,9 +261,9 @@ namespace Microsoft.PowerShell.Commands
         [ValidateNotNullOrEmpty]
         public string TypeName
         {
-            set { _typeName = value; }
-
             get { return _typeName; }
+
+            set { _typeName = value; }
         }
 
         private bool _force = false;
@@ -274,9 +274,9 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = TypeDataSet)]
         public SwitchParameter Force
         {
-            set { _force = value; }
-
             get { return _force; }
+
+            set { _force = value; }
         }
 
         #endregion dynamic type set
@@ -291,9 +291,9 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true, ParameterSetName = TypeDataSet)]
         public TypeData[] TypeData
         {
-            set { _typeData = value; }
-
             get { return _typeData; }
+
+            set { _typeData = value; }
         }
 
         #endregion strong type data set

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/TraceExpressionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/TraceExpressionCommand.cs
@@ -27,7 +27,7 @@ namespace Microsoft.PowerShell.Commands
         /// This parameter specifies the current pipeline object.
         /// </summary>
         [Parameter(ValueFromPipeline = true)]
-        public PSObject InputObject { set; get; } = AutomationNull.Value;
+        public PSObject InputObject { get; set; } = AutomationNull.Value;
 
         /// <summary>
         /// The TraceSource parameter determines which TraceSource categories the

--- a/src/Microsoft.WSMan.Management/Interop.cs
+++ b/src/Microsoft.WSMan.Management/Interop.cs
@@ -734,19 +734,18 @@ namespace Microsoft.WSMan.Management
         [SuppressMessage("Microsoft.Design", "CA1056:UriPropertiesShouldNotBeStrings")]
         string ResourceUri
         {
-            // IDL: HRESULT resourceUri (BSTR value);
-            [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "resource")]
-            [SuppressMessage("Microsoft.Design", "CA1056:UriPropertiesShouldNotBeStrings")]
-            [DispId(1)]
-            set;
-
             // IDL: HRESULT resourceUri ([out, retval] BSTR* ReturnValue);
-
             [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "resource")]
             [SuppressMessage("Microsoft.Design", "CA1056:UriPropertiesShouldNotBeStrings")]
             [DispId(1)]
             [return: MarshalAs(UnmanagedType.BStr)]
             get;
+
+            // IDL: HRESULT resourceUri (BSTR value);
+            [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "resource")]
+            [SuppressMessage("Microsoft.Design", "CA1056:UriPropertiesShouldNotBeStrings")]
+            [DispId(1)]
+            set;
         }
 
         /// <summary><para><c>AddSelector</c> method of <c>IWSManResourceLocator</c> interface.  </para><para>Add selector to resource locator</para></summary>

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseCommand.cs
@@ -150,7 +150,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// This parameter specifies the current pipeline object.
         /// </summary>
         [Parameter(ValueFromPipeline = true)]
-        public PSObject InputObject { set; get; } = AutomationNull.Value;
+        public PSObject InputObject { get; set; } = AutomationNull.Value;
 
         #endregion
 

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -596,9 +596,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         internal LineOutput LineOutput
         {
-            set { _lo = value; }
-
             get { return _lo; }
+
+            set { _lo = value; }
         }
 
         private ShapeInfo ShapeInfoOnFormatContext

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData.cs
@@ -102,19 +102,19 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     {
         internal bool MultilineTables
         {
+            get
+            {
+                if (_multilineTables.HasValue)
+                    return _multilineTables.Value;
+                return false;
+            }
+
             set
             {
                 if (!_multilineTables.HasValue)
                 {
                     _multilineTables = value;
                 }
-            }
-
-            get
-            {
-                if (_multilineTables.HasValue)
-                    return _multilineTables.Value;
-                return false;
             }
         }
 
@@ -132,19 +132,19 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// </summary>
         internal bool ShowErrorsAsMessages
         {
+            get
+            {
+                if (_showErrorsAsMessages.HasValue)
+                    return _showErrorsAsMessages.Value;
+                return false;
+            }
+
             set
             {
                 if (!_showErrorsAsMessages.HasValue)
                 {
                     _showErrorsAsMessages = value;
                 }
-            }
-
-            get
-            {
-                if (_showErrorsAsMessages.HasValue)
-                    return _showErrorsAsMessages.Value;
-                return false;
             }
         }
 
@@ -156,19 +156,19 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// </summary>
         internal bool ShowErrorsInFormattedOutput
         {
+            get
+            {
+                if (_showErrorsInFormattedOutput.HasValue)
+                    return _showErrorsInFormattedOutput.Value;
+                return false;
+            }
+
             set
             {
                 if (!_showErrorsInFormattedOutput.HasValue)
                 {
                     _showErrorsInFormattedOutput = value;
                 }
-            }
-
-            get
-            {
-                if (_showErrorsInFormattedOutput.HasValue)
-                    return _showErrorsInFormattedOutput.Value;
-                return false;
             }
         }
 
@@ -191,19 +191,19 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     {
         internal int PropertyCountForTable
         {
+            get
+            {
+                if (_propertyCountForTable.HasValue)
+                    return _propertyCountForTable.Value;
+                return 4;
+            }
+
             set
             {
                 if (!_propertyCountForTable.HasValue)
                 {
                     _propertyCountForTable = value;
                 }
-            }
-
-            get
-            {
-                if (_propertyCountForTable.HasValue)
-                    return _propertyCountForTable.Value;
-                return 4;
             }
         }
 

--- a/src/System.Management.Automation/FormatAndOutput/out-console/OutConsole.cs
+++ b/src/System.Management.Automation/FormatAndOutput/out-console/OutConsole.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerShell.Commands
         /// This parameter specifies the current pipeline object.
         /// </summary>
         [Parameter(ValueFromPipeline = true)]
-        public PSObject InputObject { set; get; } = AutomationNull.Value;
+        public PSObject InputObject { get; set; } = AutomationNull.Value;
 
         /// <summary>
         /// Do nothing.

--- a/src/System.Management.Automation/engine/Attributes.cs
+++ b/src/System.Management.Automation/engine/Attributes.cs
@@ -1265,7 +1265,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets or sets the Regex options to be used in the validation.
         /// </summary>
-        public RegexOptions Options { set; get; } = RegexOptions.IgnoreCase;
+        public RegexOptions Options { get; set; } = RegexOptions.IgnoreCase;
 
         /// <summary>
         /// Gets or sets the custom error message pattern that is displayed to the user.

--- a/src/System.Management.Automation/engine/DefaultCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/DefaultCommandRuntime.cs
@@ -30,7 +30,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Return the instance of PSHost - null by default.
         /// </summary>
-        public PSHost Host { set; get; }
+        public PSHost Host { get; set; }
 
         #region Write
         /// <summary>

--- a/src/System.Management.Automation/engine/ExecutionContext.cs
+++ b/src/System.Management.Automation/engine/ExecutionContext.cs
@@ -172,7 +172,7 @@ namespace System.Management.Automation
         /// trace flag.
         /// </summary>
         /// <value>The current state of the IgnoreScriptDebug flag.</value>
-        internal bool IgnoreScriptDebug { set; get; } = true;
+        internal bool IgnoreScriptDebug { get; set; } = true;
 
         /// <summary>
         /// Gets the automation engine instance.

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -80,9 +80,9 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ValueFromPipeline = true, ParameterSetName = ForEachObjectCommand.ParallelParameterSet)]
         public PSObject InputObject
         {
-            set { _inputObject = value; }
-
             get { return _inputObject; }
+
+            set { _inputObject = value; }
         }
 
         private PSObject _inputObject = AutomationNull.Value;
@@ -220,9 +220,9 @@ namespace Microsoft.PowerShell.Commands
         [Alias("Args")]
         public object[] ArgumentList
         {
-            set { _arguments = value; }
-
             get { return _arguments; }
+
+            set { _arguments = value; }
         }
 
         private object[] _arguments;

--- a/src/System.Management.Automation/engine/Modules/ExportModuleMemberCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ExportModuleMemberCommand.cs
@@ -28,6 +28,8 @@ namespace Microsoft.PowerShell.Commands
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public string[] Function
         {
+            get { return _functionList; }
+
             set
             {
                 _functionList = value;
@@ -42,8 +44,6 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
             }
-
-            get { return _functionList; }
         }
 
         private string[] _functionList;
@@ -57,6 +57,8 @@ namespace Microsoft.PowerShell.Commands
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public string[] Cmdlet
         {
+            get { return _cmdletList; }
+
             set
             {
                 _cmdletList = value;
@@ -71,8 +73,6 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
             }
-
-            get { return _cmdletList; }
         }
 
         private string[] _cmdletList;
@@ -86,6 +86,8 @@ namespace Microsoft.PowerShell.Commands
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public string[] Variable
         {
+            get { return _variableExportList; }
+
             set
             {
                 _variableExportList = value;
@@ -100,8 +102,6 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
             }
-
-            get { return _variableExportList; }
         }
 
         private string[] _variableExportList;
@@ -115,6 +115,8 @@ namespace Microsoft.PowerShell.Commands
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public string[] Alias
         {
+            get { return _aliasExportList; }
+
             set
             {
                 _aliasExportList = value;
@@ -129,8 +131,6 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
             }
-
-            get { return _aliasExportList; }
         }
 
         private string[] _aliasExportList;

--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -63,9 +63,9 @@ namespace Microsoft.PowerShell.Commands
         [Parameter]
         public SwitchParameter Global
         {
-            set { base.BaseGlobal = value; }
-
             get { return base.BaseGlobal; }
+
+            set { base.BaseGlobal = value; }
         }
 
         /// <summary>
@@ -75,9 +75,9 @@ namespace Microsoft.PowerShell.Commands
         [ValidateNotNull]
         public string Prefix
         {
-            set { BasePrefix = value; }
-
             get { return BasePrefix; }
+
+            set { BasePrefix = value; }
         }
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = ParameterSet_ViaWinCompat, Mandatory = true, ValueFromPipeline = true, Position = 0)]
         [ValidateTrustedData]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
-        public string[] Name { set; get; } = Array.Empty<string>();
+        public string[] Name { get; set; } = Array.Empty<string>();
 
         /// <summary>
         /// This parameter specifies the current pipeline object.
@@ -117,6 +117,8 @@ namespace Microsoft.PowerShell.Commands
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public string[] Function
         {
+            get { return _functionImportList; }
+
             set
             {
                 if (value == null)
@@ -130,8 +132,6 @@ namespace Microsoft.PowerShell.Commands
                     BaseFunctionPatterns.Add(WildcardPattern.Get(pattern, WildcardOptions.IgnoreCase));
                 }
             }
-
-            get { return _functionImportList; }
         }
 
         private string[] _functionImportList = Array.Empty<string>();
@@ -144,6 +144,8 @@ namespace Microsoft.PowerShell.Commands
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public string[] Cmdlet
         {
+            get { return _cmdletImportList; }
+
             set
             {
                 if (value == null)
@@ -158,8 +160,6 @@ namespace Microsoft.PowerShell.Commands
                     BaseCmdletPatterns.Add(WildcardPattern.Get(pattern, WildcardOptions.IgnoreCase));
                 }
             }
-
-            get { return _cmdletImportList; }
         }
 
         private string[] _cmdletImportList = Array.Empty<string>();
@@ -172,6 +172,8 @@ namespace Microsoft.PowerShell.Commands
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public string[] Variable
         {
+            get { return _variableExportList; }
+
             set
             {
                 if (value == null)
@@ -185,8 +187,6 @@ namespace Microsoft.PowerShell.Commands
                     BaseVariablePatterns.Add(WildcardPattern.Get(pattern, WildcardOptions.IgnoreCase));
                 }
             }
-
-            get { return _variableExportList; }
         }
 
         private string[] _variableExportList;
@@ -199,6 +199,8 @@ namespace Microsoft.PowerShell.Commands
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public string[] Alias
         {
+            get { return _aliasExportList; }
+
             set
             {
                 if (value == null)
@@ -213,8 +215,6 @@ namespace Microsoft.PowerShell.Commands
                     BaseAliasPatterns.Add(WildcardPattern.Get(pattern, WildcardOptions.IgnoreCase));
                 }
             }
-
-            get { return _aliasExportList; }
         }
 
         private string[] _aliasExportList;
@@ -335,7 +335,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = ParameterSet_ModuleInfo, Mandatory = true, ValueFromPipeline = true, Position = 0)]
         [ValidateTrustedData]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
-        public PSModuleInfo[] ModuleInfo { set; get; } = Array.Empty<PSModuleInfo>();
+        public PSModuleInfo[] ModuleInfo { get; set; } = Array.Empty<PSModuleInfo>();
 
         /// <summary>
         /// The arguments to pass to the module script.

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -110,7 +110,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// This parameter specified a prefix used to modify names of imported commands.
         /// </summary>
-        internal string BasePrefix { set; get; } = string.Empty;
+        internal string BasePrefix { get; set; } = string.Empty;
 
         /// <summary>
         /// Flags -force operations.

--- a/src/System.Management.Automation/engine/Modules/NewModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/NewModuleCommand.cs
@@ -27,9 +27,9 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = "Name", Mandatory = true, ValueFromPipeline = true, Position = 0)]
         public string Name
         {
-            set { _name = value; }
-
             get { return _name; }
+
+            set { _name = value; }
         }
 
         private string _name;
@@ -60,6 +60,8 @@ namespace Microsoft.PowerShell.Commands
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public string[] Function
         {
+            get { return _functionImportList; }
+
             set
             {
                 if (value == null)
@@ -74,8 +76,6 @@ namespace Microsoft.PowerShell.Commands
                     BaseFunctionPatterns.Add(WildcardPattern.Get(pattern, WildcardOptions.IgnoreCase));
                 }
             }
-
-            get { return _functionImportList; }
         }
 
         private string[] _functionImportList = Array.Empty<string>();
@@ -88,6 +88,8 @@ namespace Microsoft.PowerShell.Commands
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public string[] Cmdlet
         {
+            get { return _cmdletImportList; }
+
             set
             {
                 if (value == null)
@@ -102,8 +104,6 @@ namespace Microsoft.PowerShell.Commands
                     BaseCmdletPatterns.Add(WildcardPattern.Get(pattern, WildcardOptions.IgnoreCase));
                 }
             }
-
-            get { return _cmdletImportList; }
         }
 
         private string[] _cmdletImportList = Array.Empty<string>();

--- a/src/System.Management.Automation/engine/Modules/PSModuleInfo.cs
+++ b/src/System.Management.Automation/engine/Modules/PSModuleInfo.cs
@@ -28,7 +28,7 @@ namespace System.Management.Automation
             new ReadOnlyDictionary<string, TypeDefinitionAst>(new Dictionary<string, TypeDefinitionAst>(StringComparer.OrdinalIgnoreCase));
 
         // This dictionary doesn't include ExportedTypes from nested modules.
-        private ReadOnlyDictionary<string, TypeDefinitionAst> _exportedTypeDefinitionsNoNested { set; get; }
+        private ReadOnlyDictionary<string, TypeDefinitionAst> _exportedTypeDefinitionsNoNested { get; set; }
 
         private static readonly HashSet<string> s_scriptModuleExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {

--- a/src/System.Management.Automation/engine/Modules/RemoveModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/RemoveModuleCommand.cs
@@ -32,9 +32,9 @@ namespace Microsoft.PowerShell.Commands
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public string[] Name
         {
-            set { _name = value; }
-
             get { return _name; }
+
+            set { _name = value; }
         }
 
         private string[] _name = Array.Empty<string>();
@@ -53,9 +53,9 @@ namespace Microsoft.PowerShell.Commands
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public PSModuleInfo[] ModuleInfo
         {
-            set { _moduleInfo = value; }
-
             get { return _moduleInfo; }
+
+            set { _moduleInfo = value; }
         }
 
         private PSModuleInfo[] _moduleInfo = Array.Empty<PSModuleInfo>();

--- a/src/System.Management.Automation/engine/ParameterBinderBase.cs
+++ b/src/System.Management.Automation/engine/ParameterBinderBase.cs
@@ -172,10 +172,10 @@ namespace System.Management.Automation
         /// </summary>
         internal CommandLineParameters CommandLineParameters
         {
+            get { return _commandLineParameters ?? (_commandLineParameters = new CommandLineParameters()); }
+
             // Setter is needed to pass into RuntimeParameterBinder instances
             set { _commandLineParameters = value; }
-
-            get { return _commandLineParameters ?? (_commandLineParameters = new CommandLineParameters()); }
         }
 
         private CommandLineParameters _commandLineParameters;

--- a/src/System.Management.Automation/engine/hostifaces/History.cs
+++ b/src/System.Management.Automation/engine/hostifaces/History.cs
@@ -1338,7 +1338,7 @@ namespace Microsoft.PowerShell.Commands
         /// This parameter specifies the current pipeline object.
         /// </summary>
         [Parameter(Position = 0, ValueFromPipeline = true)]
-        public PSObject[] InputObject { set; get; }
+        public PSObject[] InputObject { get; set; }
 
         private bool _passthru;
         /// <summary>

--- a/src/System.Management.Automation/engine/remoting/client/RemoteRunspacePoolInternal.cs
+++ b/src/System.Management.Automation/engine/remoting/client/RemoteRunspacePoolInternal.cs
@@ -271,8 +271,8 @@ namespace System.Management.Automation.Runspaces.Internal
         /// </summary>
         internal bool IsRemoteDebugStop
         {
-            set;
             get;
+            set;
         }
 
         #endregion

--- a/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
+++ b/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
@@ -2491,8 +2491,8 @@ namespace System.Management.Automation
         /// </summary>
         internal bool IsRemoteDebug
         {
-            private set;
             get;
+            private set;
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
@@ -347,14 +347,14 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = InvokeCommandCommand.FilePathContainerIdParameterSet)]
         public override int ThrottleLimit
         {
-            set
-            {
-                base.ThrottleLimit = value;
-            }
-
             get
             {
                 return base.ThrottleLimit;
+            }
+
+            set
+            {
+                base.ThrottleLimit = value;
             }
         }
 

--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -620,7 +620,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = PSRemotingBaseCmdlet.ContainerIdParameterSet)]
         [Parameter(ParameterSetName = PSRemotingBaseCmdlet.VMIdParameterSet)]
         [Parameter(ParameterSetName = PSRemotingBaseCmdlet.VMNameParameterSet)]
-        public virtual int ThrottleLimit { set; get; } = 0;
+        public virtual int ThrottleLimit { get; set; } = 0;
 
         /// <summary>
         /// A complete URI(s) specified for the remote computer and shell to
@@ -3257,8 +3257,8 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         internal Runspace PipelineRunspace
         {
-            set;
             get;
+            set;
         }
 
         #region Runspace Debug

--- a/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
@@ -39,7 +39,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Disable ThrottleLimit parameter inherited from base class.
         /// </summary>
-        public new int ThrottleLimit { set { } get { return 0; } }
+        public new int ThrottleLimit { get { return 0; } set { } }
 
         private ObjectStream _stream;
         private RemoteRunspace _tempRunspace;

--- a/src/System.Management.Automation/engine/remoting/common/throttlemanager.cs
+++ b/src/System.Management.Automation/engine/remoting/common/throttlemanager.cs
@@ -204,17 +204,17 @@ namespace System.Management.Automation.Remoting
         /// </summary>
         internal int ThrottleLimit
         {
+            get
+            {
+                return _throttleLimit;
+            }
+
             set
             {
                 if (value > 0 && value <= s_THROTTLE_LIMIT_MAX)
                 {
                     _throttleLimit = value;
                 }
-            }
-
-            get
-            {
-                return _throttleLimit;
             }
         }
 

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -833,7 +833,7 @@ namespace System.Management.Automation
             set { _scriptBlockData.SkipLogging = value; }
         }
 
-        internal Assembly AssemblyDefiningPSTypes { set; get; }
+        internal Assembly AssemblyDefiningPSTypes { get; set; }
 
         internal HelpInfo GetHelpInfo(
             ExecutionContext context,

--- a/src/System.Management.Automation/engine/serialization.cs
+++ b/src/System.Management.Automation/engine/serialization.cs
@@ -322,7 +322,7 @@ namespace System.Management.Automation
         /// is used by PriorityReceivedDataCollection (remoting) to process incoming data from the
         /// remote end. A value of Null means that the max memory is unlimited.
         /// </summary>
-        internal int? MaximumAllowedMemory { set; get; }
+        internal int? MaximumAllowedMemory { get; set; }
 
         /// <summary>
         /// Logs that memory used by deserialized objects is not related to the size of input xml.

--- a/src/System.Management.Automation/help/HelpCommands.cs
+++ b/src/System.Management.Automation/help/HelpCommands.cs
@@ -185,6 +185,11 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = "Online", Mandatory = true)]
         public SwitchParameter Online
         {
+            get
+            {
+                return _showOnlineHelp;
+            }
+
             set
             {
                 _showOnlineHelp = value;
@@ -192,11 +197,6 @@ namespace Microsoft.PowerShell.Commands
                 {
                     VerifyParameterForbiddenInRemoteRunspace(this, "Online");
                 }
-            }
-
-            get
-            {
-                return _showOnlineHelp;
             }
         }
 


### PR DESCRIPTION
# PR Summary

* Fix `SA1212:PropertyAccessorsMustFollowOrder`
  * `Microsoft.PowerShell.Commands.Utility`
  * `Microsoft.Management.Infrastructure.CimCmdlets`
  * `Microsoft.PowerShell.Commands.Management`
  * `Microsoft.WSMan.Management`

## PR Context

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [NA] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [NA] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [NA] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [NA] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [NA] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [NA] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
