### PR TITLE
Revert "Change Nullable usage"

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
@@ -1793,8 +1793,8 @@ namespace Microsoft.PowerShell.Commands
         private void WriteProgress(string statusDescription, int? percentComplete, int? secondsRemaining)
         {
             ProgressRecordType recordType;
-            if (secondsRemaining.HasValue && secondsRemaining.GetValueOrDefault() == 0 &&
-                percentComplete.HasValue && percentComplete.GetValueOrDefault() == 100)
+            if (secondsRemaining.HasValue && secondsRemaining.Value == 0 &&
+                percentComplete.HasValue && percentComplete.Value == 100)
             {
                 recordType = ProgressRecordType.Completed;
             }


### PR DESCRIPTION
When the `Nullable<T>.HasValue` check is necesary, we should keep using `Nullable<T>.Value` after the check. Comparing to `Nullable<T>.GetValueOrDefault()`, it's semantically more clear that "I want the current value, not the default value" in this case.

Therefore, revert PR #13793 as agreed in https://github.com/PowerShell/PowerShell/issues/13791#issuecomment-729049790
