### PR TITLE
Fix third party signing for files in sub-folders

### DIFF
--- a/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
@@ -183,6 +183,10 @@ jobs:
         $pathWithoutLeaf = Split-Path $_
         $relativePath = $pathWithoutLeaf.replace($BuildPath,'')
         $targetDirectory = Join-Path -Path $filesToSignDirectory -ChildPath $relativePath
+        if(!(Test-Path $targetDirectory))
+        {
+          $null = New-Item -ItemType Directory -Path $targetDirectory -Force
+        }
         Copy-Item -Path $_ -Destination $targetDirectory
       }
 

--- a/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
@@ -180,7 +180,7 @@ jobs:
       $null = New-Item -ItemType Directory -Path $signedFilesDirectory -Force
 
       $missingSignatures | ForEach-Object {
-        $relativePath = $missingSignatures.replace($BuildPath)
+        $relativePath = $missingSignatures.replace($BuildPath,'')
         $targetDirectory = Join-Path -Path $filesToSignDirectory -ChildPath $relativePath
         Copy-Item -Path $_ -Destination $targetDirectory
       }

--- a/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
@@ -180,7 +180,9 @@ jobs:
       $null = New-Item -ItemType Directory -Path $signedFilesDirectory -Force
 
       $missingSignatures | ForEach-Object {
-        Copy-Item -Path $_ -Destination $filesToSignDirectory
+        $relativePath = $missingSignatures.replace($BuildPath)
+        $targetDirectory = Join-Path -Path $filesToSignDirectory -ChildPath $relativePath
+        Copy-Item -Path $_ -Destination $targetDirectory
       }
 
     displayName: Create ThirdParty Signing Folder

--- a/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
@@ -180,7 +180,7 @@ jobs:
       $null = New-Item -ItemType Directory -Path $signedFilesDirectory -Force
 
       $missingSignatures | ForEach-Object {
-        $relativePath = $missingSignatures.replace($BuildPath,'')
+        $relativePath = $_.replace($BuildPath,'')
         $targetDirectory = Join-Path -Path $filesToSignDirectory -ChildPath $relativePath
         Copy-Item -Path $_ -Destination $targetDirectory
       }

--- a/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
@@ -180,7 +180,8 @@ jobs:
       $null = New-Item -ItemType Directory -Path $signedFilesDirectory -Force
 
       $missingSignatures | ForEach-Object {
-        $relativePath = $_.replace($BuildPath,'')
+        $pathWithoutLeaf = Split-Path $_
+        $relativePath = $pathWithoutLeaf.replace($BuildPath,'')
         $targetDirectory = Join-Path -Path $filesToSignDirectory -ChildPath $relativePath
         Copy-Item -Path $_ -Destination $targetDirectory
       }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix third party signing for files in sub-folders
  * paths were being flattened

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
