### PR TITLE
Fix `Move-Item` for FileSystemProvider to use copy-delete instead of move for DFS paths

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -6098,7 +6098,7 @@ namespace Microsoft.PowerShell.Commands
 
                 directory.MoveTo(destinationPath);
             }
-            catch (IOException)
+            catch (IOException e) when (e is not FileNotFoundException && e is not DirectoryNotFoundException && e is not PathTooLongException)
             {
                 // If move doesn't work because the source and destination are on different volumes (like DFS), fall back to CopyAndDelete
                 CopyAndDelete(directory, destinationPath, force);

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -6093,22 +6093,13 @@ namespace Microsoft.PowerShell.Commands
                 CopyAndDelete(directory, destinationPath, force);
             }
 #else
-            // On Windows, being able to rename vs copy/delete a file
-            // is just a question of the drive
-            if (IsSameWindowsVolume(directory.FullName, destinationPath))
+            try
             {
-                try
-                {
-                    directory.MoveTo(destinationPath);
-                }
-                catch (IOException e) when (e.HResult == ERROR_ACCESS_DENIED)
-                {
-                    // If move doesn't work because the source and destination are on different volumes (like DFS), fall back to CopyAndDelete
-                    CopyAndDelete(directory, destinationPath, force);
-                }
+                directory.MoveTo(destinationPath);
             }
-            else
+            catch (IOException e) when (e.HResult == ERROR_ACCESS_DENIED)
             {
+                // If move doesn't work because the source and destination are on different volumes (like DFS), fall back to CopyAndDelete
                 CopyAndDelete(directory, destinationPath, force);
             }
 #endif
@@ -6148,16 +6139,6 @@ namespace Microsoft.PowerShell.Commands
                 RemoveItem(directory.FullName, false);
             }
         }
-
-#if !UNIX
-        private static bool IsSameWindowsVolume(string source, string destination)
-        {
-            FileInfo src = new FileInfo(source);
-            FileInfo dest = new FileInfo(destination);
-
-            return (src.Directory.Root.Name == dest.Directory.Root.Name);
-        }
-#endif
 
         #endregion MoveItem
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -6143,6 +6143,15 @@ namespace Microsoft.PowerShell.Commands
             FileInfo src = new FileInfo(source);
             FileInfo dest = new FileInfo(destination);
 
+            // DFS shares will have same root name, but are actually different volumes
+            // Since we cannot determine a path is a DFS share or a SMB share, we
+            // treat all UNC paths as being on different volumes which results
+            // in a copy-delete operation instead of a move which will fail across volumes
+            if (Utils.PathIsUnc(source) || Utils.PathIsUnc(destination))
+            {
+                return false;
+            }
+
             return (src.Directory.Root.Name == dest.Directory.Root.Name);
         }
 #endif

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -54,7 +54,10 @@ namespace Microsoft.PowerShell.Commands
 #if UNIX
         // This is the errno returned by the rename() syscall
         // when an item is attempted to be renamed across filesystem mount boundaries.
-        private const int UNIX_ERRNO_EXDEV = 18;
+        private const int MOVE_FAILED_ERROR = 18;
+#else
+        // 0x80070005 ACCESS_DENIED is returned when trying to move files across volumes like DFS
+        private const int MOVE_FAILED_ERROR = -2147024891;
 #endif
 
         // 4MB gives the best results without spiking the resources on the remote connection for file transfers between pssessions.
@@ -6071,39 +6074,22 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="force">If true, force move the directory, overwriting anything at the destination.</param>
         private void MoveDirectoryInfoUnchecked(DirectoryInfo directory, string destinationPath, bool force)
         {
-#if UNIX
             try
             {
                 if (InternalTestHooks.ThrowExdevErrorOnMoveDirectory)
                 {
-                    throw new IOException("Invalid cross-device link", hresult: UNIX_ERRNO_EXDEV);
+                    throw new IOException("Invalid cross-device link", hresult: MOVE_FAILED_ERROR);
                 }
 
                 directory.MoveTo(destinationPath);
             }
-            catch (IOException e) when (e.HResult == UNIX_ERRNO_EXDEV)
+            catch (IOException e) when (e.HResult == MOVE_FAILED_ERROR)
             {
                 // Rather than try to ascertain whether we can rename a directory ahead of time,
                 // it's both faster and more correct to try to rename it and fall back to copy/deleting it
                 // See also: https://github.com/coreutils/coreutils/blob/439741053256618eb651e6d43919df29625b8714/src/mv.c#L212-L216
                 CopyAndDelete(directory, destinationPath, force);
             }
-#else
-            try
-            {
-                if (InternalTestHooks.ThrowExdevErrorOnMoveDirectory)
-                {
-                    throw new IOException("Invalid cross-device link");
-                }
-
-                directory.MoveTo(destinationPath);
-            }
-            catch (IOException e) when (e is not FileNotFoundException && e is not DirectoryNotFoundException && e is not PathTooLongException)
-            {
-                // If move doesn't work because the source and destination are on different volumes (like DFS), fall back to CopyAndDelete
-                CopyAndDelete(directory, destinationPath, force);
-            }
-#endif
         }
 
         private void CopyAndDelete(DirectoryInfo directory, string destination, bool force)

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -154,7 +154,7 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
         }
 
         It "Verify Move-Item will not move to an existing file" {
-            { Move-Item -Path $testDir -Destination $testFile -ErrorAction Stop } | Should -Throw -ErrorId "MoveDirectoryItemIOError,Microsoft.PowerShell.Commands.MoveItemCommand"
+            { Move-Item -Path $testDir -Destination $testFile -ErrorAction Stop } | Should -Throw -ErrorId "DirectoryExist,Microsoft.PowerShell.Commands.MoveItemCommand"
             $error[0].Exception | Should -BeOfType System.IO.IOException
             $testDir | Should -Exist
         }
@@ -296,7 +296,7 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
             # @{cmdline = "New-Item -Type File -Path $newItemPath -ErrorAction Stop"; expectedError = "NewItemUnauthorizedAccessError,Microsoft.PowerShell.Commands.NewItemCommand"}
             @{cmdline = "Get-ChildItem $protectedPath -ErrorAction Stop"; expectedError = "DirUnauthorizedAccessError,Microsoft.PowerShell.Commands.GetChildItemCommand"}
             @{cmdline = "Rename-Item -Path $protectedPath -NewName bar -ErrorAction Stop"; expectedError = "RenameItemIOError,Microsoft.PowerShell.Commands.RenameItemCommand"},
-            @{cmdline = "Move-Item -Path $protectedPath -Destination bar -ErrorAction Stop"; expectedError = "MoveDirectoryItemIOError,Microsoft.PowerShell.Commands.MoveItemCommand"}
+            @{cmdline = "Move-Item -Path $protectedPath -Destination bar -ErrorAction Stop"; expectedError = "MoveDirectoryItemUnauthorizedAccessError,Microsoft.PowerShell.Commands.MoveItemCommand"}
         ) {
             param ($cmdline, $expectedError)
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -154,7 +154,7 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
         }
 
         It "Verify Move-Item will not move to an existing file" {
-            { Move-Item -Path $testDir -Destination $testFile -ErrorAction Stop } | Should -Throw -ErrorId "DirectoryExist,Microsoft.PowerShell.Commands.MoveItemCommand"
+            { Move-Item -Path $testDir -Destination $testFile -ErrorAction Stop } | Should -Throw -ErrorId "MoveDirectoryItemIOError,Microsoft.PowerShell.Commands.MoveItemCommand"
             $error[0].Exception | Should -BeOfType System.IO.IOException
             $testDir | Should -Exist
         }
@@ -296,7 +296,7 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
             # @{cmdline = "New-Item -Type File -Path $newItemPath -ErrorAction Stop"; expectedError = "NewItemUnauthorizedAccessError,Microsoft.PowerShell.Commands.NewItemCommand"}
             @{cmdline = "Get-ChildItem $protectedPath -ErrorAction Stop"; expectedError = "DirUnauthorizedAccessError,Microsoft.PowerShell.Commands.GetChildItemCommand"}
             @{cmdline = "Rename-Item -Path $protectedPath -NewName bar -ErrorAction Stop"; expectedError = "RenameItemIOError,Microsoft.PowerShell.Commands.RenameItemCommand"},
-            @{cmdline = "Move-Item -Path $protectedPath -Destination bar -ErrorAction Stop"; expectedError = "MoveDirectoryItemUnauthorizedAccessError,Microsoft.PowerShell.Commands.MoveItemCommand"}
+            @{cmdline = "Move-Item -Path $protectedPath -Destination bar -ErrorAction Stop"; expectedError = "MoveDirectoryItemIOError,Microsoft.PowerShell.Commands.MoveItemCommand"}
         ) {
             param ($cmdline, $expectedError)
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -287,6 +287,13 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
                 $newItemPath = Join-Path $protectedPath "foo"
                 $shouldSkip = -not (Test-Path $protectedPath)
             }
+
+            if ($IsWindows) {
+                $fqaccessdenied = "MoveDirectoryItemUnauthorizedAccessError,Microsoft.PowerShell.Commands.MoveItemCommand"
+            }
+            else {
+                $fqaccessdenied = "MoveDirectoryItemIOError,Microsoft.PowerShell.Commands.MoveItemCommand"
+            }
         }
 
         It "Access-denied test for <cmdline>" -Skip:(-not $IsWindows -or $shouldSkip) -TestCases @(
@@ -296,7 +303,7 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
             # @{cmdline = "New-Item -Type File -Path $newItemPath -ErrorAction Stop"; expectedError = "NewItemUnauthorizedAccessError,Microsoft.PowerShell.Commands.NewItemCommand"}
             @{cmdline = "Get-ChildItem $protectedPath -ErrorAction Stop"; expectedError = "DirUnauthorizedAccessError,Microsoft.PowerShell.Commands.GetChildItemCommand"}
             @{cmdline = "Rename-Item -Path $protectedPath -NewName bar -ErrorAction Stop"; expectedError = "RenameItemIOError,Microsoft.PowerShell.Commands.RenameItemCommand"},
-            @{cmdline = "Move-Item -Path $protectedPath -Destination bar -ErrorAction Stop"; expectedError = "MoveDirectoryItemIOError,Microsoft.PowerShell.Commands.MoveItemCommand"}
+            @{cmdline = "Move-Item -Path $protectedPath -Destination bar -ErrorAction Stop"; expectedError = $fqaccessdenied}
         ) {
             param ($cmdline, $expectedError)
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

When using `Move-Item` between DFS paths, the FileSystemProvider will decide whether to use the .NET `Move()` or a `Copy()` and `Delete()` operation based on comparing the root path of the source and destination.  This will work whenever the source and destination are on the same volume, but results in an Access Denied error message if not.  In the case of DFS paths, they look like SMB share paths but typically are on different volumes so the move fails with Access Denied.

There is a Win32 API that could be used to determine if a UNC path is DFS, but it appears there is a timeout of around 1 second when the path is NOT DFS, so that's too big of an impact for normal usage. 

Fix is to try `MoveTo()` as that is much faster on the same volume.  If that fails, we check the HResult to see if it's Access Denied (0x80070005) and if so (as this is what is returned in DFS scenario) we fallback to `CopyAndDelete()`.

Tested manually on a VM with DFS shares.

## PR Context

Reported through Microsoft customer support

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
