### PR TITLE
Fix blocking wait when starting file associated with a Windows application

### DIFF
--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -221,29 +221,6 @@ namespace System.Management.Automation
             }
         }
 
-        /// <summary>
-        /// Gets true if Path is Console Application.
-        /// </summary>
-        private bool IsConsoleApplication => !IsWindowsApplication;
-
-        /// <summary>
-        /// Gets true if Path is Windows Application.
-        /// </summary>
-        private bool IsWindowsApplication
-        {
-            get
-            {
-                if (!_isWindowsApplication.HasValue)
-                {
-                    _isWindowsApplication = CheckIfWindowsApplication(Path);
-                }
-
-                return _isWindowsApplication.Value;
-            }
-        }
-
-        private bool? _isWindowsApplication;
-
         #endregion ctor/native command properties
 
         #region parameter binder
@@ -423,7 +400,8 @@ namespace System.Management.Automation
 
             _startPosition = new Host.Coordinates();
 
-            CalculateIORedirection(out redirectOutput, out redirectError, out redirectInput);
+            bool isWindowsApplication = IsWindowsApplication(this.Path);
+            CalculateIORedirection(isWindowsApplication, out redirectOutput, out redirectError, out redirectInput);
 
             // Find out if it's the only command in the pipeline.
             bool soloCommand = this.Command.MyInvocation.PipelineLength == 1;
@@ -498,7 +476,8 @@ namespace System.Management.Automation
                         bool notDone = true;
                         if (!string.IsNullOrEmpty(executable))
                         {
-                            if (CheckIfConsoleApplication(executable))
+                            isWindowsApplication = IsWindowsApplication(executable);
+                            if (!isWindowsApplication)
                             {
                                 // Allocate a console if there isn't one attached already...
                                 ConsoleVisibility.AllocateHiddenConsole();
@@ -554,7 +533,7 @@ namespace System.Management.Automation
                     _isRunningInBackground = true;
                     if (startInfo.UseShellExecute == false)
                     {
-                        _isRunningInBackground = IsWindowsApplication;
+                        _isRunningInBackground = isWindowsApplication;
                     }
                 }
 
@@ -953,23 +932,12 @@ namespace System.Management.Automation
         #region checkForConsoleApplication
 
         /// <summary>
-        /// Return true if the passed in process is a console process.
-        /// </summary>
-        /// <param name="fileName"></param>
-        /// <returns></returns>
-        private bool CheckIfConsoleApplication(string fileName)
-        {
-            _isWindowsApplication = CheckIfWindowsApplication(fileName);
-            return !(bool)_isWindowsApplication;
-        }
-
-        /// <summary>
         /// Check if the passed in process is a windows application.
         /// </summary>
         /// <param name="fileName"></param>
         /// <returns></returns>
         [ArchitectureSensitive]
-        private static bool CheckIfWindowsApplication(string fileName)
+        private static bool IsWindowsApplication(string fileName)
         {
 #if UNIX
             return false;
@@ -1228,10 +1196,11 @@ namespace System.Management.Automation
         /// <summary>
         /// This method calculates if input and output of the process are redirected.
         /// </summary>
+        /// <param name="isWindowsApplication"></param>
         /// <param name="redirectOutput"></param>
         /// <param name="redirectError"></param>
         /// <param name="redirectInput"></param>
-        private void CalculateIORedirection(out bool redirectOutput, out bool redirectError, out bool redirectInput)
+        private void CalculateIORedirection(bool isWindowsApplication, out bool redirectOutput, out bool redirectError, out bool redirectInput)
         {
             redirectInput = this.Command.MyInvocation.ExpectingInput;
             redirectOutput = true;
@@ -1302,7 +1271,7 @@ namespace System.Management.Automation
                 redirectOutput = true;
                 redirectError = true;
             }
-            else if (Platform.IsWindowsDesktop && IsConsoleApplication)
+            else if (Platform.IsWindowsDesktop && !isWindowsApplication)
             {
                 // On Windows desktops, if the command to run is a console application,
                 // then allocate a console if there isn't one attached already...

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -957,9 +957,10 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="fileName"></param>
         /// <returns></returns>
-        private static bool CheckIfConsoleApplication(string fileName)
+        private bool CheckIfConsoleApplication(string fileName)
         {
-            return !CheckIfWindowsApplication(fileName);
+            _isWindowsApplication = CheckIfWindowsApplication(fileName);
+            return !(bool)_isWindowsApplication;
         }
 
         /// <summary>

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -144,6 +144,15 @@ Describe "Native Command Processor" -tags "Feature" {
     It '$ErrorActionPreference does not apply to redirected stderr output' -Skip:(!$EnabledExperimentalFeatures.Contains('PSNotApplyErrorActionToStderr')) {
         pwsh -noprofile -command '$ErrorActionPreference = ''Stop''; testexe -stderr stop 2>$null; ''hello''; $error; $?' | Should -BeExactly 'hello','True'
     }
+
+    It 'Can start an elevated associated process correctly' -Skip:(
+        !$IsWindows -or (!(Test-Path (Join-Path -Path $env:windir -ChildPath 'system32' -AdditionalChildPath 'diskmgmt.msc')))
+    ) {
+        # test bug https://github.com/PowerShell/PowerShell/issues/13744 where console is blocked
+        diskmgmt.msc
+        Wait-UntilTrue -sb { (Get-Process mmc).Count -gt 0 } -TimeoutInMilliseconds 5000 -IntervalInMilliseconds 1000 | Should -BeTrue
+        Get-Process mmc | Stop-Process
+    }
 }
 
 Describe "Open a text file with NativeCommandProcessor" -tags @("Feature", "RequireAdminOnWindows") {


### PR DESCRIPTION
# PR Summary

Change https://github.com/PowerShell/PowerShell/pull/13481 modified some logic on how console apps are detected.  The problem in this situation is:

1. user starts `diskmgmt.msc`
2. check if exe, this is not an exe so set `_isWindowsApplication = false`
3. check if associated with an exe
4. finds `mmc.exe`
5. check if exe, this is an exe, so launch this with previous "command" as the argument
6. check `_isWindowsApplication` to determine if we block waiting for exe to finish, since this value was cached and not updated on step 5, it treats as console exe and waits

Fix is to change `CheckIfConsoleApplication()` to be non-static so that the second time it's called it updates `_isWindowsApplication` to point to the new exe and not the previous file.

Tested manually.  Since CI won't have a Windows app associated with a file, can't create a test case.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/13744

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
