### PR TITLE
Revert changes to ComInterop

### DIFF
--- a/src/System.Management.Automation/engine/ComInterop/.globalconfig
+++ b/src/System.Management.Automation/engine/ComInterop/.globalconfig
@@ -1,0 +1,3 @@
+is_global = true
+
+dotnet_analyzer_diagnostic.severity = none

--- a/src/System.Management.Automation/engine/ComInterop/ComInvokeBinder.cs
+++ b/src/System.Management.Automation/engine/ComInterop/ComInvokeBinder.cs
@@ -23,7 +23,7 @@ namespace System.Management.Automation.ComInterop
         private readonly bool[] _isByRef;
         private readonly Expression _instance;
 
-        private readonly BindingRestrictions _restrictions;
+        private BindingRestrictions _restrictions;
 
         private VarEnumSelector _varEnumSelector;
         private string[] _keywordArgNames;

--- a/src/System.Management.Automation/engine/ComInterop/ExcepInfo.cs
+++ b/src/System.Management.Automation/engine/ComInterop/ExcepInfo.cs
@@ -15,15 +15,15 @@ namespace System.Management.Automation.ComInterop
     [StructLayout(LayoutKind.Sequential)]
     internal struct ExcepInfo
     {
-        private readonly short _wCode;
+        private short _wCode;
         private short _wReserved;
         private IntPtr _bstrSource;
         private IntPtr _bstrDescription;
         private IntPtr _bstrHelpFile;
-        private readonly int _dwHelpContext;
-        private readonly IntPtr _pvReserved;
-        private readonly IntPtr _pfnDeferredFillIn;
-        private readonly int _scode;
+        private int _dwHelpContext;
+        private IntPtr _pvReserved;
+        private IntPtr _pfnDeferredFillIn;
+        private int _scode;
 
 #if DEBUG
         static ExcepInfo()


### PR DESCRIPTION
According to https://github.com/PowerShell/PowerShell/pull/13880#discussion_r519262499 code in `src/System.Management.Automation/engine/ComInterop/` comes from dotnet/runtime and should be frozen.

But in #13967 (part of #13880) we made changes to fix [IDE0044: Add readonly modifier](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044).

So this PR reverts these changes and disables code analyzers in this directory.

