### PR TITLE
Sign internals of EXE package so that it works correctly when signed

### DIFF
--- a/.vsts-ci/linux.yml
+++ b/.vsts-ci/linux.yml
@@ -24,14 +24,14 @@ pr:
     include:
     - '*'
     exclude:
+    - .dependabot/config.yml
+    - .github/ISSUE_TEMPLATE/*
+    - .vsts-ci/misc-analysis.yml
+    - .vsts-ci/windows.yml
+    - .vsts-ci/windows/*
     - test/common/markdown/*
     - tools/releaseBuild/*
     - tools/releaseBuild/azureDevOps/templates/*
-    - .vsts-ci/misc-analysis.yml
-    - .github/ISSUE_TEMPLATE/*
-    - .dependabot/config.yml
-    - .vsts-ci/windows.yml
-    - .vsts-ci/windows/*
 
 variables:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/.vsts-ci/mac.yml
+++ b/.vsts-ci/mac.yml
@@ -25,14 +25,15 @@ pr:
     include:
     - '*'
     exclude:
-    - test/common/markdown/*
-    - .vsts-ci/misc-analysis.yml
-    - .github/ISSUE_TEMPLATE/*
     - .dependabot/config.yml
-    - tools/releaseBuild/*
-    - tools/releaseBuild/azureDevOps/templates/*
+    - .github/ISSUE_TEMPLATE/*
+    - .vsts-ci/misc-analysis.yml
     - /.vsts-ci/windows.yml
     - /.vsts-ci/windows/*
+    - test/common/markdown/*
+    - tools/packaging/*
+    - tools/releaseBuild/*
+    - tools/releaseBuild/azureDevOps/templates/*
 
 variables:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/.vsts-ci/windows.yml
+++ b/.vsts-ci/windows.yml
@@ -24,12 +24,13 @@ pr:
     include:
     - '*'
     exclude:
-    - .vsts-ci/misc-analysis.yml
-    - .github/ISSUE_TEMPLATE/*
     - .dependabot/config.yml
+    - .github/ISSUE_TEMPLATE/*
+    - .vsts-ci/misc-analysis.yml
+    - test/common/markdown/*
+    - tools/packaging/*
     - tools/releaseBuild/*
     - tools/releaseBuild/azureDevOps/templates/*
-    - test/common/markdown/*
 
 variables:
   GIT_CONFIG_PARAMETERS: "'core.autocrlf=false'"

--- a/tools/ci.psm1
+++ b/tools/ci.psm1
@@ -502,7 +502,11 @@ function Invoke-CIFinish
 
         # the packaging tests find the MSI package using env:PSMsiX64Path
         $env:PSMsiX64Path = $artifacts | Where-Object { $_.EndsWith(".msi")}
-        $env:PSExePath = $artifacts | Where-Object { $_.EndsWith(".exe") }
+        $architechture = $Runtime.Split('-')[1]
+        $exePath = New-ExePackage -ProductVersion ($preReleaseVersion -replace '^v') -ProductTargetArchitecture $architechture -MsiLocationPath $env:PSMsiX64Path
+        Write-Verbose "exe Path: $exePath" -Verbose
+        $artifacts.Add($exePath)
+        $env:PSExePath = $exePath
         $env:PSMsiChannel = $Channel
         $env:PSMsiRuntime = $Runtime
 

--- a/tools/packaging/packaging.psd1
+++ b/tools/packaging/packaging.psd1
@@ -6,7 +6,7 @@ Copyright="Copyright (c) Microsoft Corporation."
 ModuleVersion="1.0.0"
 PowerShellVersion="5.0"
 CmdletsToExport=@()
-FunctionsToExport=@('Start-PSPackage','New-PSSignedBuildZip', 'New-PSBuildZip', 'New-MSIPatch', 'Expand-PSSignedBuild', 'Publish-NugetToMyGet', 'New-DotnetSdkContainerFxdPackage', 'New-GlobalToolNupkg', 'New-ILNugetPackage', 'Update-PSSignedBuildFolder')
+FunctionsToExport=@('Start-PSPackage','New-PSSignedBuildZip', 'New-PSBuildZip', 'New-MSIPatch', 'Expand-PSSignedBuild', 'Publish-NugetToMyGet', 'New-DotnetSdkContainerFxdPackage', 'New-GlobalToolNupkg', 'New-ILNugetPackage', 'Update-PSSignedBuildFolder', 'New-ExePackage')
 RootModule="packaging.psm1"
 RequiredModules = @("build")
 }

--- a/tools/packaging/packaging.psd1
+++ b/tools/packaging/packaging.psd1
@@ -7,9 +7,9 @@
     PowerShellVersion = "5.0"
     CmdletsToExport   = @()
     FunctionsToExport = @(
-        'Dismount-ExePackageEngine'
+        'Expand-ExePackageEngine'
         'Expand-PSSignedBuild'
-        'Mount-ExePackageEngine'
+        'Compress-ExePackageEngine'
         'New-DotnetSdkContainerFxdPackage'
         'New-ExePackage'
         'New-GlobalToolNupkg'

--- a/tools/packaging/packaging.psd1
+++ b/tools/packaging/packaging.psd1
@@ -1,12 +1,26 @@
 @{
-GUID="41857994-4283-4757-a932-0b0edb104913"
-Author="PowerShell"
-CompanyName="Microsoft Corporation"
-Copyright="Copyright (c) Microsoft Corporation."
-ModuleVersion="1.0.0"
-PowerShellVersion="5.0"
-CmdletsToExport=@()
-FunctionsToExport=@('Start-PSPackage','New-PSSignedBuildZip', 'New-PSBuildZip', 'New-MSIPatch', 'Expand-PSSignedBuild', 'Publish-NugetToMyGet', 'New-DotnetSdkContainerFxdPackage', 'New-GlobalToolNupkg', 'New-ILNugetPackage', 'Update-PSSignedBuildFolder', 'New-ExePackage', 'Dismount-ExePackageEngine', 'Mount-ExePackageEngine')
-RootModule="packaging.psm1"
-RequiredModules = @("build")
+    GUID              = "41857994-4283-4757-a932-0b0edb104913"
+    Author            = "PowerShell"
+    CompanyName       = "Microsoft Corporation"
+    Copyright         = "Copyright (c) Microsoft Corporation."
+    ModuleVersion     = "1.0.0"
+    PowerShellVersion = "5.0"
+    CmdletsToExport   = @()
+    FunctionsToExport = @(
+        'Dismount-ExePackageEngine'
+        'Expand-PSSignedBuild'
+        'Mount-ExePackageEngine'
+        'New-DotnetSdkContainerFxdPackage'
+        'New-ExePackage'
+        'New-GlobalToolNupkg'
+        'New-ILNugetPackage'
+        'New-MSIPatch'
+        'New-PSBuildZip'
+        'New-PSSignedBuildZip'
+        'Publish-NugetToMyGet'
+        'Start-PSPackage'
+        'Update-PSSignedBuildFolder'
+    )
+    RootModule        = "packaging.psm1"
+    RequiredModules   = @("build")
 }

--- a/tools/packaging/packaging.psd1
+++ b/tools/packaging/packaging.psd1
@@ -6,7 +6,7 @@ Copyright="Copyright (c) Microsoft Corporation."
 ModuleVersion="1.0.0"
 PowerShellVersion="5.0"
 CmdletsToExport=@()
-FunctionsToExport=@('Start-PSPackage','New-PSSignedBuildZip', 'New-PSBuildZip', 'New-MSIPatch', 'Expand-PSSignedBuild', 'Publish-NugetToMyGet', 'New-DotnetSdkContainerFxdPackage', 'New-GlobalToolNupkg', 'New-ILNugetPackage', 'Update-PSSignedBuildFolder', 'New-ExePackage')
+FunctionsToExport=@('Start-PSPackage','New-PSSignedBuildZip', 'New-PSBuildZip', 'New-MSIPatch', 'Expand-PSSignedBuild', 'Publish-NugetToMyGet', 'New-DotnetSdkContainerFxdPackage', 'New-GlobalToolNupkg', 'New-ILNugetPackage', 'Update-PSSignedBuildFolder', 'New-ExePackage', 'Dismount-ExePackageEngine', 'Mount-ExePackageEngine')
 RootModule="packaging.psm1"
 RequiredModules = @("build")
 }

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -3295,7 +3295,6 @@ function Mount-ExePackageEngine {
     Start-NativeExecution -VerboseOutputOnError { & $wixPaths.wixInsigniaExePath -ab $resolvedEnginePath $resolvedExePath -o $resolvedExePath}
 }
 
-
 function New-MsiArgsArray {
     param(
         [Parameter(Mandatory)]

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -3212,6 +3212,8 @@ function New-ExePackage {
         [ValidateNotNullOrEmpty()]
         [string] $ProductTargetArchitecture,
 
+        # Location of the signed MSI
+        [Parameter(Mandatory = $true)]
         [string]
         $MsiLocationPath,
 
@@ -3222,7 +3224,7 @@ function New-ExePackage {
     $windowsNames = Get-WindowsNames -ProductName $ProductName -ProductNameSuffix $ProductNameSuffix -ProductVersion $ProductVersion
     $productSemanticVersionWithName = $windowsNames.ProductSemanticVersionWithName
     $packageName = $windowsNames.PackageName
-    $isPreview = Test-IsPreview -Version $ProductSemanticVersion
+    $isPreview = Test-IsPreview -Version $windowsNames.ProductSemanticVersion
 
     Write-Verbose "Create EXE for Product $productSemanticVersionWithName" -verbose
     Write-Verbose "packageName =  $packageName" -Verbose

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -3166,6 +3166,8 @@ function Get-WindowsNames {
         [string] $ProductVersion
     )
 
+    Write-Verbose -Message "Getting Windows Names for ProductName: $ProductName; ProductNameSuffix: $ProductNameSuffix; ProductVersion: $ProductVersion" -Verbose
+
     $ProductSemanticVersion = Get-PackageSemanticVersion -Version $ProductVersion
     $ProductVersion = Get-PackageVersionAsMajorMinorBuildRevision -Version $ProductVersion
 
@@ -3192,9 +3194,6 @@ function New-ExePackage {
         [ValidateNotNullOrEmpty()]
         [string] $ProductName = 'PowerShell',
 
-        # Suffix of the Name
-        [string] $ProductNameSuffix,
-
         # Version of the Product
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -3220,8 +3219,9 @@ function New-ExePackage {
         [string] $CurrentLocation = (Get-Location)
     )
 
+    $productNameSuffix = "win-$ProductTargetArchitecture"
 
-    $windowsNames = Get-WindowsNames -ProductName $ProductName -ProductNameSuffix $ProductNameSuffix -ProductVersion $ProductVersion
+    $windowsNames = Get-WindowsNames -ProductName $ProductName -ProductNameSuffix $productNameSuffix -ProductVersion $ProductVersion
     $productSemanticVersionWithName = $windowsNames.ProductSemanticVersionWithName
     $packageName = $windowsNames.PackageName
     $isPreview = Test-IsPreview -Version $windowsNames.ProductSemanticVersion

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -3244,14 +3244,18 @@ function New-ExePackage {
     return $exeLocationPath
 }
 
-function Dismount-ExePackageEngine {
+<#
+Allows you to extract the engine of exe package, mainly for signing
+Any existing signature will be removed.
+ #>
+function Expand-ExePackageEngine {
     param(
         # Location of the unsigned EXE
         [Parameter(Mandatory = $true)]
         [string]
         $ExePath,
 
-        # Location to put the dismounted engine.
+        # Location to put the expanded engine.
         [Parameter(Mandatory = $true)]
         [string]
         $EnginePath
@@ -3270,7 +3274,11 @@ function Dismount-ExePackageEngine {
     Start-NativeExecution -VerboseOutputOnError { & $wixPaths.wixInsigniaExePath -ib $resolvedExePath -o $resolvedEnginePath}
 }
 
-function Mount-ExePackageEngine {
+<#
+Allows you to replace the engine (installer) in the exe package.
+Used to replace the engine with a signed version
+#>
+function Compress-ExePackageEngine {
     param(
         # Location of the unsigned EXE
         [Parameter(Mandatory = $true)]

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -3240,6 +3240,8 @@ function New-ExePackage {
         TargetPath     = $MsiLocationPath
         WindowsVersion = $windowsVersion
     }  -MsiLocationPath $exeLocationPath -MsiPdbLocationPath $exePdbLocationPath
+
+    return $exeLocationPath
 }
 
 function Dismount-ExePackageEngine {

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -3263,7 +3263,7 @@ function Dismount-ExePackageEngine {
     $wixPaths = Get-WixPath
 
     $resolvedExePath = (Resolve-Path -Path $ExePath).ProviderPath
-    $resolvedEnginePath = System.IO.Path]::GetFullPath($EnginePath)
+    $resolvedEnginePath = [System.IO.Path]::GetFullPath($EnginePath)
 
     Start-NativeExecution -VerboseOutputOnError { & $wixPaths.wixInsigniaExePath -ib $resolvedExePath -o $resolvedEnginePath}
 }

--- a/tools/releaseBuild/azureDevOps/releaseBuild.yml
+++ b/tools/releaseBuild/azureDevOps/releaseBuild.yml
@@ -16,7 +16,7 @@ resources:
     type: github
     endpoint: ComplianceGHRepo
     name: PowerShell/compliance
-    ref: master
+    ref: task-prefix
 
 variables:
   - name: DOTNET_CLI_TELEMETRY_OPTOUT

--- a/tools/releaseBuild/azureDevOps/releaseBuild.yml
+++ b/tools/releaseBuild/azureDevOps/releaseBuild.yml
@@ -16,7 +16,7 @@ resources:
     type: github
     endpoint: ComplianceGHRepo
     name: PowerShell/compliance
-    ref: task-prefix
+    ref: master
 
 variables:
   - name: DOTNET_CLI_TELEMETRY_OPTOUT

--- a/tools/releaseBuild/azureDevOps/templates/linux.yml
+++ b/tools/releaseBuild/azureDevOps/templates/linux.yml
@@ -161,6 +161,7 @@ jobs:
             **\*.rpm
           useMinimatch: true
           shouldSign: $(SHOULD_SIGN)
+          displayName: Sign RPM
 
   # requires windows
   - task: AzureFileCopy@4

--- a/tools/releaseBuild/azureDevOps/templates/mac-file-signing.yml
+++ b/tools/releaseBuild/azureDevOps/templates/mac-file-signing.yml
@@ -78,6 +78,7 @@ jobs:
             **\*.zip
           useMinimatch: true
           shouldSign: $(SHOULD_SIGN)
+          displayName: Sign macOS Binaries
 
     - pwsh: |
         $destination = "$(System.ArtifactsDirectory)\azureMacOs"

--- a/tools/releaseBuild/azureDevOps/templates/mac-package-signing.yml
+++ b/tools/releaseBuild/azureDevOps/templates/mac-package-signing.yml
@@ -64,6 +64,7 @@ jobs:
           **\*.zip
         useMinimatch: true
         shouldSign: $(SHOULD_SIGN)
+        displayName: Sign pkg
 
   - template: upload-final-results.yml
     parameters:

--- a/tools/releaseBuild/azureDevOps/templates/nuget.yml
+++ b/tools/releaseBuild/azureDevOps/templates/nuget.yml
@@ -144,6 +144,7 @@ jobs:
           **\*.nupkg
         useMinimatch: true
         shouldSign: $(SHOULD_SIGN)
+        displayName: Sign NuPkg
 
   - pwsh: |
       if (-not (Test-Path '$(System.ArtifactsDirectory)\signed\')) { $null = New-Item -ItemType Directory -Path '$(System.ArtifactsDirectory)\signed\' }

--- a/tools/releaseBuild/azureDevOps/templates/upload.yml
+++ b/tools/releaseBuild/azureDevOps/templates/upload.yml
@@ -6,23 +6,6 @@ parameters:
   pdb: no
 
 steps:
-# - template: upload-final-results.yml
-#   parameters:
-#     artifactPath: $(Build.StagingDirectory)\signedPackages
-#     artifactFilter: PowerShell-${{ parameters.version }}-win-${{ parameters.architecture }}.msi
-#     condition: and(succeeded(), eq('${{ parameters.msi }}', 'yes'))
-
-# - task: AzureFileCopy@4
-#   displayName: 'upload signed msi to Azure - ${{ parameters.architecture }}'
-#   inputs:
-#     SourcePath: '$(Build.StagingDirectory)\signedPackages\PowerShell-${{ parameters.version }}-win-${{ parameters.architecture }}.msi'
-#     azureSubscription: '$(AzureFileCopySubscription)'
-#     Destination: AzureBlob
-#     storage: '$(StorageAccount)'
-#     ContainerName: '$(AzureVersion)'
-#     resourceGroup: '$(StorageResourceGroup)'
-#   condition: and(succeeded(), eq('${{ parameters.msi }}', 'yes'))
-
 - template: upload-final-results.yml
   parameters:
     artifactPath: $(System.ArtifactsDirectory)\signed

--- a/tools/releaseBuild/azureDevOps/templates/upload.yml
+++ b/tools/releaseBuild/azureDevOps/templates/upload.yml
@@ -6,22 +6,22 @@ parameters:
   pdb: no
 
 steps:
-- template: upload-final-results.yml
-  parameters:
-    artifactPath: $(Build.StagingDirectory)\signedPackages
-    artifactFilter: PowerShell-${{ parameters.version }}-win-${{ parameters.architecture }}.msi
-    condition: and(succeeded(), eq('${{ parameters.msi }}', 'yes'))
+# - template: upload-final-results.yml
+#   parameters:
+#     artifactPath: $(Build.StagingDirectory)\signedPackages
+#     artifactFilter: PowerShell-${{ parameters.version }}-win-${{ parameters.architecture }}.msi
+#     condition: and(succeeded(), eq('${{ parameters.msi }}', 'yes'))
 
-- task: AzureFileCopy@4
-  displayName: 'upload signed msi to Azure - ${{ parameters.architecture }}'
-  inputs:
-    SourcePath: '$(Build.StagingDirectory)\signedPackages\PowerShell-${{ parameters.version }}-win-${{ parameters.architecture }}.msi'
-    azureSubscription: '$(AzureFileCopySubscription)'
-    Destination: AzureBlob
-    storage: '$(StorageAccount)'
-    ContainerName: '$(AzureVersion)'
-    resourceGroup: '$(StorageResourceGroup)'
-  condition: and(succeeded(), eq('${{ parameters.msi }}', 'yes'))
+# - task: AzureFileCopy@4
+#   displayName: 'upload signed msi to Azure - ${{ parameters.architecture }}'
+#   inputs:
+#     SourcePath: '$(Build.StagingDirectory)\signedPackages\PowerShell-${{ parameters.version }}-win-${{ parameters.architecture }}.msi'
+#     azureSubscription: '$(AzureFileCopySubscription)'
+#     Destination: AzureBlob
+#     storage: '$(StorageAccount)'
+#     ContainerName: '$(AzureVersion)'
+#     resourceGroup: '$(StorageResourceGroup)'
+#   condition: and(succeeded(), eq('${{ parameters.msi }}', 'yes'))
 
 - template: upload-final-results.yml
   parameters:

--- a/tools/releaseBuild/azureDevOps/templates/windows-package-signing.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-package-signing.yml
@@ -46,7 +46,6 @@ jobs:
         signOutputPath: $(Build.StagingDirectory)\signedPackages
         certificateId: "CP-230012"
         pattern: |
-          **\*.msi
           **\*.msix
           **\*.exe
         useMinimatch: true

--- a/tools/releaseBuild/azureDevOps/templates/windows-package-signing.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-package-signing.yml
@@ -50,6 +50,7 @@ jobs:
           **\*.exe
         useMinimatch: true
         shouldSign: $(SHOULD_SIGN)
+        displayName: Sign exe and msix
 
   - powershell: |
       new-item -itemtype Directory -path '$(Build.StagingDirectory)\signedPackages'

--- a/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
@@ -277,7 +277,7 @@ jobs:
           shouldSign: $(SHOULD_SIGN)
           displayName: Sign MSI
 
-    - powershell: |
+    - pwsh: |
         Get-ChildItem '$(System.ArtifactsDirectory)\signedPackages' | ForEach-Object {
           $packagePath = $_.FullName
           Write-Host "Uploading $packagePath"
@@ -330,7 +330,7 @@ jobs:
         Compress-ExePackageEngine -ExePath $exePath -EnginePath $enginePath
       displayName: Use signed engine in exe wrapper
 
-    - powershell: |
+    - pwsh: |
         cd '$(PowerShellRoot)'
         Get-ChildItem '.\PowerShell-*.exe' | ForEach-Object {
           $packagePath = $_.FullName

--- a/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
@@ -303,7 +303,31 @@ jobs:
         $msiPath = '$(Build.StagingDirectory)\signedPackages\PowerShell-$(version)-win-${{ parameters.architecture }}.msi'
 
         New-ExePackage -ProductVersion '$(version)' -MsiLocationPath $msiPath -ProductTargetArchitecture ${{ parameters.architecture }}
+        $exePath = Get-ChildItem '.\PowerShell-*.exe' | Select-Object -First 1 -ExpandProperty fullname
+        $engiePath = Join-Path -Path $PWD -ChildPath enigne.exe
+        Dismount-ExePackageEngine -ExePath $exePath -EnginePath $enginePath
       displayName: Create exe wrapper
+
+    - template: EsrpSign.yml@ComplianceRepo
+      parameters:
+          buildOutputPath: $(System.ArtifactsDirectory)\pkgSigned
+          signOutputPath: $(Build.StagingDirectory)\signedPackages
+          certificateId: "CP-230012"
+          pattern: |
+            **\*.msi
+          useMinimatch: true
+          shouldSign: $(SHOULD_SIGN)
+          displayName: Sign Exe Wrapper Engine
+
+    - pwsh: |
+        cd $(PowerShellRoot)
+        Import-Module $(PowerShellRoot)/build.psm1 -Force
+        Import-Module $(PowerShellRoot)/tools/packaging -Force
+
+        $exePath = Get-ChildItem '.\PowerShell-*.exe' | Select-Object -First 1 -ExpandProperty fullname
+        $engiePath = Join-Path -Path $PWD -ChildPath enigne.exe
+        Mount-ExePackageEngine -ExePath $exePath -EnginePath $enginePath
+      displayName: Use signed engine in exe wrapper
 
     - powershell: |
         cd $(PowerShellRoot)

--- a/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
@@ -331,7 +331,7 @@ jobs:
       displayName: Use signed engine in exe wrapper
 
     - powershell: |
-        cd $(PowerShellRoot)
+        cd '$(PowerShellRoot)'
         Get-ChildItem '.\PowerShell-*.exe' | ForEach-Object {
           $packagePath = $_.FullName
           Write-Host "Uploading $packagePath"

--- a/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
@@ -292,7 +292,8 @@ jobs:
         ContainerName: '$(AzureVersion)'
         resourceGroup: '$(StorageResourceGroup)'
 
-    - powershell: |
+    - pwsh: |
+        cd $(PowerShellRoot)
         Import-Module $(PowerShellRoot)/build.psm1 -Force
         Import-Module $(PowerShellRoot)/tools/packaging -Force
 
@@ -302,6 +303,7 @@ jobs:
       displayName: Create exe wrapper
 
     - powershell: |
+        cd $(PowerShellRoot)
         Get-ChildItem '.\PowerShell-*.exe' | ForEach-Object {
           $packagePath = $_.FullName
           Write-Host "Uploading $packagePath"

--- a/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
@@ -265,7 +265,7 @@ jobs:
       }
     displayName: Upload unsigned packages
 
-  - ${{ if and(ne(variables['BuildConfiguration'],'minSize'), startsWith(variables['Architecture'], 'x')) }}:
+  - ${{ if and(ne(variables['BuildConfiguration'],'minSize'), in(variables['Architecture'], 'x64', 'x86')) }}:
     - template: EsrpSign.yml@ComplianceRepo
       parameters:
           buildOutputPath: $(System.ArtifactsDirectory)\pkgSigned

--- a/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
@@ -261,7 +261,53 @@ jobs:
         Write-Host "Uploading $packagePath"
         Write-Host "##vso[artifact.upload containerfolder=signed;artifactname=signed]$packagePath"
       }
-    displayName: Upload packages
+    displayName: Upload unsigned packages
+
+  - ${{ if and(ne(variables['BuildConfiguration'],'minSize'), startsWith(variables['Architecture'], 'x')) }}:
+    - template: EsrpSign.yml@ComplianceRepo
+      parameters:
+          buildOutputPath: $(System.ArtifactsDirectory)\pkgSigned
+          signOutputPath: $(Build.StagingDirectory)\signedPackages
+          certificateId: "CP-230012"
+          pattern: |
+            **\*.msi
+          useMinimatch: true
+          shouldSign: $(SHOULD_SIGN)
+
+    - powershell: |
+        Get-ChildItem '$(System.ArtifactsDirectory)\signedPackages' | ForEach-Object {
+          $packagePath = $_.FullName
+          Write-Host "Uploading $packagePath"
+          Write-Host "##vso[artifact.upload containerfolder=finalResults;artifactname=finalResults]$packagePath"
+        }
+      displayName: Upload signed MSI to finalResults
+
+    - task: AzureFileCopy@4
+      displayName: 'upload signed msi to Azure - ${{ parameters.architecture }}'
+      inputs:
+        SourcePath: '$(Build.StagingDirectory)\signedPackages\PowerShell-$(version)-win-${{ parameters.architecture }}.msi'
+        azureSubscription: '$(AzureFileCopySubscription)'
+        Destination: AzureBlob
+        storage: '$(StorageAccount)'
+        ContainerName: '$(AzureVersion)'
+        resourceGroup: '$(StorageResourceGroup)'
+
+    - powershell: |
+        Import-Module $(PowerShellRoot)/build.psm1 -Force
+        Import-Module $(PowerShellRoot)/tools/packaging -Force
+
+        $msiPath = '$(Build.StagingDirectory)\signedPackages\PowerShell-$(version)-win-${{ parameters.architecture }}.msi'
+
+        New-ExePackage -ProductVersion '$(version)' -MsiLocationPath $msiPath -ProductTargetArchitecture ${{ parameters.architecture }}
+      displayName: Create exe wrapper
+
+    - powershell: |
+        Get-ChildItem '.\PowerShell-*.exe' | ForEach-Object {
+          $packagePath = $_.FullName
+          Write-Host "Uploading $packagePath"
+          Write-Host "##vso[artifact.upload containerfolder=signed;artifactname=signed]$packagePath"
+        }
+      displayName: Upload unsigned exe
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'

--- a/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
@@ -305,6 +305,7 @@ jobs:
         New-ExePackage -ProductVersion '$(version)' -MsiLocationPath $msiPath -ProductTargetArchitecture ${{ parameters.architecture }}
         $exePath = Get-ChildItem '.\PowerShell-*.exe' | Select-Object -First 1 -ExpandProperty fullname
         $enginePath = Join-Path -Path '$(System.ArtifactsDirectory)\unsignedEngine' -ChildPath engine.exe
+        # Expand Burn Engine so we can sign it.
         Expand-ExePackageEngine -ExePath $exePath -EnginePath $enginePath
       displayName: Create exe wrapper
 
@@ -317,7 +318,7 @@ jobs:
             **\*.exe
           useMinimatch: true
           shouldSign: $(SHOULD_SIGN)
-          displayName: Sign Exe Wrapper Engine
+          displayName: Sign Burn Engine
 
     - pwsh: |
         cd '$(PowerShellRoot)'
@@ -328,7 +329,7 @@ jobs:
         $enginePath = Join-Path -Path '$(System.ArtifactsDirectory)\signedEngine' -ChildPath engine.exe
         $enginePath | Get-AuthenticodeSignature | out-string | Write-Verbose -verbose
         Compress-ExePackageEngine -ExePath $exePath -EnginePath $enginePath
-      displayName: Use signed engine in exe wrapper
+      displayName: Re-attach the signed Burn engine in exe wrapper
 
     - pwsh: |
         cd '$(PowerShellRoot)'

--- a/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
@@ -326,6 +326,7 @@ jobs:
 
         $exePath = Get-ChildItem '.\PowerShell-*.exe' | Select-Object -First 1 -ExpandProperty fullname
         $enginePath = Join-Path -Path '$(System.ArtifactsDirectory)\signedEngine' -ChildPath engine.exe
+        $enginePath | Get-AuthenticodeSignature | out-string | Write-Verbose -verbose
         Mount-ExePackageEngine -ExePath $exePath -EnginePath $enginePath
       displayName: Use signed engine in exe wrapper
 

--- a/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
@@ -203,7 +203,7 @@ jobs:
 
   - powershell: |
       Get-ChildItem '$(System.ArtifactsDirectory)\thirdPartySigned\*'
-    displayName: Captrue ThirdParty Signed files
+    displayName: Capture ThirdParty Signed files
     condition: and(succeeded(), eq(variables['SHOULD_SIGN'], 'true'))
 
   - powershell: |
@@ -304,17 +304,17 @@ jobs:
 
         New-ExePackage -ProductVersion '$(version)' -MsiLocationPath $msiPath -ProductTargetArchitecture ${{ parameters.architecture }}
         $exePath = Get-ChildItem '.\PowerShell-*.exe' | Select-Object -First 1 -ExpandProperty fullname
-        $engiePath = Join-Path -Path $PWD -ChildPath enigne.exe
+        $enginePath = Join-Path -Path '$(System.ArtifactsDirectory)\unsignedEngine' -ChildPath engine.exe
         Dismount-ExePackageEngine -ExePath $exePath -EnginePath $enginePath
       displayName: Create exe wrapper
 
     - template: EsrpSign.yml@ComplianceRepo
       parameters:
-          buildOutputPath: $(System.ArtifactsDirectory)\pkgSigned
-          signOutputPath: $(Build.StagingDirectory)\signedPackages
+          buildOutputPath: $(System.ArtifactsDirectory)\unsignedEngine
+          signOutputPath: $(System.ArtifactsDirectory)\signedEngine
           certificateId: "CP-230012"
           pattern: |
-            **\*.msi
+            **\*.exe
           useMinimatch: true
           shouldSign: $(SHOULD_SIGN)
           displayName: Sign Exe Wrapper Engine
@@ -325,7 +325,7 @@ jobs:
         Import-Module $(PowerShellRoot)/tools/packaging -Force
 
         $exePath = Get-ChildItem '.\PowerShell-*.exe' | Select-Object -First 1 -ExpandProperty fullname
-        $engiePath = Join-Path -Path $PWD -ChildPath enigne.exe
+        $enginePath = Join-Path -Path '$(System.ArtifactsDirectory)\signedEngine' -ChildPath engine.exe
         Mount-ExePackageEngine -ExePath $exePath -EnginePath $enginePath
       displayName: Use signed engine in exe wrapper
 

--- a/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
@@ -155,6 +155,7 @@ jobs:
           **\*.exe
         useMinimatch: true
         shouldSign: $(SHOULD_SIGN)
+        displayName: Sign our binaries
 
   - pwsh: |
       Import-Module $(PowerShellRoot)/build.psm1 -Force
@@ -198,6 +199,7 @@ jobs:
           **\*.dll
         useMinimatch: true
         shouldSign: $(SHOULD_SIGN)
+        displayName: Sign ThirdParty binaries
 
   - powershell: |
       Get-ChildItem '$(System.ArtifactsDirectory)\thirdPartySigned\*'
@@ -273,6 +275,7 @@ jobs:
             **\*.msi
           useMinimatch: true
           shouldSign: $(SHOULD_SIGN)
+          displayName: Sign MSI
 
     - powershell: |
         Get-ChildItem '$(System.ArtifactsDirectory)\signedPackages' | ForEach-Object {

--- a/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
@@ -320,7 +320,7 @@ jobs:
           displayName: Sign Exe Wrapper Engine
 
     - pwsh: |
-        cd $(PowerShellRoot)
+        cd '$(PowerShellRoot)'
         Import-Module $(PowerShellRoot)/build.psm1 -Force
         Import-Module $(PowerShellRoot)/tools/packaging -Force
 

--- a/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
@@ -321,8 +321,8 @@ jobs:
 
     - pwsh: |
         cd '$(PowerShellRoot)'
-        Import-Module $(PowerShellRoot)/build.psm1 -Force
-        Import-Module $(PowerShellRoot)/tools/packaging -Force
+        Import-Module '$(PowerShellRoot)/build.psm1' -Force
+        Import-Module '$(PowerShellRoot)/tools/packaging' -Force
 
         $exePath = Get-ChildItem '.\PowerShell-*.exe' | Select-Object -First 1 -ExpandProperty fullname
         $enginePath = Join-Path -Path '$(System.ArtifactsDirectory)\signedEngine' -ChildPath engine.exe

--- a/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
@@ -305,7 +305,7 @@ jobs:
         New-ExePackage -ProductVersion '$(version)' -MsiLocationPath $msiPath -ProductTargetArchitecture ${{ parameters.architecture }}
         $exePath = Get-ChildItem '.\PowerShell-*.exe' | Select-Object -First 1 -ExpandProperty fullname
         $enginePath = Join-Path -Path '$(System.ArtifactsDirectory)\unsignedEngine' -ChildPath engine.exe
-        Dismount-ExePackageEngine -ExePath $exePath -EnginePath $enginePath
+        Expand-ExePackageEngine -ExePath $exePath -EnginePath $enginePath
       displayName: Create exe wrapper
 
     - template: EsrpSign.yml@ComplianceRepo
@@ -327,7 +327,7 @@ jobs:
         $exePath = Get-ChildItem '.\PowerShell-*.exe' | Select-Object -First 1 -ExpandProperty fullname
         $enginePath = Join-Path -Path '$(System.ArtifactsDirectory)\signedEngine' -ChildPath engine.exe
         $enginePath | Get-AuthenticodeSignature | out-string | Write-Verbose -verbose
-        Mount-ExePackageEngine -ExePath $exePath -EnginePath $enginePath
+        Compress-ExePackageEngine -ExePath $exePath -EnginePath $enginePath
       displayName: Use signed engine in exe wrapper
 
     - powershell: |

--- a/tools/releaseBuild/setReleaseTag.ps1
+++ b/tools/releaseBuild/setReleaseTag.ps1
@@ -70,7 +70,7 @@ if($ReleaseTag -eq 'fromBranch' -or !$ReleaseTag)
     {
         $msixType = 'release'
         Write-Verbose "release branch:" -Verbose
-        $releaseTag = $Branch -replace $releaseBranchRegex
+        $releaseTag = $Branch -replace '^.*((release|rebuild)/)'
         $vstsCommandString = "vso[task.setvariable variable=$Variable]$releaseTag"
         Write-Verbose -Message "setting $Variable to $releaseTag" -Verbose
         Write-Host -Object "##$vstsCommandString"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Sign internals of EXE package so that it works correctly when signed
- Refactor exe package creation into separate function
- Add functions to enable signing of engine of the exe package
- Move signing of MSI to package creation Job

## PR Context

The extracted EXE and MSI of the wrapper must be signed if the EXE is signed or install will fail.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
