### PR TITLE
Mark private members as static part 6

### DIFF
--- a/src/Microsoft.PowerShell.Security/security/AclCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/AclCommands.cs
@@ -1060,7 +1060,7 @@ namespace Microsoft.PowerShell.Commands
         /// Returns a newly allocated SACL with no ACEs in it.
         /// Free the returned SACL by calling Marshal.FreeHGlobal.
         /// </summary>
-        private IntPtr GetEmptySacl()
+        private static IntPtr GetEmptySacl()
         {
             IntPtr pSacl = IntPtr.Zero;
             bool ret = true;
@@ -1246,7 +1246,7 @@ namespace Microsoft.PowerShell.Commands
         /// and the previous state of this privilege. Free the returned token
         /// by calling NativeMethods.CloseHandle.
         /// </summary>
-        private IntPtr GetTokenWithEnabledPrivilege(
+        private static IntPtr GetTokenWithEnabledPrivilege(
             string privilege,
             NativeMethods.TOKEN_PRIVILEGE previousState)
         {

--- a/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
+++ b/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
@@ -1373,7 +1373,7 @@ namespace Microsoft.PowerShell.Commands
             _hasAttemptedToLoadPkiModule = true;
         }
 
-        private string MyGetChildName(string path)
+        private static string MyGetChildName(string path)
         {
             // Verify the parameters
 
@@ -1919,7 +1919,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// <param name="storeHandle">An IntPtr for store handle.</param>
         /// <returns>No return.</returns>
-        private void CommitUserDS(IntPtr storeHandle)
+        private static void CommitUserDS(IntPtr storeHandle)
         {
             if (!Security.NativeMethods.CertControlStore(
                                         storeHandle,


### PR DESCRIPTION
`src/Microsoft.PowerShell.Security/security/`

Contributes to #13897.

https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822