### PR TITLE
Use xml documentation child blocks correctly

### DIFF
--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionProxy.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionProxy.cs
@@ -91,20 +91,20 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// <para>
         /// ComputerName of the session
         /// </para>
+        /// </summary>
         /// <remarks>
         /// return value could be null
         /// </remarks>
-        /// </summary>
         internal virtual string ComputerName { get; }
 
         /// <summary>
         /// <para>
         /// CimInstance on which the current operation against.
         /// </para>
+        /// </summary>
         /// <remarks>
         /// return value could be null
         /// </remarks>
-        /// </summary>
         internal virtual CimInstance TargetCimInstance { get; }
     }
     #endregion

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/NewCimSessionCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/NewCimSessionCommand.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// </para>
         /// <para>
         /// The unit is Second.
-        /// <para>
+        /// </para>
         /// </summary>
         [Alias(AliasOT)]
         [Parameter(ValueFromPipelineByPropertyName = true)]

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/NewCimSessionCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/NewCimSessionCommand.cs
@@ -191,9 +191,11 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// If the argument is not given, a default SessionOption will be created for
         /// the session in .NET API layer.
         /// </para>
+        /// <para>
         /// If a <see cref="DCOMSessionOption"/> object is passed, then
         /// connection is made using DCOM. If a <see cref="WsManSessionOption"/>
         /// object is passed, then connection is made using WsMan.
+        /// </para>
         /// </summary>
         [Parameter(ValueFromPipelineByPropertyName = true)]
         public Microsoft.Management.Infrastructure.Options.CimSessionOptions SessionOption

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/SetCimInstanceCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/SetCimInstanceCommand.cs
@@ -268,8 +268,10 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         private IDictionary property;
 
         /// <summary>
+        /// <para>
         /// The following is the definition of the input parameter "PassThru",
         /// indicate whether Set-CimInstance should output modified result instance or not.
+        /// </para>
         /// <para>
         /// True indicates output the result instance, otherwise output nothing as by default
         /// behavior.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
@@ -72,7 +72,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Specifies how strings are escaped when writing JSON text.
         /// If the EscapeHandling property is set to EscapeHtml, the result JSON string will
-        /// be returned with HTML (<, >, &, ', ") and control characters (e.g. newline) are escaped.
+        /// be returned with HTML (&lt;, &gt;, &amp;, ', ") and control characters (e.g. newline) are escaped.
         /// </summary>
         [Parameter]
         public StringEscapeHandling EscapeHandling { get; set; } = StringEscapeHandling.Default;


### PR DESCRIPTION
Fix [DOC101](https://github.com/DotNetAnalyzers/DocumentationAnalyzers/blob/master/docs/DOC101.md): Use child blocks consistently.