### PR TITLE
Add manual release automation steps and improve changelog script

### DIFF
--- a/tools/releaseBuild/azureDevOps/releasePipeline.yml
+++ b/tools/releaseBuild/azureDevOps/releasePipeline.yml
@@ -234,6 +234,15 @@ stages:
     pool: server
     environment: PSReleaseUpdateWinGet
 
+- stage: PublishMsix
+  dependsOn: GitHubManualTasks
+  displayName: Publish MSIX to store
+  jobs:
+  - deployment: PublishMsix
+    displayName: Publish MSIX to store
+    pool: server
+    environment: PSReleasePublishMsix
+
 - stage: BuildInfoJson
   dependsOn: GitHubManualTasks
   displayName: Upload BuildInfoJson

--- a/tools/releaseBuild/azureDevOps/releasePipeline.yml
+++ b/tools/releaseBuild/azureDevOps/releasePipeline.yml
@@ -225,6 +225,15 @@ stages:
     pool: server
     environment: PSReleaseUpdateDotnetDocker
 
+- stage: UpdateWinGet
+  dependsOn: GitHubManualTasks
+  displayName: Add manifest entry to winget
+  jobs:
+  - deployment: UpdateWinGet
+    displayName: Add manifest entry to winget
+    pool: server
+    environment: PSReleaseUpdateWinGet
+
 - stage: BuildInfoJson
   dependsOn: GitHubManualTasks
   displayName: Upload BuildInfoJson

--- a/tools/releaseTools.psm1
+++ b/tools/releaseTools.psm1
@@ -24,7 +24,7 @@ class CommitNode {
         $this.Body = $body
         $this.IsBreakingChange = $body -match "\[breaking change\]"
 
-        if ($subject -match "\(#(\d+)\)") {
+        if ($subject -match "\(#(\d+)\)$") {
             $this.PullRequest = $Matches[1]
         }
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

In three separate commits, this PR:

- Fixes the changelog script so that the PR related to a commit is only taken from the end of the commit message (@vexx32 the existing script didn't like your recent commit messages -- this change means the changelog script will work with them, although we'll take out the issue link anyway)
- Adds a manual step for MSIX publication
- Adds a manual step for winget publication

Let me know if there are other steps I can/should capture in the changes here.

One change I haven't made is for the global tool validation logic with preview builds, since I don't know what the story there is.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

During the last release I encountered a couple of issues and this PR represents some small fixes to help some of those issues.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
