### PR TITLE
Enhance Remove-Item to work with OneDrive (Second)

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
@@ -2699,7 +2699,7 @@ namespace Microsoft.PowerShell.Commands
                         try
                         {
                             System.IO.DirectoryInfo di = new(providerPath);
-                            if (di != null && (di.Attributes & System.IO.FileAttributes.ReparsePoint) != 0)
+                            if (di != null && InternalSymbolicLinkLinkCodeMethods.IsReparsePointLikeSymlink(di))
                             {
                                 shouldRecurse = false;
                                 treatAsFile = true;

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1863,7 +1863,7 @@ namespace System.Management.Automation
 
             if (ExperimentalFeature.IsEnabled("PSAnsiRendering"))
             {
-                PSStyle psstyle = PSStyle.Instance;                
+                PSStyle psstyle = PSStyle.Instance;
                 switch (formatStyle)
                 {
                     case FormatStyle.Reset:
@@ -2099,6 +2099,13 @@ namespace System.Management.Automation.Internal
         internal static bool ShowMarkdownOutputBypass;
 
         internal static bool ThrowExdevErrorOnMoveDirectory;
+
+        // To emulate OneDrive behavior we use the hard-coded symlink.
+        // If OneDriveTestRecuseOn is false then the symlink works as regular symlink.
+        // If OneDriveTestRecuseOn is true then we resurce into the symlink as OneDrive should work.
+        internal static bool OneDriveTestOn;
+        internal static bool OneDriveTestRecurseOn;
+        internal static string OneDriveTestSymlinkName = "link-Beta";
 
         /// <summary>This member is used for internal test purposes.</summary>
         public static void SetTestHook(string property, object value)

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -8246,7 +8246,8 @@ namespace Microsoft.PowerShell.Commands
             {
                 if (handle.IsInvalid)
                 {
-                    // We should never be here.
+                    // Our handle could be invalidated by something else touching the filesystem,
+                    // so ensure we deal with that possibility here
                     int lastError = Marshal.GetLastWin32Error();
                     throw new Win32Exception(lastError);
                 }

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -8254,8 +8254,8 @@ namespace Microsoft.PowerShell.Commands
                     throw new Win32Exception(lastError);
                 }
 
-                // To exclude one extra p/invoke in some scenarios
-                // we don't check fileInfo.FileAttributes
+                // We already have the file attribute information from our Win32 call,
+                // so no need to take the expense of the FileInfo.FileAttributes call
                 const int FILE_ATTRIBUTE_REPARSE_POINT = 0x0400;
                 if ((data.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) == 0)
                 {

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1890,9 +1890,17 @@ namespace Microsoft.PowerShell.Commands
                             }
 
                             bool hidden = false;
+                            bool checkReparsePoint = true;
                             if (!Force)
                             {
                                 hidden = (recursiveDirectory.Attributes & FileAttributes.Hidden) != 0;
+
+                                // Performance optimization.
+                                // Since we have already checked Attributes for Hidden we have already did a p/invoke
+                                // and initialized Attributes property.
+                                // So here we can check for ReparsePoint without new p/invoke.
+                                // If it is not a reparse point we skip one p/invoke in IsReparsePointLikeSymlink() below.
+                                checkReparsePoint = (recursiveDirectory.Attributes & FileAttributes.ReparsePoint) != 0;
                             }
 
                             // if "Hidden" is explicitly specified anywhere in the attribute filter, then override
@@ -1906,7 +1914,7 @@ namespace Microsoft.PowerShell.Commands
                                 //  c) it is not a reparse point with a target (not OneDrive or an AppX link).
                                 if (tracker == null)
                                 {
-                                    if (InternalSymbolicLinkLinkCodeMethods.IsReparsePointWithTarget(recursiveDirectory))
+                                    if (checkReparsePoint && InternalSymbolicLinkLinkCodeMethods.IsReparsePointLikeSymlink(recursiveDirectory))
                                     {
                                         continue;
                                     }
@@ -2058,7 +2066,7 @@ namespace Microsoft.PowerShell.Commands
         public static string NameString(PSObject instance)
         {
             return instance?.BaseObject is FileSystemInfo fileInfo
-                ? InternalSymbolicLinkLinkCodeMethods.IsReparsePointWithTarget(fileInfo)
+                ? InternalSymbolicLinkLinkCodeMethods.IsReparsePointLikeSymlink(fileInfo)
                     ? $"{fileInfo.Name} -> {InternalSymbolicLinkLinkCodeMethods.GetTarget(instance)}"
                     : fileInfo.Name
                 : string.Empty;
@@ -3098,22 +3106,31 @@ namespace Microsoft.PowerShell.Commands
                 continueRemoval = ShouldProcess(directory.FullName, action);
             }
 
-            if (directory.Attributes.HasFlag(FileAttributes.ReparsePoint))
+            if (InternalSymbolicLinkLinkCodeMethods.IsReparsePointLikeSymlink(directory))
             {
+                void WriteErrorHelper(Exception exception)
+                {
+                    WriteError(new ErrorRecord(exception, errorId: "DeleteSymbolicLinkFailed", ErrorCategory.WriteError, directory));
+                }
+
                 try
                 {
-                    // TODO:
-                    // Different symlinks seem to vary by behavior.
-                    // In particular, OneDrive symlinks won't remove without recurse,
-                    // but the .NET API here does not allow us to distinguish them.
-                    // We may need to revisit using p/Invokes here to get the right behavior
-                    directory.Delete();
+                    if (InternalTestHooks.OneDriveTestOn)
+                    {
+                        WriteErrorHelper(new IOException());
+                        return;
+                    }
+                    else
+                    {
+                        // Name surrogates should just be detached.
+                        directory.Delete();
+                    }
                 }
                 catch (Exception e)
                 {
                     string error = StringUtil.Format(FileSystemProviderStrings.CannotRemoveItem, directory.FullName, e.Message);
                     var exception = new IOException(error, e);
-                    WriteError(new ErrorRecord(exception, errorId: "DeleteSymbolicLinkFailed", ErrorCategory.WriteError, directory));
+                    WriteErrorHelper(exception);
                 }
 
                 return;
@@ -8215,28 +8232,47 @@ namespace Microsoft.PowerShell.Commands
             return fileInfo.Attributes.HasFlag(System.IO.FileAttributes.ReparsePoint);
         }
 
-        internal static bool IsReparsePointWithTarget(FileSystemInfo fileInfo)
+        internal static bool IsReparsePointLikeSymlink(FileSystemInfo fileInfo)
         {
-            if (!IsReparsePoint(fileInfo))
+#if UNIX
+            // Reparse point on Unix is a symlink.
+            return IsReparsePoint(fileInfo);
+#else
+            if (InternalTestHooks.OneDriveTestOn && fileInfo.Name == InternalTestHooks.OneDriveTestSymlinkName)
             {
-                return false;
+                return !InternalTestHooks.OneDriveTestRecurseOn;
             }
-#if !UNIX
-            // It is a reparse point and we should check some reparse point tags.
-            var data = new WIN32_FIND_DATA();
+
+            WIN32_FIND_DATA data = default;
             using (var handle = FindFirstFileEx(fileInfo.FullName, FINDEX_INFO_LEVELS.FindExInfoBasic, ref data, FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero, 0))
             {
+                if (handle.IsInvalid)
+                {
+                    // If we can not open the file object we assume it's a symlink.
+                    return true;
+                }
+
+                // To exclude one extra p/invoke in some scenarios
+                // we don't check fileInfo.FileAttributes
+                const int FILE_ATTRIBUTE_REPARSE_POINT = 0x0400;
+                if ((data.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) == 0)
+                {
+                    // Not a reparse point.
+                    return false;
+                }
+
                 // The name surrogate bit 0x20000000 is defined in https://docs.microsoft.com/windows/win32/fileio/reparse-point-tags
                 // Name surrogates (0x20000000) are reparse points that point to other named entities local to the filesystem
                 // (like symlinks and mount points).
                 // In the case of OneDrive, they are not name surrogates and would be safe to recurse into.
-                if (!handle.IsInvalid && (data.dwReserved0 & 0x20000000) == 0 && (data.dwReserved0 != IO_REPARSE_TAG_APPEXECLINK))
+                if ((data.dwReserved0 & 0x20000000) == 0 && (data.dwReserved0 != IO_REPARSE_TAG_APPEXECLINK))
                 {
                     return false;
                 }
             }
-#endif
+
             return true;
+#endif
         }
 
         internal static bool WinIsHardLink(FileSystemInfo fileInfo)

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1895,11 +1895,8 @@ namespace Microsoft.PowerShell.Commands
                             {
                                 hidden = (recursiveDirectory.Attributes & FileAttributes.Hidden) != 0;
 
-                                // Performance optimization.
-                                // Since we have already checked Attributes for Hidden we have already did a p/invoke
-                                // and initialized Attributes property.
-                                // So here we can check for ReparsePoint without new p/invoke.
-                                // If it is not a reparse point we skip one p/invoke in IsReparsePointLikeSymlink() below.
+                                // We've already taken the expense of initializing the Attributes property here,
+                                // so we can use that to avoid needing to call IsReparsePointLikeSymlink() later.
                                 checkReparsePoint = (recursiveDirectory.Attributes & FileAttributes.ReparsePoint) != 0;
                             }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -570,7 +570,7 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
             $omegaFile1 = Join-Path $omegaDir "OmegaFile1"
             $omegaFile2 = Join-Path $omegaDir "OmegaFile2"
             $betaDir = Join-Path $alphaDir "sub-Beta"
-            $betaLink = Join-Path $alphaDir "link-Beta"
+            $betaLink = Join-Path $alphaDir "link-Beta" # Don't change! The name is hard-coded in PowerShell for OneDrive tests.
             $betaFile1 = Join-Path $betaDir "BetaFile1.txt"
             $betaFile2 = Join-Path $betaDir "BetaFile2.txt"
             $betaFile3 = Join-Path $betaDir "BetaFile3.txt"
@@ -622,6 +622,31 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
             #New-Item -ItemType SymbolicLink -Path $betaLink -Value $betaDir
             $ci = Get-ChildItem $alphaLink -Recurse -Name
             $ci.Count | Should -BeExactly 7 # returns 10 - unexpectly recurce in link-alpha\link-Beta. See https://github.com/PowerShell/PowerShell/issues/11614
+        }
+        It "Get-ChildItem will recurse into emulated OneDrive directory" -Skip:(-not $IsWindows) {
+            # The test depends on the files created in previous test:
+            #New-Item -ItemType SymbolicLink -Path $alphaLink -Value $alphaDir
+            #New-Item -ItemType SymbolicLink -Path $betaLink -Value $betaDir
+
+            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestOn', $true)
+            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecurseOn', $false)
+            try
+            {
+                # '$betaDir' is a symlink - we don't follow symlinks
+                # This emulates PowerShell 6.2 and below behavior.
+                $ci = Get-ChildItem -Path $alphaDir -Recurse
+                $ci.Count | Should -BeExactly 7
+
+                # Now we follow the symlink like on OneDrive.
+                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecurseOn', $true)
+                $ci = Get-ChildItem -Path $alphaDir -Recurse
+                $ci.Count | Should -BeExactly 10
+            }
+            finally
+            {
+                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecurseOn', $false)
+                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestOn', $false)
+            }
         }
         It "Get-ChildItem will recurse into symlinks given -FollowSymlink, avoiding link loops" {
             New-Item -ItemType Directory -Path $gammaDir
@@ -744,6 +769,42 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
             $childB.Count | Should -BeExactly $childA.Count
             $childB.Name | Should -BeExactly $childA.Name
         }
+        It "Remove-Item will recurse into emulated OneDrive directory" -Skip:(-not $IsWindows) {
+            $alphaDir = Join-Path $TestDrive "sub-alpha2"
+            $alphaLink = Join-Path $TestDrive "link-alpha2"
+            $alphaFile1 = Join-Path $alphaDir "AlphaFile1.txt"
+            $betaDir = Join-Path $alphaDir "sub-Beta"
+            $betaLink = Join-Path $alphaDir "link-Beta"
+            $betaFile1 = Join-Path $betaDir "BetaFile1.txt"
+
+            New-Item -ItemType Directory -Path $alphaDir > $null
+            New-Item -ItemType File -Path $alphaFile1 > $null
+            New-Item -ItemType Directory -Path $betaDir > $null
+            New-Item -ItemType File -Path $betaFile1 > $null
+
+            New-Item -ItemType SymbolicLink -Path $alphaLink -Value $alphaDir > $null
+            New-Item -ItemType SymbolicLink -Path $betaLink -Value $betaDir > $null
+
+            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestOn', $true)
+            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecurseOn', $false)
+            try
+            {
+                # With the test hook turned on we don't remove '$betaDir' symlink.
+                # This emulates PowerShell 7.1 and below behavior.
+                { Remove-Item -Path $betaLink -Recurse -ErrorAction Stop } | Should -Throw -ErrorId "DeleteSymbolicLinkFailed,Microsoft.PowerShell.Commands.RemoveItemCommand"
+
+                # Now we emulate OneDrive and follow the symlink like on OneDrive.
+                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecurseOn', $true)
+                Remove-Item -Path $betaLink -Recurse
+                Test-Path -Path $betaLink | Should -BeFalse
+            }
+            finally
+            {
+                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestRecurseOn', $false)
+                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('OneDriveTestOn', $false)
+            }
+        }
+
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
@@ -126,7 +126,7 @@ Describe "Remove-Item" -Tags "CI" {
         }
 
         It "Should be able to remove a directory" {
-            { Remove-Item $testdirectory } | Should -Not -Throw
+            { Remove-Item $testdirectory -ErrorAction Stop } | Should -Not -Throw
 
             Test-Path $testdirectory | Should -BeFalse
         }
@@ -138,8 +138,24 @@ Describe "Remove-Item" -Tags "CI" {
             $complexDirectory = Join-Path -Path $testsubdirectory -ChildPath $testfile
             Test-Path $complexDirectory | Should -BeTrue
 
-            { Remove-Item $testdirectory -Recurse } | Should -Not -Throw
+            { Remove-Item $testdirectory -Recurse -ErrorAction Stop } | Should -Not -Throw
 
+            Test-Path $testdirectory | Should -BeFalse
+        }
+
+        It "Should be able to recursively delete a directory with a trailing backslash" {
+            New-Item -Name "subd" -Path $testdirectory -ItemType "directory"
+            New-Item -Name $testfile -Path $testsubdirectory -ItemType "file" -Value "lorem ipsum"
+
+            $complexDirectory = Join-Path -Path $testsubdirectory -ChildPath $testfile
+            Test-Path $complexDirectory | Should -BeTrue
+
+            $testdirectoryWithBackSlash = Join-Path -Path $testdirectory -ChildPath ([IO.Path]::DirectorySeparatorChar)
+            Test-Path $testdirectoryWithBackSlash | Should -BeTrue
+
+            { Remove-Item $testdirectoryWithBackSlash -Recurse -ErrorAction Stop } | Should -Not -Throw
+
+            Test-Path $testdirectoryWithBackSlash | Should -BeFalse
             Test-Path $testdirectory | Should -BeFalse
         }
     }
@@ -147,7 +163,7 @@ Describe "Remove-Item" -Tags "CI" {
     Context "Alternate Data Streams should be supported on Windows" {
         BeforeAll {
             if (!$IsWindows) {
-            return
+                return
             }
             $fileName = "ADStest.txt"
             $streamName = "teststream"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
@@ -1,170 +1,179 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+
 Describe "Remove-Item" -Tags "CI" {
-    $testpath = $TestDrive
-    $testfile = "testfile.txt"
-    $testfilepath = Join-Path -Path $testpath -ChildPath $testfile
+    BeforeAll {
+        $testpath = $TestDrive
+        $testfile = "testfile.txt"
+        $testfilepath = Join-Path -Path $testpath -ChildPath $testfile
+    }
+
     Context "File removal Tests" {
-	BeforeEach {
-	    New-Item -Name $testfile -Path $testpath -ItemType "file" -Value "lorem ipsum" -Force
-	    Test-Path $testfilepath | Should -BeTrue
-	}
+        BeforeEach {
+            New-Item -Name $testfile -Path $testpath -ItemType "file" -Value "lorem ipsum" -Force
+            Test-Path $testfilepath | Should -BeTrue
+        }
 
-	It "Should be able to be called on a regular file without error using the Path parameter" {
-	    { Remove-Item -Path $testfilepath } | Should -Not -Throw
+        It "Should be able to be called on a regular file without error using the Path parameter" {
+            { Remove-Item -Path $testfilepath } | Should -Not -Throw
 
-	    Test-Path $testfilepath | Should -BeFalse
-	}
+            Test-Path $testfilepath | Should -BeFalse
+        }
 
-	It "Should be able to be called on a file without the Path parameter" {
-	    { Remove-Item $testfilepath } | Should -Not -Throw
+        It "Should be able to be called on a file without the Path parameter" {
+            { Remove-Item $testfilepath } | Should -Not -Throw
 
-	    Test-Path $testfilepath | Should -BeFalse
-	}
+            Test-Path $testfilepath | Should -BeFalse
+        }
 
-	It "Should be able to call the rm alias" {
-	    { rm $testfilepath } | Should -Not -Throw
+        It "Should be able to call the rm alias" {
+            { rm $testfilepath } | Should -Not -Throw
 
-	    Test-Path $testfilepath | Should -BeFalse
-	}
+            Test-Path $testfilepath | Should -BeFalse
+        }
 
-	It "Should be able to call the del alias" {
-	    { del $testfilepath } | Should -Not -Throw
+        It "Should be able to call the del alias" {
+            { del $testfilepath } | Should -Not -Throw
 
-	    Test-Path $testfilepath | Should -BeFalse
-	}
+            Test-Path $testfilepath | Should -BeFalse
+        }
 
-	It "Should be able to call the erase alias" {
-	    { erase $testfilepath } | Should -Not -Throw
+        It "Should be able to call the erase alias" {
+            { erase $testfilepath } | Should -Not -Throw
 
-	    Test-Path $testfilepath | Should -BeFalse
-	}
+            Test-Path $testfilepath | Should -BeFalse
+        }
 
-	It "Should be able to call the ri alias" {
-	    { ri $testfilepath } | Should -Not -Throw
+        It "Should be able to call the ri alias" {
+            { ri $testfilepath } | Should -Not -Throw
 
-	    Test-Path $testfilepath | Should -BeFalse
-	}
+            Test-Path $testfilepath | Should -BeFalse
+        }
 
-	It "Should not be able to remove a read-only document without using the force switch" {
-	    # Set to read only
-	    Set-ItemProperty -Path $testfilepath -Name IsReadOnly -Value $true
+        It "Should not be able to remove a read-only document without using the force switch" {
+            # Set to read only
+            Set-ItemProperty -Path $testfilepath -Name IsReadOnly -Value $true
 
-	    # attempt to remove the file
-	    { Remove-Item $testfilepath -ErrorAction SilentlyContinue } | Should -Not -Throw
+            # attempt to remove the file
+            { Remove-Item $testfilepath -ErrorAction SilentlyContinue } | Should -Not -Throw
 
-	    # validate
-	    Test-Path $testfilepath | Should -BeTrue
+            # validate
+            Test-Path $testfilepath | Should -BeTrue
 
-	    # remove using the -force switch on the readonly object
-	    Remove-Item  $testfilepath -Force
+            # remove using the -force switch on the readonly object
+            Remove-Item  $testfilepath -Force
 
-	    # Validate
-	    Test-Path $testfilepath | Should -BeFalse
-	}
+            # Validate
+            Test-Path $testfilepath | Should -BeFalse
+        }
 
-	It "Should be able to remove all files matching a regular expression with the include parameter" {
-	    # Create multiple files with specific string
-	    New-Item -Name file1.txt -Path $testpath -ItemType "file" -Value "lorem ipsum"
-	    New-Item -Name file2.txt -Path $testpath -ItemType "file" -Value "lorem ipsum"
-	    New-Item -Name file3.txt -Path $testpath -ItemType "file" -Value "lorem ipsum"
-	    # Create a single file that does not match that string - already done in BeforeEach
+        It "Should be able to remove all files matching a regular expression with the include parameter" {
+            # Create multiple files with specific string
+            New-Item -Name file1.txt -Path $testpath -ItemType "file" -Value "lorem ipsum"
+            New-Item -Name file2.txt -Path $testpath -ItemType "file" -Value "lorem ipsum"
+            New-Item -Name file3.txt -Path $testpath -ItemType "file" -Value "lorem ipsum"
+            # Create a single file that does not match that string - already done in BeforeEach
 
-	    # Delete the specific string
-	    Remove-Item (Join-Path -Path $testpath -ChildPath "*") -Include file*.txt
-	    # validate that the string under test was deleted, and the nonmatching strings still exist
-	    Test-Path (Join-Path -Path $testpath -ChildPath file1.txt) | Should -BeFalse
-	    Test-Path (Join-Path -Path $testpath -ChildPath file2.txt) | Should -BeFalse
-	    Test-Path (Join-Path -Path $testpath -ChildPath file3.txt) | Should -BeFalse
-	    Test-Path $testfilepath  | Should -BeTrue
+            # Delete the specific string
+            Remove-Item (Join-Path -Path $testpath -ChildPath "*") -Include file*.txt
+            # validate that the string under test was deleted, and the nonmatching strings still exist
+            Test-Path (Join-Path -Path $testpath -ChildPath file1.txt) | Should -BeFalse
+            Test-Path (Join-Path -Path $testpath -ChildPath file2.txt) | Should -BeFalse
+            Test-Path (Join-Path -Path $testpath -ChildPath file3.txt) | Should -BeFalse
+            Test-Path $testfilepath  | Should -BeTrue
 
-	    # Delete the non-matching strings
-	    Remove-Item $testfilepath
+            # Delete the non-matching strings
+            Remove-Item $testfilepath
 
-	    Test-Path $testfilepath  | Should -BeFalse
-	}
+            Test-Path $testfilepath  | Should -BeFalse
+        }
 
-	It "Should be able to not remove any files matching a regular expression with the exclude parameter" {
-	    # Create multiple files with specific string
-	    New-Item -Name file1.wav -Path $testpath -ItemType "file" -Value "lorem ipsum"
-	    New-Item -Name file2.wav -Path $testpath -ItemType "file" -Value "lorem ipsum"
+        It "Should be able to not remove any files matching a regular expression with the exclude parameter" {
+            # Create multiple files with specific string
+            New-Item -Name file1.wav -Path $testpath -ItemType "file" -Value "lorem ipsum"
+            New-Item -Name file2.wav -Path $testpath -ItemType "file" -Value "lorem ipsum"
 
-	    # Create a single file that does not match that string
-	    New-Item -Name file1.txt -Path $testpath -ItemType "file" -Value "lorem ipsum"
+            # Create a single file that does not match that string
+            New-Item -Name file1.txt -Path $testpath -ItemType "file" -Value "lorem ipsum"
 
-	    # Delete the specific string
-	    Remove-Item (Join-Path -Path $testpath -ChildPath "file*") -Exclude *.wav -Include *.txt
+            # Delete the specific string
+            Remove-Item (Join-Path -Path $testpath -ChildPath "file*") -Exclude *.wav -Include *.txt
 
-	    # validate that the string under test was deleted, and the nonmatching strings still exist
-	    Test-Path (Join-Path -Path $testpath -ChildPath file1.wav) | Should -BeTrue
-	    Test-Path (Join-Path -Path $testpath -ChildPath file2.wav) | Should -BeTrue
-	    Test-Path (Join-Path -Path $testpath -ChildPath file1.txt) | Should -BeFalse
+            # validate that the string under test was deleted, and the nonmatching strings still exist
+            Test-Path (Join-Path -Path $testpath -ChildPath file1.wav) | Should -BeTrue
+            Test-Path (Join-Path -Path $testpath -ChildPath file2.wav) | Should -BeTrue
+            Test-Path (Join-Path -Path $testpath -ChildPath file1.txt) | Should -BeFalse
 
-	    # Delete the non-matching strings
-	    Remove-Item (Join-Path -Path $testpath -ChildPath file1.wav)
-	    Remove-Item (Join-Path -Path $testpath -ChildPath file2.wav)
+            # Delete the non-matching strings
+            Remove-Item (Join-Path -Path $testpath -ChildPath file1.wav)
+            Remove-Item (Join-Path -Path $testpath -ChildPath file2.wav)
 
-	    Test-Path (Join-Path -Path $testpath -ChildPath file1.wav) | Should -BeFalse
-	    Test-Path (Join-Path -Path $testpath -ChildPath file2.wav) | Should -BeFalse
-	}
+            Test-Path (Join-Path -Path $testpath -ChildPath file1.wav) | Should -BeFalse
+            Test-Path (Join-Path -Path $testpath -ChildPath file2.wav) | Should -BeFalse
+        }
     }
 
     Context "Directory Removal Tests" {
-	$testdirectory = Join-Path -Path $testpath -ChildPath testdir
-	$testsubdirectory = Join-Path -Path $testdirectory -ChildPath subd
-	BeforeEach {
-	    New-Item -Name "testdir" -Path $testpath -ItemType "directory" -Force
+        BeforeAll {
+            $testdirectory = Join-Path -Path $testpath -ChildPath testdir
+            $testsubdirectory = Join-Path -Path $testdirectory -ChildPath subd
+        }
 
-	    Test-Path $testdirectory | Should -BeTrue
-	}
+        BeforeEach {
+            New-Item -Name "testdir" -Path $testpath -ItemType "directory" -Force
 
-	It "Should be able to remove a directory" {
-	    { Remove-Item $testdirectory } | Should -Not -Throw
+            Test-Path $testdirectory | Should -BeTrue
+        }
 
-	    Test-Path $testdirectory | Should -BeFalse
-	}
+        It "Should be able to remove a directory" {
+            { Remove-Item $testdirectory } | Should -Not -Throw
 
-	It "Should be able to recursively delete subfolders" {
-	    New-Item -Name "subd" -Path $testdirectory -ItemType "directory"
-	    New-Item -Name $testfile -Path $testsubdirectory -ItemType "file" -Value "lorem ipsum"
+            Test-Path $testdirectory | Should -BeFalse
+        }
 
-	    $complexDirectory = Join-Path -Path $testsubdirectory -ChildPath $testfile
-	    Test-Path $complexDirectory | Should -BeTrue
+        It "Should be able to recursively delete subfolders" {
+            New-Item -Name "subd" -Path $testdirectory -ItemType "directory"
+            New-Item -Name $testfile -Path $testsubdirectory -ItemType "file" -Value "lorem ipsum"
 
-	    { Remove-Item $testdirectory -Recurse} | Should -Not -Throw
+            $complexDirectory = Join-Path -Path $testsubdirectory -ChildPath $testfile
+            Test-Path $complexDirectory | Should -BeTrue
 
-	    Test-Path $testdirectory | Should -BeFalse
-	}
+            { Remove-Item $testdirectory -Recurse } | Should -Not -Throw
+
+            Test-Path $testdirectory | Should -BeFalse
+        }
     }
 
     Context "Alternate Data Streams should be supported on Windows" {
-      BeforeAll {
-        if (!$IsWindows) {
-          return
-        }
-        $fileName = "ADStest.txt"
-        $streamName = "teststream"
-        $dirName = "ADStestdir"
-        $fileContent =" This is file content."
-        $streamContent = "datastream content here"
-        $streamfile = Join-Path -Path $testpath -ChildPath $fileName
-        $streamdir = Join-Path -Path $testpath -ChildPath $dirName
+        BeforeAll {
+            if (!$IsWindows) {
+            return
+            }
+            $fileName = "ADStest.txt"
+            $streamName = "teststream"
+            $dirName = "ADStestdir"
+            $fileContent =" This is file content."
+            $streamContent = "datastream content here"
+            $streamfile = Join-Path -Path $testpath -ChildPath $fileName
+            $streamdir = Join-Path -Path $testpath -ChildPath $dirName
 
-        $null = New-Item -Path $streamfile -ItemType "File" -force
-        Add-Content -Path $streamfile -Value $fileContent
-        Add-Content -Path $streamfile -Stream $streamName -Value $streamContent
-        $null = New-Item -Path $streamdir -ItemType "Directory" -Force
-        Add-Content -Path $streamdir -Stream $streamName -Value $streamContent
-      }
-      It "Should completely remove a datastream from a file" -Skip:(!$IsWindows) {
-        Get-Item -Path $streamfile -Stream $streamName | Should -Not -BeNullOrEmpty
-        Remove-Item -Path $streamfile -Stream $streamName
-        Get-Item -Path $streamfile -Stream $streamName -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
-      }
-      It "Should completely remove a datastream from a directory" -Skip:(!$IsWindows) {
-        Get-Item -Path $streamdir -Stream $streamName | Should -Not -BeNullOrEmpty
-        Remove-Item -Path $streamdir -Stream $streamName
-        Get-Item -Path $streamdir -Stream $streamname -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
-      }
+            $null = New-Item -Path $streamfile -ItemType "File" -force
+            Add-Content -Path $streamfile -Value $fileContent
+            Add-Content -Path $streamfile -Stream $streamName -Value $streamContent
+            $null = New-Item -Path $streamdir -ItemType "Directory" -Force
+            Add-Content -Path $streamdir -Stream $streamName -Value $streamContent
+        }
+
+        It "Should completely remove a datastream from a file" -Skip:(!$IsWindows) {
+            Get-Item -Path $streamfile -Stream $streamName | Should -Not -BeNullOrEmpty
+            Remove-Item -Path $streamfile -Stream $streamName
+            Get-Item -Path $streamfile -Stream $streamName -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
+        }
+
+        It "Should completely remove a datastream from a directory" -Skip:(!$IsWindows) {
+            Get-Item -Path $streamdir -Stream $streamName | Should -Not -BeNullOrEmpty
+            Remove-Item -Path $streamdir -Stream $streamName
+            Get-Item -Path $streamdir -Stream $streamname -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
+        }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Better to review commit by commit:
1. First commit comes from #14902
2. Second commit fix #15248 (see also #15253)
3. Third commit reformat old tests
4. Fourth commit add new test

--------

About second commit.

Partial regression in #14902. Partial because there are other code paths (a path comes from public with trailing backslash) which can raise an issue in the place.

[Docs](https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findfirstfileexw#parameters) say that  FindFirstFileEx does not accept a path with a trailing backslash (\\).

The fix is always removing a trailing backslash from path string before calling FindFirstFileEx.

--------

Before the fix only enumeration (Get-ChildItem) worked on OneDrive. 
Now Remove-Item correctly removes folders and files on OneDrive too.

1. Enhance IsReparsePointLikeSymlink() method so that exclude non named surrogates from reparse points. As result PowerShell recurse into such reparse points which is a OneDrive entities.
1.  Use updated IsReparsePointLikeSymlink() method in RemoveDirectoryInfoItem() and NameString() methods 
1. Add new tests and a test hook to emulate old PowerShell behavior and test new PowerShell behavior on OneDrive.
1. Add small perf improvement in Dir() and IsReparsePointLikeSymlink() methods to exclude extra p/invoke in most scenarios. 

## PR Context

Replace #14860 and #14902 (reverted in #15253)

Related #9246

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
