### PR TITLE
Fix PromptForCredential() to add `targetName` as domain

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
@@ -99,10 +99,7 @@ namespace Microsoft.PowerShell
 
             if (!InternalTestHooks.NoPromptForPassword)
             {
-                //
-                // now, prompt for the password
-                //
-                WriteToConsole(passwordPrompt, transcribeResult:true);
+                WriteToConsole(passwordPrompt, transcribeResult: true);
                 password = ReadLineAsSecureString();
                 if (password == null)
                 {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
@@ -97,17 +97,24 @@ namespace Microsoft.PowerShell
             passwordPrompt = StringUtil.Format(ConsoleHostUserInterfaceSecurityResources.PromptForCredential_Password, userName
             );
 
-            //
-            // now, prompt for the password
-            //
-            WriteToConsole(passwordPrompt, true);
-            password = ReadLineAsSecureString();
-            if (password == null)
+            if (!InternalTestHooks.NoPromptForPassword)
             {
-                return null;
-            }
+                //
+                // now, prompt for the password
+                //
+                WriteToConsole(passwordPrompt, true);
+                password = ReadLineAsSecureString();
+                if (password == null)
+                {
+                    return null;
+                }
 
-            WriteLineToConsole();
+                WriteLineToConsole();
+            }
+            else
+            {
+                password = new SecureString();
+            }
 
             if (!string.IsNullOrEmpty(targetName))
             {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
@@ -109,6 +109,11 @@ namespace Microsoft.PowerShell
 
             WriteLineToConsole();
 
+            if (!string.IsNullOrEmpty(targetName))
+            {
+                userName = StringUtil.Format("{0}\\{1}", targetName, userName);
+            }
+
             cred = new PSCredential(userName, password);
 
             return cred;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
@@ -102,7 +102,7 @@ namespace Microsoft.PowerShell
                 //
                 // now, prompt for the password
                 //
-                WriteToConsole(passwordPrompt, true);
+                WriteToConsole(passwordPrompt, transcribeResult:true);
                 password = ReadLineAsSecureString();
                 if (password == null)
                 {

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -2072,6 +2072,7 @@ namespace System.Management.Automation.Internal
         internal static bool BypassOnlineHelpRetrieval;
         internal static bool ForcePromptForChoiceDefaultOption;
         internal static bool BypassOutputRedirectionCheck;
+        internal static bool NoPromptForPassword;
 
         // Stop/Restart/Rename Computer tests
         internal static bool TestStopComputer;

--- a/test/powershell/Host/HostUtilities.Tests.ps1
+++ b/test/powershell/Host/HostUtilities.Tests.ps1
@@ -58,3 +58,23 @@ Describe "InvokeOnRunspace method on remote runspace" -tags "Feature","RequireAd
         $results[0] | Should -Be "Hello!"
     }
 }
+
+Describe 'PromptForCredential' {
+    BeforeAll {
+        [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('NoPromptForPassword', $true)
+    }
+
+    AfterAll {
+        [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('NoPromptForPassword', $false)
+    }
+
+    It 'Should accept no targetname' {
+        $out = $Host.UI.PromptForCredential('caption','message','myUser',$null)
+        $out.UserName | Should -BeExactly 'myUser'
+    }
+
+    It 'Should accept targetname as domain' {
+        $out = $Host.UI.PromptForCredential('caption','message','myUser','myDomain')
+        $out.UserName | Should -BeExactly 'myDomain\myUser'
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

When PSCore was created where Windows CredUI doesn't exist, the existing code from Windows PowerShell silently dropped the `targetName` parameter and nobody noticed.  When we made PowerShell cross-platform, the CredUI code was simply removed so that it always fell to using the existing console prompt code which dropped the `targetName`.  Fix is if `targetName` has a value, then use it as the domain.

Related #12222 

## PR Context

Reported via https://twitter.com/Jaykul/status/1343039155991932928

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
