### PR TITLE
Revert "Enhance Remove-Item to work with OneDrive (#14902)"

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
@@ -2699,7 +2699,7 @@ namespace Microsoft.PowerShell.Commands
                         try
                         {
                             System.IO.DirectoryInfo di = new(providerPath);
-                            if (di != null && InternalSymbolicLinkLinkCodeMethods.IsReparsePointLikeSymlink(di))
+                            if (di != null && (di.Attributes & System.IO.FileAttributes.ReparsePoint) != 0)
                             {
                                 shouldRecurse = false;
                                 treatAsFile = true;

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1863,7 +1863,7 @@ namespace System.Management.Automation
 
             if (ExperimentalFeature.IsEnabled("PSAnsiRendering"))
             {
-                PSStyle psstyle = PSStyle.Instance;
+                PSStyle psstyle = PSStyle.Instance;                
                 switch (formatStyle)
                 {
                     case FormatStyle.Reset:
@@ -2099,13 +2099,6 @@ namespace System.Management.Automation.Internal
         internal static bool ShowMarkdownOutputBypass;
 
         internal static bool ThrowExdevErrorOnMoveDirectory;
-
-        // To emulate OneDrive behavior we use the hard-coded symlink.
-        // If OneDriveTestRecuseOn is false then the symlink works as regular symlink.
-        // If OneDriveTestRecuseOn is true then we resurce into the symlink as OneDrive should work.
-        internal static bool OneDriveTestOn;
-        internal static bool OneDriveTestRecurseOn;
-        internal static string OneDriveTestSymlinkName = "link-Beta";
 
         /// <summary>This member is used for internal test purposes.</summary>
         public static void SetTestHook(string property, object value)

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1890,17 +1890,9 @@ namespace Microsoft.PowerShell.Commands
                             }
 
                             bool hidden = false;
-                            bool checkReparsePoint = true;
                             if (!Force)
                             {
                                 hidden = (recursiveDirectory.Attributes & FileAttributes.Hidden) != 0;
-
-                                // Performance optimization.
-                                // Since we have already checked Attributes for Hidden we have already did a p/invoke
-                                // and initialized Attributes property.
-                                // So here we can check for ReparsePoint without new p/invoke.
-                                // If it is not a reparse point we skip one p/invoke in IsReparsePointLikeSymlink() below.
-                                checkReparsePoint = (recursiveDirectory.Attributes & FileAttributes.ReparsePoint) != 0;
                             }
 
                             // if "Hidden" is explicitly specified anywhere in the attribute filter, then override
@@ -1914,7 +1906,7 @@ namespace Microsoft.PowerShell.Commands
                                 //  c) it is not a reparse point with a target (not OneDrive or an AppX link).
                                 if (tracker == null)
                                 {
-                                    if (checkReparsePoint && InternalSymbolicLinkLinkCodeMethods.IsReparsePointLikeSymlink(recursiveDirectory))
+                                    if (InternalSymbolicLinkLinkCodeMethods.IsReparsePointWithTarget(recursiveDirectory))
                                     {
                                         continue;
                                     }
@@ -2066,7 +2058,7 @@ namespace Microsoft.PowerShell.Commands
         public static string NameString(PSObject instance)
         {
             return instance?.BaseObject is FileSystemInfo fileInfo
-                ? InternalSymbolicLinkLinkCodeMethods.IsReparsePointLikeSymlink(fileInfo)
+                ? InternalSymbolicLinkLinkCodeMethods.IsReparsePointWithTarget(fileInfo)
                     ? $"{fileInfo.Name} -> {InternalSymbolicLinkLinkCodeMethods.GetTarget(instance)}"
                     : fileInfo.Name
                 : string.Empty;
@@ -3106,31 +3098,22 @@ namespace Microsoft.PowerShell.Commands
                 continueRemoval = ShouldProcess(directory.FullName, action);
             }
 
-            if (InternalSymbolicLinkLinkCodeMethods.IsReparsePointLikeSymlink(directory))
+            if (directory.Attributes.HasFlag(FileAttributes.ReparsePoint))
             {
-                void WriteErrorHelper(Exception exception)
-                {
-                    WriteError(new ErrorRecord(exception, errorId: "DeleteSymbolicLinkFailed", ErrorCategory.WriteError, directory));
-                }
-
                 try
                 {
-                    if (InternalTestHooks.OneDriveTestOn)
-                    {
-                        WriteErrorHelper(new IOException());
-                        return;
-                    }
-                    else
-                    {
-                        // Name surrogates should just be detached.
-                        directory.Delete();
-                    }
+                    // TODO:
+                    // Different symlinks seem to vary by behavior.
+                    // In particular, OneDrive symlinks won't remove without recurse,
+                    // but the .NET API here does not allow us to distinguish them.
+                    // We may need to revisit using p/Invokes here to get the right behavior
+                    directory.Delete();
                 }
                 catch (Exception e)
                 {
                     string error = StringUtil.Format(FileSystemProviderStrings.CannotRemoveItem, directory.FullName, e.Message);
                     var exception = new IOException(error, e);
-                    WriteErrorHelper(exception);
+                    WriteError(new ErrorRecord(exception, errorId: "DeleteSymbolicLinkFailed", ErrorCategory.WriteError, directory));
                 }
 
                 return;
@@ -8232,47 +8215,28 @@ namespace Microsoft.PowerShell.Commands
             return fileInfo.Attributes.HasFlag(System.IO.FileAttributes.ReparsePoint);
         }
 
-        internal static bool IsReparsePointLikeSymlink(FileSystemInfo fileInfo)
+        internal static bool IsReparsePointWithTarget(FileSystemInfo fileInfo)
         {
-#if UNIX
-            // Reparse point on Unix is a symlink.
-            return IsReparsePoint(fileInfo);
-#else
-            if (InternalTestHooks.OneDriveTestOn && fileInfo.Name == InternalTestHooks.OneDriveTestSymlinkName)
+            if (!IsReparsePoint(fileInfo))
             {
-                return !InternalTestHooks.OneDriveTestRecurseOn;
+                return false;
             }
-
-            WIN32_FIND_DATA data = default;
+#if !UNIX
+            // It is a reparse point and we should check some reparse point tags.
+            var data = new WIN32_FIND_DATA();
             using (var handle = FindFirstFileEx(fileInfo.FullName, FINDEX_INFO_LEVELS.FindExInfoBasic, ref data, FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero, 0))
             {
-                if (handle.IsInvalid)
-                {
-                    // If we can not open the file object we assume it's a symlink.
-                    return true;
-                }
-
-                // To exclude one extra p/invoke in some scenarios
-                // we don't check fileInfo.FileAttributes
-                const int FILE_ATTRIBUTE_REPARSE_POINT = 0x0400;
-                if ((data.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) == 0)
-                {
-                    // Not a reparse point.
-                    return false;
-                }
-
                 // The name surrogate bit 0x20000000 is defined in https://docs.microsoft.com/windows/win32/fileio/reparse-point-tags
                 // Name surrogates (0x20000000) are reparse points that point to other named entities local to the filesystem
                 // (like symlinks and mount points).
                 // In the case of OneDrive, they are not name surrogates and would be safe to recurse into.
-                if ((data.dwReserved0 & 0x20000000) == 0 && (data.dwReserved0 != IO_REPARSE_TAG_APPEXECLINK))
+                if (!handle.IsInvalid && (data.dwReserved0 & 0x20000000) == 0 && (data.dwReserved0 != IO_REPARSE_TAG_APPEXECLINK))
                 {
                     return false;
                 }
             }
-
-            return true;
 #endif
+            return true;
         }
 
         internal static bool WinIsHardLink(FileSystemInfo fileInfo)

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -570,7 +570,7 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
             $omegaFile1 = Join-Path $omegaDir "OmegaFile1"
             $omegaFile2 = Join-Path $omegaDir "OmegaFile2"
             $betaDir = Join-Path $alphaDir "sub-Beta"
-            $betaLink = Join-Path $alphaDir "link-Beta" # Don't change! The name is hard-coded in PowerShell for OneDrive tests.
+            $betaLink = Join-Path $alphaDir "link-Beta"
             $betaFile1 = Join-Path $betaDir "BetaFile1.txt"
             $betaFile2 = Join-Path $betaDir "BetaFile2.txt"
             $betaFile3 = Join-Path $betaDir "BetaFile3.txt"
@@ -622,31 +622,6 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
             #New-Item -ItemType SymbolicLink -Path $betaLink -Value $betaDir
             $ci = Get-ChildItem $alphaLink -Recurse -Name
             $ci.Count | Should -BeExactly 7 # returns 10 - unexpectly recurce in link-alpha\link-Beta. See https://github.com/PowerShell/PowerShell/issues/11614
-        }
-        It "Get-ChildItem will recurse into emulated OneDrive directory" -Skip:(-not $IsWindows) {
-            # The test depends on the files created in previous test:
-            #New-Item -ItemType SymbolicLink -Path $alphaLink -Value $alphaDir
-            #New-Item -ItemType SymbolicLink -Path $betaLink -Value $betaDir
-
-            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestOn', $true)
-            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecurseOn', $false)
-            try
-            {
-                # '$betaDir' is a symlink - we don't follow symlinks
-                # This emulates PowerShell 6.2 and below behavior.
-                $ci = Get-ChildItem -Path $alphaDir -Recurse
-                $ci.Count | Should -BeExactly 7
-
-                # Now we follow the symlink like on OneDrive.
-                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecurseOn', $true)
-                $ci = Get-ChildItem -Path $alphaDir -Recurse
-                $ci.Count | Should -BeExactly 10
-            }
-            finally
-            {
-                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecurseOn', $false)
-                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestOn', $false)
-            }
         }
         It "Get-ChildItem will recurse into symlinks given -FollowSymlink, avoiding link loops" {
             New-Item -ItemType Directory -Path $gammaDir
@@ -769,42 +744,6 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
             $childB.Count | Should -BeExactly $childA.Count
             $childB.Name | Should -BeExactly $childA.Name
         }
-        It "Remove-Item will recurse into emulated OneDrive directory" -Skip:(-not $IsWindows) {
-            $alphaDir = Join-Path $TestDrive "sub-alpha2"
-            $alphaLink = Join-Path $TestDrive "link-alpha2"
-            $alphaFile1 = Join-Path $alphaDir "AlphaFile1.txt"
-            $betaDir = Join-Path $alphaDir "sub-Beta"
-            $betaLink = Join-Path $alphaDir "link-Beta"
-            $betaFile1 = Join-Path $betaDir "BetaFile1.txt"
-
-            New-Item -ItemType Directory -Path $alphaDir > $null
-            New-Item -ItemType File -Path $alphaFile1 > $null
-            New-Item -ItemType Directory -Path $betaDir > $null
-            New-Item -ItemType File -Path $betaFile1 > $null
-
-            New-Item -ItemType SymbolicLink -Path $alphaLink -Value $alphaDir > $null
-            New-Item -ItemType SymbolicLink -Path $betaLink -Value $betaDir > $null
-
-            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestOn', $true)
-            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecurseOn', $false)
-            try
-            {
-                # With the test hook turned on we don't remove '$betaDir' symlink.
-                # This emulates PowerShell 7.1 and below behavior.
-                { Remove-Item -Path $betaLink -Recurse -ErrorAction Stop } | Should -Throw -ErrorId "DeleteSymbolicLinkFailed,Microsoft.PowerShell.Commands.RemoveItemCommand"
-
-                # Now we emulate OneDrive and follow the symlink like on OneDrive.
-                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecurseOn', $true)
-                Remove-Item -Path $betaLink -Recurse
-                Test-Path -Path $betaLink | Should -BeFalse
-            }
-            finally
-            {
-                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecurseOn', $false)
-                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestOn', $false)
-            }
-        }
-
     }
 }
 


### PR DESCRIPTION

# PR Summary

We have been having issues with Remove-Item -Recure -Force failing since fafc38fe5c457afbc68b379bdf9c847562e209c5.

So, reverting that commit until the issue has been addressed.

## PR Context

https://dev.azure.com/powershell/PowerShell/_build/results?buildId=76645&view=logs&j=719313b2-5d75-51d7-9f16-928d568dcba1&t=51cacb73-0bf2-5113-ddc2-bada8ccfae1e&l=114

Tests were failing with:
```
 Describing About help files can be found in AllUsers scope 
 [-] Error occurred in Describe block 0ms 
 IOException: The directory is not empty. : 'C:\Users\VssAdministrator\Documents\PowerShell\Help\' 
 IOException: Cannot remove item C:\Users\VssAdministrator\Documents\PowerShell\Help\: The directory is not empty. : 'C:\Users\VssAdministrator\Documents\PowerShell\Help\' 
 at <ScriptBlock>, D:\a\1\s\test\powershell\engine\Help\HelpSystem.Tests.ps1: line 267 
 at Invoke-Blocks, D:\a\1\s\src\powershell-win-core\bin\Release\net6.0\win7-x64\publish\Modules\Pester\4.10.1\Functions\SetupTeardown.ps1: line 135 
 at Invoke-TestGroupSetupBlocks, D:\a\1\s\src\powershell-win-core\bin\Release\net6.0\win7-x64\publish\Modules\Pester\4.10.1\Functions\SetupTeardown.ps1: line 121 
 at DescribeImpl, D:\a\1\s\src\powershell-win-core\bin\Release\net6.0\win7-x64\publish\Modules\Pester\4.10.1\Functions\Describe.ps1: line 209 
```
## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
