### PR TITLE
Turn on and off DECCKM to modify keyboard mode for unix native commands to work correctly

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -255,6 +255,11 @@ namespace Microsoft.PowerShell
 #if LEGACYTELEMETRY
                     TelemetryAPI.ReportExitTelemetry(s_theConsoleHost);
 #endif
+#if UNIX
+                    // https://github.com/dotnet/runtime/issues/27626 leaves terminal in application mode
+                    // for now, we explicitly emit DECRST 1 sequence
+                    s_theConsoleHost.UI.Write("\x1b[?1l");
+#endif
                     s_theConsoleHost.Dispose();
                 }
             }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -54,6 +54,10 @@ namespace Microsoft.PowerShell
         internal const int ExitCodeInitFailure = 70; // Internal Software Error
         internal const int ExitCodeBadCommandLineParameter = 64; // Command Line Usage Error
         private const uint SPI_GETSCREENREADER = 0x0046;
+#if UNIX
+        internal const string DECCKM_ON = "\x1b[?1h";
+        internal const string DECCKM_OFF = "\x1b[?1l";
+#endif
 
         [DllImport("user32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
@@ -260,7 +264,7 @@ namespace Microsoft.PowerShell
                     {
                         // https://github.com/dotnet/runtime/issues/27626 leaves terminal in application mode
                         // for now, we explicitly emit DECRST 1 sequence
-                        s_theConsoleHost.UI.Write("\x1b[?1l");
+                        s_theConsoleHost.UI.Write(DECCKM_OFF);
                     }
 #endif
                     s_theConsoleHost.Dispose();
@@ -2485,7 +2489,7 @@ namespace Microsoft.PowerShell
                         if (c.SupportsVirtualTerminal)
                         {
                             // enable DECCKM as .NET requires cursor keys to emit VT for Console class
-                            c.Write("\x1b[?1h");
+                            c.Write(DECCKM_ON);
                         }
 #endif
 
@@ -2596,7 +2600,7 @@ namespace Microsoft.PowerShell
                             if (c.SupportsVirtualTerminal)
                             {
                                 // disable DECCKM to standard mode as applications may not expect VT for cursor keys
-                                c.Write("\x1b[?1l");
+                                c.Write(DECCKM_OFF);
                             }
 #endif
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Dotnet runtime sets keyboard mode to application on Unix systems and does not currently reset on exit.  This change emits the DECRTS 1 sequence on pwsh exit on Unix systems (if VT is supported and interactive) to put keyboard mode back to default so that arrow keys do not emit escape sequences.

In the case of an interactive shell, we turn on DECCKM before showing prompt and turn if off before execution.  This follows what zsh does.

Validated manually with `gh auth login` works with these changes and fails without.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/12268

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
