### PR TITLE
Add support to build msixbundle

### DIFF
--- a/tools/releaseBuild/azureDevOps/releasePipeline.yml
+++ b/tools/releaseBuild/azureDevOps/releasePipeline.yml
@@ -238,10 +238,7 @@ stages:
   dependsOn: GitHubManualTasks
   displayName: Publish MSIX to store
   jobs:
-  - deployment: PublishMsix
-    displayName: Publish MSIX to store
-    pool: server
-    environment: PSReleasePublishMsix
+  - template: templates/release-MsixBundle.yml
 
 - stage: BuildInfoJson
   dependsOn: GitHubManualTasks

--- a/tools/releaseBuild/azureDevOps/templates/release-MsixBundle.yml
+++ b/tools/releaseBuild/azureDevOps/templates/release-MsixBundle.yml
@@ -1,0 +1,45 @@
+parameters:
+  jobName: ""
+  displayName: ""
+  imageName: ""
+  globalToolExeName: 'pwsh.exe'
+  globalToolPackageName: 'PowerShell.Windows.x64'
+
+
+jobs:
+- job: ${{ parameters.jobName }}
+  displayName: ${{ parameters.displayName }}
+  pool:
+    vmImage: ${{ parameters.imageName }}
+  steps:
+    - checkout: self
+      clean: true
+
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        source: specific
+        project: PowerShellCore
+        pipeline: '696'
+        preferTriggeringPipeline: true
+        runVersion: latestFromBranch
+        runBranch: '$(Build.SourceBranch)'
+        artifact: finalResults
+        patterns: '**/*.msix'
+        path: '$(Pipeline.Workspace)/msix'
+
+    - pwsh: |
+        if ($null -eq Get-Command makeappx -ErrorAction Ignore) {
+          $msixUrl = '$(makeappUrl)'
+          Invoke-RestMethod -Uri $msixUrl -OutFile '\makeappx.zip'
+          Expand-Archive '\makeappx.zip' -destination '\' -Force
+        }
+      displayName: Install tools
+
+    - pwsh: |
+        $file = Get-ChildItem "$(Pipeline.Workspace)/msix" | Select-Object -First 1
+        $release = ($file.BaseName -split "-")[2]
+        $prefix = ($file.BaseName -split "-win")[0]
+        $pkgName = "$prefix.msixbundle"
+        Write-Verbose -Verbose "Creating $pkgName"
+        makeappx.exe bundle /d "$(Pipeline.Workspace)/msix" /p "$(Build.StagingDirectory)\signedPackages\$pkgName"
+      displayName: Build MsixBundle

--- a/tools/releaseBuild/azureDevOps/templates/upload.yml
+++ b/tools/releaseBuild/azureDevOps/templates/upload.yml
@@ -66,3 +66,9 @@ steps:
     ContainerName: '$(AzureVersion)-private'
     resourceGroup: '$(StorageResourceGroup)'
   condition: and(succeeded(), eq('${{ parameters.msix }}', 'yes'), eq(variables['SHOULD_SIGN'], 'true'))
+
+- template: upload-final-results.yml
+  parameters:
+    artifactPath: $(Build.StagingDirectory)\signedPackages
+    artifactFilter: PowerShell-${{ parameters.version }}.msixbundle
+    condition: and(succeeded(), eq('${{ parameters.msix }}', 'yes'))

--- a/tools/releaseBuild/azureDevOps/templates/windows-package-signing.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-package-signing.yml
@@ -73,6 +73,7 @@ jobs:
       architecture: arm32
       version: $(version)
       msi: no
+      msix: no
 
   - template: upload.yml
     parameters:


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Update release pipeline to build msixbundle from built msix pkgs and upload.  Also disable building win-arm32 msix as it's no longer supported.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
