### PR TITLE
Fix CA1309: Use ordinal StringComparison in CertificateProvider

### DIFF
--- a/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
+++ b/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
@@ -214,7 +214,7 @@ namespace Microsoft.PowerShell.Commands
             // to differ only by upper/lower case.  If they do, that's really
             // a code bug, and the effect is to just display both strings.
 
-            return string.Equals(_punycodeName, _unicodeName) ?
+            return string.Equals(_punycodeName, _unicodeName, StringComparison.Ordinal) ?
                         _punycodeName :
                         _unicodeName + " (" + _punycodeName + ")";
         }

--- a/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
+++ b/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
@@ -214,9 +214,9 @@ namespace Microsoft.PowerShell.Commands
             // to differ only by upper/lower case.  If they do, that's really
             // a code bug, and the effect is to just display both strings.
 
-            return string.Equals(_punycodeName, _unicodeName, StringComparison.Ordinal) ?
-                        _punycodeName :
-                        _unicodeName + " (" + _punycodeName + ")";
+            return string.Equals(_punycodeName, _unicodeName, StringComparison.Ordinal)
+                ? _punycodeName
+                : _unicodeName + " (" + _punycodeName + ")";
         }
     }
 


### PR DESCRIPTION
Non-breaking change, just makes existing behaviour explicit.

https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309