### PR TITLE
Adding -Stream parameter to tee-object, with tests

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Tee-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Tee-Object.cs
@@ -164,12 +164,12 @@ namespace Microsoft.PowerShell.Commands
                                   WriteError(new ErrorRecord(exc, _message, ErrorCategory.WriteError, _inputObject));
                                   break;
                 }
-
             } 
             else 
             {
                 _commandWrapper.Process(_inputObject);
             }
+            
             WriteObject(_inputObject);
         }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Tee-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Tee-Object.cs
@@ -86,6 +86,33 @@ namespace Microsoft.PowerShell.Commands
         private string _variable;
 
         /// <summary>
+        /// Stream parameter.
+        /// </summary>
+        [Parameter(Mandatory = true, ParameterSetName = "Stream")]
+        [ValidateSet(
+            "Verbose",
+            "Warning",
+            "Information",
+            "Debug",
+            "Error")]
+
+        public string Stream
+        {
+            get
+            {
+                return _stream;
+            }
+
+            set
+            {
+                //Store the  upper-case value to simplify case statement
+                _stream = value.ToUpper();
+            }
+        }
+
+        private string _stream;
+
+        /// <summary>
         /// </summary>
         protected override void BeginProcessing()
         {
@@ -102,8 +129,10 @@ namespace Microsoft.PowerShell.Commands
                 _commandWrapper.AddNamedParameter("LiteralPath", _fileName);
                 _commandWrapper.AddNamedParameter("append", _append);
             }
-            else
+            else if (string.Equals(ParameterSetName, "Stream", StringComparison.OrdinalIgnoreCase))
             {
+    
+            } else {
                 // variable parameter set
                 _commandWrapper.Initialize(Context, "set-variable", typeof(SetVariableCommand));
                 _commandWrapper.AddNamedParameter("name", _variable);
@@ -116,7 +145,24 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void ProcessRecord()
         {
-            _commandWrapper.Process(_inputObject);
+            if (string.Equals(ParameterSetName, "Stream", StringComparison.OrdinalIgnoreCase)){ 
+                string _message = _inputObject.ToString();
+                switch (_stream) {
+                    case "VERBOSE":  WriteVerbose(_message);
+                                     break;
+                    case "WARNING":  WriteWarning(_message);
+                                     break;
+                    case "INFORMATION":  WriteInformation(new System.Management.Automation.InformationRecord(_message,"Tee-Object"));
+                                         break;
+                    case "DEBUG":  WriteDebug(_message);
+                                   break;
+                    case "ERROR":  Exception exc = new WriteErrorException();
+                                   WriteError(new ErrorRecord(exc,_message,ErrorCategory.WriteError,_inputObject));
+                                   break;
+                }
+            } else {
+                _commandWrapper.Process(_inputObject);
+            }
             WriteObject(_inputObject);
         }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Tee-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Tee-Object.cs
@@ -130,15 +130,8 @@ namespace Microsoft.PowerShell.Commands
                 _commandWrapper.AddNamedParameter("append", _append);
             }
             else if (string.Equals(ParameterSetName, "Stream", StringComparison.OrdinalIgnoreCase))
-<<<<<<< HEAD
             {
-    
-            } 
-            else
-=======
->>>>>>> 575e3ef8b42efb808738556ebc60f0cd322550f3
-            {
-    
+                // no initialization needed for this parameterset
             } else {
                 // variable parameter set
                 _commandWrapper.Initialize(Context, "set-variable", typeof(SetVariableCommand));

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Tee-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Tee-Object.cs
@@ -86,7 +86,7 @@ namespace Microsoft.PowerShell.Commands
         private string _variable;
 
         /// <summary>
-        /// Stream parameter.
+        /// Gets or sets the stream parameter.
         /// </summary>
         [Parameter(Mandatory = true, ParameterSetName = "Stream")]
         [ValidateSet(
@@ -105,7 +105,7 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                //Store the  upper-case value to simplify case statement
+                // Store the  upper-case value to simplify case statement
                 _stream = value.ToUpper();
             }
         }
@@ -132,7 +132,9 @@ namespace Microsoft.PowerShell.Commands
             else if (string.Equals(ParameterSetName, "Stream", StringComparison.OrdinalIgnoreCase))
             {
                 // no initialization needed for this parameterset
-            } else {
+            } 
+            else 
+            {
                 // variable parameter set
                 _commandWrapper.Initialize(Context, "set-variable", typeof(SetVariableCommand));
                 _commandWrapper.AddNamedParameter("name", _variable);
@@ -145,21 +147,24 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void ProcessRecord()
         {
-            if (string.Equals(ParameterSetName, "Stream", StringComparison.OrdinalIgnoreCase)){ 
+            if (string.Equals(ParameterSetName, "Stream", StringComparison.OrdinalIgnoreCase))
+            { 
                 string _message = _inputObject.ToString();
-                switch (_stream) {
+                switch (_stream) 
+                {
                     case "VERBOSE": WriteVerbose(_message);
                                     break;
                     case "WARNING": WriteWarning(_message);
                                     break;
                     case "INFORMATION": WriteInformation(new System.Management.Automation.InformationRecord(_message, "Tee-Object"));
                                         break;
-                    case "DEBUG":   WriteDebug(_message);
-                                    break;
-                    case "ERROR":   Exception exc = new WriteErrorException();
-                                    WriteError(new ErrorRecord(exc, _message, ErrorCategory.WriteError, _inputObject));
-                                   break;
+                    case "DEBUG": WriteDebug(_message);
+                                break;
+                    case "ERROR": Exception exc = new WriteErrorException();
+                                  WriteError(new ErrorRecord(exc, _message, ErrorCategory.WriteError, _inputObject));
+                                  break;
                 }
+
             } 
             else 
             {


### PR DESCRIPTION
# PR Summary

Add support for Tee-Object to tee objects to the various output streams (verbose, debug, information, error in addition to file and variable.

## PR Context

PowerShell has lots of different kinds of output streams, and it makes sense to "tee" things to those in addition to using files and variables.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
