### PR TITLE
Fix issue with unsigned build

### DIFF
--- a/tools/releaseBuild/azureDevOps/releaseBuild.yml
+++ b/tools/releaseBuild/azureDevOps/releaseBuild.yml
@@ -16,7 +16,7 @@ resources:
     type: github
     endpoint: ComplianceGHRepo
     name: PowerShell/compliance
-    ref: consolidate-conditions
+    ref: master
 
 variables:
   - name: DOTNET_CLI_TELEMETRY_OPTOUT

--- a/tools/releaseBuild/azureDevOps/releaseBuild.yml
+++ b/tools/releaseBuild/azureDevOps/releaseBuild.yml
@@ -16,7 +16,7 @@ resources:
     type: github
     endpoint: ComplianceGHRepo
     name: PowerShell/compliance
-    ref: master
+    ref: consolidate-conditions
 
 variables:
   - name: DOTNET_CLI_TELEMETRY_OPTOUT

--- a/tools/releaseBuild/azureDevOps/templates/linux.yml
+++ b/tools/releaseBuild/azureDevOps/templates/linux.yml
@@ -120,6 +120,7 @@ jobs:
           pattern: |
             **\*.rpm
           useMinimatch: true
+          shouldSign: $(SHOULD_SIGN)
 
   # requires windows
   - task: AzureFileCopy@4

--- a/tools/releaseBuild/azureDevOps/templates/mac-file-signing.yml
+++ b/tools/releaseBuild/azureDevOps/templates/mac-file-signing.yml
@@ -73,6 +73,7 @@ jobs:
           pattern: |
             **\*.zip
           useMinimatch: true
+          shouldSign: $(SHOULD_SIGN)
 
     - pwsh: |
         $destination = "$(System.ArtifactsDirectory)\azureMacOs"

--- a/tools/releaseBuild/azureDevOps/templates/mac-file-signing.yml
+++ b/tools/releaseBuild/azureDevOps/templates/mac-file-signing.yml
@@ -89,11 +89,12 @@ jobs:
         artifactName: signedMacOsBins
         condition: and(succeeded(), eq(variables['SHOULD_SIGN'], 'true'))
 
-    - template: EsrpScan.yml@ComplianceRepo
-      parameters:
-          scanPath: $(System.ArtifactsDirectory)\azureMacOs
-          pattern: |
-            **\*
+    - ${{ if eq(variables['SHOULD_SIGN'], 'true') }}:
+      - template: EsrpScan.yml@ComplianceRepo
+        parameters:
+            scanPath: $(System.ArtifactsDirectory)\azureMacOs
+            pattern: |
+              **\*
 
     - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
       displayName: 'Component Detection'

--- a/tools/releaseBuild/azureDevOps/templates/mac-package-signing.yml
+++ b/tools/releaseBuild/azureDevOps/templates/mac-package-signing.yml
@@ -60,6 +60,7 @@ jobs:
         pattern: |
           **\*.zip
         useMinimatch: true
+        shouldSign: $(SHOULD_SIGN)
 
   - template: upload-final-results.yml
     parameters:

--- a/tools/releaseBuild/azureDevOps/templates/nuget.yml
+++ b/tools/releaseBuild/azureDevOps/templates/nuget.yml
@@ -141,6 +141,7 @@ jobs:
         pattern: |
           **\*.nupkg
         useMinimatch: true
+        shouldSign: $(SHOULD_SIGN)
 
   - pwsh: |
       if (-not (Test-Path '$(System.ArtifactsDirectory)\signed\')) { $null = New-Item -ItemType Directory -Path '$(System.ArtifactsDirectory)\signed\' }

--- a/tools/releaseBuild/azureDevOps/templates/windows-package-signing.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-package-signing.yml
@@ -49,6 +49,7 @@ jobs:
           **\*.msi
           **\*.msix
         useMinimatch: true
+        shouldSign: $(SHOULD_SIGN)
 
   - powershell: |
       new-item -itemtype Directory -path '$(Build.StagingDirectory)\signedPackages'

--- a/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
@@ -153,6 +153,7 @@ jobs:
           **\*.ps1
           **\*.exe
         useMinimatch: true
+        shouldSign: $(SHOULD_SIGN)
 
   - pwsh: |
       Import-Module $(PowerShellRoot)/build.psm1 -Force
@@ -188,6 +189,7 @@ jobs:
         pattern: |
           **\*.dll
         useMinimatch: true
+        shouldSign: $(SHOULD_SIGN)
 
   - powershell: |
       Get-ChildItem '$(System.ArtifactsDirectory)\thirdPartySigned\*'

--- a/tools/releaseBuild/setReleaseTag.ps1
+++ b/tools/releaseBuild/setReleaseTag.ps1
@@ -79,7 +79,7 @@ if($ReleaseTag -eq 'fromBranch' -or !$ReleaseTag)
             New-BuildInfoJson -ReleaseTag $releaseTag
         }
     }
-    elseif($branchOnly -eq 'master' -or $branchOnly -like '*dailytest*')
+    elseif(($branchOnly -eq 'master' -and $env:BUILD_REASON -ne 'Manual')  -or $branchOnly -like '*dailytest*')
     {
         $isDaily = $true
         Write-Verbose "daily build" -Verbose


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix issue with unsigned build

Also 
  - Fix issue when master is manually triggered (setReleaseTag.ps1)

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
