### PR TITLE
Convert public field to property

### DIFF
--- a/src/System.Management.Automation/engine/remoting/fanin/PSSessionConfigurationData.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/PSSessionConfigurationData.cs
@@ -16,10 +16,6 @@ namespace System.Management.Automation.Remoting
     /// </summary>
     public sealed class PSSessionConfigurationData
     {
-        /// <summary>
-        /// </summary>
-        public static bool IsServerManager;
-
         #region Public Properties
 
         /// <summary>
@@ -54,6 +50,10 @@ namespace System.Management.Automation.Remoting
                 _privateData = value;
             }
         }
+
+        /// <summary>
+        /// </summary>
+        public static bool IsServerManager { get; set; }
 
         #endregion Public Properties
 

--- a/src/System.Management.Automation/engine/remoting/fanin/PSSessionConfigurationData.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/PSSessionConfigurationData.cs
@@ -52,6 +52,7 @@ namespace System.Management.Automation.Remoting
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether Server Manager is enabled.
         /// </summary>
         public static bool IsServerManager { get; set; }
 


### PR DESCRIPTION
Convert public field `PSSessionConfigurationData.IsServerManager` to property.

Fix [CA2211](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211): Non-constant fields should not be visible.

Breaking change.