### PR TITLE
Fix IDE0044: MakeFieldReadonly part 2

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Diagnostics/CounterSample.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/CounterSample.cs
@@ -193,6 +193,6 @@ namespace Microsoft.PowerShell.Commands.GetCounter
 
         private PerformanceCounterSample[] _counterSamples = null;
 
-        private ResourceManager _resourceMgr = null;
+        private readonly ResourceManager _resourceMgr = null;
     }
 }

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/CounterSet.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/CounterSet.cs
@@ -45,7 +45,7 @@ namespace Microsoft.PowerShell.Commands.GetCounter
             }
         }
 
-        private string _counterSetName = string.Empty;
+        private readonly string _counterSetName = string.Empty;
 
         public string MachineName
         {
@@ -55,7 +55,7 @@ namespace Microsoft.PowerShell.Commands.GetCounter
             }
         }
 
-        private string _machineName = ".";
+        private readonly string _machineName = ".";
 
         public PerformanceCounterCategoryType CounterSetType
         {
@@ -65,7 +65,7 @@ namespace Microsoft.PowerShell.Commands.GetCounter
             }
         }
 
-        private PerformanceCounterCategoryType _counterSetType;
+        private readonly PerformanceCounterCategoryType _counterSetType;
 
         public string Description
         {
@@ -75,7 +75,7 @@ namespace Microsoft.PowerShell.Commands.GetCounter
             }
         }
 
-        private string _description = string.Empty;
+        private readonly string _description = string.Empty;
 
         internal Dictionary<string, string[]> CounterInstanceMapping
         {
@@ -85,7 +85,7 @@ namespace Microsoft.PowerShell.Commands.GetCounter
             }
         }
 
-        private Dictionary<string, string[]> _counterInstanceMapping;
+        private readonly Dictionary<string, string[]> _counterInstanceMapping;
 
         public StringCollection Paths
         {

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/GetCounterCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/GetCounterCommand.cs
@@ -93,7 +93,7 @@ namespace Microsoft.PowerShell.Commands
 
         private bool _defaultCounters = true;
 
-        private List<string> _accumulatedCounters = new List<string>();
+        private readonly List<string> _accumulatedCounters = new List<string>();
 
         //
         // SampleInterval parameter.
@@ -180,7 +180,7 @@ namespace Microsoft.PowerShell.Commands
 
         private PdhHelper _pdhHelper = null;
 
-        private EventWaitHandle _cancelEventArrived = new EventWaitHandle(false, EventResetMode.ManualReset);
+        private readonly EventWaitHandle _cancelEventArrived = new EventWaitHandle(false, EventResetMode.ManualReset);
 
         // Culture identifier(s)
         private const string FrenchCultureId = "fr-FR";

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/GetEventCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/GetEventCommand.cs
@@ -396,14 +396,14 @@ namespace Microsoft.PowerShell.Commands
         // Other private members and constants
         //
         private ResourceManager _resourceMgr = null;
-        private Dictionary<string, StringCollection> _providersByLogMap = new Dictionary<string, StringCollection>();
+        private readonly Dictionary<string, StringCollection> _providersByLogMap = new Dictionary<string, StringCollection>();
 
         private StringCollection _logNamesMatchingWildcard = null;
-        private StringCollection _resolvedPaths = new StringCollection();
+        private readonly StringCollection _resolvedPaths = new StringCollection();
 
-        private List<string> _accumulatedLogNames = new List<string>();
-        private List<string> _accumulatedProviderNames = new List<string>();
-        private List<string> _accumulatedFileNames = new List<string>();
+        private readonly List<string> _accumulatedLogNames = new List<string>();
+        private readonly List<string> _accumulatedProviderNames = new List<string>();
+        private readonly List<string> _accumulatedFileNames = new List<string>();
 
         private const uint MAX_EVENT_BATCH = 100;
 

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/NewWinEventCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/NewWinEventCommand.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerShell.Commands
         private const string TemplateTag = "template";
         private const string DataTag = "data";
 
-        private ResourceManager _resourceMgr = Microsoft.PowerShell.Commands.Diagnostics.Common.CommonUtilities.GetResourceManager();
+        private readonly ResourceManager _resourceMgr = Microsoft.PowerShell.Commands.Diagnostics.Common.CommonUtilities.GetResourceManager();
 
         /// <summary>
         /// ProviderName.

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/PdhHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/PdhHelper.cs
@@ -423,7 +423,7 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
         //
         // m_ConsumerPathToHandleAndInstanceMap map is used for reading counter date (live or from files).
         //
-        private Dictionary<string, CounterHandleNInstance> _consumerPathToHandleAndInstanceMap = new Dictionary<string, CounterHandleNInstance>();
+        private readonly Dictionary<string, CounterHandleNInstance> _consumerPathToHandleAndInstanceMap = new Dictionary<string, CounterHandleNInstance>();
 
         /// <summary>
         /// A helper reading in a Unicode string with embedded NULLs and splitting it into a StringCollection.


### PR DESCRIPTION
https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044

_Split from #13880 to ease review._

`src\Microsoft.PowerShell.Commands.Diagnostics\`