### PR TITLE
Add completion for Requires statements

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -473,7 +473,7 @@ namespace System.Management.Automation
                             break;
 
                         completionContext.WordToComplete = tokenAtCursor.Text;
-                        result = CompletionCompleters.CompleteComment(completionContext);
+                        result = CompletionCompleters.CompleteComment(completionContext, ref replacementIndex, ref replacementLength);
                         break;
 
                     case TokenKind.StringExpandable:

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4935,7 +4935,10 @@ namespace System.Management.Automation
 
             // Complete the history entries
             Match matchResult = Regex.Match(context.WordToComplete, @"^#([\w\-]*)$");
-            if (!matchResult.Success) { return results; }
+            if (!matchResult.Success)
+            {
+                return results;
+            }
 
             string wordToComplete = matchResult.Groups[1].Value;
             Collection<PSObject> psobjs;
@@ -5001,13 +5004,6 @@ namespace System.Management.Automation
             var results = new List<CompletionResult>();
 
             int cursorIndex = context.CursorPosition.ColumnNumber - 1;
-
-            // cursor is within the "#requires " statement.
-            if (cursorIndex < 10)
-            {
-                return results;
-            }
-
             string lineToCursor = context.CursorPosition.Line.Substring(0, cursorIndex);
 
             // RunAsAdministrator must be the last parameter in a Requires statement so no completion if the cursor is after the parameter.
@@ -5040,7 +5036,7 @@ namespace System.Management.Automation
                     if (parameter.Key.StartsWith(currentParameterPrefix, StringComparison.OrdinalIgnoreCase)
                         && !context.CursorPosition.Line.Contains($" -{parameter.Key}", StringComparison.OrdinalIgnoreCase))
                     {
-                        results.Add(new CompletionResult(parameter.Key, parameter.Key, CompletionResultType.ParameterName, parameter.Key));
+                        results.Add(new CompletionResult(parameter.Key, parameter.Key, CompletionResultType.ParameterName, parameter.Value));
                     }
                 }
 
@@ -5118,7 +5114,6 @@ namespace System.Management.Automation
                     }
 
                     // "RequiredVersion" is mutually exclusive with "ModuleVersion" and "MaximumVersion"
-
                     if (existingHashtableKey.Equals("ModuleVersion", StringComparison.OrdinalIgnoreCase)
                         || existingHashtableKey.Equals("MaximumVersion", StringComparison.OrdinalIgnoreCase))
                     {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4947,7 +4947,7 @@ namespace System.Management.Automation
                 }
 
                 // Regex to find parameter like " -Parameter1" or " -"
-                MatchCollection foundMatches = Regex.Matches(lineToCursor, "\\s-([A-Za-z]+|$)");
+                MatchCollection foundMatches = Regex.Matches(lineToCursor, @"\s-([A-Za-z]+|$)");
                 if (foundMatches.Count == 0)
                 {
                     return results;
@@ -4980,7 +4980,7 @@ namespace System.Management.Automation
                 else
                 {
                     // Regex to find parameter values (any text that appears after various delimiters)
-                    foundMatches = Regex.Matches(lineToCursor, "(\\s|,|;|{|\"|'|=)(\\w+|$)");
+                    foundMatches = Regex.Matches(lineToCursor, @"(\s|,|;|{|\""|'|=)(\w+|$)");
                     string currentValue;
                     if (foundMatches.Count == 0)
                     {
@@ -5021,7 +5021,7 @@ namespace System.Management.Automation
                             string hashtableString = lineToCursor.Substring(hashtableStart);
 
                             // Regex to find hashtable keys with or without quotes
-                            foundMatches = Regex.Matches(hashtableString, "(@{|;)\\s*(?:'|\"|\\w*)\\w*");
+                            foundMatches = Regex.Matches(hashtableString, @"(@{|;)\s*(?:'|\""|\w*)\w*");
                             var hashtableKeys = new string[foundMatches.Count];
                             for (int i = 0; i < hashtableKeys.Length; i++)
                             {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4923,11 +4923,157 @@ namespace System.Management.Automation
 
         #region Comments
 
-        // Complete the history entries
-        internal static List<CompletionResult> CompleteComment(CompletionContext context)
+
+        internal static List<CompletionResult> CompleteComment(CompletionContext context, ref int replacementIndex, ref int replacementLength)
         {
             List<CompletionResult> results = new List<CompletionResult>();
 
+            //Complete #requires statements
+            if (context.WordToComplete.StartsWith("#requires ", StringComparison.OrdinalIgnoreCase))
+            {
+                int cursorIndex = context.CursorPosition.ColumnNumber - 1;
+                //cursor is within the "#requires " statement.
+                if (cursorIndex < 10)
+                {
+                    return results;
+                }
+
+                string lineToCursor = context.CursorPosition.Line.Substring(0, cursorIndex);
+                //RunAsAdministrator must be the last parameter in a Requires statement so no completion if the cursor is after the parameter.
+                if (lineToCursor.Contains(" -RunAsAdministrator", StringComparison.OrdinalIgnoreCase))
+                {
+                    return results;
+                }
+
+                //Regex to find parameter like " -Parameter1" or " -"
+                MatchCollection foundMatches = Regex.Matches(lineToCursor, "\\s-([A-Za-z]+|$)");
+                if (foundMatches.Count == 0)
+                {
+                    return results;
+                }
+
+                string currentParameter = foundMatches[^1].Groups[1].Value;
+                //Complete the parameter if the cursor is at a parameter
+                if (lineToCursor.LastIndexOf($"-{currentParameter}") + currentParameter.Length + 1 == cursorIndex)
+                {
+                    replacementIndex = cursorIndex - currentParameter.Length;
+                    replacementLength = currentParameter.Length;
+
+                    var requiresParameters = new Tuple<string, string>[4] {
+                        new Tuple<string, string>("Modules","Specifies PowerShell modules that the script requires."),
+                        new Tuple<string, string>("PSEdition","Specifies a PowerShell edition that the script requires."),
+                        new Tuple<string, string>("RunAsAdministrator","Specifies that PowerShell must be running as administrator on Windows."),
+                        new Tuple<string, string>("Version","Specifies the minimum version of PowerShell that the script requires.")
+                    };
+                    foreach (var parameter in requiresParameters)
+                    {
+                        if (context.CursorPosition.Line.Contains($" -{parameter.Item1}", StringComparison.OrdinalIgnoreCase) == false &&
+                            parameter.Item1.StartsWith(currentParameter, StringComparison.OrdinalIgnoreCase))
+                        {
+                            results.Add(new CompletionResult(parameter.Item1, parameter.Item1, CompletionResultType.ParameterName, parameter.Item2));
+                        }
+                    }
+                }
+                //Complete parameter values
+                else
+                {
+                    //Regex to find parameter values (any text that appears after various delimiters)
+                    foundMatches = Regex.Matches(lineToCursor, "(\\s|,|;|{|\"|'|=)(\\w+|$)");
+                    string currentValue;
+                    if (foundMatches.Count == 0)
+                    {
+                        currentValue = string.Empty;
+                    }
+                    else
+                    {
+                        currentValue = foundMatches[^1].Groups[^1].Value;
+                    }
+
+                    replacementIndex = cursorIndex - currentValue.Length;
+                    replacementLength = currentValue.Length;
+
+                    if (currentParameter.Equals("PSEdition", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var psEditionValues = new Tuple<string, string>[2] {
+                            new Tuple<string, string>("Core","Specifies that the script requires PowerShell Core to run."),
+                            new Tuple<string, string>("Desktop","Specifies that the script requires Windows PowerShell to run.")
+                        };
+                        foreach (var value in psEditionValues)
+                        {
+                            if (value.Item1.StartsWith(currentValue, StringComparison.OrdinalIgnoreCase))
+                            {
+                                results.Add(new CompletionResult(value.Item1, value.Item1, CompletionResultType.ParameterValue, value.Item2));
+                            }
+                        }
+                    }
+
+                    if (currentParameter.Equals("Modules", StringComparison.OrdinalIgnoreCase))
+                    {
+                        int hashtableStart = lineToCursor.LastIndexOf("@{");
+                        int hashtableEnd = lineToCursor.LastIndexOf('}');
+
+                        //Cursor is inside a hashtable
+                        if (hashtableStart != -1 && hashtableEnd == -1 || hashtableEnd < hashtableStart)
+                        {
+                            string hashtableString = lineToCursor.Substring(hashtableStart);
+                            //Regex to find hashtable keys with or without quotes
+                            foundMatches = Regex.Matches(hashtableString, "(@{|;)\\s*(?:'|\"|\\w*)\\w*");
+                            var hashtableKeys = new string[foundMatches.Count];
+                            for (int i = 0; i < hashtableKeys.Length; i++)
+                            {
+                                hashtableKeys[i] = foundMatches[i].Value.TrimStart('@', '{', ';', '"', '\'');
+                            }
+                            var lastCaptureGroup = foundMatches[^1].Groups[0];
+
+                            //Are we completing a key for the hashtable?
+                            if (lastCaptureGroup.Index + lastCaptureGroup.Length == hashtableString.Length)
+                            {
+                                var moduleKeys = new Tuple<string, string>[2] {
+                                    new Tuple<string, string>("ModuleName","Required. Specifies the module name."),
+                                    new Tuple<string, string>("GUID","Optional. Specifies the GUID of the module.")
+                                };
+                                //The following keys cannot be used together so they get their own table for lookup.
+                                var moduleVersionKeys = new Dictionary<string, string>(3, StringComparer.OrdinalIgnoreCase) {
+                                    {"ModuleVersion", "Specifies a minimum acceptable version of the module." },
+                                    {"RequiredVersion", "Specifies an exact, required version of the module." },
+                                    {"MaximumVersion", "Specifies the maximum acceptable version of the module." },
+                                };
+                                foreach (var value in moduleKeys)
+                                {
+                                    if (value.Item1.StartsWith(currentValue, StringComparison.OrdinalIgnoreCase) && hashtableKeys.Contains(value.Item1) == false)
+                                    {
+                                        results.Add(new CompletionResult(value.Item1, value.Item1, CompletionResultType.ParameterValue, value.Item2));
+                                    }
+                                }
+
+                                foreach (string value in moduleVersionKeys.Keys)
+                                {
+                                    if (value.StartsWith(currentValue, StringComparison.OrdinalIgnoreCase) && moduleVersionKeys.Keys.Intersect(hashtableKeys).Any() == false)
+                                    {
+                                        results.Add(new CompletionResult(value, value, CompletionResultType.ParameterValue, moduleVersionKeys[value]));
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                if (hashtableKeys[^1].Equals("ModuleName", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    context.WordToComplete = currentValue;
+                                    return CompleteModuleName(context, true);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            context.WordToComplete = currentValue;
+                            return CompleteModuleName(context, true);
+                        }
+                    }
+                }
+                return results;
+            }
+
+            // Complete the history entries
             Match matchResult = Regex.Match(context.WordToComplete, @"^#([\w\-]*)$");
             if (!matchResult.Success) { return results; }
 

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -5045,6 +5045,7 @@ namespace System.Management.Automation
 
                 // Now try to complete hashtable keys
 
+                // First add any common keys that match the current one that haven't already been used
                 foreach (KeyValuePair<string, string> modSpecKey in s_requiresModuleSpecSharedKeys)
                 {
                     if (modSpecKey.Key.StartsWith(currentValue, StringComparison.OrdinalIgnoreCase)
@@ -5054,12 +5055,21 @@ namespace System.Management.Automation
                     }
                 }
 
-                foreach (string value in s_requiresModuleSpecExclusiveKeys.Keys)
+                // Then, if the mutually-exclusive module version keys haven't been used, suggest those
+                bool alreadyHasExclusiveKeys = s_requiresModuleSpecExclusiveKeys.Keys.Intersect(hashtableKeys).Any();
+                if (!alreadyHasExclusiveKeys)
                 {
-                    if (value.StartsWith(currentValue, StringComparison.OrdinalIgnoreCase)
-                        && s_requiresModuleSpecExclusiveKeys.Keys.Intersect(hashtableKeys).Any())
+                    foreach (KeyValuePair<string, string> exclusiveKeyEntry in s_requiresModuleSpecExclusiveKeys)
                     {
-                        results.Add(new CompletionResult(value, value, CompletionResultType.ParameterValue, s_requiresModuleSpecExclusiveKeys[value]));
+                        if (exclusiveKeyEntry.Key.StartsWith(currentValue, StringComparison.OrdinalIgnoreCase))
+                        {
+                            results.Add(
+                                new CompletionResult(
+                                    exclusiveKeyEntry.Key,
+                                    exclusiveKeyEntry.Key,
+                                    CompletionResultType.ParameterValue,
+                                    exclusiveKeyEntry.Value));
+                        }
                     }
                 }
             }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4956,7 +4956,7 @@ namespace System.Management.Automation
                 //Complete the parameter if the cursor is at a parameter
                 if (lineToCursor.LastIndexOf($"-{currentParameter}") + currentParameter.Length + 1 == cursorIndex)
                 {
-                    replacementIndex = cursorIndex - currentParameter.Length;
+                    replacementIndex = context.CursorPosition.Offset - currentParameter.Length;
                     replacementLength = currentParameter.Length;
 
                     var requiresParameters = new Tuple<string, string>[4] {
@@ -4989,7 +4989,7 @@ namespace System.Management.Automation
                         currentValue = foundMatches[^1].Groups[^1].Value;
                     }
 
-                    replacementIndex = cursorIndex - currentValue.Length;
+                    replacementIndex = context.CursorPosition.Offset - currentValue.Length;
                     replacementLength = currentValue.Length;
 
                     if (currentParameter.Equals("PSEdition", StringComparison.OrdinalIgnoreCase))

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -908,6 +908,18 @@ Describe "TabCompletion" -Tags CI {
             $res.CompletionMatches[0].CompletionText | Should -BeExactly "Test history completion"
         }
 
+        It "Test requires parameter completion" {
+            $res = TabExpansion2 -inputScript "#requires -" -cursorColumn 11
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly "Modules"
+        }
+
+        It "Test requires parameter value completion" {
+            $res = TabExpansion2 -inputScript "#requires -PSEdition " -cursorColumn 21
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly "Core"
+        }
+
         It "Test Attribute member completion" {
             $inputStr = "function bar { [parameter(]param() }"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn ($inputStr.IndexOf('(') + 1)

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -908,16 +908,73 @@ Describe "TabCompletion" -Tags CI {
             $res.CompletionMatches[0].CompletionText | Should -BeExactly "Test history completion"
         }
 
-        It "Test requires parameter completion" {
+        It "Test #requires parameter completion" {
             $res = TabExpansion2 -inputScript "#requires -" -cursorColumn 11
             $res.CompletionMatches.Count | Should -BeGreaterThan 0
             $res.CompletionMatches[0].CompletionText | Should -BeExactly "Modules"
         }
 
-        It "Test requires parameter value completion" {
+        It "Test #requires parameter value completion" {
             $res = TabExpansion2 -inputScript "#requires -PSEdition " -cursorColumn 21
             $res.CompletionMatches.Count | Should -BeGreaterThan 0
             $res.CompletionMatches[0].CompletionText | Should -BeExactly "Core"
+        }
+
+        It "Test no completion after #requires -RunAsAdministrator" {
+            $res = TabExpansion2 -inputScript "#requires -RunAsAdministrator -" -cursorColumn 31
+            $res.CompletionMatches | Should -HaveCount 0
+        }
+
+        It "Test no suggestions for already existing parameters in #requires" {
+            $res = TabExpansion2 -inputScript "#requires -Modules -" -cursorColumn 20
+            $res.CompletionMatches.CompletionText | Should -Not -Contain "Modules"
+        }
+
+        It "Test module completion in #requires without quotes" {
+            $res = TabExpansion2 -inputScript "#requires -Modules P" -cursorColumn 20
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches.CompletionText | Should -Contain "Pester"
+        }
+
+        It "Test module completion in #requires with quotes" {
+            $res = TabExpansion2 -inputScript '#requires -Modules "' -cursorColumn 20
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches.CompletionText | Should -Contain "Pester"
+        }
+
+        It "Test module completion in #requires with multiple modules" {
+            $res = TabExpansion2 -inputScript "#requires -Modules Pester," -cursorColumn 26
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches.CompletionText | Should -Contain "Pester"
+        }
+
+        It "Test hashtable key completion in #requires statement for modules" {
+            $res = TabExpansion2 -inputScript "#requires -Modules @{" -cursorColumn 21
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly "GUID"
+        }
+
+        It "Test no suggestions for already existing hashtable keys in #requires statement for modules" {
+            $res = TabExpansion2 -inputScript '#requires -Modules @{ModuleName="Pester";' -cursorColumn 41
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches.CompletionText | Should -Not -Contain "ModuleName"
+        }
+
+        It "Test no suggestions for mutually exclusive hashtable keys in #requires statement for modules" {
+            $res = TabExpansion2 -inputScript '#requires -Modules @{ModuleName="Pester";RequiredVersion="1.0";' -cursorColumn 63
+            $res.CompletionMatches.CompletionText | Should -BeExactly "GUID"
+        }
+
+        It "Test no suggestions for RequiredVersion key in #requires statement when ModuleVersion is specified" {
+            $res = TabExpansion2 -inputScript '#requires -Modules @{ModuleName="Pester";ModuleVersion="1.0";' -cursorColumn 61
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches.CompletionText | Should -Not -Contain "RequiredVersion"
+        }
+
+        It "Test module completion in #requires statement for hashtables" {
+            $res = TabExpansion2 -inputScript '#requires -Modules @{ModuleName="p' -cursorColumn 34
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches.CompletionText | Should -Contain "Pester"
         }
 
         It "Test Attribute member completion" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
This adds completion for the various parameters and their values for #requires statements.  
For example: `#requires -PSEdition Core -RunAsAdministrator`  

The following parameters are supported:

- Version
- Modules
- PSEdition
- RunAsAdministrator

The following parameters are not supported because they have been deprecated or don't work:

- PSSnapin 
- ShellId 
- Assembly 

Most of the help text has been taken from the official docs but I took some creative liberties for the PSEditions text.  

I'm not sure how strict the completion should be.  
Currently it will prevent some basic mistakes like adding parameters after `RunAsAdministrator` but there's no special checks for randomly inserted characters so if for example you type: `#requires blabla -<Tab>` it will still complete to the next parameter.

<!-- Summarize your PR between here and the checklist. -->

## PR Context
The easier the requires statements are to use, the more likely it is that people will use them. The Modules parameter in particular is hard to use without looking up the documentation due to the hashtable keys you have to remember when specifying a version.
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
