### PR TITLE
Native invocation using `ArgumentList`

### DIFF
--- a/src/System.Management.Automation/engine/CommandBase.cs
+++ b/src/System.Management.Automation/engine/CommandBase.cs
@@ -272,6 +272,20 @@ namespace System.Management.Automation.Internal
 
 namespace System.Management.Automation
 {
+    #region NativeArgumentPassingStyle
+    /// <summary>
+    /// Defines the different native command argument parsing options.
+    /// </summary>
+    public enum NativeArgumentPassingStyle
+    {
+        /// <summary>Use legacy argument parsing via ProcessStartInfo.Arguments</summary>
+        Legacy = 0,
+
+        /// <summary>Use new style argument parsing via ProcessStartInfo.ArgumentList
+        Standard = 1
+    }
+    #endregion NativeArgumentPassingStyle
+
     #region ErrorView
     /// <summary>
     /// Defines the potential ErrorView options.

--- a/src/System.Management.Automation/engine/CommandBase.cs
+++ b/src/System.Management.Automation/engine/CommandBase.cs
@@ -278,10 +278,10 @@ namespace System.Management.Automation
     /// </summary>
     public enum NativeArgumentPassingStyle
     {
-        /// <summary>Use legacy argument parsing via ProcessStartInfo.Arguments</summary>
+        /// <summary>Use legacy argument parsing via ProcessStartInfo.Arguments.</summary>
         Legacy = 0,
 
-        /// <summary>Use new style argument parsing via ProcessStartInfo.ArgumentList
+        /// <summary>Use new style argument parsing via ProcessStartInfo.ArgumentList.</summary>
         Standard = 1
     }
     #endregion NativeArgumentPassingStyle

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -22,6 +22,7 @@ namespace System.Management.Automation
 
         internal const string EngineSource = "PSEngine";
         internal const string PSAnsiProgressFeatureName = "PSAnsiProgress";
+        internal const string PSNativeCommandArgumentPassingFeatureName = "PSNativeCommandArgumentPassing";
 
         #endregion
 
@@ -137,7 +138,7 @@ namespace System.Management.Automation
                     name: PSAnsiProgressFeatureName,
                     description: "Enable lightweight progress bar that leverages ANSI codes for rendering"),
                 new ExperimentalFeature(
-                    name: "PSNativeCommandArgumentPassing",
+                    name: PSNativeCommandArgumentPassingFeatureName,
                     description: "Use ArgumentList when invoking a native command"),
             };
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -136,6 +136,9 @@ namespace System.Management.Automation
                 new ExperimentalFeature(
                     name: PSAnsiProgressFeatureName,
                     description: "Enable lightweight progress bar that leverages ANSI codes for rendering"),
+                new ExperimentalFeature(
+                    name: "PSNativeCommandArgumentPassing",
+                    description: "Use ArgumentList when invoking a native command"),
             };
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);
 

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -1314,7 +1314,6 @@ namespace System.Management.Automation.Runspaces
         /// Experimental features can be handled here.
         /// </summary>
         /// <param name="variables">The variables to add to session state.</param>
-        /// <returns></returns>
         private void AddVariables(IEnumerable<SessionStateVariableEntry> variables)
         {
             Variables.Add(variables);

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4298,7 +4298,7 @@ param(
         }
         else {
             $pagerCommand = 'less'
-            $pagerArgs = '-Ps""Page %db?B of %D:.\. Press h for help or q to quit\.$""'
+            $pagerArgs = '-s','-P','Page %db?B of %D:.\. Press h for help or q to quit\.'
         }
 
         # Respect PAGER environment variable which allows user to specify a custom pager.
@@ -4340,8 +4340,8 @@ param(
             if ($pagerArgs) {
                 # Supply pager arguments to an application without any PowerShell parsing of the arguments.
                 # Leave environment variable to help user debug arguments supplied in $env:PAGER.
-                $env:__PSPAGER_ARGS = $pagerArgs
-                $help | Out-String -Stream -Width ($consoleWidth - 1) | & $pagerCommand --% %__PSPAGER_ARGS%
+                # $env:__PSPAGER_ARGS = $pagerArgs
+                $help | Out-String -Stream -Width ($consoleWidth - 1) | & $pagerCommand $pagerArgs
             }
             else {
                 $help | Out-String -Stream -Width ($consoleWidth - 1) | & $pagerCommand

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -1311,9 +1311,11 @@ namespace System.Management.Automation.Runspaces
         #region VariableHelper
         /// <summary>
         /// A helper for adding variables to session state.
-        /// Experimental features can be handled here
+        /// Experimental features can be handled here.
         /// </summary>
-        private void AddVariables(IEnumerable<SessionStateVariableEntry>variables)
+        /// <param name="variables">The variables to add to session state.</param>
+        /// <returns></returns>
+        private void AddVariables(IEnumerable<SessionStateVariableEntry> variables)
         {
             Variables.Add(variables);
 
@@ -1328,8 +1330,7 @@ namespace System.Management.Automation.Runspaces
                         NativeArgumentPassingStyle.Standard,
                         RunspaceInit.NativeCommandArgumentPassingDescription,
                         ScopedItemOptions.None,
-                        new ArgumentTypeConverterAttribute(typeof(NativeArgumentPassingStyle))
-                    ));
+                        new ArgumentTypeConverterAttribute(typeof(NativeArgumentPassingStyle))));
             }
         }
         #endregion
@@ -4582,8 +4583,6 @@ end {
                 "wsman",
                 RemotingErrorIdStrings.PSSessionAppName,
                 ScopedItemOptions.None),
-
-            // End: Variable which controls native command argument parsing
 
             #region Platform
             new SessionStateVariableEntry(

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4299,7 +4299,7 @@ param(
         else {
             $pagerCommand = 'less'
             # PSNativeCommandArgumentPassing arguments should be constructed differently.
-            if ((Get-ExperimentalFeature PSNativeCommandArgumentPassing).Enabled) {
+            if ($EnabledExperimentalFeatures -contains 'PSNativeCommandArgumentPassing') {
                 $pagerArgs = '-s','-P','Page %db?B of %D:.\. Press h for help or q to quit\.'
             }
             else {
@@ -4347,7 +4347,7 @@ param(
                 # Start the pager arguments directly if the PSNativeCommandArgumentPassing feature is enabled.
                 # Otherwise, supply pager arguments to an application without any PowerShell parsing of the arguments.
                 # Leave environment variable to help user debug arguments supplied in $env:PAGER.
-                if ((Get-ExperimentalFeature PSNativeCommandArgumentPassing).Enabled) {
+                if ($EnabledExperimentalFeatures -contains 'PSNativeCommandArgumentPassing') {
                     $help | Out-String -Stream -Width ($consoleWidth - 1) | & $pagerCommand $pagerArgs
                 }
                 else {

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4577,12 +4577,6 @@ end {
                 ScopedItemOptions.None),
             // End: Variables which control remoting behavior
 
-            new SessionStateVariableEntry(
-                SpecialVariables.PSSessionApplicationName,
-                "wsman",
-                RemotingErrorIdStrings.PSSessionAppName,
-                ScopedItemOptions.None),
-
             #region Platform
             new SessionStateVariableEntry(
                 SpecialVariables.IsLinux,

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -317,7 +317,7 @@ namespace System.Management.Automation
                             if (argArrayAst != null && UseArgumentList)
                             {
                                 // We have a literal array, so take the extent, break it on spaces and add them to the argument list.
-                                foreach (string element in argArrayAst.Extent.Text.Split(" ", StringSplitOptions.RemoveEmptyEntries))
+                                foreach (string element in argArrayAst.Extent.Text.Split(' ', StringSplitOptions.RemoveEmptyEntries))
                                 {
                                     PossiblyGlobArg(element, parameter, stringConstantType);
                                 }

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -271,7 +271,7 @@ namespace System.Management.Automation
                         _arguments.Append(arg);
 
                         // we need to split the argument on spaces
-                        _argumentList.AddRange(arg.Split(" ", StringSplitOptions.RemoveEmptyEntries));
+                        _argumentList.AddRange(arg.Split(' ', StringSplitOptions.RemoveEmptyEntries));
                     }
                     else
                     {

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -164,10 +164,11 @@ namespace System.Management.Automation
         /// Add an argument to the ArgumentList.
         /// We may need to construct the argument out of the parameter text and the argument
         /// in the case that we have a parameter that appears as "-switch:value".
+        /// <param name="parameter">The parameter associated with the operation.</param>
+        /// <param name="argument">The value used with parameter.</param>
         /// </summary>
         internal void AddToArgumentList(CommandParameterInternal parameter, string argument)
         {
-
             if (parameter.ParameterNameSpecified && parameter.ParameterText.EndsWith(":"))
             {
                 if (argument != parameter.ParameterText)
@@ -179,7 +180,6 @@ namespace System.Management.Automation
             {
                 _argumentList.Add(argument);
             }
-
         }
 
         private List<string> _argumentList = new List<string>();
@@ -221,7 +221,7 @@ namespace System.Management.Automation
         /// each of which will be stringized.
         /// </summary>
         /// <param name="context">Execution context instance.</param>
-        /// <param name="parameter">The parameter we're looking at</param>
+        /// <param name="parameter">The parameter associated with the operation.</param>
         /// <param name="obj">The object to append.</param>
         /// <param name="argArrayAst">If the argument was an array literal, the Ast, otherwise null.</param>
         /// <param name="sawVerbatimArgumentMarker">True if the argument occurs after --%.</param>
@@ -230,7 +230,7 @@ namespace System.Management.Automation
         {
             IEnumerator list = LanguagePrimitives.GetEnumerator(obj);
 
-            Diagnostics.Assert((argArrayAst == null) || obj is object[] && ((object[])obj).Length == argArrayAst.Elements.Count, "array argument and ArrayLiteralAst differ in number of elements");
+            Diagnostics.Assert((argArrayAst == null) || (obj is object[] && ((object[])obj).Length == argArrayAst.Elements.Count), "array argument and ArrayLiteralAst differ in number of elements");
 
             int currentElement = -1;
             string separator = string.Empty;
@@ -345,7 +345,7 @@ namespace System.Management.Automation
         /// On Unix, do globbing as appropriate, otherwise just append <paramref name="arg"/>.
         /// </summary>
         /// <param name="arg">The argument that possibly needs expansion.</param>
-        /// <param name="parameter">The parameter we're looking at</param>
+        /// <param name="parameter">The parameter associated with the operation.</param>
         /// <param name="stringConstantType">Bare, SingleQuoted, or DoubleQuoted.</param>
         private void PossiblyGlobArg(string arg, CommandParameterInternal parameter, StringConstantType stringConstantType)
         {

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -164,9 +164,9 @@ namespace System.Management.Automation
         /// Add an argument to the ArgumentList.
         /// We may need to construct the argument out of the parameter text and the argument
         /// in the case that we have a parameter that appears as "-switch:value".
+        /// </summary>
         /// <param name="parameter">The parameter associated with the operation.</param>
         /// <param name="argument">The value used with parameter.</param>
-        /// </summary>
         internal void AddToArgumentList(CommandParameterInternal parameter, string argument)
         {
             if (parameter.ParameterNameSpecified && parameter.ParameterText.EndsWith(":"))

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinderController.cs
@@ -39,7 +39,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Gets the command arguments as an array of strings
+        /// Gets the value of the command arguments as an array of strings.
         /// </summary>
         internal string[] ArgumentList
         {
@@ -50,7 +50,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Get whether to use the new API for StartInfo
+        /// Get a value indicating whether to use the new API for StartInfo.
         /// </summary>
         internal bool UseArgumentList
         {
@@ -71,8 +71,7 @@ namespace System.Management.Automation
         /// Ignored.
         /// </param>
         /// <returns>
-        /// True if the parameter was successfully bound. Any error condition
-        /// produces an exception.
+        /// True if the parameter was successfully bound. Any error condition produces an exception.
         /// </returns>
         internal override bool BindParameter(
             CommandParameterInternal argument,

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinderController.cs
@@ -50,7 +50,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Get a value indicating whether to use the new API for StartInfo.
+        /// Gets a value indicating whether to use the new API for StartInfo.
         /// </summary>
         internal bool UseArgumentList
         {

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinderController.cs
@@ -50,6 +50,17 @@ namespace System.Management.Automation
         }
 
         /// <summary>
+        /// Get whether to use the new API for StartInfo
+        /// </summary>
+        internal bool UseArgumentList
+        {
+            get
+            {
+                return ((NativeCommandParameterBinder)DefaultParameterBinder).UseArgumentList;
+            }
+        }
+
+        /// <summary>
         /// Passes the binding directly through to the parameter binder.
         /// It does no verification against metadata.
         /// </summary>

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinderController.cs
@@ -39,6 +39,17 @@ namespace System.Management.Automation
         }
 
         /// <summary>
+        /// Gets the command arguments as an array of strings
+        /// </summary>
+        internal string[] ArgumentList
+        {
+            get
+            {
+                return ((NativeCommandParameterBinder)DefaultParameterBinder).ArgumentList;
+            }
+        }
+
+        /// <summary>
         /// Passes the binding directly through to the parameter binder.
         /// It does no verification against metadata.
         /// </summary>

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1164,7 +1164,7 @@ namespace System.Management.Automation
             {
                 if (!NativeParameterBinderController.UseArgumentList)
                 {
-                    using (ParameterBinderBase.bindingTracer.TraceScope( "BIND argument [{0}]", NativeParameterBinderController.Arguments))
+                    using (ParameterBinderBase.bindingTracer.TraceScope("BIND argument [{0}]", NativeParameterBinderController.Arguments))
                     {
                         startInfo.Arguments = NativeParameterBinderController.Arguments;
                     }

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1160,16 +1160,9 @@ namespace System.Management.Automation
             ExecutionContext context = this.Command.Context;
 
             // We provide the user a way to select the new behavior via a new preference variable
-            // If the variable is set (and it 1) we will use the new behavior
-            bool OldStyleNativeInvocation = true;
-            string preference = LanguagePrimitives.ConvertTo<string>(context.GetVariableValue(new VariablePath("PSNativeApplicationUsesArgumentList")));
-            if (!string.IsNullOrEmpty(preference) && preference == "1")
-            {
-                OldStyleNativeInvocation = false;
-            }
             using (ParameterBinderBase.bindingTracer.TraceScope( "BIND NAMED native application line args [{0}]", this.Path))
             {
-                if (OldStyleNativeInvocation)
+                if (!NativeParameterBinderController.UseArgumentList)
                 {
                     using (ParameterBinderBase.bindingTracer.TraceScope( "BIND argument [{0}]", NativeParameterBinderController.Arguments))
                     {
@@ -1181,7 +1174,7 @@ namespace System.Management.Automation
                     // Use new API for running native application
                     int position = 0;
                     foreach (string nativeArgument in NativeParameterBinderController.ArgumentList) {
-                        if (!string.IsNullOrEmpty(nativeArgument)) {
+                        if (nativeArgument != null) {
                             using (ParameterBinderBase.bindingTracer.TraceScope( "BIND cmd line arg [{0}] to position [{1}]", nativeArgument, position++))
                             {
                                 startInfo.ArgumentList.Add(nativeArgument);

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -357,7 +357,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Indicate if we have called 'NotifyBeginApplication()' on the host, so that
-        /// we can call the counterpart 'NotifyEndApplication' as approriate.
+        /// we can call the counterpart 'NotifyEndApplication' as appropriate.
         /// </summary>
         private bool _hasNotifiedBeginApplication;
 
@@ -1157,9 +1157,39 @@ namespace System.Management.Automation
                 startInfo.CreateNoWindow = mpc.NonInteractive;
             }
 
-            startInfo.Arguments = NativeParameterBinderController.Arguments;
-
             ExecutionContext context = this.Command.Context;
+
+            // We provide the user a way to select the new behavior via a new preference variable
+            // If the variable is set (and it 1) we will use the new behavior
+            bool OldStyleNativeInvocation = true;
+            string preference = LanguagePrimitives.ConvertTo<string>(context.GetVariableValue(new VariablePath("PSNativeApplicationUsesArgumentList")));
+            if (!string.IsNullOrEmpty(preference) && preference == "1")
+            {
+                OldStyleNativeInvocation = false;
+            }
+            using (ParameterBinderBase.bindingTracer.TraceScope( "BIND NAMED native application line args [{0}]", this.Path))
+            {
+                if (OldStyleNativeInvocation)
+                {
+                    using (ParameterBinderBase.bindingTracer.TraceScope( "BIND argument [{0}]", NativeParameterBinderController.Arguments))
+                    {
+                        startInfo.Arguments = NativeParameterBinderController.Arguments;
+                    }
+                }
+                else
+                {
+                    // Use new API for running native application
+                    int position = 0;
+                    foreach (string nativeArgument in NativeParameterBinderController.ArgumentList) {
+                        if (!string.IsNullOrEmpty(nativeArgument)) {
+                            using (ParameterBinderBase.bindingTracer.TraceScope( "BIND cmd line arg [{0}] to position [{1}]", nativeArgument, position++))
+                            {
+                                startInfo.ArgumentList.Add(nativeArgument);
+                            }
+                        }
+                    }
+                }
+            }
 
             // Start command in the current filesystem directory
             string rawPath =

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1160,7 +1160,7 @@ namespace System.Management.Automation
             ExecutionContext context = this.Command.Context;
 
             // We provide the user a way to select the new behavior via a new preference variable
-            using (ParameterBinderBase.bindingTracer.TraceScope( "BIND NAMED native application line args [{0}]", this.Path))
+            using (ParameterBinderBase.bindingTracer.TraceScope("BIND NAMED native application line args [{0}]", this.Path))
             {
                 if (!NativeParameterBinderController.UseArgumentList)
                 {
@@ -1173,9 +1173,11 @@ namespace System.Management.Automation
                 {
                     // Use new API for running native application
                     int position = 0;
-                    foreach (string nativeArgument in NativeParameterBinderController.ArgumentList) {
-                        if (nativeArgument != null) {
-                            using (ParameterBinderBase.bindingTracer.TraceScope( "BIND cmd line arg [{0}] to position [{1}]", nativeArgument, position++))
+                    foreach (string nativeArgument in NativeParameterBinderController.ArgumentList)
+                    {
+                        if (nativeArgument != null)
+                        {
+                            using (ParameterBinderBase.bindingTracer.TraceScope("BIND cmd line arg [{0}] to position [{1}]", nativeArgument, position++))
                             {
                                 startInfo.ArgumentList.Add(nativeArgument);
                             }

--- a/src/System.Management.Automation/engine/SpecialVariables.cs
+++ b/src/System.Management.Automation/engine/SpecialVariables.cs
@@ -257,6 +257,11 @@ namespace System.Management.Automation
 
         #endregion Preference Variables
 
+        // Native command argument passing style
+        internal const string NativeArgumentPassing = "PSNativeCommandArgumentPassing";
+
+        internal static readonly VariablePath NativeArgumentPassingVarPath = new VariablePath(NativeArgumentPassing);
+
         internal const string ErrorView = "ErrorView";
 
         internal static readonly VariablePath ErrorViewVarPath = new VariablePath(ErrorView);

--- a/src/System.Management.Automation/resources/RunspaceInit.resx
+++ b/src/System.Management.Automation/resources/RunspaceInit.resx
@@ -189,6 +189,9 @@
   <data name="WhatIfPreferenceDescription" xml:space="preserve">
     <value>If true, WhatIf is considered to be enabled for all commands.</value>
   </data>
+  <data name="NativeCommandArgumentPassingDescription" xml:space="preserve">
+    <value>Dictates how arguments are passed to native executables.</value>
+  </data>
   <data name="FormatEnumerationLimitDescription" xml:space="preserve">
     <value>Dictates the limit of enumeration on formatting IEnumerable objects</value>
   </data>

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -235,8 +235,8 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             $observed | Should -BeExactly "h-llo"
         }
 
-        It "Empty command should fail" {
-            & $powershell -noprofile -c ''
+        It "Missing command should fail" {
+            & $powershell -noprofile -c
             $LASTEXITCODE | Should -Be 64
         }
 

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -240,6 +240,11 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             $LASTEXITCODE | Should -Be 64
         }
 
+        It "Empty space command should succeed" {
+            & $powershell -noprofile -c '' | Should -BeNullOrEmpty
+            $LASTEXITCODE | Should -Be 0
+        }
+
         It "Whitespace command should succeed" {
             & $powershell -noprofile -c ' ' | Should -BeNullOrEmpty
             $LASTEXITCODE | Should -Be 0

--- a/test/powershell/Host/Startup.Tests.ps1
+++ b/test/powershell/Host/Startup.Tests.ps1
@@ -90,7 +90,7 @@ Describe "Validate start of console host" -Tag CI {
             Remove-Item $profileDataFile -Force
         }
 
-        $loadedAssemblies = & "$PSHOME/pwsh" -noprofile -command '([System.AppDomain]::CurrentDomain.GetAssemblies()).manifestmodule | Where-Object { $_.Name -notlike ""<*>"" } | ForEach-Object { $_.Name }'
+        $loadedAssemblies = & "$PSHOME/pwsh" -noprofile -command '([System.AppDomain]::CurrentDomain.GetAssemblies()).manifestmodule | Where-Object { $_.Name -notlike "<*>" } | ForEach-Object { $_.Name }'
     }
 
     It "No new assemblies are loaded" {

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
@@ -77,8 +77,15 @@ foreach ( $argumentListValue in "Standard","Legacy" ) {
         It "Should handle arguments that include commas without spaces (windbg example)" {
             $lines = testexe -echoargs -k com:port=\\devbox\pipe\debug,pipe,resets=0,reconnect
             $lines.Count | Should -Be 2
-            $line[0] | Should -BeExactly "Arg 0 is <-k>"
-            $line[1] | Should -BeExactly "Arg 1 is <com:port=\\devbox\pipe\debug,pipe,resets=0,reconnect>"
+            $lines[0] | Should -BeExactly "Arg 0 is <-k>"
+            $lines[1] | Should -BeExactly "Arg 1 is <com:port=\\devbox\pipe\debug,pipe,resets=0,reconnect>"
+        }
+
+        It "Should handle DOS style arguments" {
+            $lines = testexe -echoargs /arg1 /c:"a string"
+            $lines.Count | Should -Be 2
+            $lines[0] | Should -BeExactly "Arg 0 is </arg1>"
+            $lines[1] | Should -BeExactly "Arg 1 is </c:a string>"
         }
 
         It "Should handle PowerShell arrays with or without spaces correctly (ArgumentList=${PSNativeCommandArgumentPassing}): <arguments>" -TestCases @(

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
@@ -1,5 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidGlobalVars", "")]
+param()
 Describe "Will error correctly if an attempt to set variable to improper value" {
     It "will error when setting variable incorrectly" {
         if ( (Get-ExperimentalFeature PSNativeCommandArgumentPassing).Enabled ) {

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
@@ -4,7 +4,7 @@
 param()
 Describe "Will error correctly if an attempt to set variable to improper value" {
     It "will error when setting variable incorrectly" {
-        if ( (Get-ExperimentalFeature PSNativeCommandArgumentPassing).Enabled ) {
+        if ($EnabledExperimentalFeatures -contains 'PSNativeCommandArgumentPassing') {
             { $global:PSNativeCommandArgumentPassing = "zzz" } | Should -Throw -ExceptionType System.Management.Automation.ArgumentTransformationMetadataException
         }
         else {
@@ -26,7 +26,7 @@ foreach ( $argumentListValue in "Standard","Legacy" ) {
             $a = 'a"b c"d'
             $lines = testexe -echoargs $a 'a"b c"d' a"b c"d "a'b c'd"
             $lines.Count | Should -Be 4
-            if ( (Get-ExperimentalFeature PSNativeCommandArgumentPassing).Enabled -and $PSNativeCommandArgumentPassing -ne "Legacy" ) {
+            if (($EnabledExperimentalFeatures -contains 'PSNativeCommandArgumentPassing') -and $PSNativeCommandArgumentPassing -ne "Legacy") {
                 $lines[0] | Should -BeExactly 'Arg 0 is <a"b c"d>'
                 $lines[1] | Should -BeExactly 'Arg 1 is <a"b c"d>'
             }
@@ -52,7 +52,7 @@ foreach ( $argumentListValue in "Standard","Legacy" ) {
         It "Should handle spaces between escaped quotes (ArgumentList=${PSNativeCommandArgumentPassing})" {
             $lines = testexe -echoargs 'a\"b c\"d' "a\`"b c\`"d"
             $lines.Count | Should -Be 2
-            if ( (Get-ExperimentalFeature PSNativeCommandArgumentPassing).Enabled -and $PSNativeCommandArgumentPassing -ne "Legacy" ) {
+            if (($EnabledExperimentalFeatures -contains 'PSNativeCommandArgumentPassing') -and $PSNativeCommandArgumentPassing -ne "Legacy") {
                 $lines[0] | Should -BeExactly 'Arg 0 is <a\"b c\"d>'
                 $lines[1] | Should -BeExactly 'Arg 1 is <a\"b c\"d>'
             }

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
@@ -74,6 +74,13 @@ foreach ( $argumentListValue in "Standard","Legacy" ) {
             }
         }
 
+        It "Should handle arguments that include commas without spaces (windbg example)" {
+            $lines = testexe -echoargs -k com:port=\\devbox\pipe\debug,pipe,resets=0,reconnect
+            $lines.Count | Should -Be 2
+            $line[0] | Should -BeExactly "Arg 0 is <-k>"
+            $line[1] | Should -BeExactly "Arg 1 is <com:port=\\devbox\pipe\debug,pipe,resets=0,reconnect>"
+        }
+
         It "Should handle PowerShell arrays with or without spaces correctly (ArgumentList=${PSNativeCommandArgumentPassing}): <arguments>" -TestCases @(
             @{arguments = "1,2"; expected = @("1,2")}
             @{arguments = "1,2,3"; expected = @("1,2,3")}

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
@@ -1,71 +1,84 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-$PSNativeApplicationUsesArgumentList = 1
-Describe "Native Command Arguments" -tags "CI" {
-    # When passing arguments to native commands, quoted segments that contain
-    # spaces need to be quoted with '"' characters when they are passed to the
-    # native command (or to bash or sh on Linux).
-    #
-    # This test checks that the proper quoting is occuring by passing arguments
-    # to the testexe native command and looking at how it got the arguments.
-    It "Should handle quoted spaces correctly" {
-        $a = 'a"b c"d'
-        $lines = testexe -echoargs $a 'a"b c"d' a"b c"d
-        $lines.Count | Should -Be 3
-        $lines[0] | Should -BeExactly 'Arg 0 is <a"b c"d>'
-        $lines[1] | Should -BeExactly 'Arg 1 is <a"b c"d>'
-        $lines[2] | Should -BeExactly 'Arg 2 is <ab cd>'
-    }
-
-    # In order to pass '"' characters so they are actually part of command line
-    # arguments for native commands, they need to be escaped with a '\' (this
-    # is in addition to the '`' escaping needed inside '"' quoted strings in
-    # PowerShell).
-    #
-    # This functionality was broken in PowerShell 5.0 and 5.1, so this test
-    # will fail on those versions unless the fix is backported to them.
-    #
-    # This test checks that the proper quoting and escaping is occurring by
-    # passing arguments with escaped quotes to the testexe native command and
-    # looking at how it got the arguments.
-    It "Should handle spaces between escaped quotes" {
-        $lines = testexe -echoargs 'a\"b c\"d' "a\`"b c\`"d"
-        $lines.Count | Should -Be 2
-        $lines[0] | Should -BeExactly 'Arg 0 is <a\"b c\"d>'
-        $lines[1] | Should -BeExactly 'Arg 1 is <a\"b c\"d>'
-    }
-
-    It "Should correctly quote paths with spaces: <arguments>" -TestCases @(
-        @{arguments = "'.\test 1\' `".\test 2\`""  ; expected = @(".\test 1\",".\test 2\")},
-        @{arguments = "'.\test 1\\\' `".\test 2\\`""; expected = @(".\test 1\\\",".\test 2\\")}
-    ) {
-        param($arguments, $expected)
-        $lines = Invoke-Expression "testexe -echoargs $arguments"
-        $lines.Count | Should -Be $expected.Count
-        for ($i = 0; $i -lt $lines.Count; $i++) {
-            $lines[$i] | Should -BeExactly "Arg $i is <$($expected[$i])>"
+foreach ( $argumentListValue in 0,1 ) {
+    $PSNativeApplicationUsesArgumentList = $argumentListValue
+    Describe "Native Command Arguments" -tags "CI" {
+        # When passing arguments to native commands, quoted segments that contain
+        # spaces need to be quoted with '"' characters when they are passed to the
+        # native command (or to bash or sh on Linux).
+        #
+        # This test checks that the proper quoting is occuring by passing arguments
+        # to the testexe native command and looking at how it got the arguments.
+        It "Should handle quoted spaces correctly (ArgumentList=${PSNativeApplicationUsesArgumentList})" {
+            $a = 'a"b c"d'
+            $lines = testexe -echoargs $a 'a"b c"d' a"b c"d
+            $lines.Count | Should -Be 3
+            if ( $PSNativeApplicationUsesArgumentList -eq 1 ) {
+                $lines[0] | Should -BeExactly 'Arg 0 is <a"b c"d>'
+                $lines[1] | Should -BeExactly 'Arg 1 is <a"b c"d>'
+            }
+            else {
+                $lines[0] | Should -BeExactly 'Arg 0 is <ab cd>'
+                $lines[1] | Should -BeExactly 'Arg 1 is <ab cd>'
+            }
+            $lines[2] | Should -BeExactly 'Arg 2 is <ab cd>'
         }
-    }
 
-    It "Should handle PowerShell arrays with or without spaces correctly: <arguments>" -TestCases @(
-        @{arguments = "1,2"; expected = @("1,2")}
-        @{arguments = "1,2,3"; expected = @("1,2,3")}
-        @{arguments = "1, 2"; expected = "1,", "2"}
-        @{arguments = "1 ,2"; expected = "1", ",2"}
-        @{arguments = "1 , 2"; expected = "1", ",", "2"}
-        @{arguments = "1, 2,3"; expected = "1,", "2,3"}
-        @{arguments = "1 ,2,3"; expected = "1", ",2,3"}
-        @{arguments = "1 , 2,3"; expected = "1", ",", "2,3"}
-    ) {
-        param($arguments, $expected)
-        $lines = @(Invoke-Expression "testexe -echoargs $arguments")
-        $lines.Count | Should -Be $expected.Count
-        for ($i = 0; $i -lt $expected.Count; $i++) {
-            $lines[$i] | Should -BeExactly "Arg $i is <$($expected[$i])>"
+        # In order to pass '"' characters so they are actually part of command line
+        # arguments for native commands, they need to be escaped with a '\' (this
+        # is in addition to the '`' escaping needed inside '"' quoted strings in
+        # PowerShell).
+        #
+        # This functionality was broken in PowerShell 5.0 and 5.1, so this test
+        # will fail on those versions unless the fix is backported to them.
+        #
+        # This test checks that the proper quoting and escaping is occurring by
+        # passing arguments with escaped quotes to the testexe native command and
+        # looking at how it got the arguments.
+        It "Should handle spaces between escaped quotes (ArgumentList=${PSNativeApplicationUsesArgumentList})" {
+            $lines = testexe -echoargs 'a\"b c\"d' "a\`"b c\`"d"
+            $lines.Count | Should -Be 2
+            if ( $PSNativeApplicationUsesArgumentList -eq 1 ) {
+                $lines[0] | Should -BeExactly 'Arg 0 is <a\"b c\"d>'
+                $lines[1] | Should -BeExactly 'Arg 1 is <a\"b c\"d>'
+            }
+            else {
+                $lines[0] | Should -BeExactly 'Arg 0 is <a"b c"d>'
+                $lines[1] | Should -BeExactly 'Arg 1 is <a"b c"d>'
+            }
+        }
+
+        It "Should correctly quote paths with spaces (ArgumentList=${PSNativeApplicationUsesArgumentList}): <arguments>" -TestCases @(
+            @{arguments = "'.\test 1\' `".\test 2\`""  ; expected = @(".\test 1\",".\test 2\")},
+            @{arguments = "'.\test 1\\\' `".\test 2\\`""; expected = @(".\test 1\\\",".\test 2\\")}
+        ) {
+            param($arguments, $expected)
+            $lines = Invoke-Expression "testexe -echoargs $arguments"
+            $lines.Count | Should -Be $expected.Count
+            for ($i = 0; $i -lt $lines.Count; $i++) {
+                $lines[$i] | Should -BeExactly "Arg $i is <$($expected[$i])>"
+            }
+        }
+
+        It "Should handle PowerShell arrays with or without spaces correctly (ArgumentList=${PSNativeApplicationUsesArgumentList}): <arguments>" -TestCases @(
+            @{arguments = "1,2"; expected = @("1,2")}
+            @{arguments = "1,2,3"; expected = @("1,2,3")}
+            @{arguments = "1, 2"; expected = "1,", "2"}
+            @{arguments = "1 ,2"; expected = "1", ",2"}
+            @{arguments = "1 , 2"; expected = "1", ",", "2"}
+            @{arguments = "1, 2,3"; expected = "1,", "2,3"}
+            @{arguments = "1 ,2,3"; expected = "1", ",2,3"}
+            @{arguments = "1 , 2,3"; expected = "1", ",", "2,3"}
+        ) {
+            param($arguments, $expected)
+            $lines = @(Invoke-Expression "testexe -echoargs $arguments")
+            $lines.Count | Should -Be $expected.Count
+            for ($i = 0; $i -lt $expected.Count; $i++) {
+                $lines[$i] | Should -BeExactly "Arg $i is <$($expected[$i])>"
+            }
         }
     }
 }
-
 Describe 'PSPath to native commands' {
     BeforeAll {
         $featureEnabled = $EnabledExperimentalFeatures.Contains('PSNativePSPathResolution')

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
@@ -24,8 +24,8 @@ foreach ( $argumentListValue in "Standard","Legacy" ) {
         # to the testexe native command and looking at how it got the arguments.
         It "Should handle quoted spaces correctly (ArgumentList=${PSNativeCommandArgumentPassing})" {
             $a = 'a"b c"d'
-            $lines = testexe -echoargs $a 'a"b c"d' a"b c"d
-            $lines.Count | Should -Be 3
+            $lines = testexe -echoargs $a 'a"b c"d' a"b c"d "a'b c'd"
+            $lines.Count | Should -Be 4
             if ( (Get-ExperimentalFeature PSNativeCommandArgumentPassing).Enabled -and $PSNativeCommandArgumentPassing -ne "Legacy" ) {
                 $lines[0] | Should -BeExactly 'Arg 0 is <a"b c"d>'
                 $lines[1] | Should -BeExactly 'Arg 1 is <a"b c"d>'
@@ -35,6 +35,7 @@ foreach ( $argumentListValue in "Standard","Legacy" ) {
                 $lines[1] | Should -BeExactly 'Arg 1 is <ab cd>'
             }
             $lines[2] | Should -BeExactly 'Arg 2 is <ab cd>'
+            $lines[3] | Should -BeExactly 'Arg 3 is <a''b c''d>'
         }
 
         # In order to pass '"' characters so they are actually part of command line

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+$PSNativeApplicationUsesArgumentList = 1
 Describe "Native Command Arguments" -tags "CI" {
     # When passing arguments to native commands, quoted segments that contain
     # spaces need to be quoted with '"' characters when they are passed to the
@@ -11,8 +12,8 @@ Describe "Native Command Arguments" -tags "CI" {
         $a = 'a"b c"d'
         $lines = testexe -echoargs $a 'a"b c"d' a"b c"d
         $lines.Count | Should -Be 3
-        $lines[0] | Should -BeExactly 'Arg 0 is <ab cd>'
-        $lines[1] | Should -BeExactly 'Arg 1 is <ab cd>'
+        $lines[0] | Should -BeExactly 'Arg 0 is <a"b c"d>'
+        $lines[1] | Should -BeExactly 'Arg 1 is <a"b c"d>'
         $lines[2] | Should -BeExactly 'Arg 2 is <ab cd>'
     }
 
@@ -30,8 +31,8 @@ Describe "Native Command Arguments" -tags "CI" {
     It "Should handle spaces between escaped quotes" {
         $lines = testexe -echoargs 'a\"b c\"d' "a\`"b c\`"d"
         $lines.Count | Should -Be 2
-        $lines[0] | Should -BeExactly 'Arg 0 is <a"b c"d>'
-        $lines[1] | Should -BeExactly 'Arg 1 is <a"b c"d>'
+        $lines[0] | Should -BeExactly 'Arg 0 is <a\"b c\"d>'
+        $lines[1] | Should -BeExactly 'Arg 1 is <a\"b c\"d>'
     }
 
     It "Should correctly quote paths with spaces: <arguments>" -TestCases @(

--- a/test/powershell/Language/Scripting/NativeExecution/NativeStreams.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeStreams.Tests.ps1
@@ -12,9 +12,9 @@ Describe "Native streams behavior with PowerShell" -Tags 'CI' {
         $error.Clear()
 
         $command = [string]::Join('', @(
-            '[Console]::Error.Write(\"foo`n`nbar`n`nbaz\"); ',
-            '[Console]::Error.Write(\"middle\"); ',
-            '[Console]::Error.Write(\"foo`n`nbar`n`nbaz\")'
+            '[Console]::Error.Write("foo`n`nbar`n`nbaz"); ',
+            '[Console]::Error.Write("middle"); ',
+            '[Console]::Error.Write("foo`n`nbar`n`nbaz")'
         ))
 
         $out = & $powershell -noprofile -command $command 2>&1


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

This adds a new behavior for native executables which uses ArgumentList as the command arguments for the native executable.

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
The experimental feature PSNativeCommandArgumentPassing when enabled will use the `ArgumentList` property of the `StartProcessInfo` object rather than our current mechanism of reconstructing a string when invoking a native executable.
`$PSNativeCommandArgumentPassing` is a new automatic variable which allows for runtime selection of behavior. `$PSNativeCommandArgumentPassing` may be set to either `Legacy` or `Standard`, `Legacy` is the historic behavior. The default when the experimental feature is enabled is the new `Standard` behavior. 

This new behavior *is a breaking change* from current behavior. This may break scripts and automation which work-around the various issues when invoking native applications. Historically, quotes must be escaped and it is not possible to provide empty arguments to a native application. This PR attempts to address these issues.

new behaviors made available by this change

- literal or expandable strings with embedded quotes the quotes are now preserved
```powershell
PS > $a = 'a" "b'
PS > $PSNativeCommandArgumentPassing = "Legacy"
PS > testexe -echoargs $a 'a" "b' a" "b    
Arg 0 is <a b>
Arg 1 is <a b>
Arg 2 is <a b>
PS > $PSNativeCommandArgumentPassing = "Standard"
PS > testexe -echoargs $a 'a" "b' a" "b    
Arg 0 is <a" "b>
Arg 1 is <a" "b>
Arg 2 is <a b>
```

- empty strings as arguments are now preserved:
```powershell
PS>  $PSNativeCommandArgumentPassing = "Legacy"
PS> testexe -echoargs '' a b ''           
Arg 0 is <a>
Arg 1 is <b>
PS> $PSNativeCommandArgumentPassing = "Standard"
PS> testexe -echoargs '' a b ''           
Arg 0 is <>
Arg 1 is <a>
Arg 2 is <b>
Arg 3 is <>
```

the new behavior does not change invocations which look like this:

```powershell
PS> $PSNativeCommandArgumentPassing = "Legacy"                                            
PS> testexe -echoargs -k com:port=\\devbox\pipe\debug,pipe,resets=0,reconnect          
Arg 0 is <-k>
Arg 1 is <com:port=\\devbox\pipe\debug,pipe,resets=0,reconnect>
PS> $PSNativeCommandArgumentPassing = "Standard"                                  
PS> testexe -echoargs -k com:port=\\devbox\pipe\debug,pipe,resets=0,reconnect
Arg 0 is <-k>
Arg 1 is <com:port=\\devbox\pipe\debug,pipe,resets=0,reconnect>
```

Additionally, parameter tracing is now provided so `Trace-Command` will provide useful information for debugging

```powershell
PS> $PSNativeCommandArgumentPassing = "Legacy"                                           
PS> trace-command -PSHOST -Name ParameterBinding { testexe -echoargs $a 'a" "b' a" "b }
DEBUG: 2021-02-01 17:19:53.6438 ParameterBinding Information: 0 : BIND NAMED native application line args [/Users/james/src/github/forks/jameswtruher/PowerShell-1/test/tools/TestExe/bin/testexe]
DEBUG: 2021-02-01 17:19:53.6440 ParameterBinding Information: 0 :     BIND argument [-echoargs a" "b a" "b "a b"]
DEBUG: 2021-02-01 17:19:53.6522 ParameterBinding Information: 0 : CALLING BeginProcessing
Arg 0 is <a b>
Arg 1 is <a b>
Arg 2 is <a b>
PS> $PSNativeCommandArgumentPassing = "Standard"                                            
PS> trace-command -PSHOST -Name ParameterBinding { testexe -echoargs $a 'a" "b' a" "b }
DEBUG: 2021-02-01 17:20:01.9829 ParameterBinding Information: 0 : BIND NAMED native application line args [/Users/james/src/github/forks/jameswtruher/PowerShell-1/test/tools/TestExe/bin/testexe]
DEBUG: 2021-02-01 17:20:01.9829 ParameterBinding Information: 0 :     BIND cmd line arg [-echoargs] to position [0]
DEBUG: 2021-02-01 17:20:01.9830 ParameterBinding Information: 0 :     BIND cmd line arg [a" "b] to position [1]
DEBUG: 2021-02-01 17:20:01.9830 ParameterBinding Information: 0 :     BIND cmd line arg [a" "b] to position [2]
DEBUG: 2021-02-01 17:20:01.9831 ParameterBinding Information: 0 :     BIND cmd line arg [a b] to position [3]
DEBUG: 2021-02-01 17:20:01.9908 ParameterBinding Information: 0 : CALLING BeginProcessing
Arg 0 is <a" "b>
Arg 1 is <a" "b>
Arg 2 is <a b>
```

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

Invoking native applications is sometimes very problematic because of how the application is invoked. A new property is available on the `ProcessStartInfo` object which hopes to improve the experience. This PR takes advantage of this new property.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [x] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): PSNativeCommandArgumentPassing
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/PowerShell/PowerShell/issues/13068
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [x] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).

The impact on completions may be affected if those completers are calling native applications.