### PR TITLE
Fix SA1642 for Microsoft.Management.Infrastructure.CimCmdlets

### DIFF
--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimAsyncOperation.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimAsyncOperation.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         #region Constructor
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimAsyncOperation"/> class.
         /// The constructor.
         /// </summary>
         protected CimAsyncOperation()

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimAsyncOperation.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimAsyncOperation.cs
@@ -27,7 +27,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimAsyncOperation"/> class.
-        /// The constructor.
         /// </summary>
         protected CimAsyncOperation()
         {

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimBaseAction.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimBaseAction.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CimBaseAction"/> class.
-        /// Constructor method.
         /// </summary>
         protected CimBaseAction()
         {
@@ -71,7 +70,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CimSyncAction"/> class.
-        /// The constructor.
         /// </summary>
         public CimSyncAction()
         {

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimBaseAction.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimBaseAction.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal abstract class CimBaseAction
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimBaseAction"/> class.
         /// Constructor method.
         /// </summary>
         protected CimBaseAction()
@@ -69,6 +70,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal class CimSyncAction : CimBaseAction, IDisposable
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimSyncAction"/> class.
         /// The constructor.
         /// </summary>
         public CimSyncAction()

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimCommandBase.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimCommandBase.cs
@@ -26,7 +26,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ParameterDefinitionEntry"/> class.
-        /// Constructor.
         /// </summary>
         /// <param name="parameterSetName"></param>
         /// <param name="mandatory"></param>
@@ -72,7 +71,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ParameterSetEntry"/> class.
-        /// Constructor.
         /// </summary>
         /// <param name="mandatoryParameterCount"></param>
         internal ParameterSetEntry(UInt32 mandatoryParameterCount)
@@ -84,7 +82,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ParameterSetEntry"/> class.
-        /// Constructor.
         /// </summary>
         /// <param name="toClone"></param>
         internal ParameterSetEntry(ParameterSetEntry toClone)
@@ -96,7 +93,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ParameterSetEntry"/> class.
-        /// Constructor.
         /// </summary>
         /// <param name="mandatoryParameterCount"></param>
         /// <param name="mandatory"></param>
@@ -222,7 +218,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ParameterBinder"/> class.
-        /// Constructor.
         /// </summary>
         /// <param name="parameters"></param>
         /// <param name="sets"></param>
@@ -573,7 +568,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimBaseCommand"/> class.
-        /// Constructor.
         /// </summary>
         internal CimBaseCommand()
         {
@@ -583,7 +577,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimBaseCommand"/> class.
-        /// Constructor.
         /// </summary>
         internal CimBaseCommand(Dictionary<string, HashSet<ParameterDefinitionEntry>> parameters,
             Dictionary<string, ParameterSetEntry> sets)

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimCommandBase.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimCommandBase.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal class ParameterDefinitionEntry
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="ParameterDefinitionEntry"/> class.
         /// Constructor.
         /// </summary>
         /// <param name="parameterSetName"></param>
@@ -70,6 +71,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal class ParameterSetEntry
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="ParameterSetEntry"/> class.
         /// Constructor.
         /// </summary>
         /// <param name="mandatoryParameterCount"></param>
@@ -81,6 +83,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="ParameterSetEntry"/> class.
         /// Constructor.
         /// </summary>
         /// <param name="toClone"></param>
@@ -92,6 +95,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="ParameterSetEntry"/> class.
         /// Constructor.
         /// </summary>
         /// <param name="mandatoryParameterCount"></param>
@@ -217,6 +221,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal class ParameterBinder
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="ParameterBinder"/> class.
         /// Constructor.
         /// </summary>
         /// <param name="parameters"></param>
@@ -567,6 +572,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         #region constructors
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimBaseCommand"/> class.
         /// Constructor.
         /// </summary>
         internal CimBaseCommand()
@@ -576,6 +582,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimBaseCommand"/> class.
         /// Constructor.
         /// </summary>
         internal CimBaseCommand(Dictionary<string, HashSet<ParameterDefinitionEntry>> parameters,

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimGetAssociatedInstance.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimGetAssociatedInstance.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal sealed class CimGetAssociatedInstance : CimAsyncOperation
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimGetAssociatedInstance"/> class.
         /// <para>
         /// Constructor
         /// </para>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimGetAssociatedInstance.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimGetAssociatedInstance.cs
@@ -18,9 +18,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CimGetAssociatedInstance"/> class.
-        /// <para>
-        /// Constructor
-        /// </para>
         /// </summary>
         public CimGetAssociatedInstance()
             : base()

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimGetCimClass.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimGetCimClass.cs
@@ -18,9 +18,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CimGetCimClassContext"/> class.
-        /// <para>
-        /// Constructor
-        /// </para>
         /// </summary>
         /// <param name="methodName"></param>
         /// <param name="propertyName"></param>
@@ -106,9 +103,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CimGetCimClass"/> class.
-        /// <para>
-        /// Constructor
-        /// </para>
         /// </summary>
         public CimGetCimClass()
             : base()

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimGetCimClass.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimGetCimClass.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal class CimGetCimClassContext : XOperationContextBase
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimGetCimClassContext"/> class.
         /// <para>
         /// Constructor
         /// </para>
@@ -104,6 +105,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal sealed class CimGetCimClass : CimAsyncOperation
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimGetCimClass"/> class.
         /// <para>
         /// Constructor
         /// </para>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimGetInstance.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimGetInstance.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal class CimGetInstance : CimAsyncOperation
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimGetInstance"/> class.
         /// <para>
         /// Constructor
         /// </para>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimIndicationWatcher.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimIndicationWatcher.cs
@@ -57,9 +57,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimIndicationEventExceptionEventArgs"/> class.
-        /// <para>
-        /// Constructor
-        /// </para>
         /// </summary>
         /// <param name="result"></param>
         public CimIndicationEventExceptionEventArgs(Exception theException)
@@ -110,9 +107,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimIndicationEventInstanceEventArgs"/> class.
-        /// <para>
-        /// Constructor
-        /// </para>
         /// </summary>
         /// <param name="result"></param>
         public CimIndicationEventInstanceEventArgs(CimSubscriptionResult result)
@@ -157,9 +151,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimIndicationWatcher"/> class.
-        /// <para>
-        /// Constructor with given computerName, namespace, queryExpression and timeout
-        /// </para>
         /// </summary>
         /// <param name="computerName"></param>
         /// <param name="nameSpace"></param>
@@ -180,9 +171,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimIndicationWatcher"/> class.
-        /// <para>
-        /// Constructor with given cimsession, namespace, queryExpression and timeout
-        /// </para>
         /// </summary>
         /// <param name="cimSession"></param>
         /// <param name="nameSpace"></param>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimIndicationWatcher.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimIndicationWatcher.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         private readonly Exception exception;
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimIndicationEventExceptionEventArgs"/> class.
         /// <para>
         /// Constructor
         /// </para>
@@ -108,6 +109,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimIndicationEventInstanceEventArgs"/> class.
         /// <para>
         /// Constructor
         /// </para>
@@ -154,6 +156,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         public event EventHandler<CimIndicationEventArgs> CimIndicationArrived;
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimIndicationWatcher"/> class.
         /// <para>
         /// Constructor with given computerName, namespace, queryExpression and timeout
         /// </para>
@@ -176,6 +179,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimIndicationWatcher"/> class.
         /// <para>
         /// Constructor with given cimsession, namespace, queryExpression and timeout
         /// </para>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimInvokeCimMethod.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimInvokeCimMethod.cs
@@ -28,9 +28,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         {
             /// <summary>
             /// Initializes a new instance of the <see cref="CimInvokeCimMethodContext"/> class.
-            /// <para>
-            /// Constructor
-            /// </para>
             /// </summary>
             /// <param name="theNamespace"></param>
             /// <param name="theCollection"></param>
@@ -75,9 +72,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimInvokeCimMethod"/> class.
-        /// <para>
-        /// Constructor
-        /// </para>
         /// </summary>
         public CimInvokeCimMethod()
             : base()

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimInvokeCimMethod.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimInvokeCimMethod.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         internal class CimInvokeCimMethodContext : XOperationContextBase
         {
             /// <summary>
+            /// Initializes a new instance of the <see cref="CimInvokeCimMethodContext"/> class.
             /// <para>
             /// Constructor
             /// </para>
@@ -73,6 +74,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimInvokeCimMethod"/> class.
         /// <para>
         /// Constructor
         /// </para>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimNewCimInstance.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimNewCimInstance.cs
@@ -21,9 +21,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CimNewCimInstanceContext"/> class.
-        /// <para>
-        /// Constructor
-        /// </para>
         /// </summary>
         /// <param name="methodName"></param>
         /// <param name="propertyName"></param>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimNewCimInstance.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimNewCimInstance.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal class CimNewCimInstanceContext : XOperationContextBase
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimNewCimInstanceContext"/> class.
         /// <para>
         /// Constructor
         /// </para>
@@ -44,6 +45,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal sealed class CimNewCimInstance : CimAsyncOperation
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimNewCimInstance"/> class.
         /// <para>
         /// Constructor
         /// </para>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimPromptUser.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimPromptUser.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal sealed class CimPromptUser : CimSyncAction
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimPromptUser"/> class.
         /// Constructor.
         /// </summary>
         public CimPromptUser(string message,

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimPromptUser.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimPromptUser.cs
@@ -23,7 +23,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CimPromptUser"/> class.
-        /// Constructor.
         /// </summary>
         public CimPromptUser(string message,
             CimPromptType prompt)

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimRegisterCimIndication.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimRegisterCimIndication.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         private readonly CimSubscriptionResult result;
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimSubscriptionResultEventArgs"/> class.
         /// <para>Constructor</para>
         /// </summary>
         /// <param name="theResult"></param>
@@ -92,6 +93,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         private readonly Exception exception;
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimSubscriptionExceptionEventArgs"/> class.
         /// <para>Constructor</para>
         /// </summary>
         /// <param name="theResult"></param>
@@ -118,6 +120,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         public event EventHandler<CimSubscriptionEventArgs> OnNewSubscriptionResult;
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimRegisterCimIndication"/> class.
         /// <para>
         /// Constructor
         /// </para>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimRegisterCimIndication.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimRegisterCimIndication.cs
@@ -59,7 +59,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimSubscriptionResultEventArgs"/> class.
-        /// <para>Constructor</para>
         /// </summary>
         /// <param name="theResult"></param>
         public CimSubscriptionResultEventArgs(
@@ -94,7 +93,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimSubscriptionExceptionEventArgs"/> class.
-        /// <para>Constructor</para>
         /// </summary>
         /// <param name="theResult"></param>
         public CimSubscriptionExceptionEventArgs(
@@ -121,9 +119,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimRegisterCimIndication"/> class.
-        /// <para>
-        /// Constructor
-        /// </para>
         /// </summary>
         public CimRegisterCimIndication()
             : base()

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimRemoveCimInstance.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimRemoveCimInstance.cs
@@ -18,9 +18,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CimRemoveCimInstanceContext"/> class.
-        /// <para>
-        /// Constructor
-        /// </para>
         /// </summary>
         /// <param name="theNamespace"></param>
         /// <param name="theProxy"></param>
@@ -41,9 +38,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CimRemoveCimInstance"/> class.
-        /// <para>
-        /// Constructor
-        /// </para>
         /// </summary>
         public CimRemoveCimInstance()
             : base()

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimRemoveCimInstance.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimRemoveCimInstance.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal class CimRemoveCimInstanceContext : XOperationContextBase
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimRemoveCimInstanceContext"/> class.
         /// <para>
         /// Constructor
         /// </para>
@@ -39,6 +40,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal sealed class CimRemoveCimInstance : CimGetInstance
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimRemoveCimInstance"/> class.
         /// <para>
         /// Constructor
         /// </para>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimResultObserver.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimResultObserver.cs
@@ -33,7 +33,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CimResultContext"/> class.
-        /// Constructor.
         /// </summary>
         /// <param name="ErrorSource"></param>
         internal CimResultContext(object ErrorSource)
@@ -66,7 +65,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AsyncResultEventArgsBase"/> class.
-        /// Constructor.
         /// </summary>
         /// <param name="session"></param>
         /// <param name="observable"></param>
@@ -83,7 +81,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AsyncResultEventArgsBase"/> class.
-        /// Constructor.
         /// </summary>
         /// <param name="session"></param>
         /// <param name="observable"></param>
@@ -121,9 +118,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AsyncResultCompleteEventArgs"/> class.
-        /// <para>
-        /// Constructor
-        /// </para>
         /// </summary>
         /// <param name="session"><see cref="CimSession"/> object.</param>
         /// <param name="cancellationDisposable"></param>
@@ -144,7 +138,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AsyncResultObjectEventArgs"/> class.
-        /// Constructor.
         /// </summary>
         /// <param name="session"></param>
         /// <param name="observable"></param>
@@ -170,7 +163,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AsyncResultErrorEventArgs"/> class.
-        /// Constructor.
         /// </summary>
         /// <param name="session"></param>
         /// <param name="observable"></param>
@@ -186,7 +178,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AsyncResultErrorEventArgs"/> class.
-        /// Constructor.
         /// </summary>
         /// <param name="session"></param>
         /// <param name="observable"></param>
@@ -230,7 +221,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimResultObserver{T}"/> class.
-        /// Constructor.
         /// </summary>
         /// <param name="session"><see cref="CimSession"/> object that issued the operation.</param>
         /// <param name="observable">Operation that can be observed.</param>
@@ -242,7 +232,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimResultObserver{T}"/> class.
-        /// Constructor.
         /// </summary>
         /// <param name="session"><see cref="CimSession"/> object that issued the operation.</param>
         /// <param name="observable">Operation that can be observed.</param>
@@ -372,7 +361,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CimSubscriptionResultObserver"/> class.
-        /// Constructor.
         /// </summary>
         /// <param name="session"></param>
         /// <param name="observable"></param>
@@ -383,7 +371,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimSubscriptionResultObserver"/> class.
-        /// Constructor.
         /// </summary>
         /// <param name="session"></param>
         /// <param name="observable"></param>
@@ -413,7 +400,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CimMethodResultObserver"/> class.
-        /// Constructor.
         /// </summary>
         /// <param name="session"></param>
         /// <param name="observable"></param>
@@ -424,7 +410,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimMethodResultObserver"/> class.
-        /// Constructor.
         /// </summary>
         /// <param name="session"></param>
         /// <param name="observable"></param>
@@ -508,7 +493,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="IgnoreResultObserver"/> class.
-        /// Constructor.
         /// </summary>
         /// <param name="session"></param>
         /// <param name="observable"></param>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimResultObserver.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimResultObserver.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal class CimResultContext
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimResultContext"/> class.
         /// Constructor.
         /// </summary>
         /// <param name="ErrorSource"></param>
@@ -64,6 +65,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal abstract class AsyncResultEventArgsBase : EventArgs
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncResultEventArgsBase"/> class.
         /// Constructor.
         /// </summary>
         /// <param name="session"></param>
@@ -80,6 +82,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncResultEventArgsBase"/> class.
         /// Constructor.
         /// </summary>
         /// <param name="session"></param>
@@ -117,6 +120,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal class AsyncResultCompleteEventArgs : AsyncResultEventArgsBase
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncResultCompleteEventArgs"/> class.
         /// <para>
         /// Constructor
         /// </para>
@@ -139,6 +143,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal class AsyncResultObjectEventArgs : AsyncResultEventArgsBase
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncResultObjectEventArgs"/> class.
         /// Constructor.
         /// </summary>
         /// <param name="session"></param>
@@ -164,6 +169,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal class AsyncResultErrorEventArgs : AsyncResultEventArgsBase
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncResultErrorEventArgs"/> class.
         /// Constructor.
         /// </summary>
         /// <param name="session"></param>
@@ -179,6 +185,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncResultErrorEventArgs"/> class.
         /// Constructor.
         /// </summary>
         /// <param name="session"></param>
@@ -222,6 +229,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         public event EventHandler<AsyncResultEventArgsBase> OnNewResult;
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimResultObserver{T}"/> class.
         /// Constructor.
         /// </summary>
         /// <param name="session"><see cref="CimSession"/> object that issued the operation.</param>
@@ -233,6 +241,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimResultObserver{T}"/> class.
         /// Constructor.
         /// </summary>
         /// <param name="session"><see cref="CimSession"/> object that issued the operation.</param>
@@ -362,6 +371,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal class CimSubscriptionResultObserver : CimResultObserver<CimSubscriptionResult>
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimSubscriptionResultObserver"/> class.
         /// Constructor.
         /// </summary>
         /// <param name="session"></param>
@@ -372,6 +382,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimSubscriptionResultObserver"/> class.
         /// Constructor.
         /// </summary>
         /// <param name="session"></param>
@@ -401,6 +412,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal class CimMethodResultObserver : CimResultObserver<CimMethodResultBase>
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimMethodResultObserver"/> class.
         /// Constructor.
         /// </summary>
         /// <param name="session"></param>
@@ -411,6 +423,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimMethodResultObserver"/> class.
         /// Constructor.
         /// </summary>
         /// <param name="session"></param>
@@ -494,6 +507,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal class IgnoreResultObserver : CimResultObserver<CimInstance>
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="IgnoreResultObserver"/> class.
         /// Constructor.
         /// </summary>
         /// <param name="session"></param>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionOperations.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionOperations.cs
@@ -264,6 +264,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         #endregion
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimSessionState"/> class.
         /// <para>
         /// The constructor.
         /// </para>
@@ -785,6 +786,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         #region constructor
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimSessionBase"/> class.
         /// The constructor.
         /// </summary>
         public CimSessionBase()
@@ -908,6 +910,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         internal class CimTestCimSessionContext : XOperationContextBase
         {
             /// <summary>
+            /// Initializes a new instance of the <see cref="CimTestCimSessionContext"/> class.
             /// <para>
             /// The constructor.
             /// </para>
@@ -938,6 +941,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimNewSession"/> class.
         /// <para>
         /// The constructor.
         /// </para>
@@ -1130,6 +1134,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal class CimGetSession : CimSessionBase
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimGetSession"/> class.
         /// The constructor.
         /// </summary>
         public CimGetSession() : base()
@@ -1212,6 +1217,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         internal static readonly string RemoveCimSessionActionName = "Remove CimSession";
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimRemoveSession"/> class.
         /// Constructor.
         /// </summary>
         public CimRemoveSession() : base()
@@ -1282,6 +1288,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal class CimTestSession : CimAsyncOperation
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimTestSession"/> class.
         /// Constructor.
         /// </summary>
         internal CimTestSession()

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionOperations.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionOperations.cs
@@ -265,9 +265,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimSessionState"/> class.
-        /// <para>
-        /// The constructor.
-        /// </para>
         /// </summary>
         internal CimSessionState()
         {
@@ -787,7 +784,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimSessionBase"/> class.
-        /// The constructor.
         /// </summary>
         public CimSessionBase()
         {
@@ -911,9 +907,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         {
             /// <summary>
             /// Initializes a new instance of the <see cref="CimTestCimSessionContext"/> class.
-            /// <para>
-            /// The constructor.
-            /// </para>
             /// </summary>
             /// <param name="theProxy"></param>
             /// <param name="wrapper"></param>
@@ -942,9 +935,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimNewSession"/> class.
-        /// <para>
-        /// The constructor.
-        /// </para>
         /// </summary>
         internal CimNewSession() : base()
         {
@@ -1135,7 +1125,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CimGetSession"/> class.
-        /// The constructor.
         /// </summary>
         public CimGetSession() : base()
         {
@@ -1218,7 +1207,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimRemoveSession"/> class.
-        /// Constructor.
         /// </summary>
         public CimRemoveSession() : base()
         {
@@ -1289,7 +1277,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CimTestSession"/> class.
-        /// Constructor.
         /// </summary>
         internal CimTestSession()
             : base()

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionProxy.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionProxy.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal class InvocationContext
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="InvocationContext"/> class.
         /// Constructor.
         /// </summary>
         /// <param name="proxy"></param>
@@ -78,6 +79,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="InvocationContext"/> class.
         /// Constructor.
         /// </summary>
         /// <param name="proxy"></param>
@@ -135,6 +137,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal sealed class CmdletActionEventArgs : EventArgs
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CmdletActionEventArgs"/> class.
         /// Constructor.
         /// </summary>
         /// <param name="action">CimBaseAction object bound to the event.</param>
@@ -152,6 +155,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal sealed class OperationEventArgs : EventArgs
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="OperationEventArgs"/> class.
         /// Constructor.
         /// </summary>
         /// <param name="operationCancellation">Object used to cancel the operation.</param>
@@ -317,6 +321,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         #region constructors
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimSessionProxy"/> class.
         /// Then create wrapper object by given CimSessionProxy object.
         /// </summary>
         /// <param name="computerName"></param>
@@ -331,6 +336,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimSessionProxy"/> class.
         /// Create <see cref="CimSession"/> by given computer name.
         /// Then create wrapper object.
         /// </summary>
@@ -342,6 +348,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimSessionProxy"/> class.
         /// Create <see cref="CimSession"/> by given computer name
         /// and session options.
         /// Then create wrapper object.
@@ -355,6 +362,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimSessionProxy"/> class.
         /// Create <see cref="CimSession"/> by given computer name
         /// and cimInstance. Then create wrapper object.
         /// </summary>
@@ -397,6 +405,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimSessionProxy"/> class.
         /// Create <see cref="CimSession"/> by given computer name,
         /// session options.
         /// </summary>
@@ -410,6 +419,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimSessionProxy"/> class.
         /// Create <see cref="CimSession"/> by given computer name.
         /// Then create wrapper object.
         /// </summary>
@@ -422,6 +432,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimSessionProxy"/> class.
         /// Create wrapper object by given session object.
         /// </summary>
         /// <param name="session"></param>
@@ -431,6 +442,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimSessionProxy"/> class.
         /// Create wrapper object by given session object.
         /// </summary>
         /// <param name="session"></param>
@@ -1969,6 +1981,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         #region constructors
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimSessionProxyTestConnection"/> class.
         /// Create <see cref="CimSession"/> by given computer name
         /// and session options.
         /// Then create wrapper object.
@@ -2018,6 +2031,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         #region constructors
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimSessionProxyGetCimClass"/> class.
         /// Create <see cref="CimSession"/> by given computer name.
         /// Then create wrapper object.
         /// </summary>
@@ -2028,6 +2042,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimSessionProxyGetCimClass"/> class.
         /// Create <see cref="CimSession"/> by given computer name
         /// and session options.
         /// Then create wrapper object.
@@ -2169,6 +2184,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         #region constructors
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimSessionProxyNewCimInstance"/> class.
         /// Create <see cref="CimSession"/> by given computer name.
         /// Then create wrapper object.
         /// </summary>
@@ -2180,6 +2196,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimSessionProxyNewCimInstance"/> class.
         /// Create <see cref="CimSession"/> by given computer name
         /// and session options.
         /// Then create wrapper object.
@@ -2249,6 +2266,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         #region constructors
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimSessionProxySetCimInstance"/> class.
         /// Create <see cref="CimSession"/> by given <see cref="CimSessionProxy"/> object.
         /// Then create wrapper object.
         /// </summary>
@@ -2261,6 +2279,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimSessionProxySetCimInstance"/> class.
         /// Create <see cref="CimSession"/> by given computer name.
         /// Then create wrapper object.
         /// </summary>
@@ -2276,6 +2295,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimSessionProxySetCimInstance"/> class.
         /// Create <see cref="CimSession"/> by given computer name
         /// and session options.
         /// Then create wrapper object.

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionProxy.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionProxy.cs
@@ -66,7 +66,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="InvocationContext"/> class.
-        /// Constructor.
         /// </summary>
         /// <param name="proxy"></param>
         internal InvocationContext(CimSessionProxy proxy)
@@ -80,7 +79,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InvocationContext"/> class.
-        /// Constructor.
         /// </summary>
         /// <param name="proxy"></param>
         internal InvocationContext(string computerName, CimInstance targetCimInstance)
@@ -138,7 +136,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CmdletActionEventArgs"/> class.
-        /// Constructor.
         /// </summary>
         /// <param name="action">CimBaseAction object bound to the event.</param>
         public CmdletActionEventArgs(CimBaseAction action)
@@ -156,7 +153,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OperationEventArgs"/> class.
-        /// Constructor.
         /// </summary>
         /// <param name="operationCancellation">Object used to cancel the operation.</param>
         /// <param name="operation">Async observable operation.</param>
@@ -322,8 +318,10 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimSessionProxy"/> class.
-        /// Then create wrapper object by given CimSessionProxy object.
         /// </summary>
+        /// <remarks>
+        /// Then create wrapper object by given CimSessionProxy object.
+        /// </remarks>
         /// <param name="computerName"></param>
         public CimSessionProxy(CimSessionProxy proxy)
         {
@@ -337,9 +335,11 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimSessionProxy"/> class.
+        /// </summary>
+        /// <remarks>
         /// Create <see cref="CimSession"/> by given computer name.
         /// Then create wrapper object.
-        /// </summary>
+        /// </remarks>
         /// <param name="computerName"></param>
         public CimSessionProxy(string computerName)
         {
@@ -349,10 +349,12 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimSessionProxy"/> class.
+        /// </summary>
+        /// <remarks>
         /// Create <see cref="CimSession"/> by given computer name
         /// and session options.
         /// Then create wrapper object.
-        /// </summary>
+        /// </remarks>
         /// <param name="computerName"></param>
         /// <param name="sessionOptions"></param>
         public CimSessionProxy(string computerName, CimSessionOptions sessionOptions)
@@ -363,9 +365,11 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimSessionProxy"/> class.
+        /// </summary>
+        /// <remarks>
         /// Create <see cref="CimSession"/> by given computer name
         /// and cimInstance. Then create wrapper object.
-        /// </summary>
+        /// </remarks>
         /// <param name="computerName"></param>
         /// <param name="cimInstance"></param>
         public CimSessionProxy(string computerName, CimInstance cimInstance)
@@ -406,9 +410,11 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimSessionProxy"/> class.
+        /// </summary>
+        /// <remarks>
         /// Create <see cref="CimSession"/> by given computer name,
         /// session options.
-        /// </summary>
+        /// </remarks>
         /// <param name="computerName"></param>
         /// <param name="sessionOptions"></param>
         /// <param name="operOptions">Used when create async operation.</param>
@@ -420,9 +426,11 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimSessionProxy"/> class.
+        /// </summary>
+        /// <remarks>
         /// Create <see cref="CimSession"/> by given computer name.
         /// Then create wrapper object.
-        /// </summary>
+        /// </remarks>
         /// <param name="computerName"></param>
         /// <param name="operOptions">Used when create async operation.</param>
         public CimSessionProxy(string computerName, CimOperationOptions operOptions)
@@ -433,8 +441,10 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimSessionProxy"/> class.
-        /// Create wrapper object by given session object.
         /// </summary>
+        /// <remarks>
+        /// Create wrapper object by given session object.
+        /// </remarks>
         /// <param name="session"></param>
         public CimSessionProxy(CimSession session)
         {
@@ -443,8 +453,10 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimSessionProxy"/> class.
-        /// Create wrapper object by given session object.
         /// </summary>
+        /// <remarks>
+        /// Create wrapper object by given session object.
+        /// </remarks>
         /// <param name="session"></param>
         /// <param name="operOptions">Used when create async operation.</param>
         public CimSessionProxy(CimSession session, CimOperationOptions operOptions)
@@ -1982,10 +1994,12 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimSessionProxyTestConnection"/> class.
+        /// </summary>
+        /// <remarks>
         /// Create <see cref="CimSession"/> by given computer name
         /// and session options.
         /// Then create wrapper object.
-        /// </summary>
+        /// </remarks>
         /// <param name="computerName"></param>
         /// <param name="sessionOptions"></param>
         public CimSessionProxyTestConnection(string computerName, CimSessionOptions sessionOptions)
@@ -2032,9 +2046,11 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimSessionProxyGetCimClass"/> class.
+        /// </summary>
+        /// <remarks>
         /// Create <see cref="CimSession"/> by given computer name.
         /// Then create wrapper object.
-        /// </summary>
+        /// </remarks>
         /// <param name="computerName"></param>
         public CimSessionProxyGetCimClass(string computerName)
             : base(computerName)
@@ -2043,10 +2059,12 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimSessionProxyGetCimClass"/> class.
+        /// </summary>
+        /// <remarks>
         /// Create <see cref="CimSession"/> by given computer name
         /// and session options.
         /// Then create wrapper object.
-        /// </summary>
+        /// </remarks>
         /// <param name="computerName"></param>
         /// <param name="sessionOptions"></param>
         public CimSessionProxyGetCimClass(CimSession session)
@@ -2185,9 +2203,11 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimSessionProxyNewCimInstance"/> class.
+        /// <summary>
+        /// <remarks>
         /// Create <see cref="CimSession"/> by given computer name.
         /// Then create wrapper object.
-        /// </summary>
+        /// </remarks>
         /// <param name="computerName"></param>
         public CimSessionProxyNewCimInstance(string computerName, CimNewCimInstance operation)
             : base(computerName)
@@ -2197,10 +2217,12 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimSessionProxyNewCimInstance"/> class.
+        /// </summary>
+        /// <remarks>
         /// Create <see cref="CimSession"/> by given computer name
         /// and session options.
         /// Then create wrapper object.
-        /// </summary>
+        /// </remarks>
         /// <param name="computerName"></param>
         /// <param name="sessionOptions"></param>
         public CimSessionProxyNewCimInstance(CimSession session, CimNewCimInstance operation)
@@ -2267,9 +2289,11 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         #region constructors
         /// <summary>
         /// Initializes a new instance of the <see cref="CimSessionProxySetCimInstance"/> class.
+        /// </summary>
+        /// <remarks>
         /// Create <see cref="CimSession"/> by given <see cref="CimSessionProxy"/> object.
         /// Then create wrapper object.
-        /// </summary>
+        /// </remarks>
         /// <param name="originalProxy"><see cref="CimSessionProxy"/> object to clone.</param>
         /// <param name="passThru">PassThru, true means output the modified instance; otherwise does not output.</param>
         public CimSessionProxySetCimInstance(CimSessionProxy originalProxy, bool passThru)
@@ -2280,9 +2304,11 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimSessionProxySetCimInstance"/> class.
+        /// </summary>
+        /// <remarks>
         /// Create <see cref="CimSession"/> by given computer name.
         /// Then create wrapper object.
-        /// </summary>
+        /// </remarks>
         /// <param name="computerName"></param>
         /// <param name="cimInstance"></param>
         /// <param name="passThru"></param>
@@ -2296,10 +2322,12 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimSessionProxySetCimInstance"/> class.
+        /// </summary>
+        /// <remarks>
         /// Create <see cref="CimSession"/> by given computer name
         /// and session options.
         /// Then create wrapper object.
-        /// </summary>
+        /// </remarks>
         /// <param name="computerName"></param>
         /// <param name="sessionOptions"></param>
         public CimSessionProxySetCimInstance(CimSession session, bool passThru)

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSetCimInstance.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSetCimInstance.cs
@@ -20,9 +20,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CimSetCimInstanceContext"/> class.
-        /// <para>
-        /// Constructor
-        /// </para>
         /// </summary>
         /// <param name="theNamespace"></param>
         /// <param name="theCollection"></param>
@@ -89,9 +86,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CimSetCimInstance"/> class.
-        /// <para>
-        /// Constructor
-        /// </para>
         /// </summary>
         public CimSetCimInstance()
             : base()

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSetCimInstance.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSetCimInstance.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal class CimSetCimInstanceContext : XOperationContextBase
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimSetCimInstanceContext"/> class.
         /// <para>
         /// Constructor
         /// </para>
@@ -87,6 +88,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal sealed class CimSetCimInstance : CimGetInstance
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimSetCimInstance"/> class.
         /// <para>
         /// Constructor
         /// </para>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimWriteError.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimWriteError.cs
@@ -317,6 +317,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal sealed class CimWriteError : CimSyncAction
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimWriteError"/> class.
         /// Constructor with an <see cref="CimInstance"/> error.
         /// </summary>
         /// <param name="error"></param>
@@ -327,6 +328,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimWriteError"/> class.
         /// Construct with an exception object.
         /// </summary>
         /// <param name="exception"></param>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimWriteError.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimWriteError.cs
@@ -317,8 +317,8 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal sealed class CimWriteError : CimSyncAction
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="CimWriteError"/> class.
-        /// Constructor with an <see cref="CimInstance"/> error.
+        /// Initializes a new instance of the <see cref="CimWriteError"/> class
+        /// with the specified <see cref="CimInstance"/>.
         /// </summary>
         /// <param name="error"></param>
         public CimWriteError(CimInstance error, InvocationContext context)
@@ -328,8 +328,8 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CimWriteError"/> class.
-        /// Construct with an exception object.
+        /// Initializes a new instance of the <see cref="CimWriteError"/> class
+        /// with the specified <see cref="Exception"/>.
         /// </summary>
         /// <param name="exception"></param>
         public CimWriteError(Exception exception, InvocationContext context, CimResultContext cimResultContext)

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimWriteMessage.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimWriteMessage.cs
@@ -46,7 +46,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CimWriteMessage"/> class.
-        /// Constructor method.
         /// </summary>
         public CimWriteMessage(UInt32 channel,
             string message)

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimWriteMessage.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimWriteMessage.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         #endregion
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimWriteMessage"/> class.
         /// Constructor method.
         /// </summary>
         public CimWriteMessage(UInt32 channel,

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimWriteProgress.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimWriteProgress.cs
@@ -19,7 +19,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CimWriteProgress"/> class.
-        /// Constructor.
         /// </summary>
         /// <param name="activity">
         ///  Activity identifier of the given activity

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimWriteProgress.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimWriteProgress.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal sealed class CimWriteProgress : CimBaseAction
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimWriteProgress"/> class.
         /// Constructor.
         /// </summary>
         /// <param name="activity">

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimWriteResultObject.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimWriteResultObject.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal sealed class CimWriteResultObject : CimBaseAction
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CimWriteResultObject"/> class.
         /// Constructor.
         /// </summary>
         public CimWriteResultObject(object result, XOperationContextBase theContext)

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimWriteResultObject.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimWriteResultObject.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CimWriteResultObject"/> class.
-        /// Constructor.
         /// </summary>
         public CimWriteResultObject(object result, XOperationContextBase theContext)
         {

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CmdletOperation.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CmdletOperation.cs
@@ -124,7 +124,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CmdletOperationBase"/> class.
-        /// Constructor method.
         /// </summary>
         public CmdletOperationBase(Cmdlet cmdlet)
         {
@@ -145,7 +144,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CmdletOperationRemoveCimInstance"/> class.
-        /// Constructor method.
         /// </summary>
         /// <param name="cmdlet"></param>
         public CmdletOperationRemoveCimInstance(Cmdlet cmdlet,
@@ -210,7 +208,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CmdletOperationSetCimInstance"/> class.
-        /// Constructor method.
         /// </summary>
         /// <param name="cmdlet"></param>
         public CmdletOperationSetCimInstance(Cmdlet cmdlet,
@@ -289,7 +286,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CmdletOperationInvokeCimMethod"/> class.
-        /// Constructor method.
         /// </summary>
         /// <param name="cmdlet"></param>
         public CmdletOperationInvokeCimMethod(Cmdlet cmdlet,
@@ -355,7 +351,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CmdletOperationTestCimSession"/> class.
-        /// Constructor method.
         /// </summary>
         /// <param name="cmdlet"></param>
         public CmdletOperationTestCimSession(Cmdlet cmdlet,

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CmdletOperation.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CmdletOperation.cs
@@ -123,6 +123,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         #endregion
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CmdletOperationBase"/> class.
         /// Constructor method.
         /// </summary>
         public CmdletOperationBase(Cmdlet cmdlet)
@@ -143,6 +144,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal class CmdletOperationRemoveCimInstance : CmdletOperationBase
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CmdletOperationRemoveCimInstance"/> class.
         /// Constructor method.
         /// </summary>
         /// <param name="cmdlet"></param>
@@ -207,6 +209,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal class CmdletOperationSetCimInstance : CmdletOperationBase
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CmdletOperationSetCimInstance"/> class.
         /// Constructor method.
         /// </summary>
         /// <param name="cmdlet"></param>
@@ -285,6 +288,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal class CmdletOperationInvokeCimMethod : CmdletOperationBase
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CmdletOperationInvokeCimMethod"/> class.
         /// Constructor method.
         /// </summary>
         /// <param name="cmdlet"></param>
@@ -350,6 +354,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     internal class CmdletOperationTestCimSession : CmdletOperationBase
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="CmdletOperationTestCimSession"/> class.
         /// Constructor method.
         /// </summary>
         /// <param name="cmdlet"></param>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/GetCimAssociatedInstanceCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/GetCimAssociatedInstanceCommand.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         #region constructor
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="GetCimAssociatedInstanceCommand"/> class.
         /// Constructor.
         /// </summary>
         public GetCimAssociatedInstanceCommand()

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/GetCimAssociatedInstanceCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/GetCimAssociatedInstanceCommand.cs
@@ -34,7 +34,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GetCimAssociatedInstanceCommand"/> class.
-        /// Constructor.
         /// </summary>
         public GetCimAssociatedInstanceCommand()
             : base(parameters, parameterSets)

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/GetCimClassCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/GetCimClassCommand.cs
@@ -32,7 +32,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GetCimClassCommand"/> class.
-        /// Constructor.
         /// </summary>
         public GetCimClassCommand()
             : base(parameters, parameterSets)

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/GetCimClassCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/GetCimClassCommand.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         #region constructor
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="GetCimClassCommand"/> class.
         /// Constructor.
         /// </summary>
         public GetCimClassCommand()

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/GetCimInstanceCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/GetCimInstanceCommand.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         #region constructor
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="GetCimInstanceCommand"/> class.
         /// Constructor.
         /// </summary>
         public GetCimInstanceCommand()

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/GetCimSessionCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/GetCimSessionCommand.cs
@@ -23,7 +23,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GetCimSessionCommand"/> class.
-        /// Constructor.
         /// </summary>
         public GetCimSessionCommand()
             : base(parameters, parameterSets)

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/GetCimSessionCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/GetCimSessionCommand.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         #region constructor
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="GetCimSessionCommand"/> class.
         /// Constructor.
         /// </summary>
         public GetCimSessionCommand()

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/InvokeCimMethodCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/InvokeCimMethodCommand.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         #region constructor
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="InvokeCimMethodCommand"/> class.
         /// Constructor.
         /// </summary>
         public InvokeCimMethodCommand()

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/InvokeCimMethodCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/InvokeCimMethodCommand.cs
@@ -28,7 +28,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InvokeCimMethodCommand"/> class.
-        /// Constructor.
         /// </summary>
         public InvokeCimMethodCommand()
             : base(parameters, parameterSets)

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/NewCimInstanceCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/NewCimInstanceCommand.cs
@@ -30,7 +30,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NewCimInstanceCommand"/> class.
-        /// Constructor.
         /// </summary>
         public NewCimInstanceCommand()
             : base(parameters, parameterSets)

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/NewCimInstanceCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/NewCimInstanceCommand.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         #region constructor
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="NewCimInstanceCommand"/> class.
         /// Constructor.
         /// </summary>
         public NewCimInstanceCommand()

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/NewCimSessionOptionCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/NewCimSessionOptionCommand.cs
@@ -46,7 +46,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NewCimSessionOptionCommand"/> class.
-        /// Constructor.
         /// </summary>
         public NewCimSessionOptionCommand()
             : base(parameters, parameterSets)

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/NewCimSessionOptionCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/NewCimSessionOptionCommand.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         #region constructor
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="NewCimSessionOptionCommand"/> class.
         /// Constructor.
         /// </summary>
         public NewCimSessionOptionCommand()

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/RemoveCimInstanceCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/RemoveCimInstanceCommand.cs
@@ -28,7 +28,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RemoveCimInstanceCommand"/> class.
-        /// Constructor.
         /// </summary>
         public RemoveCimInstanceCommand()
             : base(parameters, parameterSets)

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/RemoveCimInstanceCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/RemoveCimInstanceCommand.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         #region constructor
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="RemoveCimInstanceCommand"/> class.
         /// Constructor.
         /// </summary>
         public RemoveCimInstanceCommand()

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/RemoveCimSessionCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/RemoveCimSessionCommand.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         #region constructor
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="RemoveCimSessionCommand"/> class.
         /// Constructor.
         /// </summary>
         public RemoveCimSessionCommand()

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/RemoveCimSessionCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/RemoveCimSessionCommand.cs
@@ -30,7 +30,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RemoveCimSessionCommand"/> class.
-        /// Constructor.
         /// </summary>
         public RemoveCimSessionCommand()
             : base(parameters, parameterSets)

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/SetCimInstanceCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/SetCimInstanceCommand.cs
@@ -30,7 +30,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SetCimInstanceCommand"/> class.
-        /// Constructor.
         /// </summary>
         public SetCimInstanceCommand()
             : base(parameters, parameterSets)

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/SetCimInstanceCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/SetCimInstanceCommand.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         #region constructor
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="SetCimInstanceCommand"/> class.
         /// Constructor.
         /// </summary>
         public SetCimInstanceCommand()


### PR DESCRIPTION
Fix SA1642: Constructor summary documentation should begin with standard text.

https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1642.md