### PR TITLE
Fix SSH remoting connection hang with misconfigured endpoint

### DIFF
--- a/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
@@ -738,6 +738,30 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
+        /// Gets and sets a value for the SSH subsystem to use for the remote connection.
+        /// </summary>
+        [Parameter(ParameterSetName = InvokeCommandCommand.SSHHostParameterSet)]
+        [Parameter(ParameterSetName = InvokeCommandCommand.FilePathSSHHostParameterSet)]
+        public override string Subsystem
+        {
+            get { return base.Subsystem; }
+
+            set { base.Subsystem = value; }
+        }
+
+        /// <summary>
+        /// Gets and sets a value in milliseconds that limits the time allowed for an SSH connection to be established.
+        /// </summary>
+        [Parameter(ParameterSetName = InvokeCommandCommand.SSHHostParameterSet)]
+        [Parameter(ParameterSetName = InvokeCommandCommand.FilePathSSHHostParameterSet)]
+        public override int ConnectingTimeout
+        {
+            get { return base.ConnectingTimeout; }
+            
+            set { base.ConnectingTimeout = value; }
+        }
+
+        /// <summary>
         /// This parameter specifies that SSH is used to establish the remote
         /// connection and act as the remoting transport.  By default WinRM is used
         /// as the remoting transport.  Using the SSH transport requires that SSH is

--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -763,14 +763,14 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Gets and sets a value for the SSH subsystem to use for the remote connection.
+        /// Gets or sets a value for the SSH subsystem to use for the remote connection.
         /// </summary>
         [Parameter(ValueFromPipelineByPropertyName = true,
                    ParameterSetName = PSRemotingBaseCmdlet.SSHHostParameterSet)]
         public virtual string Subsystem { get; set; }
 
         /// <summary>
-        /// Gets and sets a value in milliseconds that limits the time allowed for an SSH connection to be established.
+        /// Gets or sets a value in milliseconds that limits the time allowed for an SSH connection to be established.
         /// </summary>
         [Parameter(ParameterSetName = PSRemotingBaseCmdlet.SSHHostParameterSet)]
         public virtual int ConnectingTimeout { get; set; } = -1;    // No timeout by default

--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -15,6 +15,7 @@ using System.Management.Automation.Language;
 using System.Management.Automation.Remoting;
 using System.Management.Automation.Remoting.Client;
 using System.Management.Automation.Runspaces;
+using System.Threading;
 
 using Dbg = System.Management.Automation.Diagnostics;
 
@@ -774,7 +775,7 @@ namespace Microsoft.PowerShell.Commands
         /// Default timeout value is infinite.
         /// </summary>
         [Parameter(ParameterSetName = PSRemotingBaseCmdlet.SSHHostParameterSet)]
-        public virtual int ConnectingTimeout { get; set; } = -1;
+        public virtual int ConnectingTimeout { get; set; } = Timeout.Infinite;
 
         /// <summary>
         /// This parameter specifies that SSH is used to establish the remote

--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -771,9 +771,10 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Gets or sets a value in milliseconds that limits the time allowed for an SSH connection to be established.
+        /// Default timeout value is infinite.
         /// </summary>
         [Parameter(ParameterSetName = PSRemotingBaseCmdlet.SSHHostParameterSet)]
-        public virtual int ConnectingTimeout { get; set; } = -1;    // No timeout by default
+        public virtual int ConnectingTimeout { get; set; } = -1;
 
         /// <summary>
         /// This parameter specifies that SSH is used to establish the remote
@@ -910,7 +911,7 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>Array of SSHConnection objects.</returns>
         internal SSHConnection[] ParseSSHConnectionHashTable()
         {
-            var connections = new List<SSHConnection>();
+            List<SSHConnection> connections = new();
             foreach (var item in this.SSHConnection)
             {
                 if (item.ContainsKey(ComputerNameParameter) && item.ContainsKey(HostNameAlias))
@@ -923,7 +924,7 @@ namespace Microsoft.PowerShell.Commands
                     throw new PSArgumentException(RemotingErrorIdStrings.SSHConnectionDuplicateKeyPath);
                 }
 
-                var connectionInfo = new SSHConnection();
+                SSHConnection connectionInfo = new();
                 foreach (var key in item.Keys)
                 {
                     string paramName = key as string;

--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -285,6 +285,7 @@ namespace Microsoft.PowerShell.Commands
         public string KeyFilePath;
         public int Port;
         public string Subsystem;
+        public int ConnectingTimeout;
     }
 
     /// <summary>
@@ -762,6 +763,19 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
+        /// Gets and sets a value for the SSH subsystem to use for the remote connection.
+        /// </summary>
+        [Parameter(ValueFromPipelineByPropertyName = true,
+                   ParameterSetName = PSRemotingBaseCmdlet.SSHHostParameterSet)]
+        public virtual string Subsystem { get; set; }
+
+        /// <summary>
+        /// Gets and sets a value in milliseconds that limits the time allowed for an SSH connection to be established.
+        /// </summary>
+        [Parameter(ParameterSetName = PSRemotingBaseCmdlet.SSHHostParameterSet)]
+        public virtual int ConnectingTimeout { get; set; } = -1;    // No timeout by default
+
+        /// <summary>
         /// This parameter specifies that SSH is used to establish the remote
         /// connection and act as the remoting transport.  By default WinRM is used
         /// as the remoting transport.  Using the SSH transport requires that SSH is
@@ -788,13 +802,6 @@ namespace Microsoft.PowerShell.Commands
             get;
             set;
         }
-
-        /// <summary>
-        /// This parameter specifies the SSH subsystem to use for the remote connection.
-        /// </summary>
-        [Parameter(ValueFromPipelineByPropertyName = true,
-                   ParameterSetName = InvokeCommandCommand.SSHHostParameterSet)]
-        public virtual string Subsystem { get; set; }
 
         #endregion
 
@@ -856,6 +863,7 @@ namespace Microsoft.PowerShell.Commands
         private const string IdentityFilePathAlias = "IdentityFilePath";
         private const string PortParameter = "Port";
         private const string SubsystemParameter = "Subsystem";
+        private const string ConnectingTimeoutParameter = "ConnectingTimeout";
 
         #endregion
 
@@ -902,7 +910,7 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>Array of SSHConnection objects.</returns>
         internal SSHConnection[] ParseSSHConnectionHashTable()
         {
-            List<SSHConnection> connections = new List<SSHConnection>();
+            var connections = new List<SSHConnection>();
             foreach (var item in this.SSHConnection)
             {
                 if (item.ContainsKey(ComputerNameParameter) && item.ContainsKey(HostNameAlias))
@@ -915,7 +923,7 @@ namespace Microsoft.PowerShell.Commands
                     throw new PSArgumentException(RemotingErrorIdStrings.SSHConnectionDuplicateKeyPath);
                 }
 
-                SSHConnection connectionInfo = new SSHConnection();
+                var connectionInfo = new SSHConnection();
                 foreach (var key in item.Keys)
                 {
                     string paramName = key as string;
@@ -954,6 +962,10 @@ namespace Microsoft.PowerShell.Commands
                     else if (paramName.Equals(SubsystemParameter, StringComparison.OrdinalIgnoreCase))
                     {
                         connectionInfo.Subsystem = GetSSHConnectionStringParameter(item[paramName]);
+                    }
+                    else if (paramName.Equals(ConnectingTimeoutParameter, StringComparison.OrdinalIgnoreCase))
+                    {
+                        connectionInfo.ConnectingTimeout = GetSSHConnectionIntParameter(item[paramName]);
                     }
                     else
                     {
@@ -1448,9 +1460,9 @@ namespace Microsoft.PowerShell.Commands
             {
                 ParseSshHostName(computerName, out string host, out string userName, out int port);
 
-                var sshConnectionInfo = new SSHConnectionInfo(userName, host, this.KeyFilePath, port, this.Subsystem);
+                var sshConnectionInfo = new SSHConnectionInfo(userName, host, KeyFilePath, port, Subsystem, ConnectingTimeout);
                 var typeTable = TypeTable.LoadDefaultTypeFiles();
-                var remoteRunspace = RunspaceFactory.CreateRunspace(sshConnectionInfo, this.Host, typeTable) as RemoteRunspace;
+                var remoteRunspace = RunspaceFactory.CreateRunspace(sshConnectionInfo, Host, typeTable) as RemoteRunspace;
                 var pipeline = CreatePipeline(remoteRunspace);
 
                 var operation = new ExecutionCmdletHelperComputerName(remoteRunspace, pipeline);
@@ -1471,7 +1483,8 @@ namespace Microsoft.PowerShell.Commands
                     sshConnection.ComputerName,
                     sshConnection.KeyFilePath,
                     sshConnection.Port,
-                    sshConnection.Subsystem);
+                    sshConnection.Subsystem,
+                    sshConnection.ConnectingTimeout);
                 var typeTable = TypeTable.LoadDefaultTypeFiles();
                 var remoteRunspace = RunspaceFactory.CreateRunspace(sshConnectionInfo, this.Host, typeTable) as RemoteRunspace;
                 var pipeline = CreatePipeline(remoteRunspace);

--- a/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
@@ -1262,7 +1262,7 @@ namespace Microsoft.PowerShell.Commands
         private RemoteRunspace GetRunspaceForSSHSession()
         {
             ParseSshHostName(HostName, out string host, out string userName, out int port);
-            var sshConnectionInfo = new SSHConnectionInfo(userName, host, this.KeyFilePath, port, this.Subsystem);
+            var sshConnectionInfo = new SSHConnectionInfo(userName, host, KeyFilePath, port, Subsystem, ConnectingTimeout);
             var typeTable = TypeTable.LoadDefaultTypeFiles();
 
             // Use the class _tempRunspace field while the runspace is being opened so that StopProcessing can be handled at that time.

--- a/src/System.Management.Automation/engine/remoting/commands/newrunspacecommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/newrunspacecommand.cs
@@ -1092,7 +1092,8 @@ namespace Microsoft.PowerShell.Commands
                     host,
                     this.KeyFilePath,
                     port,
-                    Subsystem);
+                    Subsystem,
+                    ConnectingTimeout);
                 var typeTable = TypeTable.LoadDefaultTypeFiles();
                 string rsName = GetRunspaceName(index, out int rsIdUnused);
                 index++;
@@ -1118,7 +1119,8 @@ namespace Microsoft.PowerShell.Commands
                     sshConnection.ComputerName,
                     sshConnection.KeyFilePath,
                     sshConnection.Port,
-                    sshConnection.Subsystem);
+                    sshConnection.Subsystem,
+                    sshConnection.ConnectingTimeout);
                 var typeTable = TypeTable.LoadDefaultTypeFiles();
                 string rsName = GetRunspaceName(index, out int rsIdUnused);
                 index++;

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -1917,7 +1917,7 @@ namespace System.Management.Automation.Runspaces
         /// <summary>
         /// Default value is infinite timeout.
         /// </summary>
-        private const int DefaultConnectingTimeoutTime = -1;
+        private const int DefaultConnectingTimeoutTime = Timeout.Infinite;
 
         #endregion
 

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -1913,7 +1913,11 @@ namespace System.Management.Automation.Runspaces
         /// Default value for subsystem.
         /// </summary>
         private const string DefaultSubsystem = "powershell";
-        private const int DefaultConnectingTimeoutTime = -1;    // Never time out
+        
+        /// <summary>
+        /// Default value is infinite timeout.
+        /// </summary>
+        private const int DefaultConnectingTimeoutTime = -1;
 
         #endregion
 
@@ -2028,7 +2032,7 @@ namespace System.Management.Automation.Runspaces
             int port,
             string subsystem) : this(userName, computerName, keyFilePath, port)
         {
-            Subsystem = (string.IsNullOrEmpty(subsystem)) ? DefaultSubsystem : subsystem;
+            Subsystem = string.IsNullOrEmpty(subsystem) ? DefaultSubsystem : subsystem;
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -2032,11 +2032,11 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
-        /// Constructor.
+        /// Initializes a new instance of SSHConnectionInfo.
         /// </summary>
-        /// <param name="userName">User Name.</param>
-        /// <param name="computerName">Computer Name.</param>
-        /// <param name="keyFilePath">Key File Path.</param>
+        /// <param name="userName">Name of user.</param>
+        /// <param name="computerName">Name of computer.</param>
+        /// <param name="keyFilePath">Path of key file.</param>
         /// <param name="port">Port number for connection (default 22).</param>
         /// <param name="subsystem">Subsystem to use (default 'powershell').</param>
         /// <param name="connectingTimeout">Timeout time for terminating connection attempt.</param>

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -1657,6 +1657,7 @@ namespace System.Management.Automation.Remoting.Client
             }
 
             // Start connection timeout timer if requested.
+            // Timer callback occurs only once after timeout time.
             _connectionTimer = new Timer(
                 callback: (_) => 
                 {
@@ -1685,6 +1686,7 @@ namespace System.Management.Automation.Remoting.Client
                         errorMessage += RemotingErrorIdStrings.SSHClientConnectProcessTerminated;
                     }
 
+                    // Report error and terminate connection attempt.
                     HandleSSHError(
                         new PSRemotingTransportException(errorMessage));
                 },

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -591,8 +591,9 @@ namespace System.Management.Automation.Remoting.Client
                 // start the timer..so client can fail deterministically
                 _closeTimeOutTimer.Change(60 * 1000, Timeout.Infinite);
             }
-            catch
+            catch (Exception ex) when (ex is IOException || ex is ObjectDisposedException)
             {
+
                 // Cannot communicate with server.  Allow client to complete close operation.
                 shouldRaiseCloseCompleted = true;
             }

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -585,11 +585,11 @@ namespace System.Management.Automation.Remoting.Client
 
             try
             {
-                // start the timer..so client can fail deterministically
-                _closeTimeOutTimer.Change(60 * 1000, Timeout.Infinite);
-
                 // send Close signal to the server and let it die gracefully.
                 stdInWriter.WriteLine(OutOfProcessUtils.CreateClosePacket(Guid.Empty));
+
+                // start the timer..so client can fail deterministically
+                _closeTimeOutTimer.Change(60 * 1000, Timeout.Infinite);
             }
             catch
             {

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -585,13 +585,13 @@ namespace System.Management.Automation.Remoting.Client
 
             try
             {
-                // send Close signal to the server and let it die gracefully.
-                stdInWriter.WriteLine(OutOfProcessUtils.CreateClosePacket(Guid.Empty));
-
                 // start the timer..so client can fail deterministically
                 _closeTimeOutTimer.Change(60 * 1000, Timeout.Infinite);
+
+                // send Close signal to the server and let it die gracefully.
+                stdInWriter.WriteLine(OutOfProcessUtils.CreateClosePacket(Guid.Empty));
             }
-            catch (IOException)
+            catch
             {
                 // Cannot communicate with server.  Allow client to complete close operation.
                 shouldRaiseCloseCompleted = true;

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -1711,7 +1711,7 @@ namespace System.Management.Automation.Remoting.Client
         private void CloseConnection()
         {
             // Ensure message queue is disposed.
-            base.DisposeMessageQueue();
+            DisposeMessageQueue();
 
             var connectionTimer = Interlocked.Exchange(ref _connectionTimer, null);
             connectionTimer?.Dispose();

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -593,7 +593,6 @@ namespace System.Management.Automation.Remoting.Client
             }
             catch (Exception ex) when (ex is IOException || ex is ObjectDisposedException)
             {
-
                 // Cannot communicate with server.  Allow client to complete close operation.
                 shouldRaiseCloseCompleted = true;
             }
@@ -1683,7 +1682,7 @@ namespace System.Management.Automation.Remoting.Client
                     var errorMessage = StringUtil.Format(RemotingErrorIdStrings.SSHClientConnectTimeout, _connectionInfo.ConnectingTimeout / 1000);
                     if (sshTerminated)
                     {
-                        errorMessage += "\n" + RemotingErrorIdStrings.SSHClientConnectProcessTerminated;
+                        errorMessage += RemotingErrorIdStrings.SSHClientConnectProcessTerminated;
                     }
 
                     HandleSSHError(

--- a/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
+++ b/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
@@ -1625,8 +1625,11 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
   <data name="SSHClientEndWithErrorMessage" xml:space="preserve">
     <value>The SSH client session has ended with error message: {0}</value>
   </data>
-  <data name="SSHClientCannotConnect" xml:space="preserve">
-    <value>The SSH client cannot connect to the target. This may be because the target endpoint 'sshd_config' file is misconfigured.</value>
+  <data name="SSHClientConnectTimeout" xml:space="preserve">
+    <value>SSH connection attempt failed after time out: {0} seconds.</value>
+  </data>
+  <data name="SSHClientConnectProcessTerminated" xml:space="preserve">
+    <value>SSH client process terminated before connection could be established.</value>
   </data>
   <data name="MissingRequiredSSHParameter" xml:space="preserve">
     <value>The provided SSHConnection hashtable is missing the required ComputerName or HostName parameter.</value>

--- a/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
+++ b/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
@@ -1625,6 +1625,9 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
   <data name="SSHClientEndWithErrorMessage" xml:space="preserve">
     <value>The SSH client session has ended with error message: {0}</value>
   </data>
+  <data name="SSHClientCannotConnect" xml:space="preserve">
+    <value>The SSH client cannot connect to the target. This may be because the target endpoint 'sshd_config' file is misconfigured.</value>
+  </data>
   <data name="MissingRequiredSSHParameter" xml:space="preserve">
     <value>The provided SSHConnection hashtable is missing the required ComputerName or HostName parameter.</value>
   </data>

--- a/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
+++ b/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
@@ -1629,7 +1629,8 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
     <value>SSH connection attempt failed after time out: {0} seconds.</value>
   </data>
   <data name="SSHClientConnectProcessTerminated" xml:space="preserve">
-    <value>SSH client process terminated before connection could be established.</value>
+    <value>
+SSH client process terminated before connection could be established.</value>
   </data>
   <data name="MissingRequiredSSHParameter" xml:space="preserve">
     <value>The provided SSHConnection hashtable is missing the required ComputerName or HostName parameter.</value>

--- a/test/SSHRemoting/SSHRemoting.Basic.Tests.ps1
+++ b/test/SSHRemoting/SSHRemoting.Basic.Tests.ps1
@@ -148,7 +148,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             Write-Verbose -Verbose "It Starting: Verifies new connection with implicit current User"
             $script:session = TryNewPSSession -HostName localhost
             $script:session | Should -Not -BeNullOrEmpty
-            #VerifySession $script:session
+            VerifySession $script:session
             Write-Verbose -Verbose "It Complete"
         }
 
@@ -156,7 +156,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             Write-Verbose -Verbose "It Starting: Verifies new connection with explicit User parameter"
             $script:session = TryNewPSSession -HostName localhost -UserName (whoami)
             $script:session | Should -Not -BeNullOrEmpty
-            #VerifySession $script:session
+            VerifySession $script:session
             Write-Verbose -Verbose "It Complete"
         }
 
@@ -165,7 +165,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             $sessionName = 'TestSessionNameA'
             $script:session = TryNewPSSession -HostName localhost -Name $sessionName
             $script:session | Should -Not -BeNullOrEmpty
-            #VerifySession $script:session
+            VerifySession $script:session
             $script:session.Name | Should -BeExactly $sessionName
             Write-Verbose -Verbose "It Complete"
         }
@@ -175,7 +175,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             $portNum = 22
             $script:session = TryNewPSSession -HostName localhost -Port $portNum
             $script:session | Should -Not -BeNullOrEmpty
-            #VerifySession $script:session
+            VerifySession $script:session
             Write-Verbose -Verbose "It Complete"
         }
 
@@ -185,7 +185,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             $subSystem = 'powershell'
             $script:session = TryNewPSSession -HostName localhost -Port $portNum -SubSystem $subSystem
             $script:session | Should -Not -BeNullOrEmpty
-            #VerifySession $script:session
+            VerifySession $script:session
             Write-Verbose -Verbose "It Complete"
         }
 
@@ -196,7 +196,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             $subSystem = 'powershell'
             $script:session = TryNewPSSession -HostName localhost -Port $portNum -SubSystem $subSystem -KeyFilePath $keyFilePath
             $script:session | Should -Not -BeNullOrEmpty
-            #VerifySession $script:session
+            VerifySession $script:session
             Write-Verbose -Verbose "It Complete"
         }
 
@@ -220,8 +220,8 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             $script:sessions | Should -HaveCount 2
             $script:sessions[0].Name | Should -BeLike 'Connection*'
             $script:sessions[1].Name | Should -BeLike 'Connection*'
-            #VerifySession $script:sessions[0]
-            #VerifySession $script:sessions[1]
+            VerifySession $script:sessions[0]
+            VerifySession $script:sessions[1]
             Write-Verbose -Verbose "It Complete"
         }
     }

--- a/test/SSHRemoting/SSHRemoting.Basic.Tests.ps1
+++ b/test/SSHRemoting/SSHRemoting.Basic.Tests.ps1
@@ -18,7 +18,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
         }
         else
         {
-            Write-Verbose -Verbose "Restarting Linux SSHD service..."
+            Write-Verbose -Verbose "Restarting Unix SSHD service..."
             sudo service ssh restart
             $status = sudo service ssh status
             Write-Verbose -Verbose "SSHD service status: $status"

--- a/test/SSHRemoting/SSHRemoting.Basic.Tests.ps1
+++ b/test/SSHRemoting/SSHRemoting.Basic.Tests.ps1
@@ -8,7 +8,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
 
     $script:TestConnectingTimeout = 5000    # Milliseconds
 
-    function CheckSSHDService
+    function RestartSSHDService
     {
         if ($IsWindows)
         {
@@ -48,12 +48,12 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             $session = New-PSSession @PSBoundParameters -ConnectingTimeout $timeout -ErrorVariable connectionError -ErrorAction SilentlyContinue
             if ($null -eq $session)
             {
-                Write-Verbose -Verbose "SSH New-PSSession remoting connect failed after $($timeout/1000) second wait."
+                Write-Verbose -Verbose "SSH New-PSSession remoting connect failed."
 
                 if ($count -eq 1)
                 {
                     # Try restarting sshd service
-                    CheckSSHDService
+                    RestartSSHDService
                 }
             }
         }
@@ -91,12 +91,12 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             $session = New-PSSession @PSBoundParameters -ErrorVariable connectionError -ErrorAction SilentlyContinue
             if ($null -eq $session)
             {
-                Write-Verbose -Verbose "SSH New-PSSession remoting connect failed after $($timeout/1000) second wait."
+                Write-Verbose -Verbose "SSH New-PSSession remoting connect failed."
 
                 if ($count -eq 1)
                 {
                     # Try restarting sshd service
-                    CheckSSHDService
+                    RestartSSHDService
                 }
             }
         }
@@ -216,7 +216,6 @@ Describe "SSHRemoting Basic Tests" -tags CI {
                 Subsystem = 'powershell'
             })
             $script:sessions = TryNewPSSessionHash -SSHConnection $sshConnection -Name 'Connection1','Connection2'
-            $script:session | Should -Not -BeNullOrEmpty
             $script:sessions | Should -HaveCount 2
             $script:sessions[0].Name | Should -BeLike 'Connection*'
             $script:sessions[1].Name | Should -BeLike 'Connection*'
@@ -254,19 +253,19 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             {
                 $connectionError = $_
                 $rs = $null
-                Write-Verbose -Verbose "SSH Runspace Open remoting connect failed after $($timeout/1000) second wait."
+                Write-Verbose -Verbose "SSH Runspace Open remoting connect failed."
 
                 if ($count -eq 1)
                 {
                     # Try restarting sshd service
-                    CheckSSHDService
+                    RestartSSHDService
                 }
             }
         }
 
         if ($null -eq $rs)
         {
-            $message = "Runspace open unable to connect to SSH remoting endpoint after three attempts. Error: $($connectionError.Message)"
+            $message = "Runspace open unable to connect to SSH remoting endpoint after two attempts. Error: $($connectionError.Message)"
             throw [System.Management.Automation.PSInvalidOperationException]::new($message)
         }
 

--- a/test/SSHRemoting/SSHRemoting.Basic.Tests.ps1
+++ b/test/SSHRemoting/SSHRemoting.Basic.Tests.ps1
@@ -112,13 +112,18 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             [System.Management.Automation.Runspaces.PSSession] $session
         )
 
+        Write-Verbose -Verbose "VerifySession called for session: $($session.Id)"
+
         $session.State | Should -BeExactly 'Opened'
         $session.ComputerName | Should -BeExactly 'localhost'
         $session.Transport | Should -BeExactly 'SSH'
+        Write-Verbose -Verbose "Invoking whoami"
         Invoke-Command -Session $session -ScriptBlock { whoami } | Should -BeExactly $(whoami)
+        Write-Verbose -Verbose "Invoking PSSenderInfo"
         $psRemoteVersion = Invoke-Command -Session $session -ScriptBlock { $PSSenderInfo.ApplicationArguments.PSVersionTable.PSVersion }
         $psRemoteVersion.Major | Should -BeExactly $PSVersionTable.PSVersion.Major
         $psRemoteVersion.Minor | Should -BeExactly $PSVersionTable.PSVersion.Minor
+        Write-Verbose -Verbose "VerifySession complete"
     }
 
     Context "New-PSSession Tests" {
@@ -257,6 +262,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             $ps.Commands.Clear()
             Write-Verbose -Verbose "VerifyRunspace: Invoking whoami"
             $ps.AddScript('whoami').Invoke() | Should -BeExactly $(whoami)
+            Write-Verbose -Verbose "VerifyRunspace complete"
         }
         finally
         {

--- a/test/SSHRemoting/SSHRemoting.Basic.Tests.ps1
+++ b/test/SSHRemoting/SSHRemoting.Basic.Tests.ps1
@@ -37,7 +37,6 @@ Describe "SSHRemoting Basic Tests" -tags CI {
         )
 
         Write-Verbose -Verbose "Starting TryNewPSSession ..."
-        return $null
 
         # Try creating a new SSH connection
         $timeout = $script:TestConnectingTimeout
@@ -77,7 +76,6 @@ Describe "SSHRemoting Basic Tests" -tags CI {
         )
 
         Write-Verbose -Verbose "Starting TryNewPSSessionHash ..."
-        return $null
 
         foreach ($connect in $SSHConnection)
         {
@@ -139,20 +137,18 @@ Describe "SSHRemoting Basic Tests" -tags CI {
 
     Context "New-PSSession Tests" {
 
-        <#
         AfterEach {
             Write-Verbose -Verbose "Starting New-PSSession AfterEach"
             if ($script:session -ne $null) { Remove-PSSession -Session $script:session }
             if ($script:sessions -ne $null) { Remove-PSSession -Session $script:sessions }
             Write-Verbose -Verbose "AfterEach complete"
         }
-        #>
 
         It "Verifies new connection with implicit current User" {
             Write-Verbose -Verbose "It Starting: Verifies new connection with implicit current User"
             $script:session = TryNewPSSession -HostName localhost
             $script:session | Should -Not -BeNullOrEmpty
-            VerifySession $script:session
+            #VerifySession $script:session
             Write-Verbose -Verbose "It Complete"
         }
 
@@ -160,7 +156,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             Write-Verbose -Verbose "It Starting: Verifies new connection with explicit User parameter"
             $script:session = TryNewPSSession -HostName localhost -UserName (whoami)
             $script:session | Should -Not -BeNullOrEmpty
-            VerifySession $script:session
+            #VerifySession $script:session
             Write-Verbose -Verbose "It Complete"
         }
 
@@ -169,7 +165,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             $sessionName = 'TestSessionNameA'
             $script:session = TryNewPSSession -HostName localhost -Name $sessionName
             $script:session | Should -Not -BeNullOrEmpty
-            VerifySession $script:session
+            #VerifySession $script:session
             $script:session.Name | Should -BeExactly $sessionName
             Write-Verbose -Verbose "It Complete"
         }
@@ -179,7 +175,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             $portNum = 22
             $script:session = TryNewPSSession -HostName localhost -Port $portNum
             $script:session | Should -Not -BeNullOrEmpty
-            VerifySession $script:session
+            #VerifySession $script:session
             Write-Verbose -Verbose "It Complete"
         }
 
@@ -189,7 +185,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             $subSystem = 'powershell'
             $script:session = TryNewPSSession -HostName localhost -Port $portNum -SubSystem $subSystem
             $script:session | Should -Not -BeNullOrEmpty
-            VerifySession $script:session
+            #VerifySession $script:session
             Write-Verbose -Verbose "It Complete"
         }
 
@@ -200,7 +196,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             $subSystem = 'powershell'
             $script:session = TryNewPSSession -HostName localhost -Port $portNum -SubSystem $subSystem -KeyFilePath $keyFilePath
             $script:session | Should -Not -BeNullOrEmpty
-            VerifySession $script:session
+            #VerifySession $script:session
             Write-Verbose -Verbose "It Complete"
         }
 
@@ -224,8 +220,8 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             $script:sessions | Should -HaveCount 2
             $script:sessions[0].Name | Should -BeLike 'Connection*'
             $script:sessions[1].Name | Should -BeLike 'Connection*'
-            VerifySession $script:sessions[0]
-            VerifySession $script:sessions[1]
+            #VerifySession $script:sessions[0]
+            #VerifySession $script:sessions[1]
             Write-Verbose -Verbose "It Complete"
         }
     }
@@ -241,7 +237,6 @@ Describe "SSHRemoting Basic Tests" -tags CI {
         )
 
         Write-Verbose -Verbose "Starting TryCreateRunspace ..."
-        return $null
 
         $timeout = $script:TestConnectingTimeout
         $connectionError = $null
@@ -316,13 +311,11 @@ Describe "SSHRemoting Basic Tests" -tags CI {
 
     Context "SSH Remoting API Tests" {
 
-        <#
         AfterEach {
             Write-Verbose -Verbose "Starting Runspace close AfterEach"
             if ($script:rs -ne $null) { $script:rs.Dispose() }
             Write-Verbose -Verbose "AfterEach complete"
         }
-        #>
 
         $testCases = @(
             @{
@@ -380,7 +373,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             Write-Verbose -Verbose "It Starting: $TestName"
             $script:rs = TryCreateRunspace -UserName $UserName -ComputerName $ComputerName -KeyFilePath $KeyFilePath -Port $Port -Subsystem $Subsystem
             $script:rs | Should -Not -BeNullOrEmpty
-            VerifyRunspace $script:rs
+            #VerifyRunspace $script:rs
             Write-Verbose -Verbose "It Complete"
         }
     }

--- a/test/SSHRemoting/SSHRemoting.Basic.Tests.ps1
+++ b/test/SSHRemoting/SSHRemoting.Basic.Tests.ps1
@@ -240,18 +240,22 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             [runspace] $rs
         )
 
+        Write-Verbose -Verbose "VerifyRunspace called for runspace: $($rs.Id)"
+
         $rs.RunspaceStateInfo.State | Should -BeExactly 'Opened'
         $rs.RunspaceAvailability | Should -BeExactly 'Available'
         $rs.RunspaceIsRemote | Should -BeTrue
         $ps = [powershell]::Create()
         try
         {
+            Write-Verbose -Verbose "VerifyRunspace: Invoking PSSenderInfo"
             $ps.Runspace = $rs
             $psRemoteVersion = $ps.AddScript('$PSSenderInfo.ApplicationArguments.PSVersionTable.PSVersion').Invoke()
             $psRemoteVersion.Major | Should -BeExactly $PSVersionTable.PSVersion.Major
             $psRemoteVersion.Minor | Should -BeExactly $PSVersionTable.PSVersion.Minor
 
             $ps.Commands.Clear()
+            Write-Verbose -Verbose "VerifyRunspace: Invoking whoami"
             $ps.AddScript('whoami').Invoke() | Should -BeExactly $(whoami)
         }
         finally

--- a/test/SSHRemoting/SSHRemoting.Basic.Tests.ps1
+++ b/test/SSHRemoting/SSHRemoting.Basic.Tests.ps1
@@ -37,6 +37,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
         )
 
         Write-Verbose -Verbose "Starting TryNewPSSession ..."
+        return $null
 
         # Try creating a new SSH connection
         $timeout = $script:TestConnectingTimeout
@@ -76,6 +77,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
         )
 
         Write-Verbose -Verbose "Starting TryNewPSSessionHash ..."
+        return $null
 
         foreach ($connect in $SSHConnection)
         {
@@ -115,6 +117,11 @@ Describe "SSHRemoting Basic Tests" -tags CI {
         param (
             [System.Management.Automation.Runspaces.PSSession] $session
         )
+
+        if ($null -eq $session)
+        {
+            return
+        }
 
         Write-Verbose -Verbose "VerifySession called for session: $($session.Id)"
 
@@ -234,6 +241,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
         )
 
         Write-Verbose -Verbose "Starting TryCreateRunspace ..."
+        return $null
 
         $timeout = $script:TestConnectingTimeout
         $connectionError = $null
@@ -275,6 +283,11 @@ Describe "SSHRemoting Basic Tests" -tags CI {
         param (
             [runspace] $rs
         )
+
+        if ($null -eq $rs)
+        {
+            return
+        }
 
         Write-Verbose -Verbose "VerifyRunspace called for runspace: $($rs.Id)"
 

--- a/test/SSHRemoting/SSHRemoting.Basic.Tests.ps1
+++ b/test/SSHRemoting/SSHRemoting.Basic.Tests.ps1
@@ -142,6 +142,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
         It "Verifies new connection with implicit current User" {
             Write-Verbose -Verbose "It Starting: Verifies new connection with implicit current User"
             $script:session = TryNewPSSession -HostName localhost
+            $script:session | Should -Not -BeNullOrEmpty
             VerifySession $script:session
             Write-Verbose -Verbose "It Complete"
         }
@@ -149,6 +150,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
         It "Verifies new connection with explicit User parameter" {
             Write-Verbose -Verbose "It Starting: Verifies new connection with explicit User parameter"
             $script:session = TryNewPSSession -HostName localhost -UserName (whoami)
+            $script:session | Should -Not -BeNullOrEmpty
             VerifySession $script:session
             Write-Verbose -Verbose "It Complete"
         }
@@ -157,6 +159,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             Write-Verbose -Verbose "It Starting: Verifies explicit Name parameter"
             $sessionName = 'TestSessionNameA'
             $script:session = TryNewPSSession -HostName localhost -Name $sessionName
+            $script:session | Should -Not -BeNullOrEmpty
             VerifySession $script:session
             $script:session.Name | Should -BeExactly $sessionName
             Write-Verbose -Verbose "It Complete"
@@ -166,6 +169,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             Write-Verbose -Verbose "It Starting: Verifies explicit Port parameter"
             $portNum = 22
             $script:session = TryNewPSSession -HostName localhost -Port $portNum
+            $script:session | Should -Not -BeNullOrEmpty
             VerifySession $script:session
             Write-Verbose -Verbose "It Complete"
         }
@@ -175,6 +179,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             $portNum = 22
             $subSystem = 'powershell'
             $script:session = TryNewPSSession -HostName localhost -Port $portNum -SubSystem $subSystem
+            $script:session | Should -Not -BeNullOrEmpty
             VerifySession $script:session
             Write-Verbose -Verbose "It Complete"
         }
@@ -185,6 +190,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             $portNum = 22
             $subSystem = 'powershell'
             $script:session = TryNewPSSession -HostName localhost -Port $portNum -SubSystem $subSystem -KeyFilePath $keyFilePath
+            $script:session | Should -Not -BeNullOrEmpty
             VerifySession $script:session
             Write-Verbose -Verbose "It Complete"
         }
@@ -205,6 +211,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
                 Subsystem = 'powershell'
             })
             $script:sessions = TryNewPSSessionHash -SSHConnection $sshConnection -Name 'Connection1','Connection2'
+            $script:session | Should -Not -BeNullOrEmpty
             $script:sessions | Should -HaveCount 2
             $script:sessions[0].Name | Should -BeLike 'Connection*'
             $script:sessions[1].Name | Should -BeLike 'Connection*'
@@ -353,6 +360,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
 
             Write-Verbose -Verbose "It Starting: $TestName"
             $script:rs = TryCreateRunspace -UserName $UserName -ComputerName $ComputerName -KeyFilePath $KeyFilePath -Port $Port -Subsystem $Subsystem
+            $script:rs | Should -Not -BeNullOrEmpty
             VerifyRunspace $script:rs
             Write-Verbose -Verbose "It Complete"
         }

--- a/test/SSHRemoting/SSHRemoting.Basic.Tests.ps1
+++ b/test/SSHRemoting/SSHRemoting.Basic.Tests.ps1
@@ -132,12 +132,14 @@ Describe "SSHRemoting Basic Tests" -tags CI {
 
     Context "New-PSSession Tests" {
 
+        <#
         AfterEach {
             Write-Verbose -Verbose "Starting New-PSSession AfterEach"
             if ($script:session -ne $null) { Remove-PSSession -Session $script:session }
             if ($script:sessions -ne $null) { Remove-PSSession -Session $script:sessions }
             Write-Verbose -Verbose "AfterEach complete"
         }
+        #>
 
         It "Verifies new connection with implicit current User" {
             Write-Verbose -Verbose "It Starting: Verifies new connection with implicit current User"
@@ -301,9 +303,13 @@ Describe "SSHRemoting Basic Tests" -tags CI {
 
     Context "SSH Remoting API Tests" {
 
+        <#
         AfterEach {
+            Write-Verbose -Verbose "Starting Runspace close AfterEach"
             if ($script:rs -ne $null) { $script:rs.Dispose() }
+            Write-Verbose -Verbose "AfterEach complete"
         }
+        #>
 
         $testCases = @(
             @{

--- a/test/SSHRemoting/SSHRemoting.Basic.Tests.ps1
+++ b/test/SSHRemoting/SSHRemoting.Basic.Tests.ps1
@@ -6,6 +6,107 @@ Describe "SSHRemoting Basic Tests" -tags CI {
     # SSH remoting is set up to automatically authenticate current user via SSH keys
     # All tests connect back to localhost machine
 
+    $script:TestConnectingTimeout = 5000    # Milliseconds
+
+    function CheckSSHDService
+    {
+        if ($IsWindows)
+        {
+            Write-Verbose -Verbose "Restarting Windows SSHD service..."
+            Restart-Service sshd
+            Write-Verbose -Verbose "SSHD service status: $(Get-Service sshd | Out-String)"
+        }
+        else
+        {
+            Write-Verbose -Verbose "Restarting Linux SSHD service..."
+            sudo service ssh restart
+            $status = sudo service ssh status
+            Write-Verbose -Verbose "SSHD service status: $status"
+        }
+    }
+
+    function TryNewPSSession
+    {
+        param(
+            [string[]] $HostName,
+            [string[]] $Name,
+            [int] $Port,
+            [string] $UserName,
+            [string] $KeyFilePath,
+            [string] $Subsystem
+        )
+
+        # Try creating a new SSH connection
+        $timeout = $script:TestConnectingTimeout
+        $connectionError = $null
+        $session = $null
+        $count = 0
+        while (($null -eq $session) -and ($count++ -lt 2))
+        {
+            $session = New-PSSession @PSBoundParameters -ConnectingTimeout $timeout -ErrorVariable connectionError -ErrorAction SilentlyContinue
+            if ($null -eq $session)
+            {
+                Write-Verbose -Verbose "SSH New-PSSession remoting connect failed after $($timeout/1000) second wait."
+
+                if ($count -eq 1)
+                {
+                    # Try restarting sshd service
+                    CheckSSHDService
+                }
+            }
+        }
+
+        if ($null -eq $session)
+        {
+            $message = "New-PSSession unable to connect to SSH remoting endpoint after two attempts. Error: $($connectionError.Exception.Message)"
+            throw [System.Management.Automation.PSInvalidOperationException]::new($message)
+        }
+
+        Write-Verbose -Verbose "SSH New-PSSession remoting connect succeeded."
+        Write-Output $session
+    }
+
+    function TryNewPSSessionHash
+    {
+        param (
+            [hashtable[]] $SSHConnection,
+            [string[]] $Name
+        )
+
+        foreach ($connect in $SSHConnection)
+        {
+            $connect.Add('ConnectingTimeout', $script:TestConnectingTimeout)
+        }
+
+        # Try creating a new SSH connection
+        $connectionError = $null
+        $session = $null
+        $count = 0
+        while (($null -eq $session) -and ($count++ -lt 2))
+        {
+            $session = New-PSSession @PSBoundParameters -ErrorVariable connectionError -ErrorAction SilentlyContinue
+            if ($null -eq $session)
+            {
+                Write-Verbose -Verbose "SSH New-PSSession remoting connect failed after $($timeout/1000) second wait."
+
+                if ($count -eq 1)
+                {
+                    # Try restarting sshd service
+                    CheckSSHDService
+                }
+            }
+        }
+
+        if ($null -eq $session)
+        {
+            $message = "New-PSSession unable to connect to SSH remoting endpoint after two attempts. Error: $($connectionError.Exception.Message)"
+            throw [System.Management.Automation.PSInvalidOperationException]::new($message)
+        }
+
+        Write-Verbose -Verbose "SSH New-PSSession remoting connect succeeded."
+        Write-Output $session
+    }
+
     function VerifySession {
         param (
             [System.Management.Automation.Runspaces.PSSession] $session
@@ -28,37 +129,32 @@ Describe "SSHRemoting Basic Tests" -tags CI {
         }
 
         It "Verifies new connection with implicit current User" {
-            $script:session = New-PSSession -HostName localhost -ErrorVariable err
-            $err | Should -HaveCount 0
+            $script:session = TryNewPSSession -HostName localhost
             VerifySession $script:session
         }
 
         It "Verifies new connection with explicit User parameter" {
-            $script:session = New-PSSession -HostName localhost -UserName (whoami) -ErrorVariable err
-            $err | Should -HaveCount 0
+            $script:session = TryNewPSSession -HostName localhost -UserName (whoami)
             VerifySession $script:session
         }
 
         It "Verifies explicit Name parameter" {
             $sessionName = 'TestSessionNameA'
-            $script:session = New-PSSession -HostName localhost -Name $sessionName -ErrorVariable err
-            $err | Should -HaveCount 0
+            $script:session = TryNewPSSession -HostName localhost -Name $sessionName
             VerifySession $script:session
             $script:session.Name | Should -BeExactly $sessionName
         }
 
         It "Verifies explicit Port parameter" {
             $portNum = 22
-            $script:session = New-PSSession -HostName localhost -Port $portNum -ErrorVariable err
-            $err | Should -HaveCount 0
+            $script:session = TryNewPSSession -HostName localhost -Port $portNum
             VerifySession $script:session
         }
 
         It "Verifies explicit Subsystem parameter" {
             $portNum = 22
             $subSystem = 'powershell'
-            $script:session = New-PSSession -HostName localhost -Port $portNum -SubSystem $subSystem -ErrorVariable err
-            $err | Should -HaveCount 0
+            $script:session = TryNewPSSession -HostName localhost -Port $portNum -SubSystem $subSystem
             VerifySession $script:session
         }
 
@@ -66,8 +162,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             $keyFilePath = "$HOME/.ssh/id_rsa"
             $portNum = 22
             $subSystem = 'powershell'
-            $script:session = New-PSSession -HostName localhost -Port $portNum -SubSystem $subSystem -KeyFilePath $keyFilePath -ErrorVariable err
-            $err | Should -HaveCount 0
+            $script:session = TryNewPSSession -HostName localhost -Port $portNum -SubSystem $subSystem -KeyFilePath $keyFilePath
             VerifySession $script:session
         }
 
@@ -85,14 +180,59 @@ Describe "SSHRemoting Basic Tests" -tags CI {
                 KeyFilePath = "$HOME/.ssh/id_rsa"
                 Subsystem = 'powershell'
             })
-            $script:sessions = New-PSSession -SSHConnection $sshConnection -Name 'Connection1','Connection2' -ErrorVariable err
-            $err | Should -HaveCount 0
+            $script:sessions = TryNewPSSessionHash -SSHConnection $sshConnection -Name 'Connection1','Connection2'
             $script:sessions | Should -HaveCount 2
             $script:sessions[0].Name | Should -BeLike 'Connection*'
             $script:sessions[1].Name | Should -BeLike 'Connection*'
             VerifySession $script:sessions[0]
             VerifySession $script:sessions[1]
         }
+    }
+
+    function TryCreateRunspace
+    {
+        param (
+            [string] $UserName,
+            [string] $ComputerName,
+            [string] $KeyFilePath,
+            [int] $Port,
+            [string] $Subsystem
+        )
+
+        $timeout = $script:TestConnectingTimeout
+        $connectionError = $null
+        $count = 0
+        $rs = $null
+        $ci = [System.Management.Automation.Runspaces.SSHConnectionInfo]::new($UserName, $ComputerName, $KeyFilePath, $Port, $Subsystem, $timeout)
+        while (($null -eq $rs) -and ($count++ -lt 2))
+        {
+            try
+            {
+                $rs = [runspacefactory]::CreateRunspace($host, $ci)
+                $null = $rs.Open()
+            }
+            catch
+            {
+                $connectionError = $_
+                $rs = $null
+                Write-Verbose -Verbose "SSH Runspace Open remoting connect failed after $($timeout/1000) second wait."
+
+                if ($count -eq 1)
+                {
+                    # Try restarting sshd service
+                    CheckSSHDService
+                }
+            }
+        }
+
+        if ($null -eq $rs)
+        {
+            $message = "Runspace open unable to connect to SSH remoting endpoint after three attempts. Error: $($connectionError.Message)"
+            throw [System.Management.Automation.PSInvalidOperationException]::new($message)
+        }
+
+        Write-Verbose -Verbose "SSH Runspace Open remoting connect succeeded."
+        Write-Output $rs
     }
 
     function VerifyRunspace {
@@ -178,9 +318,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
                 $SubSystem
             )
 
-            $ci = [System.Management.Automation.Runspaces.SSHConnectionInfo]::new($UserName, $ComputerName, $KeyFilePath, $Port, $Subsystem)
-            $script:rs = [runspacefactory]::CreateRunspace($host, $ci)
-            $script:rs.Open()
+            $script:rs = TryCreateRunspace -UserName $UserName -ComputerName $ComputerName -KeyFilePath $KeyFilePath -Port $Port -Subsystem $Subsystem
             VerifyRunspace $script:rs
         }
     }

--- a/test/SSHRemoting/SSHRemoting.Basic.Tests.ps1
+++ b/test/SSHRemoting/SSHRemoting.Basic.Tests.ps1
@@ -373,7 +373,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             Write-Verbose -Verbose "It Starting: $TestName"
             $script:rs = TryCreateRunspace -UserName $UserName -ComputerName $ComputerName -KeyFilePath $KeyFilePath -Port $Port -Subsystem $Subsystem
             $script:rs | Should -Not -BeNullOrEmpty
-            #VerifyRunspace $script:rs
+            VerifyRunspace $script:rs
             Write-Verbose -Verbose "It Complete"
         }
     }

--- a/test/SSHRemoting/SSHRemoting.Basic.Tests.ps1
+++ b/test/SSHRemoting/SSHRemoting.Basic.Tests.ps1
@@ -36,6 +36,8 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             [string] $Subsystem
         )
 
+        Write-Verbose -Verbose "Starting TryNewPSSession ..."
+
         # Try creating a new SSH connection
         $timeout = $script:TestConnectingTimeout
         $connectionError = $null
@@ -72,6 +74,8 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             [hashtable[]] $SSHConnection,
             [string[]] $Name
         )
+
+        Write-Verbose -Verbose "Starting TryNewPSSessionHash ..."
 
         foreach ($connect in $SSHConnection)
         {
@@ -129,49 +133,64 @@ Describe "SSHRemoting Basic Tests" -tags CI {
     Context "New-PSSession Tests" {
 
         AfterEach {
+            Write-Verbose -Verbose "Starting New-PSSession AfterEach"
             if ($script:session -ne $null) { Remove-PSSession -Session $script:session }
             if ($script:sessions -ne $null) { Remove-PSSession -Session $script:sessions }
+            Write-Verbose -Verbose "AfterEach complete"
         }
 
         It "Verifies new connection with implicit current User" {
+            Write-Verbose -Verbose "It Starting: Verifies new connection with implicit current User"
             $script:session = TryNewPSSession -HostName localhost
             VerifySession $script:session
+            Write-Verbose -Verbose "It Complete"
         }
 
         It "Verifies new connection with explicit User parameter" {
+            Write-Verbose -Verbose "It Starting: Verifies new connection with explicit User parameter"
             $script:session = TryNewPSSession -HostName localhost -UserName (whoami)
             VerifySession $script:session
+            Write-Verbose -Verbose "It Complete"
         }
 
         It "Verifies explicit Name parameter" {
+            Write-Verbose -Verbose "It Starting: Verifies explicit Name parameter"
             $sessionName = 'TestSessionNameA'
             $script:session = TryNewPSSession -HostName localhost -Name $sessionName
             VerifySession $script:session
             $script:session.Name | Should -BeExactly $sessionName
+            Write-Verbose -Verbose "It Complete"
         }
 
         It "Verifies explicit Port parameter" {
+            Write-Verbose -Verbose "It Starting: Verifies explicit Port parameter"
             $portNum = 22
             $script:session = TryNewPSSession -HostName localhost -Port $portNum
             VerifySession $script:session
+            Write-Verbose -Verbose "It Complete"
         }
 
         It "Verifies explicit Subsystem parameter" {
+            Write-Verbose -Verbose "It Starting: Verifies explicit Subsystem parameter"
             $portNum = 22
             $subSystem = 'powershell'
             $script:session = TryNewPSSession -HostName localhost -Port $portNum -SubSystem $subSystem
             VerifySession $script:session
+            Write-Verbose -Verbose "It Complete"
         }
 
         It "Verifies explicit KeyFilePath parameter" {
+            Write-Verbose -Verbose "It Starting: Verifies explicit KeyFilePath parameter"
             $keyFilePath = "$HOME/.ssh/id_rsa"
             $portNum = 22
             $subSystem = 'powershell'
             $script:session = TryNewPSSession -HostName localhost -Port $portNum -SubSystem $subSystem -KeyFilePath $keyFilePath
             VerifySession $script:session
+            Write-Verbose -Verbose "It Complete"
         }
 
         It "Verifies SSHConnection hash table parameters" {
+            Write-Verbose -Verbose "It Starting: Verifies SSHConnection hash table parameters"
             $sshConnection = @(
             @{
                 HostName = 'localhost'
@@ -191,6 +210,7 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             $script:sessions[1].Name | Should -BeLike 'Connection*'
             VerifySession $script:sessions[0]
             VerifySession $script:sessions[1]
+            Write-Verbose -Verbose "It Complete"
         }
     }
 
@@ -203,6 +223,8 @@ Describe "SSHRemoting Basic Tests" -tags CI {
             [int] $Port,
             [string] $Subsystem
         )
+
+        Write-Verbose -Verbose "Starting TryCreateRunspace ..."
 
         $timeout = $script:TestConnectingTimeout
         $connectionError = $null
@@ -325,11 +347,14 @@ Describe "SSHRemoting Basic Tests" -tags CI {
                 $ComputerName,
                 $KeyFilePath,
                 $Port,
-                $SubSystem
+                $SubSystem,
+                $TestName
             )
 
+            Write-Verbose -Verbose "It Starting: $TestName"
             $script:rs = TryCreateRunspace -UserName $UserName -ComputerName $ComputerName -KeyFilePath $KeyFilePath -Port $Port -Subsystem $Subsystem
             VerifyRunspace $script:rs
+            Write-Verbose -Verbose "It Complete"
         }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This fixes the SSH remoting hang issue: #15174 

## PR Context

If an SSH remoting endpoint configuration (sshd_config file) is misconfigured, the ssh.exe client process used to make the ssh connection fails silently.  No error is emitted.  As a result, the PowerShell remoting layer waits indefinitely for protocol messages.

I also noticed that the base transport manager message queue threads were not being cleaned up in this case, because a connection is never established and the normal protocol close processing never occurs.  So I have modified the code to ensure this clean up is done in this SSH connection failed case.

After some discussion, the proposed fix is to add a `-ConnectingTimeout` parameter to SSH remoting that abandons a connection attempt after the timeout period.  The default value will be `infinite` so as not to introduce regressions.

This change will affect:
```powershell
Enter-PSSession SSH parameter set
Invoke-PSSession SSH parameter set
New-PSSession SSH parameter set
SSHConnectionInfo class
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/7464
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
