### PR TITLE
Replace `GetDirectories` in `CimDscParser`

### DIFF
--- a/src/System.Management.Automation/DscSupport/CimDSCParser.cs
+++ b/src/System.Management.Automation/DscSupport/CimDSCParser.cs
@@ -3252,8 +3252,8 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
                 {
                     foreach (var directory in Directory.EnumerateDirectories(dscResourcesPath))
                     {
-                        var schemaFiles = Directory.EnumerateFiles(directory, "*.schema.mof", SearchOption.TopDirectoryOnly);
-                        var tempSchemaFilepath = schemaFiles.FirstOrDefault();
+                        IEnumerable<string> schemaFiles = Directory.EnumerateFiles(directory, "*.schema.mof", SearchOption.TopDirectoryOnly);
+                        string tempSchemaFilepath = schemaFiles.FirstOrDefault();
 
                         Debug.Assert(schemaFiles.Count() == 1, "A valid DSCResource module can have only one schema mof file");
                         

--- a/src/System.Management.Automation/DscSupport/CimDSCParser.cs
+++ b/src/System.Management.Automation/DscSupport/CimDSCParser.cs
@@ -3250,14 +3250,15 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
                 //
                 try
                 {
-                    var dscResourceDirectories = Directory.GetDirectories(dscResourcesPath);
-                    foreach (var directory in dscResourceDirectories)
+                    foreach (var directory in Directory.EnumerateDirectories(dscResourcesPath))
                     {
-                        var schemaFiles = Directory.GetFiles(directory, "*.schema.mof", SearchOption.TopDirectoryOnly);
-                        if (schemaFiles.Length > 0)
+                        var schemaFiles = Directory.EnumerateFiles(directory, "*.schema.mof", SearchOption.TopDirectoryOnly);
+
+                        Debug.Assert(!schemaFiles.Skip(1).Any(), "A valid DSCResource module can have only one schema mof file");
+
+                        var tempSchemaFilepath = schemaFiles.FirstOrDefault();
+                        if (tempSchemaFilepath is not null)
                         {
-                            Debug.Assert(schemaFiles.Length == 1, "A valid DSCResource module can have only one schema mof file");
-                            var tempSchemaFilepath = schemaFiles[0];
                             var classes = GetCachedClassByFileName(tempSchemaFilepath) ?? ImportClasses(tempSchemaFilepath, new Tuple<string, Version>(module.Name, module.Version), errors);
                             if (classes != null)
                             {

--- a/src/System.Management.Automation/DscSupport/CimDSCParser.cs
+++ b/src/System.Management.Automation/DscSupport/CimDSCParser.cs
@@ -3253,10 +3253,10 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
                     foreach (var directory in Directory.EnumerateDirectories(dscResourcesPath))
                     {
                         var schemaFiles = Directory.EnumerateFiles(directory, "*.schema.mof", SearchOption.TopDirectoryOnly);
+                        var tempSchemaFilepath = schemaFiles.FirstOrDefault();
 
                         Debug.Assert(!schemaFiles.Skip(1).Any(), "A valid DSCResource module can have only one schema mof file");
-
-                        var tempSchemaFilepath = schemaFiles.FirstOrDefault();
+                        
                         if (tempSchemaFilepath is not null)
                         {
                             var classes = GetCachedClassByFileName(tempSchemaFilepath) ?? ImportClasses(tempSchemaFilepath, new Tuple<string, Version>(module.Name, module.Version), errors);

--- a/src/System.Management.Automation/DscSupport/CimDSCParser.cs
+++ b/src/System.Management.Automation/DscSupport/CimDSCParser.cs
@@ -3255,7 +3255,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
                         var schemaFiles = Directory.EnumerateFiles(directory, "*.schema.mof", SearchOption.TopDirectoryOnly);
                         var tempSchemaFilepath = schemaFiles.FirstOrDefault();
 
-                        Debug.Assert(!schemaFiles.Skip(1).Any(), "A valid DSCResource module can have only one schema mof file");
+                        Debug.Assert(schemaFiles.Count() == 1, "A valid DSCResource module can have only one schema mof file");
                         
                         if (tempSchemaFilepath is not null)
                         {


### PR DESCRIPTION
Avoid array allocations from GetDirectories/GetFiles.

Contributes to #14318.
