### PR TITLE
Fix CA1003: Use generic event handler instances

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -10,7 +10,8 @@ dotnet_diagnostic.CA1001.severity = silent
 dotnet_diagnostic.CA1002.severity = none
 
 # CA1003: Use generic event handler instances
-dotnet_diagnostic.CA1003.severity = none
+dotnet_diagnostic.CA1003.severity = warning
+dotnet_code_quality.ca1003.api_surface = private, internal
 
 # CA1005: Avoid excessive parameters on generic types
 dotnet_diagnostic.CA1005.severity = none

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimResultObserver.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimResultObserver.cs
@@ -217,19 +217,9 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal class CimResultObserver<T> : IObserver<T>
     {
         /// <summary>
-        /// Define delegate that handles new cmdlet action come from
-        /// the operations related to the current CimSession object.
-        /// </summary>
-        /// <param name="cimSession">CimSession object, which raised the event.</param>
-        /// <param name="actionArgs">Event args.</param>
-        public delegate void ResultEventHandler(
-            object observer,
-            AsyncResultEventArgsBase resultArgs);
-
-        /// <summary>
         /// Define an Event based on the NewActionHandler.
         /// </summary>
-        public event ResultEventHandler OnNewResult;
+        public event EventHandler<AsyncResultEventArgsBase> OnNewResult;
 
         /// <summary>
         /// Constructor.

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionProxy.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionProxy.cs
@@ -297,40 +297,20 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         #region Event definitions
 
         /// <summary>
-        /// Define delegate that handles new cmdlet action come from
-        /// the operations related to the current CimSession object.
-        /// </summary>
-        /// <param name="cimSession">CimSession object, which raised the event.</param>
-        /// <param name="actionArgs">Event args.</param>
-        public delegate void NewCmdletActionHandler(
-            object cimSession,
-            CmdletActionEventArgs actionArgs);
-
-        /// <summary>
         /// Define an Event based on the NewActionHandler.
         /// </summary>
-        public event NewCmdletActionHandler OnNewCmdletAction;
-
-        /// <summary>
-        /// Define delegate that handles operation creation and complete
-        /// issued by the current CimSession object.
-        /// </summary>
-        /// <param name="cimSession">CimSession object, which raised the event.</param>
-        /// <param name="actionArgs">Event args.</param>
-        public delegate void OperationEventHandler(
-            object cimSession,
-            OperationEventArgs actionArgs);
+        public event EventHandler<CmdletActionEventArgs> OnNewCmdletAction;
 
         /// <summary>
         /// Event triggered when a new operation is started.
         /// </summary>
-        public event OperationEventHandler OnOperationCreated;
+        public event EventHandler<OperationEventArgs> OnOperationCreated;
 
         /// <summary>
         /// Event triggered when a new operation is completed,
         /// either success or failed.
         /// </summary>
-        public event OperationEventHandler OnOperationDeleted;
+        public event EventHandler<OperationEventArgs> OnOperationDeleted;
 
         #endregion
 
@@ -751,7 +731,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
                 return;
             }
 
-            NewCmdletActionHandler temp = this.OnNewCmdletAction;
+            EventHandler<CmdletActionEventArgs> temp = this.OnNewCmdletAction;
             if (temp != null)
             {
                 temp(this.session, actionArgs);

--- a/src/System.Management.Automation/help/HelpCommands.cs
+++ b/src/System.Management.Automation/help/HelpCommands.cs
@@ -262,7 +262,7 @@ namespace Microsoft.PowerShell.Commands
                     this.graphicalHostReflectionWrapper = GraphicalHostReflectionWrapper.GetGraphicalHostReflectionWrapper(this, "Microsoft.PowerShell.Commands.Internal.HelpWindowHelper");
                 }
 #endif
-                helpSystem.OnProgress += new HelpSystem.HelpProgressHandler(HelpSystem_OnProgress);
+                helpSystem.OnProgress += HelpSystem_OnProgress;
 
                 bool failed = false;
                 HelpCategory helpCategory = ToHelpCategory(Category, ref failed);
@@ -354,7 +354,7 @@ namespace Microsoft.PowerShell.Commands
             }
             finally
             {
-                helpSystem.OnProgress -= new HelpSystem.HelpProgressHandler(HelpSystem_OnProgress);
+                helpSystem.OnProgress -= HelpSystem_OnProgress;
                 HelpSystem_OnComplete();
 
                 // finally clear the ScriptBlockAst -> Token[] cache
@@ -683,7 +683,7 @@ namespace Microsoft.PowerShell.Commands
 
         #endregion
 
-        private void HelpSystem_OnProgress(object sender, HelpProgressInfo arg)
+        private void HelpSystem_OnProgress(object sender, HelpProgressEventArgs arg)
         {
             var record = new ProgressRecord(0, this.CommandInfo.Name, arg.Activity)
             {

--- a/src/System.Management.Automation/help/HelpSystem.cs
+++ b/src/System.Management.Automation/help/HelpSystem.cs
@@ -121,9 +121,7 @@ namespace System.Management.Automation
 
         #region Progress Callback
 
-        internal delegate void HelpProgressHandler(object sender, HelpProgressInfo arg);
-
-        internal event HelpProgressHandler OnProgress;
+        internal event EventHandler<HelpProgressEventArgs> OnProgress;
 
         #endregion
 
@@ -463,7 +461,7 @@ namespace System.Management.Automation
             bool searchInHelpContent = false;
             bool shouldBreak = false;
 
-            HelpProgressInfo progress = new HelpProgressInfo();
+            HelpProgressEventArgs progress = new HelpProgressEventArgs();
 
             progress.Activity = StringUtil.Format(HelpDisplayStrings.SearchingForHelpContent, helpRequest.Target);
             progress.Completed = false;
@@ -802,11 +800,11 @@ namespace System.Management.Automation
     /// <summary>
     /// Help progress info.
     /// </summary>
-    internal class HelpProgressInfo
+    internal class HelpProgressEventArgs : EventArgs
     {
-        internal bool Completed;
-        internal string Activity;
-        internal int PercentComplete;
+        internal bool Completed { get; set; }
+        internal string Activity { get; set; }
+        internal int PercentComplete { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003

This PR does not contain code fixes for public API surfaces, so the changes should not be breaking.
