### PR TITLE
Fix `Minimal` ProgressView to handle Activity that is longer than console width

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressNode.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressNode.cs
@@ -400,7 +400,8 @@ namespace Microsoft.PowerShell
             int padding = maxWidth + PSStyle.Instance.Progress.Style.Length + PSStyle.Instance.Reverse.Length + PSStyle.Instance.ReverseOff.Length;
             sb.Append(PSStyle.Instance.Reverse);
 
-            if (StatusDescription.Length > barWidth - secRemainLength)
+            int maxStatusLength = barWidth - secRemainLength - 1;
+            if (maxStatusLength > 0 && StatusDescription.Length > barWidth - secRemainLength)
             {
                 sb.Append(StatusDescription.Substring(0, barWidth - secRemainLength - 1));
                 sb.Append(PSObjectHelper.Ellipsis);
@@ -410,10 +411,14 @@ namespace Microsoft.PowerShell
                 sb.Append(StatusDescription);
             }
 
-            sb.Append(string.Empty.PadRight(barWidth + PSStyle.Instance.Reverse.Length - sb.Length - secRemainLength));
+            int emptyPadLength = barWidth + PSStyle.Instance.Reverse.Length - sb.Length - secRemainLength;
+            if (emptyPadLength > 0)
+            {
+                sb.Append(string.Empty.PadRight(emptyPadLength));
+            }
             sb.Append(secRemain);
 
-            if (PercentComplete > 0 && PercentComplete < 100)
+            if (PercentComplete > 0 && PercentComplete < 100 && barWidth > 0)
             {
                 int barLength = PercentComplete * barWidth / 100;
                 if (barLength >= barWidth)
@@ -421,7 +426,10 @@ namespace Microsoft.PowerShell
                     barLength = barWidth - 1;
                 }
 
-                sb.Insert(barLength + PSStyle.Instance.Reverse.Length, PSStyle.Instance.ReverseOff);
+                if (barLength < sb.Length)
+                {
+                    sb.Insert(barLength + PSStyle.Instance.Reverse.Length, PSStyle.Instance.ReverseOff);
+                }
             }
             else
             {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressNode.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressNode.cs
@@ -387,6 +387,12 @@ namespace Microsoft.PowerShell
                 maxWidth = PSStyle.Instance.Progress.MaxWidth;
             }
 
+            // if the activity is really long, only use up to half the width
+            if (Activity.Length > maxWidth / 2)
+            {
+                Activity = Activity.Substring(0, maxWidth / 2) + PSObjectHelper.Ellipsis;
+            }
+
             // 4 is for the extra space and square brackets below and one extra space
             int barWidth = maxWidth - Activity.Length - indentation - 4;
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressNode.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressNode.cs
@@ -388,13 +388,18 @@ namespace Microsoft.PowerShell
             }
 
             // if the activity is really long, only use up to half the width
+            string activity;
             if (Activity.Length > maxWidth / 2)
             {
-                Activity = Activity.Substring(0, maxWidth / 2) + PSObjectHelper.Ellipsis;
+                activity = Activity.Substring(0, maxWidth / 2) + PSObjectHelper.Ellipsis;
+            }
+            else
+            {
+                activity = Activity;
             }
 
             // 4 is for the extra space and square brackets below and one extra space
-            int barWidth = maxWidth - Activity.Length - indentation - 4;
+            int barWidth = maxWidth - activity.Length - indentation - 4;
 
             var sb = new StringBuilder();
             int padding = maxWidth + PSStyle.Instance.Progress.Style.Length + PSStyle.Instance.Reverse.Length + PSStyle.Instance.ReverseOff.Length;
@@ -442,7 +447,7 @@ namespace Microsoft.PowerShell
                     "{0}{1}{2} [{3}]{4}",
                     indent,
                     PSStyle.Instance.Progress.Style,
-                    Activity,
+                    activity,
                     sb.ToString(),
                     PSStyle.Instance.Reset)
                 .PadRight(padding));

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressNode.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressNode.cs
@@ -416,6 +416,7 @@ namespace Microsoft.PowerShell
             {
                 sb.Append(string.Empty.PadRight(emptyPadLength));
             }
+
             sb.Append(secRemain);
 
             if (PercentComplete > 0 && PercentComplete < 100 && barWidth > 0)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Progress.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Progress.Tests.ps1
@@ -22,4 +22,8 @@ Describe "Write-Progress DRT Unit Tests" -Tags "CI" {
     It "all params works" -Pending {
         { Write-Progress -Activity 'myactivity' -Status 'mystatus' -Id 1 -ParentId 2 -Completed:$false -current 'current' -sec 1 -percent 1 } | Should -Not -Throw
     }
+
+    It 'Activity longer than console width works' {
+        { Write-Progress -Activity ('a' * ([console]::WindowWidth + 1)) -Status ('b' * ([console]::WindowWidth + 1)) -Id 1 } | Should -Not -Throw
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The current code handles the case where `Status` is too long, but doesn't handle the case where `Activity` is longer than console width so that when calculating the space for status, it becomes a negative value.  Fix is to check if `Activity` is longer than the console width and truncate it so that it doesn't take up more than half the console width allowing space for the `Status`.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/15251

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
