### PR TITLE
Remove trailing slash in path passed to FindFirstFileEx

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
@@ -1,170 +1,179 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+
 Describe "Remove-Item" -Tags "CI" {
-    $testpath = $TestDrive
-    $testfile = "testfile.txt"
-    $testfilepath = Join-Path -Path $testpath -ChildPath $testfile
+    BeforeAll {
+        $testpath = $TestDrive
+        $testfile = "testfile.txt"
+        $testfilepath = Join-Path -Path $testpath -ChildPath $testfile
+    }
+
     Context "File removal Tests" {
-	BeforeEach {
-	    New-Item -Name $testfile -Path $testpath -ItemType "file" -Value "lorem ipsum" -Force
-	    Test-Path $testfilepath | Should -BeTrue
-	}
+        BeforeEach {
+            New-Item -Name $testfile -Path $testpath -ItemType "file" -Value "lorem ipsum" -Force
+            Test-Path $testfilepath | Should -BeTrue
+        }
 
-	It "Should be able to be called on a regular file without error using the Path parameter" {
-	    { Remove-Item -Path $testfilepath } | Should -Not -Throw
+        It "Should be able to be called on a regular file without error using the Path parameter" {
+            { Remove-Item -Path $testfilepath } | Should -Not -Throw
 
-	    Test-Path $testfilepath | Should -BeFalse
-	}
+            Test-Path $testfilepath | Should -BeFalse
+        }
 
-	It "Should be able to be called on a file without the Path parameter" {
-	    { Remove-Item $testfilepath } | Should -Not -Throw
+        It "Should be able to be called on a file without the Path parameter" {
+            { Remove-Item $testfilepath } | Should -Not -Throw
 
-	    Test-Path $testfilepath | Should -BeFalse
-	}
+            Test-Path $testfilepath | Should -BeFalse
+        }
 
-	It "Should be able to call the rm alias" {
-	    { rm $testfilepath } | Should -Not -Throw
+        It "Should be able to call the rm alias" {
+            { rm $testfilepath } | Should -Not -Throw
 
-	    Test-Path $testfilepath | Should -BeFalse
-	}
+            Test-Path $testfilepath | Should -BeFalse
+        }
 
-	It "Should be able to call the del alias" {
-	    { del $testfilepath } | Should -Not -Throw
+        It "Should be able to call the del alias" {
+            { del $testfilepath } | Should -Not -Throw
 
-	    Test-Path $testfilepath | Should -BeFalse
-	}
+            Test-Path $testfilepath | Should -BeFalse
+        }
 
-	It "Should be able to call the erase alias" {
-	    { erase $testfilepath } | Should -Not -Throw
+        It "Should be able to call the erase alias" {
+            { erase $testfilepath } | Should -Not -Throw
 
-	    Test-Path $testfilepath | Should -BeFalse
-	}
+            Test-Path $testfilepath | Should -BeFalse
+        }
 
-	It "Should be able to call the ri alias" {
-	    { ri $testfilepath } | Should -Not -Throw
+        It "Should be able to call the ri alias" {
+            { ri $testfilepath } | Should -Not -Throw
 
-	    Test-Path $testfilepath | Should -BeFalse
-	}
+            Test-Path $testfilepath | Should -BeFalse
+        }
 
-	It "Should not be able to remove a read-only document without using the force switch" {
-	    # Set to read only
-	    Set-ItemProperty -Path $testfilepath -Name IsReadOnly -Value $true
+        It "Should not be able to remove a read-only document without using the force switch" {
+            # Set to read only
+            Set-ItemProperty -Path $testfilepath -Name IsReadOnly -Value $true
 
-	    # attempt to remove the file
-	    { Remove-Item $testfilepath -ErrorAction SilentlyContinue } | Should -Not -Throw
+            # attempt to remove the file
+            { Remove-Item $testfilepath -ErrorAction SilentlyContinue } | Should -Not -Throw
 
-	    # validate
-	    Test-Path $testfilepath | Should -BeTrue
+            # validate
+            Test-Path $testfilepath | Should -BeTrue
 
-	    # remove using the -force switch on the readonly object
-	    Remove-Item  $testfilepath -Force
+            # remove using the -force switch on the readonly object
+            Remove-Item  $testfilepath -Force
 
-	    # Validate
-	    Test-Path $testfilepath | Should -BeFalse
-	}
+            # Validate
+            Test-Path $testfilepath | Should -BeFalse
+        }
 
-	It "Should be able to remove all files matching a regular expression with the include parameter" {
-	    # Create multiple files with specific string
-	    New-Item -Name file1.txt -Path $testpath -ItemType "file" -Value "lorem ipsum"
-	    New-Item -Name file2.txt -Path $testpath -ItemType "file" -Value "lorem ipsum"
-	    New-Item -Name file3.txt -Path $testpath -ItemType "file" -Value "lorem ipsum"
-	    # Create a single file that does not match that string - already done in BeforeEach
+        It "Should be able to remove all files matching a regular expression with the include parameter" {
+            # Create multiple files with specific string
+            New-Item -Name file1.txt -Path $testpath -ItemType "file" -Value "lorem ipsum"
+            New-Item -Name file2.txt -Path $testpath -ItemType "file" -Value "lorem ipsum"
+            New-Item -Name file3.txt -Path $testpath -ItemType "file" -Value "lorem ipsum"
+            # Create a single file that does not match that string - already done in BeforeEach
 
-	    # Delete the specific string
-	    Remove-Item (Join-Path -Path $testpath -ChildPath "*") -Include file*.txt
-	    # validate that the string under test was deleted, and the nonmatching strings still exist
-	    Test-Path (Join-Path -Path $testpath -ChildPath file1.txt) | Should -BeFalse
-	    Test-Path (Join-Path -Path $testpath -ChildPath file2.txt) | Should -BeFalse
-	    Test-Path (Join-Path -Path $testpath -ChildPath file3.txt) | Should -BeFalse
-	    Test-Path $testfilepath  | Should -BeTrue
+            # Delete the specific string
+            Remove-Item (Join-Path -Path $testpath -ChildPath "*") -Include file*.txt
+            # validate that the string under test was deleted, and the nonmatching strings still exist
+            Test-Path (Join-Path -Path $testpath -ChildPath file1.txt) | Should -BeFalse
+            Test-Path (Join-Path -Path $testpath -ChildPath file2.txt) | Should -BeFalse
+            Test-Path (Join-Path -Path $testpath -ChildPath file3.txt) | Should -BeFalse
+            Test-Path $testfilepath  | Should -BeTrue
 
-	    # Delete the non-matching strings
-	    Remove-Item $testfilepath
+            # Delete the non-matching strings
+            Remove-Item $testfilepath
 
-	    Test-Path $testfilepath  | Should -BeFalse
-	}
+            Test-Path $testfilepath  | Should -BeFalse
+        }
 
-	It "Should be able to not remove any files matching a regular expression with the exclude parameter" {
-	    # Create multiple files with specific string
-	    New-Item -Name file1.wav -Path $testpath -ItemType "file" -Value "lorem ipsum"
-	    New-Item -Name file2.wav -Path $testpath -ItemType "file" -Value "lorem ipsum"
+        It "Should be able to not remove any files matching a regular expression with the exclude parameter" {
+            # Create multiple files with specific string
+            New-Item -Name file1.wav -Path $testpath -ItemType "file" -Value "lorem ipsum"
+            New-Item -Name file2.wav -Path $testpath -ItemType "file" -Value "lorem ipsum"
 
-	    # Create a single file that does not match that string
-	    New-Item -Name file1.txt -Path $testpath -ItemType "file" -Value "lorem ipsum"
+            # Create a single file that does not match that string
+            New-Item -Name file1.txt -Path $testpath -ItemType "file" -Value "lorem ipsum"
 
-	    # Delete the specific string
-	    Remove-Item (Join-Path -Path $testpath -ChildPath "file*") -Exclude *.wav -Include *.txt
+            # Delete the specific string
+            Remove-Item (Join-Path -Path $testpath -ChildPath "file*") -Exclude *.wav -Include *.txt
 
-	    # validate that the string under test was deleted, and the nonmatching strings still exist
-	    Test-Path (Join-Path -Path $testpath -ChildPath file1.wav) | Should -BeTrue
-	    Test-Path (Join-Path -Path $testpath -ChildPath file2.wav) | Should -BeTrue
-	    Test-Path (Join-Path -Path $testpath -ChildPath file1.txt) | Should -BeFalse
+            # validate that the string under test was deleted, and the nonmatching strings still exist
+            Test-Path (Join-Path -Path $testpath -ChildPath file1.wav) | Should -BeTrue
+            Test-Path (Join-Path -Path $testpath -ChildPath file2.wav) | Should -BeTrue
+            Test-Path (Join-Path -Path $testpath -ChildPath file1.txt) | Should -BeFalse
 
-	    # Delete the non-matching strings
-	    Remove-Item (Join-Path -Path $testpath -ChildPath file1.wav)
-	    Remove-Item (Join-Path -Path $testpath -ChildPath file2.wav)
+            # Delete the non-matching strings
+            Remove-Item (Join-Path -Path $testpath -ChildPath file1.wav)
+            Remove-Item (Join-Path -Path $testpath -ChildPath file2.wav)
 
-	    Test-Path (Join-Path -Path $testpath -ChildPath file1.wav) | Should -BeFalse
-	    Test-Path (Join-Path -Path $testpath -ChildPath file2.wav) | Should -BeFalse
-	}
+            Test-Path (Join-Path -Path $testpath -ChildPath file1.wav) | Should -BeFalse
+            Test-Path (Join-Path -Path $testpath -ChildPath file2.wav) | Should -BeFalse
+        }
     }
 
     Context "Directory Removal Tests" {
-	$testdirectory = Join-Path -Path $testpath -ChildPath testdir
-	$testsubdirectory = Join-Path -Path $testdirectory -ChildPath subd
-	BeforeEach {
-	    New-Item -Name "testdir" -Path $testpath -ItemType "directory" -Force
+        BeforeAll {
+            $testdirectory = Join-Path -Path $testpath -ChildPath testdir
+            $testsubdirectory = Join-Path -Path $testdirectory -ChildPath subd
+        }
 
-	    Test-Path $testdirectory | Should -BeTrue
-	}
+        BeforeEach {
+            New-Item -Name "testdir" -Path $testpath -ItemType "directory" -Force
 
-	It "Should be able to remove a directory" {
-	    { Remove-Item $testdirectory } | Should -Not -Throw
+            Test-Path $testdirectory | Should -BeTrue
+        }
 
-	    Test-Path $testdirectory | Should -BeFalse
-	}
+        It "Should be able to remove a directory" {
+            { Remove-Item $testdirectory } | Should -Not -Throw
 
-	It "Should be able to recursively delete subfolders" {
-	    New-Item -Name "subd" -Path $testdirectory -ItemType "directory"
-	    New-Item -Name $testfile -Path $testsubdirectory -ItemType "file" -Value "lorem ipsum"
+            Test-Path $testdirectory | Should -BeFalse
+        }
 
-	    $complexDirectory = Join-Path -Path $testsubdirectory -ChildPath $testfile
-	    Test-Path $complexDirectory | Should -BeTrue
+        It "Should be able to recursively delete subfolders" {
+            New-Item -Name "subd" -Path $testdirectory -ItemType "directory"
+            New-Item -Name $testfile -Path $testsubdirectory -ItemType "file" -Value "lorem ipsum"
 
-	    { Remove-Item $testdirectory -Recurse} | Should -Not -Throw
+            $complexDirectory = Join-Path -Path $testsubdirectory -ChildPath $testfile
+            Test-Path $complexDirectory | Should -BeTrue
 
-	    Test-Path $testdirectory | Should -BeFalse
-	}
+            { Remove-Item $testdirectory -Recurse } | Should -Not -Throw
+
+            Test-Path $testdirectory | Should -BeFalse
+        }
     }
 
     Context "Alternate Data Streams should be supported on Windows" {
-      BeforeAll {
-        if (!$IsWindows) {
-          return
-        }
-        $fileName = "ADStest.txt"
-        $streamName = "teststream"
-        $dirName = "ADStestdir"
-        $fileContent =" This is file content."
-        $streamContent = "datastream content here"
-        $streamfile = Join-Path -Path $testpath -ChildPath $fileName
-        $streamdir = Join-Path -Path $testpath -ChildPath $dirName
+        BeforeAll {
+            if (!$IsWindows) {
+            return
+            }
+            $fileName = "ADStest.txt"
+            $streamName = "teststream"
+            $dirName = "ADStestdir"
+            $fileContent =" This is file content."
+            $streamContent = "datastream content here"
+            $streamfile = Join-Path -Path $testpath -ChildPath $fileName
+            $streamdir = Join-Path -Path $testpath -ChildPath $dirName
 
-        $null = New-Item -Path $streamfile -ItemType "File" -force
-        Add-Content -Path $streamfile -Value $fileContent
-        Add-Content -Path $streamfile -Stream $streamName -Value $streamContent
-        $null = New-Item -Path $streamdir -ItemType "Directory" -Force
-        Add-Content -Path $streamdir -Stream $streamName -Value $streamContent
-      }
-      It "Should completely remove a datastream from a file" -Skip:(!$IsWindows) {
-        Get-Item -Path $streamfile -Stream $streamName | Should -Not -BeNullOrEmpty
-        Remove-Item -Path $streamfile -Stream $streamName
-        Get-Item -Path $streamfile -Stream $streamName -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
-      }
-      It "Should completely remove a datastream from a directory" -Skip:(!$IsWindows) {
-        Get-Item -Path $streamdir -Stream $streamName | Should -Not -BeNullOrEmpty
-        Remove-Item -Path $streamdir -Stream $streamName
-        Get-Item -Path $streamdir -Stream $streamname -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
-      }
+            $null = New-Item -Path $streamfile -ItemType "File" -force
+            Add-Content -Path $streamfile -Value $fileContent
+            Add-Content -Path $streamfile -Stream $streamName -Value $streamContent
+            $null = New-Item -Path $streamdir -ItemType "Directory" -Force
+            Add-Content -Path $streamdir -Stream $streamName -Value $streamContent
+        }
+
+        It "Should completely remove a datastream from a file" -Skip:(!$IsWindows) {
+            Get-Item -Path $streamfile -Stream $streamName | Should -Not -BeNullOrEmpty
+            Remove-Item -Path $streamfile -Stream $streamName
+            Get-Item -Path $streamfile -Stream $streamName -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
+        }
+
+        It "Should completely remove a datastream from a directory" -Skip:(!$IsWindows) {
+            Get-Item -Path $streamdir -Stream $streamName | Should -Not -BeNullOrEmpty
+            Remove-Item -Path $streamdir -Stream $streamName
+            Get-Item -Path $streamdir -Stream $streamname -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
+        }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
@@ -126,7 +126,7 @@ Describe "Remove-Item" -Tags "CI" {
         }
 
         It "Should be able to remove a directory" {
-            { Remove-Item $testdirectory } | Should -Not -Throw
+            { Remove-Item $testdirectory -ErrorAction Stop } | Should -Not -Throw
 
             Test-Path $testdirectory | Should -BeFalse
         }
@@ -138,8 +138,24 @@ Describe "Remove-Item" -Tags "CI" {
             $complexDirectory = Join-Path -Path $testsubdirectory -ChildPath $testfile
             Test-Path $complexDirectory | Should -BeTrue
 
-            { Remove-Item $testdirectory -Recurse } | Should -Not -Throw
+            { Remove-Item $testdirectory -Recurse -ErrorAction Stop } | Should -Not -Throw
 
+            Test-Path $testdirectory | Should -BeFalse
+        }
+
+        It "Should be able to recursively delete a directory with a trailing backslash" {
+            New-Item -Name "subd" -Path $testdirectory -ItemType "directory"
+            New-Item -Name $testfile -Path $testsubdirectory -ItemType "file" -Value "lorem ipsum"
+
+            $complexDirectory = Join-Path -Path $testsubdirectory -ChildPath $testfile
+            Test-Path $complexDirectory | Should -BeTrue
+
+            $testdirectoryWithBackSlash = Join-Path -Path $testsubdirectory -ChildPath ([IO.Path]::DirectorySeparatorChar)
+            Test-Path $testdirectoryWithBackSlash | Should -BeTrue
+
+            { Remove-Item $testdirectoryWithBackSlash -Recurse -ErrorAction Stop } | Should -Not -Throw
+
+            Test-Path $testdirectoryWithBackSlash | Should -BeFalse
             Test-Path $testdirectory | Should -BeFalse
         }
     }
@@ -147,7 +163,7 @@ Describe "Remove-Item" -Tags "CI" {
     Context "Alternate Data Streams should be supported on Windows" {
         BeforeAll {
             if (!$IsWindows) {
-            return
+                return
             }
             $fileName = "ADStest.txt"
             $streamName = "teststream"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #15248.

Partial regression after #14902. Partial because there are other code paths (a path comes from public with trailing backslash) which can raise an issue in the place.

[Docs](https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findfirstfileexw#parameters) say that  FindFirstFileEx does not accept a path a trailing backslash (\\).

The fix is always removing a trailing backslash from path string before calling FindFirstFileEx.

Second commit reformat old tests (remove tabs).

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
