### PR TITLE
Mark private members as static part 4

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -470,7 +470,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         // Get the -FromMember template for a given language
-        private string GetMethodTemplate(Language language)
+        private static string GetMethodTemplate(Language language)
         {
             switch (language)
             {
@@ -486,7 +486,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         // Get the -FromMember namespace template for a given language
-        private string GetNamespaceTemplate(Language language)
+        private static string GetNamespaceTemplate(Language language)
         {
             switch (language)
             {
@@ -502,7 +502,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         // Get the -FromMember namespace template for a given language
-        private string GetUsingTemplate(Language language)
+        private static string GetUsingTemplate(Language language)
         {
             switch (language)
             {
@@ -840,7 +840,7 @@ namespace Microsoft.PowerShell.Commands
         // However, this does give us a massive usability improvement, as users can just say
         // Add-Type -AssemblyName Forms (instead of System.Windows.Forms)
         // This is just long, not unmaintainable.
-        private Assembly LoadAssemblyHelper(string assemblyName)
+        private static Assembly LoadAssemblyHelper(string assemblyName)
         {
             Assembly loadedAssembly = null;
 
@@ -898,7 +898,7 @@ namespace Microsoft.PowerShell.Commands
 
         #region SourceCodeProcessing
 
-        private OutputKind OutputAssemblyTypeToOutputKind(OutputAssemblyType outputType)
+        private static OutputKind OutputAssemblyTypeToOutputKind(OutputAssemblyType outputType)
         {
             switch (outputType)
             {
@@ -1136,7 +1136,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        private void CacheNewTypes(ConcurrentBag<string> newTypes)
+        private static void CacheNewTypes(ConcurrentBag<string> newTypes)
         {
             foreach (var typeName in newTypes)
             {
@@ -1266,7 +1266,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        private string BuildErrorMessage(Diagnostic diagnisticRecord)
+        private static string BuildErrorMessage(Diagnostic diagnisticRecord)
         {
             var location = diagnisticRecord.Location;
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertFrom-SddlString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertFrom-SddlString.cs
@@ -45,7 +45,7 @@ namespace Microsoft.PowerShell.Commands
         private AccessRightTypeNames _type;
         private bool _isTypeSet = false;
 
-        private string ConvertToNTAccount(SecurityIdentifier securityIdentifier)
+        private static string ConvertToNTAccount(SecurityIdentifier securityIdentifier)
         {
             try
             {
@@ -57,7 +57,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        private List<string> GetApplicableAccessRights(int accessMask, AccessRightTypeNames? typeName)
+        private static List<string> GetApplicableAccessRights(int accessMask, AccessRightTypeNames? typeName)
         {
             List<Type> typesToExamine = new List<Type>();
             List<string> foundAccessRightNames = new List<string>();
@@ -95,7 +95,7 @@ namespace Microsoft.PowerShell.Commands
             return foundAccessRightNames;
         }
 
-        private Type GetRealAccessRightType(AccessRightTypeNames typeName)
+        private static Type GetRealAccessRightType(AccessRightTypeNames typeName)
         {
             switch (typeName)
             {
@@ -116,7 +116,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        private string[] ConvertAccessControlListToStrings(CommonAcl acl, AccessRightTypeNames? typeName)
+        private static string[] ConvertAccessControlListToStrings(CommonAcl acl, AccessRightTypeNames? typeName)
         {
             if (acl == null || acl.Count == 0)
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertTo-Html.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertTo-Html.cs
@@ -608,7 +608,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// To write the Property name.
         /// </summary>
-        private void WritePropertyName(StringBuilder Listtag, MshParameter p)
+        private static void WritePropertyName(StringBuilder Listtag, MshParameter p)
         {
             // for writing the property name
             string label = p.GetEntry(ConvertHTMLParameterDefinitionKeys.LabelEntryKey) as string;
@@ -653,7 +653,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// To write the Table header for the object property names.
         /// </summary>
-        private void WriteTableHeader(StringBuilder THtag, List<MshParameter> resolvedNameMshParameters)
+        private static void WriteTableHeader(StringBuilder THtag, List<MshParameter> resolvedNameMshParameters)
         {
             // write the property names
             foreach (MshParameter p in resolvedNameMshParameters)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
@@ -442,7 +442,7 @@ namespace System.Management.Automation
         /// <param name="ct"></param>
         /// <param name="dictionary"></param>
         /// <param name="enumerable"></param>
-        private void GetKnownContainerTypeInfo(
+        private static void GetKnownContainerTypeInfo(
             object source, out ContainerType ct, out IDictionary dictionary, out IEnumerable enumerable)
         {
             Dbg.Assert(source != null, "caller should validate the parameter");
@@ -676,7 +676,7 @@ namespace System.Management.Automation
         /// <param name="source"></param>
         /// <returns>
         /// </returns>
-        private bool PSObjectHasNotes(PSObject source)
+        private static bool PSObjectHasNotes(PSObject source)
         {
             if (source.InstanceMembers != null && source.InstanceMembers.Count > 0)
             {
@@ -955,7 +955,7 @@ namespace System.Management.Automation
         /// <returns>
         /// string value to use for serializing this PSObject.
         /// </returns>
-        private string GetStringFromPSObject(PSObject source)
+        private static string GetStringFromPSObject(PSObject source)
         {
             Dbg.Assert(source != null, "caller should have validated the information");
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/DebugRunspaceCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/DebugRunspaceCommand.cs
@@ -549,7 +549,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        private void SetLocalMode(System.Management.Automation.Debugger debugger, bool localMode)
+        private static void SetLocalMode(System.Management.Automation.Debugger debugger, bool localMode)
         {
             ServerRemoteDebugger remoteDebugger = debugger as ServerRemoteDebugger;
             if (remoteDebugger != null)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/TableView.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/TableView.cs
@@ -191,7 +191,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// <returns>None.</returns>
         /// <remarks>This method updates "activeAssociationList" instance property.</remarks>
-        private void FilterActiveAssociationList(List<MshResolvedExpressionParameterAssociation> activeAssociationList)
+        private static void FilterActiveAssociationList(List<MshResolvedExpressionParameterAssociation> activeAssociationList)
         {
             // we got a valid set of properties from the default property set
             // make sure we do not have too many properties

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Get-PSBreakpoint.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Get-PSBreakpoint.cs
@@ -222,7 +222,7 @@ namespace Microsoft.PowerShell.Commands
         /// Returns the items in the input list that match an item in the filter array according to
         /// the given selection criterion.
         /// </summary>
-        private List<Breakpoint> Filter<T>(List<Breakpoint> input, T[] filter, FilterSelector<T> selector)
+        private static List<Breakpoint> Filter<T>(List<Breakpoint> input, T[] filter, FilterSelector<T> selector)
         {
             List<Breakpoint> output = new List<Breakpoint>();
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommand.cs
@@ -217,7 +217,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = RandomNumberParameterSet)]
         public object Minimum { get; set; }
 
-        private bool IsInt(object o)
+        private static bool IsInt(object o)
         {
             if (o == null || o is int)
             {
@@ -227,7 +227,7 @@ namespace Microsoft.PowerShell.Commands
             return false;
         }
 
-        private bool IsInt64(object o)
+        private static bool IsInt64(object o)
         {
             if (o == null || o is Int64)
             {
@@ -237,7 +237,7 @@ namespace Microsoft.PowerShell.Commands
             return false;
         }
 
-        private object ProcessOperand(object o)
+        private static object ProcessOperand(object o)
         {
             if (o == null)
             {
@@ -257,7 +257,7 @@ namespace Microsoft.PowerShell.Commands
             return baseObject;
         }
 
-        private double ConvertToDouble(object o, double defaultIfNull)
+        private static double ConvertToDouble(object o, double defaultIfNull)
         {
             if (o == null)
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
@@ -1306,7 +1306,7 @@ namespace Microsoft.PowerShell.Commands
                 parameterType);
         }
 
-        private bool IsProxyForCmdlet(Dictionary<string, ParameterMetadata> parameters)
+        private static bool IsProxyForCmdlet(Dictionary<string, ParameterMetadata> parameters)
         {
             // we are not sending CmdletBinding/DefaultParameterSet over the wire anymore
             // we need to infer IsProxyForCmdlet from presence of all common parameters
@@ -1355,7 +1355,7 @@ namespace Microsoft.PowerShell.Commands
             return new CommandMetadata(
                                    name: name,
                             commandType: commandType,
-                       isProxyForCmdlet: this.IsProxyForCmdlet(parameters),
+                       isProxyForCmdlet: IsProxyForCmdlet(parameters),
                 defaultParameterSetName: ParameterAttribute.AllParameterSets,
                   supportsShouldProcess: false,
                           confirmImpact: ConfirmImpact.None,
@@ -1365,7 +1365,7 @@ namespace Microsoft.PowerShell.Commands
                              parameters: parameters);
         }
 
-        private int GetCommandTypePriority(CommandTypes commandType)
+        private static int GetCommandTypePriority(CommandTypes commandType)
         {
             switch (commandType)
             {
@@ -1434,8 +1434,8 @@ namespace Microsoft.PowerShell.Commands
             CommandMetadata previousCommandWithSameName;
             if (name2commandMetadata.TryGetValue(commandMetadata.Name, out previousCommandWithSameName))
             {
-                int previousCommandPriority = this.GetCommandTypePriority(previousCommandWithSameName.WrappedCommandType);
-                int currentCommandPriority = this.GetCommandTypePriority(commandMetadata.WrappedCommandType);
+                int previousCommandPriority = GetCommandTypePriority(previousCommandWithSameName.WrappedCommandType);
+                int currentCommandPriority = GetCommandTypePriority(commandMetadata.WrappedCommandType);
                 if (previousCommandPriority < currentCommandPriority)
                 {
                     return;
@@ -1975,7 +1975,7 @@ namespace Microsoft.PowerShell.Commands
             return null;
         }
 
-        private string EscapeFunctionNameForRemoteHelp(string name)
+        private static string EscapeFunctionNameForRemoteHelp(string name)
         {
             if (name == null)
             {
@@ -2000,7 +2000,7 @@ namespace Microsoft.PowerShell.Commands
 ##############################################################################
 ";
 
-        private void GenerateSectionSeparator(TextWriter writer)
+        private static void GenerateSectionSeparator(TextWriter writer)
         {
             writer.Write(SectionSeparator);
         }
@@ -2135,7 +2135,7 @@ function Write-PSImplicitRemotingMessage
 }
 ";
 
-        private void GenerateHelperFunctionsWriteMessage(TextWriter writer)
+        private static void GenerateHelperFunctionsWriteMessage(TextWriter writer)
         {
             if (writer == null)
             {
@@ -2190,7 +2190,7 @@ function Set-PSImplicitRemotingSession
 if ($PSSessionOverride) {{ Set-PSImplicitRemotingSession $PSSessionOverride }}
 ";
 
-        private void GenerateHelperFunctionsSetImplicitRunspace(TextWriter writer)
+        private static void GenerateHelperFunctionsSetImplicitRunspace(TextWriter writer)
         {
             if (writer == null)
             {
@@ -2767,7 +2767,7 @@ function Get-PSImplicitRemotingClientSideParameters
 }
 ";
 
-        private void GenerateHelperFunctionsClientSideParameters(TextWriter writer)
+        private static void GenerateHelperFunctionsClientSideParameters(TextWriter writer)
         {
             if (writer == null)
             {
@@ -2781,12 +2781,12 @@ function Get-PSImplicitRemotingClientSideParameters
 
         private void GenerateHelperFunctions(TextWriter writer)
         {
-            this.GenerateSectionSeparator(writer);
-            this.GenerateHelperFunctionsWriteMessage(writer);
+            GenerateSectionSeparator(writer);
+            GenerateHelperFunctionsWriteMessage(writer);
             this.GenerateHelperFunctionsGetSessionOption(writer);
-            this.GenerateHelperFunctionsSetImplicitRunspace(writer);
+            GenerateHelperFunctionsSetImplicitRunspace(writer);
             this.GenerateHelperFunctionsGetImplicitRunspace(writer);
-            this.GenerateHelperFunctionsClientSideParameters(writer);
+            GenerateHelperFunctionsClientSideParameters(writer);
         }
 
         #endregion
@@ -2846,7 +2846,7 @@ function Get-PSImplicitRemotingClientSideParameters
 }}
         ";
 
-        private void GenerateCommandProxy(TextWriter writer, CommandMetadata commandMetadata)
+        private static void GenerateCommandProxy(TextWriter writer, CommandMetadata commandMetadata)
         {
             if (writer == null)
             {
@@ -2854,7 +2854,7 @@ function Get-PSImplicitRemotingClientSideParameters
             }
 
             string functionNameForString = CodeGeneration.EscapeSingleQuotedStringContent(commandMetadata.Name);
-            string functionNameForHelp = this.EscapeFunctionNameForRemoteHelp(commandMetadata.Name);
+            string functionNameForHelp = EscapeFunctionNameForRemoteHelp(commandMetadata.Name);
             writer.Write(
                 CommandProxyTemplate,
                 /* 0 */ functionNameForString,
@@ -2868,7 +2868,7 @@ function Get-PSImplicitRemotingClientSideParameters
                 /* 8 */ commandMetadata.WrappedAnyCmdlet);
         }
 
-        private void GenerateCommandProxy(TextWriter writer, IEnumerable<CommandMetadata> listOfCommandMetadata)
+        private static void GenerateCommandProxy(TextWriter writer, IEnumerable<CommandMetadata> listOfCommandMetadata)
         {
             if (writer == null)
             {
@@ -2880,7 +2880,7 @@ function Get-PSImplicitRemotingClientSideParameters
                 throw PSTraceSource.NewArgumentNullException(nameof(listOfCommandMetadata));
             }
 
-            this.GenerateSectionSeparator(writer);
+            GenerateSectionSeparator(writer);
             foreach (CommandMetadata commandMetadata in listOfCommandMetadata)
             {
                 GenerateCommandProxy(writer, commandMetadata);
@@ -2895,7 +2895,7 @@ function Get-PSImplicitRemotingClientSideParameters
 & $script:ExportModuleMember -Function {0}
         ";
 
-        private void GenerateExportDeclaration(TextWriter writer, IEnumerable<CommandMetadata> listOfCommandMetadata)
+        private static void GenerateExportDeclaration(TextWriter writer, IEnumerable<CommandMetadata> listOfCommandMetadata)
         {
             if (writer == null)
             {
@@ -2907,14 +2907,14 @@ function Get-PSImplicitRemotingClientSideParameters
                 throw PSTraceSource.NewArgumentNullException(nameof(listOfCommandMetadata));
             }
 
-            this.GenerateSectionSeparator(writer);
+            GenerateSectionSeparator(writer);
 
             List<string> listOfCommandNames = GetListOfCommandNames(listOfCommandMetadata);
             string exportString = GenerateArrayString(listOfCommandNames);
             writer.Write(ExportFunctionsTemplate, exportString);
         }
 
-        private List<string> GetListOfCommandNames(IEnumerable<CommandMetadata> listOfCommandMetadata)
+        private static List<string> GetListOfCommandNames(IEnumerable<CommandMetadata> listOfCommandMetadata)
         {
             if (listOfCommandMetadata == null)
             {
@@ -2930,7 +2930,7 @@ function Get-PSImplicitRemotingClientSideParameters
             return listOfCommandNames;
         }
 
-        private string GenerateArrayString(IEnumerable<string> listOfStrings)
+        private static string GenerateArrayString(IEnumerable<string> listOfStrings)
         {
             if (listOfStrings == null)
             {
@@ -2968,9 +2968,9 @@ function Get-PSImplicitRemotingClientSideParameters
 & $script:ExportModuleMember -Alias {0}
         ";
 
-        private void GenerateAliases(TextWriter writer, Dictionary<string, string> alias2resolvedCommandName)
+        private static void GenerateAliases(TextWriter writer, Dictionary<string, string> alias2resolvedCommandName)
         {
-            this.GenerateSectionSeparator(writer);
+            GenerateSectionSeparator(writer);
 
             foreach (KeyValuePair<string, string> pair in alias2resolvedCommandName)
             {
@@ -2991,7 +2991,7 @@ function Get-PSImplicitRemotingClientSideParameters
 
         #region Generating format.ps1xml file
 
-        private void GenerateFormatFile(TextWriter writer, List<ExtendedTypeDefinition> listOfFormatData)
+        private static void GenerateFormatFile(TextWriter writer, List<ExtendedTypeDefinition> listOfFormatData)
         {
             if (writer == null)
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Join-String.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Join-String.cs
@@ -177,7 +177,7 @@ namespace Microsoft.PowerShell.Commands.Utility
             return null;
         }
 
-        private IEnumerable<CompletionResult> CompleteFormatString(string wordToComplete)
+        private static IEnumerable<CompletionResult> CompleteFormatString(string wordToComplete)
         {
             var res = new List<CompletionResult>();
             void AddMatching(string completionText)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
@@ -617,7 +617,7 @@ namespace Microsoft.PowerShell.Commands
         /// If true is passed in then the minimum of the two values would be returned.
         /// If false is passed in then maximum of the two values will be returned.</param>
         /// <returns></returns>
-        private object Compare(object objValue, object statMinOrMaxValue, bool isMin)
+        private static object Compare(object objValue, object statMinOrMaxValue, bool isMin)
         {
             object currentValue = objValue;
             object statValue = statMinOrMaxValue;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/UnblockFile.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/UnblockFile.cs
@@ -196,7 +196,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
 #if UNIX
-        private bool IsBlocked(string path)
+        private static bool IsBlocked(string path)
         {
             uint valueSize = 1024;
             IntPtr value = Marshal.AllocHGlobal((int)valueSize);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Update-TypeData.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Update-TypeData.cs
@@ -570,7 +570,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        private T GetParameterType<T>(object sourceValue)
+        private static T GetParameterType<T>(object sourceValue)
         {
             return (T)LanguagePrimitives.ConvertTo(sourceValue, typeof(T), CultureInfo.InvariantCulture);
         }
@@ -746,7 +746,7 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="targetObject"></param>
         /// <param name="args"></param>
         /// <returns></returns>
-        private ErrorRecord NewError(string errorId, string template, object targetObject, params object[] args)
+        private static ErrorRecord NewError(string errorId, string template, object targetObject, params object[] args)
         {
             string message = string.Format(CultureInfo.CurrentCulture, template, args);
             ErrorRecord errorRecord = new ErrorRecord(
@@ -1255,7 +1255,7 @@ namespace Microsoft.PowerShell.Commands
             this.Context.TypeTable.ClearConsolidatedMembers();
         }
 
-        private ErrorRecord NewError(string errorId, string template, object targetObject, params object[] args)
+        private static ErrorRecord NewError(string errorId, string template, object targetObject, params object[] args)
         {
             string message = string.Format(CultureInfo.CurrentCulture, template, args);
             ErrorRecord errorRecord = new ErrorRecord(

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/BasicHtmlWebResponseObject.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/BasicHtmlWebResponseObject.Common.cs
@@ -186,7 +186,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        private PSObject CreateHtmlObject(string html, string tagName)
+        private static PSObject CreateHtmlObject(string html, string tagName)
         {
             PSObject elementObject = new PSObject();
 
@@ -198,7 +198,7 @@ namespace Microsoft.PowerShell.Commands
             return elementObject;
         }
 
-        private void EnsureHtmlParser()
+        private static void EnsureHtmlParser()
         {
             if (s_tagRegex == null)
             {
@@ -244,7 +244,7 @@ namespace Microsoft.PowerShell.Commands
             this.RawContent = raw.ToString();
         }
 
-        private void ParseAttributes(string outerHtml, PSObject elementObject)
+        private static void ParseAttributes(string outerHtml, PSObject elementObject)
         {
             // We might get an empty input for a directive from the HTML file
             if (!string.IsNullOrEmpty(outerHtml))

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -143,7 +143,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         // Mostly cribbed from Serialization.cs#GetXmlReaderSettingsForCliXml()
-        private XmlReaderSettings GetSecureXmlReaderSettings()
+        private static XmlReaderSettings GetSecureXmlReaderSettings()
         {
             XmlReaderSettings xrs = new XmlReaderSettings();
 
@@ -159,7 +159,7 @@ namespace Microsoft.PowerShell.Commands
             return xrs;
         }
 
-        private bool TryConvertToXml(string xml, out object doc, ref Exception exRef)
+        private static bool TryConvertToXml(string xml, out object doc, ref Exception exRef)
         {
             try
             {
@@ -181,7 +181,7 @@ namespace Microsoft.PowerShell.Commands
             return (doc != null);
         }
 
-        private bool TryConvertToJson(string json, out object obj, ref Exception exRef)
+        private static bool TryConvertToJson(string json, out object obj, ref Exception exRef)
         {
             bool converted = false;
             try
@@ -478,7 +478,7 @@ namespace Microsoft.PowerShell.Commands
 
         #region Helper Methods
 
-        private RestReturnType CheckReturnType(HttpResponseMessage response)
+        private static RestReturnType CheckReturnType(HttpResponseMessage response)
         {
             if (response == null) { throw new ArgumentNullException(nameof(response)); }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -754,7 +754,7 @@ namespace Microsoft.PowerShell.Commands
             return uri;
         }
 
-        private Uri CheckProtocol(Uri uri)
+        private static Uri CheckProtocol(Uri uri)
         {
             if (uri == null) { throw new ArgumentNullException(nameof(uri)); }
 
@@ -772,7 +772,7 @@ namespace Microsoft.PowerShell.Commands
             return resolvedFilePath;
         }
 
-        private string FormatDictionary(IDictionary content)
+        private static string FormatDictionary(IDictionary content)
         {
             if (content == null)
                 throw new ArgumentNullException(nameof(content));
@@ -1919,7 +1919,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// <param name="fieldName">The Field Name to use for the <see cref="StringContent" /></param>
         /// <param name="fieldValue">The Field Value to use for the <see cref="StringContent" /></param>
-        private StringContent GetMultipartStringContent(object fieldName, object fieldValue)
+        private static StringContent GetMultipartStringContent(object fieldName, object fieldValue)
         {
             var contentDisposition = new ContentDispositionHeaderValue("form-data");
             // .NET does not enclose field names in quotes, however, modern browsers and curl do.
@@ -1936,7 +1936,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// <param name="fieldName">The Field Name to use for the <see cref="StreamContent" /></param>
         /// <param name="stream">The <see cref="Stream" /> to use for the <see cref="StreamContent" /></param>
-        private StreamContent GetMultipartStreamContent(object fieldName, Stream stream)
+        private static StreamContent GetMultipartStreamContent(object fieldName, Stream stream)
         {
             var contentDisposition = new ContentDispositionHeaderValue("form-data");
             // .NET does not enclose field names in quotes, however, modern browsers and curl do.
@@ -1954,7 +1954,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// <param name="fieldName">The Field Name to use for the <see cref="StreamContent" /></param>
         /// <param name="file">The file to use for the <see cref="StreamContent" /></param>
-        private StreamContent GetMultipartFileContent(object fieldName, FileInfo file)
+        private static StreamContent GetMultipartFileContent(object fieldName, FileInfo file)
         {
             var result = GetMultipartStreamContent(fieldName: fieldName, stream: new FileStream(file.FullName, FileMode.Open));
             // .NET does not enclose field names in quotes, however, modern browsers and curl do.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebResponseObject.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebResponseObject.Common.cs
@@ -76,7 +76,7 @@ namespace Microsoft.PowerShell.Commands
             this.Content = this.RawContentStream.ToArray();
         }
 
-        private bool IsPrintable(char c)
+        private static bool IsPrintable(char c)
         {
             return (char.IsLetterOrDigit(c) || char.IsPunctuation(c) || char.IsSeparator(c) || char.IsSymbol(c) || char.IsWhiteSpace(c));
         }


### PR DESCRIPTION
`src/Microsoft.PowerShell.Commands.Utility/`

Contributes to #13897.

https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822