### PR TITLE
Fix RCS1098: Constant values should be on right side of comparisons

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/ExtrinsicMethodInvocationJob.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/ExtrinsicMethodInvocationJob.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/ExtrinsicMethodInvocationJob.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/ExtrinsicMethodInvocationJob.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -52,7 +52,7 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
         {
             Dbg.Assert(methodResult != null, "Caller should verify methodResult != null");
             Dbg.Assert(methodParameter != null, "Caller should verify methodParameter != null");
-            Dbg.Assert(0 != (methodParameter.Bindings & (MethodParameterBindings.Out | MethodParameterBindings.Error)), "Caller should verify that this is an out parameter");
+            Dbg.Assert((methodParameter.Bindings & (MethodParameterBindings.Out | MethodParameterBindings.Error)) != 0, "Caller should verify that this is an out parameter");
             Dbg.Assert(cmdletOutput != null, "Caller should verify cmdletOutput != null");
 
             Dbg.Assert(this.MethodSubject != null, "MethodSubject property should be initialized before starting main job processing");

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/MethodInvocationJobBase.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/MethodInvocationJobBase.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/MethodInvocationJobBase.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/MethodInvocationJobBase.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -104,7 +104,7 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
             }
 
             var outParameters = allParameters_plus_returnValue
-                .Where(p => (0 != (p.Bindings & (MethodParameterBindings.Out | MethodParameterBindings.Error))));
+                .Where(p => ((p.Bindings & (MethodParameterBindings.Out | MethodParameterBindings.Error)) != 0));
 
             return outParameters;
         }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
@@ -2536,7 +2536,7 @@ namespace Microsoft.PowerShell.Commands
                     try
                     {
                         resolvedPSPaths = SessionState.Path.GetResolvedPSPathFromPSPath(path, currentContext);
-                        if (true == SuppressWildcardExpansion && 0 == resolvedPSPaths.Count)
+                        if (SuppressWildcardExpansion == true && resolvedPSPaths.Count == 0)
                         {
                             ItemNotFoundException pathNotFound =
                                 new ItemNotFoundException(

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -153,7 +153,7 @@ namespace Microsoft.PowerShell.Commands
                 SafeGetProcessName(x),
                 SafeGetProcessName(y),
                 StringComparison.OrdinalIgnoreCase);
-            if (0 != diff)
+            if (diff != 0)
                 return diff;
             return SafeGetProcessId(x) - SafeGetProcessId(y);
         }
@@ -943,7 +943,7 @@ namespace Microsoft.PowerShell.Commands
         // Handle Exited event and display process information.
         private void myProcess_Exited(object sender, System.EventArgs e)
         {
-            if (0 == System.Threading.Interlocked.Decrement(ref _numberOfProcessesToWaitFor))
+            if (System.Threading.Interlocked.Decrement(ref _numberOfProcessesToWaitFor) == 0)
             {
                 if (_waitHandle != null)
                 {

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TimeZoneCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TimeZoneCommands.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TimeZoneCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TimeZoneCommands.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -188,7 +188,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 // lookup the time zone name and make sure we have one (and only one) match
                 TimeZoneInfo[] timeZones = TimeZoneHelper.LookupSystemTimeZoneInfoByName(Name);
-                if (0 == timeZones.Length)
+                if (timeZones.Length == 0)
                 {
                     string message = string.Format(CultureInfo.InvariantCulture,
                         TimeZoneResources.TimeZoneNameNotFound, Name);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Compare-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Compare-Object.cs
@@ -168,7 +168,7 @@ namespace Microsoft.PowerShell.Commands
             // 2005/07/19 Switched order of referenceEntry and differenceEntry
             //   so that we cast differenceEntry to the type of referenceEntry.
             if (referenceEntry != null && differenceEntry != null &&
-                0 == _comparer.Compare(referenceEntry, differenceEntry))
+                _comparer.Compare(referenceEntry, differenceEntry) == 0)
             {
                 EmitMatch(referenceEntry);
                 return;
@@ -284,7 +284,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 OrderByPropertyEntry listEntry = list[i];
                 Diagnostics.Assert(listEntry != null, "null listEntry " + i);
-                if (0 == _comparer.Compare(match, listEntry))
+                if (_comparer.Compare(match, listEntry) == 0)
                 {
                     list.RemoveAt(i);
                     return listEntry;
@@ -325,7 +325,7 @@ namespace Microsoft.PowerShell.Commands
             else
             {
                 mshobj = new PSObject();
-                if (Property == null || 0 == Property.Length)
+                if (Property == null || Property.Length == 0)
                 {
                     PSNoteProperty inputNote = new PSNoteProperty(
                         InputObjectPropertyName, entry.inputObject);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetUnique.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetUnique.cs
@@ -99,7 +99,7 @@ namespace Microsoft.PowerShell.Commands
                         true); // case-sensitive
                 }
 
-                isUnique = (0 != _comparer.Compare(InputObject, _lastObject));
+                isUnique = (_comparer.Compare(InputObject, _lastObject) != 0);
             }
 
             if (isUnique)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -598,7 +598,7 @@ namespace Microsoft.PowerShell.Commands
                 // supplying a credential overrides the UseDefaultCredentials setting
                 WebSession.UseDefaultCredentials = false;
             }
-            else if ((Credential != null || null != Token) && Authentication != WebAuthenticationType.None)
+            else if ((Credential != null || Token != null) && Authentication != WebAuthenticationType.None)
             {
                 ProcessAuthentication();
             }

--- a/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
+++ b/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
@@ -1703,7 +1703,7 @@ namespace Microsoft.PowerShell.Commands
                         ThrowErrorRemoting(stat);
                     }
 
-                    if (0 != (cngKeyFlag & (uint)Security.NativeMethods.NCryptDeletKeyFlag.NCRYPT_SILENT_FLAG))
+                    if ((cngKeyFlag & (uint)Security.NativeMethods.NCryptDeletKeyFlag.NCRYPT_SILENT_FLAG) != 0)
                     {
                         unsafe
                         {

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator.cs
@@ -307,7 +307,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             // we were unable to find a best match so far..try
             // to get rid of Deserialization prefix and see if a
             // match can be found.
-            if (false == result)
+            if (result == false)
             {
                 Collection<string> typesWithoutPrefix = Deserializer.MaskDeserializationPrefix(typeNames);
                 if (typesWithoutPrefix != null)

--- a/src/System.Management.Automation/engine/CommandProcessor.cs
+++ b/src/System.Management.Automation/engine/CommandProcessor.cs
@@ -528,7 +528,7 @@ namespace System.Management.Automation
                 try
                 {
                     // Process the input pipeline object
-                    if (false == ProcessInputPipelineObject(inputObject))
+                    if (ProcessInputPipelineObject(inputObject) == false)
                     {
                         // The input object was not bound to any parameters of the cmdlet.
                         // Write a non-terminating error and continue with the next input

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -1235,7 +1235,7 @@ namespace Microsoft.PowerShell.Commands
         internal static ErrorRecord GenerateNameParameterError(string paraName, string resourceString, string errorId, object target, params object[] args)
         {
             string message;
-            if (args == null || 0 == args.Length)
+            if (args == null || args.Length == 0)
             {
                 // Don't format in case the string contains literal curly braces
                 message = resourceString;

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -452,7 +452,7 @@ namespace Microsoft.PowerShell.Commands
             }
             catch (RuntimeException pe)
             {
-                if (0 != (manifestProcessingFlags & ManifestProcessingFlags.WriteErrors))
+                if ((manifestProcessingFlags & ManifestProcessingFlags.WriteErrors) != 0)
                 {
                     string message = StringUtil.Format(Modules.InvalidModuleManifest, scriptInfo.Path, pe.Message);
                     MissingMemberException mm = new MissingMemberException(message);
@@ -483,8 +483,8 @@ namespace Microsoft.PowerShell.Commands
         {
             string message;
 
-            var importingModule = 0 != (manifestProcessingFlags & ManifestProcessingFlags.LoadElements);
-            var writingErrors = 0 != (manifestProcessingFlags & ManifestProcessingFlags.WriteErrors);
+            var importingModule = (manifestProcessingFlags & ManifestProcessingFlags.LoadElements) != 0;
+            var writingErrors = (manifestProcessingFlags & ManifestProcessingFlags.WriteErrors) != 0;
 
             // Load the data file(s) to get the module info...
             try
@@ -556,7 +556,7 @@ namespace Microsoft.PowerShell.Commands
             if (validMembers != null && !ValidateManifestHash(data, validMembers, moduleManifestPath, manifestProcessingFlags))
             {
                 containedErrors = true;
-                if (0 != (manifestProcessingFlags & ManifestProcessingFlags.NullOnFirstError))
+                if ((manifestProcessingFlags & ManifestProcessingFlags.NullOnFirstError) != 0)
                     return null;
             }
 
@@ -602,7 +602,7 @@ namespace Microsoft.PowerShell.Commands
                 result = false;
                 string message = null;
 
-                if (0 != (manifestProcessingFlags & ManifestProcessingFlags.WriteErrors))
+                if ((manifestProcessingFlags & ManifestProcessingFlags.WriteErrors) != 0)
                 {
                     // Check for PowerShell Version before checking other keys
                     // If a PowerShellVersion exists and does not match the requirements, then the error is InsufficientPowerShellVersion
@@ -1527,7 +1527,7 @@ namespace Microsoft.PowerShell.Commands
                      !Context.ModuleBeingProcessed.Equals(Context.PreviousModuleProcessed,
                          StringComparison.OrdinalIgnoreCase)))
                 {
-                    if (0 != (manifestProcessingFlags & ManifestProcessingFlags.WriteWarnings))
+                    if ((manifestProcessingFlags & ManifestProcessingFlags.WriteWarnings) != 0)
                     {
                         WriteWarning(Modules.ModuleToProcessFieldDeprecated);
                     }
@@ -1779,7 +1779,7 @@ namespace Microsoft.PowerShell.Commands
                 containedErrors = true;
                 // Ignore errors related to HostVersion as per the ManifestProcessingFlags
                 // doing this at this place because we have to set "containedErrors"
-                if ((0 == (manifestProcessingFlags & ManifestProcessingFlags.IgnoreHostNameAndHostVersion)) &&
+                if (((manifestProcessingFlags & ManifestProcessingFlags.IgnoreHostNameAndHostVersion) == 0) &&
                     bailOnFirstError)
                     return null;
             }
@@ -1791,7 +1791,7 @@ namespace Microsoft.PowerShell.Commands
                     containedErrors = true;
                     // Ignore errors related to HostVersion as per the ManifestProcessingFlags
                     // doing this at this place because we have to set "containedErrors"
-                    if (0 == (manifestProcessingFlags & ManifestProcessingFlags.IgnoreHostNameAndHostVersion))
+                    if ((manifestProcessingFlags & ManifestProcessingFlags.IgnoreHostNameAndHostVersion) == 0)
                     {
                         if (writingErrors)
                         {
@@ -1817,7 +1817,7 @@ namespace Microsoft.PowerShell.Commands
                 containedErrors = true;
                 // Ignore errors related to HostVersion as per the ManifestProcessingFlags
                 // doing this at this place because we have to set "containedErrors"
-                if ((0 == (manifestProcessingFlags & ManifestProcessingFlags.IgnoreHostNameAndHostVersion)) &&
+                if (((manifestProcessingFlags & ManifestProcessingFlags.IgnoreHostNameAndHostVersion) == 0) &&
                     bailOnFirstError)
                     return null;
             }
@@ -1829,7 +1829,7 @@ namespace Microsoft.PowerShell.Commands
                     containedErrors = true;
                     // Ignore errors related to HostVersion as per the ManifestProcessingFlags
                     // doing this at this place because we have to set "containedErrors"
-                    if (0 == (manifestProcessingFlags & ManifestProcessingFlags.IgnoreHostNameAndHostVersion))
+                    if ((manifestProcessingFlags & ManifestProcessingFlags.IgnoreHostNameAndHostVersion) == 0)
                     {
                         if (writingErrors)
                         {
@@ -3030,8 +3030,8 @@ namespace Microsoft.PowerShell.Commands
                         ss: ss,
                         options: options,
                         manifestProcessingFlags: manifestProcessingFlags,
-                        loadTypesFiles: (exportedTypeFiles == null || 0 == exportedTypeFiles.Count),        // If types files already loaded, don't load snapin files
-                        loadFormatFiles: (exportedFormatFiles == null || 0 == exportedFormatFiles.Count),   // if format files already loaded, don't load snapin files
+                        loadTypesFiles: (exportedTypeFiles == null || exportedTypeFiles.Count == 0),        // If types files already loaded, don't load snapin files
+                        loadFormatFiles: (exportedFormatFiles == null || exportedFormatFiles.Count == 0),   // if format files already loaded, don't load snapin files
                         privateData: privateData,
                         found: out found,
                         shortModuleName: null,
@@ -3646,7 +3646,7 @@ namespace Microsoft.PowerShell.Commands
             Exception e,
             ManifestProcessingFlags manifestProcessingFlags)
         {
-            if (0 != (manifestProcessingFlags & ManifestProcessingFlags.WriteErrors))
+            if ((manifestProcessingFlags & ManifestProcessingFlags.WriteErrors) != 0)
             {
                 ErrorRecord er = GenerateInvalidModuleMemberErrorRecord(manifestElement, moduleManifestPath, e);
                 cmdlet.WriteError(er);
@@ -3750,7 +3750,7 @@ namespace Microsoft.PowerShell.Commands
             ManifestProcessingFlags manifestProcessingFlags,
             out ErrorRecord error)
         {
-            Dbg.Assert(0 != (manifestProcessingFlags & ManifestProcessingFlags.LoadElements), "LoadRequiredModule / RequiredModules checks should only be done when actually loading a module");
+            Dbg.Assert((manifestProcessingFlags & ManifestProcessingFlags.LoadElements) != 0, "LoadRequiredModule / RequiredModules checks should only be done when actually loading a module");
 
             error = null;
 
@@ -3817,7 +3817,7 @@ namespace Microsoft.PowerShell.Commands
                     string message;
                     if (moduleManifestPath != null)
                     {
-                        if (0 != (manifestProcessingFlags & ManifestProcessingFlags.WriteErrors))
+                        if ((manifestProcessingFlags & ManifestProcessingFlags.WriteErrors) != 0)
                         {
                             switch (loadFailureReason)
                             {
@@ -4521,7 +4521,7 @@ namespace Microsoft.PowerShell.Commands
             catch (PSInvalidCastException e)
             {
                 result = default(T);
-                if (0 != (manifestProcessingFlags & ManifestProcessingFlags.WriteErrors))
+                if ((manifestProcessingFlags & ManifestProcessingFlags.WriteErrors) != 0)
                 {
                     string message = StringUtil.Format(Modules.ModuleManifestInvalidValue, key, e.Message, moduleManifestPath);
                     ArgumentException newAe = new ArgumentException(message);
@@ -5349,7 +5349,7 @@ namespace Microsoft.PowerShell.Commands
             else
                 extensions = ModuleIntrinsics.PSModuleExtensions;
 
-            var importingModule = 0 != (manifestProcessingFlags & ManifestProcessingFlags.LoadElements);
+            var importingModule = (manifestProcessingFlags & ManifestProcessingFlags.LoadElements) != 0;
 
             // "ni.dll" has a higher priority then ".dll" to be loaded.
             for (int i = 0; i < extensions.Length; i++)
@@ -5556,8 +5556,8 @@ namespace Microsoft.PowerShell.Commands
                 return null;
             }
 
-            var importingModule = 0 != (manifestProcessingFlags & ManifestProcessingFlags.LoadElements);
-            var writingErrors = 0 != (manifestProcessingFlags & ManifestProcessingFlags.WriteErrors);
+            var importingModule = (manifestProcessingFlags & ManifestProcessingFlags.LoadElements) != 0;
+            var writingErrors = (manifestProcessingFlags & ManifestProcessingFlags.WriteErrors) != 0;
 
             // In case the file is a Ngen Assembly.
             string ext;
@@ -6558,7 +6558,7 @@ namespace Microsoft.PowerShell.Commands
             bool importSuccessful = false;
             string modulePath = string.Empty;
             Version assemblyVersion = new Version(0, 0, 0, 0);
-            var importingModule = 0 != (manifestProcessingFlags & ManifestProcessingFlags.LoadElements);
+            var importingModule = (manifestProcessingFlags & ManifestProcessingFlags.LoadElements) != 0;
 
             // See if we're loading a straight assembly...
             if (assemblyToLoad != null)

--- a/src/System.Management.Automation/engine/Modules/TestModuleManifestCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/TestModuleManifestCommand.cs
@@ -172,7 +172,7 @@ namespace Microsoft.PowerShell.Commands
                                     && !IsValidGacAssembly(nestedModule.Name))
                                 {
                                     Collection<PSModuleInfo> modules = GetModuleIfAvailable(nestedModule);
-                                    if (0 == modules.Count)
+                                    if (modules.Count == 0)
                                     {
                                         string errorMsg = StringUtil.Format(Modules.InvalidNestedModuleinModuleManifest, nestedModule.Name, filePath);
                                         var errorRecord = new ErrorRecord(new DirectoryNotFoundException(errorMsg), "Modules_InvalidNestedModuleinModuleManifest",

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -353,7 +353,7 @@ namespace System.Management.Automation
             // WriteProgress. The following logic ensures that
             // there is a unique id for each Cmdlet instance.
 
-            if (0 == _sourceId)
+            if (_sourceId == 0)
             {
                 _sourceId = Interlocked.Increment(ref s_lastUsedSourceId);
             }

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -283,12 +283,12 @@ namespace System.Management.Automation
 
         internal bool MatchesOptions(MshMemberMatchOptions options)
         {
-            if (this.IsHidden && (0 == (options & MshMemberMatchOptions.IncludeHidden)))
+            if (this.IsHidden && ((options & MshMemberMatchOptions.IncludeHidden) == 0))
             {
                 return false;
             }
 
-            if (!this.ShouldSerialize && (0 != (options & MshMemberMatchOptions.OnlySerializable)))
+            if (!this.ShouldSerialize && ((options & MshMemberMatchOptions.OnlySerializable) != 0))
             {
                 return false;
             }

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -440,7 +440,7 @@ namespace System.Management.Automation
 
                     // Also, store the Raw UI coordinates so that we can scrape the screen after
                     // if we are transcribing.
-                    if (_isTranscribing && (true == s_supportScreenScrape))
+                    if (_isTranscribing && (s_supportScreenScrape == true))
                     {
                         _startPosition = this.Command.Context.EngineHostInterface.UI.RawUI.CursorPosition;
                         _startPosition.X = 0;
@@ -688,7 +688,7 @@ namespace System.Management.Automation
                     _nativeProcess.WaitForExit();
 
                     // Capture screen output if we are transcribing and running stand alone
-                    if (_isTranscribing && (true == s_supportScreenScrape) && _runStandAlone)
+                    if (_isTranscribing && (s_supportScreenScrape == true) && _runStandAlone)
                     {
                         Host.Coordinates endPosition = this.Command.Context.EngineHostInterface.UI.RawUI.CursorPosition;
                         endPosition.X = this.Command.Context.EngineHostInterface.UI.RawUI.BufferSize.Width - 1;
@@ -1305,7 +1305,7 @@ namespace System.Management.Automation
 
                 // if screen scraping isn't supported, we enable redirection so that the output is still transcribed
                 // as redirected output is always transcribed
-                if (_isTranscribing && (false == s_supportScreenScrape))
+                if (_isTranscribing && (s_supportScreenScrape == false))
                 {
                     redirectOutput = true;
                     redirectError = true;

--- a/src/System.Management.Automation/engine/VariablePath.cs
+++ b/src/System.Management.Automation/engine/VariablePath.cs
@@ -222,48 +222,48 @@ namespace System.Management.Automation
         /// <summary>
         /// Returns true if the path explicitly specifies 'global:'.
         /// </summary>
-        public bool IsGlobal { get { return 0 != (_flags & VariablePathFlags.Global); } }
+        public bool IsGlobal { get { return (_flags & VariablePathFlags.Global) != 0; } }
 
         /// <summary>
         /// Returns true if the path explicitly specifies 'local:'.
         /// </summary>
-        public bool IsLocal { get { return 0 != (_flags & VariablePathFlags.Local); } }
+        public bool IsLocal { get { return (_flags & VariablePathFlags.Local) != 0; } }
 
         /// <summary>
         /// Returns true if the path explicitly specifies 'private:'.
         /// </summary>
-        public bool IsPrivate { get { return 0 != (_flags & VariablePathFlags.Private); } }
+        public bool IsPrivate { get { return (_flags & VariablePathFlags.Private) != 0; } }
 
         /// <summary>
         /// Returns true if the path explicitly specifies 'script:'.
         /// </summary>
-        public bool IsScript { get { return 0 != (_flags & VariablePathFlags.Script); } }
+        public bool IsScript { get { return (_flags & VariablePathFlags.Script) != 0; } }
 
         /// <summary>
         /// Returns true if the path specifies no drive or scope qualifiers.
         /// </summary>
-        public bool IsUnqualified { get { return 0 != (_flags & VariablePathFlags.Unqualified); } }
+        public bool IsUnqualified { get { return (_flags & VariablePathFlags.Unqualified) != 0; } }
 
         /// <summary>
         /// Returns true if the path specifies a variable path with no scope qualifiers.
         /// </summary>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Unscoped")]
-        public bool IsUnscopedVariable { get { return (0 == (_flags & VariablePathFlags.UnscopedVariableMask)); } }
+        public bool IsUnscopedVariable { get { return ((_flags & VariablePathFlags.UnscopedVariableMask) == 0); } }
 
         /// <summary>
         /// Returns true if the path defines a variable.
         /// </summary>
-        public bool IsVariable { get { return 0 != (_flags & VariablePathFlags.Variable); } }
+        public bool IsVariable { get { return (_flags & VariablePathFlags.Variable) != 0; } }
 
         /// <summary>
         /// Returns true if the path defines a function.
         /// </summary>
-        internal bool IsFunction { get { return 0 != (_flags & VariablePathFlags.Function); } }
+        internal bool IsFunction { get { return (_flags & VariablePathFlags.Function) != 0; } }
 
         /// <summary>
         /// Returns true if the path specifies a drive other than the variable drive.
         /// </summary>
-        public bool IsDriveQualified { get { return 0 != (_flags & VariablePathFlags.DriveQualified); } }
+        public bool IsDriveQualified { get { return (_flags & VariablePathFlags.DriveQualified) != 0; } }
 
         /// <summary>
         /// The drive name, or null if the path is for a variable.

--- a/src/System.Management.Automation/engine/hostifaces/PSDataCollection.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSDataCollection.cs
@@ -1956,7 +1956,7 @@ namespace System.Management.Automation
 
                     // we have reached the end if either the collection is closed
                     // or no powershell instance is bound to this collection.
-                    if ((0 == _collToEnumerate.RefCount) || (!_collToEnumerate.IsOpen))
+                    if ((_collToEnumerate.RefCount == 0) || (!_collToEnumerate.IsOpen))
                     {
                         return false;
                     }

--- a/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
@@ -4989,7 +4989,7 @@ namespace System.Management.Automation
 
             lock (_syncObject)
             {
-                if ((_psCommand == null) || (_psCommand.Commands == null) || (0 == _psCommand.Commands.Count))
+                if ((_psCommand == null) || (_psCommand.Commands == null) || (_psCommand.Commands.Count == 0))
                 {
                     throw PSTraceSource.NewInvalidOperationException(PowerShellStrings.NoCommandToInvoke);
                 }

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -1812,7 +1812,7 @@ namespace System.Management.Automation
             try
             {
                 string message;
-                if (args == null || 0 == args.Length)
+                if (args == null || args.Length == 0)
                 {
                     // Don't format in case the string contains literal curly braces
                     message = resourceString;
@@ -1973,7 +1973,7 @@ namespace System.Management.Automation
             if (context.PSDebugTraceLevel > level)
             {
                 string message;
-                if (args == null || 0 == args.Length)
+                if (args == null || args.Length == 0)
                 {
                     // Don't format in case the string contains literal curly braces
                     message = resourceString;

--- a/src/System.Management.Automation/engine/pipeline.cs
+++ b/src/System.Management.Automation/engine/pipeline.cs
@@ -344,9 +344,9 @@ namespace System.Management.Automation.Internal
                     PipelineStrings.CommandProcessorAlreadyUsed);
             }
 
-            if (0 == _commands.Count)
+            if (_commands.Count == 0)
             {
-                if (0 != readFromCommand)
+                if (readFromCommand != 0)
                 {
                     // "First command cannot have input"
                     throw PSTraceSource.NewArgumentException(
@@ -945,7 +945,7 @@ namespace System.Management.Automation.Internal
             if (_executionStarted)
                 return;
 
-            if (_commands == null || 0 == _commands.Count)
+            if (_commands == null || _commands.Count == 0)
             {
                 throw PSTraceSource.NewInvalidOperationException(
                     PipelineStrings.PipelineExecuteRequiresAtLeastOneCommand);

--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -1271,10 +1271,10 @@ namespace System.Management.Automation
 
             public CharacterNormalizer(WildcardOptions options)
             {
-                _caseInsensitive = 0 != (options & WildcardOptions.IgnoreCase);
+                _caseInsensitive = (options & WildcardOptions.IgnoreCase) != 0;
                 if (_caseInsensitive)
                 {
-                    _cultureInfo = 0 != (options & WildcardOptions.CultureInvariant)
+                    _cultureInfo = (options & WildcardOptions.CultureInvariant) != 0
                         ? CultureInfo.InvariantCulture
                         : CultureInfo.CurrentCulture;
                 }

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManNativeAPI.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManNativeAPI.cs
@@ -2480,8 +2480,8 @@ namespace System.Management.Automation.Remoting.Client
 
             // Now get the actual value
             int messageLength;
-            if (0 != WSManGetSessionOptionAsString(wsManAPIHandle,
-                    option, bufferSizeInBytes, msgBufferPtr, out messageLength))
+            if (WSManGetSessionOptionAsString(wsManAPIHandle,
+                    option, bufferSizeInBytes, msgBufferPtr, out messageLength) != 0)
             {
                 return returnval;
             }
@@ -2830,8 +2830,8 @@ namespace System.Management.Automation.Remoting.Client
 
             // Now get the actual value
             int messageLength;
-            if (0 != WSManGetErrorMessage(wsManAPIHandle,
-                    0, langCode, errorCode, bufferSizeInBytes, msgBufferPtr, out messageLength))
+            if (WSManGetErrorMessage(wsManAPIHandle,
+                    0, langCode, errorCode, bufferSizeInBytes, msgBufferPtr, out messageLength) != 0)
             {
                 return returnval;
             }

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManPlugin.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManPlugin.cs
@@ -247,7 +247,7 @@ namespace System.Management.Automation.Remoting
                 "CreateShell: NULL checks being performed",
                 string.Empty);
 
-            if ((0 == startupInfo.inputStreamSet.streamIDsCount) || (0 == startupInfo.outputStreamSet.streamIDsCount))
+            if ((startupInfo.inputStreamSet.streamIDsCount == 0) || (startupInfo.outputStreamSet.streamIDsCount == 0))
             {
                 ReportOperationComplete(
                     requestDetails,
@@ -1211,7 +1211,7 @@ namespace System.Management.Automation.Remoting
                     isProtocolVersionDeclared = true;
                 }
 
-                if (0 == string.Compare(option.name, 0, WSManPluginConstants.PowerShellOptionPrefix, 0, WSManPluginConstants.PowerShellOptionPrefix.Length, StringComparison.Ordinal))
+                if (string.Compare(option.name, 0, WSManPluginConstants.PowerShellOptionPrefix, 0, WSManPluginConstants.PowerShellOptionPrefix.Length, StringComparison.Ordinal) == 0)
                 {
                     if (option.mustComply)
                     {
@@ -1785,7 +1785,7 @@ namespace System.Management.Automation.Remoting
                 WSManPluginConstants.WSManPluginParamsGetRequestedLocale,
                 outputStruct);
             // ref nativeLocaleData);
-            bool retrievingLocaleSucceeded = (0 == hResult);
+            bool retrievingLocaleSucceeded = (hResult == 0);
             WSManNativeApi.WSManData_UnToMan localeData = WSManNativeApi.WSManData_UnToMan.UnMarshal(outputStruct); // nativeLocaleData
 
             // IntPtr nativeDataLocaleData = IntPtr.Zero;

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManPluginShellSession.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManPluginShellSession.cs
@@ -202,7 +202,7 @@ namespace System.Management.Automation.Remoting
             }
 
             if ((streamSet == null) ||
-                (1 != streamSet.streamIDsCount))
+                (streamSet.streamIDsCount != 1))
             {
                 // only "stdout" is the supported output stream.
                 WSManPluginInstance.ReportOperationComplete(
@@ -756,7 +756,7 @@ namespace System.Management.Automation.Remoting
         internal bool ProcessArguments(
             WSManNativeApi.WSManCommandArgSet arguments)
         {
-            if (1 != arguments.argsCount)
+            if (arguments.argsCount != 1)
             {
                 return false;
             }

--- a/src/System.Management.Automation/engine/serialization.cs
+++ b/src/System.Management.Automation/engine/serialization.cs
@@ -2311,7 +2311,7 @@ namespace System.Management.Automation
                 return 1;
             }
 
-            if (0 != (_context.options & SerializationOptions.UseDepthFromTypes))
+            if ((_context.options & SerializationOptions.UseDepthFromTypes) != 0)
             {
                 // get the depth from the PSObject
                 // NOTE: we assume that the depth out of the PSObject is > 0
@@ -2331,7 +2331,7 @@ namespace System.Management.Automation
                 }
             }
 
-            if (0 != (_context.options & SerializationOptions.PreserveSerializationSettingOfOriginal))
+            if ((_context.options & SerializationOptions.PreserveSerializationSettingOfOriginal) != 0)
             {
                 if ((pso.IsDeserialized) && (depth <= 0))
                 {
@@ -4742,7 +4742,7 @@ namespace System.Management.Automation
         {
             Dbg.Assert(!string.IsNullOrEmpty(tag), "Caller should validate the parameter");
             return (_reader.LocalName == tag) &&
-                ((0 != (_context.options & DeserializationOptions.NoNamespace)) ||
+                (((_context.options & DeserializationOptions.NoNamespace) != 0) ||
                  (_reader.NamespaceURI == SerializationStrings.MonadNamespace));
         }
 

--- a/src/System.Management.Automation/help/AliasHelpProvider.cs
+++ b/src/System.Management.Automation/help/AliasHelpProvider.cs
@@ -261,7 +261,7 @@ namespace System.Management.Automation
             if (helpRequest == null)
                 return true;
 
-            if (0 == (helpRequest.HelpCategory & helpInfo.HelpCategory))
+            if ((helpRequest.HelpCategory & helpInfo.HelpCategory) == 0)
             {
                 return false;
             }

--- a/src/System.Management.Automation/help/CabinetNativeApi.cs
+++ b/src/System.Management.Automation/help/CabinetNativeApi.cs
@@ -175,7 +175,7 @@ namespace System.Management.Automation.Internal
 
         internal static CabinetExtractorLoader GetInstance()
         {
-            if (0 == System.Threading.Interlocked.CompareExchange(ref s_created, 1, 0))
+            if (System.Threading.Interlocked.CompareExchange(ref s_created, 1, 0) == 0)
             {
                 s_instance = new CabinetExtractorLoader();
                 s_extractorInstance = new CabinetExtractor();
@@ -466,19 +466,19 @@ namespace System.Management.Automation.Internal
             {
                 return FileMode.OpenOrCreate;
             }
-            else if (0 != (oflag & (int)OpFlags.Append))
+            else if ((oflag & (int)OpFlags.Append) != 0)
             {
                 return FileMode.Append;
             }
-            else if (0 != (oflag & (int)OpFlags.Create))
+            else if ((oflag & (int)OpFlags.Create) != 0)
             {
                 return FileMode.Create;
             }
-            else if (0 != (oflag & (int)OpFlags.RdWr))
+            else if ((oflag & (int)OpFlags.RdWr) != 0)
             {
                 return FileMode.Open;
             }
-            else if (0 != (oflag & (int)OpFlags.Truncate))
+            else if ((oflag & (int)OpFlags.Truncate) != 0)
             {
                 return FileMode.Truncate;
             }
@@ -501,11 +501,11 @@ namespace System.Management.Automation.Internal
             {
                 return FileAccess.ReadWrite;
             }
-            else if (0 != (pmode & (int)PermissionMode.Read))
+            else if ((pmode & (int)PermissionMode.Read) != 0)
             {
                 return FileAccess.Read;
             }
-            else if (0 != (pmode & (int)PermissionMode.Write))
+            else if ((pmode & (int)PermissionMode.Write) != 0)
             {
                 return FileAccess.Write;
             }
@@ -528,11 +528,11 @@ namespace System.Management.Automation.Internal
             {
                 return FileShare.ReadWrite;
             }
-            else if (0 != (pmode & (int)PermissionMode.Read))
+            else if ((pmode & (int)PermissionMode.Read) != 0)
             {
                 return FileShare.Read;
             }
-            else if (0 != (pmode & (int)PermissionMode.Write))
+            else if ((pmode & (int)PermissionMode.Write) != 0)
             {
                 return FileShare.Write;
             }

--- a/src/System.Management.Automation/help/CommandHelpProvider.cs
+++ b/src/System.Management.Automation/help/CommandHelpProvider.cs
@@ -1173,7 +1173,7 @@ namespace System.Management.Automation
             if (helpRequest == null)
                 return true;
 
-            if (0 == (helpRequest.HelpCategory & commandInfo.HelpCategory))
+            if ((helpRequest.HelpCategory & commandInfo.HelpCategory) == 0)
             {
                 return false;
             }

--- a/src/System.Management.Automation/help/HelpCommands.cs
+++ b/src/System.Management.Automation/help/HelpCommands.cs
@@ -302,7 +302,7 @@ namespace Microsoft.PowerShell.Commands
                         return;
                     }
 
-                    if (0 == countOfHelpInfos)
+                    if (countOfHelpInfos == 0)
                     {
                         firstHelpInfoObject = helpInfo;
                     }
@@ -328,7 +328,7 @@ namespace Microsoft.PowerShell.Commands
                     Microsoft.PowerShell.Telemetry.Internal.TelemetryAPI.ReportGetHelpTelemetry(Name, countOfHelpInfos, _timer.ElapsedMilliseconds, _updatedHelp);
 #endif
                 // Write full help as there is only one help info object
-                if (1 == countOfHelpInfos)
+                if (countOfHelpInfos == 1)
                 {
                     WriteObjectsOrShowOnlineHelp(firstHelpInfoObject, true);
                 }

--- a/src/System.Management.Automation/utils/RuntimeException.cs
+++ b/src/System.Management.Automation/utils/RuntimeException.cs
@@ -225,7 +225,7 @@ namespace System.Management.Automation
         {
             if (errorRecord == null)
                 return string.Empty;
-            if (null != errorRecord.ErrorDetails &&
+            if (errorRecord.ErrorDetails != null &&
                 !string.IsNullOrEmpty(errorRecord.ErrorDetails.Message))
             {
                 return errorRecord.ErrorDetails.Message;


### PR DESCRIPTION
# PR Summary

Avoid so-called [Yoda conditions](https://en.wikipedia.org/wiki/Yoda_conditions).

## PR Context

* https://github.com/JosefPihrt/Roslynator/blob/master/docs/analyzers/RCS1098.md
* https://github.com/dotnet/runtime/pull/40652

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [NA] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [NA] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [NA] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [NA] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [NA] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [NA] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
