### PR TITLE
Change signature validation logic to call first without the file content

### DIFF
--- a/src/System.Management.Automation/security/SecurityManager.cs
+++ b/src/System.Management.Automation/security/SecurityManager.cs
@@ -535,7 +535,8 @@ namespace Microsoft.PowerShell
 
             // A last ditch effort -
             // If the file was originally ASCII or UTF8, the SIP may have added the Unicode BOM
-            if ((signature.Status != SignatureStatus.Valid) && (script.OriginalEncoding != Encoding.Unicode))
+            if (signature.Status != SignatureStatus.Valid
+                && script.OriginalEncoding != Encoding.Unicode)
             {
                 verificationContents = Encoding.Unicode.GetString(Encoding.Unicode.GetPreamble()) + script.ScriptContents;
                 Signature fallbackSignature = SignatureHelper.GetSignature(path, verificationContents);

--- a/src/System.Management.Automation/security/SecurityManager.cs
+++ b/src/System.Management.Automation/security/SecurityManager.cs
@@ -520,7 +520,6 @@ namespace Microsoft.PowerShell
         // or altered script.
         private static Signature GetSignatureWithEncodingRetry(string path, ExternalScriptInfo script)
         {
-
             // Invoke the SIP directly with the most simple method
             Signature signature = SignatureHelper.GetSignature(path, null);
             if (signature.Status == SignatureStatus.Valid)

--- a/src/System.Management.Automation/security/SecurityManager.cs
+++ b/src/System.Management.Automation/security/SecurityManager.cs
@@ -521,7 +521,7 @@ namespace Microsoft.PowerShell
         private static Signature GetSignatureWithEncodingRetry(string path, ExternalScriptInfo script)
         {
             // Invoke the SIP directly with the most simple method
-            Signature signature = SignatureHelper.GetSignature(path, null);
+            Signature signature = SignatureHelper.GetSignature(path, fileContent: null);
             if (signature.Status == SignatureStatus.Valid)
             {
                 return signature;

--- a/src/System.Management.Automation/security/SecurityManager.cs
+++ b/src/System.Management.Automation/security/SecurityManager.cs
@@ -11,6 +11,7 @@ using System.Management.Automation.Language;
 using System.Management.Automation.Security;
 using System.Security;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 
 using Dbg = System.Management.Automation;
 
@@ -529,14 +530,14 @@ namespace Microsoft.PowerShell
 
             // try harder to validate the signature by being explicit about encoding
             // and providing the script contents
-            string verificationContents = System.Text.Encoding.Unicode.GetString(script.OriginalEncoding.GetPreamble()) + script.ScriptContents;
+            string verificationContents = Encoding.Unicode.GetString(script.OriginalEncoding.GetPreamble()) + script.ScriptContents;
             signature = SignatureHelper.GetSignature(path, verificationContents);
 
             // A last ditch effort -
             // If the file was originally ASCII or UTF8, the SIP may have added the Unicode BOM
-            if ((signature.Status != SignatureStatus.Valid) && (script.OriginalEncoding != System.Text.Encoding.Unicode))
+            if ((signature.Status != SignatureStatus.Valid) && (script.OriginalEncoding != Encoding.Unicode))
             {
-                verificationContents = System.Text.Encoding.Unicode.GetString(System.Text.Encoding.Unicode.GetPreamble()) + script.ScriptContents;
+                verificationContents = Encoding.Unicode.GetString(Encoding.Unicode.GetPreamble()) + script.ScriptContents;
                 Signature fallbackSignature = SignatureHelper.GetSignature(path, verificationContents);
 
                 if (fallbackSignature.Status == SignatureStatus.Valid)


### PR DESCRIPTION
Only validate the signature with the content if the first non-content validation fails

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

When ExecutionPolicy is set to require a signature, under some circumstances a signature placed in a file will not execute with a "hash mismatch" error, even though `Get-AuthenticodeSignature` will return that the signature is valid.
This is because `Get-AuthenticodeSignature` and our invocation path are not symmetrical. This PR adds the same check that we do in `Get-AuthenticodeSignature` into our invocation path.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
