### PR TITLE
Use OrdinalIgnoreCase in CommandLineParser

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -602,7 +602,7 @@ namespace Microsoft.PowerShell
         /// </returns>
         private (string switchKey, bool shouldBreak) GetSwitchKey(string[] args, ref int argIndex, ref bool noexitSeen)
         {
-            string switchKey = args[argIndex].Trim().ToLowerInvariant();
+            string switchKey = args[argIndex].Trim();
             if (string.IsNullOrEmpty(switchKey))
             {
                 return (switchKey: string.Empty, shouldBreak: false);
@@ -648,7 +648,7 @@ namespace Microsoft.PowerShell
             Dbg.Assert(match.Contains(smallestUnambiguousMatch), "sUM should be a substring of match");
 
             return (switchKey.Length >= smallestUnambiguousMatch.Length
-                    && match.IndexOf(switchKey, StringComparison.Ordinal) == 0);
+                    && match.StartsWith(switchKey, StringComparison.OrdinalIgnoreCase));
         }
 
         #endregion
@@ -1131,11 +1131,11 @@ namespace Microsoft.PowerShell
                 {
                     if (args[i].StartsWith('-') && args[i].Length > 1)
                     {
-                        string param = args[i].Substring(1, args[i].Length - 1).ToLower();
+                        string param = args[i].Substring(1, args[i].Length - 1);
                         StringBuilder possibleParameters = new StringBuilder();
                         foreach (string validParameter in s_validParameters)
                         {
-                            if (validParameter.Contains(param))
+                            if (validParameter.Contains(param, StringComparison.OrdinalIgnoreCase))
                             {
                                 possibleParameters.Append("\n  -");
                                 possibleParameters.Append(validParameter);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Like #14298 the PR postpones ICU initialization at startup. Perf win ~20-27 ms.

Before:

![image](https://user-images.githubusercontent.com/22290914/100834485-cc722d80-348d-11eb-8c48-f111f43b218f.png)

After:

![image](https://user-images.githubusercontent.com/22290914/100838150-c41cf100-3493-11eb-9d52-c1d4471b6ed4.png)

## PR Context

Related #14268

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
