### PR TITLE
Fix IDE0044: MakeFieldReadonly part 15

### DIFF
--- a/src/System.Management.Automation/namespaces/CoreCommandContext.cs
+++ b/src/System.Management.Automation/namespaces/CoreCommandContext.cs
@@ -32,7 +32,7 @@ namespace System.Management.Automation
         [Dbg.TraceSourceAttribute(
              "CmdletProviderContext",
              "The context under which a core command is being run.")]
-        private static Dbg.PSTraceSource s_tracer =
+        private static readonly Dbg.PSTraceSource s_tracer =
             Dbg.PSTraceSource.GetTracer("CmdletProviderContext",
              "The context under which a core command is being run.");
 
@@ -294,12 +294,12 @@ namespace System.Management.Automation
         /// If the constructor that takes a context to copy is
         /// called, this will be set to the context being copied.
         /// </summary>
-        private CmdletProviderContext _copiedContext;
+        private readonly CmdletProviderContext _copiedContext;
 
         /// <summary>
         /// The credentials under which the operation should run.
         /// </summary>
-        private PSCredential _credentials = PSCredential.Empty;
+        private readonly PSCredential _credentials = PSCredential.Empty;
 
         /// <summary>
         /// The force parameter gives guidance to providers on how vigorously they
@@ -312,7 +312,7 @@ namespace System.Management.Automation
         /// made visible to anyone and should only be set through the
         /// constructor.
         /// </summary>
-        private Cmdlet _command;
+        private readonly Cmdlet _command;
 
         /// <summary>
         /// This makes the origin of the provider request visible to the internals.
@@ -327,7 +327,7 @@ namespace System.Management.Automation
         /// If it is false, the objects will be accumulated until the
         /// GetErrorObjects method is called.
         /// </summary>
-        private bool _streamErrors;
+        private readonly bool _streamErrors;
 
         /// <summary>
         /// A collection in which objects that are written using the WriteObject(s)

--- a/src/System.Management.Automation/namespaces/FileSystemContentStream.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemContentStream.cs
@@ -38,33 +38,33 @@ namespace Microsoft.PowerShell.Commands
         [Dbg.TraceSourceAttribute(
             "FileSystemContentStream",
             "The provider content reader and writer for the file system")]
-        private static Dbg.PSTraceSource s_tracer =
+        private static readonly Dbg.PSTraceSource s_tracer =
             Dbg.PSTraceSource.GetTracer("FileSystemContentStream",
             "The provider content reader and writer for the file system");
 
         #endregion tracer
 
-        private string _path;
-        private string _streamName;
-        private FileMode _mode;
-        private FileAccess _access;
-        private FileShare _share;
-        private Encoding _encoding;
-        private CmdletProvider _provider;
+        private readonly string _path;
+        private readonly string _streamName;
+        private readonly FileMode _mode;
+        private readonly FileAccess _access;
+        private readonly FileShare _share;
+        private readonly Encoding _encoding;
+        private readonly CmdletProvider _provider;
 
         private FileStream _stream;
         private StreamReader _reader;
         private StreamWriter _writer;
-        private bool _usingByteEncoding;
+        private readonly bool _usingByteEncoding;
 
         private const char DefaultDelimiter = '\n';
 
-        private string _delimiter = $"{DefaultDelimiter}";
-        private int[] _offsetDictionary;
-        private bool _usingDelimiter;
-        private StringBuilder _currentLineContent;
+        private readonly string _delimiter = $"{DefaultDelimiter}";
+        private readonly int[] _offsetDictionary;
+        private readonly bool _usingDelimiter;
+        private readonly StringBuilder _currentLineContent;
         private bool _waitForChanges;
-        private bool _isRawStream;
+        private readonly bool _isRawStream;
         private long _fileOffset;
 
         private FileAttributes _oldAttributes;
@@ -75,7 +75,7 @@ namespace Microsoft.PowerShell.Commands
         private bool _alreadyDetectEncoding = false;
 
         // False to add a newline to the end of the output string, true if not.
-        private bool _suppressNewline = false;
+        private readonly bool _suppressNewline = false;
 
         /// <summary>
         /// Constructor for the content stream.

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -72,7 +72,7 @@ namespace Microsoft.PowerShell.Commands
         /// using "FileSystemProvider" as the category.
         /// </summary>
         [Dbg.TraceSourceAttribute("FileSystemProvider", "The namespace navigation provider for the file system")]
-        private static Dbg.PSTraceSource s_tracer =
+        private static readonly Dbg.PSTraceSource s_tracer =
             Dbg.PSTraceSource.GetTracer("FileSystemProvider", "The namespace navigation provider for the file system");
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace Microsoft.PowerShell.Commands
 
         private Collection<WildcardPattern> _excludeMatcher = null;
 
-        private static System.IO.EnumerationOptions _enumerationOptions = new System.IO.EnumerationOptions
+        private static readonly System.IO.EnumerationOptions _enumerationOptions = new System.IO.EnumerationOptions
         {
             MatchType = MatchType.Win32,
             MatchCasing = MatchCasing.CaseInsensitive,
@@ -7374,7 +7374,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         private class InodeTracker
         {
-            private HashSet<(UInt64, UInt64)> _visitations;
+            private readonly HashSet<(UInt64, UInt64)> _visitations;
 
             /// <summary>
             /// Construct a new InodeTracker with an initial path.
@@ -7598,7 +7598,7 @@ namespace Microsoft.PowerShell.Commands
             _provider = provider;
         }
 
-        private FileSystemProvider _provider;
+        private readonly FileSystemProvider _provider;
 
         /// <summary>
         /// Gets or sets the encoding method used when
@@ -8830,9 +8830,9 @@ namespace System.Management.Automation.Internal
 
         internal const string PSCopyToSessionHelperName = @"PSCopyToSessionHelper";
 
-        private static string s_driveMaxSizeErrorFormatString = FileSystemProviderStrings.DriveMaxSizeError;
-        private static string s_PSCopyToSessionHelperDefinition = StringUtil.Format(PSCopyToSessionHelperDefinitionFormat, @"[ValidateNotNullOrEmpty()]", s_driveMaxSizeErrorFormatString);
-        private static string s_PSCopyToSessionHelperDefinitionRestricted = StringUtil.Format(PSCopyToSessionHelperDefinitionFormat, @"[ValidateUserDrive()]", s_driveMaxSizeErrorFormatString);
+        private static readonly string s_driveMaxSizeErrorFormatString = FileSystemProviderStrings.DriveMaxSizeError;
+        private static readonly string s_PSCopyToSessionHelperDefinition = StringUtil.Format(PSCopyToSessionHelperDefinitionFormat, @"[ValidateNotNullOrEmpty()]", s_driveMaxSizeErrorFormatString);
+        private static readonly string s_PSCopyToSessionHelperDefinitionRestricted = StringUtil.Format(PSCopyToSessionHelperDefinitionFormat, @"[ValidateUserDrive()]", s_driveMaxSizeErrorFormatString);
 
         private const string PSCopyToSessionHelperDefinitionFormat = @"
         param (
@@ -9281,13 +9281,13 @@ namespace System.Management.Automation.Internal
         }}
         ";
 
-        private static string s_PSCopyToSessionHelper = functionToken + PSCopyToSessionHelperName + @"
+        private static readonly string s_PSCopyToSessionHelper = functionToken + PSCopyToSessionHelperName + @"
         {
         " + s_PSCopyToSessionHelperDefinition + @"
         }
         ";
 
-        private static Hashtable s_PSCopyToSessionHelperFunction = new Hashtable() {
+        private static readonly Hashtable s_PSCopyToSessionHelperFunction = new Hashtable() {
             {nameToken, PSCopyToSessionHelperName},
             {definitionToken, s_PSCopyToSessionHelperDefinitionRestricted}
         };
@@ -9298,8 +9298,8 @@ namespace System.Management.Automation.Internal
 
         internal const string PSCopyFromSessionHelperName = @"PSCopyFromSessionHelper";
 
-        private static string s_PSCopyFromSessionHelperDefinition = StringUtil.Format(PSCopyFromSessionHelperDefinitionFormat, @"[ValidateNotNullOrEmpty()]");
-        private static string s_PSCopyFromSessionHelperDefinitionRestricted = StringUtil.Format(PSCopyFromSessionHelperDefinitionFormat, @"[ValidateUserDrive()]");
+        private static readonly string s_PSCopyFromSessionHelperDefinition = StringUtil.Format(PSCopyFromSessionHelperDefinitionFormat, @"[ValidateNotNullOrEmpty()]");
+        private static readonly string s_PSCopyFromSessionHelperDefinitionRestricted = StringUtil.Format(PSCopyFromSessionHelperDefinitionFormat, @"[ValidateUserDrive()]");
 
         private const string PSCopyFromSessionHelperDefinitionFormat = @"
         param (
@@ -9778,7 +9778,7 @@ namespace System.Management.Automation.Internal
         }
         ";
 
-        private static Hashtable s_PSCopyFromSessionHelperFunction = new Hashtable() {
+        private static readonly Hashtable s_PSCopyFromSessionHelperFunction = new Hashtable() {
             {nameToken, PSCopyFromSessionHelperName},
             {definitionToken, s_PSCopyFromSessionHelperDefinitionRestricted}
         };
@@ -9790,7 +9790,7 @@ namespace System.Management.Automation.Internal
         internal const string PSCopyRemoteUtilsName = @"PSCopyRemoteUtils";
 
         internal static readonly string PSCopyRemoteUtilsDefinition = StringUtil.Format(PSCopyRemoteUtilsDefinitionFormat, @"[ValidateNotNullOrEmpty()]", PSValidatePathFunction);
-        private static string s_PSCopyRemoteUtilsDefinitionRestricted = StringUtil.Format(PSCopyRemoteUtilsDefinitionFormat, @"[ValidateUserDrive()]", PSValidatePathFunction);
+        private static readonly string s_PSCopyRemoteUtilsDefinitionRestricted = StringUtil.Format(PSCopyRemoteUtilsDefinitionFormat, @"[ValidateUserDrive()]", PSValidatePathFunction);
 
         private const string PSCopyRemoteUtilsDefinitionFormat = @"
         param (

--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -25,7 +25,7 @@ namespace System.Management.Automation
         [Dbg.TraceSourceAttribute(
              "LocationGlobber",
              "The location globber converts PowerShell paths with glob characters to zero or more paths.")]
-        private static Dbg.PSTraceSource s_tracer =
+        private static readonly Dbg.PSTraceSource s_tracer =
             Dbg.PSTraceSource.GetTracer("LocationGlobber",
              "The location globber converts PowerShell paths with glob characters to zero or more paths.");
 
@@ -35,7 +35,7 @@ namespace System.Management.Automation
         [Dbg.TraceSourceAttribute(
              "PathResolution",
              "Traces the path resolution algorithm.")]
-        private static Dbg.PSTraceSource s_pathResolutionTracer =
+        private static readonly Dbg.PSTraceSource s_pathResolutionTracer =
             Dbg.PSTraceSource.GetTracer(
                 "PathResolution",
                 "Traces the path resolution algorithm.",
@@ -1654,7 +1654,7 @@ namespace System.Management.Automation
         /// <summary>
         /// The instance of session state on which this globber acts.
         /// </summary>
-        private SessionState _sessionState;
+        private readonly SessionState _sessionState;
 
         /// <summary>
         /// Removes the back tick "`" from any of the glob characters in the path.

--- a/src/System.Management.Automation/namespaces/PathInfo.cs
+++ b/src/System.Management.Automation/namespaces/PathInfo.cs
@@ -76,7 +76,7 @@ namespace System.Management.Automation
         }
 
         private string _providerPath;
-        private SessionState _sessionState;
+        private readonly SessionState _sessionState;
 
         /// <summary>
         /// Gets the MSH path that this object represents.
@@ -89,9 +89,9 @@ namespace System.Management.Automation
             }
         }
 
-        private PSDriveInfo _drive;
-        private ProviderInfo _provider;
-        private string _path = string.Empty;
+        private readonly PSDriveInfo _drive;
+        private readonly ProviderInfo _provider;
+        private readonly string _path = string.Empty;
 
         /// <summary>
         /// Gets a string representing the MSH path.

--- a/src/System.Management.Automation/namespaces/ProviderDeclarationAttribute.cs
+++ b/src/System.Management.Automation/namespaces/ProviderDeclarationAttribute.cs
@@ -52,7 +52,7 @@ namespace System.Management.Automation.Provider
             ProviderCapabilities = providerCapabilities;
         }
 
-        private char[] _illegalCharacters = new char[] { ':', '\\', '[', ']', '?', '*' };
+        private readonly char[] _illegalCharacters = new char[] { ':', '\\', '[', ']', '?', '*' };
 
         /// <summary>
         /// Gets the name of the provider.

--- a/src/System.Management.Automation/namespaces/RegistryProvider.cs
+++ b/src/System.Management.Automation/namespaces/RegistryProvider.cs
@@ -76,7 +76,7 @@ namespace Microsoft.PowerShell.Commands
         [Dbg.TraceSourceAttribute(
             "RegistryProvider",
             "The namespace navigation provider for the Windows Registry")]
-        private static Dbg.PSTraceSource s_tracer =
+        private static readonly Dbg.PSTraceSource s_tracer =
             Dbg.PSTraceSource.GetTracer("RegistryProvider",
             "The namespace navigation provider for the Windows Registry");
 

--- a/src/System.Management.Automation/namespaces/RegistryWrapper.cs
+++ b/src/System.Management.Automation/namespaces/RegistryWrapper.cs
@@ -114,7 +114,7 @@ namespace Microsoft.PowerShell.Commands
 
     internal class RegistryWrapper : IRegistryWrapper
     {
-        private RegistryKey _regKey;
+        private readonly RegistryKey _regKey;
 
         internal RegistryWrapper(RegistryKey regKey)
         {
@@ -246,8 +246,8 @@ namespace Microsoft.PowerShell.Commands
 
     internal class TransactedRegistryWrapper : IRegistryWrapper
     {
-        private TransactedRegistryKey _txRegKey;
-        private CmdletProvider _provider;
+        private readonly TransactedRegistryKey _txRegKey;
+        private readonly CmdletProvider _provider;
 
         internal TransactedRegistryWrapper(TransactedRegistryKey txRegKey, CmdletProvider provider)
         {

--- a/src/System.Management.Automation/namespaces/SessionStateProviderBase.cs
+++ b/src/System.Management.Automation/namespaces/SessionStateProviderBase.cs
@@ -1116,8 +1116,8 @@ namespace Microsoft.PowerShell.Commands
             _provider = provider;
         }
 
-        private string _path;
-        private SessionStateProviderBase _provider;
+        private readonly string _path;
+        private readonly SessionStateProviderBase _provider;
 
         /// <summary>
         /// Reads the content from the item.


### PR DESCRIPTION
https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044

Split from #13880 to ease review.

`src\System.Management.Automation\namespaces\`