### PR TITLE
Enable CA1012: Abstract types should not have public constructors

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -22,7 +22,8 @@ dotnet_diagnostic.CA1008.severity = none
 dotnet_diagnostic.CA1010.severity = silent
 
 # CA1012: Abstract types should not have public constructors
-dotnet_diagnostic.CA1012.severity = none
+dotnet_diagnostic.CA1012.severity = warning
+dotnet_code_quality.ca1012.api_surface = all
 
 # CA1014: Mark assemblies with CLSCompliant
 dotnet_diagnostic.CA1014.severity = none

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimAsyncOperation.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimAsyncOperation.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// <summary>
         /// The constructor.
         /// </summary>
-        public CimAsyncOperation()
+        protected CimAsyncOperation()
         {
             this.moreActionEvent = new ManualResetEventSlim(false);
             this.actionQueue = new ConcurrentQueue<CimBaseAction>();

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimBaseAction.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimBaseAction.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// <summary>
         /// Constructor method.
         /// </summary>
-        public CimBaseAction()
+        protected CimBaseAction()
         {
         }
 

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimResultObserver.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimResultObserver.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// <param name="session"></param>
         /// <param name="observable"></param>
         /// <param name="resultType"></param>
-        public AsyncResultEventArgsBase(
+        protected AsyncResultEventArgsBase(
             CimSession session,
             IObservable<object> observable,
             AsyncResultType resultType)
@@ -86,7 +86,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// <param name="observable"></param>
         /// <param name="resultType"></param>
         /// <param name="context"></param>
-        public AsyncResultEventArgsBase(
+        protected AsyncResultEventArgsBase(
             CimSession session,
             IObservable<object> observable,
             AsyncResultType resultType,

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -4197,7 +4197,7 @@ namespace System.Management.Automation
         /// <param name="runspace">Runspace.</param>
         /// <param name="runspaceType">Runspace type.</param>
         /// <param name="parentDebuggerId">Debugger Id of parent.</param>
-        public NestedRunspaceDebugger(
+        protected NestedRunspaceDebugger(
             Runspace runspace,
             PSMonitorRunspaceType runspaceType,
             Guid parentDebuggerId)

--- a/src/System.Management.Automation/engine/interpreter/ControlFlowInstructions.cs
+++ b/src/System.Management.Automation/engine/interpreter/ControlFlowInstructions.cs
@@ -204,7 +204,7 @@ namespace System.Management.Automation.Interpreter
 
         internal readonly int _labelIndex;
 
-        public IndexedBranchInstruction(int labelIndex)
+        protected IndexedBranchInstruction(int labelIndex)
         {
             _labelIndex = labelIndex;
         }

--- a/src/System.Management.Automation/utils/ObjectReader.cs
+++ b/src/System.Management.Automation/utils/ObjectReader.cs
@@ -23,7 +23,7 @@ namespace System.Management.Automation.Internal
         /// </summary>
         /// <param name="stream">The stream to read.</param>
         /// <exception cref="ArgumentNullException">Thrown if the specified stream is null.</exception>
-        public ObjectReaderBase([In, Out] ObjectStreamBase stream)
+        protected ObjectReaderBase([In, Out] ObjectStreamBase stream)
         {
             if (stream == null)
             {


### PR DESCRIPTION
https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
