### PR TITLE
Fix tab completion for unlocalized about* topics

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -6270,23 +6270,21 @@ namespace System.Management.Automation
         internal static List<CompletionResult> CompleteHelpTopics(CompletionContext context)
         {
             var results = new List<CompletionResult>();
-            var searchPaths = new List<string>();
-            var currentCulture = CultureInfo.CurrentCulture.Name;
+            string userHelpDir = HelpUtils.GetUserHomeHelpSearchPath();
+            string appHelpDir = Utils.GetApplicationBase(Utils.DefaultPowerShellShellID);
+            string currentCulture = CultureInfo.CurrentCulture.Name;
 
-            // Add the user scope path first, since it is searched in order.
-            var userHelpRoot = Path.Combine(HelpUtils.GetUserHomeHelpSearchPath(), currentCulture);
+            //search for help files for the current culture + en-US as fallback
+            var searchPaths = new string[4]
+            { 
+                Path.Combine(userHelpDir,currentCulture),
+                Path.Combine(userHelpDir,"en-US"),
+                Path.Combine(appHelpDir,currentCulture),
+                Path.Combine(appHelpDir,"en-US")
+            }.Distinct();
 
-            if (Directory.Exists(userHelpRoot))
-            {
-                searchPaths.Add(userHelpRoot);
-            }
-
-            var dirPath = Path.Combine(Utils.GetApplicationBase(Utils.DefaultPowerShellShellID), currentCulture);
-            searchPaths.Add(dirPath);
-
-            var wordToComplete = context.WordToComplete + "*";
-            var topicPattern = WildcardPattern.Get("about_*.help.txt", WildcardOptions.IgnoreCase);
-            List<string> files = new List<string>();
+            string wordToComplete = context.WordToComplete + "*";
+            var foundTopics = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
 
             try
             {
@@ -6294,11 +6292,15 @@ namespace System.Management.Automation
 
                 foreach (var dir in searchPaths)
                 {
-                    foreach (var file in Directory.EnumerateFiles(dir))
+                    if (Directory.Exists(dir))
                     {
-                        if (wildcardPattern.IsMatch(Path.GetFileName(file)))
+                        var currentDir = new DirectoryInfo(dir);
+                        foreach (var file in currentDir.EnumerateFiles("about_*.help.txt"))
                         {
-                            files.Add(file);
+                            if (wildcardPattern.IsMatch(file.Name))
+                            {
+                                foundTopics.Add(file.Name.Substring(0, file.Name.LastIndexOf(".help.txt")));
+                            }
                         }
                     }
                 }
@@ -6307,30 +6309,9 @@ namespace System.Management.Automation
             {
             }
 
-            if (files != null)
+            foreach (string topic in foundTopics)
             {
-                foreach (string file in files)
-                {
-                    if (file == null)
-                    {
-                        continue;
-                    }
-
-                    try
-                    {
-                        var fileName = Path.GetFileName(file);
-                        if (fileName == null || !topicPattern.IsMatch(fileName))
-                            continue;
-
-                        // All topic files are ending with ".help.txt"
-                        var completionText = fileName.Substring(0, fileName.Length - 9);
-                        results.Add(new CompletionResult(completionText));
-                    }
-                    catch (Exception)
-                    {
-                        continue;
-                    }
-                }
+                results.Add(new CompletionResult(topic));
             }
 
             return results;

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -6275,17 +6275,15 @@ namespace System.Management.Automation
             string currentCulture = CultureInfo.CurrentCulture.Name;
 
             //search for help files for the current culture + en-US as fallback
-            var searchPaths = new string[4]
+            var searchPaths = new string[]
             { 
                 Path.Combine(userHelpDir, currentCulture),
-                Path.Combine(userHelpDir, "en-US"),
                 Path.Combine(appHelpDir, currentCulture),
+                Path.Combine(userHelpDir, "en-US"),
                 Path.Combine(appHelpDir, "en-US")
             }.Distinct();
 
             string wordToComplete = context.WordToComplete + "*";
-            var foundTopics = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
-
             try
             {
                 var wildcardPattern = WildcardPattern.Get(wordToComplete, WildcardOptions.IgnoreCase);
@@ -6300,11 +6298,7 @@ namespace System.Management.Automation
                             if (wildcardPattern.IsMatch(file.Name))
                             {
                                 string topicName = file.Name.Substring(0, file.Name.LastIndexOf(".help.txt"));
-                                bool notDuplicate = foundTopics.Add(topicName);
-                                if (notDuplicate)
-                                {
-                                    results.Add(new CompletionResult(topicName));
-                                }
+                                results.Add(new CompletionResult(topicName));
                             }
                         }
                     }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -6277,10 +6277,10 @@ namespace System.Management.Automation
             //search for help files for the current culture + en-US as fallback
             var searchPaths = new string[4]
             { 
-                Path.Combine(userHelpDir,currentCulture),
-                Path.Combine(userHelpDir,"en-US"),
-                Path.Combine(appHelpDir,currentCulture),
-                Path.Combine(appHelpDir,"en-US")
+                Path.Combine(userHelpDir, currentCulture),
+                Path.Combine(userHelpDir, "en-US"),
+                Path.Combine(appHelpDir, currentCulture),
+                Path.Combine(appHelpDir, "en-US")
             }.Distinct();
 
             string wordToComplete = context.WordToComplete + "*";

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -6299,7 +6299,12 @@ namespace System.Management.Automation
                         {
                             if (wildcardPattern.IsMatch(file.Name))
                             {
-                                foundTopics.Add(file.Name.Substring(0, file.Name.LastIndexOf(".help.txt")));
+                                string topicName = file.Name.Substring(0, file.Name.LastIndexOf(".help.txt"));
+                                bool notDuplicate = foundTopics.Add(topicName);
+                                if (notDuplicate)
+                                {
+                                    results.Add(new CompletionResult(topicName));
+                                }
                             }
                         }
                     }
@@ -6308,12 +6313,6 @@ namespace System.Management.Automation
             catch (Exception)
             {
             }
-
-            foreach (string topic in foundTopics)
-            {
-                results.Add(new CompletionResult(topic));
-            }
-
             return results;
         }
 

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -6292,9 +6292,9 @@ namespace System.Management.Automation
 
                 foreach (var dir in searchPaths)
                 {
-                    if (Directory.Exists(dir))
+                    var currentDir = new DirectoryInfo(dir);
+                    if (currentDir.Exists)
                     {
-                        var currentDir = new DirectoryInfo(dir);
                         foreach (var file in currentDir.EnumerateFiles("about_*.help.txt"))
                         {
                             if (wildcardPattern.IsMatch(file.Name))

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1364,20 +1364,29 @@ dir -Recurse `
                 Update-Help -Force -ErrorAction SilentlyContinue -Scope 'CurrentUser'
             }
 
+            # If help content is present on both scopes, expect 2 or else expect 1 completion.
+            $expectedCompletions = if ($userScopeHelp -and $allUserScopeHelp) { 2 } else { 1 }
+
             $res = TabExpansion2 -inputScript 'get-help about_spla' -cursorColumn 'get-help about_spla'.Length
-            $res.CompletionMatches | Should -HaveCount 1
+            $res.CompletionMatches | Should -HaveCount $expectedCompletions
             $res.CompletionMatches[0].CompletionText | Should -BeExactly 'about_Splatting'
         }
 
         It 'Should complete about help topic regardless of culture' {
-            ## Save original culture and temporarily set it to da-DK because there's no localized help for da-DK.
-            $OriginalCulture = [cultureinfo]::CurrentCulture
-            [cultureinfo]::CurrentCulture="da-DK"
-            
-            $res = TabExpansion2 -inputScript 'get-help about_spla' -cursorColumn 'get-help about_spla'.Length
-            $res.CompletionMatches | Should -HaveCount 1
-            $res.CompletionMatches[0].CompletionText | Should -BeExactly 'about_Splatting'
-            [cultureinfo]::CurrentCulture=$OriginalCulture
+            try
+            {
+                ## Save original culture and temporarily set it to da-DK because there's no localized help for da-DK.
+                $OriginalCulture = [cultureinfo]::CurrentCulture
+                [cultureinfo]::CurrentCulture="da-DK"
+                
+                $res = TabExpansion2 -inputScript 'get-help about_spla' -cursorColumn 'get-help about_spla'.Length
+                $res.CompletionMatches | Should -HaveCount 1
+                $res.CompletionMatches[0].CompletionText | Should -BeExactly 'about_Splatting'
+            }
+            finally
+            {
+                [cultureinfo]::CurrentCulture = $OriginalCulture
+            }
         }
     }
 }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1364,12 +1364,20 @@ dir -Recurse `
                 Update-Help -Force -ErrorAction SilentlyContinue -Scope 'CurrentUser'
             }
 
-            # If help content is present on both scopes, expect 2 or else expect 1 completion.
-            $expectedCompletions = if ($userScopeHelp -and $allUserScopeHelp) { 2 } else { 1 }
-
             $res = TabExpansion2 -inputScript 'get-help about_spla' -cursorColumn 'get-help about_spla'.Length
-            $res.CompletionMatches | Should -HaveCount $expectedCompletions
+            $res.CompletionMatches | Should -HaveCount 1
             $res.CompletionMatches[0].CompletionText | Should -BeExactly 'about_Splatting'
+        }
+
+        It 'Should complete about help topic regardless of culture' {
+            ## Save original culture and temporarily set it to da-DK because there's no localized help for da-DK.
+            $OriginalCulture = [cultureinfo]::CurrentCulture
+            [cultureinfo]::CurrentCulture="da-DK"
+            
+            $res = TabExpansion2 -inputScript 'get-help about_spla' -cursorColumn 'get-help about_spla'.Length
+            $res.CompletionMatches | Should -HaveCount 1
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly 'about_Splatting'
+            [cultureinfo]::CurrentCulture=$OriginalCulture
         }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

Fixes tab completion for help topics on systems without localized help by adding en-US as a fallback.
`Get-Help About<Tab>`

## PR Context

Get-Help will automatically fall back to en-US help topics so the completion for it should do the same.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
