### PR TITLE
Fix redundant iteration while splitting lines

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
@@ -416,10 +416,12 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
             for (int k = 0; k < lines.Length; k++)
             {
-                if (lines[k] == null || displayCells.Length(lines[k]) <= firstLineLen)
+                var currentLine = lines[k];
+
+                if (currentLine == null || displayCells.Length(currentLine) <= firstLineLen)
                 {
                     // we do not need to split further, just add
-                    retVal.Add(lines[k]);
+                    retVal.Add(currentLine);
                     continue;
                 }
 
@@ -432,7 +434,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
                 int offset = 0; // offset into the line we are splitting
 
-                while (true)
+                while (currentLine.Length > offset)
                 {
                     // acquire the current active display line length (it can very from call to call)
                     int currentDisplayLen = accumulator.ActiveLen;
@@ -440,7 +442,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     // determine if the current tail would fit or not
 
                     // for the remaining part of the string, determine its display cell count
-                    int currentCellsToFit = displayCells.Length(lines[k], offset);
+                    int currentCellsToFit = displayCells.Length(currentLine, offset);
 
                     // determine if we fit into the line
                     int excessCells = currentCellsToFit - currentDisplayLen;
@@ -449,7 +451,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     {
                         // we are not at the end of the string, select a sub string
                         // that would fit in the remaining display length
-                        int charactersToAdd = displayCells.GetHeadSplitLength(lines[k], offset, currentDisplayLen);
+                        int charactersToAdd = displayCells.GetHeadSplitLength(currentLine, offset, currentDisplayLen);
 
                         if (charactersToAdd <= 0)
                         {
@@ -463,7 +465,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                         else
                         {
                             // of the given length, add it to the accumulator
-                            accumulator.AddLine(lines[k].Substring(offset, charactersToAdd));
+                            accumulator.AddLine(currentLine.Substring(offset, charactersToAdd));
                         }
 
                         // increase the offset by the # of characters added
@@ -472,7 +474,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     else
                     {
                         // we reached the last (partial) line, we add it all
-                        accumulator.AddLine(lines[k].Substring(offset));
+                        accumulator.AddLine(currentLine.Substring(offset));
                         break;
                     }
                 }

--- a/src/System.Management.Automation/FormatAndOutput/out-console/ConsoleLineOutput.cs
+++ b/src/System.Management.Automation/FormatAndOutput/out-console/ConsoleLineOutput.cs
@@ -87,8 +87,15 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         internal override int Length(string str, int offset)
         {
-            Dbg.Assert(offset >= 0, "offset >= 0");
-            Dbg.Assert(string.IsNullOrEmpty(str) || (offset < str.Length), "offset < str.Length");
+            if (string.IsNullOrEmpty(str))
+            {
+                return 0;
+            }
+
+            if (offset < 0 || offset >= str.Length)
+            {
+                throw PSTraceSource.NewArgumentException(nameof(offset));
+            }
 
             try
             {
@@ -100,7 +107,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 // we will fallback to the default value.
             }
 
-            return string.IsNullOrEmpty(str) ? 0 : str.Length - offset;
+            return str.Length - offset;
         }
 
         internal override int Length(string str)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix redundant iteration while splitting lines to prevent assert failure.

## PR Context

We split a line to fit in a windows width and if on last iteration we did get zero length tail we did next iteration but we should stop.

Borrowed from @iSazonov, see https://github.com/PowerShell/PowerShell/issues/13551#issuecomment-766722563

Fixes #13551

Todo: 

- ~[ ] Add tests~: can only repro in a specified range of width of window while rendering table, I don't know how to test it automatically without user interaction.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
