### PR TITLE
Enable use of TERM and NO_COLOR env var plaintext

### DIFF
--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -1003,3 +1003,40 @@ Describe 'Console host name' -Tag CI {
         (Get-Process -Id $PID).Name | Should -BeExactly 'pwsh'
     }
 }
+
+Describe 'TERM env var' -Tag CI {
+    BeforeAll {
+        $oldTERM = $env:TERM
+        $PSDefaultParameterValues.Add('It:Skip', (-not $EnabledExperimentalFeatures.Contains('PSAnsiRendering')))
+    }
+
+    AfterAll {
+        $env:TERM = $oldTERM
+        $PSDefaultParameterValues.Remove('It:Skip')
+    }
+
+    It 'TERM = "dumb"' {
+        $env:TERM = 'dumb'
+        pwsh -noprofile -command '$Host.UI.SupportsVirtualTerminal' | Should -BeExactly 'False'
+    }
+
+    It 'TERM = "<term>"' -TestCases @(
+        @{ term = "xterm-mono" }
+        @{ term = "xtermm" }
+    ) {
+        param ($term)
+
+        $env:TERM = $term
+        pwsh -noprofile -command '$PSStyle.OutputRendering' | Should -BeExactly 'PlainText'
+    }
+
+    It 'NO_COLOR' {
+        try {
+            $env:NO_COLOR = 1
+            pwsh -noprofile -command '$PSStyle.OutputRendering' | Should -BeExactly 'PlainText'
+        }
+        finally {
+            $env:NO_COLOR = $null
+        }
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Respect `TERM` env var where:

`dumb` set SupportsVirtualTerminal = false
`xterm-mono` set $PSStyle.OutputRendering = PlainText
`xtermm` set $PSStyle.OutputRendering = PlainText

if `$env:NO_COLOR` exists, set $PSStyle.OutputRendering = PlainText

Note that if you try this interactively, PSReadLine doesn't respect these two values so on screen output will be hard to read as it still emits colors and cursor movements.  Created https://github.com/PowerShell/PSReadLine/issues/2277 to track this.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/14964
Fix #16059

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [X] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): `PSAnsiRendering`
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/7326
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
