### PR TITLE
Fix nullable usage on displayDescriptionData_Table.cs

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData_Table.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData_Table.cs
@@ -263,7 +263,7 @@ namespace System.Management.Automation
             this.OutOfBand = viewDefinition.outOfBand;
             this.GroupBy = PSControlGroupBy.Get(viewDefinition.groupBy);
 
-            this.AutoSize = tcb.autosize.HasValue && tcb.autosize.Value;
+            this.AutoSize = tcb.autosize.GetValueOrDefault();
             this.HideTableHeaders = tcb.header.hideHeader;
 
             TableControlRow row = new TableControlRow(tcb.defaultDefinition);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Changed nullable usage for better implementation.
Change in displayDescriptionData_Table.cs

## PR Context

Change has done due to issue #13791 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
 