### PR TITLE
Replace locks with Interlocked.Increment

### DIFF
--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimAsyncOperation.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimAsyncOperation.cs
@@ -87,10 +87,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         {
             DebugHelper.WriteLogEx();
 
-            lock (this.a_lock)
-            {
-                this.operationCount++;
-            }
+            Interlocked.Increment(ref this.operationCount);
         }
 
         /// <summary>
@@ -107,13 +104,9 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         {
             DebugHelper.WriteLogEx();
 
-            lock (this.a_lock)
+            if (Interlocked.Decrement(ref this.operationCount) == 0)
             {
-                this.operationCount--;
-                if (this.operationCount == 0)
-                {
-                    this.moreActionEvent.Set();
-                }
+                this.moreActionEvent.Set();
             }
         }
 
@@ -542,11 +535,6 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         #endregion
 
         #region private members
-
-        /// <summary>
-        /// Lock object.
-        /// </summary>
-        private readonly object a_lock = new();
 
         /// <summary>
         /// Number of active operations.

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimAsyncOperation.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimAsyncOperation.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Management.Automation;
 using System.Threading;
 
@@ -87,7 +88,9 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         {
             DebugHelper.WriteLogEx();
 
-            Interlocked.Increment(ref this.operationCount);
+            uint count = Interlocked.Increment(ref this.operationCount);
+
+            Debug.Assert(count != uint.MinValue, "Overflow detected.");
         }
 
         /// <summary>
@@ -104,7 +107,11 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         {
             DebugHelper.WriteLogEx();
 
-            if (Interlocked.Decrement(ref this.operationCount) == 0)
+            uint count = Interlocked.Decrement(ref this.operationCount);
+
+            Debug.Assert(count != uint.MaxValue, "Underflow detected.");
+
+            if (count == 0)
             {
                 this.moreActionEvent.Set();
             }

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimAsyncOperation.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimAsyncOperation.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Management.Automation;
 using System.Threading;
 
@@ -88,9 +87,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         {
             DebugHelper.WriteLogEx();
 
-            uint count = Interlocked.Increment(ref this.operationCount);
-
-            Debug.Assert(count != uint.MinValue, "Overflow detected.");
+            Interlocked.Increment(ref this.operationCount);
         }
 
         /// <summary>
@@ -107,11 +104,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         {
             DebugHelper.WriteLogEx();
 
-            uint count = Interlocked.Decrement(ref this.operationCount);
-
-            Debug.Assert(count != uint.MaxValue, "Underflow detected.");
-
-            if (count == 0)
+            if (Interlocked.Decrement(ref this.operationCount) == 0)
             {
                 this.moreActionEvent.Set();
             }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/WMIHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/WMIHelper.cs
@@ -1532,9 +1532,7 @@ namespace Microsoft.PowerShell.Commands
             if (e.JobStateInfo.State == JobState.Blocked)
             {
                 // increment count of blocked child jobs
-                int count = Interlocked.Increment(ref _blockedChildJobsCount);
-
-                Debug.Assert(count != int.MinValue, "Underflow detected.");
+                Interlocked.Increment(ref _blockedChildJobsCount);
 
                 // if any of the child job is blocked, we set state to blocked
                 SetJobState(JobState.Blocked, null);
@@ -1554,11 +1552,7 @@ namespace Microsoft.PowerShell.Commands
             }
 
             // We are done
-            int count = Interlocked.Increment(ref _blockedChildJobsCount)
-
-            Debug.Assert(count != uint.MinValue, "Overflow detected.");
-
-            if (count == ChildJobs.Count)
+            if (Interlocked.Increment(ref _blockedChildJobsCount) == ChildJobs.Count)
             {
                 // if any child job failed, set status to failed
                 // If stop was called set, status to stopped
@@ -1735,11 +1729,7 @@ namespace Microsoft.PowerShell.Commands
         /// case</param>
         private void HandleJobUnblocked(object sender, EventArgs eventArgs)
         {
-            int count = Interlocked.Decrement(ref _blockedChildJobsCount);
-
-            Debug.Assert(count != int.MaxValue, "Underflow detected.");
-
-            if (count == 0)
+            if (Interlocked.Decrement(ref _blockedChildJobsCount) == 0)
             {
                 SetJobState(JobState.Running, null);
             }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/WebServiceProxy.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/WebServiceProxy.cs
@@ -18,6 +18,7 @@ using System.Resources;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Web.Services;
 using System.Web.Services.Description;
 using System.Web.Services.Discovery;
@@ -273,7 +274,6 @@ namespace Microsoft.PowerShell.Commands
         #region private
 
         private static ulong s_sequenceNumber = 1;
-        private static object s_sequenceNumberLock = new object();
 
         /// <summary>
         /// Generates a random name.
@@ -296,11 +296,7 @@ namespace Microsoft.PowerShell.Commands
                 }
             }
 
-            string sequenceString;
-            lock (s_sequenceNumberLock)
-            {
-                sequenceString = (s_sequenceNumber++).ToString(CultureInfo.InvariantCulture);
-            }
+            string sequenceString = Interlocked.Increment(ref s_sequenceNumber).ToString(CultureInfo.InvariantCulture);
 
             if (rndname.Length > 30)
             {

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/WebServiceProxy.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/WebServiceProxy.cs
@@ -296,11 +296,7 @@ namespace Microsoft.PowerShell.Commands
                 }
             }
 
-            int count = Interlocked.Increment(ref s_sequenceNumber);
-
-            Debug.Assert(count != uint.MinValue, "Overflow detected.");
-
-            string sequenceString = count.ToString(CultureInfo.InvariantCulture);
+            string sequenceString = Interlocked.Increment(ref s_sequenceNumber).ToString(CultureInfo.InvariantCulture);
 
             if (rndname.Length > 30)
             {

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/WebServiceProxy.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/WebServiceProxy.cs
@@ -296,7 +296,11 @@ namespace Microsoft.PowerShell.Commands
                 }
             }
 
-            string sequenceString = Interlocked.Increment(ref s_sequenceNumber).ToString(CultureInfo.InvariantCulture);
+            int count = Interlocked.Increment(ref s_sequenceNumber);
+
+            Debug.Assert(count != uint.MinValue, "Overflow detected.");
+
+            string sequenceString = count.ToString(CultureInfo.InvariantCulture);
 
             if (rndname.Length > 30)
             {

--- a/src/Microsoft.PowerShell.ScheduledJob/ScheduledJobDefinition.cs
+++ b/src/Microsoft.PowerShell.ScheduledJob/ScheduledJobDefinition.cs
@@ -1883,11 +1883,7 @@ namespace Microsoft.PowerShell.ScheduledJob
 
         private static int GetCurrentId()
         {
-            int count = Interlocked.Increment(ref CurrentId);
-
-            Debug.Assert(count != uint.MinValue, "Overflow detected.");
-
-            return count;
+            return Interlocked.Increment(ref CurrentId);
         }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.ScheduledJob/ScheduledJobDefinition.cs
+++ b/src/Microsoft.PowerShell.ScheduledJob/ScheduledJobDefinition.cs
@@ -12,6 +12,7 @@ using System.Management.Automation.Tracing;
 using System.Runtime.Serialization;
 using System.Security.Permissions;
 using System.Text.RegularExpressions;
+using System.Threading;
 
 namespace Microsoft.PowerShell.ScheduledJob
 {
@@ -44,7 +45,6 @@ namespace Microsoft.PowerShell.ScheduledJob
         // Task Action strings.
         private const string TaskExecutionPath = @"pwsh.exe";
         private const string TaskArguments = @"-NoLogo -NonInteractive -WindowStyle Hidden -Command ""Import-Module PSScheduledJob; $jobDef = [Microsoft.PowerShell.ScheduledJob.ScheduledJobDefinition]::LoadFromStore('{0}', '{1}'); $jobDef.Run()""";
-        private static object LockObject = new object();
         private static int CurrentId = 0;
         private static int DefaultExecutionHistoryLength = 32;
 
@@ -1883,10 +1883,7 @@ namespace Microsoft.PowerShell.ScheduledJob
 
         private static int GetCurrentId()
         {
-            lock (LockObject)
-            {
-                return ++CurrentId;
-            }
+            return Interlocked.Increment(ref CurrentId);
         }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.ScheduledJob/ScheduledJobDefinition.cs
+++ b/src/Microsoft.PowerShell.ScheduledJob/ScheduledJobDefinition.cs
@@ -1883,7 +1883,11 @@ namespace Microsoft.PowerShell.ScheduledJob
 
         private static int GetCurrentId()
         {
-            return Interlocked.Increment(ref CurrentId);
+            int count = Interlocked.Increment(ref CurrentId);
+
+            Debug.Assert(count != uint.MinValue, "Overflow detected.");
+
+            return count;
         }
 
         /// <summary>


### PR DESCRIPTION
# PR Summary

* Remove locks and replace with `Interlocked.Increment` and `Interlocked.Decrement` where possible.

Note: if overflow/underflow occurs, an exception will not be thrown, even if compiled in checked mode. `Debug.Assert` checks reverted as there is currently no checked build.

## PR Context

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [NA] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [NA] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [NA] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [NA] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [NA] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [NA] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
