### PR TITLE
Remove suppression of unknown compiler warnings

### DIFF
--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -4177,7 +4177,6 @@ namespace System.Management.Automation
         internal static object AuxiliaryConstructorInvoke(MethodInformation methodInformation, object[] arguments, object[] originalArguments)
         {
             object returnValue;
-#pragma warning disable 56500
             try
             {
                 returnValue = methodInformation.Invoke(target: null, arguments);
@@ -4202,7 +4201,6 @@ namespace System.Management.Automation
 
             SetReferences(arguments, methodInformation, originalArguments);
             return returnValue;
-#pragma warning restore 56500
         }
 
         /// <summary>
@@ -4218,7 +4216,6 @@ namespace System.Management.Automation
         {
             object result;
 
-#pragma warning disable 56500
             try
             {
                 // call the method and return the result unless the return type is void in which
@@ -4270,7 +4267,6 @@ namespace System.Management.Automation
                     ExtendedTypeSystem.MethodInvocationException,
                     methodInformation.method.Name, arguments.Length, e.Message);
             }
-#pragma warning restore 56500
 
             SetReferences(arguments, methodInformation, originalArguments);
             MethodInfo methodInfo = methodInformation.method as MethodInfo;

--- a/src/System.Management.Automation/engine/ExtraAdapter.cs
+++ b/src/System.Management.Automation/engine/ExtraAdapter.cs
@@ -52,7 +52,6 @@ namespace System.Management.Automation
             PropertyValueCollection collection = entry.Properties[memberName];
             object valueToTake = collection;
 
-#pragma warning disable 56500
             // Even for the cases where propertyName does not exist
             // entry.Properties[propertyName] still returns a PropertyValueCollection.
             // The non schema way to check for a non existing property is to call entry.InvokeGet
@@ -77,7 +76,6 @@ namespace System.Management.Automation
             {
                 property = null;
             }
-#pragma warning restore 56500
 
             if (valueToTake == null)
             {
@@ -148,7 +146,6 @@ namespace System.Management.Automation
 
             int countOfProperties = 0;
 
-#pragma warning disable 56500
             try
             {
                 countOfProperties = entry.Properties.PropertyNames.Count;
@@ -156,7 +153,6 @@ namespace System.Management.Automation
             catch (Exception) // swallow all non-severe exceptions
             {
             }
-#pragma warning restore 56500
 
             if (countOfProperties > 0)
             {

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -30,7 +30,6 @@ using System.Management;
 #endif
 
 #pragma warning disable 1634, 1691 // Stops compiler from warning about unknown warnings
-#pragma warning disable 56500
 
 namespace System.Management.Automation
 {
@@ -5840,5 +5839,3 @@ namespace System.Management.Automation
         #endregion type converter
     }
 }
-
-#pragma warning restore 56500

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -30,7 +30,6 @@ using System.Management;
 #endif
 
 #pragma warning disable 1634, 1691 // Stops compiler from warning about unknown warnings
-#pragma warning disable 56500
 
 namespace System.Management.Automation
 {
@@ -2489,8 +2488,6 @@ namespace System.Management.Automation
         SpecificProperties = 2
     }
 }
-
-#pragma warning restore 56500
 
 namespace Microsoft.PowerShell
 {

--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -12,7 +12,6 @@ using System.Reflection;
 using Dbg = System.Management.Automation;
 
 #pragma warning disable 1634, 1691 // Stops compiler from warning about unknown warnings
-#pragma warning disable 56500
 
 namespace System.Management.Automation
 {
@@ -4936,5 +4935,3 @@ namespace System.Management.Automation
         Delete = 2
     }
 }
-
-#pragma warning restore 56500

--- a/src/System.Management.Automation/engine/SessionStateContent.cs
+++ b/src/System.Management.Automation/engine/SessionStateContent.cs
@@ -7,7 +7,6 @@ using System.Management.Automation.Provider;
 using Dbg = System.Management.Automation;
 
 #pragma warning disable 1634, 1691 // Stops compiler from warning about unknown warnings
-#pragma warning disable 56500
 
 namespace System.Management.Automation
 {
@@ -1031,5 +1030,3 @@ namespace System.Management.Automation
         #endregion IContentCmdletProvider accessors
     }
 }
-
-#pragma warning restore 56500

--- a/src/System.Management.Automation/engine/SessionStateDriveAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateDriveAPIs.cs
@@ -11,7 +11,6 @@ using System.Management.Automation.Provider;
 using Dbg = System.Management.Automation;
 
 #pragma warning disable 1634, 1691 // Stops compiler from warning about unknown warnings
-#pragma warning disable 56500
 
 namespace System.Management.Automation
 {
@@ -1449,6 +1448,3 @@ namespace System.Management.Automation
         }
     }
 }
-
-#pragma warning restore 56500
-

--- a/src/System.Management.Automation/engine/SessionStateDynamicProperty.cs
+++ b/src/System.Management.Automation/engine/SessionStateDynamicProperty.cs
@@ -7,7 +7,6 @@ using System.Management.Automation.Provider;
 using Dbg = System.Management.Automation;
 
 #pragma warning disable 1634, 1691 // Stops compiler from warning about unknown warnings
-#pragma warning disable 56500
 
 namespace System.Management.Automation
 {
@@ -2172,5 +2171,3 @@ namespace System.Management.Automation
         #endregion IDynamicPropertyCmdletProvider accessors
     }
 }
-
-#pragma warning restore 56500

--- a/src/System.Management.Automation/engine/SessionStateItem.cs
+++ b/src/System.Management.Automation/engine/SessionStateItem.cs
@@ -7,7 +7,6 @@ using System.Management.Automation.Provider;
 using Dbg = System.Management.Automation;
 
 #pragma warning disable 1634, 1691 // Stops compiler from warning about unknown warnings
-#pragma warning disable 56500
 
 namespace System.Management.Automation
 {
@@ -1373,6 +1372,3 @@ namespace System.Management.Automation
         #endregion ItemCmdletProvider accessors
     }
 }
-
-#pragma warning restore 56500
-

--- a/src/System.Management.Automation/engine/SessionStateNavigation.cs
+++ b/src/System.Management.Automation/engine/SessionStateNavigation.cs
@@ -7,7 +7,6 @@ using System.Management.Automation.Provider;
 using Dbg = System.Management.Automation;
 
 #pragma warning disable 1634, 1691 // Stops compiler from warning about unknown warnings
-#pragma warning disable 56500
 
 namespace System.Management.Automation
 {
@@ -1747,6 +1746,3 @@ namespace System.Management.Automation
         #endregion NavigationCmdletProvider accessors
     }
 }
-
-#pragma warning restore 56500
-

--- a/src/System.Management.Automation/engine/SessionStateProperty.cs
+++ b/src/System.Management.Automation/engine/SessionStateProperty.cs
@@ -7,7 +7,6 @@ using System.Management.Automation.Provider;
 using Dbg = System.Management.Automation;
 
 #pragma warning disable 1634, 1691 // Stops compiler from warning about unknown warnings
-#pragma warning disable 56500
 
 namespace System.Management.Automation
 {
@@ -1114,6 +1113,3 @@ namespace System.Management.Automation
         #endregion IPropertyCmdletProvider accessors
     }
 }
-
-#pragma warning restore 56500
-

--- a/src/System.Management.Automation/engine/SessionStateProviderAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateProviderAPIs.cs
@@ -10,7 +10,6 @@ using System.Text;
 using Dbg = System.Management.Automation;
 
 #pragma warning disable 1634, 1691 // Stops compiler from warning about unknown warnings
-#pragma warning disable 56500
 
 namespace System.Management.Automation
 {
@@ -1555,5 +1554,3 @@ namespace System.Management.Automation
         }
     }
 }
-
-#pragma warning restore 56500

--- a/src/System.Management.Automation/engine/SessionStateScopeAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateScopeAPIs.cs
@@ -4,7 +4,6 @@
 using Dbg = System.Management.Automation;
 
 #pragma warning disable 1634, 1691 // Stops compiler from warning about unknown warnings
-#pragma warning disable 56500
 
 namespace System.Management.Automation
 {
@@ -322,5 +321,3 @@ namespace System.Management.Automation
         }
     }
 }
-
-#pragma warning restore 56500

--- a/src/System.Management.Automation/engine/SessionStateVariableAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateVariableAPIs.cs
@@ -11,7 +11,6 @@ using System.Management.Automation.Runspaces;
 using Dbg = System.Management.Automation;
 
 #pragma warning disable 1634, 1691 // Stops compiler from warning about unknown warnings
-#pragma warning disable 56500
 
 namespace System.Management.Automation
 {
@@ -1876,5 +1875,3 @@ namespace System.Management.Automation
         #endregion variables
     }
 }
-
-#pragma warning restore 56500

--- a/src/System.Management.Automation/engine/TypeTable.cs
+++ b/src/System.Management.Automation/engine/TypeTable.cs
@@ -3253,7 +3253,6 @@ namespace System.Management.Automation.Runspaces
 
             Exception instanceException = null;
 
-#pragma warning disable 56500
             try
             {
                 instance = Activator.CreateInstance(type);
@@ -3266,7 +3265,6 @@ namespace System.Management.Automation.Runspaces
             {
                 instanceException = e;
             }
-#pragma warning restore 56500
 
             if (instanceException != null)
             {

--- a/src/System.Management.Automation/engine/hostifaces/ConnectionBase.cs
+++ b/src/System.Management.Automation/engine/hostifaces/ConnectionBase.cs
@@ -774,7 +774,6 @@ namespace System.Management.Automation.Runspaces
                         this.OnAvailabilityChanged(new RunspaceAvailabilityEventArgs(queueItem.NewRunspaceAvailability));
                     }
 
-#pragma warning disable 56500
                     // Exception raised by events are not error condition for runspace
                     // object.
                     if (stateChanged != null)
@@ -787,7 +786,6 @@ namespace System.Management.Automation.Runspaces
                         {
                         }
                     }
-#pragma warning restore 56500
                 }
             }
         }

--- a/src/System.Management.Automation/engine/hostifaces/LocalConnection.cs
+++ b/src/System.Management.Automation/engine/hostifaces/LocalConnection.cs
@@ -612,7 +612,6 @@ namespace System.Management.Automation.Runspaces
         /// </summary>
         private void OpenThreadProc()
         {
-#pragma warning disable 56500
             try
             {
                 DoOpenHelper();
@@ -622,7 +621,6 @@ namespace System.Management.Automation.Runspaces
                 // This exception is reported by raising RunspaceState
                 // change event.
             }
-#pragma warning restore 56500
         }
 
         /// <summary>
@@ -799,7 +797,6 @@ namespace System.Management.Automation.Runspaces
         /// </summary>
         private void CloseThreadProc()
         {
-#pragma warning disable 56500
             try
             {
                 DoCloseHelper();
@@ -807,7 +804,6 @@ namespace System.Management.Automation.Runspaces
             catch (Exception)
             {
             }
-#pragma warning restore 56500
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
@@ -5394,7 +5394,6 @@ namespace System.Management.Automation
             /// </remarks>
             internal void CreateRunspaceIfNeededAndDoWork(Runspace rsToUse, bool isSync)
             {
-#pragma warning disable 56500
                 try
                 {
                     // Set the host for this local runspace if user specified one.
@@ -5452,7 +5451,6 @@ namespace System.Management.Automation
                         throw;
                     }
                 }
-#pragma warning restore 56500
             }
 
             /// <summary>
@@ -5469,7 +5467,6 @@ namespace System.Management.Automation
             /// </remarks>
             internal void RunspaceAvailableCallback(IAsyncResult asyncResult)
             {
-#pragma warning disable 56500
                 try
                 {
                     RunspacePool pool = _shell._rsConnection as RunspacePool;
@@ -5502,7 +5499,6 @@ namespace System.Management.Automation
                                 new PipelineStateInfo(PipelineState.Failed,
                                     e)));
                 }
-#pragma warning restore 56500
             }
 
             /// <summary>

--- a/src/System.Management.Automation/engine/hostifaces/pipelinebase.cs
+++ b/src/System.Management.Automation/engine/hostifaces/pipelinebase.cs
@@ -870,8 +870,6 @@ namespace System.Management.Automation.Runspaces
                         _runspace.RaiseAvailabilityChangedEvent(queueItem.NewRunspaceAvailability);
                     }
 
-                    // this is shipped as part of V1. So disabling the warning here.
-#pragma warning disable 56500
                     // Exception raised in the eventhandler are not error in pipeline.
                     // silently ignore them.
                     if (stateChanged != null)
@@ -884,7 +882,6 @@ namespace System.Management.Automation.Runspaces
                         {
                         }
                     }
-#pragma warning restore 56500
                 }
             }
         }

--- a/src/System.Management.Automation/engine/pipeline.cs
+++ b/src/System.Management.Automation/engine/pipeline.cs
@@ -798,6 +798,7 @@ namespace System.Management.Automation.Internal
                 {
                     throw PSTraceSource.NewInvalidOperationException();
                 }
+
                 try
                 {
                     commandProcessor.Command.DoStopProcessing();

--- a/src/System.Management.Automation/engine/pipeline.cs
+++ b/src/System.Management.Automation/engine/pipeline.cs
@@ -798,7 +798,6 @@ namespace System.Management.Automation.Internal
                 {
                     throw PSTraceSource.NewInvalidOperationException();
                 }
-#pragma warning disable 56500
                 try
                 {
                     commandProcessor.Command.DoStopProcessing();
@@ -809,7 +808,6 @@ namespace System.Management.Automation.Internal
                     // which occur during StopProcessing.
                     continue;
                 }
-#pragma warning restore 56500
             }
         }
 
@@ -1301,7 +1299,6 @@ namespace System.Management.Automation.Internal
                     CommandProcessorBase commandProcessor = _commands[i];
                     if (commandProcessor != null)
                     {
-#pragma warning disable 56500
                         // If Dispose throws an exception, record it as a
                         // pipeline failure and continue disposing cmdlets.
                         try
@@ -1343,7 +1340,6 @@ namespace System.Management.Automation.Internal
 
                             RecordFailure(e, commandProcessor.Command);
                         }
-#pragma warning restore 56500
                     }
                 }
             }
@@ -1355,7 +1351,6 @@ namespace System.Management.Automation.Internal
             {
                 foreach (PipelineProcessor redirPipe in _redirectionPipes)
                 {
-#pragma warning disable 56500
                     // The complicated logic of disposing the commands is taken care
                     // of through recursion, this routine should not be getting any
                     // exceptions...
@@ -1369,7 +1364,6 @@ namespace System.Management.Automation.Internal
                     catch (Exception)
                     {
                     }
-#pragma warning restore 56500
                 }
             }
 

--- a/src/System.Management.Automation/engine/remoting/client/Job.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job.cs
@@ -1427,7 +1427,6 @@ namespace System.Management.Automation
                     }
                 }
 
-#pragma warning disable 56500
                 // Exception raised in the eventhandler are not error in job.
                 // silently ignore them.
                 try
@@ -1454,7 +1453,6 @@ namespace System.Management.Automation
                         }
                     }
                 }
-#pragma warning restore 56500
             }
         }
 

--- a/src/System.Management.Automation/engine/remoting/client/Job2.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job2.cs
@@ -339,7 +339,6 @@ namespace System.Management.Automation
 
                     break;
             }
-#pragma warning disable 56500
             try
             {
                 handler?.Invoke(this, eventArgs);
@@ -350,7 +349,6 @@ namespace System.Management.Automation
                 // silently ignore them
                 _tracer.TraceException(exception);
             }
-#pragma warning restore 56500
         }
 
         /// <summary>
@@ -795,7 +793,6 @@ namespace System.Management.Automation
             {
                 Job2 child = ChildJobs[0] as Job2;
                 Dbg.Assert(child != null, "Job is null after initial null check");
-#pragma warning disable 56500
                 try
                 {
                     _tracer.WriteMessage(TraceClassName, "StartJob", Guid.Empty, this,
@@ -814,7 +811,6 @@ namespace System.Management.Automation
                         "Single child job threw exception, child InstanceId: {0}", child.InstanceId.ToString());
                     _tracer.TraceException(e);
                 }
-#pragma warning restore 56500
                 return;
             }
 
@@ -980,7 +976,6 @@ namespace System.Management.Automation
             {
                 Job2 child = ChildJobs[0] as Job2;
                 Dbg.Assert(child != null, "Job is null after initial null check");
-#pragma warning disable 56500
                 try
                 {
                     _tracer.WriteMessage(TraceClassName, "ResumeJob", Guid.Empty, this,
@@ -999,7 +994,6 @@ namespace System.Management.Automation
                         "Single child job threw exception, child InstanceId: {0}", child.InstanceId.ToString());
                     _tracer.TraceException(e);
                 }
-#pragma warning restore 56500
                 return;
             }
 
@@ -1220,7 +1214,6 @@ namespace System.Management.Automation
             {
                 Job2 child = ChildJobs[0] as Job2;
                 Dbg.Assert(child != null, "Job is null after initial null check");
-#pragma warning disable 56500
                 try
                 {
                     _tracer.WriteMessage(TraceClassName, "UnblockJob", Guid.Empty, this,
@@ -1238,7 +1231,6 @@ namespace System.Management.Automation
                         "Single child job threw exception, child InstanceId: {0}", child.InstanceId.ToString());
                     _tracer.TraceException(e);
                 }
-#pragma warning restore 56500
                 return;
             }
 
@@ -1388,7 +1380,6 @@ namespace System.Management.Automation
             {
                 Job2 child = ChildJobs[0] as Job2;
                 Dbg.Assert(child != null, "Job is null after initial null check");
-#pragma warning disable 56500
                 try
                 {
                     _tracer.WriteMessage(TraceClassName, "SuspendJob", Guid.Empty, this,
@@ -1410,7 +1401,6 @@ namespace System.Management.Automation
                         "Single child job threw exception, child InstanceId: {0} force: {1}", child.InstanceId.ToString(), force.ToString());
                     _tracer.TraceException(e);
                 }
-#pragma warning restore 56500
                 return;
             }
 
@@ -1564,7 +1554,6 @@ namespace System.Management.Automation
             {
                 Job2 child = ChildJobs[0] as Job2;
                 Dbg.Assert(child != null, "Job is null after initial null check");
-#pragma warning disable 56500
                 try
                 {
                     _tracer.WriteMessage(TraceClassName, "StopJob", Guid.Empty, this,
@@ -1586,7 +1575,6 @@ namespace System.Management.Automation
                                         "Single child job threw exception, child InstanceId: {0}", child.InstanceId.ToString());
                     _tracer.TraceException(e);
                 }
-#pragma warning restore 56500
                 return;
             }
 

--- a/src/System.Management.Automation/engine/remoting/client/Job2.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job2.cs
@@ -339,6 +339,7 @@ namespace System.Management.Automation
 
                     break;
             }
+
             try
             {
                 handler?.Invoke(this, eventArgs);
@@ -811,6 +812,7 @@ namespace System.Management.Automation
                         "Single child job threw exception, child InstanceId: {0}", child.InstanceId.ToString());
                     _tracer.TraceException(e);
                 }
+
                 return;
             }
 
@@ -994,6 +996,7 @@ namespace System.Management.Automation
                         "Single child job threw exception, child InstanceId: {0}", child.InstanceId.ToString());
                     _tracer.TraceException(e);
                 }
+
                 return;
             }
 
@@ -1231,6 +1234,7 @@ namespace System.Management.Automation
                         "Single child job threw exception, child InstanceId: {0}", child.InstanceId.ToString());
                     _tracer.TraceException(e);
                 }
+
                 return;
             }
 
@@ -1401,6 +1405,7 @@ namespace System.Management.Automation
                         "Single child job threw exception, child InstanceId: {0} force: {1}", child.InstanceId.ToString(), force.ToString());
                     _tracer.TraceException(e);
                 }
+
                 return;
             }
 
@@ -1575,6 +1580,7 @@ namespace System.Management.Automation
                                         "Single child job threw exception, child InstanceId: {0}", child.InstanceId.ToString());
                     _tracer.TraceException(e);
                 }
+
                 return;
             }
 

--- a/src/System.Management.Automation/engine/remoting/client/JobManager.cs
+++ b/src/System.Management.Automation/engine/remoting/client/JobManager.cs
@@ -184,7 +184,6 @@ namespace System.Management.Automation
             JobSourceAdapter sourceAdapter = GetJobSourceAdapter(definition);
             Job2 newJob;
 
-#pragma warning disable 56500
             try
             {
                 newJob = sourceAdapter.NewJob(definition);
@@ -200,7 +199,6 @@ namespace System.Management.Automation
                 _tracer.TraceException(exception);
                 throw;
             }
-#pragma warning restore 56500
 
             return newJob;
         }
@@ -229,7 +227,6 @@ namespace System.Management.Automation
             JobSourceAdapter sourceAdapter = GetJobSourceAdapter(specification.Definition);
             Job2 newJob = null;
 
-#pragma warning disable 56500
             try
             {
                 newJob = sourceAdapter.NewJob(specification);
@@ -245,7 +242,6 @@ namespace System.Management.Automation
                 _tracer.TraceException(exception);
                 throw;
             }
-#pragma warning restore 56500
 
             return newJob;
         }
@@ -575,7 +571,6 @@ namespace System.Management.Automation
                         continue;
                     }
 
-#pragma warning disable 56500
                     try
                     {
                         jobs = CallJobFilter(sourceAdapter, filter, filterType, recurse);
@@ -591,7 +586,6 @@ namespace System.Management.Automation
                         _tracer.TraceException(exception);
                         WriteErrorOrWarning(writeErrorOnException, cmdlet, exception, "JobSourceAdapterGetJobsError", sourceAdapter);
                     }
-#pragma warning restore 56500
 
                     if (jobs == null) continue;
                     allJobs.AddRange(jobs);
@@ -920,7 +914,6 @@ namespace System.Management.Automation
                 foreach (JobSourceAdapter sourceAdapter in _sourceAdapters.Values)
                 {
                     Job2 foundJob = null;
-#pragma warning disable 56500
                     try
                     {
                         foundJob = sourceAdapter.GetJobByInstanceId(job.InstanceId, true);
@@ -937,13 +930,11 @@ namespace System.Management.Automation
                         if (throwExceptions) throw;
                         WriteErrorOrWarning(writeErrorOnException, cmdlet, exception, "JobSourceAdapterGetJobError", sourceAdapter);
                     }
-#pragma warning restore 56500
 
                     if (foundJob == null) continue;
                     jobFound = true;
                     RemoveJobIdForReuse(foundJob);
 
-#pragma warning disable 56500
                     try
                     {
                         sourceAdapter.RemoveJob(job);
@@ -960,7 +951,6 @@ namespace System.Management.Automation
                         if (throwExceptions) throw;
                         WriteErrorOrWarning(writeErrorOnException, cmdlet, exception, "JobSourceAdapterRemoveJobError", sourceAdapter);
                     }
-#pragma warning restore 56500
                 }
             }
 

--- a/src/System.Management.Automation/engine/remoting/commands/ReceiveJob.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/ReceiveJob.cs
@@ -1409,7 +1409,6 @@ namespace Microsoft.PowerShell.Commands
             Job2 job2 = job as Job2;
             if (job2 != null)
             {
-#pragma warning disable 56500
                 try
                 {
                     JobManager.RemoveJob(job2, this, false, true);
@@ -1422,7 +1421,6 @@ namespace Microsoft.PowerShell.Commands
                     // so that it's written to the user.
                     AddRemoveErrorToResults(job2, ex);
                 }
-#pragma warning restore 56500
             }
             else
             {


### PR DESCRIPTION
Remove suppression of PreSharp error 56500: Avoid swallowing errors by catching non-specific exceptions.