### PR TITLE
 Use IntPtr.Addition(IntPtr, Int32) Operator

### DIFF
--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/Reader/NativeWrapper.cs
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/Reader/NativeWrapper.cs
@@ -939,7 +939,7 @@ namespace System.Diagnostics.Eventing.Reader
                             break;
                     }
 
-                    pointer = new IntPtr(((Int64)pointer + Marshal.SizeOf(varVal)));
+                    pointer += Marshal.SizeOf(varVal);
                 }
             }
             finally
@@ -984,7 +984,7 @@ namespace System.Diagnostics.Eventing.Reader
                     {
                         UnsafeNativeMethods.EvtVariant varVal = Marshal.PtrToStructure<UnsafeNativeMethods.EvtVariant>(pointer);
                         valuesList.Add(ConvertToObject(varVal));
-                        pointer = new IntPtr(((Int64)pointer + Marshal.SizeOf(varVal)));
+                        pointer += Marshal.SizeOf(varVal);
                     }
                 }
 
@@ -1106,7 +1106,7 @@ namespace System.Diagnostics.Eventing.Reader
                         break;
                     keywordsList.Add(s);
                     // nr of bytes = # chars * 2 + 2 bytes for character '\0'.
-                    pointer = new IntPtr((Int64)pointer + (s.Length * 2) + 2);
+                    pointer += (s.Length * 2) + 2;
                 }
 
                 return keywordsList.AsReadOnly();
@@ -1375,7 +1375,7 @@ namespace System.Diagnostics.Eventing.Reader
                 for (int i = 0; i < val.Count; i++)
                 {
                     array.SetValue(Marshal.PtrToStructure<T>(ptr), i);
-                    ptr = new IntPtr((Int64)ptr + size);
+                    ptr += size;
                 }
 
                 return array;
@@ -1398,7 +1398,7 @@ namespace System.Diagnostics.Eventing.Reader
                 {
                     bool value = Marshal.ReadInt32(ptr) != 0;
                     array[i] = value;
-                    ptr = new IntPtr((Int64)ptr + 4);
+                    ptr += 4;
                 }
 
                 return array;
@@ -1419,7 +1419,7 @@ namespace System.Diagnostics.Eventing.Reader
                 for (int i = 0; i < val.Count; i++)
                 {
                     array[i] = DateTime.FromFileTime(Marshal.ReadInt64(ptr));
-                    ptr = new IntPtr((Int64)ptr + 8 * sizeof(byte)); // FILETIME values are 8 bytes
+                    ptr += 8 * sizeof(byte); // FILETIME values are 8 bytes
                 }
 
                 return array;
@@ -1441,7 +1441,7 @@ namespace System.Diagnostics.Eventing.Reader
                 {
                     UnsafeNativeMethods.SystemTime sysTime = Marshal.PtrToStructure<UnsafeNativeMethods.SystemTime>(ptr);
                     array[i] = new DateTime(sysTime.Year, sysTime.Month, sysTime.Day, sysTime.Hour, sysTime.Minute, sysTime.Second, sysTime.Milliseconds);
-                    ptr = new IntPtr((Int64)ptr + 16 * sizeof(byte)); // SystemTime values are 16 bytes
+                    ptr += 16 * sizeof(byte); // SystemTime values are 16 bytes
                 }
 
                 return array;

--- a/src/System.Management.Automation/engine/COM/ComUtil.cs
+++ b/src/System.Management.Automation/engine/COM/ComUtil.cs
@@ -57,13 +57,9 @@ namespace System.Management.Automation
 
             for (int i = 0; i < funcdesc.cParams; i++)
             {
-                COM.ELEMDESC ElementDescription;
-                int ElementDescriptionArrayByteOffset;
-                IntPtr ElementDescriptionPointer;
-
-                ElementDescription = new COM.ELEMDESC();
-                ElementDescriptionArrayByteOffset = i * ElementDescriptionSize;
-                ElementDescriptionPointer = ElementDescriptionArrayPtr + ElementDescriptionArrayByteOffset;
+                COM.ELEMDESC ElementDescription = new COM.ELEMDESC();
+                int ElementDescriptionArrayByteOffset = i * ElementDescriptionSize;
+                IntPtr ElementDescriptionPointer = ElementDescriptionArrayPtr + ElementDescriptionArrayByteOffset;
                 ElementDescription = Marshal.PtrToStructure<COM.ELEMDESC>(ElementDescriptionPointer);
 
                 string paramstring = GetStringFromTypeDesc(typeinfo, ElementDescription.tdesc);
@@ -287,21 +283,17 @@ namespace System.Management.Automation
 
             for (int i = 0; i < cParams; i++)
             {
-                COM.ELEMDESC ElementDescription;
-                int ElementDescriptionArrayByteOffset;
-                IntPtr ElementDescriptionPointer;
-                bool fOptional = false;
-
-                ElementDescription = new COM.ELEMDESC();
-                ElementDescriptionArrayByteOffset = i * ElementDescriptionSize;
-                ElementDescriptionPointer = ElementDescriptionArrayPtr + ElementDescriptionArrayByteOffset;
+                COM.ELEMDESC ElementDescription = new COM.ELEMDESC();
+                int ElementDescriptionArrayByteOffset = i * ElementDescriptionSize;
+                IntPtr ElementDescriptionPointer = ElementDescriptionArrayPtr + ElementDescriptionArrayByteOffset;
                 ElementDescription = Marshal.PtrToStructure<COM.ELEMDESC>(ElementDescriptionPointer);
 
                 // get the type of parameter
                 Type type = ComUtil.GetTypeFromTypeDesc(ElementDescription.tdesc);
-                object defaultvalue = null;
-
+                
                 // check is this parameter is optional.
+                bool fOptional = false;
+                object defaultvalue = null;
                 if ((ElementDescription.desc.paramdesc.wParamFlags & COM.PARAMFLAG.PARAMFLAG_FOPT) != 0)
                 {
                     fOptional = true;

--- a/src/System.Management.Automation/engine/COM/ComUtil.cs
+++ b/src/System.Management.Automation/engine/COM/ComUtil.cs
@@ -63,20 +63,7 @@ namespace System.Management.Automation
 
                 ElementDescription = new COM.ELEMDESC();
                 ElementDescriptionArrayByteOffset = i * ElementDescriptionSize;
-
-                // Disable PRefast warning for converting to int32 and converting back into intptr.
-                // Code below takes into account 32 bit vs 64 bit conversions
-#pragma warning disable 56515
-                if (IntPtr.Size == 4)
-                {
-                    ElementDescriptionPointer = (IntPtr)(ElementDescriptionArrayPtr.ToInt32() + ElementDescriptionArrayByteOffset);
-                }
-                else
-                {
-                    ElementDescriptionPointer = (IntPtr)(ElementDescriptionArrayPtr.ToInt64() + ElementDescriptionArrayByteOffset);
-                }
-#pragma warning restore 56515
-
+                ElementDescriptionPointer = ElementDescriptionArrayPtr + ElementDescriptionArrayByteOffset;
                 ElementDescription = Marshal.PtrToStructure<COM.ELEMDESC>(ElementDescriptionPointer);
 
                 string paramstring = GetStringFromTypeDesc(typeinfo, ElementDescription.tdesc);
@@ -307,21 +294,7 @@ namespace System.Management.Automation
 
                 ElementDescription = new COM.ELEMDESC();
                 ElementDescriptionArrayByteOffset = i * ElementDescriptionSize;
-                // Disable PRefast warning for converting to int32 and converting back into intptr.
-                // Code below takes into account 32 bit vs 64 bit conversions
-#pragma warning disable 56515
-
-                if (IntPtr.Size == 4)
-                {
-                    ElementDescriptionPointer = (IntPtr)(ElementDescriptionArrayPtr.ToInt32() + ElementDescriptionArrayByteOffset);
-                }
-                else
-                {
-                    ElementDescriptionPointer = (IntPtr)(ElementDescriptionArrayPtr.ToInt64() + ElementDescriptionArrayByteOffset);
-                }
-
-#pragma warning restore 56515
-
+                ElementDescriptionPointer = ElementDescriptionArrayPtr + ElementDescriptionArrayByteOffset;
                 ElementDescription = Marshal.PtrToStructure<COM.ELEMDESC>(ElementDescriptionPointer);
 
                 // get the type of parameter

--- a/src/System.Management.Automation/engine/COM/ComUtil.cs
+++ b/src/System.Management.Automation/engine/COM/ComUtil.cs
@@ -57,10 +57,9 @@ namespace System.Management.Automation
 
             for (int i = 0; i < funcdesc.cParams; i++)
             {
-                COM.ELEMDESC ElementDescription = new COM.ELEMDESC();
                 int ElementDescriptionArrayByteOffset = i * ElementDescriptionSize;
                 IntPtr ElementDescriptionPointer = ElementDescriptionArrayPtr + ElementDescriptionArrayByteOffset;
-                ElementDescription = Marshal.PtrToStructure<COM.ELEMDESC>(ElementDescriptionPointer);
+                COM.ELEMDESC ElementDescription = Marshal.PtrToStructure<COM.ELEMDESC>(ElementDescriptionPointer);
 
                 string paramstring = GetStringFromTypeDesc(typeinfo, ElementDescription.tdesc);
 
@@ -283,10 +282,9 @@ namespace System.Management.Automation
 
             for (int i = 0; i < cParams; i++)
             {
-                COM.ELEMDESC ElementDescription = new COM.ELEMDESC();
                 int ElementDescriptionArrayByteOffset = i * ElementDescriptionSize;
                 IntPtr ElementDescriptionPointer = ElementDescriptionArrayPtr + ElementDescriptionArrayByteOffset;
-                ElementDescription = Marshal.PtrToStructure<COM.ELEMDESC>(ElementDescriptionPointer);
+                COM.ELEMDESC ElementDescription = Marshal.PtrToStructure<COM.ELEMDESC>(ElementDescriptionPointer);
 
                 // get the type of parameter
                 Type type = ComUtil.GetTypeFromTypeDesc(ElementDescription.tdesc);

--- a/src/System.Management.Automation/engine/COM/ComUtil.cs
+++ b/src/System.Management.Automation/engine/COM/ComUtil.cs
@@ -8,9 +8,6 @@ using System.Text;
 
 using COM = System.Runtime.InteropServices.ComTypes;
 
-// Stops compiler from warning about unknown warnings. Prefast warning numbers are not recognized by C# compiler
-#pragma warning disable 1634, 1691
-
 namespace System.Management.Automation
 {
     /// <summary>

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4532,7 +4532,7 @@ namespace System.Management.Automation
             {
                 for (int i = 0; i < numEntries; ++i)
                 {
-                    IntPtr curInfoPtr = (IntPtr)((long)shBuf + (Marshal.SizeOf<SHARE_INFO_1>() * i));
+                    IntPtr curInfoPtr = shBuf + (Marshal.SizeOf<SHARE_INFO_1>() * i);
                     SHARE_INFO_1 shareInfo = Marshal.PtrToStructure<SHARE_INFO_1>(curInfoPtr);
 
                     if ((shareInfo.type & STYPE_MASK) != STYPE_DISKTREE)

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManNativeAPI.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManNativeAPI.cs
@@ -1121,7 +1121,7 @@ namespace System.Management.Automation.Remoting.Client
                     // Look at the structure of native WSManOptionSet.. Options is a pointer..
                     // In C-Style array individual elements are continuous..so I am building
                     // continuous array elements here.
-                    Marshal.StructureToPtr(options[index], (IntPtr)(_optionSet.options.ToInt64() + (sizeOfOption * index)), false);
+                    Marshal.StructureToPtr(options[index], _optionSet.options + (sizeOfOption * index), false);
                 }
 
                 _data = MarshalledObject.Create<WSManOptionSetStruct>(_optionSet);


### PR DESCRIPTION
Operator is available since .NET Framework 4.0.

Also, remove suppression of: "PREfast 56515: converting to int32 and converting back into intptr."

https://docs.microsoft.com/dotnet/api/system.intptr.op_addition