### PR TITLE
Add `-Raw` Experimental switch to `ConvertTo-Json` cmdlet

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
@@ -78,6 +78,15 @@ namespace Microsoft.PowerShell.Commands
         public StringEscapeHandling EscapeHandling { get; set; } = StringEscapeHandling.Default;
 
         /// <summary>
+        /// Gets or sets the Raw property.
+        /// If the Raw property is set to true, ETS (Extended Type System) members will be
+        /// removed from the InputObject so that only the .NET members will be serialized.
+        /// </summary>
+        [Experimental("Microsoft.PowerShell.Utility.PSConvertToJsonRaw", ExperimentAction.Show)]
+        [Parameter]
+        public SwitchParameter Raw { get; set; }
+
+        /// <summary>
         /// Prerequisite checks.
         /// </summary>
         protected override void BeginProcessing()
@@ -100,7 +109,14 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void ProcessRecord()
         {
-            _inputObjects.Add(InputObject);
+            if (ExperimentalFeature.IsEnabled("Microsoft.PowerShell.Utility.PSConvertToJsonRaw") && Raw && InputObject is PSObject)
+            {
+                _inputObjects.Add(((PSObject)InputObject).BaseObject);
+            }
+            else
+            {
+                _inputObjects.Add(InputObject);
+            }
         }
 
         /// <summary>

--- a/src/Modules/Unix/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
+++ b/src/Modules/Unix/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
@@ -38,6 +38,10 @@ PrivateData = @{
         Name        = 'Microsoft.PowerShell.Utility.PSManageBreakpointsInRunspace'
         Description = 'Enables -BreakAll parameter on Debug-Runspace and Debug-Job cmdlets to allow users to decide if they want PowerShell to break immediately in the current location when they attach a debugger. Enables -Runspace parameter on *-PSBreakpoint cmdlets to support management of breakpoints in another runspace.'
       }
+      @{
+        Name        = 'Microsoft.PowerShell.Utility.PSConvertToJsonRaw'
+        Description = 'Enables -Raw switch on ConvertTo-Json cmdlet to remote ETS members before serialization'
+      }
     )
   }
 }

--- a/src/Modules/Windows/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
+++ b/src/Modules/Windows/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
@@ -37,6 +37,10 @@ PrivateData = @{
         Name        = 'Microsoft.PowerShell.Utility.PSManageBreakpointsInRunspace'
         Description = 'Enables -BreakAll parameter on Debug-Runspace and Debug-Job cmdlets to allow users to decide if they want PowerShell to break immediately in the current location when they attach a debugger. Enables -Runspace parameter on *-PSBreakpoint cmdlets to support management of breakpoints in another runspace.'
       }
+      @{
+        Name        = 'Microsoft.PowerShell.Utility.PSConvertToJsonRaw'
+        Description = 'Enables -Raw switch on ConvertTo-Json cmdlet to remote ETS members before serialization'
+      }
     )
   }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
@@ -103,4 +103,15 @@ Describe 'ConvertTo-Json' -tags "CI" {
             $p2.psobject.Properties.Remove('nullstr')
         }
     }
+
+    It "-Raw works to serialize object with ETS members" -Skip:(!$EnabledExperimentalFeatures.Contains('Microsoft.PowerShell.Utility.PSConvertToJsonRaw')) {
+        $script = {
+            Update-TypeData -TypeName System.String -MemberType ScriptProperty -MemberName Foo -Value { $this.ToUpper() }
+            $a = 'hello world' | Add-Member -NotePropertyName test -NotePropertyValue hello -PassThru
+            $a | ConvertTo-Json -Raw
+        }
+
+        $out = pwsh -noprofile -c $script
+        $out | Should -BeExactly '"hello world"'
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Objects that contain ETS members can cause problems when serializing to JSON.  In the case of script properties on a string, it gets stuck in a recursive loop.

As discussed in https://github.com/PowerShell/PowerShell/issues/5797, proposal is to have an ExperimentalFeature to add a `-Raw` switch that will use the BaseObject of the PSObject (effectively removing ETS members) for serialization.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/5797

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [x] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [x] Experimental feature name(s): Microsoft.PowerShell.Utility.PSConvertToJsonRaw
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/6847
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
