### PR TITLE
The -Stream parameter now works with directories

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1320,7 +1320,9 @@ namespace Microsoft.PowerShell.Commands
                             foreach (AlternateStreamData stream in AlternateDataStreamUtilities.GetStreams(result.FullName))
                             {
                                 if (!p.IsMatch(stream.Stream))
-                                { continue; }
+                                {
+                                    continue;
+                                }
 
                                 string outputPath = result.FullName + ":" + stream.Stream;
                                 // Alternate data streams can never be containers.

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1326,7 +1326,7 @@ namespace Microsoft.PowerShell.Commands
 
                                 string outputPath = result.FullName + ":" + stream.Stream;
                                 // Alternate data streams can never be containers.
-                                WriteItemObject(stream, outputPath, false);
+                                WriteItemObject(stream, outputPath, isContainer: false);
                                 foundStream = true;
                             }
 
@@ -6971,7 +6971,7 @@ namespace Microsoft.PowerShell.Commands
                 // alternate data streams on them that are not child items. These alternate data streams
                 // must be treated as data streams, even if they're attached to directories. However,
                 // if asked to work with a directory without a data stream specified, write a non-terminating
-                // error instead of clearing all child items of the directory.  (On non-Windows, alternate
+                // error instead of clearing all child items of the directory. (On non-Windows, alternate
                 // data streams don't exist, so in that environment always write the error when addressing
                 // a directory.)
                 if (Directory.Exists(path)
@@ -8650,6 +8650,7 @@ namespace System.Management.Automation.Internal
             SafeFindHandle handle = NativeMethods.FindFirstStreamW(
                 path, NativeMethods.StreamInfoLevels.FindStreamInfoStandard,
                 findStreamData, 0);
+
             if (handle.IsInvalid)
             {
                 int error = Marshal.GetLastWin32Error();

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1311,35 +1311,34 @@ namespace Microsoft.PowerShell.Commands
                     // If we want to retrieve the file streams, retrieve them.
                     if (retrieveStreams)
                     {
-                        if (!isContainer)
+                        foreach (string desiredStream in dynamicParameters.Stream)
                         {
-                            foreach (string desiredStream in dynamicParameters.Stream)
+                            // See that it matches the name specified
+                            WildcardPattern p = WildcardPattern.Get(desiredStream, WildcardOptions.IgnoreCase | WildcardOptions.CultureInvariant);
+                            bool foundStream = false;
+
+                            foreach (AlternateStreamData stream in AlternateDataStreamUtilities.GetStreams(result.FullName))
                             {
-                                // See that it matches the name specified
-                                WildcardPattern p = WildcardPattern.Get(desiredStream, WildcardOptions.IgnoreCase | WildcardOptions.CultureInvariant);
-                                bool foundStream = false;
+                                if (!p.IsMatch(stream.Stream))
+                                { continue; }
 
-                                foreach (AlternateStreamData stream in AlternateDataStreamUtilities.GetStreams(result.FullName))
-                                {
-                                    if (!p.IsMatch(stream.Stream)) { continue; }
+                                string outputPath = result.FullName + ":" + stream.Stream;
+                                // Alternate data streams can never be containers.
+                                WriteItemObject(stream, outputPath, false);
+                                foundStream = true;
+                            }
 
-                                    string outputPath = result.FullName + ":" + stream.Stream;
-                                    WriteItemObject(stream, outputPath, isContainer);
-                                    foundStream = true;
-                                }
+                            if ((!WildcardPattern.ContainsWildcardCharacters(desiredStream)) && (!foundStream))
+                            {
+                                string errorMessage = StringUtil.Format(
+                                    FileSystemProviderStrings.AlternateDataStreamNotFound, desiredStream, result.FullName);
+                                Exception e = new FileNotFoundException(errorMessage, result.FullName);
 
-                                if ((!WildcardPattern.ContainsWildcardCharacters(desiredStream)) && (!foundStream))
-                                {
-                                    string errorMessage = StringUtil.Format(
-                                        FileSystemProviderStrings.AlternateDataStreamNotFound, desiredStream, result.FullName);
-                                    Exception e = new FileNotFoundException(errorMessage, result.FullName);
-
-                                    WriteError(new ErrorRecord(
-                                        e,
-                                        "AlternateDataStreamNotFound",
-                                        ErrorCategory.ObjectNotFound,
-                                        path));
-                                }
+                                WriteError(new ErrorRecord(
+                                    e,
+                                    "AlternateDataStreamNotFound",
+                                    ErrorCategory.ObjectNotFound,
+                                    path));
                             }
                         }
                     }
@@ -6666,7 +6665,14 @@ namespace Microsoft.PowerShell.Commands
 
             try
             {
-                if (Directory.Exists(path))
+                // Get-Content will write a non-terminating error if the target is a directory.
+                // On Windows, the streamName must be null or empty for it to write the error. Otherwise, the
+                // alternate data stream is not a directory, even if it's set on a directory.
+                if (Directory.Exists(path)
+#if !UNIX
+                    && string.IsNullOrEmpty(streamName)
+#endif
+                    )
                 {
                     string errMsg = StringUtil.Format(SessionStateStrings.GetContainerContentException, path);
                     ErrorRecord error = new ErrorRecord(new InvalidOperationException(errMsg), "GetContainerContentException", ErrorCategory.InvalidOperation, null);
@@ -6821,7 +6827,14 @@ namespace Microsoft.PowerShell.Commands
 
             try
             {
-                if (Directory.Exists(path))
+                // Add-Content and Set-Content will write a non-terminating error if the target is a directory.
+                // On Windows, the streamName must be null or empty for it to write the error. Otherwise, the
+                // alternate data stream is not a directory, even if it's set on a directory.
+                if (Directory.Exists(path)
+#if !UNIX
+                    && string.IsNullOrEmpty(streamName)
+#endif
+                    )
                 {
                     string errMsg = StringUtil.Format(SessionStateStrings.WriteContainerContentException, path);
                     ErrorRecord error = new ErrorRecord(new InvalidOperationException(errMsg), "WriteContainerContentException", ErrorCategory.InvalidOperation, null);
@@ -6899,13 +6912,6 @@ namespace Microsoft.PowerShell.Commands
 
             path = NormalizePath(path);
 
-            if (Directory.Exists(path))
-            {
-                string errorMsg = StringUtil.Format(SessionStateStrings.ClearDirectoryContent, path);
-                WriteError(new ErrorRecord(new NotSupportedException(errorMsg), "ClearDirectoryContent", ErrorCategory.InvalidOperation, path));
-                return;
-            }
-
             try
             {
 #if !UNIX
@@ -6957,6 +6963,26 @@ namespace Microsoft.PowerShell.Commands
                     clearStream = false;
                 }
 
+#endif
+                // On Windows, determine if our argument is a directory only after we determine if
+                // we're being asked to work with an alternate data stream, because directories can have
+                // alternate data streams on them that are not child items. These alternate data streams
+                // must be treated as data streams, even if they're attached to directories. However,
+                // if asked to work with a directory without a data stream specified, write a non-terminating
+                // error instead of clearing all child items of the directory.  (On non-Windows, alternate
+                // data streams don't exist, so in that environment always write the error when addressing
+                // a directory.)
+                if (Directory.Exists(path)
+#if !UNIX
+                    && !clearStream
+#endif
+                    )
+                {
+                    string errorMsg = StringUtil.Format(SessionStateStrings.ClearDirectoryContent, path);
+                    WriteError(new ErrorRecord(new NotSupportedException(errorMsg), "ClearDirectoryContent", ErrorCategory.InvalidOperation, path));
+                    return;
+                }
+#if !UNIX
                 if (clearStream)
                 {
                     FileStream fileStream = null;
@@ -8622,7 +8648,21 @@ namespace System.Management.Automation.Internal
             SafeFindHandle handle = NativeMethods.FindFirstStreamW(
                 path, NativeMethods.StreamInfoLevels.FindStreamInfoStandard,
                 findStreamData, 0);
-            if (handle.IsInvalid) throw new Win32Exception();
+            if (handle.IsInvalid)
+            {
+                int error = Marshal.GetLastWin32Error();
+
+                // Directories don't normally have alternate streams, so this is not an exceptional state.
+                // If a directory has no alternate data streams, FindFirstStreamW returns ERROR_HANDLE_EOF.
+                if (error == NativeMethods.ERROR_HANDLE_EOF)
+                {
+                    return alternateStreams;
+                }
+
+                // An unexpected error was returned, that we don't know how to interpret. The most helpful
+                // thing we can do at this point is simply throw the raw Win32 exception.
+                throw new Win32Exception(error);
+            }
 
             try
             {
@@ -8757,6 +8797,7 @@ namespace System.Management.Automation.Internal
         internal static class NativeMethods
         {
             internal const int ERROR_HANDLE_EOF = 38;
+            internal const int ERROR_INVALID_PARAMETER = 87;
 
             internal enum StreamInfoLevels { FindStreamInfoStandard = 0 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Add-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Add-Content.Tests.ps1
@@ -5,6 +5,7 @@ Describe "Add-Content cmdlet tests" -Tags "CI" {
   BeforeAll {
     $file1 = "file1.txt"
     Setup -File "$file1"
+    $streamContent = "ShouldWork"
   }
 
   Context "Add-Content should actually add content" {
@@ -45,6 +46,27 @@ Describe "Add-Content cmdlet tests" -Tags "CI" {
 
     It "Should throw an error on a directory" {
       { Add-Content -Path . -Value "WriteContainerContentException" -ErrorAction Stop } | Should -Throw -ErrorId "WriteContainerContentException,Microsoft.PowerShell.Commands.AddContentCommand"
+    }
+
+    Context "Add-Content should work with alternate data streams on Windows" {
+      BeforeAll {
+        if (!$isWindows) {
+          return
+        }
+        $ADSTestDir = "addcontentadstest"
+        $ADSTestFile = "addcontentads.txt"
+        $streamContent = "This is a test stream."
+        Setup -Directory "$ADSTestDir"
+        Setup -File "$ADSTestFile"
+      }
+      It "Should add an alternate data stream on a directory" -Skip:(!$IsWindows) {
+        Add-Content -Path TestDrive:\$ADSTestDir -Stream Add-Content-Test-Stream -Value $streamContent -ErrorAction Stop        
+        Get-Content -Path TestDrive:\$ADSTestDir -Stream Add-Content-Test-Stream | Should -BeExactly $streamContent
+      }
+      It "Should add an alternate data stream on a file" -Skip:(!$IsWindows) {
+        Add-Content -Path TestDrive:\$ADSTestFile -Stream Add-Content-Test-Stream -Value $streamContent -ErrorAction Stop        
+        Get-Content -Path TestDrive:\$ADSTestFile -Stream Add-Content-Test-Stream | Should -BeExactly $streamContent
+      }
     }
 
     #[BugId(BugDatabase.WindowsOutOfBandReleases, 906022)]

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Add-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Add-Content.Tests.ps1
@@ -59,10 +59,12 @@ Describe "Add-Content cmdlet tests" -Tags "CI" {
         Setup -Directory "$ADSTestDir"
         Setup -File "$ADSTestFile"
       }
+
       It "Should add an alternate data stream on a directory" -Skip:(!$IsWindows) {
         Add-Content -Path TestDrive:\$ADSTestDir -Stream Add-Content-Test-Stream -Value $streamContent -ErrorAction Stop        
         Get-Content -Path TestDrive:\$ADSTestDir -Stream Add-Content-Test-Stream | Should -BeExactly $streamContent
       }
+
       It "Should add an alternate data stream on a file" -Skip:(!$IsWindows) {
         Add-Content -Path TestDrive:\$ADSTestFile -Stream Add-Content-Test-Stream -Value $streamContent -ErrorAction Stop        
         Get-Content -Path TestDrive:\$ADSTestFile -Stream Add-Content-Test-Stream | Should -BeExactly $streamContent

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-Content.Tests.ps1
@@ -51,6 +51,8 @@ Describe "Clear-Content cmdlet tests" -Tags "CI" {
     Setup -File "$file3" -Content $content2
     $streamContent = "content for alternate stream"
     $streamName = "altStream1"
+    $dirName = "clearcontent"
+    Setup -Directory "$dirName"
   }
 
   Context "Clear-Content should actually clear content" {
@@ -75,32 +77,50 @@ Describe "Clear-Content cmdlet tests" -Tags "CI" {
       $cci.SupportsShouldProcess | Should -BeTrue
     }
 
-    It "Alternate streams should be cleared with clear-content" -Skip:(!$IsWindows) {
-      # make sure that the content is correct
-      # this is here rather than BeforeAll because only windows can write to an alternate stream
-      Set-Content -Path "TestDrive:/$file3" -Stream $streamName -Value $streamContent
-      Get-Content -Path "TestDrive:/$file3" | Should -BeExactly $content2
-      Get-Content -Path "TestDrive:/$file3" -Stream $streamName | Should -BeExactly $streamContent
-      Clear-Content -Path "TestDrive:/$file3" -Stream $streamName
-      Get-Content -Path "TestDrive:/$file3" | Should -BeExactly $content2
-      Get-Content -Path "TestDrive:/$file3" -Stream $streamName | Should -BeNullOrEmpty
-    }
+    Context "Clear-Content should work with alternate data streams on Windows" {
+      It "Alternate streams should be cleared with Clear-Content on a file" -Skip:(!$IsWindows) {
 
-    It "the '-Stream' dynamic parameter is visible to get-command in the filesystem" -Skip:(!$IsWindows) {
-      try {
-        Push-Location -Path TestDrive:
-        (Get-Command Clear-Content -Stream foo).parameters.keys -eq "stream" | Should -Be "stream"
-      }
-      finally {
-        Pop-Location
-      }
-    }
+        Set-Content           -Path "TestDrive:/$file3" -Stream $streamName -Value $streamContent
+        Get-Content           -Path "TestDrive:/$file3" -Stream $streamName | Should -BeExactly $streamContent
 
-    It "the '-Stream' dynamic parameter should not be visible to get-command in the function provider" {
-      Push-Location -Path function:
-      { Get-Command Clear-Content -Stream $streamName } |
-        Should -Throw -ErrorId "NamedParameterNotFound,Microsoft.PowerShell.Commands.GetCommandCommand"
-      Pop-Location
+        Clear-Content         -Path "TestDrive:/$file3" -Stream $streamName -ErrorAction Stop
+
+        $result = Get-Item -Path "TestDrive:/$file3" -Stream $streamName
+        $result | Should -BeOfType System.Management.Automation.Internal.AlternateStreamData
+        $result.length | Should -Be 0
+      }
+
+      It "Alternate streams should be cleared with Clear-Content on a directory" -Skip:(!$IsWindows) {
+        Set-Content           -Path "TestDrive:/$dirName" -Stream $streamName -Value $streamContent
+
+        Get-Content           -Path "TestDrive:/$dirName" -Stream $streamName | Should -BeExactly $streamContent
+        Clear-Content         -Path "TestDrive:/$dirName" -Stream $streamName -ErrorAction Stop
+
+        $result = Get-Item -Path "TestDrive:/$dirName" -Stream $streamName
+        $result | Should -BeOfType System.Management.Automation.Internal.AlternateStreamData
+        $result.length | Should -Be 0
+      }
+
+      It "the '-Stream' dynamic parameter is visible to get-command in the filesystem" -Skip:(!$IsWindows) {
+        try {
+          Push-Location -Path TestDrive:
+          (Get-Command Clear-Content -Stream foo).parameters.keys -eq "Stream" | Should -BeExactly "Stream"
+        }
+        finally {
+          Pop-Location
+        }
+      }
+
+      It "the '-Stream' dynamic parameter should not be visible to get-command in the function provider" -Skip:(!$IsWindows) {
+        try {
+        Push-Location -Path function:
+          { Get-Command Clear-Content -Stream $streamName } |
+            Should -Throw -ErrorId "NamedParameterNotFound,Microsoft.PowerShell.Commands.GetCommandCommand"
+        }
+        finally {
+          Pop-Location
+        }
+      }
     }
   }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
@@ -112,15 +112,37 @@ Describe "Get-Item" -Tags "CI" {
                 return
             }
             $altStreamPath = "$TESTDRIVE/altStream.txt"
+            $altStreamDirectory = "$TESTDRIVE/altstreamdir"
+            $noAltStreamDirectory = "$TESTDRIVE/noaltstreamdir"
             $stringData = "test data"
             $streamName = "test"
-            $item = New-Item -type file $altStreamPath
+            $absentStreamName = "noExist"
+            $null = New-Item -type file $altStreamPath
             Set-Content -Path $altStreamPath -Stream $streamName -Value $stringData
+            $null = New-Item -type directory $altStreamDirectory
+            Set-Content -Path $altStreamDirectory -Stream $streamName -Value $stringData
+            $null = New-Item -type directory $noAltStreamDirectory
         }
-        It "Should find an alternate stream if present" -Skip:$skipNotWindows {
+        It "Should find an alternate stream on a file if present" -Skip:$skipNotWindows {
             $result = Get-Item $altStreamPath -Stream $streamName
             $result.Length | Should -Be ($stringData.Length + [Environment]::NewLine.Length)
             $result.Stream | Should -Be $streamName
+        }
+        It "Should error if it cannot find alternate stream on an existing file" -Skip:$skipNotWindows {
+            { Get-Item $altStreamPath -Stream $absentStreamName -ErrorAction Stop } | Should -Throw -ErrorId "AlternateDataStreamNotFound,Microsoft.PowerShell.Commands.GetItemCommand"
+        }
+        It "Should find an alternate stream on a directory if present, and it should not be a container" -Skip:$skipNotWindows {
+            $result = Get-Item $altStreamDirectory -Stream $streamName
+            $result.Length | Should -Be ($stringData.Length + [Environment]::NewLine.Length )
+            $result.Stream | Should -Be $streamName
+            $result.PSIsContainer | Should -BeExactly $false
+        }
+        It "Should not find an alternate stream on a directory if not present" -Skip:$skipNotWindows {
+            { Get-Item $noAltStreamDirectory -Stream $absentStreamName -ErrorAction Stop } | Should -Throw -ErrorId "AlternateDataStreamNotFound,Microsoft.PowerShell.Commands.GetItemCommand"
+        }
+        It "Should find zero alt streams and not fail on a directory with a wildcard stream name if no alt streams are present" -Skip:$skipNotWindows {
+            $result = Get-Item $noAltStreamDirectory -Stream * -ErrorAction Stop
+            $result | Should -BeExactly $null
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Content.Tests.ps1
@@ -72,6 +72,39 @@ Describe "Set-Content cmdlet tests" -Tags "CI" {
             $result[1]     | Should -BeExactly "world"
         }
     }
+    Context "Set-Content should work with alternate data streams on Windows" {
+        BeforeAll {
+            if ( -Not $IsWindows )
+            {
+                return
+            }
+            $altStreamPath = "$TESTDRIVE/altStream.txt"
+            $altStreamPath2 = "$TESTDRIVE/altStream2.txt"
+            $altStreamDirectory = "$TESTDRIVE/altstreamdir"
+            $altStreamDirectory2 = "$TESTDRIVE/altstream2dir"
+            $stringData = "test data"
+            $streamName = "test"
+            $absentStreamName = "noExist"
+            $item = New-Item -type file $altStreamPath
+            $altstreamdiritem = New-Item -type directory $altStreamDirectory
+        }
+        It "Should create a new data stream on a file" -Skip:(-Not $IsWindows) {
+            Set-Content -Path $altStreamPath -Stream $streamName -Value $stringData
+            Get-Content -Path $altStreamPath -Stream $streamName | Should -BeExactly $stringData
+        }
+        It "Should create a new data stream on a file using colon syntax" -Skip:(-Not $IsWindows) {
+            Set-Content -Path ${altStreamPath2}:${streamName} -Value $stringData
+            Get-Content -Path ${altStreamPath2} -Stream $streamName | Should -BeExactly $stringData
+        }
+        It "Should create a new data stream on a directory" -Skip:(-Not $IsWindows) {
+            Set-Content -Path $altStreamDirectory -Stream $streamName -Value $stringData
+            Get-Content -Path $altStreamDirectory -Stream $streamName | Should -BeExactly $stringData
+        }
+        It "Should create a new data stream on a directory using colon syntax" -Skip:(-Not $IsWindows) {
+            Set-Content -Path ${altStreamDirectory2}:${streamName} -Value $stringData
+            Get-Content -Path ${altStreamDirectory2} -Stream ${streamName} | Should -BeExactly $stringData
+        }
+    }
 }
 
 Describe "Set-Content should work for PSDrive with UNC path as root" -Tags @('CI', 'RequireAdminOnWindows') {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->
Take 3, final version.

# PR Summary

This PR allows `Get-Item -Stream`, `Get-Content -Stream`, `Clear-Content -Stream`, `Set-Content -Stream`, `Add-Content -Stream`, and `Remove-Item -Stream` to see and address alternate data streams on directories, not merely on files.

Fixes #10570. Fixes #13656.

Supersedes #13650 (squashes all intermediary commits).
Supersedes #13795 (apparently some pull I did wanted to update the workflow, and my OAUTH token doesn't have workflow scope, and I can't figure out how to fix it)

Addresses addtional comments in #13795 regarding $PSIsContainer should be false on alternate data streams on directories because ADSes cannot contain other items.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

Issue #10570 has been open for a year.  NTFS supports what are called "Alternate Data Streams" on both files and directories (multiple named discrete blobs of data which are associated with a single directory entry).  PowerShell currently supports enumeration of these Alternate Data Streams on files, using the '-Stream' parameter to 'Get-Item'.  It also supports manipulation of these alternate data streams on files, using the '-Stream' parameter to Set-Content, Add-Content, Clear-Content, and Remove-Item.

Unfortunately, the initial implementation of PowerShell only supported alternate data streams on files, not on directories.  This makes an entire facility of the OS's file system invisible, and if an administration team is relying on PowerShell it makes an attractive place for a red team to store data to exfiltrate.  (This is not an invitation to destroy the capability to store alternate data streams on directories, as they are useful for many purposes.  It is merely a rationale for making their existence visible through PowerShell.)

To create and see an alternate data stream on a directory, use cmd.exe to run the following commands:

```
> mkdir 10570demo
> cd 1057demo
> echo "This is a file." > 10570demo.txt
> echo "This is an alternate data stream on the file." > 10570demo.txt:datastream
> mkdir bug10570
> echo "This is an alternate data stream on the directory." > bug10570:datastream
> dir /r
```
The output is something like:
```
D:\10570demo>dir /r
 Volume in drive D is DATA
 Volume Serial Number is 8FD3-BD69

 Directory of D:\10570demo

09/17/2020  02:59 PM    <DIR>          .
09/17/2020  02:59 PM    <DIR>          ..
09/17/2020  02:58 PM                20 10570demo.txt
                                    50 10570demo.txt:datastream:$DATA
09/17/2020  02:59 PM    <DIR>          bug10570
                                    55 bug10570:datastream:$DATA
               1 File(s)             20 bytes
               3 Dir(s)  88,185,401,344 bytes free
```

To see the failure of PowerShell being able to see the stream on the file, but not the directory:
```
> pwsh
PS > Get-Item *


    Directory: D:\10570demo

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
da---           9/17/2020  2:59 PM                bug10570
-a---           9/17/2020  2:58 PM             20 10570demo.txt

PS > Get-Item * -stream *

PSPath        : Microsoft.PowerShell.Core\FileSystem::D:\10570demo\10570demo.txt::$DATA
PSParentPath  : Microsoft.PowerShell.Core\FileSystem::D:\10570demo
PSChildName   : 10570demo.txt::$DATA
PSDrive       : D
PSProvider    : Microsoft.PowerShell.Core\FileSystem
PSIsContainer : False
FileName      : D:\10570demo\10570demo.txt
Stream        : :$DATA
Length        : 20

PSPath        : Microsoft.PowerShell.Core\FileSystem::D:\10570demo\10570demo.txt:datastream
PSParentPath  : Microsoft.PowerShell.Core\FileSystem::D:\10570demo
PSChildName   : 10570demo.txt:datastream
PSDrive       : D
PSProvider    : Microsoft.PowerShell.Core\FileSystem
PSIsContainer : False
FileName      : D:\10570demo\10570demo.txt
Stream        : datastream
Length        : 50

PS > Get-Item bug10570 -stream *
PS >
```

Writing the tests revealed that Set-Content internally calls Clear-Content, which is hardcoded to not check for streams on directories.  This was raised as an issue in Issue #13656, but I decided to put that into this PR as well, because it made it easier to write the tests.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] I'm assuming bucket 3: current behavior of Get-Item -stream when confronted with a directory was to silently do nothing, and this PR continues to do so in the event a directory doesn't have any alternate data streams.  I would like someone to doublecheck, though.
- **User-facing changes**
    - [X] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [X] Issue filed: <!-- Number/link of that issue here --> MicrosoftDocs/Powershell-Docs#6648
- **Testing - New and feature**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
