### PR TITLE
Enable CA20XX rules with suggestion severity

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -340,13 +340,13 @@ dotnet_diagnostic.CA2007.severity = none
 dotnet_diagnostic.CA2008.severity = none
 
 # CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
-dotnet_diagnostic.CA2009.severity = suggestion
+dotnet_diagnostic.CA2009.severity = warning
 
 # CA2011: Avoid infinite recursion
-dotnet_diagnostic.CA2011.severity = suggestion
+dotnet_diagnostic.CA2011.severity = warning
 
 # CA2012: Use ValueTasks correctly
-dotnet_diagnostic.CA2012.severity = suggestion
+dotnet_diagnostic.CA2012.severity = warning
 
 # CA2013: Do not use ReferenceEquals with value types
 dotnet_diagnostic.CA2013.severity = warning


### PR DESCRIPTION
Promote CA10XX rules from suggestion to warning where there are no existing rule violations.

* [CA2009](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009): Do not call ToImmutableCollection on an ImmutableCollection value
* [CA2011](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011): Avoid infinite recursion
* [CA2012](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012): Use ValueTasks correctly

