### PR TITLE
Enable SA1006: Preprocessor keywords should not be preceded by space

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -1028,7 +1028,7 @@ dotnet_diagnostic.SA1004.severity = none
 dotnet_diagnostic.SA1005.severity = none
 
 # SA1006: Preprocessor keywords should not be preceded by space
-dotnet_diagnostic.SA1006.severity = none
+dotnet_diagnostic.SA1006.severity = warning
 
 # SA1007: Operator keyword should be followed by space
 dotnet_diagnostic.SA1007.severity = none

--- a/src/Microsoft.WSMan.Management/WSManInstance.cs
+++ b/src/Microsoft.WSMan.Management/WSManInstance.cs
@@ -391,7 +391,7 @@ namespace Microsoft.WSMan.Management
 
         #endregion parameter
 
-        #  region private
+        #region private
         private WSManHelper helper;
 
         private string GetFilter()


### PR DESCRIPTION
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1006.md

Follow-up to #8540.
