### PR TITLE
Rename 'Get-Subsystem' to 'Get-PSSubsystem'

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -738,7 +738,7 @@ namespace System.Management.Automation.Runspaces
                 "System.Management.Automation.Subsystem.SubsystemInfo",
                 TableControl.Create()
                     .AddHeader(Alignment.Left, width: 17, label: "Kind")
-                    .AddHeader(Alignment.Left, width: 15, label: "SubsystemType")
+                    .AddHeader(Alignment.Left, width: 18, label: "SubsystemType")
                     .AddHeader(Alignment.Right, width: 12, label: "IsRegistered")
                     .AddHeader(Alignment.Left, label: "Implementations")
                     .StartRowDefinition()

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -5395,7 +5395,7 @@ end {
 
             if (ExperimentalFeature.IsEnabled("PSSubsystemPluginModel"))
             {
-                cmdlets.Add("Get-Subsystem", new SessionStateCmdletEntry("Get-Subsystem", typeof(Subsystem.GetSubsystemCommand), helpFile));
+                cmdlets.Add("Get-PSSubsystem", new SessionStateCmdletEntry("Get-PSSubsystem", typeof(Subsystem.GetPSSubsystemCommand), helpFile));
             }
 
             foreach (var val in cmdlets.Values)

--- a/src/System.Management.Automation/engine/Subsystem/Commands/GetPSSubsystemCommand.cs
+++ b/src/System.Management.Automation/engine/Subsystem/Commands/GetPSSubsystemCommand.cs
@@ -6,12 +6,12 @@
 namespace System.Management.Automation.Subsystem
 {
     /// <summary>
-    /// Implementation of 'Get-Subsystem' cmdlet.
+    /// Implementation of 'Get-PSSubsystem' cmdlet.
     /// </summary>
     [Experimental("PSSubsystemPluginModel", ExperimentAction.Show)]
-    [Cmdlet(VerbsCommon.Get, "Subsystem", DefaultParameterSetName = AllSet)]
+    [Cmdlet(VerbsCommon.Get, "PSSubsystem", DefaultParameterSetName = AllSet)]
     [OutputType(typeof(SubsystemInfo))]
-    public sealed class GetSubsystemCommand : PSCmdlet
+    public sealed class GetPSSubsystemCommand : PSCmdlet
     {
         private const string AllSet = "GetAllSet";
         private const string TypeSet = "GetByTypeSet";
@@ -37,7 +37,7 @@ namespace System.Management.Automation.Subsystem
             switch (ParameterSetName)
             {
                 case AllSet:
-                    WriteObject(SubsystemManager.GetAllSubsystemInfo());
+                    WriteObject(SubsystemManager.GetAllSubsystemInfo(), enumerateCollection: true);
                     break;
                 case KindSet:
                     WriteObject(SubsystemManager.GetSubsystemInfo(Kind));

--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -16,7 +16,7 @@ $script:cmdletsToSkip = @(
     "Get-ExperimentalFeature",
     "Enable-ExperimentalFeature",
     "Disable-ExperimentalFeature",
-    "Get-Subsystem"
+    "Get-PSSubsystem"
 )
 
 function UpdateHelpFromLocalContentPath {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Rename `Get-Subsystem` to `Get-PSSubsystem` for the `PSSubsystemPluginModel` experimental feature, to reduce the chance of name collision.
Also fix two minor issues:
1. Adjust the width for `SubsystemType` in formatting;
2. Enumerate the collection when writing out `SubsystemInfo`.
    - Without `enumerateCollection: true`, the collection returned from `SubsystemManager.GetAllSubsystemInfo()` will be written out without change, and thus `Get-PSSubsystem | % { $_.GetType() }` will return something like ``...Collection`1``.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
