### PR TITLE
Fix to not allow mixed dash and slash in parameters prefix

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -608,7 +608,8 @@ namespace Microsoft.PowerShell
                 return (switchKey: string.Empty, shouldBreak: false);
             }
 
-            if (!CharExtensions.IsDash(switchKey[0]) && switchKey[0] != '/')
+            char firstChar = switchKey[0];
+            if (!CharExtensions.IsDash(firstChar) && firstChar != '/')
             {
                 // then it's a file
                 --argIndex;
@@ -622,7 +623,7 @@ namespace Microsoft.PowerShell
             switchKey = switchKey.Substring(1);
 
             // chop off the second dash so we're agnostic wrt specifying - or --
-            if (!string.IsNullOrEmpty(switchKey) && CharExtensions.IsDash(switchKey[0]))
+            if (!string.IsNullOrEmpty(switchKey) && CharExtensions.IsDash(firstChar) && switchKey[0] == firstChar)
             {
                 switchKey = switchKey.Substring(1);
             }

--- a/test/xUnit/csharp/test_CommandLineParser.cs
+++ b/test/xUnit/csharp/test_CommandLineParser.cs
@@ -145,6 +145,47 @@ namespace PSTests.Parallel
 
         [Theory]
         [InlineData("-Version")]
+        [InlineData("--Version")]
+        [InlineData("/Version")]
+        public static void TestParameter_Dash_Or_Slash(params string[] commandLine)
+        {
+            var cpp = new CommandLineParameterParser();
+
+            cpp.Parse(commandLine);
+
+            Assert.False(cpp.AbortStartup);
+            Assert.False(cpp.NoExit);
+            Assert.True(cpp.NonInteractive);
+            Assert.False(cpp.ShowBanner);
+            Assert.False(cpp.ShowShortHelp);
+            Assert.False(cpp.NoPrompt);
+            Assert.True(cpp.ShowVersion);
+            Assert.True(cpp.SkipProfiles);
+            Assert.Null(cpp.ErrorMessage);
+        }
+
+        [Theory]
+        [InlineData("/-Version")]
+        [InlineData("-/Version")]
+        public static void TestParameter_Wrong_Dash_And_Slash(params string[] commandLine)
+        {
+            var cpp = new CommandLineParameterParser();
+
+            cpp.Parse(commandLine);
+
+            Assert.True(cpp.AbortStartup);
+            Assert.False(cpp.NoExit);
+            Assert.False(cpp.NonInteractive);
+            Assert.False(cpp.ShowBanner);
+            Assert.True(cpp.ShowShortHelp);
+            Assert.False(cpp.NoPrompt);
+            Assert.False(cpp.ShowVersion);
+            Assert.False(cpp.SkipProfiles);
+            Assert.Contains(commandLine[0], cpp.ErrorMessage);
+        }
+
+        [Theory]
+        [InlineData("-Version")]
         [InlineData("-V")]
         [InlineData("-Version", "abbra")] // Ignore all after the parameter
         public static void TestParameter_Version(params string[] commandLine)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Fixes #12013 to not allow `\-` as legal prefix for a command line parameter.
<!-- Summarize your PR between here and the checklist. -->

## PR Context
Make sure that both `/-` and `-/` are not legal command line parameters prefix, with added tests to ensure `-`, `--` and `/` are legal prefixes.
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
