### PR TITLE
Revert "Fix nullable usage on authenticode"

### DIFF
--- a/src/System.Management.Automation/security/Authenticode.cs
+++ b/src/System.Management.Automation/security/Authenticode.cs
@@ -292,7 +292,7 @@ namespace System.Management.Automation
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods")]
         private static Signature GetSignatureFromCatalog(string filename)
         {
-            if (Signature.CatalogApiAvailable.HasValue && !Signature.CatalogApiAvailable.GetValueOrDefault())
+            if (Signature.CatalogApiAvailable.HasValue && !Signature.CatalogApiAvailable.Value)
             {
                 // Signature.CatalogApiAvailable would be set to false the first time it is detected that
                 // WTGetSignatureInfo API does not exist on the platform, or if the API is not functional on the target platform.


### PR DESCRIPTION
When the `Nullable<T>.HasValue` check is necesary, we should keep using `Nullable<T>.Value` after the check. Comparing to `Nullable<T>.GetValueOrDefault()`, it's semantically more clear that "I want the current value, not the default value" in this case.

Therefore, revert PR #13804 as agreed in https://github.com/PowerShell/PowerShell/issues/13791#issuecomment-729049790

