### PR TITLE
Show optional parameters as such when dislplaying method definition and overloads

### DIFF
--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -3887,6 +3887,33 @@ namespace System.Management.Automation
             return entry.isStatic;
         }
 
+        /// <summary>
+        /// Get the string representation of the default value of passed-in parameter.
+        /// </summary>
+        /// <param name="parameter">Parameter.</param>
+        /// <returns>String representation of the parameter's default value.</returns>
+        private static string GetDefaultValueStringRepresentation(ParameterInfo parameter)
+        {
+            var parameterType = parameter.ParameterType;
+            var parameterValue = parameter.DefaultValue;
+
+            if (parameterValue == null)
+            {
+                return (parameterType.IsValueType || parameterType.IsGenericMethodParameter)
+                    ? "default"
+                    : "null";
+            }
+
+            if (parameterType.IsEnum)
+            {
+                return string.Format(CultureInfo.InvariantCulture, "{0}.{1}", parameterType.ToString(), parameterValue.ToString());
+            }
+
+            return (parameterValue is string)
+                ? string.Format(CultureInfo.InvariantCulture, "\"{0}\"", parameterValue.ToString())
+                : parameterValue.ToString();
+        }
+
         #endregion auxiliary methods and classes
 
         #region virtual
@@ -4480,6 +4507,13 @@ namespace System.Management.Automation
                     builder.Append(ToStringCodeMethods.Type(parameterType));
                     builder.Append(" ");
                     builder.Append(parameter.Name);
+
+                    if (parameter.HasDefaultValue)
+                    {
+                        builder.Append(" = ");
+                        builder.Append(GetDefaultValueStringRepresentation(parameter));
+                    }
+
                     builder.Append(", ");
                 }
 

--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -3890,12 +3890,12 @@ namespace System.Management.Automation
         /// <summary>
         /// Get the string representation of the default value of passed-in parameter.
         /// </summary>
-        /// <param name="parameter">Parameter.</param>
+        /// <param name="parameterInfo">ParameterInfo containing the parameter's default value.</param>
         /// <returns>String representation of the parameter's default value.</returns>
-        private static string GetDefaultValueStringRepresentation(ParameterInfo parameter)
+        private static string GetDefaultValueStringRepresentation(ParameterInfo parameterInfo)
         {
-            var parameterType = parameter.ParameterType;
-            var parameterValue = parameter.DefaultValue;
+            var parameterType = parameterInfo.ParameterType;
+            var parameterValue = parameterInfo.DefaultValue;
 
             if (parameterValue == null)
             {

--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -3895,9 +3895,9 @@ namespace System.Management.Automation
         private static string GetDefaultValueStringRepresentation(ParameterInfo parameterInfo)
         {
             var parameterType = parameterInfo.ParameterType;
-            var parameterValue = parameterInfo.DefaultValue;
+            var parameterDefaultValue = parameterInfo.DefaultValue;
 
-            if (parameterValue == null)
+            if (parameterDefaultValue == null)
             {
                 return (parameterType.IsValueType || parameterType.IsGenericMethodParameter)
                     ? "default"
@@ -3906,12 +3906,12 @@ namespace System.Management.Automation
 
             if (parameterType.IsEnum)
             {
-                return string.Format(CultureInfo.InvariantCulture, "{0}.{1}", parameterType.ToString(), parameterValue.ToString());
+                return string.Format(CultureInfo.InvariantCulture, "{0}.{1}", parameterType.ToString(), parameterDefaultValue.ToString());
             }
 
-            return (parameterValue is string)
-                ? string.Format(CultureInfo.InvariantCulture, "\"{0}\"", parameterValue.ToString())
-                : parameterValue.ToString();
+            return (parameterDefaultValue is string)
+                ? string.Format(CultureInfo.InvariantCulture, "\"{0}\"", parameterDefaultValue.ToString())
+                : parameterDefaultValue.ToString();
         }
 
         #endregion auxiliary methods and classes

--- a/test/powershell/engine/Api/GetMethodInfoOverloadDefinition.Tests.ps1
+++ b/test/powershell/engine/Api/GetMethodInfoOverloadDefinition.Tests.ps1
@@ -131,43 +131,45 @@ public static void TestMethod_OptGeneric<T>(T param = default) { }
     Context "Verify Definition of Parameterized Property" {
         BeforeAll {
             Add-Type -TypeDefinition @"
-public class TestClass1
-{
-    private string[] _indexerArray = new string[1];
-    public string this[int i]
+namespace TestParameterizedPropertyDefinition {
+    public class TestClass1
     {
-        get => _indexerArray[i];
-        set => _indexerArray[i] = value;
+        private string[] _indexerArray = new string[1];
+        public string this[int i]
+        {
+            get => _indexerArray[i];
+            set => _indexerArray[i] = value;
+        }
     }
-}
 
-public class TestClass2
-{
-    public int this[int i] => 42;
-}
+    public class TestClass2
+    {
+        public int this[int i] => 42;
+    }
 
-public class TestClass3
-{
-    [System.Runtime.CompilerServices.IndexerName("TheItem")]
-    public int this[int i] => 42;
+    public class TestClass3
+    {
+        [System.Runtime.CompilerServices.IndexerName("TheItem")]
+        public int this[int i] => 42;
+    }
 }
 "@
         }
 
         It "Get definition of parametrized property" {
-            $obj = [TestClass1]::new()
+            $obj = [TestParameterizedPropertyDefinition.TestClass1]::new()
             $result = $obj | Get-Member -Type ParameterizedProperty
             $result.Definition | Should -BeExactly "string Item(int i) {get;set;}"
         }
 
         It "Get definition of readonly parametrized property" {
-            $obj = [TestClass2]::new()
+            $obj = [TestParameterizedPropertyDefinition.TestClass2]::new()
             $result = $obj | Get-Member -Type ParameterizedProperty
             $result.Definition | Should -BeExactly "int Item(int i) {get;}"
         }
 
         It "Get definition of parametrized property with changed name" {
-            $obj = [TestClass3]::new()
+            $obj = [TestParameterizedPropertyDefinition.TestClass3]::new()
             $result = $obj | Get-Member -Type ParameterizedProperty
             $result.Name | Should -BeExactly "TheItem"
             $result.Definition | Should -BeExactly "int TheItem(int i) {get;}"

--- a/test/powershell/engine/Api/GetMethodInfoOverloadDefinition.Tests.ps1
+++ b/test/powershell/engine/Api/GetMethodInfoOverloadDefinition.Tests.ps1
@@ -1,0 +1,166 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+Describe "Method definition Tests" -tags "CI" {
+
+    Context "Verify Definition of Parameterized Property" {
+        BeforeAll {
+            $classDefinition1 = @"
+namespace ParameterizedPropertyDefinitionTest
+{
+    public class TestClass
+    {
+        private string[] _indexerArray = new string[1];
+        public string this[int i]
+        {
+            get => _indexerArray[i];
+            set => _indexerArray[i] = value;
+        }
+    }
+}
+"@
+            $classDefinition2 = @"
+namespace ReadonlyParameterizedPropertyDefinitionTest
+{
+    public class TestClass
+    {
+        public int this[int i] => 42;
+    }
+}
+"@
+            $classDefinition3 = @"
+namespace ReadonlyParameterizedPropertyWithChangedNameDefinitionTest
+{
+    public class TestClass
+    {
+        [System.Runtime.CompilerServices.IndexerName("TheItem")]
+        public int this[int i] => 42;
+    }
+}
+"@
+            $TestType1 = Add-Type -PassThru -TypeDefinition $classDefinition1
+            $TestType2 = Add-Type -PassThru -TypeDefinition $classDefinition2
+            $TestType3 = Add-Type -PassThru -TypeDefinition $classDefinition3
+        }
+
+        It "Get definition of parametrized property" {
+            $obj = $TestType1::new()
+            $result = $obj | Get-Member -Type ParameterizedProperty
+            $result.Definition | Should -BeExactly "string Item(int i) {get;set;}"
+        }
+
+        It "Get definition of readonly parametrized property" {
+            $obj = $TestType2::new()
+            $result = $obj | Get-Member -Type ParameterizedProperty
+            $result.Definition | Should -BeExactly "int Item(int i) {get;}"
+        }
+
+        It "Get definition of parametrized property with changed name" {
+            $obj = $TestType3::new()
+            $result = $obj | Get-Member -Type ParameterizedProperty
+            $result.Name | Should -BeExactly "TheItem"
+            $result.Definition | Should -BeExactly "int TheItem(int i) {get;}"
+        }
+    }
+
+    Context "Verify overloaded method definitions" {
+        BeforeAll {
+            Add-Type -NameSpace OverloadDefinitionTest -Name TestClass -MemberDefinition @"
+public static void Bar() { }
+public static void Bar(int param) { }
+public static void Bar(int param1, string param2) { }
+public static string Bar(int? param1, string param2) { return param2; }
+"@
+        }
+
+        It "Get methods' overload definitions" {
+            $definitions = ([OverloadDefinitionTest.TestClass]::Bar).OverloadDefinitions
+            $definitions.Count | Should -BeExactly 4
+            $definitions[0] | Should -BeExactly "static void Bar()"
+            $definitions[1] | Should -BeExactly "static void Bar(int param)"
+            $definitions[2] | Should -BeExactly "static void Bar(int param1, string param2)"
+            $definitions[3] | Should -BeExactly "static string Bar(System.Nullable[int] param1, string param2)"
+        }
+    }
+
+    Context "Verify method definitions with different parameter set" {
+        BeforeAll {
+            Add-Type -NameSpace MethodDefinitionTest -Name TestClass -MemberDefinition @"
+public static void TestMethod_General(int param1, string param2) { }
+
+public static void TestMethod_Ref(ref int refParam, out string outParam) { outParam = null; }
+
+public static void TestMethod_Params(params int[] intParams) { }
+
+public static void TestMethod_Generic<T>(T param) { }
+
+public static void TestMethod_OptInt(int optParam = int.MinValue) { }
+
+public static void TestMethod_OptString(string optParam = "default string") { }
+
+public static void TestMethod_OptStruct(DateTime optParam = new DateTime()) { }
+
+public static void TestMethod_OptEnum(UriKind optParam = UriKind.Relative) { }
+
+public static void TestMethod_OptGeneric<T>(T param = default) { }
+"@
+        }
+
+        $testCases = @(
+            @{
+                Description = "general parameters";
+                MethodName = "TestMethod_General";
+                ExpectedDefinition = "static void TestMethod_General(int param1, string param2)"
+            }
+            @{
+                Description = "reference parameters";
+                MethodName = "TestMethod_Ref";
+                ExpectedDefinition = "static void TestMethod_Ref([ref] int refParam, [ref] string outParam)"
+            }
+            @{
+                Description = "parameters array";
+                MethodName = "TestMethod_Params";
+                ExpectedDefinition = "static void TestMethod_Params(Params int[] intParams)"
+            }
+            @{
+                Description = "generic parameter";
+                MethodName = "TestMethod_Generic";
+                ExpectedDefinition = "static void TestMethod_Generic[T](T param)"
+            }
+            @{
+                Description = "optional int parameter";
+                MethodName = "TestMethod_OptInt";
+                ExpectedDefinition = "static void TestMethod_OptInt(int optParam = $([int]::MinValue))"
+            }
+            @{
+                Description = "optional string parameter";
+                MethodName = "TestMethod_OptString";
+                ExpectedDefinition = 'static void TestMethod_OptString(string optParam = "default string")'
+            }
+            @{
+                Description = "optional struct parameter";
+                MethodName = "TestMethod_OptStruct";
+                ExpectedDefinition = 'static void TestMethod_OptStruct(datetime optParam = default)'
+            }
+            @{
+                Description = "optional enum parameter";
+                MethodName = "TestMethod_OptEnum";
+                ExpectedDefinition = "static void TestMethod_OptEnum(System.UriKind optParam = System.UriKind.Relative)"
+            }
+            @{
+                Description = "optional generic parameter";
+                MethodName = "TestMethod_OptGeneric";
+                ExpectedDefinition = "static void TestMethod_OptGeneric[T](T param = default)"
+            }
+        )
+
+        It 'Get definition of the method with <Description>' -TestCases $testCases {
+            param($MethodName, $ExpectedDefinition)
+
+            $definition = ([MethodDefinitionTest.TestClass] | Get-Member -Type Method -Static $MethodName).Definition
+            $definition | Should -BeExactly $ExpectedDefinition
+
+            $overloadDefinition = ([MethodDefinitionTest.TestClass]::$MethodName).OverloadDefinitions
+            $overloadDefinition | Should -BeExactly $definition
+        }
+    }
+}

--- a/test/powershell/engine/Api/GetMethodInfoOverloadDefinition.Tests.ps1
+++ b/test/powershell/engine/Api/GetMethodInfoOverloadDefinition.Tests.ps1
@@ -113,7 +113,7 @@ public static void TestMethod_OptGeneric<T>(T param = default) { }
 
         It "Tooltip should contain methods' overload definitions" {
             $result = (TabExpansion2 -inputScript ($s = '[OverloadDefinitionTest.TestClass]::Bar') -cursorColumn $s.Length).CompletionMatches
-            $tooltipParts = $result.ToolTip -split [System.Environment]::NewLine
+            $tooltipParts = $result.ToolTip -split "\r?\n"
 
             $tooltipParts.Count | Should -Be 4
             $tooltipParts[0] | Should -BeExactly "static void Bar()"

--- a/test/powershell/engine/Api/GetMethodInfoOverloadDefinition.Tests.ps1
+++ b/test/powershell/engine/Api/GetMethodInfoOverloadDefinition.Tests.ps1
@@ -3,6 +3,133 @@
 
 Describe "Method definition Tests" -tags "CI" {
 
+    BeforeAll {
+        Add-Type -NameSpace OverloadDefinitionTest -Name TestClass -MemberDefinition @"
+public static void Bar() { }
+public static void Bar(int param) { }
+public static void Bar(int param1, string param2) { }
+public static string Bar(int? param1, string param2) { return param2; }
+"@
+
+        Add-Type -NameSpace MethodDefinitionTest -Name TestClass -MemberDefinition @"
+public static void TestMethod_Ref(ref int refParam) { }
+
+public static void TestMethod_InOut(in int inParam, out string outParam) { outParam = null; }
+
+public static void TestMethod_Params(params int[] intParams) { }
+
+public static void TestMethod_Generic1<T>(T param) { }
+
+public static void TestMethod_Generic2<T, U>(T param1, U param2) { }
+
+public static void TestMethod_OptInt(int optParam = int.MinValue) { }
+
+public static void TestMethod_OptString(string optParam = "test string") { }
+
+public static void TestMethod_OptStruct(DateTime optParam = new DateTime()) { }
+
+public static void TestMethod_OptEnum(UriKind optParam = UriKind.Relative) { }
+
+public static void TestMethod_OptGeneric<T>(T param = default) { }
+"@
+
+        $testCases = @(
+            @{
+                Description = "parameter passed by reference";
+                MethodName = "TestMethod_Ref";
+                ExpectedDefinition = "static void TestMethod_Ref([ref] int refParam)"
+            }
+            @{
+                Description = "in and out parameters";
+                MethodName = "TestMethod_InOut";
+                ExpectedDefinition = "static void TestMethod_InOut([ref] int inParam, [ref] string outParam)"
+            }
+            @{
+                Description = "parameters array";
+                MethodName = "TestMethod_Params";
+                ExpectedDefinition = "static void TestMethod_Params(Params int[] intParams)"
+            }
+            @{
+                Description = "one generic parameter";
+                MethodName = "TestMethod_Generic1";
+                ExpectedDefinition = "static void TestMethod_Generic1[T](T param)"
+            }
+            @{
+                Description = "two generic parameters";
+                MethodName = "TestMethod_Generic2";
+                ExpectedDefinition = "static void TestMethod_Generic2[T, U](T param1, U param2)"
+            }
+            @{
+                Description = "optional int parameter";
+                MethodName = "TestMethod_OptInt";
+                ExpectedDefinition = "static void TestMethod_OptInt(int optParam = $([int]::MinValue))"
+            }
+            @{
+                Description = "optional string parameter";
+                MethodName = "TestMethod_OptString";
+                ExpectedDefinition = 'static void TestMethod_OptString(string optParam = "test string")'
+            }
+            @{
+                Description = "optional struct parameter";
+                MethodName = "TestMethod_OptStruct";
+                ExpectedDefinition = 'static void TestMethod_OptStruct(datetime optParam = default)'
+            }
+            @{
+                Description = "optional enum parameter";
+                MethodName = "TestMethod_OptEnum";
+                ExpectedDefinition = "static void TestMethod_OptEnum(System.UriKind optParam = System.UriKind.Relative)"
+            }
+            @{
+                Description = "optional generic parameter";
+                MethodName = "TestMethod_OptGeneric";
+                ExpectedDefinition = "static void TestMethod_OptGeneric[T](T param = default)"
+            }
+        )
+    }
+
+    Context "Verify method definitions" {
+
+        It "Get methods' overload definitions" {
+            $definitions = ([OverloadDefinitionTest.TestClass]::Bar).OverloadDefinitions
+            $definitions.Count | Should -Be 4
+            $definitions[0] | Should -BeExactly "static void Bar()"
+            $definitions[1] | Should -BeExactly "static void Bar(int param)"
+            $definitions[2] | Should -BeExactly "static void Bar(int param1, string param2)"
+            $definitions[3] | Should -BeExactly "static string Bar(System.Nullable[int] param1, string param2)"
+        }
+
+        It "Get definition of the method with <Description>" -TestCases $testCases {
+            param($MethodName, $ExpectedDefinition)
+
+            $definition = ([MethodDefinitionTest.TestClass] | Get-Member -Type Method -Static $MethodName).Definition
+            $definition | Should -BeExactly $ExpectedDefinition
+
+            $overloadDefinition = ([MethodDefinitionTest.TestClass]::$MethodName).OverloadDefinitions
+            $overloadDefinition | Should -BeExactly $definition
+        }
+    }
+
+    Context "Verify method definitions' tooltip" {
+
+        It "Tooltip should contain methods' overload definitions" {
+            $result = (TabExpansion2 -inputScript ($s = '[OverloadDefinitionTest.TestClass]::Bar') -cursorColumn $s.Length).CompletionMatches
+            $tooltipParts = $result.ToolTip -split [System.Environment]::NewLine
+
+            $tooltipParts.Count | Should -Be 4
+            $tooltipParts[0] | Should -BeExactly "static void Bar()"
+            $tooltipParts[1] | Should -BeExactly "static void Bar(int param)"
+            $tooltipParts[2] | Should -BeExactly "static void Bar(int param1, string param2)"
+            $tooltipParts[3] | Should -BeExactly "static string Bar(System.Nullable[int] param1, string param2)"
+        }
+
+        It "Tooltip should contain definition of the method with <Description>" -TestCases $testCases {
+            param($MethodName, $ExpectedDefinition)
+
+            $result = (TabExpansion2 -inputScript ($s = "[MethodDefinitionTest.TestClass]::$MethodName") -cursorColumn $s.Length).CompletionMatches
+            $result.ToolTip | Should -BeExactly $ExpectedDefinition
+        }
+    }
+
     Context "Verify Definition of Parameterized Property" {
         BeforeAll {
             $classDefinition1 = @"
@@ -60,111 +187,6 @@ namespace ReadonlyParameterizedPropertyWithChangedNameDefinitionTest
             $result = $obj | Get-Member -Type ParameterizedProperty
             $result.Name | Should -BeExactly "TheItem"
             $result.Definition | Should -BeExactly "int TheItem(int i) {get;}"
-        }
-    }
-
-    Context "Verify method definitions" {
-        BeforeAll {
-            Add-Type -NameSpace OverloadDefinitionTest -Name TestClass -MemberDefinition @"
-public static void Bar() { }
-public static void Bar(int param) { }
-public static void Bar(int param1, string param2) { }
-public static string Bar(int? param1, string param2) { return param2; }
-"@
-
-            Add-Type -NameSpace MethodDefinitionTest -Name TestClass -MemberDefinition @"
-public static void TestMethod_Ref(ref int refParam) { }
-
-public static void TestMethod_InOut(in int inParam, out string outParam) { outParam = null; }
-
-public static void TestMethod_Params(params int[] intParams) { }
-
-public static void TestMethod_Generic1<T>(T param) { }
-
-public static void TestMethod_Generic2<T, U>(T param1, U param2) { }
-
-public static void TestMethod_OptInt(int optParam = int.MinValue) { }
-
-public static void TestMethod_OptString(string optParam = "test string") { }
-
-public static void TestMethod_OptStruct(DateTime optParam = new DateTime()) { }
-
-public static void TestMethod_OptEnum(UriKind optParam = UriKind.Relative) { }
-
-public static void TestMethod_OptGeneric<T>(T param = default) { }
-"@
-
-            $testCases = @(
-                @{
-                    Description = "parameter passed by reference";
-                    MethodName = "TestMethod_Ref";
-                    ExpectedDefinition = "static void TestMethod_Ref([ref] int refParam)"
-                }
-                @{
-                    Description = "in and out parameters";
-                    MethodName = "TestMethod_InOut";
-                    ExpectedDefinition = "static void TestMethod_InOut([ref] int inParam, [ref] string outParam)"
-                }
-                @{
-                    Description = "parameters array";
-                    MethodName = "TestMethod_Params";
-                    ExpectedDefinition = "static void TestMethod_Params(Params int[] intParams)"
-                }
-                @{
-                    Description = "one generic parameter";
-                    MethodName = "TestMethod_Generic1";
-                    ExpectedDefinition = "static void TestMethod_Generic1[T](T param)"
-                }
-                @{
-                    Description = "two generic parameters";
-                    MethodName = "TestMethod_Generic2";
-                    ExpectedDefinition = "static void TestMethod_Generic2[T, U](T param1, U param2)"
-                }
-                @{
-                    Description = "optional int parameter";
-                    MethodName = "TestMethod_OptInt";
-                    ExpectedDefinition = "static void TestMethod_OptInt(int optParam = $([int]::MinValue))"
-                }
-                @{
-                    Description = "optional string parameter";
-                    MethodName = "TestMethod_OptString";
-                    ExpectedDefinition = 'static void TestMethod_OptString(string optParam = "test string")'
-                }
-                @{
-                    Description = "optional struct parameter";
-                    MethodName = "TestMethod_OptStruct";
-                    ExpectedDefinition = 'static void TestMethod_OptStruct(datetime optParam = default)'
-                }
-                @{
-                    Description = "optional enum parameter";
-                    MethodName = "TestMethod_OptEnum";
-                    ExpectedDefinition = "static void TestMethod_OptEnum(System.UriKind optParam = System.UriKind.Relative)"
-                }
-                @{
-                    Description = "optional generic parameter";
-                    MethodName = "TestMethod_OptGeneric";
-                    ExpectedDefinition = "static void TestMethod_OptGeneric[T](T param = default)"
-                }
-            )
-        }
-
-        It "Get methods' overload definitions" {
-            $definitions = ([OverloadDefinitionTest.TestClass]::Bar).OverloadDefinitions
-            $definitions.Count | Should -Be 4
-            $definitions[0] | Should -BeExactly "static void Bar()"
-            $definitions[1] | Should -BeExactly "static void Bar(int param)"
-            $definitions[2] | Should -BeExactly "static void Bar(int param1, string param2)"
-            $definitions[3] | Should -BeExactly "static string Bar(System.Nullable[int] param1, string param2)"
-        }
-
-        It "Get definition of the method with <Description>" -TestCases $testCases {
-            param($MethodName, $ExpectedDefinition)
-
-            $definition = ([MethodDefinitionTest.TestClass] | Get-Member -Type Method -Static $MethodName).Definition
-            $definition | Should -BeExactly $ExpectedDefinition
-
-            $overloadDefinition = ([MethodDefinitionTest.TestClass]::$MethodName).OverloadDefinitions
-            $overloadDefinition | Should -BeExactly $definition
         }
     }
 }


### PR DESCRIPTION
# PR Summary

These changes provide more informative method definition for methods with the optional parameters.

* Primitive value types and strings.
```
static void Bar(int optParam = -1)
static void Bar(string optParam = "default string")
```

* Reference types.
```
static void Bar(string optParam = null)
```

* Enums.
```
static void Bar(System.UriKind optParam = System.UriKind.Relative)
```

* Structs and generic method parameters.
```
static void Bar(datetime optParam = default)
static void GenericBar[T](T optParam = default)
```

## PR Context

Fix #13728

The changes don't cover a case with an `OptionalAttribute`. Calling such a method without optional arguments throws an exception.

``` powershell
Add-Type -NameSpace demo -Name Foo -MemberDefinition @"
public static void Bar([System.Runtime.InteropServices.Optional]int optParam) { }
"@

[demo.Foo]::Bar()
#OperationStopped: Expression of type 'System.Reflection.Missing' cannot be used for parameter of type 'System.Int32' of method 'Void Bar(Int32)' (Parameter 'arg0')
```

I could investigate it if you show me where to start.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
