### PR TITLE
#4750 Fix Get-Date -UFormat %G and %g behavior

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
@@ -444,23 +444,23 @@ namespace Microsoft.PowerShell.Commands
                             var isoWeek = ISOWeek.GetWeekOfYear(dateTime);
                             var isoWeekYear = dateTime.Year;
 
-                            if (isoweek == 53 && dateTime.Month == 1)
+                            if (isoWeek == 53 && dateTime.Month == 1)
                             {
-                                isoweekyear--;
+                                isoWeekYear--;
                             }
-                            else if (isoweek == 1 && dateTime.Month == 12)
+                            else if (isoWeek == 1 && dateTime.Month == 12)
                             {
-                                isoweekyear++;
+                                isoWeekYear++;
                             }
 
                             if (UFormat[i] == 'g')
                             {
-                                isoweekyear %= 100;
-                                sb.Append(StringUtil.Format("{0:00}", isoweekyear));
+                                isoWeekYear %= 100;
+                                sb.Append(StringUtil.Format("{0:00}", isoWeekYear));
                             }
                             else
                             {
-                                sb.Append(isoweekyear);
+                                sb.Append(isoWeekYear);
                             }
 
                             break;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
@@ -440,12 +440,12 @@ namespace Microsoft.PowerShell.Commands
                             break;
 
                         case 'G':
-                            sb.Append(StringUtil.Format("{0:0000}", GetIsoYear(dateTime)));
+                            sb.Append(StringUtil.Format("{0:0000}", ISOWeek.GetYear(dateTime)));
                             break;
 
                         case 'g':
-                            int isoYearWithoutCentury = GetIsoYear(dateTime) % 100;
-                            sb.Append(StringUtil.Format("{0:00}", isoYearWithoutCentury);
+                            int isoYearWithoutCentury = ISOWeek.GetYear(dateTime) % 100;
+                            sb.Append(StringUtil.Format("{0:00}", isoYearWithoutCentury));
                             break;
 
                         case 'H':
@@ -566,30 +566,6 @@ namespace Microsoft.PowerShell.Commands
             }
 
             return StringUtil.Format(sb.ToString(), dateTime);
-        }
-
-        /// <summary>
-        /// This method returns the year of the ISO week calendar, which assigns each entire week to the Gregorian year that contains Thursday.
-        /// </summary>
-        private static int GetIsoYear(DateTime dateTime)
-        {
-            int isoWeek = ISOWeek.GetWeekOfYear(dateTime);
-
-            // When the Gregorian year ends between Thursday and Sunday,
-            // the rest of that ISO week belongs to the previous ISO week calendar year.
-            if (isoWeek == 53 && dateTime.Month == 1)
-            {
-                return dateTime.Year - 1;
-            }
-
-            // When the Gregorian year begins between Sunday and Thursday,
-            // the rest of that ISO week belongs to the next ISO week calendar year.
-            if (isoWeek == 1 && dateTime.Month == 12)
-            {
-                return dateTime.Year + 1;
-            }
-
-            return dateTime.Year;
         }
 
         #endregion

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
@@ -441,8 +441,8 @@ namespace Microsoft.PowerShell.Commands
 
                         case 'G':
                         case 'g':
-                            var isoweek = ISOWeek.GetWeekOfYear(dateTime);
-                            var isoweekyear = dateTime.Year;
+                            var isoWeek = ISOWeek.GetWeekOfYear(dateTime);
+                            var isoWeekYear = dateTime.Year;
 
                             if (isoweek == 53 && dateTime.Month == 1)
                             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
@@ -440,29 +440,12 @@ namespace Microsoft.PowerShell.Commands
                             break;
 
                         case 'G':
+                            sb.Append(StringUtil.Format("{0:0000}", GetIsoYear(dateTime)));
+                            break;
+
                         case 'g':
-                            var isoWeek = ISOWeek.GetWeekOfYear(dateTime);
-                            var isoWeekYear = dateTime.Year;
-
-                            if (isoWeek == 53 && dateTime.Month == 1)
-                            {
-                                isoWeekYear--;
-                            }
-                            else if (isoWeek == 1 && dateTime.Month == 12)
-                            {
-                                isoWeekYear++;
-                            }
-
-                            if (UFormat[i] == 'g')
-                            {
-                                isoWeekYear %= 100;
-                                sb.Append(StringUtil.Format("{0:00}", isoWeekYear));
-                            }
-                            else
-                            {
-                                sb.Append(isoWeekYear);
-                            }
-
+                            int isoYearWithoutCentury = GetIsoYear(dateTime) % 100;
+                            sb.Append(StringUtil.Format("{0:00}", isoYearWithoutCentury);
                             break;
 
                         case 'H':
@@ -583,6 +566,30 @@ namespace Microsoft.PowerShell.Commands
             }
 
             return StringUtil.Format(sb.ToString(), dateTime);
+        }
+
+        /// <summary>
+        /// This method returns the year of the ISO week calendar, which assigns each entire week to the Gregorian year that contains Thursday.
+        /// </summary>
+        private static int GetIsoYear(DateTime dateTime)
+        {
+            int isoWeek = ISOWeek.GetWeekOfYear(dateTime);
+
+            // When the Gregorian year ends between Thursday and Sunday,
+            // the rest of that ISO week belongs to the previous ISO week calendar year.
+            if (isoWeek == 53 && dateTime.Month == 1)
+            {
+                return dateTime.Year - 1;
+            }
+
+            // When the Gregorian year begins between Sunday and Thursday,
+            // the rest of that ISO week belongs to the next ISO week calendar year.
+            if (isoWeek == 1 && dateTime.Month == 12)
+            {
+                return dateTime.Year + 1;
+            }
+
+            return dateTime.Year;
         }
 
         #endregion

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
@@ -440,11 +440,29 @@ namespace Microsoft.PowerShell.Commands
                             break;
 
                         case 'G':
-                            sb.Append("{0:yyyy}");
-                            break;
-
                         case 'g':
-                            sb.Append("{0:yy}");
+                            var isoweek = ISOWeek.GetWeekOfYear(dateTime);
+                            var isoweekyear = dateTime.Year;
+
+                            if (isoweek == 53 && dateTime.Month == 1)
+                            {
+                                isoweekyear--;
+                            }
+                            else if (isoweek == 1 && dateTime.Month == 12)
+                            {
+                                isoweekyear++;
+                            }
+
+                            if (UFormat[i] == 'g')
+                            {
+                                isoweekyear %= 100;
+                                sb.Append(StringUtil.Format("{0:00}", isoweekyear));
+                            }
+                            else
+                            {
+                                sb.Append(isoweekyear);
+                            }
+
                             break;
 
                         case 'H':

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
@@ -99,7 +99,7 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
 
     # Using the same test cases as V for ISO week date component parity, plus some more esoteric ones
     It "using -uformat 'G' produces the correct output" -TestCases @(
-        @{date="0055-12-31"; year = "0054"},
+        @{date="0055-12-31"; year = "0055"},
         @{date="0325-01-01"; year = "0325"},
         @{date="0777-01-01"; year = "0776"},
         @{date="1998-01-02"; year = "1998"},
@@ -110,7 +110,7 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
         @{date="2005-01-01"; year = "2004"},
         @{date="2005-01-02"; year = "2004"},
         @{date="2005-12-31"; year = "2005"},
-        @{date="2006-01-01"; year = "2006"},
+        @{date="2006-01-01"; year = "2005"},
         @{date="2006-01-02"; year = "2006"},
         @{date="2006-12-31"; year = "2006"},
         @{date="2007-01-01"; year = "2007"},
@@ -144,7 +144,7 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
 
     # Using the same test cases as V for ISO week date component parity, plus some more esoteric ones
     It "using -uformat 'g' produces the correct output" -TestCases @(
-        @{date="0055-12-31"; yy = "54"},
+        @{date="0055-12-31"; yy = "55"},
         @{date="0325-01-01"; yy = "25"},
         @{date="0777-01-01"; yy = "76"},
         @{date="1998-01-02"; yy = "98"},
@@ -155,7 +155,7 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
         @{date="2005-01-01"; yy = "04"},
         @{date="2005-01-02"; yy = "04"},
         @{date="2005-12-31"; yy = "05"},
-        @{date="2006-01-01"; yy = "06"},
+        @{date="2006-01-01"; yy = "05"},
         @{date="2006-01-02"; yy = "06"},
         @{date="2006-12-31"; yy = "06"},
         @{date="2007-01-01"; yy = "07"},

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
@@ -98,6 +98,90 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
     }
 
     # Using the same test cases as V for ISO week date component parity
+    It "using -uformat 'G' produces the correct output" -TestCases @(
+        @{date="1998-01-02"; year = "1998"},
+        @{date="1998-01-03"; year = "1998"},
+        @{date="2003-01-03"; year = "2003"},
+        @{date="2004-01-02"; year = "2004"},
+        @{date="2004-01-03"; year = "2004"},
+        @{date="2005-01-01"; year = "2004"},
+        @{date="2005-01-02"; year = "2004"},
+        @{date="2005-12-31"; year = "2005"},
+        @{date="2006-01-01"; year = "2006"},
+        @{date="2006-01-02"; year = "2006"},
+        @{date="2006-12-31"; year = "2006"},
+        @{date="2007-01-01"; year = "2007"},
+        @{date="2007-12-30"; year = "2007"},
+        @{date="2007-12-31"; year = "2008"},
+        @{date="2008-01-01"; year = "2008"},
+        @{date="2008-12-28"; year = "2008"},
+        @{date="2008-12-29"; year = "2009"},
+        @{date="2008-12-30"; year = "2009"},
+        @{date="2008-12-31"; year = "2009"},
+        @{date="2009-01-01"; year = "2009"},
+        @{date="2009-01-02"; year = "2009"},
+        @{date="2009-01-03"; year = "2009"},
+        @{date="2009-12-31"; year = "2009"},
+        @{date="2010-01-01"; year = "2009"},
+        @{date="2010-01-02"; year = "2009"},
+        @{date="2010-01-03"; year = "2009"},
+        @{date="2010-01-04"; year = "2010"},
+        @{date="2014-01-03"; year = "2014"},
+        @{date="2015-01-02"; year = "2015"},
+        @{date="2015-01-03"; year = "2015"},
+        @{date="2020-01-03"; year = "2020"},
+        @{date="2025-01-03"; year = "2025"},
+        @{date="2026-01-02"; year = "2026"},
+        @{date="2026-01-03"; year = "2026"},
+        @{date="2031-01-03"; year = "2031"}
+    ) {
+        param($date, $year)
+        Get-Date -Date $date -UFormat %G | Should -BeExactly $year
+    }
+
+    # Using the same test cases as V for ISO week date component parity
+    It "using -uformat 'g' produces the correct output" -TestCases @(
+        @{date="1998-01-02"; yy = "98"},
+        @{date="1998-01-03"; yy = "98"},
+        @{date="2003-01-03"; yy = "03"},
+        @{date="2004-01-02"; yy = "04"},
+        @{date="2004-01-03"; yy = "04"},
+        @{date="2005-01-01"; yy = "04"},
+        @{date="2005-01-02"; yy = "04"},
+        @{date="2005-12-31"; yy = "05"},
+        @{date="2006-01-01"; yy = "06"},
+        @{date="2006-01-02"; yy = "06"},
+        @{date="2006-12-31"; yy = "06"},
+        @{date="2007-01-01"; yy = "07"},
+        @{date="2007-12-30"; yy = "07"},
+        @{date="2007-12-31"; yy = "08"},
+        @{date="2008-01-01"; yy = "08"},
+        @{date="2008-12-28"; yy = "08"},
+        @{date="2008-12-29"; yy = "09"},
+        @{date="2008-12-30"; yy = "09"},
+        @{date="2008-12-31"; yy = "09"},
+        @{date="2009-01-01"; yy = "09"},
+        @{date="2009-01-02"; yy = "09"},
+        @{date="2009-01-03"; yy = "09"},
+        @{date="2009-12-31"; yy = "09"},
+        @{date="2010-01-01"; yy = "09"},
+        @{date="2010-01-02"; yy = "09"},
+        @{date="2010-01-03"; yy = "09"},
+        @{date="2010-01-04"; yy = "10"},
+        @{date="2014-01-03"; yy = "14"},
+        @{date="2015-01-02"; yy = "15"},
+        @{date="2015-01-03"; yy = "15"},
+        @{date="2020-01-03"; yy = "20"},
+        @{date="2025-01-03"; yy = "25"},
+        @{date="2026-01-02"; yy = "26"},
+        @{date="2026-01-03"; yy = "26"},
+        @{date="2031-01-03"; yy = "31"}
+    ) {
+        param($date, $yy)
+        Get-Date -Date $date -UFormat %g | Should -BeExactly $yy
+    }
+
+    # Using the same test cases as V for ISO week date component parity
     It "using -uformat 'u' produces the correct output" -TestCases @(
         @{date="1998-01-02"; dayOfWeek = "5"},
         @{date="1998-01-03"; dayOfWeek = "6"},
@@ -138,7 +222,7 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
         param($date, $dayOfWeek)
         Get-Date -Date $date -UFormat %u | Should -BeExactly $dayOfWeek
     }
-
+    
     It "Passing '<name>' to -uformat produces a descriptive error" -TestCases @(
         @{ name = "`$null"      ; value = $null; errorId = "ParameterArgumentValidationErrorNullNotAllowed" }
         @{ name = "empty string"; value = ""; errorId = "ParameterArgumentValidationErrorEmptyStringNotAllowed" }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
@@ -97,8 +97,11 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
         Get-Date -Date $date -UFormat %V | Should -BeExactly $week
     }
 
-    # Using the same test cases as V for ISO week date component parity
+    # Using the same test cases as V for ISO week date component parity, plus some more esoteric ones
     It "using -uformat 'G' produces the correct output" -TestCases @(
+        @{date="0055-12-31"; year = "0054"},
+        @{date="0325-01-01"; year = "0325"},
+        @{date="0777-01-01"; year = "0776"},
         @{date="1998-01-02"; year = "1998"},
         @{date="1998-01-03"; year = "1998"},
         @{date="2003-01-03"; year = "2003"},
@@ -139,8 +142,11 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
         Get-Date -Date $date -UFormat %G | Should -BeExactly $year
     }
 
-    # Using the same test cases as V for ISO week date component parity
+    # Using the same test cases as V for ISO week date component parity, plus some more esoteric ones
     It "using -uformat 'g' produces the correct output" -TestCases @(
+        @{date="0055-12-31"; yy = "54"},
+        @{date="0325-01-01"; yy = "25"},
+        @{date="0777-01-01"; yy = "76"},
         @{date="1998-01-02"; yy = "98"},
         @{date="1998-01-03"; yy = "98"},
         @{date="2003-01-03"; yy = "03"},
@@ -222,7 +228,6 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
         param($date, $dayOfWeek)
         Get-Date -Date $date -UFormat %u | Should -BeExactly $dayOfWeek
     }
-    
     It "Passing '<name>' to -uformat produces a descriptive error" -TestCases @(
         @{ name = "`$null"      ; value = $null; errorId = "ParameterArgumentValidationErrorNullNotAllowed" }
         @{ name = "empty string"; value = ""; errorId = "ParameterArgumentValidationErrorEmptyStringNotAllowed" }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Corrects the behavior of %G and %g (variants of the same value) in Get-Date -UFormat to match [ISO 8601](https://en.wikipedia.org/wiki/ISO_week_date).

## PR Context

This is to fix one of the format issues in #4750.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [X] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/7181
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
