### PR TITLE
Send telemetry lazy at startup

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -187,14 +187,14 @@ namespace Microsoft.PowerShell
                 // First check for and handle PowerShell running in a server mode.
                 if (s_cpp.ServerMode)
                 {
-                    ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("ServerMode");
+                    PSTelemetry.SendPSCoreStartupTelemetryInBackground("ServerMode");
                     ProfileOptimization.StartProfile("StartupProfileData-ServerMode");
                     System.Management.Automation.Remoting.Server.OutOfProcessMediator.Run(s_cpp.InitialCommand, s_cpp.WorkingDirectory);
                     exitCode = 0;
                 }
                 else if (s_cpp.NamedPipeServerMode)
                 {
-                    ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("NamedPipe");
+                    PSTelemetry.SendPSCoreStartupTelemetryInBackground("NamedPipe");
                     ProfileOptimization.StartProfile("StartupProfileData-NamedPipeServerMode");
                     System.Management.Automation.Remoting.RemoteSessionNamedPipeServer.RunServerMode(
                         s_cpp.ConfigurationName);
@@ -202,14 +202,14 @@ namespace Microsoft.PowerShell
                 }
                 else if (s_cpp.SSHServerMode)
                 {
-                    ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("SSHServer");
+                    PSTelemetry.SendPSCoreStartupTelemetryInBackground("SSHServer");
                     ProfileOptimization.StartProfile("StartupProfileData-SSHServerMode");
                     System.Management.Automation.Remoting.Server.SSHProcessMediator.Run(s_cpp.InitialCommand);
                     exitCode = 0;
                 }
                 else if (s_cpp.SocketServerMode)
                 {
-                    ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("SocketServerMode");
+                    PSTelemetry.SendPSCoreStartupTelemetryInBackground("SocketServerMode");
                     ProfileOptimization.StartProfile("StartupProfileData-SocketServerMode");
                     System.Management.Automation.Remoting.Server.HyperVSocketMediator.Run(s_cpp.InitialCommand,
                         s_cpp.ConfigurationName);
@@ -243,7 +243,7 @@ namespace Microsoft.PowerShell
                     PSHost.IsStdOutputRedirected = Console.IsOutputRedirected;
 
                     // Send startup telemetry for ConsoleHost startup
-                    ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("Normal");
+                    PSTelemetry.SendPSCoreStartupTelemetryInBackground("Normal");
 
                     exitCode = s_theConsoleHost.Run(s_cpp, false);
                 }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -250,6 +250,8 @@ namespace Microsoft.PowerShell
             }
             finally
             {
+                PSTelemetry.ContinueSendTelemetry();
+
                 if (s_theConsoleHost != null)
                 {
 #if LEGACYTELEMETRY
@@ -257,6 +259,8 @@ namespace Microsoft.PowerShell
 #endif
                     s_theConsoleHost.Dispose();
                 }
+
+                PSTelemetry.EnsureSendTelemetry();
             }
 
             unchecked

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -165,7 +165,6 @@ namespace System.Management.Automation
                 if (IsModuleFeatureName(name))
                 {
                     list.Add(name);
-                    ApplicationInsightsTelemetry.SendTelemetryMetric(TelemetryType.ExperimentalModuleFeatureActivation, name);
                 }
                 else if (IsEngineFeatureName(name))
                 {
@@ -173,7 +172,6 @@ namespace System.Management.Automation
                     {
                         feature.Enabled = true;
                         list.Add(name);
-                        ApplicationInsightsTelemetry.SendTelemetryMetric(TelemetryType.ExperimentalEngineFeatureActivation, name);
                     }
                     else
                     {
@@ -187,6 +185,8 @@ namespace System.Management.Automation
                     LogError(PSEventId.ExperimentalFeature_InvalidName, name, message);
                 }
             }
+
+            PSTelemetry.SendExperimentalFeatureTelemetryMetricInBackground();
 
             return new ReadOnlyBag<string>(new HashSet<string>(list, StringComparer.OrdinalIgnoreCase));
         }

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -186,8 +186,6 @@ namespace System.Management.Automation
                 }
             }
 
-            PSTelemetry.SendExperimentalFeatureTelemetryMetricInBackground();
-
             return new ReadOnlyBag<string>(new HashSet<string>(list, StringComparer.OrdinalIgnoreCase));
         }
 

--- a/src/System.Management.Automation/utils/Telemetry.cs
+++ b/src/System.Management.Automation/utils/Telemetry.cs
@@ -862,7 +862,7 @@ namespace Microsoft.PowerShell.Telemetry
 
         internal static void Flush()
         {
-            s_telemetryClient.Flush();
+            s_telemetryClient?.Flush();
         }
     }
 

--- a/src/System.Management.Automation/utils/Telemetry.cs
+++ b/src/System.Management.Automation/utils/Telemetry.cs
@@ -694,17 +694,20 @@ namespace Microsoft.PowerShell.Telemetry
         /// </summary>
         internal static void SendExperimentalFeatureStartupTelemetry()
         {
-            foreach (string name in ExperimentalFeature.EnabledExperimentalFeatureNames)
+            if (ExperimentalFeature.EnabledExperimentalFeatureNames is not null)
             {
-                if (ExperimentalFeature.IsModuleFeatureName(name))
+                foreach (string name in ExperimentalFeature.EnabledExperimentalFeatureNames)
                 {
-                    s_telemetryClient.GetMetric(TelemetryType.ExperimentalModuleFeatureActivation.ToString(), "uuid", "SessionId", "Detail").TrackValue(metricValue: 1.0, s_uniqueUserIdentifier, s_sessionId, name);
-                }
-                else if (ExperimentalFeature.IsEngineFeatureName(name))
-                {
-                    if (ExperimentalFeature.EngineExperimentalFeatureMap.TryGetValue(name, out ExperimentalFeature feature))
+                    if (ExperimentalFeature.IsModuleFeatureName(name))
                     {
-                        s_telemetryClient.GetMetric(TelemetryType.ExperimentalEngineFeatureActivation.ToString(), "uuid", "SessionId", "Detail").TrackValue(metricValue: 1.0, s_uniqueUserIdentifier, s_sessionId, feature.Name);
+                        s_telemetryClient.GetMetric(TelemetryType.ExperimentalModuleFeatureActivation.ToString(), "uuid", "SessionId", "Detail").TrackValue(metricValue: 1.0, s_uniqueUserIdentifier, s_sessionId, name);
+                    }
+                    else if (ExperimentalFeature.IsEngineFeatureName(name))
+                    {
+                        if (ExperimentalFeature.EngineExperimentalFeatureMap.TryGetValue(name, out ExperimentalFeature feature))
+                        {
+                            s_telemetryClient.GetMetric(TelemetryType.ExperimentalEngineFeatureActivation.ToString(), "uuid", "SessionId", "Detail").TrackValue(metricValue: 1.0, s_uniqueUserIdentifier, s_sessionId, feature.Name);
+                        }
                     }
                 }
             }

--- a/src/System.Management.Automation/utils/Telemetry.cs
+++ b/src/System.Management.Automation/utils/Telemetry.cs
@@ -694,6 +694,11 @@ namespace Microsoft.PowerShell.Telemetry
         /// </summary>
         internal static void SendExperimentalFeatureStartupTelemetry()
         {
+            if (!CanSendTelemetry)
+            {
+                return;
+            }
+
             if (ExperimentalFeature.EnabledExperimentalFeatureNames is not null)
             {
                 foreach (string name in ExperimentalFeature.EnabledExperimentalFeatureNames)

--- a/src/System.Management.Automation/utils/Telemetry.cs
+++ b/src/System.Management.Automation/utils/Telemetry.cs
@@ -708,7 +708,6 @@ namespace Microsoft.PowerShell.Telemetry
                     }
                 }
             }
-
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

At startup we send a telemetry that delays the startup.
The delay is from 10 to 100 ms on my notebook but under other conditions this delay may be even worse (issues with DNS, network, target telemetry service).
- TrackEvent() is sync and causes ApplicationInsightsTelemetry static class initialization
- GetMetric().TrackValue() delays sending telemetry on 1 minutes but initialize ApplicationInsightsTelemetry too.

The fix is to send startup telemetry in a background thread with 500 ms delay.

Open question is how many do we want to postpone the send? Current value is 500 ms. This corresponds to the start time of pwsh. If we reduce this time, it may slow down the launch. If we increase this time, we can lose telemetry for short processes.
Additionally, we could add a wait for this task to complete in PowerShell exit code to ensure that the telemetry is transmitted
 

#### Perf win on my notebook:
- 35 ms ApplicationInsightsTelemetry..cctor()
- from 10 ms up to 100 ms telemetry send

Screenshots show the delays we removed:
![image](https://user-images.githubusercontent.com/22290914/100523030-fea23780-31ce-11eb-876c-756e6f8d1fd7.png)

![image](https://user-images.githubusercontent.com/22290914/100523037-0a8df980-31cf-11eb-8c51-848b7a4997ff.png)


## PR Context

Tracking issue #14268

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
