### PR TITLE
Implement a completion for View parameter of format cmdlets

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -3866,7 +3866,7 @@ namespace System.Management.Automation
 
             if (prevType is not null)
             {
-                var inferTypeNames = prevType.Select(t => t.Name).ToArray();
+                string[] inferTypeNames = prevType.Select(t => t.Name).ToArray();
                 CompleteFormatViewByInferredType(context.TypeInferenceContext, inferTypeNames, result, commandName);
             }
 

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -5441,11 +5441,11 @@ namespace System.Management.Automation
 
             return null;
         }
-        
+
         private static List<CompletionResult> CompleteCommentParameterValue(CompletionContext context, string wordToComplete)
         {
             FunctionDefinitionAst foundFunction = GetCommentHelpFunctionTarget(context);
-            
+
             ReadOnlyCollection<ParameterAst> foundParameters = null;
             if (foundFunction is not null)
             {
@@ -5456,7 +5456,7 @@ namespace System.Management.Automation
                 // The helpblock is for a script file
                 foundParameters = scriptAst.ParamBlock?.Parameters;
             }
-            
+
             if (foundParameters is null || foundParameters.Count == 0)
             {
                 return null;
@@ -5746,9 +5746,9 @@ namespace System.Management.Automation
 
         private static void CompleteFormatViewByInferredType(TypeInferenceContext context, string[] inferredTypeNames, List<CompletionResult> results, string commandName)
         {
-            var db = context.ExecutionContext.FormatDBManager.GetTypeInfoDataBase();
+            var typeInfoDB = context.ExecutionContext.FormatDBManager.GetTypeInfoDataBase();
 
-            if (db is null)
+            if (typeInfoDB is null)
             {
                 return;
             }
@@ -5764,19 +5764,19 @@ namespace System.Management.Automation
 
             Diagnostics.Assert(controlBodyType is null, "This should never happen unless a new Format-* cmdlet is added");
 
-            HashSet<string> uniqueNames = new();
-            foreach (ViewDefinition vd in db.viewDefinitionsSection.viewDefinitionList)
+            var uniqueNames = new HashSet<string>();
+            foreach (ViewDefinition viewDefinition in typeInfoDB.viewDefinitionsSection.viewDefinitionList)
             {
-                if (vd is not null && controlBodyType == vd.mainControl.GetType() && vd.appliesTo is not null)
+                if (viewDefinition is not null && controlBodyType == viewDefinition.mainControl.GetType() && viewDefinition.appliesTo is not null)
                 {
-                    foreach (var applyTo in vd.appliesTo.referenceList)
+                    foreach (TypeOrGroupReference applyTo in viewDefinition.appliesTo.referenceList)
                     {
-                        foreach (var inferredTypeName in inferredTypeNames)
+                        foreach (string inferredTypeName in inferredTypeNames)
                         {
                             // We use 'StartsWith()' because 'applyTo.Name' can look like "System.Diagnostics.Process#IncludeUserName".
-                            if (applyTo.name.StartsWith(inferredTypeName, StringComparison.OrdinalIgnoreCase) && uniqueNames.Add(vd.name))
+                            if (applyTo.name.StartsWith(inferredTypeName, StringComparison.OrdinalIgnoreCase) && uniqueNames.Add(viewDefinition.name))
                             {
-                                results.Add(new CompletionResult(vd.name, vd.name, CompletionResultType.Text, vd.name));
+                                results.Add(new CompletionResult(viewDefinition.name, viewDefinition.name, CompletionResultType.Text, viewDefinition.name));
                             }
                         }
                     }
@@ -6618,7 +6618,7 @@ namespace System.Management.Automation
 
             //search for help files for the current culture + en-US as fallback
             var searchPaths = new string[]
-            { 
+            {
                 Path.Combine(userHelpDir, currentCulture),
                 Path.Combine(appHelpDir, currentCulture),
                 Path.Combine(userHelpDir, "en-US"),

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -3798,7 +3798,7 @@ namespace System.Management.Automation
             result.Add(CompletionResult.Null);
         }
 
-        private static IEnumerable<PSTypeName> GetInferenceTypes(CompletionContext context, List<CompletionResult> result, CommandAst commandAst)
+        private static IEnumerable<PSTypeName> GetInferenceTypes(CompletionContext context, CommandAst commandAst)
         {
             // Command is something like where-object/foreach-object/format-list/etc. where there is a parameter that is a property name
             // and we want member names based on the input object, which is either the parameter InputObject, or comes from the pipeline.
@@ -3846,7 +3846,7 @@ namespace System.Management.Automation
 
         private static void NativeCompletionMemberName(CompletionContext context, List<CompletionResult> result, CommandAst commandAst)
         {
-            IEnumerable<PSTypeName> prevType = GetInferenceTypes(context, result, commandAst);
+            IEnumerable<PSTypeName> prevType = GetInferenceTypes(context, commandAst);
             if (prevType is not null)
             {
                 CompleteMemberByInferredType(context.TypeInferenceContext, prevType, result, context.WordToComplete + "*", filter: IsPropertyMember, isStatic: false);
@@ -5767,7 +5767,7 @@ namespace System.Management.Automation
             var uniqueNames = new HashSet<string>();
             foreach (ViewDefinition viewDefinition in typeInfoDB.viewDefinitionsSection.viewDefinitionList)
             {
-                if (viewDefinition is not null && controlBodyType == viewDefinition.mainControl.GetType() && viewDefinition.appliesTo is not null)
+                if (viewDefinition?.appliesTo is not null && controlBodyType == viewDefinition.mainControl.GetType())
                 {
                     foreach (TypeOrGroupReference applyTo in viewDefinition.appliesTo.referenceList)
                     {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -5783,12 +5783,11 @@ namespace System.Management.Automation
                                 && viewPattern.IsMatch(viewDefinition.name))
                             {
                                 string completionText = viewDefinition.name;
-                                var quoteInUse = quote == string.Empty && viewDefinition.name.IndexOfAny(s_charactersRequiringQuotes) != -1 ? "'" : quote;
-                                if (quoteInUse == "'")
+                                // If the string is quoted or if it contains characters that need quoting, quote it in single quotes
+                                if (quote != string.Empty || viewDefinition.name.IndexOfAny(s_charactersRequiringQuotes) != -1)
                                 {
-                                    completionText = completionText.Replace("'", "''");
+                                    completionText = "'" + completionText.Replace("'", "''") + "'";
                                 }
-                                completionText = quoteInUse + completionText + quoteInUse;
 
                                 results.Add(new CompletionResult(completionText, viewDefinition.name, CompletionResultType.Text, viewDefinition.name));
                             }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -5783,7 +5783,7 @@ namespace System.Management.Automation
                                 && viewPattern.IsMatch(viewDefinition.name))
                             {
                                 string completionText = viewDefinition.name;
-                                var quoteInUse = quote == string.Empty ? "'" : quote;
+                                var quoteInUse = quote == string.Empty && viewDefinition.name.IndexOfAny(s_charactersRequiringQuotes) != -1 ? "'" : quote;
                                 if (quoteInUse == "'")
                                 {
                                     completionText = completionText.Replace("'", "''");

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -5762,7 +5762,7 @@ namespace System.Management.Automation
                 _ => null
             };
 
-            Diagnostics.Assert(controlBodyType is null, "This should never happen unless a new Format-* cmdlet is added");
+            Diagnostics.Assert(controlBodyType is not null, "This should never happen unless a new Format-* cmdlet is added");
 
             var uniqueNames = new HashSet<string>();
             foreach (ViewDefinition viewDefinition in typeInfoDB.viewDefinitionsSection.viewDefinitionList)
@@ -5776,7 +5776,11 @@ namespace System.Management.Automation
                             // We use 'StartsWith()' because 'applyTo.Name' can look like "System.Diagnostics.Process#IncludeUserName".
                             if (applyTo.name.StartsWith(inferredTypeName, StringComparison.OrdinalIgnoreCase) && uniqueNames.Add(viewDefinition.name))
                             {
-                                results.Add(new CompletionResult(viewDefinition.name, viewDefinition.name, CompletionResultType.Text, viewDefinition.name));
+                                string completionText = viewDefinition.name.IndexOfAny(s_charactersRequiringQuotes) != -1
+                                    ? "'" + viewDefinition.name + "'"
+                                    : viewDefinition.name;
+
+                                results.Add(new CompletionResult(completionText, viewDefinition.name, CompletionResultType.Text, viewDefinition.name));
                             }
                         }
                     }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -3873,7 +3873,6 @@ namespace System.Management.Automation
             result.Add(CompletionResult.Null);
         }
 
-
         private static void NativeCompletionTypeName(CompletionContext context, List<CompletionResult> result)
         {
             var wordToComplete = context.WordToComplete;

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -5782,11 +5782,13 @@ namespace System.Management.Automation
                                 && uniqueNames.Add(viewDefinition.name)
                                 && viewPattern.IsMatch(viewDefinition.name))
                             {
-                                string completionText = quote != string.Empty
-                                    ? quote + viewDefinition.name + quote
-                                    : viewDefinition.name.IndexOfAny(s_charactersRequiringQuotes) != -1
-                                        ? "'" + viewDefinition.name + "'"
-                                        : viewDefinition.name;
+                                string completionText = viewDefinition.name;
+                                var quoteInUse = quote == string.Empty ? "'" : quote;
+                                if (quoteInUse == "'")
+                                {
+                                    completionText = completionText.Replace("'", "''");
+                                }
+                                completionText = quoteInUse + completionText + quoteInUse;
 
                                 results.Add(new CompletionResult(completionText, viewDefinition.name, CompletionResultType.Text, viewDefinition.name));
                             }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -356,7 +356,7 @@ Describe "TabCompletion" -Tags CI {
 
             $tempViewFile = Join-Path -Path $TestDrive -ChildPath 'processViewDefinition.ps1xml'
             Set-Content -LiteralPath $tempViewFile -Value $viewDefinition -Force
-            Update-TypeData -AppendPath $tempViewFile
+            Update-FormatData -AppendPath $tempViewFile
         }
 
         It 'Should complete Get-ChildItem | <cmd> -View' -TestCases (

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -302,6 +302,63 @@ Describe "TabCompletion" -Tags CI {
     }
 
     Context "Format cmdlet's View paramter completion" {
+        BeforeAll {
+            $viewDefinition = @'
+<?xml version="1.0" encoding="utf-8"?>
+<Configuration>
+  <ViewDefinitions>
+    <View>
+      <Name>R A M</Name>
+      <ViewSelectedBy>
+        <TypeName>System.Diagnostics.Process</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ProcName</Label>
+            <Width>40</Width>
+            <Alignment>Center</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>PagedMem</Label>
+            <Width>40</Width>
+            <Alignment>Center</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>PeakWS</Label>
+            <Width>40</Width>
+            <Alignment>Center</Alignment>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <Alignment>Center</Alignment>
+                <PropertyName>Name</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <Alignment>Center</Alignment>
+                <PropertyName>PagedMemorySize</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <Alignment>Center</Alignment>
+                <PropertyName>PeakWorkingSet</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+  </ViewDefinitions>
+</Configuration>
+'@
+
+            $tempViewFile = Join-Path -Path $TestDrive -ChildPath 'processViewDefinition.ps1xml'
+            Set-Content -LiteralPath $tempViewFile -Value $viewDefinition -Force
+            Update-TypeData -AppendPath $tempViewFile
+        }
+
         It 'Should complete Get-ChildItem | <cmd> -View' -TestCases (
             @{ cmd = 'Format-Table'; expected = "children childrenWithHardlink$(if ($EnabledExperimentalFeatures.Contains('PSUnixFileStat')) { ' childrenWithUnixStat' })" },
             @{ cmd = 'Format-List'; expected = 'children' },
@@ -317,7 +374,7 @@ Describe "TabCompletion" -Tags CI {
         }
 
         It 'Should complete $processList = Get-Process; $processList | <cmd> -View' -TestCases (
-            @{ cmd = 'Format-Table'; expected = 'Priority process ProcessModule ProcessWithUserName StartTime' },
+            @{ cmd = 'Format-Table'; expected = "'R A M' Priority process ProcessModule ProcessWithUserName StartTime" },
             @{ cmd = 'Format-List'; expected = '' },
             @{ cmd = 'Format-Wide'; expected = 'process' },
             @{ cmd = 'Format-Custom'; expected = '' }
@@ -1408,7 +1465,7 @@ dir -Recurse `
                 ## Save original culture and temporarily set it to da-DK because there's no localized help for da-DK.
                 $OriginalCulture = [cultureinfo]::CurrentCulture
                 [cultureinfo]::CurrentCulture="da-DK"
-                
+
                 $res = TabExpansion2 -inputScript 'get-help about_spla' -cursorColumn 'get-help about_spla'.Length
                 $res.CompletionMatches | Should -HaveCount 1
                 $res.CompletionMatches[0].CompletionText | Should -BeExactly 'about_Splatting'

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -403,8 +403,9 @@ Describe "TabCompletion" -Tags CI {
             $ps.Commands.Clear()
 $VerbosePreference = "Continue"
 $result | out-string | write-verbose
-$result | Sort-Object | out-string | write-verbose
-$result | out-string | Sort-Object | write-verbose
+$result | Sort-Object -Culture "en-US" | out-string | write-verbose
+$result | out-string | Sort-Object -Culture "en-US" | write-verbose
+Get-Culture | write-verbose
 
             $result -join ' ' | Should -BeExactly $expected
         }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -386,7 +386,7 @@ Describe "TabCompletion" -Tags CI {
 
             # The completion is based on a type of the argument which is binded to 'InputObject' parameter.
             $processList = Get-Process
-            $res = TabExpansion2 -inputScript "`$processList | $cmd" -cursorColumn "`$processList | $cmd -View ".Length
+            $res = TabExpansion2 -inputScript "`$processList | $cmd" -cursorColumn "`$processList | $cmd".Length
             $completionText = $res.CompletionMatches.CompletionText | Sort-Object
             $completionText -join ' ' | Should -BeExactly $expected
         }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -396,13 +396,14 @@ Describe "TabCompletion" -Tags CI {
                 $processList = Get-Process
                 $res = TabExpansion2 -inputScript "`$processList | $cmd" -cursorColumn "`$processList | $cmd".Length
                 $completionText = $res.CompletionMatches.CompletionText | Sort-Object
-                $completionText -join ' '
+                $completionText
             }).AddArgument($cmd)
 
             $result = $ps.Invoke()
             $ps.Commands.Clear()
-Write-Verbose -Message $result[0]
-            $result | Should -BeExactly $expected
+$VerbosePreference = "Continue"
+$result | out-string | write-verbose
+            $result -join ' ' | Should -BeExactly $expected
         }
     }
 

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -407,7 +407,8 @@ $result | ForEach-Object { $_ } | Sort-Object -Culture "en-US" | out-string | wr
 [array]::Sort($result)
 $result | write-verbose
 Get-Culture | write-verbose
-
+$a="'R A M'", "Priority", "process", "ProcessModule", "ProcessWithUserName", "StartTime"
+$a | sort | write-verbose
             $result -join ' ' | Should -BeExactly $expected
         }
     }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -401,7 +401,7 @@ Describe "TabCompletion" -Tags CI {
 
             $result = $ps.Invoke()
             $ps.Commands.Clear()
-Write-Verbose -Message $result
+Write-Verbose -Message $result[0]
             $result | Should -BeExactly $expected
         }
     }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -380,21 +380,7 @@ Describe "TabCompletion" -Tags CI {
             $completionText -join ' ' | Should -BeExactly $expected
         }
 
-        It 'Should complete Get-ChildItem | <cmd> -View' -TestCases (
-            @{ cmd = 'Format-Table'; expected = "children childrenWithHardlink$(if ($EnabledExperimentalFeatures.Contains('PSUnixFileStat')) { ' childrenWithUnixStat' })" },
-            @{ cmd = 'Format-List'; expected = 'children' },
-            @{ cmd = 'Format-Wide'; expected = 'children' },
-            @{ cmd = 'Format-Custom'; expected = '' }
-        ) {
-            param($cmd, $expected)
-
-            # The completion is based on OutputTypeAttribute() of the cmdlet.
-            $res = TabExpansion2 -inputScript "Get-ChildItem | $cmd -View " -cursorColumn "Get-ChildItem | $cmd -View ".Length
-            $completionText = $res.CompletionMatches.CompletionText | Sort-Object
-            $completionText -join ' ' | Should -BeExactly $expected
-        }
-
-        It 'Should complete $processList = Get-Process; $processList | <cmd> -View' -TestCases (
+        It 'Should complete $processList = Get-Process; $processList | <cmd>' -TestCases (
             @{ cmd = 'Format-Table -View '; expected = "'R A M' Priority process ProcessModule ProcessWithUserName StartTime" },
             @{ cmd = 'Format-List -View '; expected = '' },
             @{ cmd = 'Format-Wide -View '; expected = 'process' },
@@ -407,7 +393,7 @@ Describe "TabCompletion" -Tags CI {
 
             $ps.AddScript({
                 param ($cmd)
-                $processList=Get-Process
+                $processList = Get-Process
                 $res = TabExpansion2 -inputScript "`$processList | $cmd" -cursorColumn "`$processList | $cmd".Length
                 $completionText = $res.CompletionMatches.CompletionText | Sort-Object
                 $completionText -join ' '

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -391,7 +391,7 @@ Describe "TabCompletion" -Tags CI {
         ) {
             param($cmd, $expected)
 
-            $ps.AddScript({
+            $null = $ps.AddScript({
                 param ($cmd)
                 $processList = Get-Process
                 $res = TabExpansion2 -inputScript "`$processList | $cmd" -cursorColumn "`$processList | $cmd".Length
@@ -401,7 +401,7 @@ Describe "TabCompletion" -Tags CI {
 
             $result = $ps.Invoke()
             $ps.Commands.Clear()
-
+Write-Verbose -Message $result
             $result | Should -BeExactly $expected
         }
     }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -395,7 +395,7 @@ Describe "TabCompletion" -Tags CI {
                 param ($cmd)
                 $processList = Get-Process
                 $res = TabExpansion2 -inputScript "`$processList | $cmd" -cursorColumn "`$processList | $cmd".Length
-                $completionText = $res.CompletionMatches.CompletionText | Sort-Object
+                $completionText = $res.CompletionMatches | Select-Object -ExpandProperty CompletionText | Sort-Object
                 $completionText
             }).AddArgument($cmd)
 

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -403,6 +403,9 @@ Describe "TabCompletion" -Tags CI {
             $ps.Commands.Clear()
 $VerbosePreference = "Continue"
 $result | out-string | write-verbose
+$result | Sort-Object | out-string | write-verbose
+$result | out-string | Sort-Object | write-verbose
+
             $result -join ' ' | Should -BeExactly $expected
         }
     }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -395,7 +395,7 @@ Describe "TabCompletion" -Tags CI {
                 param ($cmd)
                 $processList = Get-Process
                 $res = TabExpansion2 -inputScript "`$processList | $cmd" -cursorColumn "`$processList | $cmd".Length
-                $completionText = $res.CompletionMatches | Select-Object -ExpandProperty CompletionText | Sort-Object
+                $completionText = $res.CompletionMatches.CompletionText
                 $completionText
             }).AddArgument($cmd)
 
@@ -403,8 +403,9 @@ Describe "TabCompletion" -Tags CI {
             $ps.Commands.Clear()
 $VerbosePreference = "Continue"
 $result | out-string | write-verbose
-$result | Sort-Object -Culture "en-US" | out-string | write-verbose
-$result | out-string | Sort-Object -Culture "en-US" | write-verbose
+$result | ForEach-Object { $_ } | Sort-Object -Culture "en-US" | out-string | write-verbose
+[array]::Sort($result)
+$result | write-verbose
 Get-Culture | write-verbose
 
             $result -join ' ' | Should -BeExactly $expected

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -374,16 +374,19 @@ Describe "TabCompletion" -Tags CI {
         }
 
         It 'Should complete $processList = Get-Process; $processList | <cmd> -View' -TestCases (
-            @{ cmd = 'Format-Table'; expected = "'R A M' Priority process ProcessModule ProcessWithUserName StartTime" },
-            @{ cmd = 'Format-List'; expected = '' },
-            @{ cmd = 'Format-Wide'; expected = 'process' },
-            @{ cmd = 'Format-Custom'; expected = '' }
+            @{ cmd = 'Format-Table -View '; expected = "'R A M' Priority process ProcessModule ProcessWithUserName StartTime" },
+            @{ cmd = 'Format-List -View '; expected = '' },
+            @{ cmd = 'Format-Wide -View '; expected = 'process' },
+            @{ cmd = 'Format-Custom -View '; expected = '' },
+            @{ cmd = 'Format-Table -View S'; expected = "StartTime" },
+            @{ cmd = "Format-Table -View 'S"; expected = "'StartTime'" },
+            @{ cmd = "Format-Table -View R"; expected = "'R A M'" }
         ) {
             param($cmd, $expected)
 
             # The completion is based on a type of the argument which is binded to 'InputObject' parameter.
             $processList = Get-Process
-            $res = TabExpansion2 -inputScript "`$processList | $cmd -View " -cursorColumn "`$processList | $cmd -View ".Length
+            $res = TabExpansion2 -inputScript "`$processList | $cmd" -cursorColumn "`$processList | $cmd -View ".Length
             $completionText = $res.CompletionMatches.CompletionText | Sort-Object
             $completionText -join ' ' | Should -BeExactly $expected
         }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -303,7 +303,7 @@ Describe "TabCompletion" -Tags CI {
 
     Context "Format cmdlet's View paramter completion" {
         It 'Should complete Get-ChildItem | <cmd> -View' -TestCases (
-            @{ cmd = 'Format-Table'; expected = "$(if ($EnabledExperimentalFeatures.Contains('PSUnixFileStat')) { 'childrenWithUnixStat ' })children childrenWithHardlink" },
+            @{ cmd = 'Format-Table'; expected = "children childrenWithHardlink$(if ($EnabledExperimentalFeatures.Contains('PSUnixFileStat')) { ' childrenWithUnixStat' })" },
             @{ cmd = 'Format-List'; expected = 'children' },
             @{ cmd = 'Format-Wide'; expected = 'children' },
             @{ cmd = 'Format-Custom'; expected = '' }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -381,7 +381,7 @@ Describe "TabCompletion" -Tags CI {
         }
 
         It 'Should complete $processList = Get-Process; $processList | <cmd>' -TestCases (
-            @{ cmd = 'Format-Table -View '; expected = "'R A M' Priority process ProcessModule ProcessWithUserName StartTime" },
+            @{ cmd = 'Format-Table -View '; expected = "'R A M'", "Priority", "process", "ProcessModule", "ProcessWithUserName", "StartTime" },
             @{ cmd = 'Format-List -View '; expected = '' },
             @{ cmd = 'Format-Wide -View '; expected = 'process' },
             @{ cmd = 'Format-Custom -View '; expected = '' },
@@ -395,20 +395,13 @@ Describe "TabCompletion" -Tags CI {
                 param ($cmd)
                 $processList = Get-Process
                 $res = TabExpansion2 -inputScript "`$processList | $cmd" -cursorColumn "`$processList | $cmd".Length
-                $completionText = $res.CompletionMatches.CompletionText
+                $completionText = $res.CompletionMatches.CompletionText | Sort-Object
                 $completionText
             }).AddArgument($cmd)
 
             $result = $ps.Invoke()
             $ps.Commands.Clear()
-$VerbosePreference = "Continue"
-$result | out-string | write-verbose
-$result | ForEach-Object { $_ } | Sort-Object -Culture "en-US" | out-string | write-verbose
-[array]::Sort($result)
-$result | write-verbose
-Get-Culture | write-verbose
-$a="'R A M'", "Priority", "process", "ProcessModule", "ProcessWithUserName", "StartTime"
-$a | sort | write-verbose
+            $expected = ($expected | Sort-Object) -join ' '
             $result -join ' ' | Should -BeExactly $expected
         }
     }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -357,6 +357,8 @@ Describe "TabCompletion" -Tags CI {
             $tempViewFile = Join-Path -Path $TestDrive -ChildPath 'processViewDefinition.ps1xml'
             Set-Content -LiteralPath $tempViewFile -Value $viewDefinition -Force
             Update-FormatData -AppendPath $tempViewFile
+
+            Remove-Item -LiteralPath $tempViewFile -Force -ErrorAction SilentlyContinue
         }
 
         It 'Should complete Get-ChildItem | <cmd> -View' -TestCases (


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Now works `dir | ft -View <Tab>`.
It has always been a problem to find out which format views exist.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/7462
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
