### PR TITLE
Add support to colorize FileInfo file names

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -2060,6 +2060,11 @@ namespace System.Management.Automation.Runspaces
                         .AddItemScriptBlock(@"""$($_.Progress.MaxWidth)""", label: "Progress.MaxWidth")
                         .AddItemScriptBlock(@"""$($_.Progress.View)""", label: "Progress.View")
                         .AddItemScriptBlock(@"""$($_.Progress.UseOSCIndicator)""", label: "Progress.UseOSCIndicator")
+                        .AddItemScriptBlock(@"""$($_.FileInfo.Directory)$($_.FileInfo.Directory.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "FileInfo.Directory")
+                        .AddItemScriptBlock(@"""$($_.FileInfo.SymbolicLink)$($_.FileInfo.SymbolicLink.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "FileInfo.SymbolicLink")
+                        .AddItemScriptBlock(@"""$($_.FileInfo.Executable)$($_.FileInfo.Executable.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "FileInfo.Executable")
+                        .AddItemScriptBlock(@"""$($_.FileInfo.Archive)$($_.FileInfo.Archive.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "FileInfo.Archive")
+                        .AddItemScriptBlock(@"""$($_.FileInfo.PowerShell)$($_.FileInfo.PowerShell.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "FileInfo.PowerShell")
                         .AddItemScriptBlock(@"""$($_.Foreground.Black)$($_.Foreground.Black.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "Foreground.Black")
                         .AddItemScriptBlock(@"""$($_.Foreground.White)$($_.Foreground.White.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "Foreground.White")
                         .AddItemScriptBlock(@"""$($_.Foreground.DarkGray)$($_.Foreground.DarkGray.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "Foreground.DarkGray")
@@ -2120,6 +2125,20 @@ namespace System.Management.Automation.Runspaces
                         .AddItemProperty(@"MaxWidth")
                         .AddItemProperty(@"View")
                         .AddItemProperty(@"UseOSCIndicator")
+                    .EndEntry()
+                .EndList());
+        }
+
+        private static IEnumerable<FormatViewDefinition> ViewsOf_System_Management_Automation_PSStyleFileInfoFormat()
+        {
+            yield return new FormatViewDefinition("System.Management.Automation.PSStyle+FileInfoFormatting",
+                ListControl.Create()
+                    .StartEntry()
+                        .AddItemScriptBlock(@"""$($_.Directory)$($_.Directory.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "Directory")
+                        .AddItemScriptBlock(@"""$($_.SymbolicLink)$($_.SymbolicLink.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "SymbolicLink")
+                        .AddItemScriptBlock(@"""$($_.Executable)$($_.Executable.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "Executable")
+                        .AddItemScriptBlock(@"""$($_.Archive)$($_.Archive.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "Archive")
+                        .AddItemScriptBlock(@"""$($_.PowerShell)$($_.PowerShell.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "Formatting.PowerShell")
                     .EndEntry()
                 .EndList());
         }

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -2159,8 +2159,8 @@ namespace System.Management.Automation.Runspaces
                                 $null = $sb.Append([Environment]::NewLine)
                             }
 
-                            $sb.ToString()
-                        ", label: "Extension")
+                            $sb.ToString()",
+                            label: "Extension")
                     .EndEntry()
                 .EndList());
         }

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -277,6 +277,10 @@ namespace System.Management.Automation.Runspaces
                 ViewsOf_System_Management_Automation_PSStyleProgressConfiguration());
 
             yield return new ExtendedTypeDefinition(
+                "System.Management.Automation.PSStyle+FileInfoFormatting",
+                ViewsOf_System_Management_Automation_PSStyleFileInfoFormat());
+
+            yield return new ExtendedTypeDefinition(
                 "System.Management.Automation.PSStyle+ForegroundColor",
                 ViewsOf_System_Management_Automation_PSStyleForegroundColor());
 
@@ -2063,8 +2067,7 @@ namespace System.Management.Automation.Runspaces
                         .AddItemScriptBlock(@"""$($_.FileInfo.Directory)$($_.FileInfo.Directory.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "FileInfo.Directory")
                         .AddItemScriptBlock(@"""$($_.FileInfo.SymbolicLink)$($_.FileInfo.SymbolicLink.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "FileInfo.SymbolicLink")
                         .AddItemScriptBlock(@"""$($_.FileInfo.Executable)$($_.FileInfo.Executable.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "FileInfo.Executable")
-                        .AddItemScriptBlock(@"""$($_.FileInfo.Archive)$($_.FileInfo.Archive.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "FileInfo.Archive")
-                        .AddItemScriptBlock(@"""$($_.FileInfo.PowerShell)$($_.FileInfo.PowerShell.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "FileInfo.PowerShell")
+                        .AddItemScriptBlock(@"""$([string]::Join(',',$_.FileInfo.Extension.Keys))""", label: "FileInfo.Extension")
                         .AddItemScriptBlock(@"""$($_.Foreground.Black)$($_.Foreground.Black.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "Foreground.Black")
                         .AddItemScriptBlock(@"""$($_.Foreground.White)$($_.Foreground.White.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "Foreground.White")
                         .AddItemScriptBlock(@"""$($_.Foreground.DarkGray)$($_.Foreground.DarkGray.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "Foreground.DarkGray")
@@ -2137,8 +2140,27 @@ namespace System.Management.Automation.Runspaces
                         .AddItemScriptBlock(@"""$($_.Directory)$($_.Directory.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "Directory")
                         .AddItemScriptBlock(@"""$($_.SymbolicLink)$($_.SymbolicLink.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "SymbolicLink")
                         .AddItemScriptBlock(@"""$($_.Executable)$($_.Executable.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "Executable")
-                        .AddItemScriptBlock(@"""$($_.Archive)$($_.Archive.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "Archive")
-                        .AddItemScriptBlock(@"""$($_.PowerShell)$($_.PowerShell.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "Formatting.PowerShell")
+                        .AddItemScriptBlock(@"
+                            $sb = [System.Text.StringBuilder]::new()
+                            $maxKeyLength = 0
+                            foreach ($key in $_.Extension.Keys) {
+                                if ($key.Length -gt $maxKeyLength) {
+                                    $maxKeyLength = $key.Length
+                                }
+                            }
+
+                            foreach ($key in $_.Extension.Keys) {
+                                $null = $sb.Append($key.PadRight($maxKeyLength))
+                                $null = $sb.Append(' = ""')
+                                $null = $sb.Append($_.Extension[$key])
+                                $null = $sb.Append($_.Extension[$key].Replace(""`e"",'`e'))
+                                $null = $sb.Append($PSStyle.Reset)
+                                $null = $sb.Append('""')
+                                $null = $sb.Append([Environment]::NewLine)
+                            }
+
+                            $sb.ToString()
+                        ", label: "Extension")
                     .EndEntry()
                 .EndList());
         }

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -37,6 +37,7 @@ namespace System.Management.Automation
         Classic = 1,
     }
     
+    /// <summary>
     /// Type is used for custom formatting.
     /// </summary>
     public class AnsiDictionary : Dictionary<string, string>
@@ -44,7 +45,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Initializes a new instance of the <see cref="AnsiDictionary"/> class.
         /// </summary>
-        public AnsiDictionary() : base(StringComparer.OrdinalIgnoreCase){}
+        public AnsiDictionary() : base(StringComparer.OrdinalIgnoreCase) { }
     }
 
     #region PSStyle

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -369,14 +369,14 @@ namespace System.Management.Automation
             /// <summary>
             /// Gets or sets the style for archive.
             /// </summary>
-            public AnsiDictionary Extension { get; }
+            public Dictionary<string,string> Extension { get; }
 
             /// <summary>
             /// Initializes a new instance of the <see cref="FileInfoFormatting"/> class.
             /// </summary>
             public FileInfoFormatting()
             {
-                Extension = new AnsiDictionary();
+                Extension = new Dictionary<string,string>(StringComparer.OrdinalIgnoreCase);
 
                 // archives
                 Extension.Add(".zip", "\x1b[31;1m");

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+
 namespace System.Management.Automation
 {
     #region OutputRendering
@@ -33,6 +35,16 @@ namespace System.Management.Automation
 
         /// <summary>Classic rendering of progress.</summary>
         Classic = 1,
+    }
+    
+    /// Type is used for custom formatting.
+    /// </summary>
+    public class AnsiDictionary : Dictionary<string, string>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AnsiDictionary"/> class.
+        /// </summary>
+        public AnsiDictionary():base(StringComparer.OrdinalIgnoreCase){}
     }
 
     #region PSStyle
@@ -357,13 +369,30 @@ namespace System.Management.Automation
             /// <summary>
             /// Gets or sets the style for archive.
             /// </summary>
-            public string Archive { get; set; } = "\x1b[31;1m";
+            public AnsiDictionary Extension { get; }
 
             /// <summary>
-            /// Gets or sets the style for PowerShell files.
+            /// Initializes a new instance of the <see cref="FileInfoFormatting"/> class.
             /// </summary>
+            public FileInfoFormatting()
+            {
+                Extension = new AnsiDictionary();
 
-            public string PowerShell { get; set; } = "\x1b[33;1m";
+                // archives
+                Extension.Add(".zip", "\x1b[31;1m");
+                Extension.Add(".tgz", "\x1b[31;1m");
+                Extension.Add(".gz", "\x1b[31;1m");
+                Extension.Add(".tar", "\x1b[31;1m");
+                Extension.Add(".nupkg", "\x1b[31;1m");
+                Extension.Add(".cab", "\x1b[31;1m");
+                Extension.Add(".7z", "\x1b[31;1m");
+
+                // powershell
+                Extension.Add(".ps1", "\x1b[33;1m");
+                Extension.Add(".psd1", "\x1b[33;1m");
+                Extension.Add(".psm1", "\x1b[33;1m");
+                Extension.Add(".ps1xml", "\x1b[33;1m");
+            }
         }
 
         /// <summary>

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -334,6 +334,39 @@ namespace System.Management.Automation
         }
 
         /// <summary>
+        /// Contains formatting styles for FileInfo objects.
+        /// </summary>
+
+        public class FileInfoFormatting
+        {
+            /// <summary>
+            /// Gets or sets the style for directories.
+            /// </summary>
+            public string Directory { get; set; } = "\x1b[44;1m";
+
+            /// <summary>
+            /// Gets or sets the style for symbolic links.
+            /// </summary>
+            public string SymbolicLink { get; set; } = "\x1b[36;1m";
+
+            /// <summary>
+            /// Gets or sets the style for executables.
+            /// </summary>
+            public string Executable { get; set; } = "\x1b[32;1m";
+
+            /// <summary>
+            /// Gets or sets the style for archive.
+            /// </summary>
+            public string Archive { get; set; } = "\x1b[31;1m";
+
+            /// <summary>
+            /// Gets or sets the style for PowerShell files.
+            /// </summary>
+
+            public string PowerShell { get; set; } = "\x1b[33;1m";
+        }
+
+        /// <summary>
         /// Gets or sets the rendering mode for output.
         /// </summary>
         public OutputRendering OutputRendering { get; set; } = OutputRendering.Automatic;
@@ -444,6 +477,11 @@ namespace System.Management.Automation
         /// </summary>
         public BackgroundColor Background { get; }
 
+        /// <summary>
+        /// Gets FileInfo colors.
+        /// </summary>
+        public FileInfoFormatting FileInfo { get; }
+
         private static readonly PSStyle s_psstyle = new PSStyle();
 
         private PSStyle()
@@ -452,6 +490,7 @@ namespace System.Management.Automation
             Progress   = new ProgressConfiguration();
             Foreground = new ForegroundColor();
             Background = new BackgroundColor();
+            FileInfo = new FileInfoFormatting();
         }
 
         /// <summary>

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -37,17 +37,6 @@ namespace System.Management.Automation
         Classic = 1,
     }
     
-    /// <summary>
-    /// Type is used for custom formatting.
-    /// </summary>
-    public class AnsiDictionary : Dictionary<string, string>
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AnsiDictionary"/> class.
-        /// </summary>
-        public AnsiDictionary() : base(StringComparer.OrdinalIgnoreCase) { }
-    }
-
     #region PSStyle
     /// <summary>
     /// Contains configuration for how PowerShell renders text.
@@ -349,7 +338,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Contains formatting styles for FileInfo objects.
         /// </summary>
-        public class FileInfoFormatting
+        public sealed class FileInfoFormatting
         {
             /// <summary>
             /// Gets or sets the style for directories.

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -348,7 +348,6 @@ namespace System.Management.Automation
         /// <summary>
         /// Contains formatting styles for FileInfo objects.
         /// </summary>
-
         public class FileInfoFormatting
         {
             /// <summary>
@@ -367,16 +366,16 @@ namespace System.Management.Automation
             public string Executable { get; set; } = "\x1b[32;1m";
 
             /// <summary>
-            /// Gets or sets the style for archive.
+            /// Gets the style for archive.
             /// </summary>
-            public Dictionary<string,string> Extension { get; }
+            public Dictionary<string, string> Extension { get; }
 
             /// <summary>
             /// Initializes a new instance of the <see cref="FileInfoFormatting"/> class.
             /// </summary>
             public FileInfoFormatting()
             {
-                Extension = new Dictionary<string,string>(StringComparer.OrdinalIgnoreCase);
+                Extension = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
                 // archives
                 Extension.Add(".zip", "\x1b[31;1m");

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -44,7 +44,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Initializes a new instance of the <see cref="AnsiDictionary"/> class.
         /// </summary>
-        public AnsiDictionary():base(StringComparer.OrdinalIgnoreCase){}
+        public AnsiDictionary() : base(StringComparer.OrdinalIgnoreCase){}
     }
 
     #region PSStyle

--- a/src/System.Management.Automation/engine/CommandDiscovery.cs
+++ b/src/System.Management.Automation/engine/CommandDiscovery.cs
@@ -1410,7 +1410,7 @@ namespace System.Management.Automation
             lock (s_lockObject)
             {
                 s_cachedPathExtCollection = pathExt != null
-                    ? pathExt.Split(Utils.Separators.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+                    ? pathExt.ToLower().Split(Utils.Separators.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
                     : Array.Empty<string>();
                 s_cachedPathExtCollectionWithPs1 = new string[s_cachedPathExtCollection.Length + 1];
                 s_cachedPathExtCollectionWithPs1[0] = StringLiterals.PowerShellScriptFileExtension;

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -141,7 +141,7 @@ namespace System.Management.Automation
                     name: "PSLoadAssemblyFromNativeCode",
                     description: "Expose an API to allow assembly loading from native code"),
                 new ExperimentalFeature(
-                    name: "PSFileInfoColor",
+                    name: "PSAnsiRendering.FileInfo",
                     description: "Enable coloring for FileInfo objects"),
             };
 

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -140,6 +140,9 @@ namespace System.Management.Automation
                 new ExperimentalFeature(
                     name: "PSLoadAssemblyFromNativeCode",
                     description: "Expose an API to allow assembly loading from native code"),
+                new ExperimentalFeature(
+                    name: "PSFileInfoColor",
+                    description: "Enable coloring for FileInfo objects"),
             };
 
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -141,7 +141,7 @@ namespace System.Management.Automation
                     name: "PSLoadAssemblyFromNativeCode",
                     description: "Expose an API to allow assembly loading from native code"),
                 new ExperimentalFeature(
-                    name: "PSAnsiRendering.FileInfo",
+                    name: "PSAnsiRenderingFileInfo",
                     description: "Enable coloring for FileInfo objects"),
             };
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -2060,7 +2060,7 @@ namespace Microsoft.PowerShell.Commands
         {
             string[] executableExtensions = { ".exe", ".bat", ".com", ".cmd" };
 
-            if (ExperimentalFeature.IsEnabled("PSAnsiRendering") && ExperimentalFeature.IsEnabled("PSFileInfoColor"))
+            if (ExperimentalFeature.IsEnabled("PSAnsiRendering") && ExperimentalFeature.IsEnabled("PSAnsiRendering.FileInfo"))
             {
                 if (instance?.BaseObject is FileSystemInfo fileInfo)
                 {

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -2058,7 +2058,7 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>Name if a file or directory, Name -> Target if symlink.</returns>
         public static string NameString(PSObject instance)
         {
-            string[] executableExtensions = {".exe", ".bat", ".com", ".cmd"};
+            string[] executableExtensions = { ".exe", ".bat", ".com", ".cmd" };
 
             if (ExperimentalFeature.IsEnabled("PSAnsiRendering") && ExperimentalFeature.IsEnabled("PSFileInfoColor"))
             {

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -2058,7 +2058,7 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>Name if a file or directory, Name -> Target if symlink.</returns>
         public static string NameString(PSObject instance)
         {
-            if (ExperimentalFeature.IsEnabled("PSAnsiRendering") && ExperimentalFeature.IsEnabled("PSAnsiRendering.FileInfo"))
+            if (ExperimentalFeature.IsEnabled("PSAnsiRendering") && ExperimentalFeature.IsEnabled("PSAnsiRenderingFileInfo"))
             {
                 if (instance?.BaseObject is FileSystemInfo fileInfo)
                 {

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -2058,11 +2058,9 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>Name if a file or directory, Name -> Target if symlink.</returns>
         public static string NameString(PSObject instance)
         {
-            string[] archiveExtensions = {".zip", ".tar.gz", ".tgz", ".7z", ".tar", ".cab", ".nupkg"};
             string[] executableExtensions = {".exe", ".bat", ".com", ".cmd"};
-            string[] powershellExtensions = {".ps1", ".psm1", ".psd1", ".ps1xml"};
 
-            if (ExperimentalFeature.IsEnabled("PSAnsiRendering"))
+            if (ExperimentalFeature.IsEnabled("PSAnsiRendering") && ExperimentalFeature.IsEnabled("PSFileInfoColor"))
             {
                 if (instance?.BaseObject is FileSystemInfo fileInfo)
                 {
@@ -2070,17 +2068,13 @@ namespace Microsoft.PowerShell.Commands
                     {
                         return $"{PSStyle.Instance.FileInfo.SymbolicLink}{fileInfo.Name}{PSStyle.Instance.Reset} -> {InternalSymbolicLinkLinkCodeMethods.GetTarget(instance)}";
                     }
-                    else if (archiveExtensions.Contains(fileInfo.Extension.ToLower()))
-                    {
-                        return $"{PSStyle.Instance.FileInfo.Archive}{fileInfo.Name}{PSStyle.Instance.Reset}";
-                    }
                     else if (fileInfo.Attributes.HasFlag(FileAttributes.Directory))
                     {
                         return $"{PSStyle.Instance.FileInfo.Directory}{fileInfo.Name}{PSStyle.Instance.Reset}";
                     }
-                    else if (powershellExtensions.Contains(fileInfo.Extension.ToLower()))
+                    else if (PSStyle.Instance.FileInfo.Extension.ContainsKey(fileInfo.Extension))
                     {
-                        return $"{PSStyle.Instance.FileInfo.PowerShell}{fileInfo.Name}{PSStyle.Instance.Reset}";
+                        return $"{PSStyle.Instance.FileInfo.Extension[fileInfo.Extension]}{fileInfo.Name}{PSStyle.Instance.Reset}";
                     }
                     else if ((Platform.IsWindows && executableExtensions.Contains(fileInfo.Extension.ToLower())) ||
                         (!Platform.IsWindows && Platform.NonWindowsIsExecutable(fileInfo.FullName)))

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -2058,8 +2058,6 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>Name if a file or directory, Name -> Target if symlink.</returns>
         public static string NameString(PSObject instance)
         {
-            string[] executableExtensions = { ".exe", ".bat", ".com", ".cmd" };
-
             if (ExperimentalFeature.IsEnabled("PSAnsiRendering") && ExperimentalFeature.IsEnabled("PSAnsiRendering.FileInfo"))
             {
                 if (instance?.BaseObject is FileSystemInfo fileInfo)
@@ -2076,7 +2074,7 @@ namespace Microsoft.PowerShell.Commands
                     {
                         return $"{PSStyle.Instance.FileInfo.Extension[fileInfo.Extension]}{fileInfo.Name}{PSStyle.Instance.Reset}";
                     }
-                    else if ((Platform.IsWindows && executableExtensions.Contains(fileInfo.Extension.ToLower())) ||
+                    else if ((Platform.IsWindows && CommandDiscovery.PathExtensions.Contains(fileInfo.Extension.ToLower())) ||
                         (!Platform.IsWindows && Platform.NonWindowsIsExecutable(fileInfo.FullName)))
                     {
                         return $"{PSStyle.Instance.FileInfo.Executable}{fileInfo.Name}{PSStyle.Instance.Reset}";

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
@@ -205,3 +205,52 @@ Describe "Get-Item environment provider on Windows with accidental case-variant 
         }
     }
 }
+
+Describe 'Formatting for FileInfo objects' -Tags 'CI' {
+    BeforeAll {
+        $PSDefaultParameterValues.Add('It:Skip', (-not $EnabledExperimentalFeatures.Contains('PSFileInfoColor')))
+        $extensionTests = [System.Collections.Generic.List[HashTable]]::new()
+        foreach ($extension in @('.zip', '.tgz', '.tar', '.gz', '.nupkg', '.cab', '.7z', '.ps1', '.psd1', '.psm1', '.ps1xml')) {
+            $extensionTests.Add(@{extension = $extension})
+        }
+    }
+
+    AfterAll {
+        $PSDefaultParameterValues.Remove('It:Skip')
+    }
+
+    It 'File type <extension> should have correct color' -TestCases $extensionTests {
+        param($extension)
+
+        $testFile = Join-Path -Path $TestDrive -ChildPath "test$extension"
+        $file = New-Item -ItemType File -Path $testFile
+        $file.NameString | Should -BeExactly "$($PSStyle.FileInfo.Extension[$extension] + $file.Name + $PSStyle.Reset)"
+    }
+
+    It 'Directory should have correct color' {
+        $dirPath = Join-Path -Path $TestDrive -ChildPath 'myDir'
+        $dir = New-Item -ItemType Directory -Path $dirPath
+        $dir.NameString | Should -BeExactly "$($PSStyle.FileInfo.Directory + $dir.Name + $PSStyle.Reset)"
+    }
+
+    It 'Executable should have correct color' {
+        if ($IsWindows) {
+            $exePath = Join-Path -Path $TestDrive -ChildPath 'myExe.exe'
+            $exe = New-Item -ItemType File -Path $exePath
+        }
+        else {
+            $exePath = Join-Path -Path $TestDrive -ChildPath 'myExe'
+            $null = New-Item -ItemType File -Path $exePath
+            chmod +x $exePath
+            $exe = Get-Item -Path $exePath
+        }
+
+        $exe.NameString | Should -BeExactly "$($PSStyle.FileInfo.Executable + $exe.Name + $PSStyle.Reset)"
+    }
+
+    It 'Symlink should have correct color' {
+        $linkPath = Join-Path -Path $TestDrive -ChildPath 'link'
+        $link = New-Item -ItemType SymbolicLink -Name 'link' -Value $TestDrive -Path $TestDrive
+        $link.NameString | Should -BeExactly "$($PSStyle.FileInfo.SymbolicLink + $link.Name + $PSStyle.Reset) -> $TestDrive"
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
@@ -208,7 +208,7 @@ Describe "Get-Item environment provider on Windows with accidental case-variant 
 
 Describe 'Formatting for FileInfo objects' -Tags 'CI' {
     BeforeAll {
-        $PSDefaultParameterValues.Add('It:Skip', (-not $EnabledExperimentalFeatures.Contains('PSFileInfoColor')))
+        $PSDefaultParameterValues.Add('It:Skip', (-not $EnabledExperimentalFeatures.Contains('PSAnsiRendering.FileInfo')))
         $extensionTests = [System.Collections.Generic.List[HashTable]]::new()
         foreach ($extension in @('.zip', '.tgz', '.tar', '.gz', '.nupkg', '.cab', '.7z', '.ps1', '.psd1', '.psm1', '.ps1xml')) {
             $extensionTests.Add(@{extension = $extension})
@@ -251,7 +251,7 @@ Describe 'Formatting for FileInfo objects' -Tags 'CI' {
 
 Describe 'Formatting for FileInfo requiring admin' -Tags 'CI','RequireAdminOnWindows' {
     BeforeAll {
-        $PSDefaultParameterValues.Add('It:Skip', (-not $EnabledExperimentalFeatures.Contains('PSFileInfoColor')))
+        $PSDefaultParameterValues.Add('It:Skip', (-not $EnabledExperimentalFeatures.Contains('PSAnsiRendering.FileInfo')))
     }
 
     AfterAll {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
@@ -208,7 +208,7 @@ Describe "Get-Item environment provider on Windows with accidental case-variant 
 
 Describe 'Formatting for FileInfo objects' -Tags 'CI' {
     BeforeAll {
-        $PSDefaultParameterValues.Add('It:Skip', (-not $EnabledExperimentalFeatures.Contains('PSAnsiRendering.FileInfo')))
+        $PSDefaultParameterValues.Add('It:Skip', (-not $EnabledExperimentalFeatures.Contains('PSAnsiRenderingFileInfo')))
         $extensionTests = [System.Collections.Generic.List[HashTable]]::new()
         foreach ($extension in @('.zip', '.tgz', '.tar', '.gz', '.nupkg', '.cab', '.7z', '.ps1', '.psd1', '.psm1', '.ps1xml')) {
             $extensionTests.Add(@{extension = $extension})
@@ -251,7 +251,7 @@ Describe 'Formatting for FileInfo objects' -Tags 'CI' {
 
 Describe 'Formatting for FileInfo requiring admin' -Tags 'CI','RequireAdminOnWindows' {
     BeforeAll {
-        $PSDefaultParameterValues.Add('It:Skip', (-not $EnabledExperimentalFeatures.Contains('PSAnsiRendering.FileInfo')))
+        $PSDefaultParameterValues.Add('It:Skip', (-not $EnabledExperimentalFeatures.Contains('PSAnsiRenderingFileInfo')))
     }
 
     AfterAll {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
@@ -247,6 +247,16 @@ Describe 'Formatting for FileInfo objects' -Tags 'CI' {
 
         $exe.NameString | Should -BeExactly "$($PSStyle.FileInfo.Executable + $exe.Name + $PSStyle.Reset)"
     }
+}
+
+Describe 'Formatting for FileInfo requiring admin' -Tags 'CI','RequireAdminOnWindows' {
+    BeforeAll {
+        $PSDefaultParameterValues.Add('It:Skip', (-not $EnabledExperimentalFeatures.Contains('PSFileInfoColor')))
+    }
+
+    AfterAll {
+        $PSDefaultParameterValues.Remove('It:Skip')
+    }
 
     It 'Symlink should have correct color' {
         $linkPath = Join-Path -Path $TestDrive -ChildPath 'link'


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Built on `PSAnsiRendering` experimental feature to enable coloring of specific file types.  Example:

![Screen Shot 2020-12-12 at 10 32 02 AM](https://user-images.githubusercontent.com/11859881/101992048-5f1c8480-3c65-11eb-86d5-886c09ba9d84.png)

Adds `FileInfo` member to `$PSStyle` automatic variable to allow customization.  `Directory`, `SymbolicLink`, and `Executable` are built-in, but an `Extension` member which is a dictionary allows modification and addition of new extensions and custom styles.  Leverages existing `NameString` extended member for coloring.  Pre-included extensions for archives and PowerShell files.  Default color choices are mostly consistent with `ls --color`.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/9270

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [x] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [x] Experimental feature name(s): `PSAnsiRenderingFileInfo`
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/7017
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
