### PR TITLE
Improve completion of parameters for attributes

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -836,6 +836,7 @@ namespace System.Management.Automation
                                                 break;
                                             }
                                         }
+                                        
                                         if (lastAst is AttributeAst)
                                         {
                                             completionContext.ReplacementLength = replacementLength = 0;

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -526,6 +526,12 @@ namespace System.Management.Automation
 
                             result = CompletionCompleters.CompleteCommandArgument(completionContext);
                         }
+                        else if (lastAst is AttributeAst)
+                        {
+                            completionContext.ReplacementIndex = replacementIndex += tokenAtCursor.Text.Length;
+                            completionContext.ReplacementLength = replacementLength = 0;
+                            result = GetResultForAttributeArgument(completionContext, ref replacementIndex, ref replacementLength);
+                        }
                         else
                         {
                             //
@@ -820,6 +826,7 @@ namespace System.Management.Automation
                                 case TokenKind.Equals:
                                 case TokenKind.Comma:
                                 case TokenKind.AtParen:
+                                case TokenKind.LParen:
                                     {
                                         if (lastAst is AssignmentStatementAst assignmentAst)
                                         {
@@ -829,25 +836,17 @@ namespace System.Management.Automation
                                                 break;
                                             }
                                         }
+                                        if (lastAst is AttributeAst)
+                                        {
+                                            completionContext.ReplacementLength = replacementLength = 0;
+                                            result = GetResultForAttributeArgument(completionContext, ref replacementIndex, ref replacementLength);
+                                            break;
+                                        }
 
                                         bool unused;
                                         result = GetResultForEnumPropertyValueOfDSCResource(completionContext, string.Empty, ref replacementIndex, ref replacementLength, out unused);
                                         break;
                                     }
-                                case TokenKind.LParen:
-                                    if (lastAst is AttributeAst)
-                                    {
-                                        completionContext.ReplacementLength = replacementLength = 0;
-                                        result = GetResultForAttributeArgument(completionContext, ref replacementIndex, ref replacementLength);
-                                    }
-                                    else
-                                    {
-                                        bool unused;
-                                        result = GetResultForEnumPropertyValueOfDSCResource(completionContext, string.Empty,
-                                            ref replacementIndex, ref replacementLength, out unused);
-                                    }
-
-                                    break;
                                 default:
                                     break;
                             }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -915,6 +915,13 @@ Describe "TabCompletion" -Tags CI {
             $entry = $res.CompletionMatches | Where-Object CompletionText -EQ "Position"
             $entry.CompletionText | Should -BeExactly "Position"
         }
+        It "Test Attribute member completion multiple members" {
+            $inputStr = "function bar { [parameter(Position,]param() }"
+            $res = TabExpansion2 -inputScript $inputStr -cursorColumn ($inputStr.IndexOf(',') + 1)
+            $res.CompletionMatches | Should -HaveCount 10
+            $entry = $res.CompletionMatches | Where-Object CompletionText -EQ "Mandatory"
+            $entry.CompletionText | Should -BeExactly "Mandatory"
+        }
 
         It "Test completion with line continuation" {
             $inputStr = @'


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
Fixes: https://github.com/PowerShell/PowerShell/issues/12771
Fixes issue where tab completion for attribute parameters only works for the first parameter due to the comma(s) required for the following parameters.
## PR Context
If you are using an attribute like [Parameter()] you need to remember the full list of parameters because tab completion/intellisense doesn't work unless you are writing the first parameter.
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
