### PR TITLE
SemanticVersion now handles metadata with no pre-release label present

### DIFF
--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -431,7 +431,7 @@ namespace System.Management.Automation
         // to be remove to work with the dotnet regex engine.
         // https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         private const string SemVer2RegEx = @"^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-(?<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$";
-        private const string SemVer2PreReleaseWithBuildMetadataRegEx = @"(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$";
+        private const string SemVer2PreReleaseWithBuildMetadataRegEx = @"(?:-(?<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$";
         private const string SingleDigitRegEx = @"^\d+$";
         private const string DoubleDigitRegEx = @"^\d+.\d+$";
         private const string PreLabelPropertyName = "PSSemVerPreReleaseLabel";

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -505,7 +505,7 @@ namespace System.Management.Automation
         public SemanticVersion(int major, int minor, int patch, string label)
             : this(major, minor, patch)
         {
-            // We presume the SymVer :
+            // We presume the SemVer :
             // 1) major.minor.patch-label
             // 2) 'label' starts with letter or digit.
             if (!string.IsNullOrEmpty(label))
@@ -643,12 +643,12 @@ namespace System.Management.Automation
         public int Patch { get; }
 
         /// <summary>
-        /// PreReleaseLabel position in the SymVer string 'major.minor.patch-PreReleaseLabel+BuildLabel'.
+        /// PreReleaseLabel position in the SemVer string 'major.minor.patch-PreReleaseLabel+BuildLabel'.
         /// </summary>
         public string PreReleaseLabel { get; }
 
         /// <summary>
-        /// BuildLabel position in the SymVer string 'major.minor.patch-PreReleaseLabel+BuildLabel'.
+        /// BuildLabel position in the SemVer string 'major.minor.patch-PreReleaseLabel+BuildLabel'.
         /// </summary>
         public string BuildLabel { get; }
 
@@ -827,7 +827,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Implement <see cref="IComparable{T}.CompareTo"/>.
-        /// Meets SymVer 2.0 p.11 https://semver.org/
+        /// Meets SemVer 2.0 p.11 https://semver.org/
         /// </summary>
         public int CompareTo(SemanticVersion value)
         {
@@ -843,7 +843,7 @@ namespace System.Management.Automation
             if (Patch != value.Patch)
                 return Patch > value.Patch ? 1 : -1;
 
-            // SymVer 2.0 standard requires to ignore 'BuildLabel' (Build metadata).
+            // SemVer 2.0 standard requires to ignore 'BuildLabel' (Build metadata).
             return ComparePreLabel(this.PreReleaseLabel, value.PreReleaseLabel);
         }
 
@@ -860,7 +860,7 @@ namespace System.Management.Automation
         /// </summary>
         public bool Equals(SemanticVersion other)
         {
-            // SymVer 2.0 standard requires to ignore 'BuildLabel' (Build metadata).
+            // SemVer 2.0 standard requires to ignore 'BuildLabel' (Build metadata).
             return other != null &&
                    (Major == other.Major) && (Minor == other.Minor) && (Patch == other.Patch) &&
                    string.Equals(PreReleaseLabel, other.PreReleaseLabel, StringComparison.Ordinal);

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -431,7 +431,8 @@ namespace System.Management.Automation
         // to be remove to work with the dotnet regex engine.
         // https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         private const string SemVer2RegEx = @"^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-(?<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$";
-        private const string SemVer2PreReleaseWithBuildMetadataRegEx = @"(?:-(?<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$";
+        private const string SemVer2PreReleaseRegEx = @"(?<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)";
+        private const string SemVer2MetadataRegEx = @"(?<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)";
         private const string SingleDigitRegEx = @"^\d+$";
         private const string DoubleDigitRegEx = @"^\d+.\d+$";
         private const string PreLabelPropertyName = "PSSemVerPreReleaseLabel";
@@ -472,20 +473,21 @@ namespace System.Management.Automation
         public SemanticVersion(int major, int minor, int patch, string preReleaseLabel, string buildLabel)
             : this(major, minor, patch)
         {
-            if (string.IsNullOrEmpty(preReleaseLabel) && string.IsNullOrEmpty(buildLabel))
+            if (!string.IsNullOrEmpty(preReleaseLabel))
             {
-                return;
+                var prereleaseResults = Regex.Match(preReleaseLabel, SemVer2PreReleaseRegEx);
+                if (prereleaseResults.Groups["prerelease"].Success)
+                {
+                    PreReleaseLabel = prereleaseResults.Groups["prerelease"].Value;
+                }
             }
-
-            var labelsCombined = preReleaseLabel + buildLabel;
-            var labelResults = Regex.Match(labelsCombined, SemVer2PreReleaseWithBuildMetadataRegEx);
-            if (labelResults.Groups["prerelease"].Success)
+            if (!string.IsNullOrEmpty(buildLabel))
             {
-                PreReleaseLabel = labelResults.Groups["prerelease"].Value;
-            }
-            if (labelResults.Groups["buildmetadata"].Success)
-            {
-                BuildLabel = labelResults.Groups["buildmetadata"].Value;
+                var metadataResults = Regex.Match(buildLabel, SemVer2MetadataRegEx);
+                if (metadataResults.Groups["buildmetadata"].Success)
+                {
+                    BuildLabel = metadataResults.Groups["buildmetadata"].Value;
+                }
             }
         }
 

--- a/test/powershell/engine/Basic/SemanticVersion.Tests.ps1
+++ b/test/powershell/engine/Basic/SemanticVersion.Tests.ps1
@@ -14,6 +14,14 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
             $v.BuildLabel | Should -Be "BLD.a1-xxx.03"
             $v.ToString() | Should -Be "1.2.3-Alpha-super.3+BLD.a1-xxx.03"
 
+            $v = [SemanticVersion]::new("0.1.23+Branch.main.Sha.05f7624c8c48ef6fa1da9e11601dec4584333e56")
+            $v.Major | Should -Be 0
+            $v.Minor | Should -Be 1
+            $v.Patch | Should -Be 23
+            $v.PreReleaseLabel | Should -BeNullOrEmpty
+            $v.BuildLabel | Should -Be "Branch.main.Sha.05f7624c8c48ef6fa1da9e11601dec4584333e56"
+            $v.ToString() | Should -Be "0.1.23+Branch.main.Sha.05f7624c8c48ef6fa1da9e11601dec4584333e56"
+
             $v = [SemanticVersion]::new("1.0.0")
             $v.Major | Should -Be 1
             $v.Minor | Should -Be 0
@@ -188,7 +196,6 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
             @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1.0.+alpha" }
             @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1.0.0-alpha+" }
             @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1.0.0-+" }
-            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1.0.0+-" }
             @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1.0.0+" }
             @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1.0.0-" }
             @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1.0.0." }

--- a/test/powershell/engine/Basic/SemanticVersion.Tests.ps1
+++ b/test/powershell/engine/Basic/SemanticVersion.Tests.ps1
@@ -14,6 +14,12 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
             $v.BuildLabel | Should -Be "BLD.a1-xxx.03"
             $v.ToString() | Should -Be "1.2.3-Alpha-super.3+BLD.a1-xxx.03"
 
+            $v = [SemanticVersion]::new("1.0.0+-")
+            $v.Major | Should -Be 1
+            $v.Minor | Should -Be 0
+            $v.Patch | Should -Be 0
+            $v.BuildLabel | Should -Be "-"
+
             $v = [SemanticVersion]::new("0.1.23+Branch.main.Sha.05f7624c8c48ef6fa1da9e11601dec4584333e56")
             $v.Major | Should -Be 0
             $v.Minor | Should -Be 1
@@ -208,6 +214,12 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
             @{ name = "Format errors";               errorId = "FormatException";    expectedResult = $false; version = "aa.0.0"  }
             @{ name = "Format errors";               errorId = "FormatException";    expectedResult = $false; version = "1.bb.0"  }
             @{ name = "Format errors";               errorId = "FormatException";    expectedResult = $false; version = "1.0.cc"  }
+            @{ name = "Format errors: 'Non-ascii'";  errorId = "FormatException";    expectedResult = $false; version = "1.0.0+😲" }
+            @{ name = "Format errors: 'Non-ascii'";  errorId = "FormatException";    expectedResult = $false; version = "1.0.0-😨" }
+            @{ name = "Format errors: 'Non-ascii'";  errorId = "FormatException";    expectedResult = $false; version = "1.0.0-😲+😨" }
+            @{ name = "Format errors: 'Non-alphanumeric'";errorId = "FormatException";expectedResult = $false; version = "1.0.0+!@#$&*())" }
+            @{ name = "Format errors: 'Non-alphanumeric'";errorId = "FormatException";expectedResult = $false; version = "1.0.0-alpha!@#$&*())" }
+            @{ name = "Format errors: 'Non-alphanumeric'";errorId = "FormatException";expectedResult = $false; version = "1.0.0-beta!@#$&*())+!@#$&*())" }
         ) {
             param($version, $expectedResult, $errorId)
             { [SemanticVersion]::new($version) } | Should -Throw -ErrorId $errorId


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This brings the class up to par with the standard. This change uses the official RegEx that the semver project has for validating versions.

The test expecting `1.0.0+-` to fail was removed as this is a valid semver 2.0 version string as per the semver 2.0 RegEx.

https://regex101.com/r/s3wbbH/4/

<!-- Summarize your PR between here and the checklist. -->

## PR Context

This is to resolve #14605 which is an issue that affects me.

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->