### PR TITLE
Relax further SSL verification checks for WSMan on non-Windows hosts with verification available

### DIFF
--- a/src/System.Management.Automation/engine/remoting/fanin/WSManNativeAPI.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManNativeAPI.cs
@@ -2443,7 +2443,7 @@ namespace System.Management.Automation.Remoting.Client
         /// <param name="value">
         /// An int (DWORD) data.
         /// </param>
-        /// <returns></returns>
+        /// <returns>zero on success, otherwise the error code</returns>
         [DllImport(WSManNativeApi.WSManClientApiDll, SetLastError = false, CharSet = CharSet.Unicode)]
         internal static extern int WSManGetSessionOptionAsDword(IntPtr wsManSessionHandle,
             WSManSessionOption option,

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManNativeAPI.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManNativeAPI.cs
@@ -2443,7 +2443,7 @@ namespace System.Management.Automation.Remoting.Client
         /// <param name="value">
         /// An int (DWORD) data.
         /// </param>
-        /// <returns>zero on success, otherwise the error code</returns>
+        /// <returns>Zero on success, otherwise the error code.</returns>
         [DllImport(WSManNativeApi.WSManClientApiDll, SetLastError = false, CharSet = CharSet.Unicode)]
         internal static extern int WSManGetSessionOptionAsDword(IntPtr wsManSessionHandle,
             WSManSessionOption option,

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManNativeAPI.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManNativeAPI.cs
@@ -2445,7 +2445,7 @@ namespace System.Management.Automation.Remoting.Client
         /// </param>
         /// <returns></returns>
         [DllImport(WSManNativeApi.WSManClientApiDll, SetLastError = false, CharSet = CharSet.Unicode)]
-        internal static extern void WSManGetSessionOptionAsDword(IntPtr wsManSessionHandle,
+        internal static extern int WSManGetSessionOptionAsDword(IntPtr wsManSessionHandle,
             WSManSessionOption option,
             out int value);
 

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManTransportManager.cs
@@ -1549,9 +1549,8 @@ namespace System.Management.Automation.Remoting.Client
             // The OMI client distributed with PowerShell does not support validating server certificates. Check if
             // psrpclient supports the CA check to determine if a custom build of psrpclient and mi are present which
             // do support verification. If WSManGetSessionOptionAsDword does not return 0 then it's not supported.
-            int sslResult;
             bool verificationAvailable = WSManNativeApi.WSManGetSessionOptionAsDword(_wsManSessionHandle,
-                WSManNativeApi.WSManSessionOption.WSMAN_OPTION_SKIP_CA_CHECK, out sslResult) == 0;
+                WSManNativeApi.WSManSessionOption.WSMAN_OPTION_SKIP_CA_CHECK, out _) == 0;
 
             if (isSSLSpecified && !verificationAvailable && (!connectionInfo.SkipCACheck || !connectionInfo.SkipCNCheck))
             {

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManTransportManager.cs
@@ -1546,9 +1546,9 @@ namespace System.Management.Automation.Remoting.Client
                 throw new PSRemotingTransportException(PSRemotingErrorId.ConnectFailed, RemotingErrorIdStrings.BasicAuthOverHttpNotSupported);
             }
 
-            // The OMI client distributed with PowerShell does not support validating server certificates. Check if
-            // psrpclient supports the CA check to determine if a custom build of psrpclient and mi are present which
-            // do support verification. If WSManGetSessionOptionAsDword does not return 0 then it's not supported.
+            // The OMI client distributed with PowerShell does not support validating server certificates on Unix.
+            // Check if third-party psrpclient and MI support the verification.
+            // If WSManGetSessionOptionAsDword does not return 0 then it's not supported.
             bool verificationAvailable = WSManNativeApi.WSManGetSessionOptionAsDword(_wsManSessionHandle,
                 WSManNativeApi.WSManSessionOption.WSMAN_OPTION_SKIP_CA_CHECK, out _) == 0;
 


### PR DESCRIPTION
# PR Summary

Only require `-SessionOption (New-PSSessionOption -SkipCACheck -SkipCNCheck)` on non-Windows hosts when the client OMI library does not support cert verification.

## PR Context

The version of `psrpclient` and `mi` that are shipped with PowerShell on non-Windows hosts do not support certificate verification. Because of this limitation if you try to connect over a HTTPS WSMan listener with just `-UseSSL` PowerShell will fail with

```
Invoke-Command: HTTPS on Unix does not currently support CA or CN checks. Use the PSSessionOption -SkipCACheck and -SkipCNCheck if you are certain you trust the server you are connecting to and the network in between.
```

This is a perfectly adequate method to ensure end users are aware no cert verification is happening. In the meantime I have a fork of both `psrpclient` and `mi` that are designed to fix some of the bugs and limitations that face WSMan users on non-Windows clients and one of those fixes is to add certificate verification for WSMan. The current fork is set to always do certificate verification regardless of the session options for 2 reasons

* The session options right now are not based down from PowerShell to `psrpclient` to `mi`
    * First reason for this is the hardcoded check but even without that, the build of `psrpclient` that is shipped by PowerShell does nothing when it's told to set those options
* Without a way to get PowerShell to tell `mi` that cert verification is off or on, I decided to use env vars to control the behaviour and have verification on by default
    * If a user wants to disable verification they need to set the proper env vars
    * Unfortunately they still need `SessionOption (New-PSSessionOption -SkipCACheck -SkipCNCheck)` in PowerShell due to the hardcoded check

What I'm proposing is to relax that check to only fail if the underlying `psrpclient` library does not support passing those options along. That way people using the libs shipped by PowerShell continue to work as usual but people who use my forked copy of `psrpclient` and `mi` will be able to omit the options and only add them if they truly want to disable cert verification. This check in PowerShell is simple, it will call [WSManGetSessionOptionAsDword](https://github.com/PowerShell/psl-omi-provider/blob/59ab42f3bc769b1aa31c1181e3a97ea3e1b1c96e/src/Client.c#L589) with the `WSMAN_OPTION_SKIP_CA_CHECK` option. The current build of `psrpclient` shipped by PowerShell will return `MI_RESULT_NOT_SUPPORTED` for options that aren't implemented (this being one of them) whereas my fork will return `MI_RESULT_OK` to state the option was available. By checking that value we can see if the underlying libs support verification and control whether PowerShell displays the error message or not.

The underlying changes required to `psrpclient` and `mi` are currently in this PR https://github.com/jborean93/omi/pull/15. I still need to do some more testing but so far they seem to work as desired.

More background can be found here https://github.com/PowerShell/PowerShell/issues/13577.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
