### PR TITLE
Write proper error messages for Get-Command ' '

### DIFF
--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -1100,7 +1100,6 @@ namespace System.Management.Automation
                 // Home Path:           "~\command.exe"
                 // Drive Relative Path: "\Users\User\AppData\Local\Temp\command.exe"
 
-                //char firstChar = _commandName[0];
                 if (_commandName.Length != 0) 
                 {
                     char firstChar = _commandName[0];

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -1334,10 +1334,6 @@ namespace System.Management.Automation
         /// </exception>
         internal LookupPathCollection ConstructSearchPatternsFromName(string name, bool commandDiscovery = false)
         {
-            Dbg.Assert(
-                !string.IsNullOrEmpty(name),
-                "Caller should verify name");
-
             var result = new LookupPathCollection();
 
             // First check to see if the commandName has an extension, if so

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -1099,7 +1099,7 @@ namespace System.Management.Automation
                 // Relative Path:       ".\command.exe"
                 // Home Path:           "~\command.exe"
                 // Drive Relative Path: "\Users\User\AppData\Local\Temp\command.exe"
-                if (_commandName[0] == '.' || _commandName[0] == '~' || _commandName[0] == '\\')
+                if (!string.IsNullOrEmpty(_commandName) && (_commandName[0] == '.' || _commandName[0] == '~' || _commandName[0] == '\\'))
                 {
                     using (CommandDiscovery.discoveryTracer.TraceScope(
                         "{0} appears to be a relative path. Trying to resolve relative path",

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -1087,7 +1087,7 @@ namespace System.Management.Automation
             string? result = null;
 
             if (_context.EngineSessionState != null &&
-                _context.EngineSessionState.ProviderCount > 0)
+                _context.EngineSessionState.ProviderCount > 0 && _commandName.Length != 0)
             {
                 // NTRAID#Windows OS Bugs-1009294-2004/02/04-JeffJon
                 // This is really slow.  Maybe since we are only allowing FS paths right
@@ -1100,17 +1100,14 @@ namespace System.Management.Automation
                 // Home Path:           "~\command.exe"
                 // Drive Relative Path: "\Users\User\AppData\Local\Temp\command.exe"
 
-                if (_commandName.Length != 0) 
+                char firstChar = _commandName[0];
+                if (firstChar == '.' || firstChar == '~' || firstChar == '\\')
                 {
-                    char firstChar = _commandName[0];
-                    if (firstChar == '.' || firstChar == '~' || firstChar == '\\')
+                    using (CommandDiscovery.discoveryTracer.TraceScope(
+                        "{0} appears to be a relative path. Trying to resolve relative path",
+                        _commandName))
                     {
-                        using (CommandDiscovery.discoveryTracer.TraceScope(
-                            "{0} appears to be a relative path. Trying to resolve relative path",
-                            _commandName))
-                        {
-                            result = ResolvePSPath(_commandName);
-                        }
+                        result = ResolvePSPath(_commandName);
                     }
                 }
             }

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -1099,13 +1099,19 @@ namespace System.Management.Automation
                 // Relative Path:       ".\command.exe"
                 // Home Path:           "~\command.exe"
                 // Drive Relative Path: "\Users\User\AppData\Local\Temp\command.exe"
-                if (!string.IsNullOrEmpty(_commandName) && (_commandName[0] == '.' || _commandName[0] == '~' || _commandName[0] == '\\'))
+
+                //char firstChar = _commandName[0];
+                if (_commandName.Length != 0) 
                 {
-                    using (CommandDiscovery.discoveryTracer.TraceScope(
-                        "{0} appears to be a relative path. Trying to resolve relative path",
-                        _commandName))
+                    char firstChar = _commandName[0];
+                    if (firstChar == '.' || firstChar == '~' || firstChar == '\\')
                     {
-                        result = ResolvePSPath(_commandName);
+                        using (CommandDiscovery.discoveryTracer.TraceScope(
+                            "{0} appears to be a relative path. Trying to resolve relative path",
+                            _commandName))
+                        {
+                            result = ResolvePSPath(_commandName);
+                        }
                     }
                 }
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
@@ -102,9 +102,6 @@ Describe "Get-Command Feature tests" -Tag Feature {
             Get-Command i-psd* -UseAbbreviationExpansion | Should -BeNullOrEmpty
         }
 
-        It "Returns CommandNotFoundException if a single space is used" {
-            {Get-Command ' ' -ErrorAction Stop} | Should -Throw -ErrorId "CommandNotFoundException,Microsoft.PowerShell.Commands.GetCommandCommand"
-        }
     }
 }
 
@@ -181,6 +178,16 @@ Describe "Get-Command" -Tag CI {
             $Result = Get-Command -Name Remove-Item
 
             $Result | Should -BeOfType [System.Management.Automation.CommandInfo]
+        }
+
+        It "Throws <expected> exception if <name> name is used" -TestCases @(
+            @{ Name = ' '; expected = "CommandNotFoundException,Microsoft.PowerShell.Commands.GetCommandCommand" }
+            @{ Name = ''; expected = "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.GetCommandCommand" }
+            @{ Name = $null; expected = "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.GetCommandCommand" }
+        ) {
+            param($name, $expected)
+            $shortExpected = $expected -split ","
+            { Get-Command $name -ErrorAction Stop } | Should -Throw -ErrorId $expected
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
@@ -186,7 +186,6 @@ Describe "Get-Command" -Tag CI {
             @{ Name = $null; expected = "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.GetCommandCommand" }
         ) {
             param($name, $expected)
-            $shortExpected = $expected -split ","
             { Get-Command $name -ErrorAction Stop } | Should -Throw -ErrorId $expected
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
@@ -180,13 +180,13 @@ Describe "Get-Command" -Tag CI {
             $Result | Should -BeOfType [System.Management.Automation.CommandInfo]
         }
 
-        It "Throws <expected> exception if <name> name is used" -TestCases @(
-            @{ Name = ' '; expected = "CommandNotFoundException,Microsoft.PowerShell.Commands.GetCommandCommand" }
-            @{ Name = ''; expected = "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.GetCommandCommand" }
-            @{ Name = $null; expected = "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.GetCommandCommand" }
+        It "Throws '<expected>' exception if <name> name is used" -TestCases @(
+            @{ Name = 'space'; Value = ' '; expected = "CommandNotFoundException,Microsoft.PowerShell.Commands.GetCommandCommand" }
+            @{ Name = 'empty'; Value = ''; expected = "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.GetCommandCommand" }
+            @{ Name = 'null'; Value = $null; expected = "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.GetCommandCommand" }
         ) {
-            param($name, $expected)
-            { Get-Command $name -ErrorAction Stop } | Should -Throw -ErrorId $expected
+            param($value, $expected)
+            { Get-Command $value -ErrorAction Stop } | Should -Throw -ErrorId $expected
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
@@ -101,6 +101,10 @@ Describe "Get-Command Feature tests" -Tag Feature {
         It "No results if wildcard is used" {
             Get-Command i-psd* -UseAbbreviationExpansion | Should -BeNullOrEmpty
         }
+
+        It "Returns CommandNotFoundException if a single space is used" {
+            {Get-Command ' ' -ErrorAction Stop} | Should -Throw -ErrorId "CommandNotFoundException,Microsoft.PowerShell.Commands.GetCommandCommand"
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
@@ -180,7 +180,7 @@ Describe "Get-Command" -Tag CI {
             $Result | Should -BeOfType [System.Management.Automation.CommandInfo]
         }
 
-        It "Throws '<expected>' exception if <name> name is used" -TestCases @(
+        It "Throws '<expected>' exception if '<Name>' name is used" -TestCases @(
             @{ Name = 'space'; Value = ' '; expected = "CommandNotFoundException,Microsoft.PowerShell.Commands.GetCommandCommand" }
             @{ Name = 'empty'; Value = ''; expected = "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.GetCommandCommand" }
             @{ Name = 'null'; Value = $null; expected = "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.GetCommandCommand" }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
@@ -101,7 +101,6 @@ Describe "Get-Command Feature tests" -Tag Feature {
         It "No results if wildcard is used" {
             Get-Command i-psd* -UseAbbreviationExpansion | Should -BeNullOrEmpty
         }
-
     }
 }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #13342. Checks if _commandName is empty or null in the DoPowerShellRelativePathLookup() method. Removes a Dbg.Assert() that checks if the name is empty or null. The assertion fails because _commandName is trimmed in setupPathSearcher().
<!-- Summarize your PR between here and the checklist. -->

## PR Context

After this change `Get-Command ' '` will return a CommandNotFoundException instead of a IndexOutOfRangeException. The Dbg.Assert was removed because according to Issue #10165 whitespace should be a valid argument for Get-Command.
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
