### PR TITLE
Mark private members as static part 1

### DIFF
--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimGetAssociatedInstance.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimGetAssociatedInstance.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// </summary>
         /// <param name="proxy"></param>
         /// <param name="cmdlet"></param>
-        private void SetSessionProxyProperties(
+        private static void SetSessionProxyProperties(
             ref CimSessionProxy proxy,
             GetCimAssociatedInstanceCommand cmdlet)
         {

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimGetCimClass.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimGetCimClass.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// </summary>
         /// <param name="proxy"></param>
         /// <param name="cmdlet"></param>
-        private void SetSessionProxyProperties(
+        private static void SetSessionProxyProperties(
             ref CimSessionProxy proxy,
             GetCimClassCommand cmdlet)
         {

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimGetInstance.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimGetInstance.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
                         CimSessionProxy proxy = CreateSessionProxy(computerName, targetCimInstance, cmdlet);
                         if (isGetCimInstanceCommand)
                         {
-                            this.SetPreProcess(proxy, cmdlet as GetCimInstanceCommand);
+                            SetPreProcess(proxy, cmdlet as GetCimInstanceCommand);
                         }
 
                         proxys.Add(proxy);
@@ -108,7 +108,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
                         CimSessionProxy proxy = CreateSessionProxy(computerName, cmdlet);
                         if (isGetCimInstanceCommand)
                         {
-                            this.SetPreProcess(proxy, cmdlet as GetCimInstanceCommand);
+                            SetPreProcess(proxy, cmdlet as GetCimInstanceCommand);
                         }
 
                         proxys.Add(proxy);
@@ -124,7 +124,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
                         CimSessionProxy proxy = CreateSessionProxy(session, cmdlet);
                         if (isGetCimInstanceCommand)
                         {
-                            this.SetPreProcess(proxy, cmdlet as GetCimInstanceCommand);
+                            SetPreProcess(proxy, cmdlet as GetCimInstanceCommand);
                         }
 
                         proxys.Add(proxy);
@@ -373,7 +373,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// </summary>
         /// <param name="proxy"></param>
         /// <param name="cmdlet"></param>
-        private void SetSessionProxyProperties(
+        private static void SetSessionProxyProperties(
             ref CimSessionProxy proxy,
             CimBaseCommand cmdlet)
         {
@@ -514,7 +514,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// </summary>
         /// <param name="proxy"></param>
         /// <param name="cmdlet"></param>
-        private void SetPreProcess(CimSessionProxy proxy, GetCimInstanceCommand cmdlet)
+        private static void SetPreProcess(CimSessionProxy proxy, GetCimInstanceCommand cmdlet)
         {
             if (cmdlet.KeyOnly || (cmdlet.SelectProperties != null))
             {

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimInvokeCimMethod.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimInvokeCimMethod.cs
@@ -274,7 +274,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// </summary>
         /// <param name="proxy"></param>
         /// <param name="cmdlet"></param>
-        private void SetSessionProxyProperties(
+        private static void SetSessionProxyProperties(
             ref CimSessionProxy proxy,
             InvokeCimMethodCommand cmdlet)
         {

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimNewCimInstance.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimNewCimInstance.cs
@@ -203,7 +203,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// </summary>
         /// <param name="proxy"></param>
         /// <param name="cmdlet"></param>
-        private void SetSessionProxyProperties(
+        private static void SetSessionProxyProperties(
             ref CimSessionProxy proxy,
             NewCimInstanceCommand cmdlet)
         {

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionOperations.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionOperations.cs
@@ -546,7 +546,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// <param name="errRecords"></param>
         /// <param name="propertyName"></param>
         /// <param name="propertyValue"></param>
-        private void AddErrorRecord(
+        private static void AddErrorRecord(
             ref List<ErrorRecord> errRecords,
             string propertyName,
             object propertyValue)

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionProxy.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionProxy.cs
@@ -1036,7 +1036,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
             return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CDXML_CLIXML_TEST"));
         }
 
-        private object PostProcessCimInstance(object resultObject)
+        private static object PostProcessCimInstance(object resultObject)
         {
             DebugHelper.WriteLogEx();
             if (isCliXmlTestabilityHookActive && (resultObject is CimInstance))


### PR DESCRIPTION
`src/Microsoft.Management.Infrastructure.CimCmdlets/`

Contributes to #13897.

https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
