### PR TITLE
Disable IDE0073: FileHeaderMismatch

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -943,7 +943,7 @@ dotnet_diagnostic.IDE0071.severity = silent
 dotnet_diagnostic.IDE0072.severity = silent
 
 # FileHeaderMismatch
-dotnet_diagnostic.IDE0073.severity = warning
+dotnet_diagnostic.IDE0073.severity = silent
 
 # UseCoalesceCompoundAssignment
 dotnet_diagnostic.IDE0074.severity = silent

--- a/.globalconfig
+++ b/.globalconfig
@@ -943,7 +943,7 @@ dotnet_diagnostic.IDE0071.severity = silent
 dotnet_diagnostic.IDE0072.severity = silent
 
 # FileHeaderMismatch
-dotnet_diagnostic.IDE0073.severity = silent
+dotnet_diagnostic.IDE0073.severity = suggestion
 
 # UseCoalesceCompoundAssignment
 dotnet_diagnostic.IDE0074.severity = silent


### PR DESCRIPTION
Various files do not match the `file_header_template` in root EditorConfig:
`Copyright (c) Microsoft Corporation.\nLicensed under the MIT License.`

For example, `src\System.Management.Automation\engine\interpreter\InstructionList.cs` uses Apache License.

This PR sets the rule severity to `suggestion`.