### PR TITLE
Fix IDE0044: MakeFieldReadonly part 16

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/BaseCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseCommand.cs
@@ -27,7 +27,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             _command.ThrowTerminatingError(errorRecord);
         }
 
-        private PSCmdlet _command;
+        private readonly PSCmdlet _command;
     }
 
     /// <summary>
@@ -133,7 +133,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         private string _commandName = null;
         private Type _commandType;
-        private List<CommandParameterInternal> _commandParameterList = new List<CommandParameterInternal>();
+        private readonly List<CommandParameterInternal> _commandParameterList = new List<CommandParameterInternal>();
 
         private ExecutionContext _context = null;
     }

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommand.cs
@@ -517,7 +517,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// The formatting shape this formatter emits.
         /// </summary>
-        private FormatShape _shape;
+        private readonly FormatShape _shape;
 
         #region expression factory
 
@@ -537,7 +537,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         private TypeInfoDataBase _typeInfoDataBase = null;
 
         private FormattingCommandLineParameters _parameters = null;
-        private FormatViewManager _viewManager = new FormatViewManager();
+        private readonly FormatViewManager _viewManager = new FormatViewManager();
 
         private int _enumerationLimit = InitialSessionState.DefaultFormatEnumerationLimit;
     }

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommandParameters.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommandParameters.cs
@@ -249,7 +249,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         #endregion
 
-        private bool _noGlobbing;
+        private readonly bool _noGlobbing;
     }
 
     internal class AlignmentEntryDefinition : HashtableEntryDefinition

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -637,7 +637,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// Context manager instance to guide the message traversal.
         /// </summary>
-        private FormatMessagesContextManager _ctxManager = new FormatMessagesContextManager();
+        private readonly FormatMessagesContextManager _ctxManager = new FormatMessagesContextManager();
 
         private FormattedObjectsCache _cache = null;
 
@@ -940,7 +940,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             /// <summary>
             /// Helper class to properly write a table using text output.
             /// </summary>
-            private TableWriter _tableWriter = new TableWriter();
+            private readonly TableWriter _tableWriter = new TableWriter();
         }
 
         private sealed class TableOutputContext : TableOutputContextBase
@@ -951,7 +951,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
             private const int WhitespaceAndPagerLineCount = 2;
 
-            private bool _repeatHeader = false;
+            private readonly bool _repeatHeader = false;
 
             /// <summary>
             /// Construct a context to push on the stack.
@@ -1174,7 +1174,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             /// <summary>
             /// Writer to do the actual formatting.
             /// </summary>
-            private ListWriter _listWriter = new ListWriter();
+            private readonly ListWriter _listWriter = new ListWriter();
         }
 
         private sealed class WideOutputContext : TableOutputContextBase
@@ -1357,7 +1357,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                         _arr[k] = null;
                 }
 
-                private string[] _arr;
+                private readonly string[] _arr;
                 private int _lastEmptySpot;
             }
         }
@@ -1395,7 +1395,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 _writer.WriteObject(cve.formatValueList);
             }
 
-            private ComplexWriter _writer = new ComplexWriter();
+            private readonly ComplexWriter _writer = new ComplexWriter();
         }
     }
 }

--- a/src/System.Management.Automation/FormatAndOutput/common/ColumnWidthManager.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ColumnWidthManager.cs
@@ -201,8 +201,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return columnWidths.Length - 1;
         }
 
-        private int _tableWidth;
-        private int _minimumColumnWidth;
-        private int _separatorWidth;
+        private readonly int _tableWidth;
+        private readonly int _minimumColumnWidth;
+        private readonly int _separatorWidth;
     }
 }

--- a/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
@@ -206,7 +206,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// Helper object to manage the frame-based indentation and margins.
         /// </summary>
-        private IndentationManager _indentationManager = new IndentationManager();
+        private readonly IndentationManager _indentationManager = new IndentationManager();
 
         /// <summary>
         /// Buffer to accumulate partially constructed text.
@@ -243,7 +243,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 }
             }
 
-            private IndentationManager _mgr;
+            private readonly IndentationManager _mgr;
         }
 
         internal void Clear()
@@ -311,7 +311,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return val;
         }
 
-        private Stack<FrameInfo> _frameInfoStack = new Stack<FrameInfo>();
+        private readonly Stack<FrameInfo> _frameInfoStack = new Stack<FrameInfo>();
     }
 
     /// <summary>
@@ -331,7 +331,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         private static readonly char s_softHyphen = '\u00AD';
         private static readonly char s_hardHyphen = '\u2011';
         private static readonly char s_nonBreakingSpace = '\u00A0';
-        private static Collection<string> s_cultureCollection = new Collection<string>();
+        private static readonly Collection<string> s_cultureCollection = new Collection<string>();
 
         static StringManipulationHelper()
         {
@@ -510,10 +510,10 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 }
             }
 
-            private StringCollection _retVal;
+            private readonly StringCollection _retVal;
             private bool _addedFirstLine;
-            private int _firstLineLen;
-            private int _followingLinesLen;
+            private readonly int _firstLineLen;
+            private readonly int _followingLinesLen;
         }
 
         private static StringCollection GenerateLinesWithWordWrap(DisplayCells displayCells, string val, int firstLineLen, int followingLinesLen)

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/FormatTable.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/FormatTable.cs
@@ -25,7 +25,7 @@ namespace System.Management.Automation.Runspaces
     [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", MessageId = "FormatTable")]
     public class FormatTableLoadException : RuntimeException
     {
-        private Collection<string> _errors;
+        private readonly Collection<string> _errors;
 
         #region Constructors
 
@@ -160,7 +160,7 @@ namespace System.Management.Automation.Runspaces
     {
         #region Private Data
 
-        private TypeInfoDataBaseManager _formatDBMgr;
+        private readonly TypeInfoDataBaseManager _formatDBMgr;
 
         #endregion
 

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/XmlLoaderBase.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/XmlLoaderBase.cs
@@ -81,7 +81,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         #region tracer
         // PSS/end-user tracer
         [TraceSource("FormatFileLoading", "Loading format files")]
-        private static PSTraceSource s_formatFileLoadingtracer = PSTraceSource.GetTracer("FormatFileLoading", "Loading format files", false);
+        private static readonly PSTraceSource s_formatFileLoadingtracer = PSTraceSource.GetTracer("FormatFileLoading", "Loading format files", false);
 
         #endregion tracer
         /// <summary>
@@ -149,12 +149,12 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// If true, log entries to memory.
         /// </summary>
-        private bool _saveInMemory = true;
+        private readonly bool _saveInMemory = true;
 
         /// <summary>
         /// List of entries logged if saveInMemory is true.
         /// </summary>
-        private List<XmlLoaderLoggerEntry> _entries = new List<XmlLoaderLoggerEntry>();
+        private readonly List<XmlLoaderLoggerEntry> _entries = new List<XmlLoaderLoggerEntry>();
 
         /// <summary>
         /// True if we ever logged an error.
@@ -170,7 +170,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     {
         #region tracer
         [TraceSource("XmlLoaderBase", "XmlLoaderBase")]
-        private static PSTraceSource s_tracer = PSTraceSource.GetTracer("XmlLoaderBase", "XmlLoaderBase");
+        private static readonly PSTraceSource s_tracer = PSTraceSource.GetTracer("XmlLoaderBase", "XmlLoaderBase");
         #endregion tracer
 
         /// <summary>
@@ -690,7 +690,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             _loadingInfo.isProductCode = isProductCode;
         }
 
-        private DatabaseLoadingInfo _loadingInfo = new DatabaseLoadingInfo();
+        private readonly DatabaseLoadingInfo _loadingInfo = new DatabaseLoadingInfo();
 
         protected DatabaseLoadingInfo LoadingInfo
         {
@@ -711,13 +711,13 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         internal bool VerifyStringResources { get; } = true;
 
-        private int _maxNumberOfErrors = 30;
+        private readonly int _maxNumberOfErrors = 30;
 
         private int _currentErrorCount = 0;
 
-        private bool _logStackActivity = false;
+        private readonly bool _logStackActivity = false;
 
-        private Stack<XmlLoaderStackFrame> _executionStack = new Stack<XmlLoaderStackFrame>();
+        private readonly Stack<XmlLoaderStackFrame> _executionStack = new Stack<XmlLoaderStackFrame>();
 
         private XmlLoaderLogger _logger = new XmlLoaderLogger();
     }

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayResourceManagerCache.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayResourceManagerCache.cs
@@ -216,11 +216,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 return result;
             }
 
-            private Hashtable _assemblyReferences = new Hashtable(StringComparer.OrdinalIgnoreCase);
+            private readonly Hashtable _assemblyReferences = new Hashtable(StringComparer.OrdinalIgnoreCase);
         }
 
-        private AssemblyNameResolver _assemblyNameResolver = new AssemblyNameResolver();
-        private Hashtable _resourceReferenceToAssemblyCache = new Hashtable();
+        private readonly AssemblyNameResolver _assemblyNameResolver = new AssemblyNameResolver();
+        private readonly Hashtable _resourceReferenceToAssemblyCache = new Hashtable();
     }
 }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataManager.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataManager.cs
@@ -33,7 +33,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         internal object updateDatabaseLock = new object();
         // this is used to throw errors when updating a shared TypeTable.
         internal bool isShared;
-        private List<string> _formatFileList;
+        private readonly List<string> _formatFileList;
 
         internal bool DisableFormatTableUpdates { get; set; }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataQuery.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataQuery.cs
@@ -230,10 +230,10 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return retVal;
         }
 
-        private PSPropertyExpressionFactory _expressionFactory;
-        private TypeInfoDataBase _db;
-        private Collection<string> _typeNameHierarchy;
-        private bool _useInheritance;
+        private readonly PSPropertyExpressionFactory _expressionFactory;
+        private readonly TypeInfoDataBase _db;
+        private readonly Collection<string> _typeNameHierarchy;
+        private readonly bool _useInheritance;
 
         private int _bestMatchIndex = BestMatchIndexUndefined;
         private TypeMatchItem _bestMatchItem;

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         #region tracer
         [TraceSource("TypeInfoDataBaseLoader", "TypeInfoDataBaseLoader")]
-        private static PSTraceSource s_tracer = PSTraceSource.GetTracer("TypeInfoDataBaseLoader", "TypeInfoDataBaseLoader");
+        private static readonly PSTraceSource s_tracer = PSTraceSource.GetTracer("TypeInfoDataBaseLoader", "TypeInfoDataBaseLoader");
         #endregion tracer
 
         /// <summary>
@@ -2035,7 +2035,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 return _token;
             }
 
-            private TypeInfoDataBaseLoader _loader;
+            private readonly TypeInfoDataBaseLoader _loader;
             private ExpressionToken _token;
             private bool _fatalError = false;
         }
@@ -2175,7 +2175,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             private TextToken _textToken;
             private ExpressionToken _expression;
 
-            private TypeInfoDataBaseLoader _loader;
+            private readonly TypeInfoDataBaseLoader _loader;
         }
 
         #endregion
@@ -2228,7 +2228,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             }
 
             private ControlBase _control;
-            private TypeInfoDataBaseLoader _loader;
+            private readonly TypeInfoDataBaseLoader _loader;
         }
 
         #endregion

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatMsgCtxManager.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatMsgCtxManager.cs
@@ -135,6 +135,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// Internal stack to manage context.
         /// </summary>
-        private Stack<OutputContext> _stack = new Stack<OutputContext>();
+        private readonly Stack<OutputContext> _stack = new Stack<OutputContext>();
     }
 }

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Complex.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Complex.cs
@@ -383,13 +383,13 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return retVal;
         }
 
-        private TypeInfoDataBase _db;
-        private DatabaseLoadingInfo _loadingInfo;
-        private PSPropertyExpressionFactory _expressionFactory;
-        private List<ControlDefinition> _controlDefinitionList;
-        private FormatErrorManager _errorManager;
-        private TerminatingErrorContext _errorContext;
-        private int _enumerationLimit;
+        private readonly TypeInfoDataBase _db;
+        private readonly DatabaseLoadingInfo _loadingInfo;
+        private readonly PSPropertyExpressionFactory _expressionFactory;
+        private readonly List<ControlDefinition> _controlDefinitionList;
+        private readonly FormatErrorManager _errorManager;
+        private readonly TerminatingErrorContext _errorContext;
+        private readonly int _enumerationLimit;
     }
 
     internal class TraversalInfo
@@ -412,8 +412,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             }
         }
 
-        private int _level;
-        private int _maxDepth;
+        private readonly int _level;
+        private readonly int _maxDepth;
     }
 
     /// <summary>
@@ -771,13 +771,13 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// Indentation added to each level in the recursion.
         /// </summary>
-        private int _indentationStep = 2;
+        private readonly int _indentationStep = 2;
 
-        private FormatErrorManager _errorManager;
+        private readonly FormatErrorManager _errorManager;
 
-        private PSPropertyExpressionFactory _expressionFactory;
+        private readonly PSPropertyExpressionFactory _expressionFactory;
 
-        private int _enumerationLimit;
+        private readonly int _enumerationLimit;
     }
 }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
@@ -70,7 +70,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     {
         #region tracer
         [TraceSource("FormatViewBinding", "Format view binding")]
-        private static PSTraceSource s_formatViewBindingTracer = PSTraceSource.GetTracer("FormatViewBinding", "Format view binding", false);
+        private static readonly PSTraceSource s_formatViewBindingTracer = PSTraceSource.GetTracer("FormatViewBinding", "Format view binding", false);
         #endregion tracer
 
         private static string PSObjectTypeName(PSObject so)
@@ -677,12 +677,12 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return errorRecord;
         }
 
-        private FormatErrorPolicy _formatErrorPolicy;
+        private readonly FormatErrorPolicy _formatErrorPolicy;
 
         /// <summary>
         /// Current list of failed PSPropertyExpression evaluations.
         /// </summary>
-        private List<FormattingError> _formattingErrorList = new List<FormattingError>();
+        private readonly List<FormattingError> _formattingErrorList = new List<FormattingError>();
     }
 }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/ILineOutput.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ILineOutput.cs
@@ -258,17 +258,17 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// Instance of the delegate previously defined
         /// for line that has EXACTLY this.ncols characters.
         /// </summary>
-        private WriteCallback _writeCall = null;
+        private readonly WriteCallback _writeCall = null;
 
         /// <summary>
         /// Instance of the delegate previously defined
         /// for generic line, less that this.ncols characters.
         /// </summary>
-        private WriteCallback _writeLineCall = null;
+        private readonly WriteCallback _writeLineCall = null;
 
         #endregion
 
-        private bool _lineWrap;
+        private readonly bool _lineWrap;
 
         /// <summary>
         /// Construct an instance, given the two callbacks
@@ -367,7 +367,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             }
         }
 
-        private DisplayCells _displayCells;
+        private readonly DisplayCells _displayCells;
     }
 
     /// <summary>
@@ -447,11 +447,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             _suppressNewline = suppressNewline;
         }
 
-        private int _columns = 0;
+        private readonly int _columns = 0;
 
-        private TextWriter _writer = null;
+        private readonly TextWriter _writer = null;
 
-        private bool _suppressNewline = false;
+        private readonly bool _suppressNewline = false;
     }
 
     /// <summary>
@@ -462,7 +462,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     {
         #region tracer
         [TraceSource("StreamingTextWriter", "StreamingTextWriter")]
-        private static PSTraceSource s_tracer = PSTraceSource.GetTracer("StreamingTextWriter", "StreamingTextWriter");
+        private static readonly PSTraceSource s_tracer = PSTraceSource.GetTracer("StreamingTextWriter", "StreamingTextWriter");
         #endregion tracer
 
         /// <summary>
@@ -499,6 +499,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// Instance of the delegate previously defined.
         /// </summary>
-        private WriteLineCallback _writeCall = null;
+        private readonly WriteLineCallback _writeCall = null;
     }
 }

--- a/src/System.Management.Automation/FormatAndOutput/common/OutputManager.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/OutputManager.cs
@@ -135,7 +135,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// Lock object.
         /// </summary>
-        private object _syncRoot = new object();
+        private readonly object _syncRoot = new object();
     }
 
     /// <summary>
@@ -185,7 +185,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             /// <summary>
             /// Ordered list of ETS type names this object is handling.
             /// </summary>
-            private StringCollection _applicableTypes = new StringCollection();
+            private readonly StringCollection _applicableTypes = new StringCollection();
         }
 
         /// <summary>
@@ -322,7 +322,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// List of command entries, each with a set of applicable types.
         /// </summary>
-        private List<CommandEntry> _commandEntryList = new List<CommandEntry>();
+        private readonly List<CommandEntry> _commandEntryList = new List<CommandEntry>();
 
         /// <summary>
         /// Default command entry to be executed when all type matches fail.

--- a/src/System.Management.Automation/FormatAndOutput/common/OutputQueue.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/OutputQueue.cs
@@ -164,28 +164,28 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// Queue to store the currently cached objects.
         /// </summary>
-        private Queue<PacketInfoData> _queue = new Queue<PacketInfoData>();
+        private readonly Queue<PacketInfoData> _queue = new Queue<PacketInfoData>();
 
         /// <summary>
         /// Number of objects to compute the best fit.
         /// Zero: all the objects
         /// a positive number N: use the first N.
         /// </summary>
-        private int _objectCount = 0;
+        private readonly int _objectCount = 0;
 
         /// <summary>
         /// Maximum amount of time for record processing to compute the best fit.
         /// MaxValue: all the objects.
         /// A positive timespan: use all objects that have been processed within the timeframe.
         /// </summary>
-        private TimeSpan _groupingDuration = TimeSpan.MinValue;
+        private readonly TimeSpan _groupingDuration = TimeSpan.MinValue;
         private Stopwatch _groupingTimer = null;
 
         /// <summary>
         /// Notification callback to be called when we have accumulated enough
         /// data to compute a hint.
         /// </summary>
-        private FormattedObjectsCache.ProcessCachedGroupNotification _notificationCallBack = null;
+        private readonly FormattedObjectsCache.ProcessCachedGroupNotification _notificationCallBack = null;
 
         /// <summary>
         /// Reference kept to be used during notification.
@@ -327,7 +327,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// Front end queue (if present, cache ALL, if not, bypass)
         /// </summary>
-        private Queue<PacketInfoData> _frontEndQueue;
+        private readonly Queue<PacketInfoData> _frontEndQueue;
 
         /// <summary>
         /// Back end grouping queue.

--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshParameter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshParameter.cs
@@ -524,7 +524,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         #endregion
 
-        private CommandParameterDefinition _paramDef = null;
+        private readonly CommandParameterDefinition _paramDef = null;
     }
 }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/Mshexpression.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/Mshexpression.cs
@@ -375,7 +375,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         // private members
-        private string _stringValue;
+        private readonly string _stringValue;
         private bool _isResolved = false;
 
         #endregion Private Members

--- a/src/System.Management.Automation/FormatAndOutput/out-console/ConsoleLineOutput.cs
+++ b/src/System.Management.Automation/FormatAndOutput/out-console/ConsoleLineOutput.cs
@@ -143,7 +143,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return GetSplitLengthInternalHelper(str, offset, displayCells, false);
         }
 
-        private PSHostRawUserInterface _rawUserInterface;
+        private readonly PSHostRawUserInterface _rawUserInterface;
     }
 
     /// <summary>
@@ -555,12 +555,12 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             /// <summary>
             /// Prompt string as passed at initialization.
             /// </summary>
-            private string _promptString;
+            private readonly string _promptString;
 
             /// <summary>
             /// The cmdlet that uses this prompt helper.
             /// </summary>
-            private ConsoleLineOutput _callingCmdlet = null;
+            private readonly ConsoleLineOutput _callingCmdlet = null;
         }
 
         /// <summary>
@@ -568,25 +568,25 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// usable width to N-1 (e.g. 80-1) and forcing a call
         /// to WriteLine()
         /// </summary>
-        private bool _forceNewLine = true;
+        private readonly bool _forceNewLine = true;
 
         /// <summary>
         /// Use this if IRawConsole is null;
         /// </summary>
-        private int _fallbackRawConsoleColumnNumber = 80;
+        private readonly int _fallbackRawConsoleColumnNumber = 80;
 
         /// <summary>
         /// Use this if IRawConsole is null;
         /// </summary>
-        private int _fallbackRawConsoleRowNumber = 40;
+        private readonly int _fallbackRawConsoleRowNumber = 40;
 
-        private WriteLineHelper _writeLineHelper;
+        private readonly WriteLineHelper _writeLineHelper;
 
         /// <summary>
         /// Handler to prompt the user for page breaks
         /// if this handler is not null, we have prompting.
         /// </summary>
-        private PromptHandler _prompt = null;
+        private readonly PromptHandler _prompt = null;
 
         /// <summary>
         /// Conter for the # of lines written when prompting is on.
@@ -601,17 +601,17 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// Refecence to the PSHostUserInterface interface we use.
         /// </summary>
-        private PSHostUserInterface _console = null;
+        private readonly PSHostUserInterface _console = null;
 
         /// <summary>
         /// Msh host specific string manipulation helper.
         /// </summary>
-        private DisplayCells _displayCellsPSHost;
+        private readonly DisplayCells _displayCellsPSHost;
 
         /// <summary>
         /// Reference to error context to throw Msh exceptions.
         /// </summary>
-        private TerminatingErrorContext _errorContext = null;
+        private readonly TerminatingErrorContext _errorContext = null;
 
         #endregion
     }


### PR DESCRIPTION
https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044

Split from #13880 to ease review.

`src\System.Management.Automation\FormatAndOutput\`