### PR TITLE
Fix using variable for nested foreach parallel calls

### DIFF
--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -385,7 +385,8 @@ namespace Microsoft.PowerShell.Commands
         // TODO: Look into using SessionState.Internal.GetAliasTable() to find all user created aliases.
         //       But update Alias command logic to maintain reverse table that lists all aliases mapping
         //       to a single command definition, for performance.
-        private static string[] ForEachNames = new string[] {
+        private static string[] forEachNames = new string[]
+        {
             "ForEach-Object",
             "foreach",
             "%"
@@ -422,7 +423,7 @@ namespace Microsoft.PowerShell.Commands
                 scriptBlock: Parallel,
                 isTrustedInput: allowUsingExpression,
                 context: this.Context,
-                foreachNames: ForEachNames);
+                foreachNames: forEachNames);
 
             // Validate using values map, which is a map of '$using:' variables referenced in the script.
             // Script block variables are not allowed since their behavior is undefined outside the runspace

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -381,6 +381,16 @@ namespace Microsoft.PowerShell.Commands
         private Exception _taskCollectionException;
         private string _currentLocationPath;
 
+        // List of Foreach-Object command names and aliases.
+        // TODO: Look into using SessionState.Internal.GetAliasTable() to find all user created aliases.
+        //       But update Alias command logic to maintain reverse table that lists all aliases mapping
+        //       to a single command definition, for performance.
+        private static string[] ForEachNames = new string[] {
+            "ForEach-Object",
+            "foreach",
+            "%"
+        };
+
         private void InitParallelParameterSet()
         {
             // The following common parameters are not (yet) supported in this parameter set.
@@ -407,11 +417,12 @@ namespace Microsoft.PowerShell.Commands
             {
             }
 
-            bool allowUsingExpression = this.Context.SessionState.LanguageMode != PSLanguageMode.NoLanguage;
+            var allowUsingExpression = this.Context.SessionState.LanguageMode != PSLanguageMode.NoLanguage;
             _usingValuesMap = ScriptBlockToPowerShellConverter.GetUsingValuesForEachParallel(
                 scriptBlock: Parallel,
                 isTrustedInput: allowUsingExpression,
-                context: this.Context);
+                context: this.Context,
+                foreachNames: ForEachNames);
 
             // Validate using values map, which is a map of '$using:' variables referenced in the script.
             // Script block variables are not allowed since their behavior is undefined outside the runspace

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -408,11 +408,10 @@ namespace Microsoft.PowerShell.Commands
             }
 
             bool allowUsingExpression = this.Context.SessionState.LanguageMode != PSLanguageMode.NoLanguage;
-            _usingValuesMap = ScriptBlockToPowerShellConverter.GetUsingValuesAsDictionary(
-                                Parallel,
-                                allowUsingExpression,
-                                this.Context,
-                                null);
+            _usingValuesMap = ScriptBlockToPowerShellConverter.GetUsingValuesForEachParallel(
+                scriptBlock: Parallel,
+                isTrustedInput: allowUsingExpression,
+                context: this.Context);
 
             // Validate using values map, which is a map of '$using:' variables referenced in the script.
             // Script block variables are not allowed since their behavior is undefined outside the runspace

--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -2434,7 +2434,7 @@ namespace Microsoft.PowerShell.Commands
                 throw new ArgumentNullException(nameof(localScriptBlock), "Caller needs to make sure the parameter value is not null");
             }
 
-            var allUsingExprs = UsingExpressionAstSearcher.FindAllUsingExpressionExceptForWorkflow(localScriptBlock.Ast);
+            var allUsingExprs = UsingExpressionAstSearcher.FindAllUsingExpressions(localScriptBlock.Ast);
             return allUsingExprs.Select(usingExpr => UsingExpressionAst.ExtractUsingVariable((UsingExpressionAst)usingExpr)).ToList();
         }
 

--- a/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
+++ b/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
@@ -174,11 +174,14 @@ namespace System.Management.Automation
 
     internal class UsingExpressionAstSearcher : AstSearcher
     {
-        internal static IEnumerable<Ast> FindAllUsingExpressionExceptForWorkflow(Ast ast)
+        internal static IEnumerable<Ast> FindAllUsingExpressions(Ast ast)
         {
             Diagnostics.Assert(ast != null, "caller to verify arguments");
 
-            var searcher = new UsingExpressionAstSearcher(astParam => astParam is UsingExpressionAst, stopOnFirst: false, searchNestedScriptBlocks: true);
+            var searcher = new UsingExpressionAstSearcher(
+                callback: astParam => astParam is UsingExpressionAst,
+                stopOnFirst: false,
+                searchNestedScriptBlocks: true);
             ast.InternalVisit(searcher);
             return searcher.Results;
         }
@@ -314,6 +317,127 @@ namespace System.Management.Automation
         }
 
         /// <summary>
+        /// Get using values as dictionary for the Foreach-Object parallel cmdlet.
+        /// Ignore any using expressions that are associated with inner nested Foreach-Object parallel calls,
+        /// since they are only effective in the nested call scope and not the current outer scope.
+        /// </summary>
+        /// <param name = "scriptBlock">Scriptblock to search.</param>
+        /// <param name = "isTrustedInput">True when input is trusted.</param>
+        /// <param name = "context">Execution context.</param>
+        /// <returns>Dictionary of using variable map.</returns>
+        internal static Dictionary<string, object> GetUsingValuesForEachParallel(
+            ScriptBlock scriptBlock,
+            bool isTrustedInput,
+            ExecutionContext context)
+        {
+            // Using variables for Foreach-Object -Parallel use are restricted to be within the 
+            // Foreach-Object -Parallel call scope. This will filter the using variable map to variables 
+            // only within the current (outer) Foreach-Object -Parallel call scope.
+            var usingAsts = UsingExpressionAstSearcher.FindAllUsingExpressions(scriptBlock.Ast).ToList();
+            UsingExpressionAst usingAst = null;
+            var usingValueMap = new Dictionary<string, object>(usingAsts.Count);
+            Version oldStrictVersion = null;
+            try
+            {
+                if (context != null)
+                {
+                    oldStrictVersion = context.EngineSessionState.CurrentScope.StrictModeVersion;
+                    context.EngineSessionState.CurrentScope.StrictModeVersion = PSVersionInfo.PSVersion;
+                }
+
+                for (int i = 0; i < usingAsts.Count; ++i)
+                {
+                    usingAst = (UsingExpressionAst)usingAsts[i];
+                    if (IsInForeachParallelCallingScope(usingAst))
+                    {
+                        var value = Compiler.GetExpressionValue(usingAst.SubExpression, isTrustedInput, context);
+                        string usingAstKey = PsUtils.GetUsingExpressionKey(usingAst);
+                        usingValueMap.TryAdd(usingAstKey, value);
+                    }
+                }
+            }
+            catch (RuntimeException rte)
+            {
+                if (rte.ErrorRecord.FullyQualifiedErrorId.Equals("VariableIsUndefined", StringComparison.Ordinal))
+                {
+                    throw InterpreterError.NewInterpreterException(
+                        targetObject: null, 
+                        exceptionType: typeof(RuntimeException),
+                        errorPosition: usingAst.Extent, 
+                        resourceIdAndErrorId: "UsingVariableIsUndefined",
+                        resourceString: AutomationExceptions.UsingVariableIsUndefined, 
+                        args: rte.ErrorRecord.TargetObject);
+                }
+            }
+            finally
+            {
+                if (context != null)
+                {
+                    context.EngineSessionState.CurrentScope.StrictModeVersion = oldStrictVersion;
+                }
+            }
+
+            return usingValueMap;
+        }
+
+        /// <summary>
+        /// Walks the using Ast to verify it is used within a foreach-object -parallel command
+        /// and parameter set scope, and not from within a nested foreach-object -parallel call.
+        ///     $Test1 = "Hello"
+        ///     1 | ForEach-Object -Parallel { 
+        ///         $using:Test1
+        ///         $Test2 = "Goodbye"
+        ///         1 | ForEach-Object -Parallel {
+        ///             $using:Test1    # Invalid using scope
+        ///             $using:Test2    # Valid using scope
+        ///         }
+        ///     }
+        /// </summary>
+        private static bool IsInForeachParallelCallingScope(UsingExpressionAst usingAst)
+        {
+            Diagnostics.Assert(usingAst != null, "usingAst argument cannot be null.");
+
+            // Search up the parent Ast chain for 'Foreach-Object -Parallel' commands.
+            Ast currentParent = usingAst.Parent;
+            int foreachNestedCount = 0;
+            while (currentParent != null)
+            {
+                // Look for Foreach-Object outer commands
+                if (currentParent is CommandAst commandAst)
+                {
+                    foreach (var commandElement in commandAst.CommandElements)
+                    {
+                        if (commandElement is StringConstantExpressionAst commandName)
+                        {
+                            if (commandName.Value.Equals("foreach", StringComparison.OrdinalIgnoreCase) ||
+                                commandName.Value.Equals("foreach-object", StringComparison.OrdinalIgnoreCase) ||
+                                commandName.Value.Equals("%"))
+                            {
+                                // Verify this is foreach-object with parallel parameter set.
+                                var bindingResult = StaticParameterBinder.BindCommand(commandAst);
+                                if (bindingResult.BoundParameters.ContainsKey("Parallel"))
+                                {
+                                    foreachNestedCount++;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (foreachNestedCount > 1)
+                {
+                    // This using expression Ast is outside the original calling scope.
+                    return false;
+                }
+
+                currentParent = currentParent.Parent;
+            }
+
+            return (foreachNestedCount == 1);
+        }
+
+        /// <summary>
         /// Get using values in the dictionary form.
         /// </summary>
         internal static Dictionary<string, object> GetUsingValuesAsDictionary(ScriptBlock scriptBlock, bool isTrustedInput, ExecutionContext context, Dictionary<string, object> variables)
@@ -343,11 +467,16 @@ namespace System.Management.Automation
         /// A tuple of the dictionary-form and the array-form using values.
         /// If the array-form using value is null, then there are UsingExpressions used in different scopes.
         /// </returns>
-        private static Tuple<Dictionary<string, object>, object[]> GetUsingValues(Ast body, bool isTrustedInput, ExecutionContext context, Dictionary<string, object> variables, bool filterNonUsingVariables)
+        private static Tuple<Dictionary<string, object>, object[]> GetUsingValues(
+            Ast body,
+            bool isTrustedInput,
+            ExecutionContext context,
+            Dictionary<string, object> variables,
+            bool filterNonUsingVariables)
         {
             Diagnostics.Assert(context != null || variables != null, "can't retrieve variables with no context and no variables");
 
-            var usingAsts = UsingExpressionAstSearcher.FindAllUsingExpressionExceptForWorkflow(body).ToList();
+            var usingAsts = UsingExpressionAstSearcher.FindAllUsingExpressions(body).ToList();
             var usingValueArray = new object[usingAsts.Count];
             var usingValueMap = new Dictionary<string, object>(usingAsts.Count);
             HashSet<string> usingVarNames = (variables != null && filterNonUsingVariables) ? new HashSet<string>() : null;
@@ -456,7 +585,7 @@ namespace System.Management.Automation
         /// Check if the given UsingExpression is in a different scope from the previous UsingExpression that we analyzed.
         /// </summary>
         /// <remarks>
-        /// Note that the value of <paramref name="usingExpr"/> is retrieved by calling 'UsingExpressionAstSearcher.FindAllUsingExpressionExceptForWorkflow'.
+        /// Note that the value of <paramref name="usingExpr"/> is retrieved by calling 'UsingExpressionAstSearcher.FindAllUsingExpressions'.
         /// So <paramref name="usingExpr"/> is guaranteed not inside a workflow.
         /// </remarks>
         /// <param name="usingExpr">The UsingExpression to analyze.</param>

--- a/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
+++ b/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
@@ -324,7 +324,7 @@ namespace System.Management.Automation
         /// <param name = "scriptBlock">Scriptblock to search.</param>
         /// <param name = "isTrustedInput">True when input is trusted.</param>
         /// <param name = "context">Execution context.</param>
-        /// <param name = "foreachNames">List of foreach command names and aliases</param>
+        /// <param name = "foreachNames">List of foreach command names and aliases.</param>
         /// <returns>Dictionary of using variable map.</returns>
         internal static Dictionary<string, object> GetUsingValuesForEachParallel(
             ScriptBlock scriptBlock,
@@ -385,15 +385,6 @@ namespace System.Management.Automation
         /// <summary>
         /// Walks the using Ast to verify it is used within a foreach-object -parallel command
         /// and parameter set scope, and not from within a nested foreach-object -parallel call.
-        ///     $Test1 = "Hello"
-        ///     1 | ForEach-Object -Parallel { 
-        ///         $using:Test1
-        ///         $Test2 = "Goodbye"
-        ///         1 | ForEach-Object -Parallel {
-        ///             $using:Test1    # Invalid using scope
-        ///             $using:Test2    # Valid using scope
-        ///         }
-        ///     }
         /// </summary>
         /// <param name="usingAst">Using Ast to check.</param>
         /// <param name-"foreachNames">List of foreach-object command names.</param>
@@ -402,6 +393,17 @@ namespace System.Management.Automation
             UsingExpressionAst usingAst,
             string[] foreachNames)
         {
+            // Example:
+            //  $Test1 = "Hello"
+            //  1 | ForEach-Object -Parallel { 
+            //      $using:Test1
+            //      $Test2 = "Goodbye"
+            //      1 | ForEach-Object -Parallel {
+            //          $using:Test1    # Invalid using scope
+            //          $using:Test2    # Valid using scope
+            //      }
+            //  }
+
             Diagnostics.Assert(usingAst != null, "usingAst argument cannot be null.");
 
             // Search up the parent Ast chain for 'Foreach-Object -Parallel' commands.
@@ -425,6 +427,7 @@ namespace System.Management.Automation
                                     break;
                                 }
                             }
+                            
                             if (found)
                             {
                                 // Verify this is foreach-object with parallel parameter set.

--- a/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
+++ b/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
@@ -393,17 +393,18 @@ namespace System.Management.Automation
             UsingExpressionAst usingAst,
             string[] foreachNames)
         {
-            // Example:
-            //  $Test1 = "Hello"
-            //  1 | ForEach-Object -Parallel { 
-            //      $using:Test1
-            //      $Test2 = "Goodbye"
-            //      1 | ForEach-Object -Parallel {
-            //          $using:Test1    # Invalid using scope
-            //          $using:Test2    # Valid using scope
-            //      }
-            //  }
-
+            /*
+                Example:
+                $Test1 = "Hello"
+                1 | ForEach-Object -Parallel { 
+                   $using:Test1
+                   $Test2 = "Goodbye"
+                   1 | ForEach-Object -Parallel {
+                       $using:Test1    # Invalid using scope
+                       $using:Test2    # Valid using scope
+                   }
+                }
+            */
             Diagnostics.Assert(usingAst != null, "usingAst argument cannot be null.");
 
             // Search up the parent Ast chain for 'Foreach-Object -Parallel' commands.

--- a/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
+++ b/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
@@ -393,6 +393,8 @@ namespace System.Management.Automation
         ///         }
         ///     }
         /// </summary>
+        /// <param name="usingAst">Using Ast to check.</param>
+        /// <returns>True if using expression is in current call scope.</returns>
         private static bool IsInForeachParallelCallingScope(UsingExpressionAst usingAst)
         {
             Diagnostics.Assert(usingAst != null, "usingAst argument cannot be null.");
@@ -434,7 +436,7 @@ namespace System.Management.Automation
                 currentParent = currentParent.Parent;
             }
 
-            return (foreachNestedCount == 1);
+            return foreachNestedCount == 1;
         }
 
         /// <summary>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
@@ -26,6 +26,67 @@ Describe 'ForEach-Object -Parallel Basic Tests' -Tags 'CI' {
         $result[1] | Should -BeExactly $varArray[1]
     }
 
+    It 'Verifies in scope using variables in nested calls' {
+
+        $Test = "Test1"
+        $results = 1..2 | ForEach-Object -Parallel {
+            $using:Test
+            $Test = "Test2"
+            1..2 | ForEach-Object -Parallel {
+                $using:Test
+                $Test = "Test3"
+                1..2 | ForEach-Object -Parallel {
+                    $using:Test
+                }
+            }
+        }
+        $results.Count | Should -BeExactly 14
+        $groups = $results | Group-Object -AsHashTable
+        $groups['Test1'].Count | Should -BeExactly 2
+        $groups['Test2'].Count | Should -BeExactly 4
+        $groups['Test3'].Count | Should -BeExactly 8
+    }
+
+    It 'Verifies in scope using variables with different names in nested calls' {
+        $Test1 = "TestA"
+        $results = 1..2 | ForEach-Object -parallel {
+          $using:Test1
+          $Test2 = "TestB"
+          1..2 | ForEach-Object -parallel {
+            $using:Test2
+          }
+        }
+        $results.Count | Should -BeExactly 6
+        $groups = $results | Group-Object -AsHashTable
+        $groups['TestA'].Count | Should -BeExactly 2
+        $groups['TestB'].Count | Should -BeExactly 4
+    }
+
+    It 'Verifies using variable in nested scriptblock' {
+
+        $test = 'testC'
+        $results = 1..2 | ForEach-Object -parallel {
+            & { $using:test }
+        }
+        $results.Count | Should -BeExactly 2
+        $groups = $results | Group-Object -AsHashTable
+        $groups['TestC'].Count | Should -BeExactly 2
+    }
+
+    It 'Verifies expected error for out of scope using variable in nested calls' {
+
+        $Test = "TestZ"
+        1..1 | ForEach-Object -Parallel {
+            $using:Test
+            # Variable '$Test' is not defined in this scope.
+            1..1 | ForEach-Object -Parallel {
+                $using:Test
+            }
+        } -ErrorVariable usingErrors 2>$null
+
+        $usingErrors[0].FullyQualifiedErrorId | Should -BeExactly 'UsingVariableIsUndefined,Microsoft.PowerShell.Commands.ForEachObjectCommand'
+    }
+
     It 'Verifies terminating error streaming' {
 
         $result = 1..1 | ForEach-Object -Parallel { throw 'Terminating Error!'; "Hello" } 2>&1

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
@@ -50,11 +50,11 @@ Describe 'ForEach-Object -Parallel Basic Tests' -Tags 'CI' {
     It 'Verifies in scope using variables with different names in nested calls' {
         $Test1 = "TestA"
         $results = 1..2 | ForEach-Object -parallel {
-          $using:Test1
-          $Test2 = "TestB"
-          1..2 | ForEach-Object -parallel {
-            $using:Test2
-          }
+            $using:Test1
+            $Test2 = "TestB"
+            1..2 | ForEach-Object -parallel {
+                $using:Test2
+            }
         }
         $results.Count | Should -BeExactly 6
         $groups = $results | Group-Object -AsHashTable


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This fixes a bug in ForEach-Object -Parallel where a using variable in a nested ForEach-Object -Parallel throws an error even when the variable is defined in the correct scope (Issue #11817).

## PR Context

This error was occurring because, when ForEach-Object -Parallel was assembling the user variable map, it was searching all nested scriptblocks within the ForEach scriptblock, with the result of finding nested using variables where the variable had not yet been defined. Since the nested scriptblock using variable had not been defined in the current scope, a mapping error was thrown.

Fix is to change the using variable map function to not search nested scriptblocks in the ForEach -Parallel case. This way foreach -parallel using variable mapping is always performed only for the current scope.

Many thanks to @mklement0 for pointing out the fix.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
