### PR TITLE
Add `-SkipLimitCheck` switch to `Import-PowerShellDataFile`

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImportPowerShellDataFile.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImportPowerShellDataFile.cs
@@ -40,6 +40,13 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
+        /// Determines if built-in limits are applied to the data.
+        /// </summary>
+        [Experimental("Microsoft.PowerShell.Utility.PSImportPSDataFileNoLimit", ExperimentAction.Show)]
+        [Parameter]
+        public SwitchParameter NoLimit { get; set; }
+
+        /// <summary>
         /// For each path, resolve it, parse it and write all hashtables to the output stream.
         /// </summary>
         protected override void ProcessRecord()
@@ -61,7 +68,7 @@ namespace Microsoft.PowerShell.Commands
                         var data = ast.Find(a => a is HashtableAst, false);
                         if (data != null)
                         {
-                            WriteObject(data.SafeGetValue());
+                            WriteObject(data.SafeGetValue(NoLimit));
                         }
                         else
                         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImportPowerShellDataFile.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImportPowerShellDataFile.cs
@@ -42,9 +42,9 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Gets or sets switch that determines if built-in limits are applied to the data.
         /// </summary>
-        [Experimental("Microsoft.PowerShell.Utility.PSImportPSDataFileNoLimit", ExperimentAction.Show)]
+        [Experimental("Microsoft.PowerShell.Utility.PSImportPSDataFileSkipLimitCheck", ExperimentAction.Show)]
         [Parameter]
-        public SwitchParameter NoLimit { get; set; }
+        public SwitchParameter SkipLimitCheck { get; set; }
 
         /// <summary>
         /// For each path, resolve it, parse it and write all hashtables to the output stream.
@@ -68,7 +68,7 @@ namespace Microsoft.PowerShell.Commands
                         var data = ast.Find(a => a is HashtableAst, false);
                         if (data != null)
                         {
-                            WriteObject(data.SafeGetValue(NoLimit));
+                            WriteObject(data.SafeGetValue(SkipLimitCheck));
                         }
                         else
                         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImportPowerShellDataFile.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImportPowerShellDataFile.cs
@@ -40,7 +40,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Determines if built-in limits are applied to the data.
+        /// Gets or sets switch that determines if built-in limits are applied to the data.
         /// </summary>
         [Experimental("Microsoft.PowerShell.Utility.PSImportPSDataFileNoLimit", ExperimentAction.Show)]
         [Parameter]

--- a/src/Modules/Unix/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
+++ b/src/Modules/Unix/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
@@ -39,7 +39,7 @@ PrivateData = @{
         Description = 'Enables -BreakAll parameter on Debug-Runspace and Debug-Job cmdlets to allow users to decide if they want PowerShell to break immediately in the current location when they attach a debugger. Enables -Runspace parameter on *-PSBreakpoint cmdlets to support management of breakpoints in another runspace.'
       }
       @{
-        Name        = 'Microsoft.PowerShell.Utility.PSImportPSDataFileNoLimit'
+        Name        = 'Microsoft.PowerShell.Utility.PSImportPSDataFileSkipLimitCheck'
         Description = 'Enable -NoLimit switch for Import-PowerShellDataFile to not enforce built-in hashtable limits'
       }
     )

--- a/src/Modules/Unix/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
+++ b/src/Modules/Unix/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
@@ -40,7 +40,7 @@ PrivateData = @{
       }
       @{
         Name        = 'Microsoft.PowerShell.Utility.PSImportPSDataFileSkipLimitCheck'
-        Description = 'Enable -NoLimit switch for Import-PowerShellDataFile to not enforce built-in hashtable limits'
+        Description = 'Enable -SkipLimitCheck switch for Import-PowerShellDataFile to not enforce built-in hashtable limits'
       }
     )
   }

--- a/src/Modules/Unix/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
+++ b/src/Modules/Unix/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
@@ -38,6 +38,10 @@ PrivateData = @{
         Name        = 'Microsoft.PowerShell.Utility.PSManageBreakpointsInRunspace'
         Description = 'Enables -BreakAll parameter on Debug-Runspace and Debug-Job cmdlets to allow users to decide if they want PowerShell to break immediately in the current location when they attach a debugger. Enables -Runspace parameter on *-PSBreakpoint cmdlets to support management of breakpoints in another runspace.'
       }
+      @{
+        Name        = 'Microsoft.PowerShell.Utility.PSImportPSDataFileNoLimit'
+        Description = 'Enable -NoLimit switch for Import-PowerShellDataFile to not enforce built-in hashtable limits'
+      }
     )
   }
 }

--- a/src/Modules/Windows/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
+++ b/src/Modules/Windows/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
@@ -38,7 +38,7 @@ PrivateData = @{
         Description = 'Enables -BreakAll parameter on Debug-Runspace and Debug-Job cmdlets to allow users to decide if they want PowerShell to break immediately in the current location when they attach a debugger. Enables -Runspace parameter on *-PSBreakpoint cmdlets to support management of breakpoints in another runspace.'
       }
       @{
-        Name        = 'Microsoft.PowerShell.Utility.PSImportPSDataFileNoLimit'
+        Name        = 'Microsoft.PowerShell.Utility.PSImportPSDataFileSkipLimitCheck'
         Description = 'Enable -NoLimit switch for Import-PowerShellDataFile to not enforce built-in hashtable limits'
       }
     )

--- a/src/Modules/Windows/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
+++ b/src/Modules/Windows/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
@@ -37,6 +37,10 @@ PrivateData = @{
         Name        = 'Microsoft.PowerShell.Utility.PSManageBreakpointsInRunspace'
         Description = 'Enables -BreakAll parameter on Debug-Runspace and Debug-Job cmdlets to allow users to decide if they want PowerShell to break immediately in the current location when they attach a debugger. Enables -Runspace parameter on *-PSBreakpoint cmdlets to support management of breakpoints in another runspace.'
       }
+      @{
+        Name        = 'Microsoft.PowerShell.Utility.PSImportPSDataFileNoLimit'
+        Description = 'Enable -NoLimit switch for Import-PowerShellDataFile to not enforce built-in hashtable limits'
+      }
     )
   }
 }

--- a/src/System.Management.Automation/engine/parser/SafeValues.cs
+++ b/src/System.Management.Automation/engine/parser/SafeValues.cs
@@ -362,7 +362,8 @@ namespace System.Management.Automation.Language
         {
             Default,
             GetPowerShell,
-            ModuleAnalysis
+            ModuleAnalysis,
+            SkipHashtableCheck,
         }
 
         // future proofing
@@ -371,7 +372,8 @@ namespace System.Management.Automation.Language
         public static object GetSafeValue(Ast ast, ExecutionContext context, SafeValueContext safeValueContext)
         {
             t_context = context;
-            if (IsSafeValueVisitor.IsAstSafe(ast, safeValueContext))
+
+            if (safeValueContext == SafeValueContext.SkipHashtableCheck || IsSafeValueVisitor.IsAstSafe(ast, safeValueContext))
             {
                 return ast.Accept(new GetSafeValueVisitor());
             }

--- a/src/System.Management.Automation/engine/parser/SafeValues.cs
+++ b/src/System.Management.Automation/engine/parser/SafeValues.cs
@@ -363,7 +363,7 @@ namespace System.Management.Automation.Language
             Default,
             GetPowerShell,
             ModuleAnalysis,
-            SkipHashtableCheck,
+            SkipHashtableSizeCheck,
         }
 
         // future proofing
@@ -373,7 +373,7 @@ namespace System.Management.Automation.Language
         {
             t_context = context;
 
-            if (safeValueContext == SafeValueContext.SkipHashtableCheck || IsSafeValueVisitor.IsAstSafe(ast, safeValueContext))
+            if (safeValueContext == SafeValueContext.SkipHashtableSizeCheck || IsSafeValueVisitor.IsAstSafe(ast, safeValueContext))
             {
                 return ast.Accept(new GetSafeValueVisitor());
             }

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -196,6 +196,19 @@ namespace System.Management.Automation.Language
         /// </exception>
         public object SafeGetValue()
         {
+            return SafeGetValue(skipHashtableCheck: false);
+        }
+
+        /// <summary>
+        /// Constructs the resultant object from the AST and returns it if it is safe.
+        /// </summary>
+        /// <param name="skipHashtableCheck">Set to skip hashtable limit validation.</param>
+        /// <returns>The object represented by the AST as a safe object.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// If <paramref name="extent"/> is deemed unsafe
+        /// </exception>
+        public object SafeGetValue(bool skipHashtableCheck)
+        {
             try
             {
                 ExecutionContext context = null;
@@ -204,7 +217,7 @@ namespace System.Management.Automation.Language
                     context = System.Management.Automation.Runspaces.Runspace.DefaultRunspace.ExecutionContext;
                 }
 
-                return GetSafeValueVisitor.GetSafeValue(this, context, GetSafeValueVisitor.SafeValueContext.Default);
+                return GetSafeValueVisitor.GetSafeValue(this, context, skipHashtableCheck ? GetSafeValueVisitor.SafeValueContext.SkipHashtableCheck : GetSafeValueVisitor.SafeValueContext.Default);
             }
             catch
             {

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -196,18 +196,18 @@ namespace System.Management.Automation.Language
         /// </exception>
         public object SafeGetValue()
         {
-            return SafeGetValue(skipHashtableCheck: false);
+            return SafeGetValue(skipHashtableSizeCheck: false);
         }
 
         /// <summary>
         /// Constructs the resultant object from the AST and returns it if it is safe.
         /// </summary>
-        /// <param name="skipHashtableCheck">Set to skip hashtable limit validation.</param>
+        /// <param name="skipHashtableSizeCheck">Set to skip hashtable limit validation.</param>
         /// <returns>The object represented by the AST as a safe object.</returns>
         /// <exception cref="InvalidOperationException">
         /// If <paramref name="extent"/> is deemed unsafe.
         /// </exception>
-        public object SafeGetValue(bool skipHashtableCheck)
+        public object SafeGetValue(bool skipHashtableSizeCheck)
         {
             try
             {
@@ -217,7 +217,7 @@ namespace System.Management.Automation.Language
                     context = System.Management.Automation.Runspaces.Runspace.DefaultRunspace.ExecutionContext;
                 }
 
-                return GetSafeValueVisitor.GetSafeValue(this, context, skipHashtableCheck ? GetSafeValueVisitor.SafeValueContext.SkipHashtableCheck : GetSafeValueVisitor.SafeValueContext.Default);
+                return GetSafeValueVisitor.GetSafeValue(this, context, skipHashtableSizeCheck ? GetSafeValueVisitor.SafeValueContext.SkipHashtableSizeCheck : GetSafeValueVisitor.SafeValueContext.Default);
             }
             catch
             {

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -205,7 +205,7 @@ namespace System.Management.Automation.Language
         /// <param name="skipHashtableCheck">Set to skip hashtable limit validation.</param>
         /// <returns>The object represented by the AST as a safe object.</returns>
         /// <exception cref="InvalidOperationException">
-        /// If <paramref name="extent"/> is deemed unsafe
+        /// If <paramref name="extent"/> is deemed unsafe.
         /// </exception>
         public object SafeGetValue(bool skipHashtableCheck)
         {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/PowerShellData.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/PowerShellData.tests.ps1
@@ -50,7 +50,7 @@ Describe "Tests for the Import-PowerShellDataFile cmdlet" -Tags "CI" {
     }
 
     It 'Succeeds if -NoLimit is used and has more than 500 keys' -Skip:$skipTest {
-        $result = Import-PowerShellDataFile $largePsd1Path -NoLimit
+        $result = Import-PowerShellDataFile $largePsd1Path -SkipLimitCheck
         $result.Keys.Count | Should -Be 501
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/PowerShellData.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/PowerShellData.tests.ps1
@@ -10,7 +10,7 @@ Describe "Tests for the Import-PowerShellDataFile cmdlet" -Tags "CI" {
         $largePsd1Builder.Append('}')
         Set-Content -Path $largePsd1Path -Value $largePsd1Builder.ToString()
 
-        if ((Get-ExperimentalFeature Microsoft.PowerShell.Utility.PSImportPSDataFileNoLimit).Enabled -ne $true) {
+        if ((Get-ExperimentalFeature Microsoft.PowerShell.Utility.PSImportPSDataFileSkipLimitCheck).Enabled -ne $true) {
             $skipTest = $true
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/PowerShellData.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/PowerShellData.tests.ps1
@@ -1,6 +1,19 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 Describe "Tests for the Import-PowerShellDataFile cmdlet" -Tags "CI" {
+    BeforeAll {
+        $largePsd1Path = Join-Path -Path $TestDrive -ChildPath 'large.psd1'
+        $largePsd1Builder = [System.Text.StringBuilder]::new('@{')
+        1..501 | ForEach-Object {
+            $largePsd1Builder.Append("key$_ = $_;")
+        }
+        $largePsd1Builder.Append('}')
+        Set-Content -Path $largePsd1Path -Value $largePsd1Builder.ToString()
+
+        if ((Get-ExperimentalFeature Microsoft.PowerShell.Utility.PSImportPSDataFileNoLimit).Enabled -ne $true) {
+            $skipTest = $true
+        }
+    }
 
     It "Validates error on a missing path" {
         { Import-PowerShellDataFile -Path /SomeMissingDirectory -ErrorAction Stop } |
@@ -32,4 +45,12 @@ Describe "Tests for the Import-PowerShellDataFile cmdlet" -Tags "CI" {
         $result.Hello | Should -BeExactly "World"
     }
 
+    It 'Fails if psd1 file has more than 500 keys' {
+        { Import-PowerShellDataFile $largePsd1Path } | Should -Throw -ErrorId 'System.InvalidOperationException,Microsoft.PowerShell.Commands.ImportPowerShellDataFileCommand'
+    }
+
+    It 'Succeeds if -NoLimit is used and has more than 500 keys' -Skip:$skipTest {
+        $result = Import-PowerShellDataFile $largePsd1Path -NoLimit
+        $result.Keys.Count | Should -Be 501
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

By default, there is a limit to the number of keys in a hashtable allowed to be converted from a psd1 file (500 keys).  This limit is hitting user cases like DSC configuration.  Change is to add a `-SkipLimitCheck` switch to by-pass the validation step for a hashtable.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/7979

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [x] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [x] Experimental feature name(s): `Microsoft.PowerShell.Utility.PSImportPSDataFileNoLimit`
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
