### PR TITLE
Fix IDE0044: MakeFieldReadonly part 8

### DIFF
--- a/src/Microsoft.PowerShell.Security/security/CatalogCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CatalogCommands.cs
@@ -60,7 +60,7 @@ namespace Microsoft.PowerShell.Commands
         //
         // name of this command
         //
-        private string commandName;
+        private readonly string commandName;
 
         /// <summary>
         /// Initializes a new instance of the CatalogCommandsBase class,

--- a/src/Microsoft.PowerShell.Security/security/CertificateCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CertificateCommands.cs
@@ -80,7 +80,7 @@ namespace Microsoft.PowerShell.Commands
         //
         // list of files that were not found
         //
-        private List<string> _filesNotFound = new List<string>();
+        private readonly List<string> _filesNotFound = new List<string>();
 
         /// <summary>
         /// Initializes a new instance of the GetPfxCertificateCommand

--- a/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
+++ b/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
@@ -127,12 +127,12 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Punycode version of DNS name.
         /// </summary>
-        private string _punycodeName;
+        private readonly string _punycodeName;
 
         /// <summary>
         /// Unicode version of DNS name.
         /// </summary>
-        private string _unicodeName;
+        private readonly string _unicodeName;
 
         /// <summary>
         /// Ambiguous constructor of a DnsNameRepresentation.
@@ -511,8 +511,8 @@ namespace Microsoft.PowerShell.Commands
         }
 
         private bool _archivedCerts = false;
-        private X509StoreLocation _storeLocation = null;
-        private string _storeName = null;
+        private readonly X509StoreLocation _storeLocation = null;
+        private readonly string _storeName = null;
         private CertificateStoreHandle _storeHandle = null;
         private bool _valid = false;
         private bool _open = false;
@@ -581,7 +581,7 @@ namespace Microsoft.PowerShell.Commands
         /// -- storeLocations
         /// -- pathCache.
         /// </summary>
-        private static object s_staticLock = new object();
+        private static readonly object s_staticLock = new object();
 
         /// <summary>
         /// List of store locations. They do not change once initialized.
@@ -3068,12 +3068,12 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Localized friendly name of EKU.
         /// </summary>
-        private string _friendlyName;
+        private readonly string _friendlyName;
 
         /// <summary>
         /// OID of EKU.
         /// </summary>
-        private string _oid;
+        private readonly string _oid;
 
         /// <summary>
         /// Constructor of an EnhancedKeyUsageRepresentation.
@@ -3302,7 +3302,7 @@ namespace Microsoft.PowerShell.Commands
     /// </summary>
     public sealed class EnhancedKeyUsageProperty
     {
-        private List<EnhancedKeyUsageRepresentation> _ekuList = new List<EnhancedKeyUsageRepresentation>();
+        private readonly List<EnhancedKeyUsageRepresentation> _ekuList = new List<EnhancedKeyUsageRepresentation>();
 
         /// <summary>
         /// Get property of EKUList.
@@ -3345,8 +3345,8 @@ namespace Microsoft.PowerShell.Commands
     /// </summary>
     public sealed class DnsNameProperty
     {
-        private List<DnsNameRepresentation> _dnsList = new List<DnsNameRepresentation>();
-        private System.Globalization.IdnMapping idnMapping = new System.Globalization.IdnMapping();
+        private readonly List<DnsNameRepresentation> _dnsList = new List<DnsNameRepresentation>();
+        private readonly System.Globalization.IdnMapping idnMapping = new System.Globalization.IdnMapping();
 
         private const string dnsNamePrefix = "DNS Name=";
         private const string distinguishedNamePrefix = "CN=";
@@ -3552,7 +3552,7 @@ namespace Microsoft.PowerShell.Commands
         /// Lock that guards access to the following static members
         /// -- storeNames.
         /// </summary>
-        private static object s_staticLock = new object();
+        private static readonly object s_staticLock = new object();
 
         internal static readonly List<string> storeNames = new List<string>();
 

--- a/src/Microsoft.PowerShell.Security/security/CmsCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CmsCommands.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerShell.Commands
             set;
         }
 
-        private PSDataCollection<PSObject> _inputObjects = new PSDataCollection<PSObject>();
+        private readonly PSDataCollection<PSObject> _inputObjects = new PSDataCollection<PSObject>();
 
         /// <summary>
         /// Gets or sets the content of the CMS Message by path.
@@ -206,7 +206,7 @@ namespace Microsoft.PowerShell.Commands
             set;
         }
 
-        private StringBuilder _contentBuffer = new StringBuilder();
+        private readonly StringBuilder _contentBuffer = new StringBuilder();
 
         /// <summary>
         /// Gets or sets the CMS Message by path.
@@ -351,7 +351,7 @@ namespace Microsoft.PowerShell.Commands
             set;
         }
 
-        private StringBuilder _contentBuffer = new StringBuilder();
+        private readonly StringBuilder _contentBuffer = new StringBuilder();
 
         /// <summary>
         /// Gets or sets the Windows Event Log Message with contents to be decrypted.

--- a/src/Microsoft.PowerShell.Security/security/SecureStringCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/SecureStringCommands.cs
@@ -35,7 +35,7 @@ namespace Microsoft.PowerShell.Commands
         //
         // name of this command
         //
-        private string _commandName;
+        private readonly string _commandName;
 
         /// <summary>
         /// Initializes a new instance of the SecureStringCommandBase

--- a/src/Microsoft.PowerShell.Security/security/SignatureCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/SignatureCommands.cs
@@ -124,7 +124,7 @@ namespace Microsoft.PowerShell.Commands
         //
         // name of this command
         //
-        private string _commandName;
+        private readonly string _commandName;
 
         /// <summary>
         /// Initializes a new instance of the SignatureCommandsBase class,


### PR DESCRIPTION
https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044

_Split from #13880 to ease review._

`src\Microsoft.PowerShell.Security\`