### PR TITLE
Enable SA1643: Destructor summary documentation

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -1531,7 +1531,7 @@ dotnet_diagnostic.SA1641.severity = none
 dotnet_diagnostic.SA1642.severity = none
 
 # SA1643: Destructor summary documentation should begin with standard text
-dotnet_diagnostic.SA1643.severity = none
+dotnet_diagnostic.SA1643.severity = warning
 
 # SA1648: inheritdoc should be used with inheriting class
 dotnet_diagnostic.SA1648.severity = none

--- a/src/Microsoft.PowerShell.ConsoleHost/WindowsTaskbarJumpList/PropVariant.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/WindowsTaskbarJumpList/PropVariant.cs
@@ -51,7 +51,7 @@ namespace Microsoft.PowerShell
         }
 
         /// <summary>
-        /// Finalizer.
+        /// Finalizes an instance of the <see cref="PropVariant"/> class.
         /// </summary>
         ~PropVariant()
         {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -1195,14 +1195,6 @@ namespace Microsoft.PowerShell
         }
 
         /// <summary>
-        /// Finalizes the instance.
-        /// </summary>
-        ~ConsoleHost()
-        {
-            Dispose(false);
-        }
-
-        /// <summary>
         /// Disposes of this instance, per the IDisposable pattern.
         /// </summary>
         public void Dispose()
@@ -1258,6 +1250,14 @@ namespace Microsoft.PowerShell
             }
 
             _isDisposed = true;
+        }
+
+        /// <summary>
+        /// Finalizes an instance of the <see cref="ConsoleHost"/> class.
+        /// </summary>
+        ~ConsoleHost()
+        {
+            Dispose(false);
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/EventManager.cs
+++ b/src/System.Management.Automation/engine/EventManager.cs
@@ -1544,6 +1544,14 @@ namespace System.Management.Automation
                 }
             }
         }
+
+        /// <summary>
+        /// Finalizes an instance of the <see cref="PSLocalEventManager"/> class.
+        /// </summary>
+        ~PSLocalEventManager()
+        {
+            Dispose(false);
+        }
     }
 
     /// <summary>

--- a/src/System.Management.Automation/engine/hostifaces/LocalPipeline.cs
+++ b/src/System.Management.Automation/engine/hostifaces/LocalPipeline.cs
@@ -1251,7 +1251,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
-        /// Ensure we release the worker thread.
+        /// Finalizes an instance of the <see cref="PipelineThread"/> class.
         /// </summary>
         ~PipelineThread()
         {

--- a/src/System.Management.Automation/engine/remoting/fanin/BaseTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/BaseTransportManager.cs
@@ -972,7 +972,7 @@ namespace System.Management.Automation.Remoting.Client
         #region Clean up
 
         /// <summary>
-        /// Finalizer.
+        /// Finalizes an instance of the <see cref="BaseClientTransportManager"/> class.
         /// </summary>
         ~BaseClientTransportManager()
         {

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManNativeAPI.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManNativeAPI.cs
@@ -688,18 +688,6 @@ namespace System.Management.Automation.Remoting.Client
             }
 
             /// <summary>
-            /// Finalizer
-            ///
-            /// Note: Do not depend on the finalizer! This object should be
-            /// properly disposed of when no longer needed via a direct call
-            /// to Dispose().
-            /// </summary>
-            ~WSManData_ManToUn()
-            {
-                Dispose(false);
-            }
-
-            /// <summary>
             /// Gets the type of data.
             /// </summary>
             internal uint Type
@@ -745,6 +733,14 @@ namespace System.Management.Automation.Remoting.Client
                     Marshal.FreeHGlobal(_marshalledObject);
                     _marshalledObject = IntPtr.Zero;
                 }
+            }
+
+            /// <summary>
+            /// Finalizes an instance of the <see cref="WSManData_ManToUn"/> class.
+            /// </summary>
+            ~WSManData_ManToUn()
+            {
+                Dispose(false);
             }
 
             /// <summary>

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManPluginFacade.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManPluginFacade.cs
@@ -234,11 +234,7 @@ namespace System.Management.Automation.Remoting
         }
 
         /// <summary>
-        /// Use C# destructor syntax for finalization code.
-        /// This destructor will run only if the Dispose method
-        /// does not get called.
-        /// It gives your base class the opportunity to finalize.
-        /// Do not provide destructors in types derived from this class.
+        /// Finalizes an instance of the <see cref="WSManPluginEntryDelegates"/> class.
         /// </summary>
         ~WSManPluginEntryDelegates()
         {
@@ -766,11 +762,7 @@ namespace System.Management.Automation.Remoting
         }
 
         /// <summary>
-        /// Use C# destructor syntax for finalization code.
-        /// This destructor will run only if the Dispose method
-        /// does not get called.
-        /// It gives your base class the opportunity to finalize.
-        /// Do not provide destructors in types derived from this class.
+        /// Finalizes an instance of the <see cref="WSManPluginManagedEntryInstanceWrapper"/> class.
         /// </summary>
         ~WSManPluginManagedEntryInstanceWrapper()
         {

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManPluginShellSession.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManPluginShellSession.cs
@@ -111,11 +111,7 @@ namespace System.Management.Automation.Remoting
         }
 
         /// <summary>
-        /// Use C# destructor syntax for finalization code.
-        /// This destructor will run only if the Dispose method
-        /// does not get called.
-        /// It gives your base class the opportunity to finalize.
-        /// Do not provide destructors in types derived from this class.
+        /// Finalizes an instance of the <see cref="WSManPluginServerSession"/> class.
         /// </summary>
         ~WSManPluginServerSession()
         {

--- a/src/System.Management.Automation/help/CabinetNativeApi.cs
+++ b/src/System.Management.Automation/help/CabinetNativeApi.cs
@@ -84,7 +84,7 @@ namespace System.Management.Automation.Internal
         }
 
         /// <summary>
-        /// Finalizer to ensure destruction of unmanaged resources.
+        /// Finalizes an instance of the <see cref="CabinetExtractor"/> class.
         /// </summary>
         ~CabinetExtractor()
         {


### PR DESCRIPTION
Enable SA1643: Destructor summary documentation should begin with standard text

https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1643.md
