### PR TITLE
When formatting, if collection is modified, don't fail the entire pipeline

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     {
         #region tracer
         [TraceSource("PSObjectHelper", "PSObjectHelper")]
-        internal static readonly PSTraceSource Tracer = PSTraceSource.GetTracer("PSObjectHelper", "PSObjectHelper");
+        private static readonly PSTraceSource s_tracer = PSTraceSource.GetTracer("PSObjectHelper", "PSObjectHelper");
         #endregion tracer
 
         internal const char Ellipsis = '\u2026';

--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
@@ -293,6 +293,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             }
             catch (Exception e) when (e is ExtendedTypeSystemException || e is InvalidOperationException)
             {
+                // These exceptions are being caught and handled by returning an empty string when
+                // the object cannot be stringified due to ETS or an instance in the collection has been modified
                 if (formatErrorObject != null)
                 {
                     formatErrorObject.sourceObject = so;

--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
@@ -300,7 +300,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             {
                 // These exceptions are being caught and handled by returning an empty string when
                 // the object cannot be stringified due to ETS or an instance in the collection has been modified
-                s_tracer.TraceWarning("SmartToString method: Exception during conversion to string, emitting empty string.");
+                s_tracer.TraceWarning($"SmartToString method: Exception during conversion to string, emitting empty string: {e.Message}");
 
                 if (formatErrorObject != null)
                 {

--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     {
         #region tracer
         [TraceSource("PSObjectHelper", "PSObjectHelper")]
-        internal static readonly PSTraceSource tracer = PSTraceSource.GetTracer("PSObjectHelper", "PSObjectHelper");
+        internal static readonly PSTraceSource Tracer = PSTraceSource.GetTracer("PSObjectHelper", "PSObjectHelper");
         #endregion tracer
 
         internal const char Ellipsis = '\u2026';
@@ -300,7 +300,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             {
                 // These exceptions are being caught and handled by returning an empty string when
                 // the object cannot be stringified due to ETS or an instance in the collection has been modified
-                tracer.WriteLine("Exception during conversion to string, emitting empty string.");
+                Tracer.WriteLine("Exception during conversion to string, emitting empty string.");
 
                 if (formatErrorObject != null)
                 {

--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Management.Automation;
+using System.Management.Automation.Internal;
 using System.Management.Automation.Runspaces;
 using System.Reflection;
 using System.Text;
@@ -290,17 +291,20 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 // take care of the case there is no base object
                 return so.ToString();
             }
-            catch (ExtendedTypeSystemException e)
+            catch (Exception e)
             {
-                // NOTE: we catch all the exceptions, since we do not know
-                // what the underlying object access would throw
-                if (formatErrorObject != null)
+                if (e is ExtendedTypeSystemException || e is InvalidOperationException)
                 {
-                    formatErrorObject.sourceObject = so;
-                    formatErrorObject.exception = e;
+                    if (formatErrorObject != null)
+                    {
+                        formatErrorObject.sourceObject = so;
+                        formatErrorObject.exception = e;
+                    }
+
+                    return string.Empty;
                 }
 
-                return string.Empty;
+                throw;
             }
         }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
@@ -291,20 +291,15 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 // take care of the case there is no base object
                 return so.ToString();
             }
-            catch (Exception e)
+            catch (Exception e) when (e is ExtendedTypeSystemException || e is InvalidOperationException)
             {
-                if (e is ExtendedTypeSystemException || e is InvalidOperationException)
+                if (formatErrorObject != null)
                 {
-                    if (formatErrorObject != null)
-                    {
-                        formatErrorObject.sourceObject = so;
-                        formatErrorObject.exception = e;
-                    }
-
-                    return string.Empty;
+                    formatErrorObject.sourceObject = so;
+                    formatErrorObject.exception = e;
                 }
 
-                throw;
+                return string.Empty;
             }
         }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
@@ -20,6 +20,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     /// </summary>
     internal static class PSObjectHelper
     {
+        #region tracer
+        [TraceSource("PSObjectHelper", "PSObjectHelper")]
+        internal static readonly PSTraceSource tracer = PSTraceSource.GetTracer("PSObjectHelper", "PSObjectHelper");
+        #endregion tracer
+
         internal const char Ellipsis = '\u2026';
 
         internal static string PSObjectIsOfExactType(Collection<string> typeNames)
@@ -295,6 +300,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             {
                 // These exceptions are being caught and handled by returning an empty string when
                 // the object cannot be stringified due to ETS or an instance in the collection has been modified
+                tracer.WriteLine("Exception during conversion to string, emitting empty string.");
+
                 if (formatErrorObject != null)
                 {
                     formatErrorObject.sourceObject = so;

--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
@@ -300,7 +300,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             {
                 // These exceptions are being caught and handled by returning an empty string when
                 // the object cannot be stringified due to ETS or an instance in the collection has been modified
-                Tracer.WriteLine("Exception during conversion to string, emitting empty string.");
+                s_tracer.TraceWarning("SmartToString method: Exception during conversion to string, emitting empty string.");
 
                 if (formatErrorObject != null)
                 {

--- a/src/System.Management.Automation/resources/FormatAndOut_format_xxx.resx
+++ b/src/System.Management.Automation/resources/FormatAndOut_format_xxx.resx
@@ -179,4 +179,7 @@
   <data name="FormattingError" xml:space="preserve">
     <value>Failed to interpret format string "{0}".</value>
   </data>
+  <data name="SmartToStringError" xml:space="preserve">
+    <value>Object skipped: {0}.</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/resources/FormatAndOut_format_xxx.resx
+++ b/src/System.Management.Automation/resources/FormatAndOut_format_xxx.resx
@@ -179,7 +179,4 @@
   <data name="FormattingError" xml:space="preserve">
     <value>Failed to interpret format string "{0}".</value>
   </data>
-  <data name="SmartToStringError" xml:space="preserve">
-    <value>Object skipped: {0}.</value>
-  </data>
 </root>


### PR DESCRIPTION
# PR Summary

If a cmdlet emitting objects in a collection inadvertently modifies an instance within the collection, an InvalidOperationException gets thrown.  This results in the entire pipeline failing as the exception is not being handled.  Customers are seeing this with apps that use PowerShell to enumerate a large collection like AD users, then piping that to `Format-List` (and then `Out-String`).

The proposed fix is to modify the existing exception handling block to also cover InvalidOperationException.

Originally, the decision was to emit a warning message, however, the code calling this helper method is also within the engine for formatting which itself doesn't have a means to write a warning message.  Since the existing code for ExtendedTypeSystemException already has this behavior, it seems acceptable to extend it to InvalidOperationException.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/11797

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
