### PR TITLE
Fix IDE0090: Simplify new expression part 4.1

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/HeaderInfo.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/HeaderInfo.cs
@@ -9,7 +9,7 @@ namespace Microsoft.PowerShell.Commands
 {
     internal class HeaderInfo
     {
-        private readonly List<ColumnInfo> _columns = new List<ColumnInfo>();
+        private readonly List<ColumnInfo> _columns = new();
 
         internal void AddColumn(ColumnInfo col)
         {
@@ -18,7 +18,7 @@ namespace Microsoft.PowerShell.Commands
 
         internal PSObject AddColumnsToWindow(OutWindowProxy windowProxy, PSObject liveObject)
         {
-            PSObject staleObject = new PSObject();
+            PSObject staleObject = new();
 
             // Initiate arrays to be of the same size.
             int count = _columns.Count;
@@ -47,7 +47,7 @@ namespace Microsoft.PowerShell.Commands
 
         internal PSObject CreateStalePSObject(PSObject liveObject)
         {
-            PSObject staleObject = new PSObject();
+            PSObject staleObject = new();
             foreach (ColumnInfo column in _columns)
             {
                 // Add a property to the stale PSObject.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutGridViewCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutGridViewCommand.cs
@@ -212,7 +212,7 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="liveObject">PSObject to be converted to a string.</param>
         internal string ConvertToString(PSObject liveObject)
         {
-            StringFormatError formatErrorObject = new StringFormatError();
+            StringFormatError formatErrorObject = new();
             string smartToString = PSObjectHelper.SmartToString(liveObject,
                                                                 _expressionFactory,
                                                                 InnerFormatShapeCommand.FormatEnumerationLimit(),
@@ -265,7 +265,7 @@ namespace Microsoft.PowerShell.Commands
                 baseObject is FormatInfoData ||
                 baseObject is PSObject)
             {
-                ErrorRecord error = new ErrorRecord(
+                ErrorRecord error = new(
                     new FormatException(StringUtil.Format(FormatAndOut_out_gridview.DataNotQualifiedForGridView)),
                     DataNotQualifiedForGridView,
                     ErrorCategory.InvalidType,
@@ -289,7 +289,7 @@ namespace Microsoft.PowerShell.Commands
             Exception exception = _windowProxy.GetLastException();
             if (exception != null)
             {
-                ErrorRecord error = new ErrorRecord(
+                ErrorRecord error = new(
                     exception,
                     "ManagementListInvocationException",
                     ErrorCategory.OperationStopped,
@@ -357,7 +357,7 @@ namespace Microsoft.PowerShell.Commands
             internal NonscalarTypeHeader(OutGridViewCommand parentCmd, PSObject input) : base(parentCmd)
             {
                 // Prepare a table view.
-                TableView tableView = new TableView();
+                TableView tableView = new();
                 tableView.Initialize(parentCmd._expressionFactory, parentCmd._typeInfoDataBase);
 
                 // Request a view definition from the type database.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/TableView.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/TableView.cs
@@ -25,7 +25,7 @@ namespace Microsoft.PowerShell.Commands
             _typeInfoDatabase = db;
 
             // Initialize Format Error Manager.
-            FormatErrorPolicy formatErrorPolicy = new FormatErrorPolicy();
+            FormatErrorPolicy formatErrorPolicy = new();
 
             formatErrorPolicy.ShowErrorsAsMessages = _typeInfoDatabase.defaultSettingsSection.formatErrorPolicy.ShowErrorsAsMessages;
             formatErrorPolicy.ShowErrorsInFormattedOutput = _typeInfoDatabase.defaultSettingsSection.formatErrorPolicy.ShowErrorsInFormattedOutput;
@@ -35,7 +35,7 @@ namespace Microsoft.PowerShell.Commands
 
         internal HeaderInfo GenerateHeaderInfo(PSObject input, TableControlBody tableBody, OutGridViewCommand parentCmdlet)
         {
-            HeaderInfo headerInfo = new HeaderInfo();
+            HeaderInfo headerInfo = new();
 
             // This verification is needed because the database returns "LastWriteTime" value for file system objects
             // as strings and it is used to detect this situation and use the actual field value.
@@ -124,7 +124,7 @@ namespace Microsoft.PowerShell.Commands
 
         internal HeaderInfo GenerateHeaderInfo(PSObject input, OutGridViewCommand parentCmdlet)
         {
-            HeaderInfo headerInfo = new HeaderInfo();
+            HeaderInfo headerInfo = new();
             List<MshResolvedExpressionParameterAssociation> activeAssociationList;
 
             // Get properties from the default property set of the object
@@ -201,7 +201,7 @@ namespace Microsoft.PowerShell.Commands
 
             if (activeAssociationList.Count > nMax)
             {
-                List<MshResolvedExpressionParameterAssociation> tmp = new List<MshResolvedExpressionParameterAssociation>(activeAssociationList);
+                List<MshResolvedExpressionParameterAssociation> tmp = new(activeAssociationList);
                 activeAssociationList.Clear();
                 for (int k = 0; k < nMax; k++)
                     activeAssociationList.Add(tmp[k]);
@@ -222,7 +222,7 @@ namespace Microsoft.PowerShell.Commands
             TableRowDefinition matchingRowDefinition = null;
 
             var typeNames = so.InternalTypeNames;
-            TypeMatch match = new TypeMatch(_expressionFactory, _typeInfoDatabase, typeNames);
+            TypeMatch match = new(_expressionFactory, _typeInfoDatabase, typeNames);
 
             foreach (TableRowDefinition x in tableBody.optionalDefinitionList)
             {
@@ -268,7 +268,7 @@ namespace Microsoft.PowerShell.Commands
             }
 
             // we have an override, we need to compute the merge of the active cells
-            List<TableRowItemDefinition> activeRowItemDefinitionList = new List<TableRowItemDefinition>();
+            List<TableRowItemDefinition> activeRowItemDefinitionList = new();
             int col = 0;
             foreach (TableRowItemDefinition rowItem in matchingRowDefinition.rowItemDefinitionList)
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/WriteFormatDataCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/WriteFormatDataCommand.cs
@@ -74,7 +74,7 @@ namespace Microsoft.PowerShell.Commands
 
         private bool _isLiteralPath = false;
 
-        private readonly List<ExtendedTypeDefinition> _typeDefinitions = new List<ExtendedTypeDefinition>();
+        private readonly List<ExtendedTypeDefinition> _typeDefinitions = new();
 
         private bool _force;
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-hex/Format-Hex.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-hex/Format-Hex.cs
@@ -27,7 +27,7 @@ namespace Microsoft.PowerShell.Commands
         /// For cases where a homogenous collection of bytes or other items are directly piped in, we collect all the
         /// bytes in a List&lt;byte&gt; and then output the formatted result all at once in EndProcessing().
         /// </summary>
-        private readonly List<byte> _inputBuffer = new List<byte>();
+        private readonly List<byte> _inputBuffer = new();
 
         /// <summary>
         /// Expect to group <see cref="InputObject"/>s by default. When receiving input that should not be grouped,
@@ -153,12 +153,12 @@ namespace Microsoft.PowerShell.Commands
         /// <returns></returns>
         private List<string> ResolvePaths(string[] path, bool literalPath)
         {
-            List<string> pathsToProcess = new List<string>();
+            List<string> pathsToProcess = new();
             ProviderInfo provider = null;
 
             foreach (string currentPath in path)
             {
-                List<string> newPaths = new List<string>();
+                List<string> newPaths = new();
 
                 if (literalPath)
                 {
@@ -174,7 +174,7 @@ namespace Microsoft.PowerShell.Commands
                     {
                         if (!WildcardPattern.ContainsWildcardCharacters(currentPath))
                         {
-                            ErrorRecord errorRecord = new ErrorRecord(e, "FileNotFound", ErrorCategory.ObjectNotFound, path);
+                            ErrorRecord errorRecord = new(e, "FileNotFound", ErrorCategory.ObjectNotFound, path);
                             WriteError(errorRecord);
                             continue;
                         }
@@ -185,7 +185,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     // Write a non-terminating error message indicating that path specified is not supported.
                     string errorMessage = StringUtil.Format(UtilityCommonStrings.FormatHexOnlySupportsFileSystemPaths, currentPath);
-                    ErrorRecord errorRecord = new ErrorRecord(
+                    ErrorRecord errorRecord = new(
                         new ArgumentException(errorMessage),
                         "FormatHexOnlySupportsFileSystemPaths",
                         ErrorCategory.InvalidArgument,
@@ -293,7 +293,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        private static readonly Random _idGenerator = new Random();
+        private static readonly Random _idGenerator = new();
 
         private static string GetGroupLabel(Type inputType)
             => string.Format("{0} ({1}) <{2:X8}>", inputType.Name, inputType.FullName, _idGenerator.Next());
@@ -370,7 +370,7 @@ namespace Microsoft.PowerShell.Commands
             else
             {
                 string errorMessage = StringUtil.Format(UtilityCommonStrings.FormatHexTypeNotSupported, obj.GetType());
-                ErrorRecord errorRecord = new ErrorRecord(
+                ErrorRecord errorRecord = new(
                     new ArgumentException(errorMessage),
                     "FormatHexTypeNotSupported",
                     ErrorCategory.InvalidArgument,

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-object/Format-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-object/Format-Object.cs
@@ -57,12 +57,12 @@ namespace Microsoft.PowerShell.Commands
 
         internal override FormattingCommandLineParameters GetCommandLineParameters()
         {
-            FormattingCommandLineParameters parameters = new FormattingCommandLineParameters();
+            FormattingCommandLineParameters parameters = new();
 
             if (_props != null)
             {
-                ParameterProcessor processor = new ParameterProcessor(new FormatObjectParameterDefinition());
-                TerminatingErrorContext invocationContext = new TerminatingErrorContext(this);
+                ParameterProcessor processor = new(new FormatObjectParameterDefinition());
+                TerminatingErrorContext invocationContext = new(this);
                 parameters.mshParameterList = processor.ProcessParameters(_props, invocationContext);
             }
 
@@ -86,7 +86,7 @@ namespace Microsoft.PowerShell.Commands
 
             parameters.expansion = ProcessExpandParameter();
 
-            ComplexSpecificParameters csp = new ComplexSpecificParameters();
+            ComplexSpecificParameters csp = new();
             csp.maxDepth = _depth;
             parameters.shapeParameters = csp;
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-wide/Format-Wide.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-wide/Format-Wide.cs
@@ -82,12 +82,12 @@ namespace Microsoft.PowerShell.Commands
 
         internal override FormattingCommandLineParameters GetCommandLineParameters()
         {
-            FormattingCommandLineParameters parameters = new FormattingCommandLineParameters();
+            FormattingCommandLineParameters parameters = new();
 
             if (_prop != null)
             {
-                ParameterProcessor processor = new ParameterProcessor(new FormatWideParameterDefinition());
-                TerminatingErrorContext invocationContext = new TerminatingErrorContext(this);
+                ParameterProcessor processor = new(new FormatWideParameterDefinition());
+                TerminatingErrorContext invocationContext = new(this);
                 parameters.mshParameterList = processor.ProcessParameters(new object[] { _prop }, invocationContext);
             }
 
@@ -110,7 +110,7 @@ namespace Microsoft.PowerShell.Commands
                     // the user specified -autosize:true AND a column number
                     string msg = StringUtil.Format(FormatAndOut_format_xxx.CannotSpecifyAutosizeAndColumnsError);
 
-                    ErrorRecord errorRecord = new ErrorRecord(
+                    ErrorRecord errorRecord = new(
                         new InvalidDataException(),
                         "FormatCannotSpecifyAutosizeAndColumns",
                         ErrorCategory.InvalidArgument,
@@ -133,7 +133,7 @@ namespace Microsoft.PowerShell.Commands
             if (_autosize.HasValue)
                 parameters.autosize = _autosize.Value;
 
-            WideSpecificParameters wideSpecific = new WideSpecificParameters();
+            WideSpecificParameters wideSpecific = new();
             parameters.shapeParameters = wideSpecific;
             if (_column.HasValue)
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-file/Out-File.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-file/Out-File.cs
@@ -227,7 +227,7 @@ namespace Microsoft.PowerShell.Commands
             }
 
             // use the stream writer to create and initialize the Line Output writer
-            TextWriterLineOutput twlo = new TextWriterLineOutput(_sw, computedWidth, _suppressNewline);
+            TextWriterLineOutput twlo = new(_sw, computedWidth, _suppressNewline);
 
             // finally have the ILineOutput interface extracted
             return (LineOutput)twlo;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-printer/Out-Printer.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-printer/Out-Printer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         private LineOutput InstantiateLineOutputInterface()
         {
-            PrinterLineOutput printOutput = new PrinterLineOutput(_printerName);
+            PrinterLineOutput printOutput = new(_printerName);
             return (LineOutput)printOutput;
         }
     }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-printer/PrinterLineOutput.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-printer/PrinterLineOutput.cs
@@ -89,8 +89,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             _printerName = printerName;
 
             // instantiate the helper to do the line processing when LineOutput.WriteXXX() is called
-            WriteLineHelper.WriteCallback wl = new WriteLineHelper.WriteCallback(this.OnWriteLine);
-            WriteLineHelper.WriteCallback w = new WriteLineHelper.WriteCallback(this.OnWrite);
+            WriteLineHelper.WriteCallback wl = new(this.OnWriteLine);
+            WriteLineHelper.WriteCallback w = new(this.OnWrite);
 
             _writeLineHelper = new WriteLineHelper(true, wl, w, this.DisplayCells);
         }
@@ -123,7 +123,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             try
             {
                 // create a new print document object and set the printer name, if available
-                PrintDocument pd = new PrintDocument();
+                PrintDocument pd = new();
 
                 if (!string.IsNullOrEmpty(_printerName))
                 {
@@ -315,7 +315,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// Text lines ready to print (after output cache playback).
         /// </summary>
-        private readonly Queue<string> _lines = new Queue<string>();
+        private readonly Queue<string> _lines = new();
 
         /// <summary>
         /// Cached font object.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-string/Out-String.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-string/Out-String.cs
@@ -89,7 +89,7 @@ namespace Microsoft.PowerShell.Commands
         private LineOutput InstantiateLineOutputInterface()
         {
             // set up the streaming text writer
-            StreamingTextWriter.WriteLineCallback callback = new StreamingTextWriter.WriteLineCallback(this.OnWriteLine);
+            StreamingTextWriter.WriteLineCallback callback = new(this.OnWriteLine);
 
             _writer = new StreamingTextWriter(callback, Host.CurrentCulture);
 
@@ -103,7 +103,7 @@ namespace Microsoft.PowerShell.Commands
             }
 
             // use it to create and initialize the Line Output writer
-            TextWriterLineOutput twlo = new TextWriterLineOutput(_writer, computedWidth);
+            TextWriterLineOutput twlo = new(_writer, computedWidth);
 
             // finally have the LineOutput interface extracted
             return (LineOutput)twlo;
@@ -164,6 +164,6 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Buffer used when buffering until the end.
         /// </summary>
-        private readonly StringBuilder _buffer = new StringBuilder();
+        private readonly StringBuilder _buffer = new();
     }
 }


### PR DESCRIPTION
`src\Microsoft.PowerShell.Commands.Utility\commands\utility\FormatAndOutput\`

Contributes to #14202.

https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0090
