### PR TITLE
Enable IDE0048: AddRequiredParentheses

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -868,7 +868,7 @@ dotnet_diagnostic.IDE0046.severity = silent
 dotnet_diagnostic.IDE0047.severity = silent
 
 # IDE0048: AddRequiredParentheses
-dotnet_diagnostic.IDE0048.severity = warning
+dotnet_diagnostic.IDE0048.severity = suggestion
 
 # IDE0049: PreferBuiltInOrFrameworkType
 dotnet_diagnostic.IDE0049.severity = silent

--- a/.globalconfig
+++ b/.globalconfig
@@ -868,7 +868,7 @@ dotnet_diagnostic.IDE0046.severity = silent
 dotnet_diagnostic.IDE0047.severity = silent
 
 # IDE0048: AddRequiredParentheses
-dotnet_diagnostic.IDE0048.severity = suggestion
+dotnet_diagnostic.IDE0048.severity = warning
 
 # IDE0049: PreferBuiltInOrFrameworkType
 dotnet_diagnostic.IDE0049.severity = silent

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
@@ -1834,7 +1834,7 @@ $result
 
             for (int i = 0; i < passwordLength; i++)
             {
-                chars[i] = (char)(randomBytes[i] % allowedCharsCount + charMin);
+                chars[i] = (char)((randomBytes[i] % allowedCharsCount) + charMin);
             }
 
             return new string(chars);
@@ -2013,8 +2013,8 @@ $result
 
             foreach (char t in computerName)
             {
-                if (t >= 'A' && t <= 'Z' ||
-                    t >= 'a' && t <= 'z')
+                if ((t >= 'A' && t <= 'Z') ||
+                    (t >= 'a' && t <= 'z'))
                 {
                     allDigits = false;
                     continue;

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetComputerInfoCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetComputerInfoCommand.cs
@@ -1159,13 +1159,13 @@ namespace Microsoft.PowerShell.Commands
             return DateTimeOffset.FromUnixTimeSeconds(seconds).DateTime;
 #else
             const int DaysPerYear = 365;
-            const int DaysPer4Years = DaysPerYear * 4 + 1;
-            const int DaysPer100Years = DaysPer4Years * 25 - 1;
-            const int DaysPer400Years = DaysPer100Years * 4 + 1;
-            const int DaysTo1970 = DaysPer400Years * 4 + DaysPer100Years * 3 + DaysPer4Years * 17 + DaysPerYear;
+            const int DaysPer4Years = (DaysPerYear * 4) + 1;
+            const int DaysPer100Years = (DaysPer4Years * 25) - 1;
+            const int DaysPer400Years = (DaysPer100Years * 4) + 1;
+            const int DaysTo1970 = (DaysPer400Years * 4) + (DaysPer100Years * 3) + (DaysPer4Years * 17) + DaysPerYear;
             const long UnixEpochTicks = TimeSpan.TicksPerDay * DaysTo1970;
 
-            long ticks = seconds * TimeSpan.TicksPerSecond + UnixEpochTicks;
+            long ticks = (seconds * TimeSpan.TicksPerSecond) + UnixEpochTicks;
 
             return new DateTimeOffset(ticks, TimeSpan.Zero).DateTime;
 #endif

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -805,7 +805,7 @@ namespace Microsoft.PowerShell.Commands
 
             for (int i = 0; i < bufferSize; i++)
             {
-                sendBuffer[i] = (byte)((int)'a' + i % 23);
+                sendBuffer[i] = (byte)((int)'a' + (i % 23));
             }
 
             if (bufferSize == DefaultSendBufferSize && s_DefaultSendBuffer == null)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -1289,7 +1289,7 @@ namespace Microsoft.PowerShell.Commands
                 var errorLineString = textLines[errorLineNumber].ToString();
                 var errorPosition = lineSpan.StartLinePosition.Character;
 
-                StringBuilder sb = new StringBuilder(diagnisticMessage.Length + errorLineString.Length * 2 + 4);
+                StringBuilder sb = new StringBuilder(diagnisticMessage.Length + (errorLineString.Length * 2) + 4);
 
                 sb.AppendLine(diagnisticMessage);
                 sb.AppendLine(errorLineString);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommand.cs
@@ -324,7 +324,7 @@ namespace Microsoft.PowerShell.Commands
                 do
                 {
                     double r = Generator.NextDouble();
-                    randomNumber = minValue + r * maxValue - r * minValue;
+                    randomNumber = minValue + (r * maxValue) - (r * minValue);
                 }
                 while (randomNumber >= maxValue);
             }
@@ -333,7 +333,7 @@ namespace Microsoft.PowerShell.Commands
                 do
                 {
                     double r = Generator.NextDouble();
-                    randomNumber = minValue + r * diff;
+                    randomNumber = minValue + (r * diff);
                     diff = diff * r;
                 }
                 while (randomNumber >= maxValue);
@@ -385,7 +385,7 @@ namespace Microsoft.PowerShell.Commands
                 randomUint64 &= mask;
             } while (uint64Diff <= randomUint64);
 
-            double randomNumber = minValue * 1.0 + randomUint64 * 1.0;
+            double randomNumber = (minValue * 1.0) + (randomUint64 * 1.0);
             return (Int64)randomNumber;
         }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Set-PSBreakpoint.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Set-PSBreakpoint.cs
@@ -88,8 +88,8 @@ namespace Microsoft.PowerShell.Commands
             // whether the RemoteScript debug option is selected.
             if (this.Context.InternalHost.ExternalHost is System.Management.Automation.Remoting.ServerRemoteHost &&
                 ((this.Context.CurrentRunspace == null) || (this.Context.CurrentRunspace.Debugger == null) ||
-                 ((this.Context.CurrentRunspace.Debugger.DebugMode & DebugModes.RemoteScript) != DebugModes.RemoteScript) &&
-                  (this.Context.CurrentRunspace.Debugger.DebugMode != DebugModes.None)))
+                 (((this.Context.CurrentRunspace.Debugger.DebugMode & DebugModes.RemoteScript) != DebugModes.RemoteScript) &&
+                  (this.Context.CurrentRunspace.Debugger.DebugMode != DebugModes.None))))
             {
                 ThrowTerminatingError(
                     new ErrorRecord(

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -2006,8 +2006,8 @@ namespace Microsoft.PowerShell
                     // the user hit tab up to the current cursor position after writing the completed text.
 
                     int deltaInput =
-                        (endOfInputCursorPos.Y * screenBufferSize.Width + endOfInputCursorPos.X)
-                        - (endOfCompletionCursorPos.Y * screenBufferSize.Width + endOfCompletionCursorPos.X);
+                        ((endOfInputCursorPos.Y * screenBufferSize.Width) + endOfInputCursorPos.X)
+                        - ((endOfCompletionCursorPos.Y * screenBufferSize.Width) + endOfCompletionCursorPos.X);
 
                     if (deltaInput > 0)
                     {
@@ -2066,7 +2066,7 @@ namespace Microsoft.PowerShell
                 up.Data.Keyboard.ExtraInfo = IntPtr.Zero;
 
                 inputs[2 * i] = down;
-                inputs[2 * i + 1] = up;
+                inputs[(2 * i) + 1] = up;
             }
 
             ConsoleControl.MimicKeyPress(inputs);

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/Reader/NativeWrapper.cs
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/Reader/NativeWrapper.cs
@@ -1419,7 +1419,7 @@ namespace System.Diagnostics.Eventing.Reader
                 for (int i = 0; i < val.Count; i++)
                 {
                     array[i] = DateTime.FromFileTime(Marshal.ReadInt64(ptr));
-                    ptr = new IntPtr((Int64)ptr + 8 * sizeof(byte)); // FILETIME values are 8 bytes
+                    ptr = new IntPtr((Int64)ptr + (8 * sizeof(byte))); // FILETIME values are 8 bytes
                 }
 
                 return array;
@@ -1441,7 +1441,7 @@ namespace System.Diagnostics.Eventing.Reader
                 {
                     UnsafeNativeMethods.SystemTime sysTime = Marshal.PtrToStructure<UnsafeNativeMethods.SystemTime>(ptr);
                     array[i] = new DateTime(sysTime.Year, sysTime.Month, sysTime.Day, sysTime.Hour, sysTime.Minute, sysTime.Second, sysTime.Milliseconds);
-                    ptr = new IntPtr((Int64)ptr + 16 * sizeof(byte)); // SystemTime values are 16 bytes
+                    ptr = new IntPtr((Int64)ptr + (16 * sizeof(byte))); // SystemTime values are 16 bytes
                 }
 
                 return array;

--- a/src/System.Management.Automation/DscSupport/CimDSCParser.cs
+++ b/src/System.Management.Automation/DscSupport/CimDSCParser.cs
@@ -3626,7 +3626,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
                     }
 
                     var propVal = prop.Value;
-                    if (listKeyProperties && propVal.IsKey || !listKeyProperties && !propVal.IsKey)
+                    if ((listKeyProperties && propVal.IsKey) || (!listKeyProperties && !propVal.IsKey))
                     {
                         usageString.Append(propVal.Mandatory ? "    " : "    [ ");
                         usageString.Append(prop.Key);

--- a/src/System.Management.Automation/FormatAndOutput/common/ColumnWidthManager.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ColumnWidthManager.cs
@@ -182,7 +182,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 }
             }
 
-            return sum + _separatorWidth * (visibleColumns - 1);
+            return sum + (_separatorWidth * (visibleColumns - 1));
         }
 
         /// <summary>

--- a/src/System.Management.Automation/FormatAndOutput/common/OutputQueue.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/OutputQueue.cs
@@ -69,9 +69,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             }
 
             // STATE TRANSITION: we are processing and we stop
-            if (_processingGroup &&
+            if ((_processingGroup &&
                 ((o is GroupEndData) ||
-                (_objectCount > 0) && (_currentObjectCount >= _objectCount)) ||
+                ((_objectCount > 0) && (_currentObjectCount >= _objectCount)))) ||
                 ((_groupingTimer != null) && (_groupingTimer.Elapsed > _groupingDuration))
                 )
             {

--- a/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
@@ -64,7 +64,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 // would we fit with one more column?
                 int nextValue = columnNumber + 1;
                 // compute the width if we added the extra column
-                int width = stringLen * nextValue + (nextValue - 1) * ScreenInfo.separatorCharacterCount;
+                int width = (stringLen * nextValue) + ((nextValue - 1) * ScreenInfo.separatorCharacterCount);
 
                 if (width >= screenColumns)
                 {

--- a/src/System.Management.Automation/cimSupport/cmdletization/ScriptWriter.cs
+++ b/src/System.Management.Automation/cimSupport/cmdletization/ScriptWriter.cs
@@ -908,7 +908,7 @@ function __cmdletization_BindCommonParameters
 
             if ((maxBeforePosition >= 0) && (minAfterPosition <= maxBeforePosition))
             {
-                int delta = (1001 - minAfterPosition % 1000);
+                int delta = (1001 - (minAfterPosition % 1000));
                 foreach (ParameterMetadata afterParameter in afterParameters.Values)
                 {
                     foreach (ParameterSetMetadata afterParameterSet in afterParameter.ParameterSets.Values)

--- a/src/System.Management.Automation/engine/COM/ComInvoker.cs
+++ b/src/System.Management.Automation/engine/COM/ComInvoker.cs
@@ -82,7 +82,7 @@ namespace System.Management.Automation
 
             for (int i = 0; i < length; i++)
             {
-                IntPtr currentVarPtr = variantArray + s_variantSize * i;
+                IntPtr currentVarPtr = variantArray + (s_variantSize * i);
                 var currentVar = (Variant*)currentVarPtr;
                 currentVar->_typeUnion._vt = (ushort)VarEnum.VT_EMPTY;
             }
@@ -157,7 +157,7 @@ namespace System.Management.Automation
                     {
                         // !! The arguments should be in REVERSED order!!
                         int actualIndex = argCount - i - 1;
-                        IntPtr varArgPtr = variantArgArray + s_variantSize * actualIndex;
+                        IntPtr varArgPtr = variantArgArray + (s_variantSize * actualIndex);
 
                         // If need to pass by ref, create a by-ref variant
                         if (byRef != null && byRef[i])
@@ -169,7 +169,7 @@ namespace System.Management.Automation
                             }
 
                             // Create a VARIANT that the by-ref VARIANT points to
-                            IntPtr tmpVarPtr = tmpVariants + s_variantSize * refIndex;
+                            IntPtr tmpVarPtr = tmpVariants + (s_variantSize * refIndex);
                             Marshal.GetNativeVariantForObject(args[i], tmpVarPtr);
 
                             // Create the by-ref VARIANT
@@ -266,7 +266,7 @@ namespace System.Management.Automation
                         // If need to pass by ref, back propagate
                         if (byRef != null && byRef[i])
                         {
-                            args[i] = Marshal.GetObjectForNativeVariant(variantArgArray + s_variantSize * actualIndex);
+                            args[i] = Marshal.GetObjectForNativeVariant(variantArgArray + (s_variantSize * actualIndex));
                         }
                     }
                 }
@@ -280,7 +280,7 @@ namespace System.Management.Automation
                 {
                     for (int i = 0; i < argCount; i++)
                     {
-                        VariantClear(variantArgArray + s_variantSize * i);
+                        VariantClear(variantArgArray + (s_variantSize * i));
                     }
 
                     Marshal.FreeCoTaskMem(variantArgArray);
@@ -297,7 +297,7 @@ namespace System.Management.Automation
                 {
                     for (int i = 0; i < refCount; i++)
                     {
-                        VariantClear(tmpVariants + s_variantSize * i);
+                        VariantClear(tmpVariants + (s_variantSize * i));
                     }
 
                     Marshal.FreeCoTaskMem(tmpVariants);

--- a/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
@@ -2564,8 +2564,8 @@ namespace System.Management.Automation
                 // If the valid parameter set is the default parameter set, or if the default
                 // parameter set has been defined and one of the valid parameter sets is
                 // the default parameter set, then use the default parameter set.
-                else if (!prePipelineInput &&
-                    validSetIsDefault ||
+                else if ((!prePipelineInput &&
+                    validSetIsDefault) ||
                     (hasDefaultSetDefined && (_currentParameterSetFlag & defaultParameterSetFlag) != 0))
                 {
                     // NTRAID#Windows Out Of Band Releases-2006/02/14-928660-JonN

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -1021,8 +1021,8 @@ namespace System.Management.Automation
                     {
                         foreach (CmdletInfo cmdlet in cmdletList)
                         {
-                            if (cmdletMatcher != null &&
-                                cmdletMatcher.IsMatch(cmdlet.Name) ||
+                            if ((cmdletMatcher != null &&
+                                cmdletMatcher.IsMatch(cmdlet.Name)) ||
                                 (_commandResolutionOptions.HasFlag(SearchResolutionOptions.FuzzyMatch) &&
                                  FuzzyMatcher.IsFuzzyMatch(cmdlet.Name, _commandName)))
                             {

--- a/src/System.Management.Automation/engine/CompiledCommandParameter.cs
+++ b/src/System.Management.Automation/engine/CompiledCommandParameter.cs
@@ -63,7 +63,7 @@ namespace System.Management.Automation
                     // and disabled parameter attributes. We should ignore those attributes.
                     // When processing non-dynamic parameters, the experimental attributes and disabled parameter
                     // attributes have already been filtered out when constructing the RuntimeDefinedParameter.
-                    if (attribute is ExperimentalAttribute || attribute is ParameterAttribute param && param.ToHide)
+                    if (attribute is ExperimentalAttribute || (attribute is ParameterAttribute param && param.ToHide))
                     {
                         continue;
                     }

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -4331,7 +4331,7 @@ namespace System.Management.Automation
                 {
                     // To prevent to/from == from/to, multiply and add rather than use
                     // an operation that won't overflow, like bitwise xor.
-                    return from.GetHashCode() + 37 * to.GetHashCode();
+                    return from.GetHashCode() + (37 * to.GetHashCode());
                 }
             }
 
@@ -5180,8 +5180,8 @@ namespace System.Management.Automation
                     var sourceTypeDef = sourceType.GetGenericTypeDefinition();
                     bool isOutParameter = matchContext == TypeMatchingContext.OutParameterType;
 
-                    if (targetType.IsByRef && sourceTypeDef == (isOutParameter ? typeof(PSOutParameter<>) : typeof(PSReference<>)) ||
-                        targetType.IsPointer && sourceTypeDef == typeof(PSPointer<>))
+                    if ((targetType.IsByRef && sourceTypeDef == (isOutParameter ? typeof(PSOutParameter<>) : typeof(PSReference<>))) ||
+                        (targetType.IsPointer && sourceTypeDef == typeof(PSPointer<>)))
                     {
                         // For ref/out parameter types and pointer types, the element types need to match exactly.
                         if (targetType.GetElementType() == sourceType.GenericTypeArguments[0])
@@ -5195,8 +5195,8 @@ namespace System.Management.Automation
                 }
 
                 if (targetType == sourceType ||
-                    targetType == typeof(void) && sourceType == typeof(VOID) ||
-                    targetType == typeof(TypedReference) && sourceType == typeof(PSTypedReference))
+                    (targetType == typeof(void) && sourceType == typeof(VOID)) ||
+                    (targetType == typeof(TypedReference) && sourceType == typeof(PSTypedReference)))
                 {
                     matchExactly = true;
                     return true;

--- a/src/System.Management.Automation/engine/Modules/PSModuleInfo.cs
+++ b/src/System.Management.Automation/engine/Modules/PSModuleInfo.cs
@@ -1627,17 +1627,17 @@ namespace System.Management.Automation
                     result = 23;
                     if (obj.Name != null)
                     {
-                        result = result * 17 + obj.Name.GetHashCode();
+                        result = (result * 17) + obj.Name.GetHashCode();
                     }
 
                     if (obj.Guid != Guid.Empty)
                     {
-                        result = result * 17 + obj.Guid.GetHashCode();
+                        result = (result * 17) + obj.Guid.GetHashCode();
                     }
 
                     if (obj.Version != null)
                     {
-                        result = result * 17 + obj.Version.GetHashCode();
+                        result = (result * 17) + obj.Version.GetHashCode();
                     }
                 }
 

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -2287,7 +2287,7 @@ namespace System.Management.Automation
         {
             if (this.PipelineProcessor == null
                 || _thisCommand != this.PipelineProcessor._permittedToWrite
-                || needsToWriteToPipeline && !this.PipelineProcessor._permittedToWriteToPipeline
+                || (needsToWriteToPipeline && !this.PipelineProcessor._permittedToWriteToPipeline)
                 || Thread.CurrentThread != this.PipelineProcessor._permittedToWriteThread
                )
             {

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -1996,8 +1996,8 @@ namespace System.Management.Automation
             {
                 int result = 61;
 
-                result = result * 397 + (MethodTargetType != null ? MethodTargetType.GetHashCode() : 0);
-                result = result * 397 + ParameterTypes.SequenceGetHashCode();
+                result = (result * 397) + (MethodTargetType != null ? MethodTargetType.GetHashCode() : 0);
+                result = (result * 397) + ParameterTypes.SequenceGetHashCode();
 
                 return result;
             }

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -169,7 +169,7 @@ namespace System.Management.Automation
         {
             IEnumerator list = LanguagePrimitives.GetEnumerator(obj);
 
-            Diagnostics.Assert((argArrayAst == null) || obj is object[] && ((object[])obj).Length == argArrayAst.Elements.Count, "array argument and ArrayLiteralAst differ in number of elements");
+            Diagnostics.Assert((argArrayAst == null) || (obj is object[] && ((object[])obj).Length == argArrayAst.Elements.Count), "array argument and ArrayLiteralAst differ in number of elements");
 
             int currentElement = -1;
             string separator = string.Empty;

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -778,7 +778,7 @@ namespace System.Management.Automation
                 return false;
             }
 
-            if (preLabel != null && !Regex.IsMatch(preLabel, LabelUnitRegEx) ||
+            if ((preLabel != null && !Regex.IsMatch(preLabel, LabelUnitRegEx)) ||
                (buildLabel != null && !Regex.IsMatch(buildLabel, LabelUnitRegEx)))
             {
                 result.SetFailure(ParseFailureKind.FormatException);

--- a/src/System.Management.Automation/engine/hostifaces/Connection.cs
+++ b/src/System.Management.Automation/engine/hostifaces/Connection.cs
@@ -943,7 +943,7 @@ namespace System.Management.Automation.Runspaces
                         case PipelineState.Completed:
                         case PipelineState.Stopped:
                         case PipelineState.Failed:
-                            if (this.InNestedPrompt || !(this is RemoteRunspace) && this.Debugger.InBreakpoint)
+                            if (this.InNestedPrompt || (!(this is RemoteRunspace) && this.Debugger.InBreakpoint))
                             {
                                 this.RunspaceAvailability = RunspaceAvailability.AvailableForNestedCommand;
                             }

--- a/src/System.Management.Automation/engine/hostifaces/LocalConnection.cs
+++ b/src/System.Management.Automation/engine/hostifaces/LocalConnection.cs
@@ -987,7 +987,7 @@ namespace System.Management.Automation.Runspaces
                 foreach (Job job in this.JobRepository.Jobs)
                 {
                     // Only stop or disconnect PowerShell jobs.
-                    if (job is PSRemotingJob == false)
+                    if ((job is PSRemotingJob) == false)
                     {
                         continue;
                     }

--- a/src/System.Management.Automation/engine/interpreter/CallInstruction.cs
+++ b/src/System.Management.Automation/engine/interpreter/CallInstruction.cs
@@ -57,7 +57,7 @@ namespace System.Management.Automation.Interpreter
                 return GetArrayAccessor(info, argumentCount);
             }
 
-            if (info is DynamicMethod || !info.IsStatic && info.DeclaringType.IsValueType)
+            if (info is DynamicMethod || (!info.IsStatic && info.DeclaringType.IsValueType))
             {
                 return new MethodInfoCallInstruction(info, argumentCount);
             }

--- a/src/System.Management.Automation/engine/interpreter/ControlFlowInstructions.cs
+++ b/src/System.Management.Automation/engine/interpreter/ControlFlowInstructions.cs
@@ -291,7 +291,7 @@ namespace System.Management.Automation.Interpreter
         {
             if (labelIndex < CacheSize)
             {
-                var index = Variants * labelIndex | (hasResult ? 2 : 0) | (hasValue ? 1 : 0);
+                var index = (Variants * labelIndex) | (hasResult ? 2 : 0) | (hasValue ? 1 : 0);
                 return s_cache[index] ?? (s_cache[index] = new GotoInstruction(labelIndex, hasResult, hasValue));
             }
 

--- a/src/System.Management.Automation/engine/interpreter/LightCompiler.cs
+++ b/src/System.Management.Automation/engine/interpreter/LightCompiler.cs
@@ -799,7 +799,7 @@ namespace System.Management.Automation.Interpreter
         private void CompileEqual(Expression left, Expression right)
         {
             Debug.Assert(left.Type == right.Type ||
-                         !left.Type.IsValueType && !right.Type.IsValueType);
+                         (!left.Type.IsValueType && !right.Type.IsValueType));
             Compile(left);
             Compile(right);
             _instructions.EmitEqual(left.Type);
@@ -808,7 +808,7 @@ namespace System.Management.Automation.Interpreter
         private void CompileNotEqual(Expression left, Expression right)
         {
             Debug.Assert(left.Type == right.Type ||
-                         !left.Type.IsValueType && !right.Type.IsValueType);
+                         (!left.Type.IsValueType && !right.Type.IsValueType));
             Compile(left);
             Compile(right);
             _instructions.EmitNotEqual(left.Type);

--- a/src/System.Management.Automation/engine/parser/Position.cs
+++ b/src/System.Management.Automation/engine/parser/Position.cs
@@ -177,7 +177,7 @@ namespace System.Management.Automation.Language
                 bool needsSuffixDots = false;
 
                 int lineLength = sourceLine.Length;
-                var sb = new StringBuilder(sourceLine.Length * 2 + 4);
+                var sb = new StringBuilder((sourceLine.Length * 2) + 4);
                 if (lineLength > maxLineLength)
                 {
                     // Need to truncate - include as much of the error as we can, but with

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -1364,7 +1364,7 @@ namespace System.Management.Automation.Language
 
         bool IParameterMetadataProvider.HasAnyScriptBlockAttributes()
         {
-            return Attributes.Count > 0 || ParamBlock != null && ParamBlock.Attributes.Count > 0;
+            return Attributes.Count > 0 || (ParamBlock != null && ParamBlock.Attributes.Count > 0);
         }
 
         RuntimeDefinedParameterDictionary IParameterMetadataProvider.GetParameterMetadata(bool automaticPositions, ref bool usesCmdletBinding)

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -1593,8 +1593,8 @@ namespace System.Management.Automation.Language
             else
             {
                 Diagnostics.Assert((codepoint > 0x0000FFFF) && (codepoint <= 0x0010FFFF), "Codepoint is out of range for a surrogate pair");
-                lowSurrogate = (char)((codepoint - 0x00010000) % 0x0400 + 0xDC00);
-                return (char)((codepoint - 0x00010000) / 0x0400 + 0xD800);
+                lowSurrogate = (char)(((codepoint - 0x00010000) % 0x0400) + 0xDC00);
+                return (char)(((codepoint - 0x00010000) / 0x0400) + 0xD800);
             }
         }
 

--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -230,7 +230,7 @@ namespace System.Management.Automation
                 return pattern;
             }
 
-            Span<char> temp = pattern.Length < StackAllocThreshold ? stackalloc char[pattern.Length * 2 + 1] : new char[pattern.Length * 2 + 1];
+            Span<char> temp = pattern.Length < StackAllocThreshold ? stackalloc char[(pattern.Length * 2) + 1] : new char[(pattern.Length * 2) + 1];
             int tempIndex = 0;
 
             for (int i = 0; i < pattern.Length; i++)
@@ -790,7 +790,7 @@ namespace System.Management.Automation
 
         protected override void BeginWildcardPattern(WildcardPattern pattern)
         {
-            _regexPattern = new StringBuilder(pattern.Pattern.Length * 2 + 2);
+            _regexPattern = new StringBuilder((pattern.Pattern.Length * 2) + 2);
             _regexPattern.Append('^');
 
             _regexOptions = TranslateWildcardOptionsIntoRegexOptions(pattern.Options);

--- a/src/System.Management.Automation/engine/remoting/client/clientremotesessionprotocolstatemachine.cs
+++ b/src/System.Management.Automation/engine/remoting/client/clientremotesessionprotocolstatemachine.cs
@@ -359,8 +359,8 @@ namespace System.Management.Automation.Remoting
         /// <param name="eventArgs">Event args.</param>
         private void SetStateToClosedHandler(object sender, RemoteSessionStateMachineEventArgs eventArgs)
         {
-            Dbg.Assert(_state == RemoteSessionState.NegotiationReceived &&
-                            eventArgs.StateEvent == RemoteSessionEvent.NegotiationFailed ||
+            Dbg.Assert((_state == RemoteSessionState.NegotiationReceived &&
+                            eventArgs.StateEvent == RemoteSessionEvent.NegotiationFailed) ||
                             eventArgs.StateEvent == RemoteSessionEvent.SendFailed ||
                             eventArgs.StateEvent == RemoteSessionEvent.ReceiveFailed ||
                             eventArgs.StateEvent == RemoteSessionEvent.NegotiationTimeout ||

--- a/src/System.Management.Automation/engine/remoting/commands/DebugJob.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/DebugJob.cs
@@ -431,7 +431,7 @@ namespace Microsoft.PowerShell.Commands
             }
 
             if ((jobs1.Count > 1) ||
-                (jobs1.Count == 1) && (job2 != null))
+                ((jobs1.Count == 1) && (job2 != null)))
             {
                 ThrowTerminatingError(
                     new ErrorRecord(

--- a/src/System.Management.Automation/engine/remoting/commands/WaitJob.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/WaitJob.cs
@@ -149,7 +149,7 @@ namespace Microsoft.PowerShell.Commands
                 // Wait should wait until a job is in a persistent state, OR if the force parameter
                 // is specified, until the job is in a finished state, which is a subset of
                 // persistent states.
-                if (!Force && job.IsPersistentState(eventArgs.JobStateInfo.State) || (Force && job.IsFinishedState(eventArgs.JobStateInfo.State)))
+                if ((!Force && job.IsPersistentState(eventArgs.JobStateInfo.State)) || (Force && job.IsFinishedState(eventArgs.JobStateInfo.State)))
                 {
                     if (!job.IsFinishedState(eventArgs.JobStateInfo.State))
                     {

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManTransportManager.cs
@@ -395,7 +395,7 @@ namespace System.Management.Automation.Remoting.Client
                                 int decimalIndex = timeoutString.IndexOf('.');
                                 try
                                 {
-                                    int timeout = Convert.ToInt32(timeoutString.Substring(2, decimalIndex - 2), NumberFormatInfo.InvariantInfo) * 1000 + Convert.ToInt32(timeoutString.Substring(decimalIndex + 1, 3), NumberFormatInfo.InvariantInfo);
+                                    int timeout = (Convert.ToInt32(timeoutString.Substring(2, decimalIndex - 2), NumberFormatInfo.InvariantInfo) * 1000) + Convert.ToInt32(timeoutString.Substring(decimalIndex + 1, 3), NumberFormatInfo.InvariantInfo);
                                     if (settingIdleTimeout)
                                     {
                                         ConnectionInfo.IdleTimeout = timeout;

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -4569,7 +4569,7 @@ namespace System.Management.Automation.Language
                 return Defer(indexes.Prepend(target).Append(value).ToArray()).WriteToDebugLog(this);
             }
 
-            if (target.Value is PSObject && (PSObject.Base(target.Value) != target.Value) ||
+            if ((target.Value is PSObject && (PSObject.Base(target.Value) != target.Value)) ||
                 indexes.Any(mo => mo.Value is PSObject && (PSObject.Base(mo.Value) != mo.Value)))
             {
                 return this.DeferForPSObject(indexes.Prepend(target).Append(value).ToArray()).WriteToDebugLog(this);
@@ -6909,8 +6909,8 @@ namespace System.Management.Automation.Language
                 // to wrap exceptions - this is very much a special case to help error
                 // propagation and ensure errors are attributed to the correct code (the
                 // cmdlet invoked, not the method call from some proxy.)
-                if (methodInfo.DeclaringType == typeof(SteppablePipeline)
-                    && (methodInfo.Name.Equals("Begin", StringComparison.Ordinal))
+                if ((methodInfo.DeclaringType == typeof(SteppablePipeline)
+                    && (methodInfo.Name.Equals("Begin", StringComparison.Ordinal)))
                         || methodInfo.Name.Equals("Process", StringComparison.Ordinal)
                         || methodInfo.Name.Equals("End", StringComparison.Ordinal))
                 {

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -2024,7 +2024,7 @@ namespace System.Management.Automation
                         // LCG comes from a trivial (bad) random number generator,
                         // but it's sufficient for us - the hashes for our patterns
                         // are unique, and processing of 2200 files found no false matches.
-                        runningHash[j] = LCG * runningHash[j - 1] + h;
+                        runningHash[j] = (LCG * runningHash[j - 1]) + h;
                     }
 
                     runningHash[0] = h;

--- a/src/System.Management.Automation/engine/serialization.cs
+++ b/src/System.Management.Automation/engine/serialization.cs
@@ -2841,7 +2841,7 @@ namespace System.Management.Automation
             Dbg.Assert(indexOfFirstEncodableCharacter < s.Length, "Caller should verify validity of indexOfFirstEncodableCharacter");
 
             int slen = s.Length;
-            char[] result = new char[indexOfFirstEncodableCharacter + (slen - indexOfFirstEncodableCharacter) * 7];
+            char[] result = new char[indexOfFirstEncodableCharacter + ((slen - indexOfFirstEncodableCharacter) * 7)];
 
             s.CopyTo(0, result, 0, indexOfFirstEncodableCharacter);
             int rlen = indexOfFirstEncodableCharacter;
@@ -3802,7 +3802,7 @@ namespace System.Management.Automation
                 // allocating much more memory than the length of the xml string
                 // We have to account for that to limit that to remoting quota and protect against OOM.
                 _context.LogExtraMemoryUsage(
-                    typeNames.Key.Length * sizeof(char) // Key is shared among the cloned and original object
+                    (typeNames.Key.Length * sizeof(char)) // Key is shared among the cloned and original object
                                                         // but the list of strings isn't.  The expression to the left
                                                         // is roughly the size of memory the list of strings occupies
                     - 29 // size of <Obj><TNRef RefId="0"/></Obj> in UTF8 encoding
@@ -5710,7 +5710,7 @@ namespace System.Management.Automation
                 }
 
                 _dictionary = alive;
-                _cleanupTriggerSize = initialCleanupTriggerSize + this.Count * 2;
+                _cleanupTriggerSize = initialCleanupTriggerSize + (this.Count * 2);
             }
         }
 

--- a/src/System.Management.Automation/logging/LogProvider.cs
+++ b/src/System.Management.Automation/logging/LogProvider.cs
@@ -228,7 +228,7 @@ namespace System.Management.Automation
         // Estimated length of all Strings.* values
         // Rough estimate of values
         // max path for Command path
-        private const int LogContextInitialSize = 30 * 16 + 13 * 20 + 255;
+        private const int LogContextInitialSize = (30 * 16) + (13 * 20) + 255;
 
         /// <summary>
         /// Converts log context to string.

--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -3356,8 +3356,8 @@ namespace System.Management.Automation
 
             // Only loop through the child names if the leafElement contains a glob character
 
-            if (!string.IsNullOrEmpty(leafElement) &&
-                StringContainsGlobCharacters(leafElement) ||
+            if ((!string.IsNullOrEmpty(leafElement) &&
+                StringContainsGlobCharacters(leafElement)) ||
                 isLastLeaf)
             {
                 string regexEscapedLeafElement = ConvertMshEscapeToRegexEscape(leafElement);

--- a/src/System.Management.Automation/security/SecureStringHelper.cs
+++ b/src/System.Management.Automation/security/SecureStringHelper.cs
@@ -49,14 +49,14 @@ namespace Microsoft.PowerShell
 
             for (int i = 0; i < len; i++)
             {
-                ch = (char)(data[2 * i + 1] * 256 + data[2 * i]);
+                ch = (char)((data[(2 * i) + 1] * 256) + data[2 * i]);
                 ss.AppendChar(ch);
 
                 //
                 // zero out the data slots as soon as we use them
                 //
                 data[2 * i] = 0;
-                data[2 * i + 1] = 0;
+                data[(2 * i) + 1] = 0;
             }
 
             return ss;

--- a/src/System.Management.Automation/utils/PsUtils.cs
+++ b/src/System.Management.Automation/utils/PsUtils.cs
@@ -599,7 +599,7 @@ namespace System.Management.Automation
             uint crc = 0xFFFFFFFF;
             for (int i = 0; i < buffer.Length; ++i)
             {
-                var index = (byte)(crc ^ buffer[i] & 0xff);
+                var index = (byte)(crc ^ (buffer[i] & 0xff));
                 crc = (crc >> 8) ^ table[index];
             }
 


### PR DESCRIPTION
https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0047-ide0048

Follow-up to #13896, after `EnforceCodeStyleInBuild` was enabled in #13957.