### PR TITLE
Forwarding progress stream changes from Foreach-Object -Parallel runspaces

### DIFF
--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -68,6 +68,7 @@ namespace System.Management.Automation.PSTasks
             _powershell.Streams.Warning.DataAdded += (sender, args) => HandleWarningData();
             _powershell.Streams.Verbose.DataAdded += (sender, args) => HandleVerboseData();
             _powershell.Streams.Debug.DataAdded += (sender, args) => HandleDebugData();
+            _powershell.Streams.Progress.DataAdded += (sender, args) => HandleProgressData();
             _powershell.Streams.Information.DataAdded += (sender, args) => HandleInformationData();
 
             // State change handler
@@ -129,6 +130,15 @@ namespace System.Management.Automation.PSTasks
             {
                 _dataStreamWriter.Add(
                     new PSStreamObject(PSStreamObjectType.Information, item));
+            }
+        }
+
+        private void HandleProgressData()
+        {
+            foreach (var item in _powershell.Streams.Progress.ReadAll())
+            {
+                _dataStreamWriter.Add(
+                    new PSStreamObject(PSStreamObjectType.Progress, item));
             }
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
@@ -77,6 +77,19 @@ Describe 'ForEach-Object -Parallel Basic Tests' -Tags 'CI' {
         $actualDebug.Message | Should -BeExactly 'Debug!'
     }
 
+    It 'Verifies progress data streaming' {
+
+        $ps = [Powershell]::Create([System.Management.Automation.RunspaceMode]::NewRunspace)
+
+        $ps.Commands.AddScript("`$ProgressPreference='Continue'; 1..2 | ForEach-Object -Parallel { Write-Progress -Activity Progress -Status Running }") | Out-Null
+        $ps.Invoke()
+        $pr = $ps.Streams.Progress.ReadAll()
+        $pr.Count | Should -be 2
+        $pr[0].Activity | Should -be Progress
+        $pr[0].StatusDescription | Should -be Running
+        $ps.Dispose()
+    }
+ 
     It 'Verifies information data streaming' {
 
         $actualInformation = 1..1 | ForEach-Object -Parallel { Write-Information "Information!" } 6>&1

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
@@ -84,9 +84,9 @@ Describe 'ForEach-Object -Parallel Basic Tests' -Tags 'CI' {
         $ps.Commands.AddScript("`$ProgressPreference='Continue'; 1..2 | ForEach-Object -Parallel { Write-Progress -Activity Progress -Status Running }") | Out-Null
         $ps.Invoke()
         $pr = $ps.Streams.Progress.ReadAll()
-        $pr.Count | Should -be 2
-        $pr[0].Activity | Should -be Progress
-        $pr[0].StatusDescription | Should -be Running
+        $pr.Count | Should -Be 2
+        $pr[0].Activity | Should -Be Progress
+        $pr[0].StatusDescription | Should -Be Running
         $ps.Dispose()
     }
  


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
Forwarding progress stream changes from `Foreach-Object -Parallel` runspaces in the same way as the other streams.
#14254
## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

Now looks like this.
That it doesn't render perfectly is a separate issue.

```powershell
function Show-Progress {
    param([int] $ThrottleLimit = 4)
    $parentId = 100
    Write-Progress -Id $parentId -Activity Parent -status Parallel
    1..20 | Foreach-Object -ThrottleLimit $ThrottleLimit -Parallel {
        $progress = @{
            Id               = $_
            Activity         = "Activity $_"
            CurrentOperation = "Operation $_"
            PercentComplete  = 0
            ParentId         = $using:parentId
        }
        
        Write-Progress @progress
        Start-sleep -Seconds 1
        $id
        foreach ($p in 1..100) {
            $progress.PercentComplete = $p
            Write-Progress @progress
            Start-Sleep -Milliseconds 100
        }
        start-sleep -Seconds 1
        Write-Progress @progress -Completed
    }         
    Write-Progress -Id 1 -Acti Parent -completed
}
```

![image](https://user-images.githubusercontent.com/3505151/100378243-0321f100-3013-11eb-85bc-49a3cf44cc37.png)

![image](https://user-images.githubusercontent.com/3505151/100378365-42504200-3013-11eb-80bc-c93ca26a70a5.png)


The test looks different as the Progress stream is not forwardable. So the API is used instead.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
