### PR TITLE
Fix CA2000: Dispose objects before losing scope

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -333,7 +333,7 @@ dotnet_diagnostic.CA1837.severity = warning
 dotnet_diagnostic.CA1838.severity = silent
 
 # CA2000: Dispose objects before losing scope
-dotnet_diagnostic.CA2000.severity = none
+dotnet_diagnostic.CA2000.severity = suggestion
 
 # CA2002: Do not lock on objects with weak identity
 dotnet_diagnostic.CA2002.severity = none

--- a/src/System.Management.Automation/engine/SessionStateVariableAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateVariableAPIs.cs
@@ -296,7 +296,7 @@ namespace System.Management.Automation
 
             context = null;
 
-            DriveScopeItemSearcher searcher =
+            using DriveScopeItemSearcher searcher =
                 new DriveScopeItemSearcher(
                     this,
                     variablePath);
@@ -547,7 +547,7 @@ namespace System.Management.Automation
 
             Dbg.Diagnostics.Assert(variablePath.IsVariable, "Can't get variable w/ non-variable path");
 
-            VariableScopeItemSearcher searcher =
+            using VariableScopeItemSearcher searcher =
                 new VariableScopeItemSearcher(this, variablePath, origin);
 
             PSVariable result = null;
@@ -905,7 +905,7 @@ namespace System.Management.Automation
 
         internal object GetAutomaticVariableValue(AutomaticVariable variable)
         {
-            var scopeEnumerator = new SessionStateScopeEnumerator(CurrentScope);
+            using var scopeEnumerator = new SessionStateScopeEnumerator(CurrentScope);
             object result = AutomationNull.Value;
             foreach (var scope in scopeEnumerator)
             {
@@ -1802,7 +1802,7 @@ namespace System.Management.Automation
         /// </returns>
         internal IDictionary<string, PSVariable> GetVariableTable()
         {
-            SessionStateScopeEnumerator scopeEnumerator =
+            using SessionStateScopeEnumerator scopeEnumerator =
                 new SessionStateScopeEnumerator(_currentScope);
 
             Dictionary<string, PSVariable> result =


### PR DESCRIPTION
Enable [CA2000](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000) as a suggestion and fix a few rule violations:

* `src/System.Management.Automation/engine/SessionStateVariableAPIs.cs`
* `src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs`
* `src/System.Management.Automation/help/UpdatableHelpSystem.cs`

Looking for feedback on whether any further changes like this would be worthwhile.