### PR TITLE
PowerShell profiler

### DIFF
--- a/src/System.Management.Automation/engine/ExternalScriptInfo.cs
+++ b/src/System.Management.Automation/engine/ExternalScriptInfo.cs
@@ -188,7 +188,8 @@ namespace System.Management.Automation
         {
             get
             {
-                if (Context == null) return SessionStateEntryVisibility.Public;
+                if (Context == null)
+                    return SessionStateEntryVisibility.Public;
 
                 return Context.EngineSessionState.CheckScriptVisibility(_path);
             }
@@ -267,7 +268,11 @@ namespace System.Management.Automation
             var scriptContents = ScriptContents;
             if (_scriptBlock == null)
             {
-                this.ScriptBlock = ScriptBlock.TryGetCachedScriptBlock(_path, scriptContents);
+                var compiledScriptBlockData = ScriptBlock.TryGetCompiledCachedScriptBlock(_path, scriptContents);
+                if (compiledScriptBlockData != null)
+                {
+                    this.ScriptBlock = new ScriptBlock(compiledScriptBlockData);
+                }
             }
 
             if (_scriptBlock != null)
@@ -305,7 +310,7 @@ namespace System.Management.Automation
                 if (errors.Length == 0)
                 {
                     this.ScriptBlock = new ScriptBlock(_scriptBlockAst, isFilter: false);
-                    ScriptBlock.CacheScriptBlock(_scriptBlock.Clone(), _path, scriptContents);
+                    ScriptBlock.CacheCompiledScriptBlock(_scriptBlock.Clone(), _path, scriptContents);
                 }
             }
 

--- a/src/System.Management.Automation/engine/ExternalScriptInfo.cs
+++ b/src/System.Management.Automation/engine/ExternalScriptInfo.cs
@@ -189,7 +189,9 @@ namespace System.Management.Automation
             get
             {
                 if (Context == null)
+                {
                     return SessionStateEntryVisibility.Public;
+                }
 
                 return Context.EngineSessionState.CheckScriptVisibility(_path);
             }
@@ -268,7 +270,7 @@ namespace System.Management.Automation
             var scriptContents = ScriptContents;
             if (_scriptBlock == null)
             {
-                var compiledScriptBlockData = ScriptBlock.TryGetCompiledCachedScriptBlock(_path, scriptContents);
+                CompiledScriptBlockData compiledScriptBlockData = ScriptBlock.TryGetCachedCompiledScriptBlock(_path, scriptContents);
                 if (compiledScriptBlockData != null)
                 {
                     this.ScriptBlock = new ScriptBlock(compiledScriptBlockData);

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -5269,6 +5269,7 @@ end {
                 { "Import-Module",                     new SessionStateCmdletEntry("Import-Module", typeof(ImportModuleCommand), helpFile) },
                 { "Invoke-Command",                    new SessionStateCmdletEntry("Invoke-Command", typeof(InvokeCommandCommand), helpFile) },
                 { "Invoke-History",                    new SessionStateCmdletEntry("Invoke-History", typeof(InvokeHistoryCommand), helpFile) },
+                { "Measure-Script",                    new SessionStateCmdletEntry("Measure-Script", typeof(MeasureScriptCommand), helpFile) },
                 { "New-Module",                        new SessionStateCmdletEntry("New-Module", typeof(NewModuleCommand), helpFile) },
                 { "New-ModuleManifest",                new SessionStateCmdletEntry("New-ModuleManifest", typeof(NewModuleManifestCommand), helpFile) },
                 { "New-PSRoleCapabilityFile",          new SessionStateCmdletEntry("New-PSRoleCapabilityFile", typeof(NewPSRoleCapabilityFileCommand), helpFile) },

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -1232,6 +1232,20 @@ namespace System.Management.Automation
             }
         }
 
+        internal Guid GetParentScriptBlockId()
+        {
+            if (_callStack.Count > 1)
+            {
+                var scriptBlock = _callStack[_callStack.Count - 2].FunctionContext._scriptBlock;
+                if (scriptBlock is not null)
+                {
+                    return scriptBlock.Id;
+                }
+            }
+
+            return Guid.Empty;
+        }
+
         #endregion Call stack management
 
         #region setting breakpoints

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -1241,7 +1241,7 @@ namespace System.Management.Automation
             int shift = sequencePointPosition == 0 ? 1 : 2;
             if (_callStack.Count - shift >= 0)
             {
-                var scriptBlock = _callStack[_callStack.Count - shift].FunctionContext._scriptBlock;
+                ScriptBlock scriptBlock = _callStack[_callStack.Count - shift].FunctionContext._scriptBlock;
                 if (scriptBlock is not null)
                 {
                     return scriptBlock.Id;

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -1232,11 +1232,16 @@ namespace System.Management.Automation
             }
         }
 
-        internal Guid GetParentScriptBlockId()
+        internal Guid GetParentScriptBlockId(int sequencePointPosition)
         {
-            if (_callStack.Count > 1)
+            // Sequence point on 0 position is an entry point in a scriptblock.
+            // In the time the callstack has still point to parent scriptblock
+            // so we take last element from the callstack,
+            // for rest sequence points we take an element before last as parent.
+            int shift = sequencePointPosition == 0 ? 1 : 2;
+            if (_callStack.Count - shift > 0)
             {
-                var scriptBlock = _callStack[_callStack.Count - 2].FunctionContext._scriptBlock;
+                var scriptBlock = _callStack[_callStack.Count - shift].FunctionContext._scriptBlock;
                 if (scriptBlock is not null)
                 {
                     return scriptBlock.Id;

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -1239,7 +1239,7 @@ namespace System.Management.Automation
             // so we take last element from the callstack,
             // for rest sequence points we take an element before last as parent.
             int shift = sequencePointPosition == 0 ? 1 : 2;
-            if (_callStack.Count - shift > 0)
+            if (_callStack.Count - shift >= 0)
             {
                 var scriptBlock = _callStack[_callStack.Count - shift].FunctionContext._scriptBlock;
                 if (scriptBlock is not null)

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -1135,6 +1135,16 @@ namespace System.Management.Automation
             Diagnostics.Assert(functionContext._executionContext == _context, "Wrong debugger is being used.");
 
             var invocationInfo = (InvocationInfo)functionContext._localsTuple.GetAutomaticVariable(AutomaticVariable.MyInvocation);
+
+            if (ProfilerEventSource.LogInstance.IsEnabled())
+            {
+                ProfilerEventSource.LogInstance.SequencePoint(
+                    functionContext._scriptBlock?.Id ?? Guid.Empty,
+                    functionContext._executionContext.CurrentRunspace.InstanceId,
+                    _callStack.Last()?.FunctionContext._scriptBlock.Id ?? Guid.Empty,
+                    0);
+            }
+
             var newCallStackInfo = new CallStackInfo
             {
                 InvocationInfo = invocationInfo,

--- a/src/System.Management.Automation/engine/interpreter/PowerShellInstructions.cs
+++ b/src/System.Management.Automation/engine/interpreter/PowerShellInstructions.cs
@@ -29,17 +29,14 @@ namespace System.Management.Automation.Interpreter
         public override int Run(InterpretedFrame frame)
         {
             var functionContext = frame.FunctionContext;
-            var context = frame.ExecutionContext;
-
-            functionContext._currentSequencePointIndex = _sequencePoint;
             if (_checkBreakpoints)
             {
-                if (context._debuggingMode > 0)
-                {
-                    context.Debugger.OnSequencePointHit(functionContext);
-                }
+                functionContext.UpdatePosition(_sequencePoint);
             }
-
+            else
+            {
+                functionContext.UpdatePositionNoBreak(_sequencePoint);
+            }
             return +1;
         }
 

--- a/src/System.Management.Automation/engine/interpreter/PowerShellInstructions.cs
+++ b/src/System.Management.Automation/engine/interpreter/PowerShellInstructions.cs
@@ -37,6 +37,7 @@ namespace System.Management.Automation.Interpreter
             {
                 functionContext.UpdatePositionNoBreak(_sequencePoint);
             }
+
             return +1;
         }
 

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -816,9 +816,9 @@ namespace System.Management.Automation.Language
             if (ProfilerEventSource.LogInstance.IsEnabled())
             {
                 ProfilerEventSource.LogInstance.SequencePoint(
-                    _scriptBlock.Id,
-                    _scriptBlock.SessionStateInternal.ExecutionContext.CurrentRunspace.InstanceId,
-                    _executionContext.Debugger.GetParentScriptBlockId(),
+                    _scriptBlock is not null ? _scriptBlock.Id : Guid.Empty,
+                    _executionContext.CurrentRunspace.InstanceId,
+                    _executionContext.Debugger.GetParentScriptBlockId(pos),
                      pos);
             }
         }

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -1172,12 +1172,9 @@ namespace System.Management.Automation.Language
             // in EnterScriptFunction.
             // Except for while/do loops, in this case we want to check breakpoints on the first sequence point since it
             // will be executed multiple times.
-            //return (index == 0 && !_generatingWhileOrDoLoop)
-            //           ? ExpressionCache.Empty
-            //           : new UpdatePositionExpr(extent, index, _debugSymbolDocument, !_compilingSingleExpression);
-            return _generatingWhileOrDoLoop
-                ? new UpdatePositionExpr(extent, index, _debugSymbolDocument, !_compilingSingleExpression)
-                : new UpdatePositionExpr(extent, index, _debugSymbolDocument, !_compilingSingleExpression);
+            return (index == 0 && !_generatingWhileOrDoLoop)
+                       ? ExpressionCache.Empty
+                       : new UpdatePositionExpr(extent, index, _debugSymbolDocument, !_compilingSingleExpression);
         }
 
         private int _tempCounter;

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -812,6 +812,11 @@ namespace System.Management.Automation.Language
         internal void UpdatePositionNoBreak(int pos)
         {
             _currentSequencePointIndex = pos;
+        }
+
+        internal void UpdatePosition(int pos)
+        {
+            UpdatePositionNoBreak(pos);
 
             if (ProfilerEventSource.LogInstance.IsEnabled())
             {
@@ -821,11 +826,7 @@ namespace System.Management.Automation.Language
                     _executionContext.Debugger.GetParentScriptBlockId(pos),
                     pos);
             }
-        }
 
-        internal void UpdatePosition(int pos)
-        {
-            UpdatePositionNoBreak(pos);
             if (_executionContext._debuggingMode > 0)
             {
                 _executionContext.Debugger.OnSequencePointHit(this);

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -816,7 +816,7 @@ namespace System.Management.Automation.Language
             if (ProfilerEventSource.LogInstance.IsEnabled())
             {
                 ProfilerEventSource.LogInstance.SequencePoint(
-                    _scriptBlock is not null ? _scriptBlock.Id : Guid.Empty,
+                    _scriptBlock?.Id ?? Guid.Empty,
                     _executionContext.CurrentRunspace.InstanceId,
                     _executionContext.Debugger.GetParentScriptBlockId(pos),
                     pos);

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -7099,7 +7099,7 @@ namespace System.Management.Automation.Language
                 exprs.Add(Expression.DebugInfo(_debugSymbolDocument, _extent.StartLineNumber, _extent.StartColumnNumber, _extent.EndLineNumber, _extent.EndColumnNumber));
             }
 
-            var method = _checkBreakpoints
+            MethodInfo method = _checkBreakpoints
                 ? CachedReflectionInfo.FunctionContext_UpdatePosition
                 : CachedReflectionInfo.FunctionContext_UpdatePositionNoBreak;
             exprs.Add(Expression.Call(Compiler.s_functionContext, method, ExpressionCache.Constant(_sequencePoint)));

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -815,7 +815,11 @@ namespace System.Management.Automation.Language
 
             if (ProfilerEventSource.LogInstance.IsEnabled())
             {
-                ProfilerEventSource.LogInstance.SequencePoint(_scriptBlock.Id, pos);
+                ProfilerEventSource.LogInstance.SequencePoint(
+                    _scriptBlock.Id,
+                    _scriptBlock.SessionStateInternal.ExecutionContext.CurrentRunspace.InstanceId,
+                    _executionContext.Debugger.GetParentScriptBlockId(),
+                     pos);
             }
         }
 

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -1172,9 +1172,12 @@ namespace System.Management.Automation.Language
             // in EnterScriptFunction.
             // Except for while/do loops, in this case we want to check breakpoints on the first sequence point since it
             // will be executed multiple times.
-            return (index == 0 && !_generatingWhileOrDoLoop)
-                       ? ExpressionCache.Empty
-                       : new UpdatePositionExpr(extent, index, _debugSymbolDocument, !_compilingSingleExpression);
+            //return (index == 0 && !_generatingWhileOrDoLoop)
+            //           ? ExpressionCache.Empty
+            //           : new UpdatePositionExpr(extent, index, _debugSymbolDocument, !_compilingSingleExpression);
+            return _generatingWhileOrDoLoop
+                ? new UpdatePositionExpr(extent, index, _debugSymbolDocument, !_compilingSingleExpression)
+                : new UpdatePositionExpr(extent, index, _debugSymbolDocument, !_compilingSingleExpression);
         }
 
         private int _tempCounter;

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -39,7 +39,7 @@ namespace System.Management.Automation
 
     internal class CompiledScriptBlockData
     {
-        private readonly static ConcurrentDictionary<Guid, CompiledScriptBlockData> s_IdToScriptBlock
+        private static readonly ConcurrentDictionary<Guid, CompiledScriptBlockData> s_IdToScriptBlock
             = new ConcurrentDictionary<Guid, CompiledScriptBlockData>();
 
         internal static void ResetIdToScriptBlock()

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -164,6 +164,11 @@ namespace System.Management.Automation
 
         private void CompileUnoptimized()
         {
+            if (_compiledUnoptimized)
+            {
+                return;
+            }
+
             lock (this)
             {
                 if (_compiledUnoptimized)
@@ -179,6 +184,11 @@ namespace System.Management.Automation
 
         private void CompileOptimized()
         {
+            if (_compiledOptimized)
+            {
+                return;
+            }
+
             lock (this)
             {
                 if (_compiledOptimized)

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -56,7 +56,7 @@ namespace System.Management.Automation
         {
             ClearCompiledScriptBlockTable();
 
-            foreach (var csb in ScriptBlock.GetCachedCompiledScriptBlockData())
+            foreach (CompiledScriptBlockData csb in ScriptBlock.GetCachedCompiledScriptBlockData())
             {
                 s_compiledScriptBlockTable.TryAdd(csb, csb);
             }
@@ -627,7 +627,7 @@ namespace System.Management.Automation
             return s_cachedScripts.Values;
         }
 
-        internal static CompiledScriptBlockData TryGetCompiledCachedScriptBlock(string fileName, string fileContents)
+        internal static CompiledScriptBlockData TryGetCachedCompiledScriptBlock(string fileName, string fileContents)
         {
             if (InternalTestHooks.IgnoreScriptBlockCache)
             {
@@ -684,7 +684,7 @@ namespace System.Management.Automation
 
         internal static ScriptBlock Create(Parser parser, string fileName, string fileContents)
         {
-            var compiledScriptBlockData = TryGetCompiledCachedScriptBlock(fileName, fileContents);
+            var compiledScriptBlockData = TryGetCachedCompiledScriptBlock(fileName, fileContents);
             if (compiledScriptBlockData != null)
             {
                 return new ScriptBlock(compiledScriptBlockData);

--- a/src/System.Management.Automation/engine/runtime/Profiler.cs
+++ b/src/System.Management.Automation/engine/runtime/Profiler.cs
@@ -1,0 +1,391 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Management.Automation.Internal;
+
+namespace System.Management.Automation
+{
+    /// <summary>
+    /// This class is a source of performance events for script block profiling.
+    /// Guid is {092ae15a-d5fb-5d8d-9ffd-68891d24c5f6}.
+    /// </summary>
+    [EventSource(Name = "Microsoft-PowerShell-Profiler")]
+    internal class ProfilerEventSource : EventSource
+    {
+        internal static ProfilerEventSource LogInstance = new ProfilerEventSource();
+
+        [Event(1)]
+        public void SequencePoint(Guid ScriptBlockId, int SequencePointPosition)
+        {
+            // We could use:
+            // WriteEvent(eventId: 1, ScriptBlockId, SequencePointPosition);
+            // but we care about performance.
+            if (IsEnabled())
+            {
+                unsafe
+                {
+                    EventData* eventPayload = stackalloc EventData[2];
+
+                    eventPayload[0] = new EventData
+                    {
+                        Size = sizeof(Guid),
+                        DataPointer = ((IntPtr)(&ScriptBlockId))
+                    };
+                    eventPayload[1] = new EventData
+                    {
+                        Size = sizeof(int),
+                        DataPointer = ((IntPtr)(&SequencePointPosition))
+                    };
+
+                    WriteEventCore(eventId: 1, eventDataCount: 2, eventPayload);
+                }
+            }
+        }
+
+        protected override void OnEventCommand(EventCommandEventArgs command)
+        {
+            base.OnEventCommand(command);
+
+            if (command.Command == EventCommand.Disable)
+            {
+                // At the end of the profile session, we send all the metadata.
+                ProfilerRundownEventSource.LogInstance.WriteRundownEvents();
+            }
+        }
+    }
+
+    /// <summary>
+    /// This class is a source of rundown (meta data) events for script block profiling.
+    /// Guid is {f348266e-dde6-5590-4bc9-10e1e2b6fe16}.
+    /// </summary>
+    [EventSource(Name = "Microsoft-PowerShell-Profiler-Rundown")]
+    internal class ProfilerRundownEventSource : EventSource
+    {
+        internal static ProfilerRundownEventSource LogInstance = new ProfilerRundownEventSource();
+
+        [Event(2)]
+        public void SequencePointRundown(
+            Guid ScriptBlockId,
+            int SequencePointCount,
+            int SequencePoint,
+            string File,
+            int StartLineNumber,
+            int StartColumnNumber,
+            int EndLineNumber,
+            int EndColumnNumber,
+            string Text,
+            int StartOffset,
+            int EndOffset)
+        {
+            // It is not performance critical so we use the standard method overload.
+            WriteEvent(
+                eventId: 2,
+                ScriptBlockId,
+                SequencePointCount,
+                SequencePoint,
+                File,
+                StartLineNumber,
+                StartColumnNumber,
+                EndLineNumber,
+                EndColumnNumber,
+                Text,
+                StartOffset,
+                EndOffset);
+        }
+
+        [NonEvent]
+        internal void WriteRundownEvents()
+        {
+            foreach (var csb in CompiledScriptBlockData.GetCompiledScriptBlockData().Values)
+            {
+                for (var position = 0; position < csb.SequencePoints.Length; position++)
+                {
+                    var sequencePoint = csb.SequencePoints[position];
+
+                    SequencePointRundown(
+                        csb.Id,
+                        csb.SequencePoints.Length,
+                        position,
+                        sequencePoint.File,
+                        sequencePoint.StartLineNumber,
+                        sequencePoint.StartColumnNumber,
+                        sequencePoint.EndLineNumber,
+                        sequencePoint.EndColumnNumber,
+                        sequencePoint.Text,
+                        sequencePoint.StartOffset,
+                        sequencePoint.EndOffset);
+                }
+            }
+        }
+
+        protected override void OnEventCommand(EventCommandEventArgs command)
+        {
+            base.OnEventCommand(command);
+
+            if (command.Command == EventCommand.Enable)
+            {
+                CompiledScriptBlockData.ResetIdToScriptBlock();
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            CompiledScriptBlockData.ResetIdToScriptBlock();
+            base.Dispose(disposing);
+        }
+    }
+
+    /// <summary>
+    /// Represents a span of text in a script.
+    /// </summary>
+    internal struct ScriptExtentEventData
+    {
+        /// <summary>
+        /// The filename the extent includes, or null if the extent is not included in any file.
+        /// </summary>
+        public string File;
+
+        /// <summary>
+        /// The line number at the beginning of the extent, with the value 1 being the first line.
+        /// </summary>
+        public int StartLineNumber;
+
+        /// <summary>
+        /// The column number at the beginning of the extent, with the value 1 being the first column.
+        /// </summary>
+        public int StartColumnNumber;
+
+        /// <summary>
+        /// The line number at the end of the extent, with the value 1 being the first line.
+        /// </summary>
+        public int EndLineNumber;
+
+        /// <summary>
+        /// The column number at the end of the extent, with the value 1 being the first column.
+        /// </summary>
+        public int EndColumnNumber;
+
+        /// <summary>
+        /// The script text that the extent includes.
+        /// </summary>
+        public string Text;
+
+        /// <summary>
+        /// The starting offset of the extent.
+        /// </summary>
+        public int StartOffset;
+
+        /// <summary>
+        /// The ending offset of the extent.
+        /// </summary>
+        public int EndOffset;
+    }
+
+    /// <summary>
+    /// This class is PowerShell script block profiler.
+    /// </summary>
+    internal class InternalProfiler : EventListener
+    {
+        /// <summary>
+        /// Represents a SequencePoint profile event data.
+        /// The event is raised at every sequence point start.
+        /// The event must be as small as possible for performance.
+        /// </summary>
+        internal struct SequencePointProfileEventData
+        {
+            /// <summary>
+            /// Start time of the SequencePoint.
+            /// </summary>
+            public DateTime Timestamp;
+
+            /// <summary>
+            /// Unique identifer of the script block.
+            /// </summary>
+            public Guid ScriptId;
+
+            /// <summary>
+            /// SequencePoint index number/position of the script block.
+            /// </summary>
+            public int SequencePointPosition;
+        }
+
+        /// <summary>
+        /// Represents a SequencePoint rundown profile event data.
+        /// The rundown event contains a meta data about script block sequence points.
+        /// The rundown event is raised once for every script block sequence point
+        /// at profile session end.
+        /// </summary>
+        internal struct CompiledScriptBlockRundownProfileEventData
+        {
+            /// <summary>
+            /// Timestamp of first rundown profile event for the script block.
+            /// </summary>
+            public DateTime Timestamp;
+
+            /// <summary>
+            /// Unique identifer of the script block.
+            /// </summary>
+            public Guid ScriptId;
+
+            /// <summary>
+            /// Sequence points of the script block.
+            /// </summary>
+            public ScriptExtentEventData[] SequencePoints;
+        }
+
+        // Buffer to collect a performance event data.
+        internal List<SequencePointProfileEventData> SequencePointProfileEvents = new List<SequencePointProfileEventData>(5000);
+
+        // Buffer to collect a script block meta data.
+        internal Dictionary<Guid, CompiledScriptBlockRundownProfileEventData> CompiledScriptBlockMetaData = new Dictionary<Guid, CompiledScriptBlockRundownProfileEventData>(5000);
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            var payload = eventData.Payload;
+            if (payload is null)
+            {
+                // there is a bug in our custom EventSource.
+                throw new ArgumentNullException(nameof(payload));
+            }
+
+            switch (eventData.EventId)
+            {
+                case 1:
+                    SequencePointProfileEvents.Add(new SequencePointProfileEventData
+                    {
+                        Timestamp = eventData.TimeStamp,
+                        ScriptId = (Guid)payload[0]!,
+                        SequencePointPosition = (int)payload[1]!
+                    });
+                    break;
+                case 2:
+                    ScriptExtentEventData sequencePoint;
+                    var scriptId = (Guid)payload[0]!;
+                    var sequencePointCount = (int)payload[1]!;
+                    var pos = (int)payload[2]!;
+                    sequencePoint.File = (string)payload[3]!;
+                    sequencePoint.StartLineNumber = (int)payload[4]!;
+                    sequencePoint.StartColumnNumber = (int)payload[5]!;
+                    sequencePoint.EndLineNumber = (int)payload[6]!;
+                    sequencePoint.EndColumnNumber = (int)payload[7]!;
+                    sequencePoint.Text = (string)payload[8]!;
+                    sequencePoint.StartOffset = (int)payload[9]!;
+                    sequencePoint.EndOffset = (int)payload[10]!;
+
+                    if (CompiledScriptBlockMetaData.TryGetValue(scriptId, out var sbe))
+                    {
+                        sbe.SequencePoints[pos] = sequencePoint;
+                    }
+                    else
+                    {
+                        sbe = new CompiledScriptBlockRundownProfileEventData()
+                        {
+                            Timestamp = eventData.TimeStamp,
+                            ScriptId = scriptId,
+                            SequencePoints = new ScriptExtentEventData[sequencePointCount]
+                        };
+
+                        sbe.SequencePoints[pos] = sequencePoint;
+
+                        CompiledScriptBlockMetaData.TryAdd(sbe.ScriptId, sbe);
+                    }
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Start the profiler.
+        /// </summary>
+        public void EnableEvents()
+        {
+            EnableEvents(ProfilerRundownEventSource.LogInstance, EventLevel.LogAlways);
+            EnableEvents(ProfilerEventSource.LogInstance, EventLevel.LogAlways);
+        }
+
+        /// <summary>
+        /// Stop the profiler.
+        /// </summary>
+        public void DisableEvents()
+        {
+            DisableEvents(ProfilerEventSource.LogInstance);
+            DisableEvents(ProfilerRundownEventSource.LogInstance);
+        }
+    }
+
+    /// <summary>
+    /// The cmdlet profiles a script block.
+    /// </summary>
+    [Cmdlet(VerbsDiagnostic.Measure, "Script", RemotingCapability = RemotingCapability.None)]
+    public class MeasureScriptCommand : PSCmdlet
+    {
+        /// <summary>
+        /// A script block to profile.
+        /// </summary>
+        [Parameter(Position = 0, Mandatory = true)]
+        public ScriptBlock ScriptBlock { get; set; } = null!;
+
+        /// <summary>
+        /// Process a profile data.
+        /// </summary>
+        protected override void EndProcessing()
+        {
+            using (var profiler = new InternalProfiler())
+            {
+                try
+                {
+                    profiler.EnableEvents();
+
+                    ScriptBlock.InvokeWithPipe(
+                        useLocalScope: false,
+                        errorHandlingBehavior: ScriptBlock.ErrorHandlingBehavior.WriteToCurrentErrorPipe,
+                        dollarUnder: null,
+                        input: Array.Empty<object>(),
+                        scriptThis: AutomationNull.Value,
+                        outputPipe: new Pipe { NullPipe = true },
+                        invocationInfo: null);
+                }
+                finally
+                {
+                    profiler.DisableEvents();
+                }
+
+                var events = profiler.SequencePointProfileEvents;
+                if (events.Count == 0)
+                {
+                    return;
+                }
+
+                var metaData = profiler.CompiledScriptBlockMetaData;
+
+                // We have only start timestamp for sequence point.
+                // To evaluate a duration of the sequence point
+                // we take a start timestamp from next sequence point
+                // that is actually a stop timestamp for the previous sequence point.
+                // For last sequence point we have not next timestamp
+                // so we add a copy of the last sequence point as a workaround.
+                events.Add(events[events.Count - 1]);
+
+                for (var i = 0; i < events.Count - 1; i++)
+                {
+                    var profileDate = events[i];
+                    if (metaData.TryGetValue(profileDate.ScriptId, out var compiledScriptBlockData))
+                    {
+                        var extent = compiledScriptBlockData.SequencePoints[profileDate.SequencePointPosition];
+
+                        PSObject result = new PSObject();
+                        result.Properties.Add(new PSNoteProperty("TimeStamp", profileDate.Timestamp.TimeOfDay));
+                        result.Properties.Add(new PSNoteProperty("Duration", events[i + 1].Timestamp - profileDate.Timestamp));
+                        result.Properties.Add(new PSNoteProperty("ExtentText", extent.Text));
+                        result.Properties.Add(new PSNoteProperty("Extent", extent));
+
+                        WriteObject(result);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/System.Management.Automation/engine/runtime/Profiler.cs
+++ b/src/System.Management.Automation/engine/runtime/Profiler.cs
@@ -68,6 +68,18 @@ namespace System.Management.Automation
         internal static ProfilerRundownEventSource LogInstance = new ProfilerRundownEventSource();
 
         [Event(2)]
+        public void ScriptBlockRundown(
+            Guid ScriptBlockId,
+            string ScriptBlockText)
+        {
+            // It is not performance critical so we use the standard method overload.
+            WriteEvent(
+                eventId: 2,
+                ScriptBlockId,
+                ScriptBlockText);
+        }
+
+        [Event(3)]
         public void SequencePointRundown(
             Guid ScriptBlockId,
             int SequencePointCount,
@@ -83,7 +95,7 @@ namespace System.Management.Automation
         {
             // It is not performance critical so we use the standard method overload.
             WriteEvent(
-                eventId: 2,
+                eventId: 3,
                 ScriptBlockId,
                 SequencePointCount,
                 SequencePoint,
@@ -102,6 +114,8 @@ namespace System.Management.Automation
         {
             foreach (var csb in CompiledScriptBlockData.GetCompiledScriptBlockData().Values)
             {
+                ScriptBlockRundown(csb.Id, csb.Ast.Body.Extent.Text);
+
                 for (var position = 0; position < csb.SequencePoints.Length; position++)
                 {
                     var sequencePoint = csb.SequencePoints[position];
@@ -255,6 +269,7 @@ namespace System.Management.Automation
             switch (eventData.EventId)
             {
                 case 1:
+                    // Performance event
                     SequencePointProfileEvents.Add(new SequencePointProfileEventData
                     {
                         Timestamp = eventData.TimeStamp,
@@ -263,6 +278,10 @@ namespace System.Management.Automation
                     });
                     break;
                 case 2:
+                    // Scriptblock rundown event
+                    break;
+                case 3:
+                    // SequencePoint rundown event
                     ScriptExtentEventData sequencePoint;
                     var scriptId = (Guid)payload[0]!;
                     var sequencePointCount = (int)payload[1]!;

--- a/src/System.Management.Automation/engine/runtime/Profiler.cs
+++ b/src/System.Management.Automation/engine/runtime/Profiler.cs
@@ -33,22 +33,22 @@ namespace System.Management.Automation
                     eventPayload[0] = new EventData
                     {
                         Size = sizeof(Guid),
-                        DataPointer = ((IntPtr)(&scriptBlockId))
+                        DataPointer = (IntPtr)(&scriptBlockId)
                     };
                     eventPayload[1] = new EventData
                     {
                         Size = sizeof(Guid),
-                        DataPointer = ((IntPtr)(&runspaceInstanceId))
+                        DataPointer = (IntPtr)(&runspaceInstanceId)
                     };
                     eventPayload[2] = new EventData
                     {
                         Size = sizeof(Guid),
-                        DataPointer = ((IntPtr)(&parentScriptBlockId))
+                        DataPointer = (IntPtr)(&parentScriptBlockId)
                     };
                     eventPayload[3] = new EventData
                     {
                         Size = sizeof(int),
-                        DataPointer = ((IntPtr)(&sequencePointPosition))
+                        DataPointer = (IntPtr)(&sequencePointPosition)
                     };
 
                     WriteEventCore(eventId: 1, eventDataCount: 4, eventPayload);
@@ -91,32 +91,32 @@ namespace System.Management.Automation
 
         [Event(3)]
         public void SequencePointRundown(
-            Guid ScriptBlockId,
-            int SequencePointCount,
-            int SequencePoint,
-            string? File,
-            int StartLineNumber,
-            int StartColumnNumber,
-            int EndLineNumber,
-            int EndColumnNumber,
-            string Text,
-            int StartOffset,
-            int EndOffset)
+            Guid scriptBlockId,
+            int sequencePointCount,
+            int sequencePoint,
+            string? file,
+            int startLineNumber,
+            int startColumnNumber,
+            int endLineNumber,
+            int endColumnNumber,
+            string text,
+            int startOffset,
+            int endOffset)
         {
             // It is not performance critical so we use the standard method overload.
             WriteEvent(
                 eventId: 3,
-                ScriptBlockId,
-                SequencePointCount,
-                SequencePoint,
-                File,
-                StartLineNumber,
-                StartColumnNumber,
-                EndLineNumber,
-                EndColumnNumber,
-                Text,
-                StartOffset,
-                EndOffset);
+                scriptBlockId,
+                sequencePointCount,
+                sequencePoint,
+                file,
+                startLineNumber,
+                startColumnNumber,
+                endLineNumber,
+                endColumnNumber,
+                text,
+                startOffset,
+                endOffset);
         }
 
         [NonEvent]
@@ -345,6 +345,7 @@ namespace System.Management.Automation
 
                         CompiledScriptBlockMetaData.TryAdd(sbe.ScriptId, sbe);
                     }
+
                     break;
             }
         }
@@ -376,7 +377,7 @@ namespace System.Management.Automation
     public class MeasureScriptCommand : PSCmdlet
     {
         /// <summary>
-        /// A script block to profile.
+        /// Gets or sets a script block to profile.
         /// </summary>
         [Parameter(Position = 0, Mandatory = true)]
         public ScriptBlock ScriptBlock { get; set; } = null!;
@@ -423,7 +424,7 @@ namespace System.Management.Automation
                 //
                 // 3. Last event of every runspace we output as-is
                 // without evaluating a duration because we have not a stop event.
-                //
+                // ---------------------------------------------------------------
                 Dictionary<Guid, InternalProfiler.SequencePointProfileEventData> runspaceCurrentEvent = new();
 
                 for (var i = 0; i < events.Count; i++)

--- a/src/System.Management.Automation/engine/runtime/Profiler.cs
+++ b/src/System.Management.Automation/engine/runtime/Profiler.cs
@@ -112,25 +112,17 @@ namespace System.Management.Automation
         [NonEvent]
         internal void WriteRundownEvents()
         {
-            foreach (var pair in CompiledScriptBlockData.GetCompiledScriptBlockTable())
+            foreach (var csb in CompiledScriptBlockData.GetCompiledScriptBlockData().Values)
             {
-                var compiledScriptBlock = pair.Key;
-                ScriptBlockRundown(compiledScriptBlock.Id, compiledScriptBlock.Ast.Body.Extent.Text);
+                ScriptBlockRundown(csb.Id, csb.Ast.Body.Extent.Text);
 
-                if (compiledScriptBlock.SequencePoints is null)
+                for (var position = 0; position < csb.SequencePoints.Length; position++)
                 {
-                    // Why do we get script blocks without sequence points?
-                    // See a comment in Compiler.cs line 2035.
-                    continue;
-                }
-
-                for (var position = 0; position < compiledScriptBlock.SequencePoints.Length; position++)
-                {
-                    var sequencePoint = compiledScriptBlock.SequencePoints[position];
+                    var sequencePoint = csb.SequencePoints[position];
 
                     SequencePointRundown(
-                        compiledScriptBlock.Id,
-                        compiledScriptBlock.SequencePoints.Length,
+                        csb.Id,
+                        csb.SequencePoints.Length,
                         position,
                         sequencePoint.File,
                         sequencePoint.StartLineNumber,
@@ -142,6 +134,22 @@ namespace System.Management.Automation
                         sequencePoint.EndOffset);
                 }
             }
+        }
+
+        protected override void OnEventCommand(EventCommandEventArgs command)
+        {
+            base.OnEventCommand(command);
+
+            if (command.Command == EventCommand.Enable)
+            {
+                CompiledScriptBlockData.ResetIdToScriptBlock();
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            CompiledScriptBlockData.ResetIdToScriptBlock();
+            base.Dispose(disposing);
         }
     }
 

--- a/src/System.Management.Automation/engine/runtime/Profiler.cs
+++ b/src/System.Management.Automation/engine/runtime/Profiler.cs
@@ -18,7 +18,7 @@ namespace System.Management.Automation
     {
         internal static ProfilerEventSource LogInstance = new ProfilerEventSource();
 
-        [Event(1)]
+        [Event(1, Opcode = EventOpcode.Start, ActivityOptions = EventActivityOptions.Recursive)]
         public void SequencePoint(Guid scriptBlockId, Guid runspaceInstanceId, Guid parentScriptBlockId, int sequencePointPosition)
         {
             // We could use:
@@ -372,6 +372,7 @@ namespace System.Management.Automation
     /// The cmdlet profiles a script block.
     /// </summary>
     [Cmdlet(VerbsDiagnostic.Measure, "Script", HelpUri = "", RemotingCapability = RemotingCapability.None)]
+    [OutputType(typeof(ProfileEventRecord))]
     public class MeasureScriptCommand : PSCmdlet
     {
         /// <summary>

--- a/src/System.Management.Automation/engine/runtime/Profiler.cs
+++ b/src/System.Management.Automation/engine/runtime/Profiler.cs
@@ -435,7 +435,8 @@ namespace System.Management.Automation
                             Source = extent.Text,
                             Extent = extent,
                             RunspaceId = profileData.RunspaceId,
-                            ParentScriptBlockId = profileData.ParentScriptBlockId
+                            ParentScriptBlockId = profileData.ParentScriptBlockId,
+                            ScriptBlockId = profileData.ScriptId
                         };
 
                         WriteObject(result);
@@ -478,6 +479,11 @@ namespace System.Management.Automation
             /// Unique identifer of the parent script block.
             /// </summary>
             public Guid ParentScriptBlockId;
+
+            /// <summary>
+            /// Unique identifer of the script block.
+            /// </summary>
+            public Guid ScriptBlockId;
         }
     }
 }

--- a/src/System.Management.Automation/engine/runtime/Profiler.cs
+++ b/src/System.Management.Automation/engine/runtime/Profiler.cs
@@ -79,14 +79,14 @@ namespace System.Management.Automation
 
         [Event(2)]
         public void ScriptBlockRundown(
-            Guid ScriptBlockId,
-            string ScriptBlockText)
+            Guid scriptBlockId,
+            string scriptBlockText)
         {
             // It is not performance critical so we use the standard method overload.
             WriteEvent(
                 eventId: 2,
-                ScriptBlockId,
-                ScriptBlockText);
+                scriptBlockId,
+                scriptBlockText);
         }
 
         [Event(3)]

--- a/src/System.Management.Automation/engine/runtime/Profiler.cs
+++ b/src/System.Management.Automation/engine/runtime/Profiler.cs
@@ -372,7 +372,7 @@ namespace System.Management.Automation
     /// <summary>
     /// The cmdlet profiles a script block.
     /// </summary>
-    [Cmdlet(VerbsDiagnostic.Measure, "Script", HelpUri = "", RemotingCapability = RemotingCapability.None)]
+    [Cmdlet(VerbsDiagnostic.Measure, "Script", HelpUri = "https://go.microsoft.com/fwlink/?LinkId=", RemotingCapability = RemotingCapability.None)]
     [OutputType(typeof(ProfileEventRecord))]
     public class MeasureScriptCommand : PSCmdlet
     {

--- a/src/System.Management.Automation/engine/runtime/Profiler.cs
+++ b/src/System.Management.Automation/engine/runtime/Profiler.cs
@@ -349,7 +349,7 @@ namespace System.Management.Automation
     /// <summary>
     /// The cmdlet profiles a script block.
     /// </summary>
-    [Cmdlet(VerbsDiagnostic.Measure, "Script", RemotingCapability = RemotingCapability.None)]
+    [Cmdlet(VerbsDiagnostic.Measure, "Script", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=2097029", RemotingCapability = RemotingCapability.None)]
     public class MeasureScriptCommand : PSCmdlet
     {
         /// <summary>

--- a/src/System.Management.Automation/engine/runtime/Profiler.cs
+++ b/src/System.Management.Automation/engine/runtime/Profiler.cs
@@ -349,7 +349,7 @@ namespace System.Management.Automation
     /// <summary>
     /// The cmdlet profiles a script block.
     /// </summary>
-    [Cmdlet(VerbsDiagnostic.Measure, "Script", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=2097029", RemotingCapability = RemotingCapability.None)]
+    [Cmdlet(VerbsDiagnostic.Measure, "Script", HelpUri = "", RemotingCapability = RemotingCapability.None)]
     public class MeasureScriptCommand : PSCmdlet
     {
         /// <summary>

--- a/src/System.Management.Automation/engine/runtime/Profiler.cs
+++ b/src/System.Management.Automation/engine/runtime/Profiler.cs
@@ -94,7 +94,7 @@ namespace System.Management.Automation
             Guid ScriptBlockId,
             int SequencePointCount,
             int SequencePoint,
-            string File,
+            string? File,
             int StartLineNumber,
             int StartColumnNumber,
             int EndLineNumber,

--- a/src/System.Management.Automation/engine/runtime/Profiler.cs
+++ b/src/System.Management.Automation/engine/runtime/Profiler.cs
@@ -112,17 +112,24 @@ namespace System.Management.Automation
         [NonEvent]
         internal void WriteRundownEvents()
         {
-            foreach (var csb in CompiledScriptBlockData.GetCompiledScriptBlockData().Values)
+            foreach (var compiledScriptBlock in CompiledScriptBlockData.GetCompiledScriptBlockList())
             {
-                ScriptBlockRundown(csb.Id, csb.Ast.Body.Extent.Text);
+                ScriptBlockRundown(compiledScriptBlock.Id, compiledScriptBlock.Ast.Body.Extent.Text);
 
-                for (var position = 0; position < csb.SequencePoints.Length; position++)
+                if (compiledScriptBlock.SequencePoints is null)
                 {
-                    var sequencePoint = csb.SequencePoints[position];
+                    // Why do we get script blocks without sequence points?
+                    // See a comment in Compiler.cs line 2035.
+                    continue;
+                }
+
+                for (var position = 0; position < compiledScriptBlock.SequencePoints.Length; position++)
+                {
+                    var sequencePoint = compiledScriptBlock.SequencePoints[position];
 
                     SequencePointRundown(
-                        csb.Id,
-                        csb.SequencePoints.Length,
+                        compiledScriptBlock.Id,
+                        compiledScriptBlock.SequencePoints.Length,
                         position,
                         sequencePoint.File,
                         sequencePoint.StartLineNumber,
@@ -142,13 +149,17 @@ namespace System.Management.Automation
 
             if (command.Command == EventCommand.Enable)
             {
-                CompiledScriptBlockData.ResetIdToScriptBlock();
+                CompiledScriptBlockData.InitCompiledScriptBlockTable();
+            }
+            else if (command.Command == EventCommand.Disable)
+            {
+                CompiledScriptBlockData.ClearCompiledScriptBlockTable();
             }
         }
 
         protected override void Dispose(bool disposing)
         {
-            CompiledScriptBlockData.ResetIdToScriptBlock();
+            CompiledScriptBlockData.ClearCompiledScriptBlockTable();
             base.Dispose(disposing);
         }
     }

--- a/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
+++ b/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
@@ -357,6 +357,7 @@ Describe "Verify approved aliases list" -Tags "CI" {
 "Cmdlet",       "Limit-EventLog",                   "",                                 $($FullCLR                               ),     "",                     "",                     ""
 "Cmdlet",       "Measure-Command",                  "",                                 $($FullCLR -or $CoreWindows -or $CoreUnix),     "",                     "",                     "None"
 "Cmdlet",       "Measure-Object",                   "",                                 $($FullCLR -or $CoreWindows -or $CoreUnix),     "",                     "",                     "None"
+"Cmdlet",       "Measure-Script",                   "",                                 $(             $CoreWindows -or $CoreUnix),     "",                     "",                     "None"
 "Cmdlet",       "Move-Item",                        "",                                 $($FullCLR -or $CoreWindows -or $CoreUnix),     "",                     "",                     "Medium"
 "Cmdlet",       "Move-ItemProperty",                "",                                 $($FullCLR -or $CoreWindows -or $CoreUnix),     "",                     "",                     "Medium"
 "Cmdlet",       "New-Alias",                        "",                                 $($FullCLR -or $CoreWindows -or $CoreUnix),     "",                     "",                     "Low"

--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -17,7 +17,8 @@ $script:cmdletsToSkip = @(
     "Enable-ExperimentalFeature",
     "Disable-ExperimentalFeature",
     "Get-PSSubsystem",
-    "Switch-Process"
+    "Switch-Process",
+    "Measure-Script"
 )
 
 function UpdateHelpFromLocalContentPath {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Simple demo:
```powershell
$sb = { $a = 3; if ($a -eq 3) { Write-Host ">$a" } else { Sleep 5 } Sleep 2 }
Measure-Script -ScriptBlock $sb
```

```powershell
Measure-Script { function f { param($p = @{ a=$(Sleep 2;1)}) $p }; f }
```

## PR Context

Based on Jason's approach https://github.com/lzybkr/PowerShell/commit/d620bb4494b94a85a479ebd62ce935ba8e797ff5

- Perf event (with minimal data) issues for every sequence point while measure runs
    - the event is marked as start and recursive event
- Perf events are implemented in ProfilerEventSource class
- Perf event contains
    - Timestamp
    - script block Id
    - parent script block Id (allow to keep track of the call stack)
    - runspace Id (allow to support jobs, ForEach -Parallel and many runspaces)
- Now perf events are issued for default parameter evaluations (and more). 
- Limitations:
    - no Stop events
    - we do not explicitly see parameter binding operations, pipeline/cmdlet phases (Begin, Process, End)

- Rundown event (with full meta data) issues for every sequence point after measure stops
- Rundown event issues for every script block (not used in Measure-Script now)
- Rundown event issues are implemented in ProfilerRundownEventSource class

- Scriptblock cache was simplifed and now it caches `CompiledScriptBlock`-s
    - previously ScriptBlock object was cached but never used directly - before use we always cloned them and a comment says it is because we should avoid a reference to SessionStateInternal and memory leak.
    - the ScriptBlock cloning was really `new ScriptBlock(CompiledScriptBlock)`
    - so it makes sense to cache ScriptBlock objects, now we cache CompiledScriptBlock-s and create script blocks with `new ScriptBlock(CompiledScriptBlock)` without extra cloning.
    - removed a lock if script block is already compiled

- To collect meta data we use `ConcurrentDictionary` `CompiledScriptBlock.s_cachedScripts` cache
- To initialize the cache at measure start we use CompiledScriptBlock cache and then register every script block at creation time.
- This allow us to have meta data for every script block.
- Exception (an edge case) - long running script blocks already removed from CompiledScriptBlock cache.

- Measure-Script cmdlet is implemented for demo use
- ProfileEventRecord is used for typed output
- Duration is broken in common
    - now duration is calculated as substruction two Start event timestamps
    - we haven't Stop events
    - so it is not work for last event

#### For discussion

Since we have only start timestamps we haven't stop timestamp for last sequence point. Perhaps we need a script block stop event and maybe start event.

Here a question is should we think about measuring pipelines, parameter bindings.

Also can we be compatible with PerfView tool?

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
