### PR TITLE
Fix splatting being treated as positional parameter

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
@@ -1862,13 +1862,16 @@ namespace System.Management.Automation.Language
             while (unboundArgumentsIndex < unboundArgumentsCollection.Count)
             {
                 AstParameterArgumentPair argument = unboundArgumentsCollection[unboundArgumentsIndex++];
-                if (!argument.ParameterSpecified)
+                bool splatted = (argument is AstPair a) && (a.Argument is VariableExpressionAst v) && v.Splatted;
+                if (!argument.ParameterSpecified && splatted == false)
                 {
                     result = argument;
                     break;
                 }
-
-                nonPositionalArguments.Add(argument);
+                if (splatted == false)
+                {
+                    nonPositionalArguments.Add(argument);
+                } 
             }
 
             return result;

--- a/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
@@ -1868,6 +1868,7 @@ namespace System.Management.Automation.Language
                     result = argument;
                     break;
                 }
+
                 if (splatted == false)
                 {
                     nonPositionalArguments.Add(argument);

--- a/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
@@ -1865,16 +1865,17 @@ namespace System.Management.Automation.Language
                 bool splatted = argument is AstPair astPair
                     && astPair.Argument is VariableExpressionAst argumentVariable
                     && argumentVariable.Splatted;
-                if (!splatted && !argument.ParameterSpecified)
+                if (splatted)
+                {
+                    continue;
+                }
+                if (!argument.ParameterSpecified)
                 {
                     result = argument;
                     break;
                 }
-
-                if (!splatted)
-                {
-                    nonPositionalArguments.Add(argument);
-                } 
+                
+                nonPositionalArguments.Add(argument);
             }
 
             return result;

--- a/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
@@ -1862,14 +1862,16 @@ namespace System.Management.Automation.Language
             while (unboundArgumentsIndex < unboundArgumentsCollection.Count)
             {
                 AstParameterArgumentPair argument = unboundArgumentsCollection[unboundArgumentsIndex++];
-                bool splatted = (argument is AstPair a) && (a.Argument is VariableExpressionAst v) && v.Splatted;
-                if (!argument.ParameterSpecified && splatted == false)
+                bool splatted = argument is AstPair astPair
+                    && astPair.Argument is VariableExpressionAst argumentVariable
+                    && argumentVariable.Splatted;
+                if (!splatted && !argument.ParameterSpecified)
                 {
                     result = argument;
                     break;
                 }
 
-                if (splatted == false)
+                if (!splatted)
                 {
                     nonPositionalArguments.Add(argument);
                 } 

--- a/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
@@ -1869,6 +1869,7 @@ namespace System.Management.Automation.Language
                 {
                     continue;
                 }
+
                 if (!argument.ParameterSpecified)
                 {
                     result = argument;

--- a/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
@@ -1862,10 +1862,9 @@ namespace System.Management.Automation.Language
             while (unboundArgumentsIndex < unboundArgumentsCollection.Count)
             {
                 AstParameterArgumentPair argument = unboundArgumentsCollection[unboundArgumentsIndex++];
-                bool splatted = argument is AstPair astPair
+                if (argument is AstPair astPair
                     && astPair.Argument is VariableExpressionAst argumentVariable
-                    && argumentVariable.Splatted;
-                if (splatted)
+                    && argumentVariable.Splatted)
                 {
                     continue;
                 }

--- a/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
@@ -1874,7 +1874,7 @@ namespace System.Management.Automation.Language
                     result = argument;
                     break;
                 }
-                
+
                 nonPositionalArguments.Add(argument);
             }
 

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -953,6 +953,13 @@ dir -Recurse `
             $res.CompletionMatches | Should -HaveCount 4
             [string]::Join(',', ($res.CompletionMatches.completiontext | Sort-Object)) | Should -BeExactly "-wa,-Wait,-WarningAction,-WarningVariable"
         }
+
+        It "Test completion with splatted variable" {
+            $inputStr = 'Get-Content @Splat -P'
+            $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
+            $res.CompletionMatches | Should -HaveCount 4
+            [string]::Join(',', ($res.CompletionMatches.completiontext | Sort-Object)) | Should -BeExactly "-Path,-PipelineVariable,-PSPath,-pv"
+        }
     }
 
     Context "Module completion for 'using module'" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Fixes https://github.com/PowerShell/PowerShell/issues/3650 where if you use splatting it counts as a positional argument so you lose the parameter in the tab completion suggestions.  
For example `Get-ChildItem @Splat -P` won't suggest the Path parameter because @<!-- -->Splat is incorrectly being treated as a value for the Path parameter.
<!-- Summarize your PR between here and the checklist. -->

## PR Context
It's annoying to forget about a parameter because IntelliSense didn't show it to you.
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
