### PR TITLE
Enable CA1830: Prefer strongly-typed Append and Insert method overloads on StringBuilder

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -301,7 +301,7 @@ dotnet_diagnostic.CA1828.severity = suggestion
 dotnet_diagnostic.CA1829.severity = suggestion
 
 # CA1830: Prefer strongly-typed Append and Insert method overloads on StringBuilder
-dotnet_diagnostic.CA1830.severity = suggestion
+dotnet_diagnostic.CA1830.severity = warning
 
 # CA1831: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
 dotnet_diagnostic.CA1831.severity = warning

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
@@ -336,7 +336,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 {
                     // unKnowViewFormatStringBuilder.Append(StringUtil.Format(FormatAndOut_format_xxx.UnknownViewNameError, viewName));
                     unKnowViewFormatStringBuilder.Append(StringUtil.Format(FormatAndOut_format_xxx.UnknownViewNameErrorSuffix, viewName, formatTypeName));
-                    unKnowViewFormatStringBuilder.Append(validViewFormats.ToString());
+                    unKnowViewFormatStringBuilder.Append(validViewFormats);
                 }
                 else
                 {

--- a/src/System.Management.Automation/engine/ManagementObjectAdapter.cs
+++ b/src/System.Management.Automation/engine/ManagementObjectAdapter.cs
@@ -873,7 +873,7 @@ namespace System.Management.Automation
             builder.Append("System.Management.ManagementBaseObject ");
             builder.Append(mData.Name);
             builder.Append('(');
-            builder.Append(inParameterString.ToString());
+            builder.Append(inParameterString);
             builder.Append(')');
 
             string returnValue = builder.ToString();

--- a/src/System.Management.Automation/engine/ProxyCommand.cs
+++ b/src/System.Management.Automation/engine/ProxyCommand.cs
@@ -441,7 +441,7 @@ namespace System.Management.Automation
                     if (exsb.Length > 0)
                     {
                         sb.Append("\n\n.EXAMPLE\n\n");
-                        sb.Append(exsb.ToString());
+                        sb.Append(exsb);
                     }
                 }
             }


### PR DESCRIPTION
https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
