### PR TITLE
Mark private members as static part 2

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Diagnostics/GetEventCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/GetEventCommand.cs
@@ -1346,7 +1346,7 @@ namespace Microsoft.PowerShell.Commands
         // HandleEventIdHashValue helper for hashtable structured query builder.
         // Constructs and returns EventId XPath portion as a string.
         //
-        private string HandleEventIdHashValue(object value)
+        private static string HandleEventIdHashValue(object value)
         {
             StringBuilder ret = new StringBuilder();
             Array idsArray = value as Array;
@@ -1376,7 +1376,7 @@ namespace Microsoft.PowerShell.Commands
         // HandleLevelHashValue helper for hashtable structured query builder.
         // Constructs and returns Level XPath portion as a string.
         //
-        private string HandleLevelHashValue(object value)
+        private static string HandleLevelHashValue(object value)
         {
             StringBuilder ret = new StringBuilder();
             Array levelsArray = value as Array;
@@ -1564,7 +1564,7 @@ namespace Microsoft.PowerShell.Commands
         // HandleDataHashValue helper for hashtable structured query builder.
         // Constructs and returns EventData/Data XPath portion as a string.
         //
-        private string HandleDataHashValue(object value)
+        private static string HandleDataHashValue(object value)
         {
             StringBuilder ret = new StringBuilder();
             Array dataArray = value as Array;
@@ -1595,7 +1595,7 @@ namespace Microsoft.PowerShell.Commands
         // Constructs and returns named event data field XPath portion as a string.
         // Fix Issue #2327
         //
-        private string HandleNamedDataHashValue(string key, object value)
+        private static string HandleNamedDataHashValue(string key, object value)
         {
             StringBuilder ret = new StringBuilder();
             Array dataArray = value as Array;
@@ -1909,7 +1909,7 @@ namespace Microsoft.PowerShell.Commands
         // "System/Provider[@Name='a' or @Name='b']"
         // for all provider names specified in the "providers" argument.
         //
-        private string BuildProvidersPredicate(StringCollection providers)
+        private static string BuildProvidersPredicate(StringCollection providers)
         {
             if (providers.Count == 0)
             {

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/PdhHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/PdhHelper.cs
@@ -429,7 +429,7 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
         /// <param name="strNative"></param>
         /// <param name="strSize"></param>
         /// <param name="strColl"></param>
-        private void ReadPdhMultiString(ref IntPtr strNative, Int32 strSize, ref StringCollection strColl)
+        private static void ReadPdhMultiString(ref IntPtr strNative, Int32 strSize, ref StringCollection strColl)
         {
             Debug.Assert(strSize >= 2);
             int offset = 0;
@@ -452,7 +452,7 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
             strColl.AddRange(allSubstringsWithNulls.Split('\0'));
         }
 
-        private uint GetCounterInfoPlus(IntPtr hCounter, out UInt32 counterType, out UInt32 defaultScale, out UInt64 timeBase)
+        private static uint GetCounterInfoPlus(IntPtr hCounter, out UInt32 counterType, out UInt32 defaultScale, out UInt64 timeBase)
         {
             counterType = 0;
             defaultScale = 0;
@@ -824,7 +824,7 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
             return (PdhValidatePathEx(_hDataSource, path) == PdhResults.PDH_CSTATUS_VALID_DATA);
         }
 
-        private uint MakePath(PDH_COUNTER_PATH_ELEMENTS pathElts, out string outPath, bool bWildcardInstances)
+        private static uint MakePath(PDH_COUNTER_PATH_ELEMENTS pathElts, out string outPath, bool bWildcardInstances)
         {
             outPath = string.Empty;
             IntPtr pPathBufferSize = new IntPtr(0);
@@ -861,7 +861,7 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
             return res;
         }
 
-        private uint MakeAllInstancePath(string origPath, out string unifiedPath)
+        private static uint MakeAllInstancePath(string origPath, out string unifiedPath)
         {
             unifiedPath = origPath;
 
@@ -876,7 +876,7 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
             return MakePath(elts, out unifiedPath, true);
         }
 
-        private uint ParsePath(string fullPath, ref PDH_COUNTER_PATH_ELEMENTS pCounterPathElements)
+        private static uint ParsePath(string fullPath, ref PDH_COUNTER_PATH_ELEMENTS pCounterPathElements)
         {
             IntPtr bufSize = new IntPtr(0);
 


### PR DESCRIPTION
`src/Microsoft.PowerShell.Commands.Diagnostics/`

Contributes to #13897.

https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
