### PR TITLE
Allow `Set-Clipboard` to accept empty string

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Clipboard.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Clipboard.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PowerShell.Commands.Internal
         private static string StartProcess(
             string tool,
             string args,
-            string stdin = "",
+            string stdin = string.Empty,
             bool readStdout = true)
         {
             ProcessStartInfo startInfo = new();

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Clipboard.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Clipboard.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PowerShell.Commands.Internal
         private static string StartProcess(
             string tool,
             string args,
-            string stdin = string.Empty,
+            string stdin = "",
             bool readStdout = true)
         {
             ProcessStartInfo startInfo = new();

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Clipboard.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Clipboard.cs
@@ -43,11 +43,8 @@ namespace Microsoft.PowerShell.Commands.Internal
                     return string.Empty;
                 }
 
-                if (!string.IsNullOrEmpty(stdin))
-                {
-                    process.StandardInput.Write(stdin);
-                    process.StandardInput.Close();
-                }
+                process.StandardInput.Write(stdin);
+                process.StandardInput.Close();
 
                 stdout = process.StandardOutput.ReadToEnd();
                 process.WaitForExit(250);
@@ -93,11 +90,6 @@ namespace Microsoft.PowerShell.Commands.Internal
 
         public static void SetText(string text)
         {
-            if (string.IsNullOrEmpty(text))
-            {
-                return;
-            }
-
             if (_clipboardSupported == false)
             {
                 _internalClipboard = text;

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Clipboard.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Clipboard.Tests.ps1
@@ -42,8 +42,13 @@ Describe 'Clipboard cmdlet tests' -Tag CI {
             Get-Clipboard -Raw | Should -BeExactly "hello$([Environment]::NewLine)world"
         }
 
-        It 'Set-Clipboard accepts empty string' {
-            '' | Set-Clipboard
+        It 'Set-Clipboard accepts <value> string' -TestCases @(
+            @{ value = 'empty'; input = "" }
+            @{ value = 'null' ; input = $null }
+        ){
+            param ($input)
+
+            $input | Set-Clipboard
             Get-Clipboard -Raw | Should -BeNullOrEmpty
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Clipboard.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Clipboard.Tests.ps1
@@ -41,5 +41,10 @@ Describe 'Clipboard cmdlet tests' -Tag CI {
             'world' | Set-Clipboard -Append
             Get-Clipboard -Raw | Should -BeExactly "hello$([Environment]::NewLine)world"
         }
+
+        It 'Set-Clipboard accepts empty string' {
+            '' | Set-Clipboard
+            Get-Clipboard -Raw | Should -BeNullOrEmpty
+        }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Clipboard.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Clipboard.Tests.ps1
@@ -43,12 +43,12 @@ Describe 'Clipboard cmdlet tests' -Tag CI {
         }
 
         It 'Set-Clipboard accepts <value> string' -TestCases @(
-            @{ value = 'empty'; input = "" }
-            @{ value = 'null' ; input = $null }
+            @{ value = 'empty'; text = "" }
+            @{ value = 'null' ; text = $null }
         ){
-            param ($input)
+            param ($text)
 
-            $input | Set-Clipboard
+            $text | Set-Clipboard
             Get-Clipboard -Raw | Should -BeNullOrEmpty
         }
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

`Set-Clipboard` had a regression from Windows PowerShell where you could pass `$null` to `Set-Clipboard` to clear it.  With the change to make this cmdlet cross platform, validation was added to explicitly not allow this.  This change makes it work across macOS, Linux, and Windows.

## PR Context

Reported via https://github.com/MicrosoftDocs/PowerShell-Docs/issues/7111

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
