### PR TITLE
Add check if STA is supported before using on console startup

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -17,7 +17,6 @@ using System.Management.Automation.Language;
 using System.Management.Automation.Runspaces;
 using System.Security;
 using System.Text;
-using System.Threading;
 
 using Dbg = System.Management.Automation.Diagnostics;
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -654,7 +654,7 @@ namespace Microsoft.PowerShell
 
         private static bool IsStaSupported()
         {
-                Thread thread = new Thread(() => {});
+                Thread thread = new Thread(() => { });
                 thread.SetApartmentState(ApartmentState.STA);
                 try
                 {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -657,6 +657,8 @@ namespace Microsoft.PowerShell
 #if UNIX
             return false;
 #else
+            // On some variants of Windows, STA is not supported and pwsh will fail to start.
+            // The exception to determine if STA is supported only occurs on thread Start().
             Thread thread = new Thread(() => { });
             thread.SetApartmentState(ApartmentState.STA);
             try

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -478,7 +478,7 @@ namespace Microsoft.PowerShell
                 }
                 else
                 {
-                    return IsStaSupported();
+                    return Platform.IsStaSupported;
                 }
             }
         }
@@ -650,27 +650,6 @@ namespace Microsoft.PowerShell
 
             return (switchKey.Length >= smallestUnambiguousMatch.Length
                     && match.StartsWith(switchKey, StringComparison.OrdinalIgnoreCase));
-        }
-
-        private static bool IsStaSupported()
-        {
-#if UNIX
-            return false;
-#else
-            // On some variants of Windows, STA is not supported and pwsh will fail to start.
-            // The exception to determine if STA is supported only occurs on thread Start().
-            Thread thread = new Thread(() => { });
-            thread.SetApartmentState(ApartmentState.STA);
-            try
-            {
-                thread.Start();
-                return true;
-            }
-            catch
-            {
-                return false;
-            }
-#endif
         }
 
         #endregion
@@ -950,7 +929,7 @@ namespace Microsoft.PowerShell
                 }
                 else if (MatchSwitch(switchKey, "sta", "sta"))
                 {
-                    if (!Platform.IsWindowsDesktop || !IsStaSupported())
+                    if (!Platform.IsWindowsDesktop || !Platform.IsStaSupported)
                     {
                         SetCommandLineError(
                             CommandLineParameterParserStrings.STANotImplemented);

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -654,17 +654,21 @@ namespace Microsoft.PowerShell
 
         private static bool IsStaSupported()
         {
-                Thread thread = new Thread(() => { });
-                thread.SetApartmentState(ApartmentState.STA);
-                try
-                {
-                    thread.Start();
-                    return true;
-                }
-                catch
-                {
-                    return false;
-                }
+#if UNIX
+            return false;
+#else
+            Thread thread = new Thread(() => { });
+            thread.SetApartmentState(ApartmentState.STA);
+            try
+            {
+                thread.Start();
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+#endif
         }
 
         #endregion

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -17,6 +17,7 @@ using System.Management.Automation.Language;
 using System.Management.Automation.Runspaces;
 using System.Security;
 using System.Text;
+using System.Threading;
 
 using Dbg = System.Management.Automation.Diagnostics;
 
@@ -477,7 +478,7 @@ namespace Microsoft.PowerShell
                 }
                 else
                 {
-                    return true;
+                    return IsStaSupported();
                 }
             }
         }
@@ -649,6 +650,21 @@ namespace Microsoft.PowerShell
 
             return (switchKey.Length >= smallestUnambiguousMatch.Length
                     && match.StartsWith(switchKey, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static bool IsStaSupported()
+        {
+                Thread thread = new Thread(() => {});
+                thread.SetApartmentState(ApartmentState.STA);
+                try
+                {
+                    thread.Start();
+                    return true;
+                }
+                catch
+                {
+                    return false;
+                }
         }
 
         #endregion
@@ -928,7 +944,7 @@ namespace Microsoft.PowerShell
                 }
                 else if (MatchSwitch(switchKey, "sta", "sta"))
                 {
-                    if (!Platform.IsWindowsDesktop)
+                    if (!Platform.IsWindowsDesktop || !IsStaSupported())
                     {
                         SetCommandLineError(
                             CommandLineParameterParserStrings.STANotImplemented);

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -16,8 +16,6 @@ namespace System.Management.Automation
     /// </summary>
     public static class Platform
     {
-        private static string _tempDirectory = null;
-
         /// <summary>
         /// True if the current platform is Linux.
         /// </summary>
@@ -163,11 +161,6 @@ namespace System.Management.Automation
         // Gets the location for cache and config folders.
         internal static readonly string CacheDirectory = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + @"\Microsoft\PowerShell";
         internal static readonly string ConfigDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Personal) + @"\PowerShell";
-
-        private static bool? _isNanoServer = null;
-        private static bool? _isIoT = null;
-        private static bool? _isWindowsDesktop = null;
-
         private static readonly Lazy<bool> _isStaSupported = new Lazy<bool>(() =>
         {
             // See objbase.h
@@ -184,6 +177,10 @@ namespace System.Management.Automation
 
             return result != E_NOTIMPL;
         });
+
+        private static bool? _isNanoServer = null;
+        private static bool? _isIoT = null;
+        private static bool? _isWindowsDesktop = null;
 #endif
 
         // format files
@@ -201,6 +198,8 @@ namespace System.Management.Automation
             "Registry.format.ps1xml",
             "WSMan.format.ps1xml"
         };
+
+        private static string _tempDirectory = null;
 
         /// <summary>
         /// Some common environment variables used in PS have different

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -141,7 +141,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// True if underlying system supports single-threaded apartment.
+        /// Gets a value indicating whether the underlying system supports single-threaded apartment.
         /// </summary>
         public static bool IsStaSupported
         {
@@ -600,11 +600,10 @@ namespace System.Management.Automation
                 private const string ole32Lib = "api-ms-win-core-com-l1-1-0.dll";
 
                 [DllImport(ole32Lib)]
-                internal extern static int CoInitializeEx(IntPtr reserve, int coinit);
+                internal static extern int CoInitializeEx(IntPtr reserve, int coinit);
 
                 [DllImport(ole32Lib)]
-                internal extern static void CoUninitialize();
-
+                internal static extern void CoUninitialize();
             }
         }
 

--- a/src/System.Management.Automation/engine/hostifaces/LocalPipeline.cs
+++ b/src/System.Management.Automation/engine/hostifaces/LocalPipeline.cs
@@ -192,7 +192,7 @@ namespace System.Management.Automation.Runspaces
                         }
 
 #if !UNIX
-                        if (apartmentState != ApartmentState.Unknown && !Platform.IsNanoServer && !Platform.IsIoT)
+                        if (apartmentState != ApartmentState.Unknown && Platform.IsStaSupported)
                         {
                             invokeThread.SetApartmentState(apartmentState);
                         }
@@ -1165,7 +1165,7 @@ namespace System.Management.Automation.Runspaces
             _closed = false;
 
 #if !UNIX
-            if (apartmentState != ApartmentState.Unknown && !Platform.IsNanoServer && !Platform.IsIoT)
+            if (apartmentState != ApartmentState.Unknown && Platform.IsStaSupported)
             {
                 _worker.SetApartmentState(apartmentState);
             }

--- a/test/xUnit/csharp/test_CommandLineParser.cs
+++ b/test/xUnit/csharp/test_CommandLineParser.cs
@@ -48,7 +48,15 @@ namespace PSTests.Parallel
             Assert.False(cpp.SkipProfiles);
             Assert.False(cpp.SocketServerMode);
             Assert.False(cpp.SSHServerMode);
-            Assert.True(cpp.StaMode);
+            if (Platform.IsWindows)
+            {
+                Assert.True(cpp.StaMode);
+            }
+            else
+            {
+                Assert.False(cpp.StaMode);
+            }
+
             Assert.False(cpp.ThrowOnReadAndPrompt);
             Assert.False(cpp.WasInitialCommandEncoded);
             Assert.Null(cpp.WorkingDirectory);
@@ -1185,13 +1193,13 @@ namespace PSTests.Parallel
             Assert.False(cpp.NoExit);
             Assert.False(cpp.ShowShortHelp);
             Assert.False(cpp.ShowBanner);
-            if (!Platform.IsWindows)
+            if (Platform.IsWindows)
             {
-                Assert.False(cpp.StaMode);
+                Assert.True(cpp.StaMode);
             }
             else
             {
-                Assert.True(cpp.StaMode);
+                Assert.False(cpp.StaMode);
             }
 
             Assert.Equal(CommandLineParameterParser.NormalizeFilePath(commandLine[commandLine.Length - 1]), cpp.File);

--- a/test/xUnit/csharp/test_CommandLineParser.cs
+++ b/test/xUnit/csharp/test_CommandLineParser.cs
@@ -1185,7 +1185,15 @@ namespace PSTests.Parallel
             Assert.False(cpp.NoExit);
             Assert.False(cpp.ShowShortHelp);
             Assert.False(cpp.ShowBanner);
-            Assert.True(cpp.StaMode);
+            if (!Platform.IsWindows)
+            {
+                Assert.False(cpp.StaMode);
+            }
+            else
+            {
+                Assert.True(cpp.StaMode);
+            }
+
             Assert.Equal(CommandLineParameterParser.NormalizeFilePath(commandLine[commandLine.Length - 1]), cpp.File);
             Assert.Null(cpp.ErrorMessage);
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Some specific builds of Windows do not support STA.  However, pwsh defaults to STA to support WinForms/WPF (same as Windows PowerShell).  This results in an error and unusable PowerShell runspace.  Fix is to have a check whether `-STA` is explicitly used or implicitly where `-MTA` is not specified by attempting to create a STA thread.

Validated manually.

## PR Context

Reported by internal Msft partner

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
