### PR TITLE
Remove unnecessary finalizers

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ContentCommandBase.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ContentCommandBase.cs
@@ -705,14 +705,6 @@ namespace Microsoft.PowerShell.Commands
             GC.SuppressFinalize(this);
         }
 
-        /// <summary>
-        /// Finalizer.
-        /// </summary>
-        ~ContentCommandBase()
-        {
-            Dispose(false);
-        }
         #endregion IDisposable
-
     }
 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutGridViewCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutGridViewCommand.cs
@@ -492,13 +492,5 @@ namespace Microsoft.PowerShell.Commands
             this.Dispose(true);
             GC.SuppressFinalize(this);
         }
-
-        /// <summary>
-        /// Finalizer.
-        /// </summary>
-        ~OutGridViewCommand()
-        {
-            Dispose(false);
-        }
     }
 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommand.cs
@@ -63,14 +63,6 @@ namespace Microsoft.PowerShell.Commands
         private object _commandViewModelObj;
         #endregion
 
-        /// <summary>
-        /// Finalizes an instance of the ShowCommandCommand class.
-        /// </summary>
-        ~ShowCommandCommand()
-        {
-            this.Dispose(false);
-        }
-
         #region Input Cmdlet Parameter
         /// <summary>
         /// Gets or sets the command name.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Tee-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Tee-Object.cs
@@ -149,14 +149,6 @@ namespace Microsoft.PowerShell.Commands
             GC.SuppressFinalize(this);
         }
 
-        /// <summary>
-        /// Finalizer.
-        /// </summary>
-        ~TeeObjectCommand()
-        {
-            Dispose(false);
-        }
-
         #region private
         private CommandWrapper _commandWrapper;
         private bool _alreadyDisposed;

--- a/src/System.Management.Automation/engine/CommandProcessorBase.cs
+++ b/src/System.Management.Automation/engine/CommandProcessorBase.cs
@@ -957,14 +957,6 @@ namespace System.Management.Automation
             _disposed = true;
         }
 
-        /// <summary>
-        /// Finalizer for class CommandProcessorBase.
-        /// </summary>
-        ~CommandProcessorBase()
-        {
-            Dispose(false);
-        }
-
         #endregion IDispose
     }
 }

--- a/src/System.Management.Automation/engine/EventManager.cs
+++ b/src/System.Management.Automation/engine/EventManager.cs
@@ -1511,14 +1511,6 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Destructor for the EventManager class.
-        /// </summary>
-        ~PSLocalEventManager()
-        {
-            Dispose(false);
-        }
-
-        /// <summary>
         /// Disposes the EventManager class.
         /// </summary>
         public void Dispose()

--- a/src/System.Management.Automation/engine/lang/scriptblock.cs
+++ b/src/System.Management.Automation/engine/lang/scriptblock.cs
@@ -1313,14 +1313,6 @@ namespace System.Management.Automation
             _disposed = true;
         }
 
-        /// <summary>
-        /// Finalizer for class SteppablePipeline.
-        /// </summary>
-        ~SteppablePipeline()
-        {
-            Dispose(false);
-        }
-
         #endregion IDispose
     }
 

--- a/src/System.Management.Automation/engine/pipeline.cs
+++ b/src/System.Management.Automation/engine/pipeline.cs
@@ -91,14 +91,6 @@ namespace System.Management.Automation.Internal
             _disposed = true;
         }
 
-        /// <summary>
-        /// Finalizer for class PipelineProcessor.
-        /// </summary>
-        ~PipelineProcessor()
-        {
-            Dispose(false);
-        }
-
         #endregion IDispose
 
         #region Execution Logging


### PR DESCRIPTION
Remove finalizer when there are no unmanaged resources to cleanup.

Follow-up to #14236, #14246.