### PR TITLE
Fix slow execution when many breakpoints are used

### DIFF
--- a/src/System.Management.Automation/engine/debugger/Breakpoint.cs
+++ b/src/System.Management.Automation/engine/debugger/Breakpoint.cs
@@ -93,7 +93,7 @@ namespace System.Management.Automation
             Enabled = true;
             Script = string.IsNullOrEmpty(script) ? null : script;
             Id = id;
-            Action = string.IsNullOrWhiteSpace(action?.ToString()) ? ScriptBlock.EmptyScriptBlock : action;
+            Action = action;
             HitCount = 0;
         }
 
@@ -107,11 +107,6 @@ namespace System.Management.Automation
             if (Action == null)
             {
                 return BreakpointAction.Break;
-            }
-
-            if (Action == ScriptBlock.EmptyScriptBlock)
-            {
-                return BreakpointAction.Continue;
             }
 
             try

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -1692,7 +1692,7 @@ namespace System.Management.Automation
         }
 
         private readonly ExecutionContext _context;
-        private ConcurrentDictionary<string, ConcurrentDictionary<int, LineBreakpoint>> _pendingBreakpoints;
+        private readonly ConcurrentDictionary<string, ConcurrentDictionary<int, LineBreakpoint>> _pendingBreakpoints;
         private readonly ConcurrentDictionary<string, Tuple<WeakReference, ConcurrentDictionary<int, LineBreakpoint>>> _boundBreakpoints;
         private readonly ConcurrentDictionary<int, CommandBreakpoint> _commandBreakpoints;
         private readonly ConcurrentDictionary<string, ConcurrentDictionary<int, VariableBreakpoint>> _variableBreakpoints;

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -1264,8 +1264,7 @@ namespace System.Management.Automation
             _pendingBreakpoints.AddOrUpdate(
                 breakpoint.Script,
                 new ConcurrentDictionary<int, LineBreakpoint> { [breakpoint.Id] = breakpoint },
-                (_, dictionary) => { dictionary.TryAdd(breakpoint.Id, breakpoint); return dictionary; }
-            );
+                (_, dictionary) => { dictionary.TryAdd(breakpoint.Id, breakpoint); return dictionary; });
         }
 
         private void AddNewBreakpoint(Breakpoint breakpoint)

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -1261,9 +1261,11 @@ namespace System.Management.Automation
 
         private void AddPendingBreakpoint(LineBreakpoint breakpoint)
         {
-            _pendingBreakpoints.AddOrUpdate(breakpoint.Script,
+            _pendingBreakpoints.AddOrUpdate(
+                breakpoint.Script,
                 new ConcurrentDictionary<int, LineBreakpoint> { [breakpoint.Id] = breakpoint },
-                (_, dictionary) => { dictionary.TryAdd(breakpoint.Id, breakpoint); return dictionary; });
+                (_, dictionary) => { dictionary.TryAdd(breakpoint.Id, breakpoint); return dictionary; }
+            );
         }
 
         private void AddNewBreakpoint(Breakpoint breakpoint)
@@ -2059,7 +2061,7 @@ namespace System.Management.Automation
                     }
                     else
                     {
-                        tuple.Item1.Add(breakpoint.SequencePointIndex , new List<LineBreakpoint> { breakpoint });
+                        tuple.Item1.Add(breakpoint.SequencePointIndex, new List<LineBreakpoint> { breakpoint });
                     } 
                     
                     // We need to keep track of any breakpoints that are bound in each script because they may

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -1320,7 +1320,7 @@ namespace System.Management.Automation
 
                 if (_pendingBreakpoints.TryGetValue(functionContext._file, out var dictionary))
                 {
-                    if (dictionary.Count > 0)
+                    if (!dictionary.IsEmpty)
                     {
                         SetPendingBreakpoints(functionContext);
                     }
@@ -2024,8 +2024,7 @@ namespace System.Management.Automation
             if (currentScriptFile == null)
                 return;
 
-
-            if (!_pendingBreakpoints.TryGetValue(currentScriptFile, out var breakpoints) || breakpoints.Count == 0)
+            if (!_pendingBreakpoints.TryGetValue(currentScriptFile, out var breakpoints) || breakpoints.IsEmpty)
                 return;
 
             // Normally we register a script file when the script is run or the module is imported,
@@ -2063,7 +2062,6 @@ namespace System.Management.Automation
                         tuple.Item1.Add(breakpoint.SequencePointIndex , new List<LineBreakpoint> { breakpoint });
                     } 
                     
-
                     // We need to keep track of any breakpoints that are bound in each script because they may
                     // need to be rebound if the script changes.
                     var boundBreakpoints = _boundBreakpoints[currentScriptFile].Item2;

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -2028,7 +2028,9 @@ namespace System.Management.Automation
                 return;
 
             if (!_pendingBreakpoints.TryGetValue(currentScriptFile, out var breakpoints) || breakpoints.IsEmpty)
+            {
                 return;
+            }
 
             // Normally we register a script file when the script is run or the module is imported,
             // but if there weren't any breakpoints when the script was run and the script was dotted,

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -782,7 +782,7 @@ namespace System.Management.Automation.Language
         internal ExecutionContext _executionContext;
         internal Pipe _outputPipe;
         internal BitArray _breakPoints;
-        internal List<LineBreakpoint> _boundBreakpoints;
+        internal Dictionary<int, List<LineBreakpoint>> _boundBreakpoints;
         internal int _currentSequencePointIndex;
         internal MutableTuple _localsTuple;
         internal List<Tuple<Type[], Action<FunctionContext>[], Type[]>> _traps = new List<Tuple<Type[], Action<FunctionContext>[], Type[]>>();


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

In Pester we use breakpoints in CodeCoverage and can set thousands of them. This makes execution of scripts really slow. This is because on every sequence point, every breakpoint is inspected to see if it should be bound. This PR uses dictionaries to split breakpoints by path, and by sequence point index, to make the lookup fast. 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [x] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
