### PR TITLE
Fallback to `CopyAndDelete()` when `MoveTo()` fails due to an IOException

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -51,15 +51,6 @@ namespace Microsoft.PowerShell.Commands
                                                      ISecurityDescriptorCmdletProvider,
                                                      ICmdletProviderSupportsHelp
     {
-#if UNIX
-        // This is the errno returned by the rename() syscall
-        // when an item is attempted to be renamed across filesystem mount boundaries.
-        private const int MOVE_FAILED_ERROR = 18;
-#else
-        // 0x80070005 ACCESS_DENIED is returned when trying to move files across volumes like DFS
-        private const int MOVE_FAILED_ERROR = -2147024891;
-#endif
-
         // 4MB gives the best results without spiking the resources on the remote connection for file transfers between pssessions.
         // NOTE: The script used to copy file data from session (PSCopyFromSessionHelper) has a
         // maximum fragment size value for security.  If FILETRANSFERSIZE changes make sure the
@@ -6074,41 +6065,22 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="force">If true, force move the directory, overwriting anything at the destination.</param>
         private void MoveDirectoryInfoUnchecked(DirectoryInfo directory, string destinationPath, bool force)
         {
-            if (!IsSameWindowsVolume(directory.FullName, destinationPath))
+            try
             {
+                if (InternalTestHooks.ThrowExdevErrorOnMoveDirectory)
+                {
+                    throw new IOException("Invalid cross-device link");
+                }
+
+                directory.MoveTo(destinationPath);
+            }
+            catch (IOException)
+            {
+                // Rather than try to ascertain whether we can rename a directory ahead of time,
+                // it's both faster and more correct to try to rename it and fall back to copy/deleting it
+                // See also: https://github.com/coreutils/coreutils/blob/439741053256618eb651e6d43919df29625b8714/src/mv.c#L212-L216
                 CopyAndDelete(directory, destinationPath, force);
             }
-            else
-            {
-                try
-                {
-                    if (InternalTestHooks.ThrowExdevErrorOnMoveDirectory)
-                    {
-                        throw new IOException("Invalid cross-device link", hresult: MOVE_FAILED_ERROR);
-                    }
-
-                    directory.MoveTo(destinationPath);
-                }
-                catch (IOException e) when (e.HResult == MOVE_FAILED_ERROR)
-                {
-                    // Rather than try to ascertain whether we can rename a directory ahead of time,
-                    // it's both faster and more correct to try to rename it and fall back to copy/deleting it
-                    // See also: https://github.com/coreutils/coreutils/blob/439741053256618eb651e6d43919df29625b8714/src/mv.c#L212-L216
-                    CopyAndDelete(directory, destinationPath, force);
-                }
-            }
-        }
-
-        private static bool IsSameWindowsVolume(string source, string destination)
-        {
-#if UNIX
-            return true;
-#else
-            FileInfo src = new FileInfo(source);
-            FileInfo dest = new FileInfo(destination);
-
-            return src.Directory.Root.Name == dest.Directory.Root.Name;
-#endif
         }
 
         private void CopyAndDelete(DirectoryInfo directory, string destination, bool force)

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -6103,12 +6103,12 @@ namespace Microsoft.PowerShell.Commands
         {
 #if UNIX
             return true;
-#endif
-
+#else
             FileInfo src = new FileInfo(source);
             FileInfo dest = new FileInfo(destination);
 
-            return (src.Directory.Root.Name == dest.Directory.Root.Name);
+            return src.Directory.Root.Name == dest.Directory.Root.Name;
+#endif
         }
 
         private void CopyAndDelete(DirectoryInfo directory, string destination, bool force)

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -157,7 +157,7 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
             try {
                 # find first available drive letter, unfortunately need to use both function: and Win32_LogicalDisk to cover
                 # both subst drives and bitlocker drives
-                $drive = Get-ChildItem function:[d-z]: -Name | Where-Object { !(Test-Path -Path $_) -and !(Get-CimInstance Win32_LogicalDisk -Filter "DeviceID='$_'") } | Select-Object -First 1
+                $drive = Get-ChildItem function:[f-z]: -Name | Where-Object { !(Test-Path -Path $_) -and !(Get-CimInstance Win32_LogicalDisk -Filter "DeviceID='$_'") } | Select-Object -First 1
                 if ($null -eq $drive) {
                     throw "Test cannot continue as no drive letter available"
                 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -154,7 +154,7 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
         }
 
         It "Verify Move-Item will not move to an existing file" {
-            { Move-Item -Path $testDir -Destination $testFile -ErrorAction Stop } | Should -Throw -ErrorId "MoveDirectoryItemIOError,Microsoft.PowerShell.Commands.MoveItemCommand"
+            { Move-Item -Path $testDir -Destination $testFile -ErrorAction Stop } | Should -Throw -ErrorId 'DirectoryExist,Microsoft.PowerShell.Commands.MoveItemCommand'
             $error[0].Exception | Should -BeOfType System.IO.IOException
             $testDir | Should -Exist
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -157,7 +157,7 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
             try {
                 # find first available drive letter, unfortunately need to use both function: and Win32_LogicalDisk to cover
                 # both subst drives and bitlocker drives
-                $drive = Get-ChildItem function:[f-z]: -Name | Where-Object { !(Test-Path -Path $_) -and !(Get-CimInstance Win32_LogicalDisk -Filter "DeviceID='$_'") } | Select-Object -First 1
+                $drive = Get-ChildItem function:[h-z]: -Name | Where-Object { !(Test-Path -Path $_) -and !(Get-CimInstance Win32_LogicalDisk -Filter "DeviceID='$_'") } | Select-Object -First 1
                 if ($null -eq $drive) {
                     throw "Test cannot continue as no drive letter available"
                 }
@@ -166,7 +166,7 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
                 $null = New-Item -ItemType Directory -Path $dest -Name test
                 $out = subst $drive $dest 2>&1
                 if ($LASTEXITCODE -ne 0) {
-                    throw "subst failed with exit code ${LASTEXITCODE}: $out"
+                    throw "subst failed with exit code ${LASTEXITCODE} for drive '$drive': $out"
                 }
 
                 $testdir = New-Item -ItemType Directory -Path $drive -Name testmovedir -Force

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -153,33 +153,6 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
             }
         }
 
-        It "Verify Move-Item for directory across drives on Windows" -Skip:(!$IsWindows) {
-            try {
-                # find first available drive letter, unfortunately need to use both function: and Win32_LogicalDisk to cover
-                # both subst drives and bitlocker drives
-                $drive = Get-ChildItem function:[h-z]: -Name | Where-Object { !(Test-Path -Path $_) -and !(Get-CimInstance Win32_LogicalDisk -Filter "DeviceID='$_'") } | Select-Object -First 1
-                if ($null -eq $drive) {
-                    throw "Test cannot continue as no drive letter available"
-                }
-
-                $dest = (Resolve-Path -Path $TestDrive).ProviderPath
-                $null = New-Item -ItemType Directory -Path $dest -Name test
-                $out = subst $drive $dest 2>&1
-                if ($LASTEXITCODE -ne 0) {
-                    throw "subst failed with exit code ${LASTEXITCODE} for drive '$drive': $out"
-                }
-
-                $testdir = New-Item -ItemType Directory -Path $drive -Name testmovedir -Force
-                1 > $testdir\test.txt
-                Move-Item $drive\testmovedir $dest\test
-                "$drive\testmovedir" | Should -Not -Exist
-                "$dest\test\testmovedir\test.txt" | Should -FileContentMatchExactly 1
-            }
-            finally {
-                subst $drive /d
-            }
-        }
-
         It "Verify Move-Item will not move to an existing file" {
             { Move-Item -Path $testDir -Destination $testFile -ErrorAction Stop } | Should -Throw -ErrorId "MoveDirectoryItemIOError,Microsoft.PowerShell.Commands.MoveItemCommand"
             $error[0].Exception | Should -BeOfType System.IO.IOException
@@ -1525,5 +1498,34 @@ Describe "Verify sub-directory creation under root" -Tag 'CI','RequireSudoOnUnix
     It "Can create a sub directory under root path" -Skip:$IsMacOs {
         New-Item -Path $dirPath -ItemType Directory -Force > $null
         $dirPath | Should -Exist
+    }
+}
+
+Describe "Windows admin tests" -Tag 'RequireAdminOnWindows' {
+    It "Verify Move-Item for directory across drives on Windows" -Skip:(!$IsWindows) {
+        try {
+            # find first available drive letter, unfortunately need to use both function: and Win32_LogicalDisk to cover
+            # both subst drives and bitlocker drives
+            $drive = Get-ChildItem function:[h-z]: -Name | Where-Object { !(Test-Path -Path $_) -and !(Get-CimInstance Win32_LogicalDisk -Filter "DeviceID='$_'") } | Select-Object -First 1
+            if ($null -eq $drive) {
+                throw "Test cannot continue as no drive letter available"
+            }
+
+            $dest = (Resolve-Path -Path $TestDrive).ProviderPath
+            $null = New-Item -ItemType Directory -Path $dest -Name test
+            $out = subst $drive $dest 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                throw "subst failed with exit code ${LASTEXITCODE} for drive '$drive': $out"
+            }
+
+            $testdir = New-Item -ItemType Directory -Path $drive -Name testmovedir -Force
+            1 > $testdir\test.txt
+            Move-Item $drive\testmovedir $dest\test
+            "$drive\testmovedir" | Should -Not -Exist
+            "$dest\test\testmovedir\test.txt" | Should -FileContentMatchExactly 1
+        }
+        finally {
+            subst $drive /d
+        }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -164,9 +164,9 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
 
                 $dest = (Resolve-Path -Path $TestDrive).ProviderPath
                 $null = New-Item -ItemType Directory -Path $dest -Name test
-                subst $drive $dest
+                $out = subst $drive $dest 2>&1
                 if ($LASTEXITCODE -ne 0) {
-                    throw "subst failed with exit code $LASTEXITCODE"
+                    throw "subst failed with exit code ${LASTEXITCODE}: $out"
                 }
 
                 $testdir = New-Item -ItemType Directory -Path $drive -Name testmovedir -Force


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The PR https://github.com/PowerShell/PowerShell/pull/14913 introduced a regression by removing some Windows specific code thinking it was no longer needed.  That code checked if the root of a file path starts with the same drive letter and if not, uses `CopyAndDelete()` as `MoveTo()` would fail.  This change instead will use `CopyAndDelete()` for any `IOException`.  Based on the .NET code, there's only two cases where `IOException` is raised for `MoveTo()` so falling back to `CopyAndDelete()` is fine for these two cases.

A new test was added leveraging `subst` to emulate different drive volumes on Windows.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/15072

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
