### PR TITLE
#4750 Fix Get-Date -UFormat %u behavior

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
@@ -516,7 +516,8 @@ namespace Microsoft.PowerShell.Commands
                             break;
 
                         case 'u':
-                            sb.Append(StringUtil.Format("{0:0;0;\7}", (int)dateTime.DayOfWeek));
+                            var dayOfWeek = dateTime.DayOfWeek == DayOfWeek.Sunday ? 7 : (int)dateTime.DayOfWeek;
+                            sb.Append(dayOfWeek);
                             break;
 
                         case 'V':

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
@@ -516,7 +516,15 @@ namespace Microsoft.PowerShell.Commands
                             break;
 
                         case 'u':
-                            sb.Append((int)dateTime.DayOfWeek);
+                            if (dateTime.DayOfWeek == DayOfWeek.Sunday)
+                            {
+                                sb.Append(7);
+                            }
+                            else
+                            {
+                                sb.Append((int)dateTime.DayOfWeek);
+                            }
+                            
                             break;
 
                         case 'V':

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
@@ -516,15 +516,7 @@ namespace Microsoft.PowerShell.Commands
                             break;
 
                         case 'u':
-                            if (dateTime.DayOfWeek == DayOfWeek.Sunday)
-                            {
-                                sb.Append(7);
-                            }
-                            else
-                            {
-                                sb.Append((int)dateTime.DayOfWeek);
-                            }
-                            
+                            sb.Append(StringUtil.Format("{0:0;0;\7}", (int)dateTime.DayOfWeek));
                             break;
 
                         case 'V':

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
@@ -516,7 +516,7 @@ namespace Microsoft.PowerShell.Commands
                             break;
 
                         case 'u':
-                            var dayOfWeek = dateTime.DayOfWeek == DayOfWeek.Sunday ? 7 : (int)dateTime.DayOfWeek;
+                            int dayOfWeek = dateTime.DayOfWeek == DayOfWeek.Sunday ? 7 : (int)dateTime.DayOfWeek;
                             sb.Append(dayOfWeek);
                             break;
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
@@ -97,6 +97,7 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
         Get-Date -Date $date -UFormat %V | Should -BeExactly $week
     }
 
+    # Using the same test cases as V for ISO week date component parity
     It "using -uformat 'u' produces the correct output" -TestCases @(
         @{date="1998-01-02"; dayOfWeek = "5"},
         @{date="1998-01-03"; dayOfWeek = "6"},
@@ -129,8 +130,6 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
         @{date="2015-01-02"; dayOfWeek = "5"},
         @{date="2015-01-03"; dayOfWeek = "6"},
         @{date="2020-01-03"; dayOfWeek = "5"},
-        @{date="2021-01-03"; dayOfWeek = "7"},
-        @{date="2021-01-04"; dayOfWeek = "1"},
         @{date="2025-01-03"; dayOfWeek = "5"},
         @{date="2026-01-02"; dayOfWeek = "5"},
         @{date="2026-01-03"; dayOfWeek = "6"},

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
@@ -97,6 +97,49 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
         Get-Date -Date $date -UFormat %V | Should -BeExactly $week
     }
 
+    It "using -uformat 'u' produces the correct output" -TestCases @(
+        @{date="1998-01-02"; dayOfWeek = "5"},
+        @{date="1998-01-03"; dayOfWeek = "6"},
+        @{date="2003-01-03"; dayOfWeek = "5"},
+        @{date="2004-01-02"; dayOfWeek = "5"},
+        @{date="2004-01-03"; dayOfWeek = "6"},
+        @{date="2005-01-01"; dayOfWeek = "6"},
+        @{date="2005-01-02"; dayOfWeek = "7"},
+        @{date="2005-12-31"; dayOfWeek = "6"},
+        @{date="2006-01-01"; dayOfWeek = "7"},
+        @{date="2006-01-02"; dayOfWeek = "1"},
+        @{date="2006-12-31"; dayOfWeek = "7"},
+        @{date="2007-01-01"; dayOfWeek = "1"},
+        @{date="2007-12-30"; dayOfWeek = "7"},
+        @{date="2007-12-31"; dayOfWeek = "1"},
+        @{date="2008-01-01"; dayOfWeek = "2"},
+        @{date="2008-12-28"; dayOfWeek = "7"},
+        @{date="2008-12-29"; dayOfWeek = "1"},
+        @{date="2008-12-30"; dayOfWeek = "2"},
+        @{date="2008-12-31"; dayOfWeek = "3"},
+        @{date="2009-01-01"; dayOfWeek = "4"},
+        @{date="2009-01-02"; dayOfWeek = "5"},
+        @{date="2009-01-03"; dayOfWeek = "6"},
+        @{date="2009-12-31"; dayOfWeek = "4"},
+        @{date="2010-01-01"; dayOfWeek = "5"},
+        @{date="2010-01-02"; dayOfWeek = "6"},
+        @{date="2010-01-03"; dayOfWeek = "7"},
+        @{date="2010-01-04"; dayOfWeek = "1"},
+        @{date="2014-01-03"; dayOfWeek = "5"},
+        @{date="2015-01-02"; dayOfWeek = "5"},
+        @{date="2015-01-03"; dayOfWeek = "6"},
+        @{date="2020-01-03"; dayOfWeek = "5"},
+        @{date="2021-01-03"; dayOfWeek = "7"},
+        @{date="2021-01-04"; dayOfWeek = "1"},
+        @{date="2025-01-03"; dayOfWeek = "5"},
+        @{date="2026-01-02"; dayOfWeek = "5"},
+        @{date="2026-01-03"; dayOfWeek = "6"},
+        @{date="2031-01-03"; dayOfWeek = "5"}
+    ) {
+        param($date, $dayOfWeek)
+        Get-Date -Date $date -UFormat %u | Should -BeExactly $dayOfWeek
+    }
+
     It "Passing '<name>' to -uformat produces a descriptive error" -TestCases @(
         @{ name = "`$null"      ; value = $null; errorId = "ParameterArgumentValidationErrorNullNotAllowed" }
         @{ name = "empty string"; value = ""; errorId = "ParameterArgumentValidationErrorEmptyStringNotAllowed" }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Corrects the behavior of %u in Get-Date -UFormat to match [ISO 8601](https://en.wikipedia.org/wiki/ISO_week_date).

## PR Context

This is to fix one of the format issues in #4750.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/7180
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
