### PR TITLE
Add position 0 to Write-Error parameters

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Write.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Write.cs
@@ -214,7 +214,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// ErrorRecord.Exception -- if not specified, ErrorRecord.Exception is System.Exception.
         /// </summary>
-        [Parameter(ParameterSetName = "WithException", Mandatory = true)]
+        [Parameter(Position = 0, ParameterSetName = "WithException", Mandatory = true)]
         public Exception Exception { get; set; }
 
         /// <summary>
@@ -232,9 +232,9 @@ namespace Microsoft.PowerShell.Commands
         /// If Exception is specified, this is ErrorRecord.ErrorDetails.Message;
         /// otherwise, the Exception is System.Exception, and this is Exception.Message.
         /// </summary>
-        [Parameter(ParameterSetName = "ErrorRecord", Mandatory = true)]
+        [Parameter(Position = 0, ParameterSetName = "ErrorRecord", Mandatory = true)]
         public ErrorRecord ErrorRecord { get; set; }
-
+        
         /// <summary>
         /// ErrorRecord.CategoryInfo.Category.
         /// </summary>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
@@ -105,4 +105,31 @@ Describe "Write-Error Tests" -Tags "CI" {
         $result.Count | Should -BeExactly 3
         $result[0] | Should -Match $longtext
     }
+
+    It "Should be able to pass ErrorRecord to parameter position 0." {
+        try {
+            [int]::parse('foo')
+        } catch { }
+
+        (Write-Error $Error[0] 2>&1).Exception.GetType().FullName |
+            Should -Be System.Management.Automation.MethodInvocationException
+    }
+
+    It "Should be able to pass Exception to parameter position 0." {
+        try {
+            [int]::parse('foo')
+        } catch { }
+
+        (Write-Error $Error[0].Exception.InnerException 2>&1).Exception.GetType().FullName |
+            Should -Be System.FormatException
+    }
+
+    It "Should be able to pass string to parameter position 0." {
+        try {
+            [int]::parse('foo')
+        } catch { }
+
+        (Write-Error "$($Error[0])" 2>&1).Exception.GetType().FullName |
+            Should -Be Microsoft.PowerShell.Commands.WriteErrorException
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add `Position = 0` to `Write-Error` to `Exception` and `ErrorRecord` parameters.

## PR Context

Resolves #10739

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/6771
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
