### PR TITLE
Disable SA1000: Keywords should be spaced correctly

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -1012,7 +1012,7 @@ dotnet_diagnostic.SA0001.severity = none
 dotnet_diagnostic.SA0002.severity = none
 
 # SA1000: Keywords should be spaced correctly
-dotnet_diagnostic.SA1000.severity = warning
+dotnet_diagnostic.SA1000.severity = none
 
 # SA1001: Commas should be spaced correctly
 dotnet_diagnostic.SA1001.severity = none


### PR DESCRIPTION
Disable [SA1000](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1000.md) analyzer that was enabled in #13973 because the StyleCopAnalyzers version does not recognise target-typed new expressions.