### PR TITLE
Fix FileSystemProvider to not treat all reparsepoints as files

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
@@ -2699,7 +2699,7 @@ namespace Microsoft.PowerShell.Commands
                         try
                         {
                             System.IO.DirectoryInfo di = new(providerPath);
-                            if (di != null && di.Attributes.HasFlag(System.IO.FileAttributes.ReparsePoint) && !di.Attributes.HasFlag(System.IO.FileAttributes.Directory))
+                            if (di != null && di.Attributes.HasFlag(System.IO.FileAttributes.ReparsePoint) && (di.Attributes.HasFlag(System.IO.FileAttributes.Directory) && !shouldRecurse))
                             {
                                 shouldRecurse = false;
                                 treatAsFile = true;

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
@@ -2699,7 +2699,7 @@ namespace Microsoft.PowerShell.Commands
                         try
                         {
                             System.IO.DirectoryInfo di = new(providerPath);
-                            if (di != null && (di.Attributes & System.IO.FileAttributes.ReparsePoint) != 0)
+                            if (di != null && di.Attributes.HasFlag(System.IO.FileAttributes.ReparsePoint) && !di.Attributes.HasFlag(System.IO.FileAttributes.Directory))
                             {
                                 shouldRecurse = false;
                                 treatAsFile = true;

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
@@ -2693,7 +2693,7 @@ namespace Microsoft.PowerShell.Commands
                     bool shouldRecurse = Recurse;
                     bool treatAsFile = false;
 
-                    // only check if path is a directory using DirectoryInfo if using FileSystemProvider
+                    // only check if path is a directory using DirectoryInfo if using FileSystemProvider, otherwise will fail for other providers like Registry
                     if (resolvedPath.Provider.Name.Equals(FileSystemProvider.ProviderName, StringComparison.OrdinalIgnoreCase))
                     {
                         try

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
@@ -2699,7 +2699,16 @@ namespace Microsoft.PowerShell.Commands
                         try
                         {
                             System.IO.DirectoryInfo di = new(providerPath);
-                            if (di != null && di.Attributes.HasFlag(System.IO.FileAttributes.ReparsePoint) && (di.Attributes.HasFlag(System.IO.FileAttributes.Directory) && !shouldRecurse))
+
+                            if (ExperimentalFeature.IsEnabled(ExperimentalFeature.PSForceRemoveReparsePoint))
+                            {
+                                if (di != null && di.Attributes.HasFlag(System.IO.FileAttributes.ReparsePoint) && (di.Attributes.HasFlag(System.IO.FileAttributes.Directory) && !shouldRecurse))
+                                {
+                                    shouldRecurse = false;
+                                    treatAsFile = true;
+                                }
+                            }
+                            else if (di != null && (di.Attributes & System.IO.FileAttributes.ReparsePoint) != 0)
                             {
                                 shouldRecurse = false;
                                 treatAsFile = true;

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -22,6 +22,7 @@ namespace System.Management.Automation
 
         internal const string EngineSource = "PSEngine";
         internal const string PSAnsiProgressFeatureName = "PSAnsiProgress";
+        internal const string PSForceRemoveReparsePoint = "PSForceRemoveReparsePoint";
 
         #endregion
 
@@ -136,6 +137,9 @@ namespace System.Management.Automation
                 new ExperimentalFeature(
                     name: PSAnsiProgressFeatureName,
                     description: "Enable lightweight progress bar that leverages ANSI codes for rendering"),
+                new ExperimentalFeature(
+                    name: PSForceRemoveReparsePoint,
+                    description: "Enable -Force to remove reparsepoint folders like on OneDrive"),
             };
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -3108,6 +3108,10 @@ namespace Microsoft.PowerShell.Commands
             {
                 try
                 {
+                    // For non-reparse points, the behavior is to manually recurse so if `-Confirm` is used, then the user
+                    // gets a confirmation at each level.  Unfortunately, a reparse point behaves differently and requires
+                    // the `Delete(recursive)` overload to successfully delete the folder (like a OneDrive folder).
+                    // Symlinks are still treated as files.
                     directory.Delete(recursive: recurse);
                 }
                 catch (Exception e)

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -3108,12 +3108,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 try
                 {
-                    // TODO:
-                    // Different symlinks seem to vary by behavior.
-                    // In particular, OneDrive symlinks won't remove without recurse,
-                    // but the .NET API here does not allow us to distinguish them.
-                    // We may need to revisit using p/Invokes here to get the right behavior
-                    directory.Delete();
+                    directory.Delete(recursive: recurse);
                 }
                 catch (Exception e)
                 {

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -3108,11 +3108,18 @@ namespace Microsoft.PowerShell.Commands
             {
                 try
                 {
-                    // For non-reparse points, the behavior is to manually recurse so if `-Confirm` is used, then the user
-                    // gets a confirmation at each level.  Unfortunately, a reparse point behaves differently and requires
-                    // the `Delete(recursive)` overload to successfully delete the folder (like a OneDrive folder).
-                    // Symlinks are still treated as files.
-                    directory.Delete(recursive: recurse);
+                    if (force && ExperimentalFeature.IsEnabled(ExperimentalFeature.PSForceRemoveReparsePoint))
+                    {
+                        // For non-reparse points, the behavior is to manually recurse so if `-Confirm` is used, then the user
+                        // gets a confirmation at each level.  Unfortunately, a reparse point behaves differently and requires
+                        // the `Delete(recursive)` overload to successfully delete the folder (like a OneDrive folder).
+                        // Symlinks are still treated as files.
+                        directory.Delete(recursive: recurse);
+                    }
+                    else
+                    {
+                        directory.Delete();
+                    }
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The FileSystemProvider treats all reparsepoints as symlinks (files) so that trying to recursively remove a directory from OneDrive fails as it won't recurse and thus fails because the directory is not empty.  Fix is to don't treat reparse points as files if it is also a directory and also pass the recurse flag to the Directory.Remove() overload only if `-Force` is specified.

The breaking change behavior is that if you use `-Recurse -Force -Confirm` then it will now only confirm the top level folder before removing compared to the previous behavior (for a non-Onedrive folder) which prompts to confirm for every item within the folder.

Manually validated that removing nested non-empty folder on OneDrive works and also removing a directory symlink removes the symlink and not the target.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/9246

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [X] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [X] Experimental feature name(s): `PSForceRemoveReparsePoint`
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
