### PR TITLE
Add UseOSCIndicator setting to enable progress indicator in terminal

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceProgress.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceProgress.cs
@@ -47,6 +47,13 @@ namespace Microsoft.PowerShell
                 }
 
                 _pendingProgress = null;
+
+                if (ExperimentalFeature.IsEnabled(ExperimentalFeature.PSAnsiProgressFeatureName) && PSStyle.Instance.Progress.UseOSCIndicator)
+                {
+                    // OSC sequence to turn off progress indicator
+                    // https://github.com/microsoft/terminal/issues/6700
+                    Console.Write("\x1b]9;4;0\x1b\\");
+                }
             }
         }
 
@@ -92,6 +99,21 @@ namespace Microsoft.PowerShell
             {
                 // Update the progress pane only when the timer set up the update flag or WriteProgress is completed.
                 // As a result, we do not block WriteProgress and whole script and eliminate unnecessary console locks and updates.
+                if (ExperimentalFeature.IsEnabled(ExperimentalFeature.PSAnsiProgressFeatureName) && PSStyle.Instance.Progress.UseOSCIndicator)
+                {
+                    // OSC sequence to turn off progress indicator
+                    // https://github.com/microsoft/terminal/issues/6700
+                    int percentComplete = record.PercentComplete;
+                    if (percentComplete < 0)
+                    {
+                        // Write-Progress allows for negative percent complete, but not greater than 100
+                        // but OSC sequence is limited from 0 to 100.
+                        percentComplete = 0;
+                    }
+
+                    Console.Write($"\x1b]9;4;1;{percentComplete}\x1b\\");
+                }
+
                 _progPane.Show(_pendingProgress);
             }
         }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceProgress.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceProgress.cs
@@ -101,8 +101,6 @@ namespace Microsoft.PowerShell
                 // As a result, we do not block WriteProgress and whole script and eliminate unnecessary console locks and updates.
                 if (ExperimentalFeature.IsEnabled(ExperimentalFeature.PSAnsiProgressFeatureName) && PSStyle.Instance.Progress.UseOSCIndicator)
                 {
-                    // OSC sequence to turn off progress indicator
-                    // https://github.com/microsoft/terminal/issues/6700
                     int percentComplete = record.PercentComplete;
                     if (percentComplete < 0)
                     {
@@ -111,6 +109,8 @@ namespace Microsoft.PowerShell
                         percentComplete = 0;
                     }
 
+                    // OSC sequence to turn on progress indicator
+                    // https://github.com/microsoft/terminal/issues/6700
                     Console.Write($"\x1b]9;4;1;{percentComplete}\x1b\\");
                 }
 

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1687,8 +1687,8 @@ namespace System.Management.Automation.Runspaces
         }
 
         private const string PreReleaseStringScriptBlock = @"
-                            if ($_.PrivateData -and 
-                                $_.PrivateData.ContainsKey('PSData') -and 
+                            if ($_.PrivateData -and
+                                $_.PrivateData.ContainsKey('PSData') -and
                                 $_.PrivateData.PSData.ContainsKey('PreRelease'))
                             {
                                     $_.PrivateData.PSData.PreRelease
@@ -2055,6 +2055,7 @@ namespace System.Management.Automation.Runspaces
                         .AddItemScriptBlock(@"""$($_.Progress.Style)$($_.Progress.Style.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "Progress.Style")
                         .AddItemScriptBlock(@"""$($_.Progress.MaxWidth)""", label: "Progress.MaxWidth")
                         .AddItemScriptBlock(@"""$($_.Progress.View)""", label: "Progress.View")
+                        .AddItemScriptBlock(@"""$($_.Progress.UseOSCIndicator)""", label: "Progress.UseOSCIndicator")
                         .AddItemScriptBlock(@"""$($_.Foreground.Black)$($_.Foreground.Black.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "Foreground.Black")
                         .AddItemScriptBlock(@"""$($_.Foreground.White)$($_.Foreground.White.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "Foreground.White")
                         .AddItemScriptBlock(@"""$($_.Foreground.DarkGray)$($_.Foreground.DarkGray.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "Foreground.DarkGray")
@@ -2114,6 +2115,7 @@ namespace System.Management.Automation.Runspaces
                         .AddItemScriptBlock(@"""$($_.Style)$($_.Style.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "Style")
                         .AddItemProperty(@"MaxWidth")
                         .AddItemProperty(@"View")
+                        .AddItemProperty(@"UseOSCIndicator")
                     .EndEntry()
                 .EndList());
         }

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -292,8 +292,7 @@ namespace System.Management.Automation
             public ProgressView View { get; set; } = ProgressView.Minimal;
 
             /// <summary>
-            /// Enable use of OSC 9 4 to show indicator in terminal.
-            /// Ensure terminal supports this sequence before enabling.
+            /// Gets or sets a value indicating whether to use OSC 9 4 to show indicator in terminal.
             /// </summary>
             public bool UseOSCIndicator { get; set; } = false;
         }

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -292,7 +292,7 @@ namespace System.Management.Automation
             public ProgressView View { get; set; } = ProgressView.Minimal;
 
             /// <summary>
-            /// Gets or sets a value indicating whether to use OSC 9 4 to show indicator in terminal.
+            /// Gets or sets a value indicating whether to use Operating System Command (OSC) control sequences 'ESC ]9;4;' to show indicator in terminal.
             /// </summary>
             public bool UseOSCIndicator { get; set; } = false;
         }

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -290,6 +290,12 @@ namespace System.Management.Automation
             /// Gets or sets the view for progress bar.
             /// </summary>
             public ProgressView View { get; set; } = ProgressView.Minimal;
+
+            /// <summary>
+            /// Enable use of OSC 9 4 to show indicator in terminal.
+            /// Ensure terminal supports this sequence before enabling.
+            /// </summary>
+            public bool UseOSCIndicator { get; set; } = false;
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add new `$PSStyle.Progress.UseOSCIndicator` setting to use conemu's OSC indicator to show progress in the terminal window, which is also supported by Windows Terminal.  Since this is a custom OSC that isn't widely supported, it defaults to `$false`.  Since this is an advanced setting not supported by many terminals, had to give it a technical name.  iTerm2, for example, uses `ESC]9;` as a notification OSC sequence so you get a pop-up dialog instead of progress.

This is enabled as part of `PSAnsiProgress` experimental feature

![image](https://i.imgur.com/WJYh2OB.gif)

cc @dhowett

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [x] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [x] Experimental feature name(s): `PSAnsiProgress`
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/7304
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
