### PR TITLE
Fix SA1122: Use string.Empty for empty strings

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -1162,7 +1162,7 @@ dotnet_diagnostic.SA1120.severity = none
 dotnet_diagnostic.SA1121.severity = none
 
 # SA1122: Use string.Empty for empty strings
-dotnet_diagnostic.SA1122.severity = none
+dotnet_diagnostic.SA1122.severity = warning
 
 # SA1123: Do not place regions within elements
 dotnet_diagnostic.SA1123.severity = none

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
@@ -137,7 +137,7 @@ namespace Microsoft.PowerShell.Commands
         /// Run a command.
         /// </summary>
         protected void RunCommand(String command, String args) {
-            String cmd = "";
+            String cmd = string.Empty;
 
             _process = new Process()
             {

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -233,7 +233,7 @@ namespace Microsoft.PowerShell.Commands
                 catch (ArgumentException)
                 {
                     WriteNonTerminatingError(
-                        "",
+                        string.Empty,
                         processId,
                         processId,
                         null,

--- a/src/Microsoft.WSMan.Management/ConfigProvider.cs
+++ b/src/Microsoft.WSMan.Management/ConfigProvider.cs
@@ -1284,7 +1284,7 @@ namespace Microsoft.WSMan.Management
                             {
                                 if (!Force)
                                 {
-                                    string query = "";
+                                    string query = string.Empty;
                                     string caption = helper.GetResourceMsgFromResourcetext("SetItemGeneralSecurityCaption");
                                     if (ChildName.Equals("TrustedHosts", StringComparison.OrdinalIgnoreCase))
                                     {

--- a/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
@@ -129,7 +129,7 @@ namespace System.Management.Automation
 
             if (CommandName == null || CommandName.Length == 0)
             {
-                CommandName = new[] { "" };
+                CommandName = new[] { string.Empty };
             }
 
             for (int i = 0; i < CommandName.Length; i++)

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -2345,7 +2345,7 @@ namespace Microsoft.PowerShell.Commands
                 key: "FileList",
                 manifestProcessingFlags,
                 moduleBase,
-                extension: "",
+                extension: string.Empty,
                 // Don't check file existence - don't want to change current behavior without feature team discussion.
                 verifyFilesExist: false,
                 out List<string> fileList))

--- a/src/System.Management.Automation/engine/hostifaces/LocalPipeline.cs
+++ b/src/System.Management.Automation/engine/hostifaces/LocalPipeline.cs
@@ -249,7 +249,7 @@ namespace System.Management.Automation.Runspaces
                     }
 
                 default:
-                    Debug.Fail("");
+                    Debug.Fail(string.Empty);
                     break;
             }
         }

--- a/src/System.Management.Automation/engine/remoting/common/WireDataFormat/EncodeAndDecode.cs
+++ b/src/System.Management.Automation/engine/remoting/common/WireDataFormat/EncodeAndDecode.cs
@@ -2236,7 +2236,7 @@ namespace System.Management.Automation
             }
             else
             {
-                module = new string[] { "" };
+                module = new string[] { string.Empty };
             }
 
             ModuleSpecification[] fullyQualifiedName = null;

--- a/src/powershell/Program.cs
+++ b/src/powershell/Program.cs
@@ -320,7 +320,7 @@ namespace Microsoft.PowerShell
             //
             // Since command_name is ignored and we can't use null (it's the terminator)
             // we use empty string
-            execArgs[4] = "";
+            execArgs[4] = string.Empty;
 
             // Add the arguments passed to pwsh on the end.
             args.CopyTo(execArgs, 5);


### PR DESCRIPTION
Follow-up to #6950.

https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1122.md
