### PR TITLE
Fixing Crontab formatting

### DIFF
--- a/demos/crontab/CronTab/CronTab.psm1
+++ b/demos/crontab/CronTab/CronTab.psm1
@@ -149,20 +149,28 @@ function New-CronJob {
   0-23/2 or */2.
 .EXAMPLE
   New-CronJob -Minute 10-30 -Hour 10-20/2 -DayOfMonth */2 -Command "/bin/bash -c 'echo hello' > ~/hello"
+
 .RETURNVALUE
   If successful, an object representing the cron job is returned
+
 .PARAMETER UserName
   Optional parameter to specify a specific user's cron table
+
 .PARAMETER Minute
   Valid values are 0 to 59.  If not specified, defaults to *.
+
 .PARAMETER Hour
   Valid values are 0-23.  If not specified, defaults to *.
+
 .PARAMETER DayOfMonth
   Valid values are 1-31.  If not specified, defaults to *.
+
 .PARAMETER Month
   Valid values are 1-12.  If not specified, defaults to *.
+
 .PARAMETER DayOfWeek
   Valid values are 0-7.  0 and 7 are both Sunday.  If not specified, defaults to *.
+
 .PARAMETER Command
   Command to execute at the scheduled time and day.
 #>
@@ -196,12 +204,16 @@ function Get-CronJob {
 <#
 .SYNOPSIS
   Returns the current cron jobs from the cron table
+
 .DESCRIPTION
   Returns the current cron jobs from the cron table
+
 .EXAMPLE
   Get-CronJob -UserName Steve
+
 .RETURNVALUE
   CronJob objects
+  
 .PARAMETER UserName
   Optional parameter to specify a specific user's cron table
 #>

--- a/demos/crontab/CronTab/CronTab.psm1
+++ b/demos/crontab/CronTab/CronTab.psm1
@@ -77,16 +77,22 @@ function Remove-CronJob {
 <#
 .SYNOPSIS
   Removes the exactly matching cron job from the cron table
+
 .DESCRIPTION
   Removes the exactly matching cron job from the cron table
+
 .EXAMPLE
   Get-CronJob | Where-Object {%_.Command -like 'foo *'} | Remove-CronJob
+
 .RETURNVALUE
   None
+
 .PARAMETER UserName
   Optional parameter to specify a specific user's cron table
+
 .PARAMETER Job
   Cron job object returned from Get-CronJob
+
 .PARAMETER Force
   Don't prompt when removing the cron job
 #>


### PR DESCRIPTION
# PR Summary

During a code review I help formatting issues in a typo in two files Out-File and Out-Printer where Screen was misspelled.

## PR Context

Fixed formatting for readability reasons.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [X] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
