### PR TITLE
Make Title and Message settable in Credential Attribute

### DIFF
--- a/src/System.Management.Automation/security/CredentialParameter.cs
+++ b/src/System.Management.Automation/security/CredentialParameter.cs
@@ -13,6 +13,33 @@ namespace System.Management.Automation
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false)]
     public sealed class CredentialAttribute : ArgumentTransformationAttribute
     {
+        private string caption = CredentialAttributeStrings.CredentialAttribute_Prompt_Caption;
+        private string prompt = CredentialAttributeStrings.CredentialAttribute_Prompt;
+
+        /// <summary>
+        /// Sets the title text to be used when prompting for credentials
+        /// </summary>
+        public string Title {
+            set {
+                if (string.IsNullOrWhiteSpace(value)) {
+                    throw PSTraceSource.NewArgumentNullException(nameof(Caption));
+                }
+                caption = value;
+            }
+        }
+
+        /// <summary>
+        /// Sets the message to be used when prompting for credentials
+        /// </summary>
+        public string Message {
+            set {
+                if (string.IsNullOrWhiteSpace(value)) {
+                    throw PSTraceSource.NewArgumentNullException(nameof(Message));
+                }
+                caption = value;
+            }
+        }
+
         /// <summary>
         /// Transforms the input data to an PSCredential.
         /// </summary>
@@ -66,13 +93,6 @@ namespace System.Management.Automation
 
             if (shouldPrompt)
             {
-                string caption = null;
-                string prompt = null;
-
-                caption = CredentialAttributeStrings.CredentialAttribute_Prompt_Caption;
-
-                prompt = CredentialAttributeStrings.CredentialAttribute_Prompt;
-
                 cred = engineIntrinsics.Host.UI.PromptForCredential(
                            caption,
                            prompt,


### PR DESCRIPTION
# Make Title and Message settable in Credential Attribute

For parity with Get-Credential, this exposes `Title` and `Message` properties in the Credential attribute, while maintaining the current behavior.

## Requested by @potatoqualitee ...
https://twitter.com/cl/status/1339896630863159296

The key feature request was to be able to customize the prompt for the password even when a username was being passed to the Credential parameter.

Note: I've not touched any _tests_ here. If anyone who thinks something more should be done can point me in the right direction, I'm happy to do it.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
