### PR TITLE
Reduce aggressive correcting casing of file system paths

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -5089,7 +5089,7 @@ namespace Microsoft.PowerShell.Commands
 
             do // false loop
             {
-                path = NormalizePath(path);
+                path = GetCorrectCasedPath(path);
                 path = EnsureDriveIsRooted(path);
 
                 // If it's not fully normalized, normalize it.

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -5095,7 +5095,7 @@ namespace Microsoft.PowerShell.Commands
                 // If it's not fully normalized, normalize it.
                 path = NormalizeRelativePathHelper(path, basePath);
 
-                basePath = NormalizePath(basePath);
+                basePath = GetCorrectCasedPath(basePath);
                 basePath = EnsureDriveIsRooted(basePath);
 
                 result = path;
@@ -5230,7 +5230,7 @@ namespace Microsoft.PowerShell.Commands
                 }
             } while (false);
 
-            return GetCorrectCasedPath(result);
+            return result;
         }
 
         /// <summary>

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -108,12 +108,11 @@ namespace Microsoft.PowerShell.Commands
         /// </returns>
         private static string NormalizePath(string path)
         {
-            return GetCorrectCasedPath(path.Replace(StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator));
+            return path.Replace(StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator);
         }
 
         /// <summary>
-        /// Get the correct casing for a path.  This method assumes it's being called by NormalizePath()
-        /// so that the path is already normalized.
+        /// Normalize and get the correct casing for a path.
         /// </summary>
         /// <param name="path">
         /// The path to retrieve.
@@ -123,6 +122,13 @@ namespace Microsoft.PowerShell.Commands
         /// </returns>
         private static string GetCorrectCasedPath(string path)
         {
+            path = NormalizePath(path);
+
+            if (Platform.IsLinux)
+            {
+                return path;
+            }
+
             // Only apply to directories where there are issues with some tools if the casing
             // doesn't match the source like git
             if (Directory.Exists(path))
@@ -167,13 +173,13 @@ namespace Microsoft.PowerShell.Commands
                     }
                     else
                     {
-                        // Use GetFileSystemEntries to get the correct casing of this element
+                        // Use enumeration to get the correct casing of this element
                         try
                         {
-                            var entries = Directory.GetFileSystemEntries(exactPath, item);
-                            if (entries.Length > 0)
+                            var entry = Directory.EnumerateFileSystemEntries(exactPath, item).FirstOrDefault();
+                            if (entry is not null)
                             {
-                                exactPath = entries[0];
+                                exactPath = entry;
                             }
                             else
                             {
@@ -1376,7 +1382,7 @@ namespace Microsoft.PowerShell.Commands
 
         private FileSystemInfo GetFileSystemItem(string path, ref bool isContainer, bool showHidden)
         {
-            path = NormalizePath(path);
+            path = GetCorrectCasedPath(path);
             FileInfo result = new FileInfo(path);
 
             // FileInfo.Exists is always false for a directory path, so we check the attribute for existence.
@@ -1639,7 +1645,7 @@ namespace Microsoft.PowerShell.Commands
                 throw PSTraceSource.NewArgumentException(nameof(path));
             }
 
-            path = NormalizePath(path);
+            path = GetCorrectCasedPath(path);
 
             var fsinfo = GetFileSystemInfo(path, out bool isDirectory);
 
@@ -2125,7 +2131,7 @@ namespace Microsoft.PowerShell.Commands
                 throw PSTraceSource.NewArgumentException(nameof(path));
             }
 
-            path = NormalizePath(path);
+            path = GetCorrectCasedPath(path);
 
             if (string.IsNullOrEmpty(newName))
             {
@@ -2271,7 +2277,7 @@ namespace Microsoft.PowerShell.Commands
                 type = "file";
             }
 
-            path = NormalizePath(path);
+            path = GetCorrectCasedPath(path);
 
             if (Force)
             {
@@ -3616,8 +3622,8 @@ namespace Microsoft.PowerShell.Commands
                 throw PSTraceSource.NewArgumentException(nameof(destinationPath));
             }
 
-            path = NormalizePath(path);
-            destinationPath = NormalizePath(destinationPath);
+            path = GetCorrectCasedPath(path);
+            destinationPath = GetCorrectCasedPath(destinationPath);
 
             PSSession fromSession = null;
             PSSession toSession = null;
@@ -5224,7 +5230,7 @@ namespace Microsoft.PowerShell.Commands
                 }
             } while (false);
 
-            return result;
+            return GetCorrectCasedPath(result);
         }
 
         /// <summary>
@@ -5785,8 +5791,8 @@ namespace Microsoft.PowerShell.Commands
                 throw PSTraceSource.NewArgumentException(nameof(destination));
             }
 
-            path = NormalizePath(path);
-            destination = NormalizePath(destination);
+            path = GetCorrectCasedPath(path);
+            destination = GetCorrectCasedPath(destination);
 
             // Verify that the target doesn't represent a device name
             if (PathIsReservedDeviceName(destination, "MoveError"))
@@ -6170,7 +6176,7 @@ namespace Microsoft.PowerShell.Commands
                 throw PSTraceSource.NewArgumentException(nameof(path));
             }
 
-            path = NormalizePath(path);
+            path = GetCorrectCasedPath(path);
 
             PSObject result = null;
 
@@ -6308,7 +6314,7 @@ namespace Microsoft.PowerShell.Commands
                 throw PSTraceSource.NewArgumentNullException(nameof(propertyToSet));
             }
 
-            path = NormalizePath(path);
+            path = GetCorrectCasedPath(path);
 
             PSObject results = new PSObject();
 
@@ -6474,7 +6480,7 @@ namespace Microsoft.PowerShell.Commands
                 throw PSTraceSource.NewArgumentException(nameof(path));
             }
 
-            path = NormalizePath(path);
+            path = GetCorrectCasedPath(path);
 
             if (propertiesToClear == null ||
                 propertiesToClear.Count == 0)

--- a/src/System.Management.Automation/namespaces/FileSystemSecurity.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemSecurity.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerShell.Commands
                                           AccessControlSections sections)
         {
             ObjectSecurity sd = null;
-            path = NormalizePath(path);
+            path = GetCorrectCasedPath(path);
 
             if (string.IsNullOrEmpty(path))
             {
@@ -106,7 +106,7 @@ namespace Microsoft.PowerShell.Commands
                 throw PSTraceSource.NewArgumentException(nameof(path));
             }
 
-            path = NormalizePath(path);
+            path = GetCorrectCasedPath(path);
 
             if (securityDescriptor == null)
             {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #12795

While modern (SSD) disks are fast, this does not mean that disk operations have become so insignificant that they can be neglected. For case correction we use additional disk operations (enumerations).

It is very weird that we do case corrections for file paths which are excluded in the PR:
- on Linux
- for operations without output like IsItemContainer()

## PR Context

#9250 Return correct casing of filesystem path during normalization

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
