### PR TITLE
Enable CA1822: Mark private members as static

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -280,7 +280,8 @@ dotnet_diagnostic.CA1820.severity = none
 dotnet_diagnostic.CA1821.severity = warning
 
 # CA1822: Mark members as static
-dotnet_diagnostic.CA1822.severity = suggestion
+dotnet_diagnostic.CA1822.severity = warning
+dotnet_code_quality.ca1822.api_surface = private
 
 # CA1823: Avoid unused private fields
 dotnet_diagnostic.CA1823.severity = none

--- a/src/Microsoft.PowerShell.MarkdownRender/ListBlockRenderer.cs
+++ b/src/Microsoft.PowerShell.MarkdownRender/ListBlockRenderer.cs
@@ -33,7 +33,7 @@ namespace Microsoft.PowerShell.MarkdownRender
             renderer.WriteLine();
         }
 
-        private void RenderNumberedList(VT100Renderer renderer, ListItemBlock block, int index)
+        private static void RenderNumberedList(VT100Renderer renderer, ListItemBlock block, int index)
         {
             // For a numbered list, we need to make sure the index is incremented.
             foreach (var line in block)

--- a/src/TypeCatalogGen/TypeCatalogGen.cs
+++ b/src/TypeCatalogGen/TypeCatalogGen.cs
@@ -431,7 +431,7 @@ namespace System.Management.Automation
 {{
     internal partial class PowerShellAssemblyLoadContext
     {{
-        private Dictionary<string, string> InitializeTypeCatalog()
+        private static Dictionary<string, string> InitializeTypeCatalog()
         {{
             return new Dictionary<string, string>({0}, StringComparer.OrdinalIgnoreCase) {{";
             const string SourceEnd = @"

--- a/test/tools/WebListener/Controllers/LinkController.cs
+++ b/test/tools/WebListener/Controllers/LinkController.cs
@@ -109,7 +109,7 @@ namespace mvc.Controllers
             return View(new ErrorViewModel { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });
         }
 
-        private string GetLink(string baseUri, int maxLinks, int linkNumber, string whitespace, string type, string rel)
+        private static string GetLink(string baseUri, int maxLinks, int linkNumber, string whitespace, string type, string rel)
         {
             return string.Format(Constants.LinkUriTemplate, baseUri, maxLinks, linkNumber, type, whitespace, rel);
         }

--- a/test/tools/WebListener/Controllers/ResponseController.cs
+++ b/test/tools/WebListener/Controllers/ResponseController.cs
@@ -99,7 +99,7 @@ namespace mvc.Controllers
             return View(new ErrorViewModel { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });
         }
 
-        private List<T> GetSingleOrArray<T>(JToken token)
+        private static List<T> GetSingleOrArray<T>(JToken token)
         {
             if (token.HasValues)
             {

--- a/test/tools/WebListener/Controllers/ResumeController.cs
+++ b/test/tools/WebListener/Controllers/ResumeController.cs
@@ -91,7 +91,7 @@ namespace mvc.Controllers
             return View(new ErrorViewModel { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });
         }
 
-        private RangeItemHeaderValue GetRange(string rangeHeader)
+        private static RangeItemHeaderValue GetRange(string rangeHeader)
         {
             return RangeHeaderValue.Parse(rangeHeader).Ranges.FirstOrDefault();
         }

--- a/test/xUnit/csharp/test_FileSystemProvider.cs
+++ b/test/xUnit/csharp/test_FileSystemProvider.cs
@@ -63,7 +63,7 @@ namespace PSTests.Parallel
             return executionContext;
         }
 
-        private ProviderInfo GetProvider()
+        private static ProviderInfo GetProvider()
         {
             ExecutionContext executionContext = GetExecutionContext();
             SessionStateInternal sessionState = new SessionStateInternal(executionContext);

--- a/test/xUnit/csharp/test_FileSystemProvider.cs
+++ b/test/xUnit/csharp/test_FileSystemProvider.cs
@@ -53,7 +53,7 @@ namespace PSTests.Parallel
             }
         }
 
-        private ExecutionContext GetExecutionContext()
+        private static ExecutionContext GetExecutionContext()
         {
             CultureInfo currentCulture = CultureInfo.CurrentCulture;
             PSHost hostInterface = new DefaultHost(currentCulture, currentCulture);

--- a/test/xUnit/csharp/test_PSConfiguration.cs
+++ b/test/xUnit/csharp/test_PSConfiguration.cs
@@ -366,7 +366,7 @@ namespace PSTests.Sequential
             CreateEmptyFile(currentUserConfigFile);
         }
 
-        private void CreateEmptyFile(string fileName)
+        private static void CreateEmptyFile(string fileName)
         {
             File.Create(fileName).Dispose();
         }

--- a/test/xUnit/csharp/test_PSConfiguration.cs
+++ b/test/xUnit/csharp/test_PSConfiguration.cs
@@ -382,7 +382,7 @@ namespace PSTests.Sequential
             CreateBrokenConfigFile(currentUserConfigFile);
         }
 
-        private void CreateBrokenConfigFile(string fileName)
+        private static void CreateBrokenConfigFile(string fileName)
         {
             File.WriteAllText(fileName, "[abbra");
         }


### PR DESCRIPTION
https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822

Non-breaking change as only enabled for non-public API surface.