### PR TITLE
WIP: Add -SSHTransportPath Parameter

### DIFF
--- a/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
@@ -754,6 +754,19 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
+        /// This parameter allows you to specify a custom executable name to use for the SSH transport. The executable must be on the path.
+        /// </summary>
+        [Parameter(ParameterSetName = PSRemotingBaseCmdlet.SSHHostParameterSet)]
+        [Parameter(ParameterSetName = InvokeCommandCommand.FilePathSSHHostParameterSet)]
+        [ValidateSet("true")]
+        public override string SSHTransportName
+        {
+            get { return base.SSHTransportName; }
+
+            set { base.SSHTransportName = value; }
+        }
+
+        /// <summary>
         /// Hashtable array containing SSH connection parameters for each remote target
         ///   ComputerName  (Alias: HostName)           (required)
         ///   UserName                                  (optional)

--- a/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
@@ -758,12 +758,11 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(ParameterSetName = PSRemotingBaseCmdlet.SSHHostParameterSet)]
         [Parameter(ParameterSetName = InvokeCommandCommand.FilePathSSHHostParameterSet)]
-        [ValidateSet("true")]
-        public override string SSHTransportName
+        public override string SSHTransportPath
         {
-            get { return base.SSHTransportName; }
+            get { return base.SSHTransportPath; }
 
-            set { base.SSHTransportName = value; }
+            set { base.SSHTransportPath = value; }
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -770,6 +770,17 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
+        /// This parameter allows you to specify a custom executable name to use for the SSH transport. The executable must be on the path.
+        /// </summary>
+        [Parameter(ParameterSetName = PSRemotingBaseCmdlet.SSHHostParameterSet)]
+        [ValidateSet("true")]
+        public virtual string SSHTransportName
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Hashtable array containing SSH connection parameters for each remote target
         ///   ComputerName  (Alias: HostName)           (required)
         ///   UserName                                  (optional)

--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -773,8 +773,7 @@ namespace Microsoft.PowerShell.Commands
         /// This parameter allows you to specify a custom executable name to use for the SSH transport. The executable must be on the path.
         /// </summary>
         [Parameter(ParameterSetName = PSRemotingBaseCmdlet.SSHHostParameterSet)]
-        [ValidateSet("true")]
-        public virtual string SSHTransportName
+        public virtual string SSHTransportPath
         {
             get;
             set;

--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -770,7 +770,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// This parameter allows you to specify a custom executable name to use for the SSH transport. The executable must be on the path.
+        /// Gets or sets a custom executable name to use for the SSH transport. The executable must be on the path.
         /// </summary>
         [Parameter(ParameterSetName = PSRemotingBaseCmdlet.SSHHostParameterSet)]
         public virtual string SSHTransportPath

--- a/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
@@ -1262,7 +1262,7 @@ namespace Microsoft.PowerShell.Commands
         private RemoteRunspace GetRunspaceForSSHSession()
         {
             ParseSshHostName(HostName, out string host, out string userName, out int port);
-            var sshConnectionInfo = new SSHConnectionInfo(userName, host, this.KeyFilePath, port, this.Subsystem);
+            var sshConnectionInfo = new SSHConnectionInfo(userName, host, this.KeyFilePath, port, this.Subsystem, base.SSHTransportPath);
             var typeTable = TypeTable.LoadDefaultTypeFiles();
 
             // Use the class _tempRunspace field while the runspace is being opened so that StopProcessing can be handled at that time.

--- a/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
@@ -1262,7 +1262,7 @@ namespace Microsoft.PowerShell.Commands
         private RemoteRunspace GetRunspaceForSSHSession()
         {
             ParseSshHostName(HostName, out string host, out string userName, out int port);
-            var sshConnectionInfo = new SSHConnectionInfo(userName, host, this.KeyFilePath, port, this.Subsystem, base.SSHTransportPath);
+            var sshConnectionInfo = new SSHConnectionInfo(userName, host, KeyFilePath, port, Subsystem, SSHTransportPath);
             var typeTable = TypeTable.LoadDefaultTypeFiles();
 
             // Use the class _tempRunspace field while the runspace is being opened so that StopProcessing can be handled at that time.

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -1892,6 +1892,15 @@ namespace System.Management.Automation.Runspaces
             set;
         }
 
+        /// <summary>
+        /// Name of the ssh executable to use
+        /// </summary>
+        private string sshPath
+        {
+            get;
+            set;
+        }
+
         #endregion
 
         #region Constructors
@@ -1961,6 +1970,27 @@ namespace System.Management.Automation.Runspaces
             this.Subsystem = (string.IsNullOrEmpty(subsystem)) ? DefaultSubsystem : subsystem;
         }
 
+        
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="userName">User Name.</param>
+        /// <param name="computerName">Computer Name.</param>
+        /// <param name="keyFilePath">Key File Path.</param>
+        /// <param name="port">Port number for connection (default 22).</param>
+        /// <param name="subsystem">Subsystem to use (default 'powershell').</param>
+        /// <param name="sshPath">Name or path to ssh executable (default 'ssh' or 'ssh.exe')</param>
+        public SSHConnectionInfo(
+            string userName,
+            string computerName,
+            string keyFilePath,
+            int port,
+            string subsystem,
+            string sshPath) : this(userName, computerName, keyFilePath, port, subsystem)
+        {
+            this.sshPath = sshPath;
+        }
+
         #endregion
 
         #region Overrides
@@ -2016,6 +2046,7 @@ namespace System.Management.Automation.Runspaces
             newCopy.KeyFilePath = this.KeyFilePath;
             newCopy.Port = this.Port;
             newCopy.Subsystem = this.Subsystem;
+            newCopy.sshPath = this.sshPath;
 
             return newCopy;
         }
@@ -2049,15 +2080,18 @@ namespace System.Management.Automation.Runspaces
             out StreamReader stdErrReaderVar)
         {
             string filePath = string.Empty;
-#if UNIX
-            string sshCommand = "ssh";
-#else
-            string sshCommand = "ssh.exe";
-#endif
+            if (sshPath == null) {
+                #if UNIX
+                    sshPath = "ssh";
+                #else
+                    sshPath = "ssh.exe";
+                #endif
+            }
+
             var context = Runspaces.LocalPipeline.GetExecutionContextFromTLS();
             if (context != null)
             {
-                var cmdInfo = context.CommandDiscovery.LookupCommandInfo(sshCommand, CommandOrigin.Internal) as ApplicationInfo;
+                var cmdInfo = context.CommandDiscovery.LookupCommandInfo(sshPath, CommandOrigin.Internal) as ApplicationInfo;
                 if (cmdInfo != null)
                 {
                     filePath = cmdInfo.Path;

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -1893,7 +1893,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
-        /// Gets or sets theName of the ssh executable to use
+        /// Gets or sets the name of the ssh executable to use.
         /// </summary>
         private string SshPath
         {
@@ -1978,16 +1978,16 @@ namespace System.Management.Automation.Runspaces
         /// <param name="keyFilePath">Key File Path.</param>
         /// <param name="port">Port number for connection (default 22).</param>
         /// <param name="subsystem">Subsystem to use (default 'powershell').</param>
-        /// <param name="SshPath">Name or path to ssh executable (default 'ssh' or 'ssh.exe')'.</param>
+        /// <param name="sshPath">Name or path to ssh executable (default 'ssh' or 'ssh.exe')'.</param>
         public SSHConnectionInfo(
             string userName,
             string computerName,
             string keyFilePath,
             int port,
             string subsystem,
-            string SshPath) : this(userName, computerName, keyFilePath, port, subsystem)
+            string sshPath) : this(userName, computerName, keyFilePath, port, subsystem)
         {
-            this.SshPath = SshPath;
+            this.SshPath = sshPath;
         }
 
         #endregion

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -2050,9 +2050,9 @@ namespace System.Management.Automation.Runspaces
         {
             string filePath = string.Empty;
 #if UNIX
-            const string sshCommand = "ssh";
+            string sshCommand = "ssh";
 #else
-            const string sshCommand = "ssh.exe";
+            string sshCommand = "ssh.exe";
 #endif
             var context = Runspaces.LocalPipeline.GetExecutionContextFromTLS();
             if (context != null)

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -1893,9 +1893,9 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
-        /// Name of the ssh executable to use
+        /// Gets or sets theName of the ssh executable to use
         /// </summary>
-        private string sshPath
+        private string SshPath
         {
             get;
             set;
@@ -1969,26 +1969,25 @@ namespace System.Management.Automation.Runspaces
             this.Port = port;
             this.Subsystem = (string.IsNullOrEmpty(subsystem)) ? DefaultSubsystem : subsystem;
         }
-
         
         /// <summary>
-        /// Constructor.
+        /// Initializes a new instance of the SSHConnectionInfo class.
         /// </summary>
         /// <param name="userName">User Name.</param>
         /// <param name="computerName">Computer Name.</param>
         /// <param name="keyFilePath">Key File Path.</param>
         /// <param name="port">Port number for connection (default 22).</param>
         /// <param name="subsystem">Subsystem to use (default 'powershell').</param>
-        /// <param name="sshPath">Name or path to ssh executable (default 'ssh' or 'ssh.exe')</param>
+        /// <param name="SshPath">Name or path to ssh executable (default 'ssh' or 'ssh.exe')'.</param>
         public SSHConnectionInfo(
             string userName,
             string computerName,
             string keyFilePath,
             int port,
             string subsystem,
-            string sshPath) : this(userName, computerName, keyFilePath, port, subsystem)
+            string SshPath) : this(userName, computerName, keyFilePath, port, subsystem)
         {
-            this.sshPath = sshPath;
+            this.SshPath = SshPath;
         }
 
         #endregion
@@ -2046,7 +2045,7 @@ namespace System.Management.Automation.Runspaces
             newCopy.KeyFilePath = this.KeyFilePath;
             newCopy.Port = this.Port;
             newCopy.Subsystem = this.Subsystem;
-            newCopy.sshPath = this.sshPath;
+            newCopy.SshPath = this.SshPath;
 
             return newCopy;
         }
@@ -2080,18 +2079,19 @@ namespace System.Management.Automation.Runspaces
             out StreamReader stdErrReaderVar)
         {
             string filePath = string.Empty;
-            if (sshPath == null) {
+            if (SshPath == null) 
+            {
                 #if UNIX
-                    sshPath = "ssh";
+                    SshPath = "ssh";
                 #else
-                    sshPath = "ssh.exe";
+                    SshPath = "ssh.exe";
                 #endif
             }
 
             var context = Runspaces.LocalPipeline.GetExecutionContextFromTLS();
             if (context != null)
             {
-                var cmdInfo = context.CommandDiscovery.LookupCommandInfo(sshPath, CommandOrigin.Internal) as ApplicationInfo;
+                var cmdInfo = context.CommandDiscovery.LookupCommandInfo(SshPath, CommandOrigin.Internal) as ApplicationInfo;
                 if (cmdInfo != null)
                 {
                     filePath = cmdInfo.Path;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Implementation of https://github.com/PowerShell/PowerShell/issues/13282
<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
This PR adds the `-SSHTransportPath` parameter to allow specification of a custom ssh executable. While it can be used to use a custom version of OpenSSH for compatibility or troubleshooting reasons,  the primary impetus is to enable transport authors to substitute their own executables in order to provide alternative transports (such as websockets, rendevous, Azure Bastion-like services, phone-home debug sessions, etc.), since all Powershell does is spawn ssh and then pass stdin/stdout PSRemoting XML to/from the program.

This PR is intended to be as low impact and non-breaking as possible, and as such the Arguments passed to the command do not change and are not customizable, however they do provide all the information required to establish a session so a custom wrapper can translate the SSH arguments into whatever working options it requires.

This is intended as a low-impact stop gap until the PSRemoting engine is decoupled into a subsystem and a proper CustomTransportHandler interface is provided.

## WIP to complete

- [ ] @PaulHigin in the case the executable is not found, it currently gets wrapped and throws a generic eventing error, is it OK to adjust the eventing error with the file not found exception?
- [ ] Tests


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
