### PR TITLE
Optimize IEnumerable variant of replace operator

### DIFF
--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -1002,8 +1002,8 @@ namespace System.Management.Automation
             }
 
             private readonly Regex _regex;
-            private string _cachedReplacementString;
-            private MatchEvaluator _cachedMatchEvaluator;
+            private readonly string _cachedReplacementString;
+            private readonly MatchEvaluator _cachedMatchEvaluator;
 
             private ReplacerOperator(
                 ExecutionContext context,

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -1065,7 +1065,7 @@ namespace System.Management.Automation
                     return _regex.Replace(input, _cachedReplacementString);
                 }
 
-                // _cachedMatchEvaluator is not null when code reach here.
+                Dbg.Assert(_cachedMatchEvaluator is not null, "_cachedMatchEvaluator should be not null when code reach here.");
                 return _regex.Replace(input, _cachedMatchEvaluator);
             }
         }

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -1066,7 +1066,7 @@ namespace System.Management.Automation
                 }
                 else
                 {
-                    // if (_cachedMatchEvaluator is not null)
+                    // _cachedMatchEvaluator is not null when code reach here.
                     return _regex.Replace(input, _cachedMatchEvaluator);
                 }
 

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -998,7 +998,7 @@ namespace System.Management.Automation
         {
             public static ReplacerOperator Create(ExecutionContext context, Regex regex, object substitute)
             {
-                return new ReplacerOperator(context, regex, substitute, replacementString: null, matchEvaluator: null);
+                return new ReplacerOperator(context, regex, substitute);
             }
 
             private readonly Regex _regex;
@@ -1008,13 +1008,11 @@ namespace System.Management.Automation
             private ReplacerOperator(
                 ExecutionContext context,
                 Regex regex,
-                object substitute,
-                string replacementString,
-                MatchEvaluator matchEvaluator)
+                object substitute)
             {
                 _regex = regex;
-                _cachedReplacementString = replacementString;
-                _cachedMatchEvaluator = matchEvaluator;
+                _cachedReplacementString = null;
+                _cachedMatchEvaluator = null;
 
                 switch (substitute)
                 {

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -965,7 +965,7 @@ namespace System.Management.Automation
                 }
             }
 
-            var replacer = ReplacerOperator.Create(context, rr, substitute);
+            var replacer = ReplaceOperator.Create(context, rr, substitute);
             IEnumerator list = LanguagePrimitives.GetEnumerator(lval);
             if (list == null)
             {
@@ -994,18 +994,18 @@ namespace System.Management.Automation
             }
         }
 
-        private struct ReplacerOperator
+        private struct ReplaceOperator
         {
-            public static ReplacerOperator Create(ExecutionContext context, Regex regex, object substitute)
+            public static ReplaceOperator Create(ExecutionContext context, Regex regex, object substitute)
             {
-                return new ReplacerOperator(context, regex, substitute);
+                return new ReplaceOperator(context, regex, substitute);
             }
 
             private readonly Regex _regex;
             private readonly string _cachedReplacementString;
             private readonly MatchEvaluator _cachedMatchEvaluator;
 
-            private ReplacerOperator(
+            private ReplaceOperator(
                 ExecutionContext context,
                 Regex regex,
                 object substitute)

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -1064,12 +1064,9 @@ namespace System.Management.Automation
                 {
                     return _regex.Replace(input, _cachedReplacementString);
                 }
-                else
-                {
-                    // _cachedMatchEvaluator is not null when code reach here.
-                    return _regex.Replace(input, _cachedMatchEvaluator);
-                }
 
+                // _cachedMatchEvaluator is not null when code reach here.
+                return _regex.Replace(input, _cachedMatchEvaluator);
             }
         }
 

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -965,7 +965,7 @@ namespace System.Management.Automation
                 }
             }
 
-            var replacer = ReplaceOperator.Create(context, rr, substitute);
+            var replacer = ReplaceOperatorImpl.Create(context, rr, substitute);
             IEnumerator list = LanguagePrimitives.GetEnumerator(lval);
             if (list == null)
             {
@@ -994,18 +994,18 @@ namespace System.Management.Automation
             }
         }
 
-        private struct ReplaceOperator
+        private struct ReplaceOperatorImpl
         {
-            public static ReplaceOperator Create(ExecutionContext context, Regex regex, object substitute)
+            public static ReplaceOperatorImpl Create(ExecutionContext context, Regex regex, object substitute)
             {
-                return new ReplaceOperator(context, regex, substitute);
+                return new ReplaceOperatorImpl(context, regex, substitute);
             }
 
             private readonly Regex _regex;
             private readonly string _cachedReplacementString;
             private readonly MatchEvaluator _cachedMatchEvaluator;
 
-            private ReplaceOperator(
+            private ReplaceOperatorImpl(
                 ExecutionContext context,
                 Regex regex,
                 object substitute)

--- a/test/powershell/Language/Operators/ReplaceOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/ReplaceOperator.Tests.ps1
@@ -11,6 +11,12 @@ Describe "Replace Operator" -Tags CI {
             $res | Should -BeExactly "image.jpg"
         }
 
+        It "Replace operator can convert an substitution object to string" {
+            $substitution = Get-Process -Name pwsh
+            $res = "!3!" -replace "3",$substitution
+            $res | Should -BeExactly "!System.Diagnostics.Process (pwsh)!"
+        }
+
         It "Replace operator can be case-insensitive and case-sensitive" {
             $res = "book" -replace "B","C"
             $res | Should -BeExactly "Cook"

--- a/test/powershell/Language/Operators/ReplaceOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/ReplaceOperator.Tests.ps1
@@ -12,7 +12,7 @@ Describe "Replace Operator" -Tags CI {
         }
 
         It "Replace operator can convert an substitution object to string" {
-            $substitution = Get-Process -Name pwsh
+            $substitution = Get-Process -Id $pid
             $res = "!3!" -replace "3",$substitution
             $res | Should -BeExactly "!System.Diagnostics.Process (pwsh)!"
         }

--- a/test/powershell/Language/Operators/ReplaceOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/ReplaceOperator.Tests.ps1
@@ -29,6 +29,18 @@ Describe "Replace Operator" -Tags CI {
             $res = "PowerPoint" -replace "Point"
             $res | Should -BeExactly "Power"
         }
+
+        It "Replace operator can take an enumerable as first argument, a mandatory pattern, and an optional substitution" {
+            $res = "PowerPoint1","PowerPoint2" -replace "Point","Shell"
+            $res.Count | Should -Be 2
+            $res[0] | Should -BeExactly "PowerShell1"
+            $res[1] | Should -BeExactly "PowerShell2"
+
+            $res = "PowerPoint1","PowerPoint2" -replace "Point"
+            $res.Count | Should -Be 2
+            $res[0] | Should -BeExactly "Power1"
+            $res[1] | Should -BeExactly "Power2"
+        }
     }
 
     Context "Replace operator substitutions" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The PR does an optimization of IEnumerable variant of replace operator:
`$ABigList -replace "search pattern", <substitution>`.

Before the change we evaluate the substitution for every element from $ABigList that can be very expensive if the list is large.
If the substitution is a string we do no extra operations.
But if the substitution is:
- a custom type with defined custom type converter from the custom type to `MatchEvaluator` class
- falling in last resort conversion to string with `PSObject.ToStringParser()` (see  `ReplaceOperatorImpl()` method)

evaluating the substitution for every element becomes expensive.

`PSObject.ToStringParser()` is PowerShell _magic_ and it is important to have it fast.
Conversion to `MatchEvaluator` looks like an edge case but it is before `PSObject.ToStringParser()` so we should optimize the case too.

The PR does simple optimization - after first evaluation the substitution is stored in a variable and reused for follow elements of the list.

Follow demo script takes 5 seconds before the change and 1 second after:
```powerShell
class A {
    [string] ToString() { Sleep 1; return "A" }
}

$a = [A]::new()
"B1","B2","B3","B4","B5" -replace "B", $a
```

## PR Context

Follow  #14128 and #14087.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
