### PR TITLE
Fix SA1119: Statement should not use unnecessary parenthesis part 1

### DIFF
--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimGetInstance.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimGetInstance.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
                 GetComputerName(cmdlet));
             string nameSpace;
             List<CimSessionProxy> proxys = new();
-            bool isGetCimInstanceCommand = (cmdlet is GetCimInstanceCommand);
+            bool isGetCimInstanceCommand = cmdlet is GetCimInstanceCommand;
             CimInstance targetCimInstance = null;
             switch (cmdlet.ParameterSetName)
             {

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionOperations.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionOperations.cs
@@ -604,7 +604,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
                     if (pattern.IsMatch(kvp.Key))
                     {
                         HashSet<CimSessionWrapper> wrappers = kvp.Value;
-                        foundSession = (wrappers.Count > 0);
+                        foundSession = wrappers.Count > 0;
                         foreach (CimSessionWrapper wrapper in wrappers)
                         {
                             if (!sessionIds.Contains(wrapper.SessionId))
@@ -644,7 +644,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
                 if (this.curCimSessionsByComputerName.ContainsKey(computername))
                 {
                     HashSet<CimSessionWrapper> wrappers = this.curCimSessionsByComputerName[computername];
-                    foundSession = (wrappers.Count > 0);
+                    foundSession = wrappers.Count > 0;
                     foreach (CimSessionWrapper wrapper in wrappers)
                     {
                         if (!sessionIds.Contains(wrapper.SessionId))

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionProxy.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionProxy.cs
@@ -344,7 +344,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         public CimSessionProxy(string computerName)
         {
             CreateSetSession(computerName, null, null, null, false);
-            this.isDefaultSession = (computerName == ConstValue.NullComputerName);
+            this.isDefaultSession = computerName == ConstValue.NullComputerName;
         }
 
         /// <summary>
@@ -360,7 +360,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         public CimSessionProxy(string computerName, CimSessionOptions sessionOptions)
         {
             CreateSetSession(computerName, null, sessionOptions, null, false);
-            this.isDefaultSession = (computerName == ConstValue.NullComputerName);
+            this.isDefaultSession = computerName == ConstValue.NullComputerName;
         }
 
         /// <summary>
@@ -403,7 +403,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
             string cimsessionComputerName = cimInstance.GetCimSessionComputerName();
             CreateSetSession(cimsessionComputerName, null, null, null, false);
-            this.isDefaultSession = (cimsessionComputerName == ConstValue.NullComputerName);
+            this.isDefaultSession = cimsessionComputerName == ConstValue.NullComputerName;
 
             DebugHelper.WriteLogEx("Create a temp session with computerName = {0}.", 0, cimsessionComputerName);
         }
@@ -421,7 +421,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         public CimSessionProxy(string computerName, CimSessionOptions sessionOptions, CimOperationOptions operOptions)
         {
             CreateSetSession(computerName, null, sessionOptions, operOptions, false);
-            this.isDefaultSession = (computerName == ConstValue.NullComputerName);
+            this.isDefaultSession = computerName == ConstValue.NullComputerName;
         }
 
         /// <summary>
@@ -436,7 +436,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         public CimSessionProxy(string computerName, CimOperationOptions operOptions)
         {
             CreateSetSession(computerName, null, null, operOptions, false);
-            this.isDefaultSession = (computerName == ConstValue.NullComputerName);
+            this.isDefaultSession = computerName == ConstValue.NullComputerName;
         }
 
         /// <summary>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/GetCimClassCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/GetCimClassCommand.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// </summary>
         private CimGetCimClass GetOperationAgent()
         {
-            return (this.AsyncOperation as CimGetCimClass);
+            return this.AsyncOperation as CimGetCimClass;
         }
 
         /// <summary>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/GetCimInstanceCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/GetCimInstanceCommand.cs
@@ -474,7 +474,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// </summary>
         private CimGetInstance GetOperationAgent()
         {
-            return (this.AsyncOperation as CimGetInstance);
+            return this.AsyncOperation as CimGetInstance;
         }
 
         /// <summary>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/NewCimInstanceCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/NewCimInstanceCommand.cs
@@ -371,7 +371,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// </summary>
         private CimNewCimInstance GetOperationAgent()
         {
-            return (this.AsyncOperation as CimNewCimInstance);
+            return this.AsyncOperation as CimNewCimInstance;
         }
 
         /// <summary>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/NewCimSessionCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/NewCimSessionCommand.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
             outputCredential = null;
             if (options != null)
             {
-                DComSessionOptions dcomOptions = (options as DComSessionOptions);
+                DComSessionOptions dcomOptions = options as DComSessionOptions;
                 if (dcomOptions != null)
                 {
                     bool conflict = false;

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/RemoveCimInstanceCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/RemoveCimInstanceCommand.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// </summary>
         private CimRemoveCimInstance GetOperationAgent()
         {
-            return (this.AsyncOperation as CimRemoveCimInstance);
+            return this.AsyncOperation as CimRemoveCimInstance;
         }
 
         /// <summary>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/SetCimInstanceCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/SetCimInstanceCommand.cs
@@ -319,7 +319,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// </summary>
         private CimSetCimInstance GetOperationAgent()
         {
-            return (this.AsyncOperation as CimSetCimInstance);
+            return this.AsyncOperation as CimSetCimInstance;
         }
 
         /// <summary>


### PR DESCRIPTION
`src\Microsoft.Management.Infrastructure.CimCmdlets\`

Contributes to "Enable SA1119: Statement should not use unnecessary parenthesis" (#14133).

https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1119.md
