### PR TITLE
Add documentation comments section to coding guidelines

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -383,6 +383,7 @@ includeusername
 informationrecord
 initializers
 install-packageprovider
+IntelliSense
 interactivetesting
 interop
 interoperation

--- a/docs/dev-process/coding-guidelines.md
+++ b/docs/dev-process/coding-guidelines.md
@@ -86,8 +86,13 @@ We also run the [.NET code formatter tool](https://github.com/dotnet/codeformatt
 
 * Make sure the added/updated comments are meaningful, accurate and easy to understand.
 
-* Public members must use [doc comments](https://docs.microsoft.com/dotnet/csharp/programming-guide/xmldoc/).
-  Internal and private members may use doc comments but it is not required.
+### Documentation comments
+
+* Create documentation using [XML documentation comments](https://docs.microsoft.com/dotnet/csharp/codedoc) so that Visual Studio and other IDEs can use IntelliSense to show quick information about types or members.
+
+* Publicly visible types and their members must be documented.
+
+* Documentation text should be written using complete sentences ending with full stops.
 
 ## Performance Considerations
 

--- a/docs/dev-process/coding-guidelines.md
+++ b/docs/dev-process/coding-guidelines.md
@@ -91,6 +91,7 @@ We also run the [.NET code formatter tool](https://github.com/dotnet/codeformatt
 * Create documentation using [XML documentation comments](https://docs.microsoft.com/dotnet/csharp/codedoc) so that Visual Studio and other IDEs can use IntelliSense to show quick information about types or members.
 
 * Publicly visible types and their members must be documented.
+  Internal and private members may use doc comments but it is not required.
 
 * Documentation text should be written using complete sentences ending with full stops.
 


### PR DESCRIPTION
* Add new documentation comments section
* Retarget doc comments link to conceptual article

Follow-up to #14314.