### PR TITLE
Fix RCS1188: Remove redundant auto-property initialization part 1

### DIFF
--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimCommandBase.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimCommandBase.cs
@@ -38,12 +38,12 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// <summary>
         /// Property ParameterSetName.
         /// </summary>
-        internal string ParameterSetName { get; } = null;
+        internal string ParameterSetName { get; }
 
         /// <summary>
         /// Whether the parameter is mandatory to the set.
         /// </summary>
-        internal bool IsMandatory { get; } = false;
+        internal bool IsMandatory { get; }
     }
 
     /// <summary>
@@ -99,7 +99,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// <summary>
         /// Property <c>DefaultParameterSet</c>
         /// </summary>
-        internal bool IsDefaultParameterSet { get; } = false;
+        internal bool IsDefaultParameterSet { get; }
 
         /// <summary>
         /// Property <c>MandatoryParameterCount</c>
@@ -109,12 +109,12 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// <summary>
         /// Property <c>IsValueSet</c>
         /// </summary>
-        internal bool IsValueSet { get; set; } = false;
+        internal bool IsValueSet { get; set; }
 
         /// <summary>
         /// Property <c>IsValueSetAtBeginProcess</c>
         /// </summary>
-        internal bool IsValueSetAtBeginProcess { get; set; } = false;
+        internal bool IsValueSetAtBeginProcess { get; set; }
 
         /// <summary>
         /// Property <c>SetMandatoryParameterCount</c>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionProxy.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionProxy.cs
@@ -1457,7 +1457,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// The current CimInstance object, against which issued
         /// current operation, it could be null.
         /// </summary>
-        internal CimInstance TargetCimInstance { get; private set; } = null;
+        internal CimInstance TargetCimInstance { get; private set; }
 
         internal bool IsTemporaryCimSession { get; private set; }
 
@@ -2154,7 +2154,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         #region private members
 
-        internal CimNewCimInstance NewCimInstanceOperation { get; } = null;
+        internal CimNewCimInstance NewCimInstanceOperation { get; }
 
         #endregion
     }


### PR DESCRIPTION
`src\Microsoft.Management.Infrastructure.CimCmdlets\Microsoft.Management.Infrastructure.CimCmdlets.csproj`

Follow-up to #14244.

https://github.com/JosefPihrt/Roslynator/blob/master/docs/analyzers/RCS1188.md
