### PR TITLE
Change Stop-Process to request Close (instead of Kill) by default

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -1255,7 +1255,7 @@ namespace Microsoft.PowerShell.Commands
 
                     // If CloseMainWindow request was not successful, or unsupported, fallback to Kill
                     // In some cases, this can have the affect that running Stop-Process without Force 
-                    /// twice would revert to Kill()
+                    // twice would revert to Kill()
                     if (!_closeRequest)
                     {
                         process.Kill();

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -1247,7 +1247,16 @@ namespace Microsoft.PowerShell.Commands
                         StopDependentService(process);
                     }
 
-                    if (!process.HasExited)
+                    // If the process has not exited and we are not Forcing, attempt close request 
+                    if (!process.HasExited && !Force)
+                    {
+                        _closeRequest = process.CloseMainWindow();
+                    }
+
+                    // If CloseMainWindow request was not successful, or unsupported, fallback to Kill
+                    // In some cases, this can have the affect that running Stop-Process without Force 
+                    /// twice would revert to Kill()
+                    if (!_closeRequest)
                     {
                         process.Kill();
                     }
@@ -1296,6 +1305,11 @@ namespace Microsoft.PowerShell.Commands
         /// Should the current powershell process to be killed.
         /// </summary>
         private bool _shouldKillCurrentProcess;
+
+        /// <summary>
+        /// Was the current process successfully sent a Close Request, or should it be Killed.
+        /// </summary>
+        private bool _closeRequest;
 
         /// <summary>
         /// Boolean variables to display the warning using ShouldContinue.


### PR DESCRIPTION
Request Close by default, but allow Force to still Kill directly.

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Change Stop-Process to attempt to [CloseMainWindow](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.closemainwindow?view=netcore-3.1) by default instead of [Kill](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.kill?view=netcore-3.1) directly. 

This should allow the Stop-Process to enable gentler close processes for things like 

- Tray Agents 
- Office Documents 
- Notepad windows
- Any program/window which has a state that prefers to gracefully close itself when possible

## PR Context

Originally prompted from https://github.com/PowerShell/PowerShell/issues/13664. When you try to close processes with Kill, they don't have a chance to handle anything, and are immediately closed and then disposed of. In some cases like Tray agents, this even leaves behind blank whole in tray agents and other remnants behind, 

CloseMainWindow sends a request for the program to close, instead of forcing it to close immediately. Which gives it a chance to [handle closing](https://docs.microsoft.com/en-us/dotnet/api/system.windows.window.closing?view=netcore-3.1) and prompt for things, save state to be recoverable later, or gracefully close their active connections.

For example, closing a PowerShell ISE Window that has an unopened document gracefully will result in ISE asking to save the document, but killing it will result in immediate close of the program. 

![image](https://user-images.githubusercontent.com/3719116/105913389-c23a5e80-5ffa-11eb-8dd7-905d4b19dc40.png)

My changes adjust so that `Get-Process $ProcessName | Stop-Process` will default to request a graceful Close, and will only Kill the process if the program cannot handle CloseMainWindow or -Force is specified. 

Some useful test-cases to demonstrate this

 - Notepad Prompts to close if you run a gentle close Stop-Process once, but falls back to kill on trying to run a second time, because the "Do you want to Save?" window is Modal
   - Open Notepad and enter some text but do not save. 
   - Run `Stop-Process -name Notepad` and it should prompt to save changes. 
   - Do not close the prompt to save
   - Run `Stop-Process -name Notepad` a second time (while the Save prompt is still open) and it will fail to request a gentle close, and will default to Killing the process directly, without saving any changes
 - Microsoft Word handles the close method and prompts to save with a custom window that is not Modal and will keep accepting gentle close Stop-Process requests without forcing it to close. 
   - Open Microsoft Word and enter some text but do not save
   - Run `Stop-Process -name winword` and it should prompt to save changes. 
   - Do not close the prompt to save
   - Run `Stop-Process -name winword` a second time (while the Save prompt is still open) and it will still generate a gentle close and word will continue waiting for you to Save/Not Save/Cancel
   - Run `Stop-Process -name winword -Force` (while the Save prompt is open or not) and it will Kill the Process directly, skipping the prompt to Save/Not Save/Cancel 
 - When Microsoft  Outlook is sent a Close signal, it will attempt to close sessions and finish sending any items in the outbox before closing itself, but with a Kill signal it closes immediately, without exiting gracefully
   - Note in the animation below, when `Stop-Process Outlook` runs without -Force there is briefly a white icon shown for Outlook, which is labeled "Outlook is Closing"
   - But when Closed with a KILL it immediately stops 

![image](https://i.imgur.com/DPzHUqV.gif)


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [X] ~~N/A~~ or **can only be tested interactively**
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
