### PR TITLE
Enable IDE0036: OrderModifiers

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -832,7 +832,7 @@ dotnet_diagnostic.IDE0034.severity = silent
 dotnet_diagnostic.IDE0035.severity = silent
 
 # OrderModifiers
-dotnet_diagnostic.IDE0036.severity = suggestion
+dotnet_diagnostic.IDE0036.severity = warning
 
 # UseInferredMemberName
 dotnet_diagnostic.IDE0037.severity = silent

--- a/src/powershell/Program.cs
+++ b/src/powershell/Program.cs
@@ -502,7 +502,7 @@ namespace Microsoft.PowerShell
             CallingConvention = CallingConvention.Cdecl,
             CharSet = CharSet.Ansi,
             SetLastError = true)]
-        private static unsafe extern int SysCtl(int *mib, int mibLength, void *oldp, int *oldlenp, IntPtr newp, int newlenp);
+        private static extern unsafe int SysCtl(int *mib, int mibLength, void *oldp, int *oldlenp, IntPtr newp, int newlenp);
 #endif
     }
 }


### PR DESCRIPTION
https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0036

Follow-up to #13881, after `EnforceCodeStyleInBuild` was enabled in #13957.