### PR TITLE
Use string.Contains(char) overload

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
@@ -1793,7 +1793,7 @@ $result
             string localUserName = null;
 
             // The format of local admin username should be "ComputerName\AdminName"
-            if (psLocalCredential.UserName.Contains("\\"))
+            if (psLocalCredential.UserName.Contains('\\'))
             {
                 localUserName = psLocalCredential.UserName;
             }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
@@ -1128,7 +1128,7 @@ namespace Microsoft.PowerShell.Commands
         /// <returns><see langword="true"/> if the name is safe; <see langword="false"/> otherwise.</returns>
         private static bool IsSafeParameterName(string parameterName)
         {
-            return IsSafeNameOrIdentifier(parameterName) && !parameterName.Contains(":");
+            return IsSafeNameOrIdentifier(parameterName) && !parameterName.Contains(':');
         }
 
         /// <summary>

--- a/src/Microsoft.WSMan.Management/ConfigProvider.cs
+++ b/src/Microsoft.WSMan.Management/ConfigProvider.cs
@@ -3573,7 +3573,7 @@ namespace Microsoft.WSMan.Management
             string result = ChildName;
             if (ChildName != null)
             {
-                if (!ChildName.Contains("_"))
+                if (!ChildName.Contains('_'))
                 {
                     if (ChildName.Equals(WSManStringLiterals.containerQuotasParameters, StringComparison.OrdinalIgnoreCase))
                         result = WSManStringLiterals.containerQuotasParameters;

--- a/src/Microsoft.WSMan.Management/WsManHelper.cs
+++ b/src/Microsoft.WSMan.Management/WsManHelper.cs
@@ -1092,7 +1092,7 @@ namespace Microsoft.WSMan.Management
                     while (!_sr.EndOfStream)
                     {
                         string Line = _sr.ReadLine();
-                        if (Line.Contains("="))
+                        if (Line.Contains('='))
                         {
                             string[] arr = Line.Split('=', count: 2);
                             if (!ResourceValueCache.ContainsKey(arr[0].Trim()))

--- a/src/System.Management.Automation/DscSupport/CimDSCParser.cs
+++ b/src/System.Management.Automation/DscSupport/CimDSCParser.cs
@@ -2148,7 +2148,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
                         }
 
                         // resource name without wildcard (*) should be imported only once
-                        if (!resourceToImport.Contains("*") && foundResources)
+                        if (!resourceToImport.Contains('*') && foundResources)
                         {
                             resourcesFound.Add(resourceToImport);
                         }
@@ -2170,7 +2170,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
             {
                 foreach (var resourceNameToImport in resourcesToImport)
                 {
-                    if (!resourceNameToImport.Contains("*"))
+                    if (!resourceNameToImport.Contains('*'))
                     {
                         errorList.Add(new ParseError(scriptExtent,
                                                      "DscResourcesNotFoundDuringParsing",

--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
@@ -333,7 +333,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 {
                     // use some heuristics to determine if we have "composite formatting"
                     // 2004/11/16-JonN This is heuristic but should be safe enough
-                    if (directive.formatString.Contains("{0") || directive.formatString.Contains("}"))
+                    if (directive.formatString.Contains("{0") || directive.formatString.Contains('}'))
                     {
                         // we do have it, just use it
                         return string.Format(CultureInfo.CurrentCulture, directive.formatString, so);

--- a/src/System.Management.Automation/engine/CommandDiscovery.cs
+++ b/src/System.Management.Automation/engine/CommandDiscovery.cs
@@ -994,7 +994,7 @@ namespace System.Management.Automation
             {
                 if (!searcher.MoveNext())
                 {
-                    if (!commandName.Contains("-") && !commandName.Contains("\\"))
+                    if (!commandName.Contains('-') && !commandName.Contains('\\'))
                     {
                         discoveryTracer.WriteLine(
                             "The command [{0}] was not found, trying again with get- prepended",

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -2655,7 +2655,7 @@ namespace Microsoft.PowerShell.Commands
                         return PSVersionInfo.PSVersion;
                     }
 
-                    if (versionStr.Contains("."))
+                    if (versionStr.Contains('.'))
                     {
                         // If the string contains a '.', let the Version constructor handle the conversion.
                         return inputData;

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -2133,7 +2133,7 @@ namespace System.Management.Automation
                 WildcardPattern[] fromValuePatterns;
                 if (!multipleValues)
                 {
-                    if (sourceValueString.Contains(","))
+                    if (sourceValueString.Contains(','))
                     {
                         throw new PSInvalidCastException("InvalidCastEnumCommaAndNoFlags", null,
                             ExtendedTypeSystem.InvalidCastExceptionEnumerationNoFlagAndComma,

--- a/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
@@ -2373,7 +2373,7 @@ else
                         // Add this check after checking if it a path
                         if (!string.IsNullOrEmpty(modulepath.Trim()))
                         {
-                            if ((modulepath.Contains("\\") || modulepath.Contains(":")) &&
+                            if ((modulepath.Contains('\\') || modulepath.Contains(':')) &&
                                 !(Directory.Exists(modulepath) || File.Exists(modulepath)))
                             {
                                 throw new ArgumentException(

--- a/src/System.Management.Automation/help/SaveHelpCommand.cs
+++ b/src/System.Management.Automation/help/SaveHelpCommand.cs
@@ -188,7 +188,7 @@ namespace Microsoft.PowerShell.Commands
 
                     if (_credential != null)
                     {
-                        if (path.Contains("*"))
+                        if (path.Contains('*'))
                         {
                             // Deal with wildcards
 


### PR DESCRIPTION
Avoid some small string allocations.

The overload is available since .NET Core 2.1.

See also: https://github.com/dotnet/coreclr/pull/15740
