### PR TITLE
Simplify getting Encoding in `TranscriptionOption.FlushContentToDisk`

### DIFF
--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1406,7 +1406,7 @@ namespace System.Management.Automation
                     return sr.CurrentEncoding;
                 }
             }
-            catch (System.Exception)
+            catch (IOException)
             {
                 return ClrFacade.GetDefaultEncoding();
             }

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1399,66 +1399,17 @@ namespace System.Management.Automation
                 return ClrFacade.GetDefaultEncoding();
             }
 
-            byte[] initialBytes = new byte[100];
-            int bytesRead = 0;
-
             try
             {
-                using (FileStream stream = System.IO.File.OpenRead(path))
+                using (StreamReader sr = new StreamReader(path, true))
                 {
-                    using (BinaryReader reader = new BinaryReader(stream))
-                    {
-                        bytesRead = reader.Read(initialBytes, 0, 100);
-                    }
+                    return sr.CurrentEncoding;
                 }
             }
-            catch (IOException)
+            catch (System.Exception)
             {
                 return ClrFacade.GetDefaultEncoding();
             }
-
-            // Test for four-byte preambles
-            string preamble = null;
-            Encoding foundEncoding = ClrFacade.GetDefaultEncoding();
-
-            if (bytesRead > 3)
-            {
-                preamble = string.Join("-", initialBytes[0], initialBytes[1], initialBytes[2], initialBytes[3]);
-
-                if (encodingMap.TryGetValue(preamble, out foundEncoding))
-                {
-                    return foundEncoding;
-                }
-            }
-
-            // Test for three-byte preambles
-            if (bytesRead > 2)
-            {
-                preamble = string.Join("-", initialBytes[0], initialBytes[1], initialBytes[2]);
-                if (encodingMap.TryGetValue(preamble, out foundEncoding))
-                {
-                    return foundEncoding;
-                }
-            }
-
-            // Test for two-byte preambles
-            if (bytesRead > 1)
-            {
-                preamble = string.Join("-", initialBytes[0], initialBytes[1]);
-                if (encodingMap.TryGetValue(preamble, out foundEncoding))
-                {
-                    return foundEncoding;
-                }
-            }
-
-            // Check for binary
-            string initialBytesAsAscii = System.Text.Encoding.ASCII.GetString(initialBytes, 0, bytesRead);
-            if (initialBytesAsAscii.IndexOfAny(nonPrintableCharacters) >= 0)
-            {
-                return Encoding.Unicode;
-            }
-
-            return utf8NoBom;
         }
 
         // BigEndianUTF32 encoding is possible, but requires creation

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1391,47 +1391,11 @@ namespace System.Management.Automation
             return hresult >= 0;
         }
 
-        // Attempt to determine the existing encoding
-        internal static Encoding GetEncoding(string path)
-        {
-            if (!File.Exists(path))
-            {
-                return ClrFacade.GetDefaultEncoding();
-            }
-
-            try
-            {
-                using (StreamReader sr = new StreamReader(path, true))
-                {
-                    return sr.CurrentEncoding;
-                }
-            }
-            catch (IOException)
-            {
-                return ClrFacade.GetDefaultEncoding();
-            }
-        }
-
         // BigEndianUTF32 encoding is possible, but requires creation
         internal static readonly Encoding BigEndianUTF32Encoding = new UTF32Encoding(bigEndian: true, byteOrderMark: true);
         // [System.Text.Encoding]::GetEncodings() | Where-Object { $_.GetEncoding().GetPreamble() } |
         //     Add-Member ScriptProperty Preamble { $this.GetEncoding().GetPreamble() -join "-" } -PassThru |
         //     Format-Table -Auto
-        internal static readonly Dictionary<string, Encoding> encodingMap =
-            new Dictionary<string, Encoding>()
-            {
-                { "255-254", Encoding.Unicode },
-                { "254-255", Encoding.BigEndianUnicode },
-                { "255-254-0-0", Encoding.UTF32 },
-                { "0-0-254-255", BigEndianUTF32Encoding },
-                { "239-187-191", Encoding.UTF8 },
-            };
-
-        internal static readonly char[] nonPrintableCharacters = {
-            (char) 0, (char) 1, (char) 2, (char) 3, (char) 4, (char) 5, (char) 6, (char) 7, (char) 8,
-            (char) 11, (char) 12, (char) 14, (char) 15, (char) 16, (char) 17, (char) 18, (char) 19, (char) 20,
-            (char) 21, (char) 22, (char) 23, (char) 24, (char) 25, (char) 26, (char) 28, (char) 29, (char) 30,
-            (char) 31, (char) 127, (char) 129, (char) 141, (char) 143, (char) 144, (char) 157 };
 
         internal static readonly UTF8Encoding utf8NoBom =
             new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);

--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -1101,10 +1101,11 @@ namespace System.Management.Automation.Host
                     {
                         try
                         {
-                            Encoding currentEncoding = null;
+                            Encoding currentEncoding = Utils.utf8NoBom;
 
-                            using (StreamReader reader = new StreamReader(this.Path, Utils.utf8NoBom, true))
+                            using (StreamReader reader = new StreamReader(this.Path, Utils.utf8NoBom, detectEncodingFromByteOrderMarks: true))
                             {
+                                _ = reader.Read();
                                 currentEncoding = reader.CurrentEncoding;
                             }
 
@@ -1112,7 +1113,7 @@ namespace System.Management.Automation.Host
                             // later.
                             _contentWriter = new StreamWriter(
                                 new FileStream(this.Path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read),
-                                currentEncoding ?? Utils.utf8NoBom);
+                                currentEncoding);
                             _contentWriter.BaseStream.Seek(0, SeekOrigin.End);
                         }
                         catch (IOException)

--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -1093,13 +1093,11 @@ namespace System.Management.Automation.Host
         /// </summary>
         internal void FlushContentToDisk()
         {
-            Encoding GetPathEncoding()
+            static Encoding GetPathEncoding(string path)
             {
-                using (StreamReader reader = new StreamReader(this.Path, Utils.utf8NoBom, detectEncodingFromByteOrderMarks: true))
-                {
-                    _ = reader.Read();
-                    return reader.CurrentEncoding;
-                }
+                using StreamReader reader = new StreamReader(path, Utils.utf8NoBom, detectEncodingFromByteOrderMarks: true);
+                _ = reader.Read();
+                return reader.CurrentEncoding;
             }
 
             lock (OutputBeingLogged)
@@ -1322,4 +1320,3 @@ namespace System.Management.Automation.Host
         }
     }
 }
-

--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -1099,13 +1099,14 @@ namespace System.Management.Automation.Host
                 {
                     if (_contentWriter == null)
                     {
+                        var encoding = Utils.GetEncoding(this.Path);
                         try
                         {
                             // Try to first open the file with permissions that will allow us to read from it
                             // later.
                             _contentWriter = new StreamWriter(
                                 new FileStream(this.Path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read),
-                                this.Encoding);
+                                encoding);
                             _contentWriter.BaseStream.Seek(0, SeekOrigin.End);
                         }
                         catch (IOException)
@@ -1114,7 +1115,7 @@ namespace System.Management.Automation.Host
                             // file permissions.
                             _contentWriter = new StreamWriter(
                                 new FileStream(this.Path, FileMode.Append, FileAccess.Write, FileShare.Read),
-                                this.Encoding);
+                                encoding);
                         }
 
                         _contentWriter.AutoFlush = true;

--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -1093,6 +1093,15 @@ namespace System.Management.Automation.Host
         /// </summary>
         internal void FlushContentToDisk()
         {
+            Encoding GetPathEncoding()
+            {
+                using (StreamReader reader = new StreamReader(this.Path, Utils.utf8NoBom, detectEncodingFromByteOrderMarks: true))
+                {
+                    _ = reader.Read();
+                    return reader.CurrentEncoding;
+                }
+            }
+
             lock (OutputBeingLogged)
             {
                 if (!_disposed)
@@ -1101,7 +1110,7 @@ namespace System.Management.Automation.Host
                     {
                         try
                         {
-                            var currentEncoding = getPathEncoding();
+                            var currentEncoding = GetPathEncoding();
 
                             // Try to first open the file with permissions that will allow us to read from it
                             // later.
@@ -1129,15 +1138,6 @@ namespace System.Management.Automation.Host
                 }
 
                 OutputBeingLogged.Clear();
-            }
-
-            Encoding getPathEncoding()
-            {
-                using (StreamReader reader = new StreamReader(this.Path, Utils.utf8NoBom, detectEncodingFromByteOrderMarks: true))
-                {
-                    _ = reader.Read();
-                    return reader.CurrentEncoding;
-                }
             }
         }
 

--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -1101,13 +1101,7 @@ namespace System.Management.Automation.Host
                     {
                         try
                         {
-                            Encoding currentEncoding;
-
-                            using (StreamReader reader = new StreamReader(this.Path, Utils.utf8NoBom, detectEncodingFromByteOrderMarks: true))
-                            {
-                                _ = reader.Read();
-                                currentEncoding = reader.CurrentEncoding;
-                            }
+                            var currentEncoding = getPathEncoding();
 
                             // Try to first open the file with permissions that will allow us to read from it
                             // later.
@@ -1135,6 +1129,15 @@ namespace System.Management.Automation.Host
                 }
 
                 OutputBeingLogged.Clear();
+            }
+
+            Encoding getPathEncoding()
+            {
+                using (StreamReader reader = new StreamReader(this.Path, Utils.utf8NoBom, detectEncodingFromByteOrderMarks: true))
+                {
+                    _ = reader.Read();
+                    return reader.CurrentEncoding;
+                }
             }
         }
 

--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -1099,14 +1099,20 @@ namespace System.Management.Automation.Host
                 {
                     if (_contentWriter == null)
                     {
-                        var encoding = Utils.GetEncoding(this.Path);
                         try
                         {
+                            Encoding currentEncoding = null;
+
+                            using (StreamReader reader = new StreamReader(this.Path, Utils.utf8NoBom, true))
+                            {
+                                currentEncoding = reader.CurrentEncoding;
+                            }
+
                             // Try to first open the file with permissions that will allow us to read from it
                             // later.
                             _contentWriter = new StreamWriter(
                                 new FileStream(this.Path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read),
-                                encoding);
+                                currentEncoding ?? Utils.utf8NoBom);
                             _contentWriter.BaseStream.Seek(0, SeekOrigin.End);
                         }
                         catch (IOException)
@@ -1115,7 +1121,7 @@ namespace System.Management.Automation.Host
                             // file permissions.
                             _contentWriter = new StreamWriter(
                                 new FileStream(this.Path, FileMode.Append, FileAccess.Write, FileShare.Read),
-                                encoding);
+                                Utils.utf8NoBom);
                         }
 
                         _contentWriter.AutoFlush = true;

--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -1101,7 +1101,7 @@ namespace System.Management.Automation.Host
                     {
                         try
                         {
-                            Encoding currentEncoding = Utils.utf8NoBom;
+                            Encoding currentEncoding;
 
                             using (StreamReader reader = new StreamReader(this.Path, Utils.utf8NoBom, detectEncodingFromByteOrderMarks: true))
                             {

--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -1068,22 +1068,7 @@ namespace System.Management.Automation.Host
         /// <summary>
         /// The path that this transcript is being logged to.
         /// </summary>
-        internal string Path
-        {
-            get
-            {
-                return _path;
-            }
-
-            set
-            {
-                _path = value;
-                // Get the encoding from the file, or default (UTF8-NoBom)
-                Encoding = Utils.GetEncoding(value);
-            }
-        }
-
-        private string _path;
+        internal string Path { get; set; }
 
         /// <summary>
         /// Any output to log for this transcript.
@@ -1100,12 +1085,6 @@ namespace System.Management.Automation.Host
         /// transcript output.
         /// </summary>
         internal bool IncludeInvocationHeader { get; set; }
-
-        /// <summary>
-        /// The encoding of this transcript, so that appending to it
-        /// can be done correctly.
-        /// </summary>
-        internal Encoding Encoding { get; private set; }
 
         /// <summary>
         /// Logs buffered content to disk. We use this instead of File.AppendAllLines

--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -1108,7 +1108,7 @@ namespace System.Management.Automation.Host
                     {
                         try
                         {
-                            var currentEncoding = GetPathEncoding();
+                            var currentEncoding = GetPathEncoding(this.Path);
 
                             // Try to first open the file with permissions that will allow us to read from it
                             // later.


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Simplify getting encoding of existing file in the `FlushContentToDisk` method of the `TranscriptionOption` class called when the transcription file is flushed to disk.

## PR Context

The `FlushContentToDisk` method was calling a complex `GetEncoding` utils that was trying to read the file encoding "by hand". Through a discussion with @iSazonov in #13677 and #13899 it was decided that this could be simplified by using a StreamReader and taking advantage of the `CurrentEncoding` property.

This allows to reduce code complexity and should also improve compatibility with different encoding. This PR should have no functional impact except improve recognition of encoding of existing files in some cases not covered by the existing code.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
