### PR TITLE
Fix SA1642 for Microsoft.PowerShell.Commands.Utility

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConsoleColorCmdlet.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConsoleColorCmdlet.cs
@@ -14,6 +14,7 @@ namespace Microsoft.PowerShell.Commands
     class ConsoleColorCmdlet : PSCmdlet
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="ConsoleColorCmdlet"/> class.
         /// Default ctor.
         /// </summary>
         public ConsoleColorCmdlet()

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConsoleColorCmdlet.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConsoleColorCmdlet.cs
@@ -15,7 +15,6 @@ namespace Microsoft.PowerShell.Commands
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ConsoleColorCmdlet"/> class.
-        /// Default ctor.
         /// </summary>
         public ConsoleColorCmdlet()
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -884,7 +884,6 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ExportCsvHelper"/> class.
-        /// Create ExportCsvHelper instance.
         /// </summary>
         /// <param name="delimiter">Delimiter char.</param>
         /// <param name="quoteKind">Kind of quoting.</param>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -883,6 +883,7 @@ namespace Microsoft.PowerShell.Commands
         private readonly StringBuilder _outputString;
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="ExportCsvHelper"/> class.
         /// Create ExportCsvHelper instance.
         /// </summary>
         /// <param name="delimiter">Delimiter char.</param>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
@@ -38,6 +38,7 @@ namespace System.Management.Automation
         private CustomInternalSerializer _serializer;
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CustomSerialization"/> class.
         /// Constructor.
         /// </summary>
         /// <param name="writer">
@@ -74,6 +75,7 @@ namespace System.Management.Automation
         public static int MshDefaultSerializationDepth { get; } = 1;
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CustomSerialization"/> class.
         /// Constructor.
         /// </summary>
         /// <param name="writer">
@@ -208,6 +210,7 @@ namespace System.Management.Automation
         private bool _firstobjectcall = true;
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CustomInternalSerializer"/> class.
         /// Constructor.
         /// </summary>
         /// <param name="writer">

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
@@ -39,7 +39,6 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CustomSerialization"/> class.
-        /// Constructor.
         /// </summary>
         /// <param name="writer">
         /// writer to be used for serialization.
@@ -76,7 +75,6 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CustomSerialization"/> class.
-        /// Constructor.
         /// </summary>
         /// <param name="writer">
         /// writer to be used for serialization.
@@ -211,7 +209,6 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CustomInternalSerializer"/> class.
-        /// Constructor.
         /// </summary>
         /// <param name="writer">
         /// Xml writer to be used.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/EnableDisableRunspaceDebugCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/EnableDisableRunspaceDebugCommand.cs
@@ -51,6 +51,7 @@ namespace Microsoft.PowerShell.Commands
         #region Constructors
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="PSRunspaceDebug"/> class.
         /// Constructor.
         /// </summary>
         /// <param name="enabled">Enable debugger option.</param>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/EnableDisableRunspaceDebugCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/EnableDisableRunspaceDebugCommand.cs
@@ -52,7 +52,6 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PSRunspaceDebug"/> class.
-        /// Constructor.
         /// </summary>
         /// <param name="enabled">Enable debugger option.</param>
         /// <param name="breakAll">BreakAll option.</param>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutGridViewCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutGridViewCommand.cs
@@ -55,7 +55,6 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OutGridViewCommand"/> class.
-        /// Constructor for OutGridView.
         /// </summary>
         public OutGridViewCommand()
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutGridViewCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutGridViewCommand.cs
@@ -54,6 +54,7 @@ namespace Microsoft.PowerShell.Commands
         #region Constructors
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="OutGridViewCommand"/> class.
         /// Constructor for OutGridView.
         /// </summary>
         public OutGridViewCommand()

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutWindowProxy.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutWindowProxy.cs
@@ -39,7 +39,7 @@ namespace Microsoft.PowerShell.Commands
         private readonly GraphicalHostReflectionWrapper _graphicalHostReflectionWrapper;
 
         /// <summary>
-        /// Initializes a new instance of the OutWindowProxy class.
+        /// Initializes a new instance of the <see cref="OutWindowProxy"/> class.
         /// </summary>
         internal OutWindowProxy(string title, OutputModeOption outPutMode, OutGridViewCommand parentCmdlet)
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-list/Format-List.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-list/Format-List.cs
@@ -14,8 +14,8 @@ namespace Microsoft.PowerShell.Commands
     public class FormatListCommand : OuterFormatTableAndListBase
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="FormatListCommand"/> class.
-        /// Constructor to set the inner command.
+        /// Initializes a new instance of the <see cref="FormatListCommand"/> class
+        /// and sets the inner command.
         /// </summary>
         public FormatListCommand()
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-list/Format-List.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-list/Format-List.cs
@@ -14,6 +14,7 @@ namespace Microsoft.PowerShell.Commands
     public class FormatListCommand : OuterFormatTableAndListBase
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="FormatListCommand"/> class.
         /// Constructor to set the inner command.
         /// </summary>
         public FormatListCommand()

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-object/Format-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-object/Format-Object.cs
@@ -14,6 +14,7 @@ namespace Microsoft.PowerShell.Commands
     public class FormatCustomCommand : OuterFormatShapeCommandBase
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="FormatCustomCommand"/> class.
         /// Constructor to se the inner command.
         /// </summary>
         public FormatCustomCommand()

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-object/Format-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-object/Format-Object.cs
@@ -14,8 +14,8 @@ namespace Microsoft.PowerShell.Commands
     public class FormatCustomCommand : OuterFormatShapeCommandBase
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="FormatCustomCommand"/> class.
-        /// Constructor to se the inner command.
+        /// Initializes a new instance of the <see cref="FormatCustomCommand"/> class
+        /// and sets the inner command.
         /// </summary>
         public FormatCustomCommand()
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-table/Format-Table.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-table/Format-Table.cs
@@ -14,8 +14,8 @@ namespace Microsoft.PowerShell.Commands
     public class FormatTableCommand : OuterFormatTableBase
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="FormatTableCommand"/> class.
-        /// Constructor to set the inner command.
+        /// Initializes a new instance of the <see cref="FormatTableCommand"/> class
+        /// and sets the inner command.
         /// </summary>
         public FormatTableCommand()
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-table/Format-Table.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-table/Format-Table.cs
@@ -14,6 +14,7 @@ namespace Microsoft.PowerShell.Commands
     public class FormatTableCommand : OuterFormatTableBase
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="FormatTableCommand"/> class.
         /// Constructor to set the inner command.
         /// </summary>
         public FormatTableCommand()

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-wide/Format-Wide.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-wide/Format-Wide.cs
@@ -16,6 +16,7 @@ namespace Microsoft.PowerShell.Commands
     public class FormatWideCommand : OuterFormatShapeCommandBase
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="FormatWideCommand"/> class.
         /// Constructor to se the inner command.
         /// </summary>
         public FormatWideCommand()

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-wide/Format-Wide.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-wide/Format-Wide.cs
@@ -16,8 +16,8 @@ namespace Microsoft.PowerShell.Commands
     public class FormatWideCommand : OuterFormatShapeCommandBase
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="FormatWideCommand"/> class.
-        /// Constructor to se the inner command.
+        /// Initializes a new instance of the <see cref="FormatWideCommand"/> class
+        /// and sets the inner command.
         /// </summary>
         public FormatWideCommand()
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-file/Out-File.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-file/Out-File.cs
@@ -25,8 +25,8 @@ namespace Microsoft.PowerShell.Commands
     public class OutFileCommand : FrontEndCommandBase
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="OutFileCommand"/> class.
-        /// Set inner command.
+        /// Initializes a new instance of the <see cref="OutFileCommand"/> class
+        /// and sets the inner command.
         /// </summary>
         public OutFileCommand()
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-file/Out-File.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-file/Out-File.cs
@@ -25,6 +25,7 @@ namespace Microsoft.PowerShell.Commands
     public class OutFileCommand : FrontEndCommandBase
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="OutFileCommand"/> class.
         /// Set inner command.
         /// </summary>
         public OutFileCommand()

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-printer/Out-Printer.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-printer/Out-Printer.cs
@@ -14,6 +14,7 @@ namespace Microsoft.PowerShell.Commands
     public class OutPrinterCommand : FrontEndCommandBase
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="OutPrinterCommand"/> class.
         /// Set inner command.
         /// </summary>
         public OutPrinterCommand()

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-printer/Out-Printer.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-printer/Out-Printer.cs
@@ -14,8 +14,8 @@ namespace Microsoft.PowerShell.Commands
     public class OutPrinterCommand : FrontEndCommandBase
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="OutPrinterCommand"/> class.
-        /// Set inner command.
+        /// Initializes a new instance of the <see cref="OutPrinterCommand"/> class
+        /// and sets the inner command.
         /// </summary>
         public OutPrinterCommand()
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-printer/PrinterLineOutput.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-printer/PrinterLineOutput.cs
@@ -70,6 +70,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         #endregion
 
         /// <summary>
+        /// Initializes static members of the <see cref="PrinterLineOutput"/> class.
         /// Used for static initializations like DefaultPrintFontName.
         /// </summary>
         static PrinterLineOutput()
@@ -81,6 +82,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="PrinterLineOutput"/> class.
         /// Constructor for the class.
         /// </summary>
         /// <param name="printerName">Name of printer, if null use default printer.</param>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-printer/PrinterLineOutput.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-printer/PrinterLineOutput.cs
@@ -83,7 +83,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PrinterLineOutput"/> class.
-        /// Constructor for the class.
         /// </summary>
         /// <param name="printerName">Name of printer, if null use default printer.</param>
         internal PrinterLineOutput(string printerName)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-string/Out-String.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-string/Out-String.cs
@@ -61,8 +61,8 @@ namespace Microsoft.PowerShell.Commands
         #endregion
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="OutStringCommand"/> class.
-        /// Set inner command.
+        /// Initializes a new instance of the <see cref="OutStringCommand"/> class
+        /// and sets the inner command.
         /// </summary>
         public OutStringCommand()
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-string/Out-String.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-string/Out-String.cs
@@ -61,6 +61,7 @@ namespace Microsoft.PowerShell.Commands
         #endregion
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="OutStringCommand"/> class.
         /// Set inner command.
         /// </summary>
         public OutStringCommand()

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetMember.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetMember.cs
@@ -23,7 +23,6 @@ namespace Microsoft.PowerShell.Commands
         }
         /// <summary>
         /// Initializes a new instance of the <see cref="MemberDefinition"/> class.
-        /// Initializes a new instance of this class.
         /// </summary>
         public MemberDefinition(string typeName, string name, PSMemberTypes memberType, string definition)
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetMember.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetMember.cs
@@ -22,6 +22,7 @@ namespace Microsoft.PowerShell.Commands
             return Definition;
         }
         /// <summary>
+        /// Initializes a new instance of the <see cref="MemberDefinition"/> class.
         /// Initializes a new instance of this class.
         /// </summary>
         public MemberDefinition(string typeName, string name, PSMemberTypes memberType, string definition)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommand.cs
@@ -584,7 +584,6 @@ namespace Microsoft.PowerShell.Commands
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicRandomNumberGenerator"/> class.
-        /// Constructor.
         /// </summary>
         public PolymorphicRandomNumberGenerator()
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommand.cs
@@ -583,6 +583,7 @@ namespace Microsoft.PowerShell.Commands
     internal class PolymorphicRandomNumberGenerator
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="PolymorphicRandomNumberGenerator"/> class.
         /// Constructor.
         /// </summary>
         public PolymorphicRandomNumberGenerator()

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
@@ -28,7 +28,6 @@ namespace Microsoft.PowerShell.Commands
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GenericMeasureInfo"/> class.
-        /// Default ctor.
         /// </summary>
         public GenericMeasureInfo()
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
@@ -27,6 +27,7 @@ namespace Microsoft.PowerShell.Commands
     public sealed class GenericMeasureInfo : MeasureInfo
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="GenericMeasureInfo"/> class.
         /// Default ctor.
         /// </summary>
         public GenericMeasureInfo()
@@ -77,6 +78,7 @@ namespace Microsoft.PowerShell.Commands
     public sealed class GenericObjectMeasureInfo : MeasureInfo
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="GenericObjectMeasureInfo"/> class.
         /// Default ctor.
         /// </summary>
         public GenericObjectMeasureInfo()
@@ -122,6 +124,7 @@ namespace Microsoft.PowerShell.Commands
     public sealed class TextMeasureInfo : MeasureInfo
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="TextMeasureInfo"/> class.
         /// Default ctor.
         /// </summary>
         public TextMeasureInfo()
@@ -162,6 +165,7 @@ namespace Microsoft.PowerShell.Commands
             where V : new()
         {
             /// <summary>
+            /// Initializes a new instance of the <see cref="MeasureObjectDictionary{V}"/> class.
             /// Default ctor.
             /// </summary>
             internal MeasureObjectDictionary() : base(StringComparer.OrdinalIgnoreCase)
@@ -216,6 +220,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="MeasureObjectCommand"/> class.
         /// Default constructor.
         /// </summary>
         public MeasureObjectCommand()

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ObjectCommandComparer.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ObjectCommandComparer.cs
@@ -30,6 +30,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="ObjectCommandPropertyValue"/> class.
         /// ObjectCommandPropertyValue constructor.
         /// </summary>
         /// <param name="propVal">Property Value.</param>
@@ -139,6 +140,7 @@ namespace Microsoft.PowerShell.Commands
     internal class ObjectCommandComparer : IComparer
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="ObjectCommandComparer"/> class.
         /// Constructor that doesn't set any private field.
         /// Necessary because compareTo can compare two objects by calling
         /// ((ICompare)obj1).CompareTo(obj2) without using a key.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ObjectCommandComparer.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ObjectCommandComparer.cs
@@ -31,7 +31,6 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectCommandPropertyValue"/> class.
-        /// ObjectCommandPropertyValue constructor.
         /// </summary>
         /// <param name="propVal">Property Value.</param>
         /// <param name="isCaseSensitive">Indicates if the Property value comparison has to be case sensitive or not.</param>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/OrderObjectBase.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/OrderObjectBase.cs
@@ -479,7 +479,6 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OrderByProperty"/> class.
-        /// OrderByProperty constructor.
         /// </summary>
         internal OrderByProperty()
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/OrderObjectBase.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/OrderObjectBase.cs
@@ -478,6 +478,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="OrderByProperty"/> class.
         /// OrderByProperty constructor.
         /// </summary>
         internal OrderByProperty()

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ReadConsoleCmdlet.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ReadConsoleCmdlet.cs
@@ -20,6 +20,7 @@ namespace Microsoft.PowerShell.Commands
     public sealed class ReadHostCommand : PSCmdlet
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="ReadHostCommand"/> class.
         /// Constructs a new instance.
         /// </summary>
         public

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ReadConsoleCmdlet.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ReadConsoleCmdlet.cs
@@ -21,7 +21,6 @@ namespace Microsoft.PowerShell.Commands
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ReadHostCommand"/> class.
-        /// Constructs a new instance.
         /// </summary>
         public
         ReadHostCommand()

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -18,6 +18,7 @@ namespace Microsoft.PowerShell.Commands
     internal sealed class PSPropertyExpressionFilter
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="PSPropertyExpressionFilter"/> class.
         /// Construct the class, using an array of patterns.
         /// </summary>
         /// <param name="wildcardPatternsStrings">Array of pattern strings to use.</param>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -18,8 +18,8 @@ namespace Microsoft.PowerShell.Commands
     internal sealed class PSPropertyExpressionFilter
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="PSPropertyExpressionFilter"/> class.
-        /// Construct the class, using an array of patterns.
+        /// Initializes a new instance of the <see cref="PSPropertyExpressionFilter"/> class
+        /// with the specified array of patterns.
         /// </summary>
         /// <param name="wildcardPatternsStrings">Array of pattern strings to use.</param>
         internal PSPropertyExpressionFilter(string[] wildcardPatternsStrings)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandCommandInfo.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandCommandInfo.cs
@@ -14,6 +14,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
     public class ShowCommandCommandInfo
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="ShowCommandCommandInfo"/> class.
         /// Creates an instance of the ShowCommandCommandInfo class based on a CommandInfo object.
         /// </summary>
         /// <param name="other">
@@ -62,6 +63,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="ShowCommandCommandInfo"/> class.
         /// Creates an instance of the ShowCommandCommandInfo class based on a PSObject object.
         /// </summary>
         /// <param name="other">

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandCommandInfo.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandCommandInfo.cs
@@ -14,8 +14,8 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
     public class ShowCommandCommandInfo
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ShowCommandCommandInfo"/> class.
-        /// Creates an instance of the ShowCommandCommandInfo class based on a CommandInfo object.
+        /// Initializes a new instance of the <see cref="ShowCommandCommandInfo"/> class
+        /// with the specified <see cref="CommandInfo"/>.
         /// </summary>
         /// <param name="other">
         /// The object to wrap.
@@ -63,8 +63,8 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ShowCommandCommandInfo"/> class.
-        /// Creates an instance of the ShowCommandCommandInfo class based on a PSObject object.
+        /// Initializes a new instance of the <see cref="ShowCommandCommandInfo"/> class
+        /// with the specified <see cref="PSObject"/>.
         /// </summary>
         /// <param name="other">
         /// The object to wrap.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandModuleInfo.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandModuleInfo.cs
@@ -12,6 +12,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
     public class ShowCommandModuleInfo
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="ShowCommandModuleInfo"/> class.
         /// Creates an instance of the ShowCommandModuleInfo class based on a CommandInfo object.
         /// </summary>
         /// <param name="other">
@@ -28,6 +29,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="ShowCommandModuleInfo"/> class.
         /// Creates an instance of the ShowCommandModuleInfo class based on a PSObject object.
         /// </summary>
         /// <param name="other">

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandModuleInfo.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandModuleInfo.cs
@@ -12,8 +12,8 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
     public class ShowCommandModuleInfo
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ShowCommandModuleInfo"/> class.
-        /// Creates an instance of the ShowCommandModuleInfo class based on a CommandInfo object.
+        /// Initializes a new instance of the <see cref="ShowCommandModuleInfo"/> class
+        /// with the specified <see cref="CommandInfo"/>.
         /// </summary>
         /// <param name="other">
         /// The object to wrap.
@@ -29,8 +29,8 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ShowCommandModuleInfo"/> class.
-        /// Creates an instance of the ShowCommandModuleInfo class based on a PSObject object.
+        /// Initializes a new instance of the <see cref="ShowCommandModuleInfo"/> class
+        /// with the specified <see cref="PSObject"/>.
         /// </summary>
         /// <param name="other">
         /// The object to wrap.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandParameterInfo.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandParameterInfo.cs
@@ -14,8 +14,8 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
     public class ShowCommandParameterInfo
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ShowCommandParameterInfo"/> class.
-        /// Creates an instance of the ShowCommandParameterInfo class based on a CommandParameterInfo object.
+        /// Initializes a new instance of the <see cref="ShowCommandParameterInfo"/> class
+        /// with the specified <see cref="CommandParameterInfo"/>.
         /// </summary>
         /// <param name="other">
         /// The object to wrap.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandParameterInfo.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandParameterInfo.cs
@@ -14,6 +14,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
     public class ShowCommandParameterInfo
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="ShowCommandParameterInfo"/> class.
         /// Creates an instance of the ShowCommandParameterInfo class based on a CommandParameterInfo object.
         /// </summary>
         /// <param name="other">
@@ -41,6 +42,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="ShowCommandParameterInfo"/> class.
         /// Creates an instance of the ShowCommandParameterInfo class based on a PSObject object.
         /// </summary>
         /// <param name="other">

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandParameterSetInfo.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandParameterSetInfo.cs
@@ -14,6 +14,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
     public class ShowCommandParameterSetInfo
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="ShowCommandParameterSetInfo"/> class.
         /// Creates an instance of the ShowCommandParameterSetInfo class based on a CommandParameterSetInfo object.
         /// </summary>
         /// <param name="other">
@@ -32,6 +33,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="ShowCommandParameterSetInfo"/> class.
         /// Creates an instance of the ShowCommandParameterSetInfo class based on a PSObject object.
         /// </summary>
         /// <param name="other">

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandParameterSetInfo.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandParameterSetInfo.cs
@@ -14,8 +14,8 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
     public class ShowCommandParameterSetInfo
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ShowCommandParameterSetInfo"/> class.
-        /// Creates an instance of the ShowCommandParameterSetInfo class based on a CommandParameterSetInfo object.
+        /// Initializes a new instance of the <see cref="ShowCommandParameterSetInfo"/> class
+        /// with the specified <see cref="CommandParameterSetInfo"/>.
         /// </summary>
         /// <param name="other">
         /// The object to wrap.
@@ -33,8 +33,8 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ShowCommandParameterSetInfo"/> class.
-        /// Creates an instance of the ShowCommandParameterSetInfo class based on a PSObject object.
+        /// Initializes a new instance of the <see cref="ShowCommandParameterSetInfo"/> class
+        /// with the specified <see cref="PSObject"/>.
         /// </summary>
         /// <param name="other">
         /// The object to wrap.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandParameterType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandParameterType.cs
@@ -13,6 +13,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
     public class ShowCommandParameterType
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="ShowCommandParameterType"/> class.
         /// Creates an instance of the ShowCommandParameterType class based on a Type object.
         /// </summary>
         /// <param name="other">
@@ -42,6 +43,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="ShowCommandParameterType"/> class.
         /// Creates an instance of the ShowCommandParameterType class based on a Type object.
         /// </summary>
         /// <param name="other">

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandParameterType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandParameterType.cs
@@ -13,8 +13,8 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
     public class ShowCommandParameterType
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ShowCommandParameterType"/> class.
-        /// Creates an instance of the ShowCommandParameterType class based on a Type object.
+        /// Initializes a new instance of the <see cref="ShowCommandParameterType"/> class
+        /// with the specified <see cref="Type"/>.
         /// </summary>
         /// <param name="other">
         /// The object to wrap.
@@ -43,8 +43,8 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ShowCommandParameterType"/> class.
-        /// Creates an instance of the ShowCommandParameterType class based on a Type object.
+        /// Initializes a new instance of the <see cref="ShowCommandParameterType"/> class
+        /// with the specified <see cref="Type"/>.
         /// </summary>
         /// <param name="other">
         /// The object to wrap.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/BasicHtmlWebResponseObject.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/BasicHtmlWebResponseObject.Common.cs
@@ -31,7 +31,6 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BasicHtmlWebResponseObject"/> class.
-        /// Constructor for BasicHtmlWebResponseObject.
         /// </summary>
         /// <param name="response"></param>
         public BasicHtmlWebResponseObject(HttpResponseMessage response)
@@ -39,8 +38,8 @@ namespace Microsoft.PowerShell.Commands
         { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="BasicHtmlWebResponseObject"/> class.
-        /// Constructor for HtmlWebResponseObject with memory stream.
+        /// Initializes a new instance of the <see cref="BasicHtmlWebResponseObject"/> class
+        /// with the specified <paramref name="contentStream"/>.
         /// </summary>
         /// <param name="response"></param>
         /// <param name="contentStream"></param>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/BasicHtmlWebResponseObject.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/BasicHtmlWebResponseObject.Common.cs
@@ -30,6 +30,7 @@ namespace Microsoft.PowerShell.Commands
         #region Constructors
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="BasicHtmlWebResponseObject"/> class.
         /// Constructor for BasicHtmlWebResponseObject.
         /// </summary>
         /// <param name="response"></param>
@@ -38,6 +39,7 @@ namespace Microsoft.PowerShell.Commands
         { }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="BasicHtmlWebResponseObject"/> class.
         /// Constructor for HtmlWebResponseObject with memory stream.
         /// </summary>
         /// <param name="response"></param>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -863,6 +863,7 @@ namespace Microsoft.PowerShell.Commands
     public sealed class HttpResponseException : HttpRequestException
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="HttpResponseException"/> class.
         /// Constructor for HttpResponseException.
         /// </summary>
         /// <param name="message">Message for the exception.</param>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -864,7 +864,6 @@ namespace Microsoft.PowerShell.Commands
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="HttpResponseException"/> class.
-        /// Constructor for HttpResponseException.
         /// </summary>
         /// <param name="message">Message for the exception.</param>
         /// <param name="response">Response from the HTTP server.</param>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebResponseObject.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebResponseObject.Common.cs
@@ -144,6 +144,7 @@ namespace Microsoft.PowerShell.Commands
         #region Constructors
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="WebResponseObject"/> class.
         /// Constructor for WebResponseObject.
         /// </summary>
         /// <param name="response"></param>
@@ -152,6 +153,7 @@ namespace Microsoft.PowerShell.Commands
         { }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="WebResponseObject"/> class.
         /// Constructor for WebResponseObject with contentStream.
         /// </summary>
         /// <param name="response"></param>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebResponseObject.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebResponseObject.Common.cs
@@ -145,7 +145,6 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WebResponseObject"/> class.
-        /// Constructor for WebResponseObject.
         /// </summary>
         /// <param name="response"></param>
         public WebResponseObject(HttpResponseMessage response)
@@ -153,8 +152,8 @@ namespace Microsoft.PowerShell.Commands
         { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="WebResponseObject"/> class.
-        /// Constructor for WebResponseObject with contentStream.
+        /// Initializes a new instance of the <see cref="WebResponseObject"/> class
+        /// with the specified <paramref name="contentStream"/>.
         /// </summary>
         /// <param name="response"></param>
         /// <param name="contentStream"></param>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeWebRequestCommand.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeWebRequestCommand.CoreClr.cs
@@ -19,7 +19,6 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InvokeWebRequestCommand"/> class.
-        /// Default constructor for InvokeWebRequestCommand.
         /// </summary>
         public InvokeWebRequestCommand() : base()
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeWebRequestCommand.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeWebRequestCommand.CoreClr.cs
@@ -18,6 +18,7 @@ namespace Microsoft.PowerShell.Commands
         #region Virtual Method Overrides
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="InvokeWebRequestCommand"/> class.
         /// Default constructor for InvokeWebRequestCommand.
         /// </summary>
         public InvokeWebRequestCommand() : base()

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/FormObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/FormObject.cs
@@ -31,6 +31,7 @@ namespace Microsoft.PowerShell.Commands
         public Dictionary<string, string> Fields { get; }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="FormObject"/> class.
         /// Constructor for FormObject.
         /// </summary>
         /// <param name="id"></param>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/FormObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/FormObject.cs
@@ -32,7 +32,6 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FormObject"/> class.
-        /// Constructor for FormObject.
         /// </summary>
         /// <param name="id"></param>
         /// <param name="method"></param>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -32,6 +32,7 @@ namespace Microsoft.PowerShell.Commands
 
         #region Constructors
         /// <summary>
+        /// Initializes a new instance of the <see cref="WebResponseContentMemoryStream"/> class.
         /// </summary>
         /// <param name="stream"></param>
         /// <param name="initialCapacity"></param>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/WebRequestSession.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/WebRequestSession.cs
@@ -75,6 +75,7 @@ namespace Microsoft.PowerShell.Commands
         public int RetryIntervalInSeconds { get; set; }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="WebRequestSession"/> class.
         /// Construct a new instance of a WebRequestSession object.
         /// </summary>
         public WebRequestSession()

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/WebRequestSession.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/WebRequestSession.cs
@@ -76,7 +76,6 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WebRequestSession"/> class.
-        /// Construct a new instance of a WebRequestSession object.
         /// </summary>
         public WebRequestSession()
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Write.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Write.cs
@@ -393,6 +393,7 @@ namespace Microsoft.PowerShell.Commands
     public sealed class WriteErrorCommand : WriteOrThrowErrorCommand
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="WriteErrorCommand"/> class.
         /// Constructor.
         /// </summary>
         public WriteErrorCommand()
@@ -433,6 +434,7 @@ namespace Microsoft.PowerShell.Commands
     {
         #region ctor
         /// <summary>
+        /// Initializes a new instance of the <see cref="WriteErrorException"/> class.
         /// Constructor for class WriteErrorException.
         /// </summary>
         /// <returns>Constructed object.</returns>
@@ -442,6 +444,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="WriteErrorException"/> class.
         /// Constructor for class WriteErrorException.
         /// </summary>
         /// <param name="message"></param>
@@ -452,6 +455,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="WriteErrorException"/> class.
         /// Constructor for class WriteErrorException.
         /// </summary>
         /// <param name="message"></param>
@@ -466,6 +470,7 @@ namespace Microsoft.PowerShell.Commands
 
         #region Serialization
         /// <summary>
+        /// Initializes a new instance of the <see cref="WriteErrorException"/> class.
         /// Serialization constructor for class WriteErrorException.
         /// </summary>
         /// <param name="info">Serialization information.</param>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Write.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Write.cs
@@ -394,7 +394,6 @@ namespace Microsoft.PowerShell.Commands
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="WriteErrorCommand"/> class.
-        /// Constructor.
         /// </summary>
         public WriteErrorCommand()
         {
@@ -435,7 +434,6 @@ namespace Microsoft.PowerShell.Commands
         #region ctor
         /// <summary>
         /// Initializes a new instance of the <see cref="WriteErrorException"/> class.
-        /// Constructor for class WriteErrorException.
         /// </summary>
         /// <returns>Constructed object.</returns>
         public WriteErrorException()
@@ -445,7 +443,6 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WriteErrorException"/> class.
-        /// Constructor for class WriteErrorException.
         /// </summary>
         /// <param name="message"></param>
         /// <returns>Constructed object.</returns>
@@ -456,7 +453,6 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WriteErrorException"/> class.
-        /// Constructor for class WriteErrorException.
         /// </summary>
         /// <param name="message"></param>
         /// <param name="innerException"></param>
@@ -470,8 +466,7 @@ namespace Microsoft.PowerShell.Commands
 
         #region Serialization
         /// <summary>
-        /// Initializes a new instance of the <see cref="WriteErrorException"/> class.
-        /// Serialization constructor for class WriteErrorException.
+        /// Initializes a new instance of the <see cref="WriteErrorException"/> class for serialization.
         /// </summary>
         /// <param name="info">Serialization information.</param>
         /// <param name="context">Streaming context.</param>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/MshHostTraceListener.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/MshHostTraceListener.cs
@@ -24,7 +24,6 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PSHostTraceListener"/> class.
-        /// Default constructor used if no.
         /// </summary>
         internal PSHostTraceListener(PSCmdlet cmdlet)
             : base(string.Empty)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/MshHostTraceListener.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/MshHostTraceListener.cs
@@ -23,6 +23,7 @@ namespace Microsoft.PowerShell.Commands
         #region TraceListener constructors and disposer
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="PSHostTraceListener"/> class.
         /// Default constructor used if no.
         /// </summary>
         internal PSHostTraceListener(PSCmdlet cmdlet)


### PR DESCRIPTION
Fix SA1642: Constructor summary documentation should begin with standard text for `Microsoft.PowerShell.Commands.Utility`.

https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1642.md