### PR TITLE
Fix non append encoding to UTF8 No BOM in Start Transcript

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/StartTranscriptCmdlet.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/StartTranscriptCmdlet.cs
@@ -228,7 +228,7 @@ namespace Microsoft.PowerShell.Commands
                     // If they didn't specify -Append, empty the file
                     if (!_shouldAppend)
                     {
-                        System.IO.File.WriteAllText(effectiveFilePath, string.Empty);
+                        System.IO.File.WriteAllText(effectiveFilePath, string.Empty, Utils.utf8NoBom);
                     }
                 }
 

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -148,7 +148,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         Get-Date | Out-Null
         Stop-Transcript
 
-        GetFileEncoding $transcriptFilePath | Should -Be 'utf-16'
+        GetFileEncoding $transcriptFilePath | Should -BeExactly 'utf-16'
     }
     It "Should default to utf8 with 'Append' parameter and file doesn't exist"{
         $transcriptFilePath = Join-Path $TestDrive ([System.IO.Path]::GetRandomFileName())
@@ -157,7 +157,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         Get-Date | Out-Null
         Stop-Transcript
 
-        GetFileEncoding $transcriptFilePath | Should -Be 'utf-8'
+        GetFileEncoding $transcriptFilePath | Should -BeExactly 'utf-8'
     }
     It "Should create a new utf8 encoded file if no 'Append' parameter is set regardless of existing file's encoding"{
         $transcriptFilePath = Join-Path $TestDrive ([System.IO.Path]::GetRandomFileName())
@@ -167,7 +167,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         Get-Date | Out-Null
         Stop-Transcript
 
-        GetFileEncoding $transcriptFilePath | Should -Be 'utf-8'
+        GetFileEncoding $transcriptFilePath | Should -BeExactly 'utf-8'
     }
     It "Transcription should remain active if other runspace in the host get closed" {
         try {

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -47,13 +47,13 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         }
         ## function ends here
 
-        $defaultEncoding = New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $true
+        $defaultEncoding = [System.Text.UTF8Encoding]::new($true)
         function GetFileEncoding {
             param (
                 [string] $filePath
             )
 
-            $reader = New-Object -TypeName System.IO.StreamReader -ArgumentList $filePath,$defaultEncoding,$true
+            $reader = [System.IO.StreamReader]::new($filePath, $defaultEncoding, $true)
             $reader.Read() | Out-Null
             return $reader.CurrentEncoding.BodyName
         }

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -141,7 +141,6 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         Receive-Job $job | Should -Be $null
     }
     It "Should keep the existing file's encoding if the 'Append' parameter is used"{
-        $transcriptFilePath = Join-Path $TestDrive ([System.IO.Path]::GetRandomFileName())
         "Text" | Out-File -Encoding unicode $transcriptFilePath
 
         Start-Transcript -Append -Path $transcriptFilePath
@@ -151,8 +150,6 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         GetFileEncoding $transcriptFilePath | Should -BeExactly 'utf-16'
     }
     It "Should default to utf8 with 'Append' parameter and file doesn't exist"{
-        $transcriptFilePath = Join-Path $TestDrive ([System.IO.Path]::GetRandomFileName())
-
         Start-Transcript -Append -Path $transcriptFilePath
         Get-Date | Out-Null
         Stop-Transcript
@@ -160,7 +157,6 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         GetFileEncoding $transcriptFilePath | Should -BeExactly 'utf-8'
     }
     It "Should create a new utf8 encoded file if no 'Append' parameter is set regardless of existing file's encoding"{
-        $transcriptFilePath = Join-Path $TestDrive ([System.IO.Path]::GetRandomFileName())
         "Text" | Out-File -Encoding unicode $transcriptFilePath
 
         Start-Transcript -Path $transcriptFilePath


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

When the -Append file has not been set by the user, the file is emptied using WriteAllText.

This method seems to keep the encoding of the file if it existed prior, which as discussed in #13677 shouldn't be the case. Instead, it should simply use the default encoding which should be UTF8 Without BOM.

The fix is to call the override with the encoding set in the part of the code that clears the file content.

## PR Context

Fixes #13677 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
