### PR TITLE
Upgrade StyleCopAnalyzers to v1.2.0-beta.312

### DIFF
--- a/Analyzers.props
+++ b/Analyzers.props
@@ -1,5 +1,5 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.261" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.312" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/releases/tag/1.2.0-beta.312

Supercedes #14333.

Follow-up to #14293.
