### PR TITLE
Enable CA1827: Do not use Count() or LongCount() when Any() can be used

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -292,7 +292,7 @@ dotnet_diagnostic.CA1825.severity = suggestion
 dotnet_diagnostic.CA1826.severity = suggestion
 
 # CA1827: Do not use Count() or LongCount() when Any() can be used
-dotnet_diagnostic.CA1827.severity = suggestion
+dotnet_diagnostic.CA1827.severity = warning
 
 # CA1828: Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
 dotnet_diagnostic.CA1828.severity = suggestion

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -3213,7 +3213,7 @@ namespace Microsoft.PowerShell.Commands
                     newManifestInfo.Prefix = resolvedCommandPrefix;
                 }
 
-                if (newManifestInfo.FileList == null || newManifestInfo.FileList.LongCount() == 0)
+                if (newManifestInfo.FileList == null || !newManifestInfo.FileList.Any())
                 {
                     if (fileList != null)
                     {
@@ -3224,7 +3224,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
 
-                if (newManifestInfo.ModuleList == null || newManifestInfo.ModuleList.LongCount() == 0)
+                if (newManifestInfo.ModuleList == null || !newManifestInfo.ModuleList.Any())
                 {
                     if (moduleList != null)
                     {
@@ -3235,7 +3235,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
 
-                if (newManifestInfo.CompatiblePSEditions == null || newManifestInfo.CompatiblePSEditions.LongCount() == 0)
+                if (newManifestInfo.CompatiblePSEditions == null || !newManifestInfo.CompatiblePSEditions.Any())
                 {
                     if (compatiblePSEditions != null)
                     {
@@ -3248,7 +3248,7 @@ namespace Microsoft.PowerShell.Commands
                     newManifestInfo.ProcessorArchitecture = requiredProcessorArchitecture;
                 }
 
-                if (newManifestInfo.RequiredAssemblies == null || newManifestInfo.RequiredAssemblies.LongCount() == 0)
+                if (newManifestInfo.RequiredAssemblies == null || !newManifestInfo.RequiredAssemblies.Any())
                 {
                     if (assemblyList != null)
                     {
@@ -3259,7 +3259,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
 
-                if (newManifestInfo.Scripts == null || newManifestInfo.Scripts.LongCount() == 0)
+                if (newManifestInfo.Scripts == null || !newManifestInfo.Scripts.Any())
                 {
                     if (scriptsToProcess != null)
                     {


### PR DESCRIPTION
https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
