### PR TITLE
Use String.Split(char) instead of String.Split(String)

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1837,7 +1837,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 foreach (string linkHeader in links)
                 {
-                    foreach (string link in linkHeader.Split(","))
+                    foreach (string link in linkHeader.Split(','))
                     {
                         Match match = Regex.Match(link, pattern);
                         if (match.Success)


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/api/system.string.split#System_String_Split_System_Char_System_StringSplitOptions_

Overload was introduced in .NET Core 2.0.