### PR TITLE
Update the `ICommandPredictor` to provide more feedback and also make feedback easier to be corelated

### DIFF
--- a/src/System.Management.Automation/engine/Subsystem/CommandPrediction/CommandPrediction.cs
+++ b/src/System.Management.Automation/engine/Subsystem/CommandPrediction/CommandPrediction.cs
@@ -94,9 +94,7 @@ namespace System.Management.Automation.Subsystem
                     {
                         var predictor = (ICommandPredictor)state!;
                         SuggestionPackage pkg = predictor.GetSuggestion(client, context, cancellationSource.Token);
-                        return pkg.Session.HasValue && pkg.SuggestionEntries?.Count > 0
-                            ? new PredictionResult(predictor.Id, predictor.Name, pkg.Session.Value, pkg.SuggestionEntries)
-                            : null;
+                        return pkg.SuggestionEntries?.Count > 0 ? new PredictionResult(predictor.Id, predictor.Name, pkg.Session, pkg.SuggestionEntries) : null;
                     },
                     predictor,
                     cancellationSource.Token,

--- a/src/System.Management.Automation/engine/Subsystem/CommandPrediction/CommandPrediction.cs
+++ b/src/System.Management.Automation/engine/Subsystem/CommandPrediction/CommandPrediction.cs
@@ -156,8 +156,8 @@ namespace System.Management.Automation.Subsystem
         /// <param name="predictorId">The identifier of the predictor whose prediction result was accepted.</param>
         /// <param name="session">The mini-session where the displayed suggestions came from.</param>
         /// <param name="countOrIndex">
-        /// When the value is <code>> 0</code>, it's the number of displayed suggestions from the list returned in <see cref="session"/>, starting from the index 0.
-        /// When the value is <code><= 0</code>, it means a single suggestion from the list got displayed, and the index is the absolute value.
+        /// When the value is greater than 0, it's the number of displayed suggestions from the list returned in <paramref name="session"/>, starting from the index 0.
+        /// When the value is less than or equal to 0, it means a single suggestion from the list got displayed, and the index is the absolute value.
         /// </param>
         public static void OnSuggestionDisplayed(Guid predictorId, uint session, int countOrIndex)
         {

--- a/src/System.Management.Automation/engine/Subsystem/CommandPrediction/ICommandPredictor.cs
+++ b/src/System.Management.Automation/engine/Subsystem/CommandPrediction/ICommandPredictor.cs
@@ -40,22 +40,35 @@ namespace System.Management.Automation.Subsystem
         /// A command line was accepted to execute.
         /// The predictor can start processing early as needed with the latest history.
         /// </summary>
+        /// <param name="clientId">Represents the client that initiates the call.</param>
         /// <param name="history">History command lines provided as references for prediction.</param>
-        void StartEarlyProcessing(IReadOnlyList<string> history);
+        void StartEarlyProcessing(string clientId, IReadOnlyList<string> history);
 
         /// <summary>
-        /// The suggestion given by the predictor was accepted.
+        /// Get the predictive suggestions. It indicates the start of a suggestion rendering session.
         /// </summary>
-        /// <param name="acceptedSuggestion">The accepted suggestion text.</param>
-        void OnSuggestionAccepted(string acceptedSuggestion);
-
-        /// <summary>
-        /// Get the predictive suggestions.
-        /// </summary>
+        /// <param name="clientId">Represents the client that initiates the call.</param>
         /// <param name="context">The <see cref="PredictionContext"/> object to be used for prediction.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the prediction.</param>
-        /// <returns>A list of predictive suggestions.</returns>
-        List<PredictiveSuggestion>? GetSuggestion(PredictionContext context, CancellationToken cancellationToken);
+        /// <returns>A value tuple consist of a session id, and a list of predictive suggestions.</returns>
+        (string? Session, List<PredictiveSuggestion>? List) GetSuggestion(string clientId, PredictionContext context, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// One or more suggestions provided by the predictor were displayed to the user.
+        /// </summary>
+        /// <param name="session">The mini-session where the displayed suggestions came from.</param>
+        /// <param name="countOrIndex">
+        /// When the value is <code>> 0</code>, it's the number of displayed suggestions from the list returned in <see cref="session"/>, starting from the index 0.
+        /// When the value is <code><= 0</code>, it means a single suggestion from the list got displayed, and the index is the absolute value.
+        /// </param>
+        void OnSuggestionDisplayed(string session, int countOrIndex);
+
+        /// <summary>
+        /// The suggestion provided by the predictor was accepted.
+        /// </summary>
+        /// <param name="session">Represents the mini-session where the accepted suggestion came from.</param>
+        /// <param name="acceptedSuggestion">The accepted suggestion text.</param>
+        void OnSuggestionAccepted(string session, string acceptedSuggestion);
     }
 
     /// <summary>

--- a/src/System.Management.Automation/engine/Subsystem/CommandPrediction/ICommandPredictor.cs
+++ b/src/System.Management.Automation/engine/Subsystem/CommandPrediction/ICommandPredictor.cs
@@ -50,8 +50,8 @@ namespace System.Management.Automation.Subsystem
         /// <param name="clientId">Represents the client that initiates the call.</param>
         /// <param name="context">The <see cref="PredictionContext"/> object to be used for prediction.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the prediction.</param>
-        /// <returns>A value tuple consist of a session id, and a list of predictive suggestions.</returns>
-        (string? Session, List<PredictiveSuggestion>? List) GetSuggestion(string clientId, PredictionContext context, CancellationToken cancellationToken);
+        /// <returns>An instance of <see cref="SuggestionPackage"/>.</returns>
+        SuggestionPackage GetSuggestion(string clientId, PredictionContext context, CancellationToken cancellationToken);
 
         /// <summary>
         /// One or more suggestions provided by the predictor were displayed to the user.
@@ -61,14 +61,14 @@ namespace System.Management.Automation.Subsystem
         /// When the value is <code>> 0</code>, it's the number of displayed suggestions from the list returned in <see cref="session"/>, starting from the index 0.
         /// When the value is <code><= 0</code>, it means a single suggestion from the list got displayed, and the index is the absolute value.
         /// </param>
-        void OnSuggestionDisplayed(string session, int countOrIndex);
+        void OnSuggestionDisplayed(uint session, int countOrIndex);
 
         /// <summary>
         /// The suggestion provided by the predictor was accepted.
         /// </summary>
         /// <param name="session">Represents the mini-session where the accepted suggestion came from.</param>
         /// <param name="acceptedSuggestion">The accepted suggestion text.</param>
-        void OnSuggestionAccepted(string session, string acceptedSuggestion);
+        void OnSuggestionAccepted(uint session, string acceptedSuggestion);
     }
 
     /// <summary>
@@ -171,6 +171,31 @@ namespace System.Management.Automation.Subsystem
 
             SuggestionText = suggestion;
             ToolTip = toolTip;
+        }
+    }
+
+    /// <summary>
+    /// A package returned from <see cref="ICommandPredictor.GetSuggestion"/>.
+    /// </summary>
+    public struct SuggestionPackage
+    {
+        /// <summary>
+        /// The mini-session that represents a specific invocation to <see cref="ICommandPredictor.GetSuggestion"/>.
+        /// </summary>
+        public uint? Session { get; }
+
+        /// <summary>
+        /// Suggestion entries returned from that mini-session.
+        /// </summary>
+        public List<PredictiveSuggestion>? SuggestionEntries { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SuggestionPackage"/> struct.
+        /// </summary>
+        public SuggestionPackage(uint session, List<PredictiveSuggestion> suggestionEntries)
+        {
+            Session = session;
+            SuggestionEntries = suggestionEntries;
         }
     }
 }

--- a/src/System.Management.Automation/engine/Subsystem/CommandPrediction/ICommandPredictor.cs
+++ b/src/System.Management.Automation/engine/Subsystem/CommandPrediction/ICommandPredictor.cs
@@ -182,7 +182,7 @@ namespace System.Management.Automation.Subsystem
         /// <summary>
         /// The mini-session that represents a specific invocation to <see cref="ICommandPredictor.GetSuggestion"/>.
         /// </summary>
-        public uint? Session { get; }
+        public uint Session { get; }
 
         /// <summary>
         /// Suggestion entries returned from that mini-session.

--- a/src/System.Management.Automation/engine/Subsystem/CommandPrediction/ICommandPredictor.cs
+++ b/src/System.Management.Automation/engine/Subsystem/CommandPrediction/ICommandPredictor.cs
@@ -194,6 +194,7 @@ namespace System.Management.Automation.Subsystem
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SuggestionPackage"/> struct without providing a session id.
+        /// Note that, when a session id is not specified, it's considered by a client that the predictor doesn't expect feedback.
         /// </summary>
         /// <param name="suggestionEntries">The suggestions to return.</param>
         public SuggestionPackage(List<PredictiveSuggestion> suggestionEntries)

--- a/src/System.Management.Automation/engine/Subsystem/CommandPrediction/ICommandPredictor.cs
+++ b/src/System.Management.Automation/engine/Subsystem/CommandPrediction/ICommandPredictor.cs
@@ -56,19 +56,21 @@ namespace System.Management.Automation.Subsystem
         /// <summary>
         /// One or more suggestions provided by the predictor were displayed to the user.
         /// </summary>
+        /// <param name="clientId">Represents the client that initiates the call.</param>
         /// <param name="session">The mini-session where the displayed suggestions came from.</param>
         /// <param name="countOrIndex">
         /// When the value is greater than 0, it's the number of displayed suggestions from the list returned in <paramref name="session"/>, starting from the index 0.
         /// When the value is less than or equal to 0, it means a single suggestion from the list got displayed, and the index is the absolute value.
         /// </param>
-        void OnSuggestionDisplayed(uint session, int countOrIndex);
+        void OnSuggestionDisplayed(string clientId, uint session, int countOrIndex);
 
         /// <summary>
         /// The suggestion provided by the predictor was accepted.
         /// </summary>
+        /// <param name="clientId">Represents the client that initiates the call.</param>
         /// <param name="session">Represents the mini-session where the accepted suggestion came from.</param>
         /// <param name="acceptedSuggestion">The accepted suggestion text.</param>
-        void OnSuggestionAccepted(uint session, string acceptedSuggestion);
+        void OnSuggestionAccepted(string clientId, uint session, string acceptedSuggestion);
     }
 
     /// <summary>
@@ -181,8 +183,9 @@ namespace System.Management.Automation.Subsystem
     {
         /// <summary>
         /// Gets the mini-session that represents a specific invocation to <see cref="ICommandPredictor.GetSuggestion"/>.
+        /// When it's not specified, it's considered by a client that the predictor doesn't expect feedback.
         /// </summary>
-        public uint Session { get; }
+        public uint? Session { get; }
 
         /// <summary>
         /// Gets the suggestion entries returned from that mini-session.
@@ -190,12 +193,26 @@ namespace System.Management.Automation.Subsystem
         public List<PredictiveSuggestion>? SuggestionEntries { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SuggestionPackage"/> struct.
+        /// Initializes a new instance of the <see cref="SuggestionPackage"/> struct without providing a session id.
+        /// </summary>
+        /// <param name="suggestionEntries">The suggestions to return.</param>
+        public SuggestionPackage(List<PredictiveSuggestion> suggestionEntries)
+        {
+            Requires.NotNullOrEmpty(suggestionEntries, nameof(suggestionEntries));
+
+            Session = null;
+            SuggestionEntries = suggestionEntries;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SuggestionPackage"/> struct with the mini-session id and the suggestions.
         /// </summary>
         /// <param name="session">The mini-session where suggestions came from.</param>
         /// <param name="suggestionEntries">The suggestions to return.</param>
         public SuggestionPackage(uint session, List<PredictiveSuggestion> suggestionEntries)
         {
+            Requires.NotNullOrEmpty(suggestionEntries, nameof(suggestionEntries));
+
             Session = session;
             SuggestionEntries = suggestionEntries;
         }

--- a/src/System.Management.Automation/engine/Subsystem/CommandPrediction/ICommandPredictor.cs
+++ b/src/System.Management.Automation/engine/Subsystem/CommandPrediction/ICommandPredictor.cs
@@ -58,8 +58,8 @@ namespace System.Management.Automation.Subsystem
         /// </summary>
         /// <param name="session">The mini-session where the displayed suggestions came from.</param>
         /// <param name="countOrIndex">
-        /// When the value is <code>> 0</code>, it's the number of displayed suggestions from the list returned in <see cref="session"/>, starting from the index 0.
-        /// When the value is <code><= 0</code>, it means a single suggestion from the list got displayed, and the index is the absolute value.
+        /// When the value is greater than 0, it's the number of displayed suggestions from the list returned in <paramref name="session"/>, starting from the index 0.
+        /// When the value is less than or equal to 0, it means a single suggestion from the list got displayed, and the index is the absolute value.
         /// </param>
         void OnSuggestionDisplayed(uint session, int countOrIndex);
 
@@ -180,18 +180,20 @@ namespace System.Management.Automation.Subsystem
     public struct SuggestionPackage
     {
         /// <summary>
-        /// The mini-session that represents a specific invocation to <see cref="ICommandPredictor.GetSuggestion"/>.
+        /// Gets the mini-session that represents a specific invocation to <see cref="ICommandPredictor.GetSuggestion"/>.
         /// </summary>
         public uint Session { get; }
 
         /// <summary>
-        /// Suggestion entries returned from that mini-session.
+        /// Gets the suggestion entries returned from that mini-session.
         /// </summary>
         public List<PredictiveSuggestion>? SuggestionEntries { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SuggestionPackage"/> struct.
         /// </summary>
+        /// <param name="session">The mini-session where suggestions came from.</param>
+        /// <param name="suggestionEntries">The suggestions to return.</param>
         public SuggestionPackage(uint session, List<PredictiveSuggestion> suggestionEntries)
         {
             Session = session;

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -2312,6 +2312,14 @@ namespace System.Management.Automation.Internal
             }
         }
 
+        internal static void NotNullOrEmpty(ICollection value, string paramName)
+        {
+            if (value == null || value.Count == 0)
+            {
+                throw new ArgumentNullException(paramName);
+            }
+        }
+
         internal static void Condition([DoesNotReturnIf(false)] bool precondition, string paramName)
         {
             if (!precondition)

--- a/test/xUnit/csharp/test_Prediction.cs
+++ b/test/xUnit/csharp/test_Prediction.cs
@@ -69,14 +69,14 @@ namespace PSTests.Sequential
             }
         }
 
-        public void OnSuggestionDisplayed(uint session, int countOrIndex)
+        public void OnSuggestionDisplayed(string clientId, uint session, int countOrIndex)
         {
-            DisplayedSuggestions.Add($"{session}-{countOrIndex}");
+            DisplayedSuggestions.Add($"{clientId}-{session}-{countOrIndex}");
         }
 
-        public void OnSuggestionAccepted(uint session, string acceptedSuggestion)
+        public void OnSuggestionAccepted(string clientId, uint session, string acceptedSuggestion)
         {
-            AcceptedSuggestions.Add($"{session}-{acceptedSuggestion}");
+            AcceptedSuggestions.Add($"{clientId}-{session}-{acceptedSuggestion}");
         }
 
         public SuggestionPackage GetSuggestion(string clientId, PredictionContext context, CancellationToken cancellationToken)
@@ -180,9 +180,9 @@ namespace PSTests.Sequential
                 var ids = new HashSet<Guid> { slow.Id, fast.Id };
 
                 CommandPrediction.OnCommandLineAccepted(Client, history);
-                CommandPrediction.OnSuggestionDisplayed(slow.Id, Session, 2);
-                CommandPrediction.OnSuggestionDisplayed(fast.Id, Session, -1);
-                CommandPrediction.OnSuggestionAccepted(slow.Id, Session, "Yeah");
+                CommandPrediction.OnSuggestionDisplayed(Client, slow.Id, Session, 2);
+                CommandPrediction.OnSuggestionDisplayed(Client, fast.Id, Session, -1);
+                CommandPrediction.OnSuggestionAccepted(Client, slow.Id, Session, "Yeah");
 
                 // The calls to 'StartEarlyProcessing' and 'OnSuggestionAccepted' are queued in thread pool,
                 // so we wait a bit to make sure the calls are done.
@@ -200,13 +200,13 @@ namespace PSTests.Sequential
                 Assert.Equal($"{Client}-{history[1]}", fast.History[1]);
 
                 Assert.Single(slow.DisplayedSuggestions);
-                Assert.Equal($"{Session}-2", slow.DisplayedSuggestions[0]);
+                Assert.Equal($"{Client}-{Session}-2", slow.DisplayedSuggestions[0]);
 
                 Assert.Single(fast.DisplayedSuggestions);
-                Assert.Equal($"{Session}--1", fast.DisplayedSuggestions[0]);
+                Assert.Equal($"{Client}-{Session}--1", fast.DisplayedSuggestions[0]);
 
                 Assert.Single(slow.AcceptedSuggestions);
-                Assert.Equal($"{Session}-Yeah", slow.AcceptedSuggestions[0]);
+                Assert.Equal($"{Client}-{Session}-Yeah", slow.AcceptedSuggestions[0]);
 
                 Assert.Empty(fast.AcceptedSuggestions);
             }

--- a/test/xUnit/csharp/test_Prediction.cs
+++ b/test/xUnit/csharp/test_Prediction.cs
@@ -90,7 +90,8 @@ namespace PSTests.Sequential
 
             // You can get the user input from the AST.
             var userInput = context.InputAst.Extent.Text;
-            var entries = new List<PredictiveSuggestion> {
+            var entries = new List<PredictiveSuggestion>
+            {
                 new PredictiveSuggestion($"'{userInput}' from '{clientId}' - TEST-1 from {Name}"),
                 new PredictiveSuggestion($"'{userInput}' from '{clientId}' - TeSt-2 from {Name}"),
             };
@@ -101,19 +102,19 @@ namespace PSTests.Sequential
 
     public static class CommandPredictionTests
     {
-        private const string client = "PredictionTest";
-        private const uint session = 56;
+        private const string Client = "PredictionTest";
+        private const uint Session = 56;
 
         [Fact]
         public static void PredictInput()
         {
-            const string input = "Hello world";
+            const string Input = "Hello world";
             MyPredictor slow = MyPredictor.SlowPredictor;
             MyPredictor fast = MyPredictor.FastPredictor;
-            Ast ast = Parser.ParseInput(input, out Token[] tokens, out _);
+            Ast ast = Parser.ParseInput(Input, out Token[] tokens, out _);
 
             // Returns null when no predictor implementation registered
-            List<PredictionResult> results = CommandPrediction.PredictInput(client, ast, tokens).Result;
+            List<PredictionResult> results = CommandPrediction.PredictInput(Client, ast, tokens).Result;
             Assert.Null(results);
 
             try
@@ -126,35 +127,35 @@ namespace PSTests.Sequential
                 // cannot finish before the specified timeout.
                 // The specified timeout is exaggerated to make the test reliable.
                 // xUnit must spin up a lot tasks, which makes the test unreliable when the time difference between 'delay' and 'timeout' is small.
-                results = CommandPrediction.PredictInput(client, ast, tokens, millisecondsTimeout: 1000).Result;
+                results = CommandPrediction.PredictInput(Client, ast, tokens, millisecondsTimeout: 1000).Result;
                 Assert.Single(results);
 
                 PredictionResult res = results[0];
                 Assert.Equal(fast.Id, res.Id);
-                Assert.Equal(session, res.Session);
+                Assert.Equal(Session, res.Session);
                 Assert.Equal(2, res.Suggestions.Count);
-                Assert.Equal($"'{input}' from '{client}' - TEST-1 from {fast.Name}", res.Suggestions[0].SuggestionText);
-                Assert.Equal($"'{input}' from '{client}' - TeSt-2 from {fast.Name}", res.Suggestions[1].SuggestionText);
+                Assert.Equal($"'{Input}' from '{Client}' - TEST-1 from {fast.Name}", res.Suggestions[0].SuggestionText);
+                Assert.Equal($"'{Input}' from '{Client}' - TeSt-2 from {fast.Name}", res.Suggestions[1].SuggestionText);
 
                 // Expect the results from both 'slow' and 'fast' predictors
                 // Same here -- the specified timeout is exaggerated to make the test reliable.
                 // xUnit must spin up a lot tasks, which makes the test unreliable when the time difference between 'delay' and 'timeout' is small.
-                results = CommandPrediction.PredictInput(client, ast, tokens, millisecondsTimeout: 4000).Result;
+                results = CommandPrediction.PredictInput(Client, ast, tokens, millisecondsTimeout: 4000).Result;
                 Assert.Equal(2, results.Count);
 
                 PredictionResult res1 = results[0];
                 Assert.Equal(slow.Id, res1.Id);
-                Assert.Equal(session, res1.Session);
+                Assert.Equal(Session, res1.Session);
                 Assert.Equal(2, res1.Suggestions.Count);
-                Assert.Equal($"'{input}' from '{client}' - TEST-1 from {slow.Name}", res1.Suggestions[0].SuggestionText);
-                Assert.Equal($"'{input}' from '{client}' - TeSt-2 from {slow.Name}", res1.Suggestions[1].SuggestionText);
+                Assert.Equal($"'{Input}' from '{Client}' - TEST-1 from {slow.Name}", res1.Suggestions[0].SuggestionText);
+                Assert.Equal($"'{Input}' from '{Client}' - TeSt-2 from {slow.Name}", res1.Suggestions[1].SuggestionText);
 
                 PredictionResult res2 = results[1];
                 Assert.Equal(fast.Id, res2.Id);
-                Assert.Equal(session, res2.Session);
+                Assert.Equal(Session, res2.Session);
                 Assert.Equal(2, res2.Suggestions.Count);
-                Assert.Equal($"'{input}' from '{client}' - TEST-1 from {fast.Name}", res2.Suggestions[0].SuggestionText);
-                Assert.Equal($"'{input}' from '{client}' - TeSt-2 from {fast.Name}", res2.Suggestions[1].SuggestionText);
+                Assert.Equal($"'{Input}' from '{Client}' - TEST-1 from {fast.Name}", res2.Suggestions[0].SuggestionText);
+                Assert.Equal($"'{Input}' from '{Client}' - TeSt-2 from {fast.Name}", res2.Suggestions[1].SuggestionText);
             }
             finally
             {
@@ -178,10 +179,10 @@ namespace PSTests.Sequential
                 var history = new[] { "hello", "world" };
                 var ids = new HashSet<Guid> { slow.Id, fast.Id };
 
-                CommandPrediction.OnCommandLineAccepted(client, history);
-                CommandPrediction.OnSuggestionDisplayed(slow.Id, session, 2);
-                CommandPrediction.OnSuggestionDisplayed(fast.Id, session, -1);
-                CommandPrediction.OnSuggestionAccepted(slow.Id, session, "Yeah");
+                CommandPrediction.OnCommandLineAccepted(Client, history);
+                CommandPrediction.OnSuggestionDisplayed(slow.Id, Session, 2);
+                CommandPrediction.OnSuggestionDisplayed(fast.Id, Session, -1);
+                CommandPrediction.OnSuggestionAccepted(slow.Id, Session, "Yeah");
 
                 // The calls to 'StartEarlyProcessing' and 'OnSuggestionAccepted' are queued in thread pool,
                 // so we wait a bit to make sure the calls are done.
@@ -191,21 +192,21 @@ namespace PSTests.Sequential
                 }
 
                 Assert.Equal(2, slow.History.Count);
-                Assert.Equal($"{client}-{history[0]}", slow.History[0]);
-                Assert.Equal($"{client}-{history[1]}", slow.History[1]);
+                Assert.Equal($"{Client}-{history[0]}", slow.History[0]);
+                Assert.Equal($"{Client}-{history[1]}", slow.History[1]);
 
                 Assert.Equal(2, fast.History.Count);
-                Assert.Equal($"{client}-{history[0]}", fast.History[0]);
-                Assert.Equal($"{client}-{history[1]}", fast.History[1]);
+                Assert.Equal($"{Client}-{history[0]}", fast.History[0]);
+                Assert.Equal($"{Client}-{history[1]}", fast.History[1]);
 
                 Assert.Single(slow.DisplayedSuggestions);
-                Assert.Equal($"{session}-2", slow.DisplayedSuggestions[0]);
+                Assert.Equal($"{Session}-2", slow.DisplayedSuggestions[0]);
 
                 Assert.Single(fast.DisplayedSuggestions);
-                Assert.Equal($"{session}--1", fast.DisplayedSuggestions[0]);
+                Assert.Equal($"{Session}--1", fast.DisplayedSuggestions[0]);
 
                 Assert.Single(slow.AcceptedSuggestions);
-                Assert.Equal($"{session}-Yeah", slow.AcceptedSuggestions[0]);
+                Assert.Equal($"{Session}-Yeah", slow.AcceptedSuggestions[0]);
 
                 Assert.Empty(fast.AcceptedSuggestions);
             }

--- a/test/xUnit/csharp/test_Subsystem.cs
+++ b/test/xUnit/csharp/test_Subsystem.cs
@@ -95,10 +95,12 @@ namespace PSTests.Sequential
                 Assert.Null(impl.FunctionsToDefine);
                 Assert.Equal(SubsystemKind.CommandPredictor, impl.Kind);
 
-                var predCxt = PredictionContext.Create("Hello world");
-                var results = impl.GetSuggestion(predCxt, CancellationToken.None);
-                Assert.Equal($"Hello world TEST-1 from {impl.Name}", results[0].SuggestionText);
-                Assert.Equal($"Hello world TeSt-2 from {impl.Name}", results[1].SuggestionText);
+                const string client = "SubsystemTest";
+                const string input = "Hello world";
+                var predCxt = PredictionContext.Create(input);
+                var results = impl.GetSuggestion(client, predCxt, CancellationToken.None);
+                Assert.Equal($"'{input}' from '{client}' - TEST-1 from {impl.Name}", results.SuggestionEntries[0].SuggestionText);
+                Assert.Equal($"'{input}' from '{client}' - TeSt-2 from {impl.Name}", results.SuggestionEntries[1].SuggestionText);
 
                 // Now validate the all-subsystem-implementation collection.
                 ReadOnlyCollection<ICommandPredictor> impls = SubsystemManager.GetSubsystems<ICommandPredictor>();

--- a/test/xUnit/csharp/test_Subsystem.cs
+++ b/test/xUnit/csharp/test_Subsystem.cs
@@ -95,12 +95,12 @@ namespace PSTests.Sequential
                 Assert.Null(impl.FunctionsToDefine);
                 Assert.Equal(SubsystemKind.CommandPredictor, impl.Kind);
 
-                const string client = "SubsystemTest";
-                const string input = "Hello world";
-                var predCxt = PredictionContext.Create(input);
-                var results = impl.GetSuggestion(client, predCxt, CancellationToken.None);
-                Assert.Equal($"'{input}' from '{client}' - TEST-1 from {impl.Name}", results.SuggestionEntries[0].SuggestionText);
-                Assert.Equal($"'{input}' from '{client}' - TeSt-2 from {impl.Name}", results.SuggestionEntries[1].SuggestionText);
+                const string Client = "SubsystemTest";
+                const string Input = "Hello world";
+                var predCxt = PredictionContext.Create(Input);
+                var results = impl.GetSuggestion(Client, predCxt, CancellationToken.None);
+                Assert.Equal($"'{Input}' from '{Client}' - TEST-1 from {impl.Name}", results.SuggestionEntries[0].SuggestionText);
+                Assert.Equal($"'{Input}' from '{Client}' - TeSt-2 from {impl.Name}", results.SuggestionEntries[1].SuggestionText);
 
                 // Now validate the all-subsystem-implementation collection.
                 ReadOnlyCollection<ICommandPredictor> impls = SubsystemManager.GetSubsystems<ICommandPredictor>();

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -2368,6 +2368,11 @@ function CleanupGeneratedSourceCode
             Replacement = "/* [System.Runtime.CompilerServices.CompilerGeneratedAttribute, System.Runtime.CompilerServices.NullableContextAttribute((byte)2)] */ "
         },
         @{
+            ApplyTo = @("System.Management.Automation")
+            Pattern = "[System.Runtime.CompilerServices.CompilerGeneratedAttribute, System.Runtime.CompilerServices.IsReadOnlyAttribute]"
+            Replacement = "/* [System.Runtime.CompilerServices.CompilerGeneratedAttribute, System.Runtime.CompilerServices.IsReadOnlyAttribute] */ "
+        },
+        @{
             ApplyTo = @("System.Management.Automation", "Microsoft.PowerShell.ConsoleHost")
             Pattern = "[System.Runtime.CompilerServices.NullableAttribute((byte)2)]"
             Replacement = "/* [System.Runtime.CompilerServices.NullableAttribute((byte)2)] */"

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -2036,24 +2036,27 @@ function CopyReferenceAssemblies
     switch ($assemblyName) {
         { $_ -in $supportedRefList } {
             $refDll = Join-Path -Path $refBinPath -ChildPath "$assemblyName.dll"
-            Copy-Item $refDll -Destination $refNugetPath -Force
-            Write-Log "Copied file $refDll to $refNugetPath"
+            $refDoc = Join-Path -Path $refBinPath -ChildPath "$assemblyName.xml"
+            Copy-Item $refDll, $refDoc -Destination $refNugetPath -Force
+            Write-Log "Copied file '$refDll' and '$refDoc' to '$refNugetPath'"
         }
 
         "Microsoft.PowerShell.SDK" {
             foreach ($asmFileName in $assemblyFileList) {
                 $refFile = Join-Path -Path $refBinPath -ChildPath $asmFileName
                 if (Test-Path -Path $refFile) {
-                    Copy-Item $refFile -Destination $refNugetPath -Force
-                    Write-Log "Copied file $refFile to $refNugetPath"
+                    $refDoc = Join-Path -Path $refBinPath -ChildPath ([System.IO.Path]::ChangeExtension($asmFileName, "xml"))
+                    Copy-Item $refFile, $refDoc -Destination $refNugetPath -Force
+                    Write-Log "Copied file '$refFile' and '$refDoc' to '$refNugetPath'"
                 }
             }
         }
 
         default {
             $ref_SMA = Join-Path -Path $refBinPath -ChildPath System.Management.Automation.dll
-            Copy-Item $ref_SMA -Destination $refNugetPath -Force
-            Write-Log "Copied file $ref_SMA to $refNugetPath"
+            $ref_doc = Join-Path -Path $refBinPath -ChildPath System.Management.Automation.xml
+            Copy-Item $ref_SMA, $ref_doc -Destination $refNugetPath -Force
+            Write-Log "Copied file '$ref_SMA' and '$ref_doc' to '$refNugetPath'"
         }
     }
 }
@@ -2235,8 +2238,13 @@ function New-ReferenceAssembly
             throw "$assemblyName.dll was not found at: $Linux64BinPath"
         }
 
+        $dllXmlDoc = Join-Path $Linux64BinPath "$assemblyName.xml"
+        if (-not (Test-Path $dllXmlDoc)) {
+            throw "$assemblyName.xml was not found at: $Linux64BinPath"
+        }
+
         $genAPIArgs = "$linuxDllPath","-libPath:$Linux64BinPath,$Linux64BinPath\ref"
-        Write-Log "GenAPI cmd: $genAPIExe $genAPIArgsString"
+        Write-Log "GenAPI cmd: $genAPIExe $genAPIArgs"
 
         Start-NativeExecution { & $genAPIExe $genAPIArgs } | Out-File $generatedSource -Force
         Write-Log "Reference assembly file generated at: $generatedSource"
@@ -2267,6 +2275,9 @@ function New-ReferenceAssembly
 
             Copy-Item $refBinPath $RefAssemblyDestinationPath -Force
             Write-Log "Reference assembly '$assemblyName.dll' built and copied to $RefAssemblyDestinationPath"
+
+            Copy-Item $dllXmlDoc $RefAssemblyDestinationPath -Force
+            Write-Log "Xml document '$assemblyName.xml' copied to $RefAssemblyDestinationPath"
 
             if ($assemblyName -eq "System.Management.Automation") {
                 $SMAReferenceAssembly = $refBinPath


### PR DESCRIPTION
# PR Summary

Update the `ICommandPredictor` interface APIs to allow a predictor to get feedback about what suggestions from it were displayed to the user, and also make it easier for a predictor to corelate feedback events.

1. Add `ICommandPredictor.OnSuggestionDisplayed`, to let a predictor know what results were displayed to the user when rendering the results: `void OnSuggestionDisplayed(uint session, int countOrIndex);`
    - The `countOrIndex` parameter can help a predictor to tell if the display was in `ListView` or `InlineView`:
       - When the value is `> 0`, it's the number of displayed suggestions from the list returned in <see cref="session"/>, starting from the index 0. This indicates the `ListView` is in use.
       - When the value is `<= 0`, it means a single suggestion from the list got displayed, and the index is the absolute value. This indicates the `InlineView` is in use.

2. Add `clientId` and `session` parameters to the existing interface APIs. The `clientId` parameter helps a predictor to know what host client is calling it (`PSReadLine` only today, but it could be the PS VSCode extension some day in future); the `session` parameter helps a predictor to corelate feedback events.
    - `GetSuggestion` and `StartEarlyProcessing` both take a `string` parameter `clientId`, so it knows the client that makes the call
    - `GetSuggestion` returns a `uint` type `session` value, along with the list of suggestion entries it provides.
    - `OnSuggestionDisplayed` and `OnSuggestionAccepted` both take a `uint` parameter `session`, which indicates where the displayed or accepted suggestions were from.

/cc @kceiw

This PR also includes a few changes to the scripts that generate PowerShell SDK NuGet packages, to make it works properly with the other changes from this PR, and also make NuGet packages include the XML document files.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [x] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [x] Experimental feature name(s): `PSSubsystemPluginModel`
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: No need to update PowerShell docs. It affect the XML documentation only.
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
