### PR TITLE
Remove incorrectly implemented finalizer

### DIFF
--- a/src/System.Management.Automation/utils/CryptoUtils.cs
+++ b/src/System.Management.Automation/utils/CryptoUtils.cs
@@ -627,18 +627,6 @@ namespace System.Management.Automation.Internal
             }
         }
 
-        /// <summary>
-        /// Destructor.
-        /// </summary>
-        ~PSRSACryptoServiceProvider()
-        {
-            // When Dispose() is called, GC.SuppressFinalize()
-            // is called and therefore this finalizer will not
-            // be invoked. Hence this is run only on process
-            // shutdown
-            Dispose(true);
-        }
-
         #endregion IDisposable
     }
 


### PR DESCRIPTION
Don't use finalizer to dispose of managed resources.

Follow-up to #14236.