### PR TITLE
Enhance Remove-Item to work with OneDrive

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
@@ -2699,7 +2699,7 @@ namespace Microsoft.PowerShell.Commands
                         try
                         {
                             System.IO.DirectoryInfo di = new(providerPath);
-                            if (di != null && (di.Attributes & System.IO.FileAttributes.ReparsePoint) != 0)
+                            if (di != null && InternalSymbolicLinkLinkCodeMethods.IsReparsePointLikeSymlink(di))
                             {
                                 shouldRecurse = false;
                                 treatAsFile = true;

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -2099,7 +2099,12 @@ namespace System.Management.Automation.Internal
 
         internal static bool ThrowExdevErrorOnMoveDirectory;
 
-        internal static bool EmulateOneDrive;
+        // To emulate OneDrive behavior we use the hard-coded symlink.
+        // If OneDriveTestRecuseOn is false then the symlink works as regular symlink.
+        // If OneDriveTestRecuseOn is true then we resurce into the symlink as OneDrive should work.
+        internal static bool OneDriveTestOn;
+        internal static bool OneDriveTestRecuseOn;
+        internal static string OneDriveTestSymlinkName = "link-Beta";
 
         /// <summary>This member is used for internal test purposes.</summary>
         public static void SetTestHook(string property, object value)

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1863,7 +1863,7 @@ namespace System.Management.Automation
 
             if (ExperimentalFeature.IsEnabled("PSAnsiRendering"))
             {
-                PSStyle psstyle = PSStyle.Instance;                
+                PSStyle psstyle = PSStyle.Instance;
                 switch (formatStyle)
                 {
                     case FormatStyle.Reset:
@@ -2098,6 +2098,8 @@ namespace System.Management.Automation.Internal
         internal static bool ShowMarkdownOutputBypass;
 
         internal static bool ThrowExdevErrorOnMoveDirectory;
+
+        internal static bool EmulateOneDrive;
 
         /// <summary>This member is used for internal test purposes.</summary>
         public static void SetTestHook(string property, object value)

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -2103,7 +2103,7 @@ namespace System.Management.Automation.Internal
         // If OneDriveTestRecuseOn is false then the symlink works as regular symlink.
         // If OneDriveTestRecuseOn is true then we resurce into the symlink as OneDrive should work.
         internal static bool OneDriveTestOn;
-        internal static bool OneDriveTestRecuseOn;
+        internal static bool OneDriveTestRecurseOn;
         internal static string OneDriveTestSymlinkName = "link-Beta";
 
         /// <summary>This member is used for internal test purposes.</summary>

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -3101,6 +3101,11 @@ namespace Microsoft.PowerShell.Commands
         {
             Dbg.Diagnostics.Assert(directory != null, "Caller should always check directory");
 
+            if (InternalTestHooks.OneDriveTestOn && !InternalTestHooks.OneDriveTestRecuseOn && directory.Name == InternalTestHooks.OneDriveTestSymlinkName)
+            {
+                return;
+            }
+
             bool continueRemoval = true;
 
             // We only want to confirm the removal if this is the root of the
@@ -8254,9 +8259,9 @@ namespace Microsoft.PowerShell.Commands
             // Reparse point on Unix is a symlink.
             return IsReparsePoint(fileInfo);
 #else
-            if (InternalTestHooks.EmulateOneDrive)
+            if (InternalTestHooks.OneDriveTestOn && fileInfo.Name == InternalTestHooks.OneDriveTestSymlinkName)
             {
-                return fileInfo.Name != "link-Beta";
+                return !InternalTestHooks.OneDriveTestRecuseOn;
             }
 
             WIN32_FIND_DATA data = default;

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -8254,6 +8254,11 @@ namespace Microsoft.PowerShell.Commands
             // Reparse point on Unix is a symlink.
             return IsReparsePoint(fileInfo);
 #else
+            if (InternalTestHooks.EmulateOneDrive)
+            {
+                return fileInfo.Name != "link-Beta";
+            }
+
             WIN32_FIND_DATA data = default;
             using (var handle = FindFirstFileEx(fileInfo.FullName, FINDEX_INFO_LEVELS.FindExInfoBasic, ref data, FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero, 0))
             {

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -3101,12 +3101,6 @@ namespace Microsoft.PowerShell.Commands
         {
             Dbg.Diagnostics.Assert(directory != null, "Caller should always check directory");
 
-            //if (InternalTestHooks.OneDriveTestOn && !InternalTestHooks.OneDriveTestRecuseOn && directory.Name == InternalTestHooks.OneDriveTestSymlinkName)
-            //{
-            //    WriteError(new ErrorRecord(exception: null, errorId: "DeleteSymbolicLinkFailed", ErrorCategory.WriteError, directory));
-            //    return;
-            //}
-
             bool continueRemoval = true;
 
             // We only want to confirm the removal if this is the root of the
@@ -3120,11 +3114,16 @@ namespace Microsoft.PowerShell.Commands
 
             if (InternalSymbolicLinkLinkCodeMethods.IsReparsePointLikeSymlink(directory))
             {
+                void WriteErrorHelper(Exception exception)
+                {
+                    WriteError(new ErrorRecord(exception, errorId: "DeleteSymbolicLinkFailed", ErrorCategory.WriteError, directory));
+                }
+
                 try
                 {
                     if (InternalTestHooks.OneDriveTestOn)
                     {
-                        WriteError(new ErrorRecord(new IOException(), errorId: "DeleteSymbolicLinkFailed", ErrorCategory.WriteError, directory));
+                        WriteErrorHelper(new IOException());
                         return;
                     }
                     else
@@ -3137,7 +3136,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     string error = StringUtil.Format(FileSystemProviderStrings.CannotRemoveItem, directory.FullName, e.Message);
                     var exception = new IOException(error, e);
-                    WriteError(new ErrorRecord(exception, errorId: "DeleteSymbolicLinkFailed", ErrorCategory.WriteError, directory));
+                    WriteErrorHelper(exception);
                 }
 
                 return;

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -8255,7 +8255,10 @@ namespace Microsoft.PowerShell.Commands
                     return true;
                 }
 
-                if ((data.dwReserved0 & 0x0400) == 0)
+                // To exclude one extra p/invoke in some scenarios
+                // we don't check fileInfo.FileAttributes
+                const int FILE_ATTRIBUTE_REPARSE_POINT = 0x0400;
+                if ((data.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) == 0)
                 {
                     // Not a reparse point.
                     return false;

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -8269,7 +8269,7 @@ namespace Microsoft.PowerShell.Commands
 #else
             if (InternalTestHooks.OneDriveTestOn && fileInfo.Name == InternalTestHooks.OneDriveTestSymlinkName)
             {
-                return !InternalTestHooks.OneDriveTestRecuseOn;
+                return !InternalTestHooks.OneDriveTestRecurseOn;
             }
 
             WIN32_FIND_DATA data = default;
@@ -8277,7 +8277,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 if (handle.IsInvalid)
                 {
-                    // It is our convention - if we can not open the file object we process it like a symlink.
+                    // If we can not open the file object we assume it's a symlink.
                     return true;
                 }
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -3101,10 +3101,11 @@ namespace Microsoft.PowerShell.Commands
         {
             Dbg.Diagnostics.Assert(directory != null, "Caller should always check directory");
 
-            if (InternalTestHooks.OneDriveTestOn && !InternalTestHooks.OneDriveTestRecuseOn && directory.Name == InternalTestHooks.OneDriveTestSymlinkName)
-            {
-                return;
-            }
+            //if (InternalTestHooks.OneDriveTestOn && !InternalTestHooks.OneDriveTestRecuseOn && directory.Name == InternalTestHooks.OneDriveTestSymlinkName)
+            //{
+            //    WriteError(new ErrorRecord(exception: null, errorId: "DeleteSymbolicLinkFailed", ErrorCategory.WriteError, directory));
+            //    return;
+            //}
 
             bool continueRemoval = true;
 
@@ -3121,8 +3122,16 @@ namespace Microsoft.PowerShell.Commands
             {
                 try
                 {
-                    // Name surrogates should just be detached.
-                    directory.Delete();
+                    if (InternalTestHooks.OneDriveTestOn)
+                    {
+                        WriteError(new ErrorRecord(new IOException(), errorId: "DeleteSymbolicLinkFailed", ErrorCategory.WriteError, directory));
+                        return;
+                    }
+                    else
+                    {
+                        // Name surrogates should just be detached.
+                        directory.Delete();
+                    }
                 }
                 catch (Exception e)
                 {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -626,10 +626,11 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
             try
             {
                 # '$betaDir' is a symlink - we don't follow symlinks
+                # This emulates PowerShell 6.2 and below behavior.
                 $ci = Get-ChildItem -Path $alphaDir -Recurse
                 $ci.Count | Should -BeExactly 7
 
-                # Now we follow the symlink like on OneDrive
+                # Now we follow the symlink like on OneDrive.
                 [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecuseOn', $true)
                 $ci = Get-ChildItem -Path $alphaDir -Recurse
                 $ci.Count | Should -BeExactly 10
@@ -782,7 +783,7 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
             try
             {
                 # With the test hook turned on we don't remove '$betaDir' symlink.
-                # This emulate PowerShell 7.1 and below behavior.
+                # This emulates PowerShell 7.1 and below behavior.
                 { Remove-Item -Path $betaLink -Recurse -ErrorAction Stop } | Should -Throw -ErrorId "DeleteSymbolicLinkFailed,Microsoft.PowerShell.Commands.RemoveItemCommand"
 
                 # Now we emulate OneDrive and follow the symlink like on OneDrive.

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -563,7 +563,7 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
             $omegaFile1 = Join-Path $omegaDir "OmegaFile1"
             $omegaFile2 = Join-Path $omegaDir "OmegaFile2"
             $betaDir = Join-Path $alphaDir "sub-Beta"
-            $betaLink = Join-Path $alphaDir "link-Beta" # Don't change! The name is hard-code in PowerShell for OneDrive tests.
+            $betaLink = Join-Path $alphaDir "link-Beta" # Don't change! The name is hard-coded in PowerShell for OneDrive tests.
             $betaFile1 = Join-Path $betaDir "BetaFile1.txt"
             $betaFile2 = Join-Path $betaDir "BetaFile2.txt"
             $betaFile3 = Join-Path $betaDir "BetaFile3.txt"
@@ -622,7 +622,7 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
             #New-Item -ItemType SymbolicLink -Path $betaLink -Value $betaDir
 
             [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestOn', $true)
-            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecuseOn', $false)
+            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecurseOn', $false)
             try
             {
                 # '$betaDir' is a symlink - we don't follow symlinks
@@ -631,13 +631,13 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
                 $ci.Count | Should -BeExactly 7
 
                 # Now we follow the symlink like on OneDrive.
-                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecuseOn', $true)
+                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecurseOn', $true)
                 $ci = Get-ChildItem -Path $alphaDir -Recurse
                 $ci.Count | Should -BeExactly 10
             }
             finally
             {
-                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecuseOn', $false)
+                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecurseOn', $false)
                 [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestOn', $false)
             }
         }
@@ -779,7 +779,7 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
             New-Item -ItemType SymbolicLink -Path $betaLink -Value $betaDir > $null
 
             [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestOn', $true)
-            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecuseOn', $false)
+            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecurseOn', $false)
             try
             {
                 # With the test hook turned on we don't remove '$betaDir' symlink.
@@ -787,13 +787,13 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
                 { Remove-Item -Path $betaLink -Recurse -ErrorAction Stop } | Should -Throw -ErrorId "DeleteSymbolicLinkFailed,Microsoft.PowerShell.Commands.RemoveItemCommand"
 
                 # Now we emulate OneDrive and follow the symlink like on OneDrive.
-                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecuseOn', $true)
+                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecurseOn', $true)
                 Remove-Item -Path $betaLink -Recurse
                 Test-Path -Path $betaLink | Should -BeFalse
             }
             finally
             {
-                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecuseOn', $false)
+                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecurseOn', $false)
                 [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestOn', $false)
             }
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -781,13 +781,14 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
             [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecuseOn', $false)
             try
             {
-                # '$betaDir' is a symlink - we don't follow symlinks
-                { Remove-Item -Path $alphaDir -Recurse -ErrorAction Stop } | Should -Throw -ErrorId "DeleteSymbolicLinkFailed,Microsoft.PowerShell.Commands.RemoveItemCommand"
+                # With the test hook turned on we don't remove '$betaDir' symlink.
+                # This emulate PowerShell 7.1 and below behavior.
+                { Remove-Item -Path $betaLink -Recurse -ErrorAction Stop } | Should -Throw -ErrorId "DeleteSymbolicLinkFailed,Microsoft.PowerShell.Commands.RemoveItemCommand"
 
-                # Now we follow the symlink like on OneDrive
+                # Now we emulate OneDrive and follow the symlink like on OneDrive.
                 [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecuseOn', $true)
-                Remove-Item -Path $alphaDir -Recurse
-                Test-Item -Path $alphaDir | Should -BeFalse
+                Remove-Item -Path $betaLink -Recurse
+                Test-Path -Path $betaLink | Should -BeFalse
             }
             finally
             {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -563,7 +563,7 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
             $omegaFile1 = Join-Path $omegaDir "OmegaFile1"
             $omegaFile2 = Join-Path $omegaDir "OmegaFile2"
             $betaDir = Join-Path $alphaDir "sub-Beta"
-            $betaLink = Join-Path $alphaDir "link-Beta"
+            $betaLink = Join-Path $alphaDir "link-Beta" # Don't change! The name is hard-code in PowerShell for OneDrive tests.
             $betaFile1 = Join-Path $betaDir "BetaFile1.txt"
             $betaFile2 = Join-Path $betaDir "BetaFile2.txt"
             $betaFile3 = Join-Path $betaDir "BetaFile3.txt"
@@ -620,6 +620,9 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
             # The test depends on the files created in previous test:
             #New-Item -ItemType SymbolicLink -Path $alphaLink -Value $alphaDir
             #New-Item -ItemType SymbolicLink -Path $betaLink -Value $betaDir
+
+            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestOn', $true)
+            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecuseOn', $false)
             try
             {
                 # '$betaDir' is a symlink - we don't follow symlinks
@@ -627,13 +630,14 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
                 $ci.Count | Should -BeExactly 7
 
                 # Now we follow the symlink like on OneDrive
-                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('EmulateOneDrive', $true)
+                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecuseOn', $true)
                 $ci = Get-ChildItem -Path $alphaDir -Recurse
                 $ci.Count | Should -BeExactly 10
             }
             finally
             {
-                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('EmulateOneDrive', $false)
+                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecuseOn', $false)
+                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestOn', $false)
             }
         }
         It "Get-ChildItem will recurse into symlinks given -FollowSymlink, avoiding link loops" {
@@ -757,6 +761,41 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
             $childB.Count | Should -BeExactly $childA.Count
             $childB.Name | Should -BeExactly $childA.Name
         }
+        It "Remove-Item will recurse into emulated OneDrive directory" -Skip:(-not $IsWindows) {
+            $alphaDir = Join-Path $TestDrive "sub-alpha2"
+            $alphaLink = Join-Path $TestDrive "link-alpha2"
+            $alphaFile1 = Join-Path $alphaDir "AlphaFile1.txt"
+            $betaDir = Join-Path $alphaDir "sub-Beta"
+            $betaLink = Join-Path $alphaDir "link-Beta"
+            $betaFile1 = Join-Path $betaDir "BetaFile1.txt"
+
+            New-Item -ItemType Directory -Path $alphaDir > $null
+            New-Item -ItemType File -Path $alphaFile1 > $null
+            New-Item -ItemType Directory -Path $betaDir > $null
+            New-Item -ItemType File -Path $betaFile1 > $null
+
+            New-Item -ItemType SymbolicLink -Path $alphaLink -Value $alphaDir > $null
+            New-Item -ItemType SymbolicLink -Path $betaLink -Value $betaDir > $null
+
+            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestOn', $true)
+            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecuseOn', $false)
+            try
+            {
+                # '$betaDir' is a symlink - we don't follow symlinks
+                { Remove-Item -Path $alphaDir -Recurse -ErrorAction Stop } | Should -Throw -ErrorId "DeleteSymbolicLinkFailed,Microsoft.PowerShell.Commands.RemoveItemCommand"
+
+                # Now we follow the symlink like on OneDrive
+                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecuseOn', $true)
+                Remove-Item -Path $alphaDir -Recurse
+                Test-Item -Path $alphaDir | Should -BeFalse
+            }
+            finally
+            {
+                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecuseOn', $false)
+                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestOn', $false)
+            }
+        }
+
     }
 }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Before the fix only enumeration (Get-ChildItem) worked on OneDrive. 
Now Remove-Item correctly removes folders and files on OneDrive too.

1. Enhance IsReparsePointLikeSymlink() method so that exclude non named surrogates from reparse points. As result PowerShell recurse into such reparse points which is a OneDrive entities.
1.  Use updated IsReparsePointLikeSymlink() method in RemoveDirectoryInfoItem() and NameString() methods 
1. Add new tests and a test hook to emulate old PowerShell behavior and test new PowerShell behavior on OneDrive.
1. Add small perf improvement in Dir() and IsReparsePointLikeSymlink() methods to exclude extra p/invoke in most scenarios. 

## PR Context

Replace #14860

Related #9246


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
