### PR TITLE
Change minimum depth to 0 for `ConvertTo-Json`

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
@@ -35,7 +35,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the Depth property.
         /// </summary>
         [Parameter]
-        [ValidateRange(1, int.MaxValue)]
+        [ValidateRange(0, int.MaxValue)]
         public int Depth
         {
             get { return _depth; }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
@@ -44,18 +44,24 @@ Describe 'ConvertTo-Json' -tags "CI" {
         $ComplexObject = [PSCustomObject] @{
             FirstLevel1  = @{
                 Child1_1 = 0
+                Bool = $True
             }
             FirstLevel2 = @{
                 Child2_1 = 'Child_2_1_Value'
                 Child2_2 = @{
                      ChildOfChild2_2= @(1,2,3)
                     }
+                    Float = 1.2
                 }
+                Integer = 10
+                Bool = $False
             }
 
         $ExpectedOutput = '{
   "FirstLevel1": "System.Collections.Hashtable",
-  "FirstLevel2": "System.Collections.Hashtable"
+  "FirstLevel2": "System.Collections.Hashtable",
+  "Integer": 10,
+  "Bool": false
 }'
 
         $output = $ComplexObject | ConvertTo-Json -Depth 0

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
@@ -40,6 +40,28 @@ Describe 'ConvertTo-Json' -tags "CI" {
         $ps.Dispose()
     }
 
+    It "Should accept minimum depth as 0." {
+        $ComplexObject = [PSCustomObject] @{
+            FirstLevel1  = @{
+                Child1_1 = 0
+            }
+            FirstLevel2 = @{
+                Child2_1 = 'Child_2_1_Value'
+                Child2_2 = @{
+                     ChildOfChild2_2= @(1,2,3)
+                    }
+                }
+            }
+
+        $ExpectedOutput = '{
+  "FirstLevel1": "System.Collections.Hashtable",
+  "FirstLevel2": "System.Collections.Hashtable"
+}'
+
+        $output = $ComplexObject | ConvertTo-Json -Depth 0
+        $output | Should -Be $ExpectedOutput
+    }
+
     It "The result string is packed in an array symbols when AsArray parameter is used." {
         $output = 1 | ConvertTo-Json -AsArray
         $output | Should -BeLike "``[*1*]"


### PR DESCRIPTION
Recreating PR https://github.com/PowerShell/PowerShell/pull/13700

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Change min depth to 0 for ConvertTo-Json

Related to:  https://github.com/PowerShell/PowerShell/issues/13660

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/PowerShell/PowerShell/issues/13660
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary. This may include:
        - Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode (which runs in a different PS Host).
        - Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
        - Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
        - Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
