### PR TITLE
Enable CA10XX rules with suggestion severity

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -28,13 +28,13 @@ dotnet_diagnostic.CA1012.severity = none
 dotnet_diagnostic.CA1014.severity = none
 
 # CA1016: Mark assemblies with assembly version
-dotnet_diagnostic.CA1016.severity = suggestion
+dotnet_diagnostic.CA1016.severity = warning
 
 # CA1017: Mark assemblies with ComVisible
 dotnet_diagnostic.CA1017.severity = none
 
 # CA1018: Mark attributes with AttributeUsageAttribute
-dotnet_diagnostic.CA1018.severity = suggestion
+dotnet_diagnostic.CA1018.severity = warning
 
 # CA1019: Define accessors for attribute arguments
 dotnet_diagnostic.CA1019.severity = none
@@ -73,7 +73,7 @@ dotnet_diagnostic.CA1036.severity = silent
 dotnet_diagnostic.CA1040.severity = none
 
 # CA1041: Provide ObsoleteAttribute message
-dotnet_diagnostic.CA1041.severity = suggestion
+dotnet_diagnostic.CA1041.severity = warning
 
 # CA1043: Use Integral Or String Argument For Indexers
 dotnet_diagnostic.CA1043.severity = none
@@ -88,7 +88,7 @@ dotnet_diagnostic.CA1045.severity = none
 dotnet_diagnostic.CA1046.severity = none
 
 # CA1047: Do not declare protected member in sealed type
-dotnet_diagnostic.CA1047.severity = suggestion
+dotnet_diagnostic.CA1047.severity = warning
 
 # CA1050: Declare types in namespaces
 dotnet_diagnostic.CA1050.severity = suggestion
@@ -115,7 +115,7 @@ dotnet_diagnostic.CA1058.severity = none
 dotnet_diagnostic.CA1060.severity = none
 
 # CA1061: Do not hide base class methods
-dotnet_diagnostic.CA1061.severity = suggestion
+dotnet_diagnostic.CA1061.severity = warning
 
 # CA1062: Validate arguments of public methods
 dotnet_diagnostic.CA1062.severity = none
@@ -142,7 +142,7 @@ dotnet_diagnostic.CA1068.severity = suggestion
 dotnet_diagnostic.CA1069.severity = suggestion
 
 # CA1070: Do not declare event fields as virtual
-dotnet_diagnostic.CA1070.severity = suggestion
+dotnet_diagnostic.CA1070.severity = warning
 
 # CA1200: Avoid using cref tags with a prefix
 dotnet_diagnostic.CA1200.severity = silent


### PR DESCRIPTION
Promote CA10XX rules from suggestion to warning where there are no existing rule violations.

* [CA1016: Mark assemblies with assembly version](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1016)
* [CA1018: Mark attributes with AttributeUsageAttribute](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1018)
* [CA1041: Provide ObsoleteAttribute message](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1041)
* [CA1047: Do not declare protected member in sealed type](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1047)
* [CA1061: Do not hide base class methods](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1061)
* [CA1070: Do not declare event fields as virtual](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1070)
