### PR TITLE
Refactor multiply operation for better performance in 2 Commands.Utility functions

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
@@ -619,7 +619,6 @@ namespace Microsoft.PowerShell.Commands
         {
             object currentValue = objValue;
             object statValue = statMinOrMaxValue;
-            int factor = isMin ? 1 : -1;
 
             double temp;
             currentValue = ((objValue != null) && LanguagePrimitives.TryConvertTo<double>(objValue, out temp)) ? temp : currentValue;
@@ -631,13 +630,15 @@ namespace Microsoft.PowerShell.Commands
                 statValue = PSObject.AsPSObject(statValue).ToString();
             }
 
-            if ((statValue == null) ||
-                ((LanguagePrimitives.Compare(statValue, currentValue, false, CultureInfo.CurrentCulture) * factor) > 0))
+            if (statValue == null)
             {
                 return objValue;
             }
 
-            return statMinOrMaxValue;
+            int comp = LanguagePrimitives.Compare(statValue, currentValue, false, CultureInfo.CurrentCulture);
+            return (isMin ? comp : -comp) > 0
+                ? objValue
+                : statMinOrMaxValue;
         }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
@@ -635,8 +635,8 @@ namespace Microsoft.PowerShell.Commands
                 return objValue;
             }
 
-            int comp = LanguagePrimitives.Compare(statValue, currentValue, false, CultureInfo.CurrentCulture);
-            return (isMin ? comp : -comp) > 0
+            int comparisonResult = LanguagePrimitives.Compare(statValue, currentValue, ignoreCase: false, CultureInfo.CurrentCulture);
+            return (isMin ? comparisonResult : -comparisonResult) > 0
                 ? objValue
                 : statMinOrMaxValue;
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ObjectCommandComparer.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ObjectCommandComparer.cs
@@ -209,19 +209,17 @@ namespace Microsoft.PowerShell.Commands
                 second = secondMsh.BaseObject;
             }
 
-            if (LanguagePrimitives.TryCompare(first, second, !_caseSensitive, _cultureInfo, out int result))
+            if (!LanguagePrimitives.TryCompare(first, second, !_caseSensitive, _cultureInfo, out int result))
             {
-                return _ascendingOrder ? result : -result;
+                // Note that this will occur if the objects do not support
+                // IComparable.  We fall back to comparing as strings.
+
+                // being here means the first object doesn't support ICompare
+                string firstString = PSObject.AsPSObject(first).ToString();
+                string secondString = PSObject.AsPSObject(second).ToString();
+
+                result = _cultureInfo.CompareInfo.Compare(firstString, secondString, _caseSensitive ? CompareOptions.None : CompareOptions.IgnoreCase);
             }
-
-            // Note that this will occur if the objects do not support
-            // IComparable.  We fall back to comparing as strings.
-
-            // being here means the first object doesn't support ICompare
-            string firstString = PSObject.AsPSObject(first).ToString();
-            string secondString = PSObject.AsPSObject(second).ToString();
-
-            result = _cultureInfo.CompareInfo.Compare(firstString, secondString, _caseSensitive ? CompareOptions.None : CompareOptions.IgnoreCase);
 
             return _ascendingOrder ? result : -result;
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ObjectCommandComparer.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ObjectCommandComparer.cs
@@ -221,7 +221,7 @@ namespace Microsoft.PowerShell.Commands
             string firstString = PSObject.AsPSObject(first).ToString();
             string secondString = PSObject.AsPSObject(second).ToString();
 
-            int result = _cultureInfo.CompareInfo.Compare(firstString, secondString, _caseSensitive ? CompareOptions.None : CompareOptions.IgnoreCase);
+            result = _cultureInfo.CompareInfo.Compare(firstString, secondString, _caseSensitive ? CompareOptions.None : CompareOptions.IgnoreCase);
 
             return _ascendingOrder ? result : -result;
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ObjectCommandComparer.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ObjectCommandComparer.cs
@@ -211,7 +211,7 @@ namespace Microsoft.PowerShell.Commands
 
             if (LanguagePrimitives.TryCompare(first, second, !_caseSensitive, _cultureInfo, out int result))
             {
-                return result * (_ascendingOrder ? 1 : -1);
+                return _ascendingOrder ? result : -result;
             }
 
             // Note that this will occur if the objects do not support
@@ -221,7 +221,9 @@ namespace Microsoft.PowerShell.Commands
             string firstString = PSObject.AsPSObject(first).ToString();
             string secondString = PSObject.AsPSObject(second).ToString();
 
-            return _cultureInfo.CompareInfo.Compare(firstString, secondString, _caseSensitive ? CompareOptions.None : CompareOptions.IgnoreCase) * (_ascendingOrder ? 1 : -1);
+            int result = _cultureInfo.CompareInfo.Compare(firstString, secondString, _caseSensitive ? CompareOptions.None : CompareOptions.IgnoreCase);
+
+            return _ascendingOrder ? result : -result;
         }
 
         private readonly CultureInfo _cultureInfo = null;


### PR DESCRIPTION
# PR Summary

Factor out multiply operation for slightly more readable code.

Replace all instances of `x * (y ? 1 : -1)` with `y ? x : -x`.

## PR Context

As shown in following micro-benchmark results, these changes do not worsen performance, there is in fact a very small absolute gain.

```
| Method |      Mean |     Error |    StdDev |    Median | Code Size | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |----------:|----------:|----------:|----------:|----------:|------:|------:|------:|----------:|
|    Mul | 0.6288 ns | 0.0518 ns | 0.0836 ns | 0.5843 ns |      25 B |     - |     - |     - |         - |
|    Neg | 0.0358 ns | 0.0275 ns | 0.0496 ns | 0.0000 ns |      16 B |     - |     - |     - |         - |
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [NA] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [NA] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [NA] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [NA] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [NA] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [NA] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
