### PR TITLE
Emit warning if `ConvertTo-Json` exceeds `-Depth` value

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -485,7 +485,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        private static bool _maxDepthWarningWritten = false;
+        private static bool _maxDepthWarningWritten;
 
         /// <summary>
         /// Return an alternate representation of the specified object that serializes the same JSON, except
@@ -564,7 +564,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     if (currentDepth > context.MaxDepth)
                     {
-                        if (!_maxDepthWarningWritten)
+                        if (!_maxDepthWarningWritten && context.Cmdlet != null)
                         {
                             _maxDepthWarningWritten = true;
                             string maxDepthMessage = string.Format(

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -457,6 +457,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 // Pre-process the object so that it serializes the same, except that properties whose
                 // values cannot be evaluated are treated as having the value null.
+                _maxDepthWarningWritten = false;
                 object preprocessedObject = ProcessValue(objectToProcess, currentDepth: 0, in context);
                 var jsonSettings = new JsonSerializerSettings
                 {
@@ -483,6 +484,8 @@ namespace Microsoft.PowerShell.Commands
                 return null;
             }
         }
+
+        private static bool _maxDepthWarningWritten = false;
 
         /// <summary>
         /// Return an alternate representation of the specified object that serializes the same JSON, except
@@ -561,6 +564,16 @@ namespace Microsoft.PowerShell.Commands
                 {
                     if (currentDepth > context.MaxDepth)
                     {
+                        if (!_maxDepthWarningWritten)
+                        {
+                            _maxDepthWarningWritten = true;
+                            string maxDepthMessage = string.Format(
+                                CultureInfo.CurrentCulture,
+                                WebCmdletStrings.JsonMaxDepthReached,
+                                context.MaxDepth);
+                            context.Cmdlet.WriteWarning(maxDepthMessage);
+                        }
+
                         if (pso != null && pso.ImmediateBaseObjectIsEmpty)
                         {
                             // The obj is a pure PSObject, we convert the original PSObject to a string,

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
@@ -261,4 +261,7 @@
   <data name="RetryVerboseMsg" xml:space="preserve">
     <value>Retrying after interval of {0} seconds. Status code for previous attempt: {1}</value>
   </data>
+  <data name="JsonMaxDepthReached" xml:space="preserve">
+    <value>Resulting JSON is truncated as serialization has exceeded the set depth of {0}.</value>
+  </data>
 </root>

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1
@@ -1,5 +1,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
+param()
+
 Describe "SecureString conversion tests" -Tags "CI" {
     BeforeAll {
         $string = "ABCD"

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1
@@ -24,9 +24,8 @@ Describe "SecureString conversion tests" -Tags "CI" {
     }
 
     It "can convert back from a secure string" {
-        $secret = "abcd"
-        $ss1 = ConvertTo-SecureString -AsPlainText -Force $secret
+        $ss1 = ConvertTo-SecureString -AsPlainText -Force $string
         $ss2 = ConvertFrom-SecureString $ss1 | ConvertTo-SecureString
-        $ss2 | ConvertFrom-SecureString -AsPlainText | Should -Be $secret
+        $ss2 | ConvertFrom-SecureString -AsPlainText | Should -Be $string
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
@@ -1463,4 +1463,11 @@ Describe "Json Bug fixes"  -Tags "Feature" {
         $result = "[1,","2,","3]" | ConvertFrom-Json
         $result.Count | Should -Be 3
     }
+
+    It 'ConvertTo-Json will output warning if depth is exceeded.' {
+        $a = @{ a = @{ b = @{ c = @{ d = 1 } } } }
+        $json = $a | ConvertTo-Json -Depth 2 -WarningVariable warningMessage -WarningAction SilentlyContinue
+        $json | Should -Not -BeNullOrEmpty
+        $warningMessage | Should -Not -BeNullOrEmpty
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

When using `ConvertTo-Json`, the default `-Depth` value is 2 to avoid recursion for objects like Services on Windows.  Users who do not set a deep enough depth may be losing data they may not be aware of as they expected full fidelity of the object to be serialized to JSON.  The change agreed by @PowerShell/powershell-committee is to emit a warning message once the depth is exceeded.  The warning is only emitted once per object serialized, but note that arrays are treated as a single object and not unrolled.

The SecureString tests were updated because it seems a credscan change identified a test "secret" in the script and caused CI to fail.  After fixing that, I needed to have scriptanalyzer not fail on using plaintext "secret".

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/8393

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
