### PR TITLE
Update the Bug_Report.md template to remove the default title and provide better guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -11,7 +11,7 @@ assignees: ''
 For Windows PowerShell 5.1 issues, suggestions, or feature requests please use the following link instead:
 Windows PowerShell [UserVoice](https://windowsserver.uservoice.com/forums/301869-powershell)
 
-This repository is **ONLY** for PowerShell Core 6 and PowerShell 7+ issues:
+This repository is **ONLY** for PowerShell 7+ issues:
 
   - If you're seeing behavior that deviates from the intended, documented behavior, report it here, assuming that you can reproduce it in the [latest released version](https://github.com/PowerShell/PowerShell/releases) and that it hasn't already been reported (please search the existing issues).
   

--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report 🐛
 about: Report errors or unexpected behavior 🤔
-title: "My bug report"
+title: 
 labels: Issue-Question
 assignees: ''
 
@@ -11,12 +11,19 @@ assignees: ''
 For Windows PowerShell 5.1 issues, suggestions, or feature requests please use the following link instead:
 Windows PowerShell [UserVoice](https://windowsserver.uservoice.com/forums/301869-powershell)
 
-This repository is **ONLY** for PowerShell Core 6 and PowerShell 7+ issues.
+This repository is **ONLY** for PowerShell Core 6 and PowerShell 7+ issues:
 
-- Make sure you are able to repro it on the [latest released version](https://github.com/PowerShell/PowerShell/releases)
-- Search the existing issues.
-- Refer to the [FAQ](https://github.com/PowerShell/PowerShell/blob/master/docs/FAQ.md).
-- Refer to the [known issues](https://docs.microsoft.com/powershell/scripting/whats-new/known-issues-ps6).
+  - If you're seeing behavior that deviates from the intended, documented behavior, report it here, assuming that you can reproduce it in the [latest released version](https://github.com/PowerShell/PowerShell/releases) and that it hasn't already been reported (please search the existing issues).
+  
+  - If you need to get clarity on what the intended behavior is or if you have questions about PowerShell in general, please instead seek help from the community via the following forums:
+  
+    - The [Slack](https://join.slack.com/t/powershell/shared_invite/enQtMzA3MDcxNTM5MTkxLTBmMWIyNzhkYzVjNGRiOTgxZmFlN2E0ZmVmOWU5NDczNTY2NDFhZjFlZTM1MTZiMWIzZDcwMGYzNjQ3YTRkNWM) and [Discord](https://discordapp.com/invite/AtzXnJM) community chat forums (they seamless talk to each other).
+ 
+    - Q&A site [StackOverflow.com](https://stackoverflow.com/questions/tagged/powershell) and the [PowerShell.org](https://powershell.org/forums/) forum for searching or posting questions about PowerShell.
+
+See also:
+- [FAQ](https://github.com/PowerShell/PowerShell/blob/master/docs/FAQ.md).
+- [Known Issues](https://docs.microsoft.com/powershell/scripting/whats-new/known-issues-ps6).
 
 -->
 

--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -17,7 +17,7 @@ This repository is **ONLY** for PowerShell 7+ issues:
   
   - If you need to get clarity on what the intended behavior is or if you have questions about PowerShell in general, please instead seek help from the community via the following forums:
   
-    - The [Slack](https://join.slack.com/t/powershell/shared_invite/enQtMzA3MDcxNTM5MTkxLTBmMWIyNzhkYzVjNGRiOTgxZmFlN2E0ZmVmOWU5NDczNTY2NDFhZjFlZTM1MTZiMWIzZDcwMGYzNjQ3YTRkNWM) and [Discord](https://discordapp.com/invite/AtzXnJM) community chat forums (they seamless talk to each other).
+    - The [Slack](https://join.slack.com/t/powershell/shared_invite/enQtMzA3MDcxNTM5MTkxLTBmMWIyNzhkYzVjNGRiOTgxZmFlN2E0ZmVmOWU5NDczNTY2NDFhZjFlZTM1MTZiMWIzZDcwMGYzNjQ3YTRkNWM) and [Discord](https://discordapp.com/invite/AtzXnJM) community chat forums (they seamlessly talk to each other).
  
     - Q&A site [StackOverflow.com](https://stackoverflow.com/questions/tagged/powershell) and the [PowerShell.org](https://powershell.org/forums/) forum for searching or posting questions about PowerShell.
 

--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -17,7 +17,7 @@ This repository is **ONLY** for PowerShell 7+ issues:
   
   - If you need to get clarity on what the intended behavior is or if you have questions about PowerShell in general, please instead seek help from the community via the following forums:
   
-    - The [Slack](https://join.slack.com/t/powershell/shared_invite/enQtMzA3MDcxNTM5MTkxLTBmMWIyNzhkYzVjNGRiOTgxZmFlN2E0ZmVmOWU5NDczNTY2NDFhZjFlZTM1MTZiMWIzZDcwMGYzNjQ3YTRkNWM) and [Discord](https://discordapp.com/invite/AtzXnJM) community chat forums (they seamlessly talk to each other).
+    - The [Slack](https://aka.ms/psslack) and [Discord](https://aka.ms/psdiscord) community chat forums (they seamlessly talk to each other).
  
     - Q&A site [StackOverflow.com](https://stackoverflow.com/questions/tagged/powershell) and the [PowerShell.org](https://powershell.org/forums/) forum for searching or posting questions about PowerShell.
 


### PR DESCRIPTION
# PR Summary

* Remove the "title" default value, so that users are forced to type their own (hopefully descriptive) title before being able to submit.

* Add guidance as to when it is appropriate to post, along with alternative resources; see the discussion in https://github.com/PowerShell/PowerShell/issues/14474 for background.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
