### PR TITLE
Make sure daily release tag does not change when retrying failures

### DIFF
--- a/tools/releaseBuild/azureDevOps/templates/SetVersionVariables.yml
+++ b/tools/releaseBuild/azureDevOps/templates/SetVersionVariables.yml
@@ -4,6 +4,12 @@ parameters:
   CreateJson: 'no'
 
 steps:
+- task: DownloadBuildArtifacts@0
+  inputs:
+    artifactName: 'BuildInfoJson'
+    itemPattern: '**/daily.json'
+    downloadPath: '$(System.ArtifactsDirectory)\BuildInfoJson'
+
 - powershell: |
     $path = "./build.psm1"
 

--- a/tools/releaseBuild/azureDevOps/templates/SetVersionVariables.yml
+++ b/tools/releaseBuild/azureDevOps/templates/SetVersionVariables.yml
@@ -10,7 +10,7 @@ steps:
     inputs:
       artifactName: 'BuildInfoJson'
       itemPattern: '**/*.json'
-      downloadPath: '$(System.ArtifactsDirectory)\BuildInfoJson'
+      downloadPath: '$(System.ArtifactsDirectory)'
     displayName: Download Build Info Json
 
 - powershell: |

--- a/tools/releaseBuild/azureDevOps/templates/SetVersionVariables.yml
+++ b/tools/releaseBuild/azureDevOps/templates/SetVersionVariables.yml
@@ -34,7 +34,7 @@ steps:
   displayName: 'Set repo Root'
 
 - powershell: |
-    $createJson = ("${{ parameters.ReleaseTagVarName }}" -ne "no")
+    $createJson = ("${{ parameters.CreateJson }}" -ne "no")
     $releaseTag = & "$env:REPOROOT/tools/releaseBuild/setReleaseTag.ps1" -ReleaseTag ${{ parameters.ReleaseTagVar }} -Variable "${{ parameters.ReleaseTagVarName }}" -CreateJson:$createJson
     $version = $releaseTag.Substring(1)
     $vstsCommandString = "vso[task.setvariable variable=Version]$version"

--- a/tools/releaseBuild/azureDevOps/templates/SetVersionVariables.yml
+++ b/tools/releaseBuild/azureDevOps/templates/SetVersionVariables.yml
@@ -2,13 +2,16 @@ parameters:
   ReleaseTagVar: v6.2.0
   ReleaseTagVarName: ReleaseTagVar
   CreateJson: 'no'
+  UseJson: 'yes'
 
 steps:
-- task: DownloadBuildArtifacts@0
-  inputs:
-    artifactName: 'BuildInfoJson'
-    itemPattern: '**/daily.json'
-    downloadPath: '$(System.ArtifactsDirectory)\BuildInfoJson'
+- ${{ if eq(parameters['UseJson'],'yes') }}:
+  - task: DownloadBuildArtifacts@0
+    inputs:
+      artifactName: 'BuildInfoJson'
+      itemPattern: '**/*.json'
+      downloadPath: '$(System.ArtifactsDirectory)\BuildInfoJson'
+    displayName: Download Build Info Json
 
 - powershell: |
     $path = "./build.psm1"

--- a/tools/releaseBuild/azureDevOps/templates/checkAzureContainer.yml
+++ b/tools/releaseBuild/azureDevOps/templates/checkAzureContainer.yml
@@ -12,9 +12,11 @@ jobs:
   steps:
   - checkout: self
     clean: true
+
   - template: SetVersionVariables.yml
     parameters:
       ReleaseTagVar: $(ReleaseTagVar)
+      CreateJson: yes
 
   - task: AzurePowerShell@4
     inputs:

--- a/tools/releaseBuild/azureDevOps/templates/checkAzureContainer.yml
+++ b/tools/releaseBuild/azureDevOps/templates/checkAzureContainer.yml
@@ -17,6 +17,7 @@ jobs:
     parameters:
       ReleaseTagVar: $(ReleaseTagVar)
       CreateJson: yes
+      UseJson: no
 
   - task: AzurePowerShell@4
     inputs:

--- a/tools/releaseBuild/setReleaseTag.ps1
+++ b/tools/releaseBuild/setReleaseTag.ps1
@@ -84,7 +84,7 @@ if($ReleaseTag -eq 'fromBranch' -or !$ReleaseTag)
     {
         $isDaily = $true
         Write-Verbose "daily build" -Verbose
-        $jsonPath = "$(System.ArtifactsDirectory)\BuildInfoJson\daily.json"
+        $jsonPath = "${env:SYSTEM_ARTIFACTSDIRECTORY}\BuildInfoJson\daily.json"
         if (test-path -Path $jsonPath) {
             Write-Verbose "restoring from buildinfo json..." -Verbose
             $buildInfo = Get-Content -Path $jsonPath | ConvertFrom-Json

--- a/tools/releaseBuild/setReleaseTag.ps1
+++ b/tools/releaseBuild/setReleaseTag.ps1
@@ -84,15 +84,23 @@ if($ReleaseTag -eq 'fromBranch' -or !$ReleaseTag)
     {
         $isDaily = $true
         Write-Verbose "daily build" -Verbose
-        $metaDataJsonPath = Join-Path $PSScriptRoot -ChildPath '..\metadata.json'
-        $metadata = Get-Content $metaDataJsonPath | ConvertFrom-Json
-        $versionPart = $metadata.PreviewReleaseTag
-        if($versionPart -match '-.*$')
-        {
-            $versionPart = $versionPart -replace '-.*$'
+        $jsonPath = "$(System.ArtifactsDirectory)\BuildInfoJson\daily.json"
+        if (test-path -Path $jsonPath) {
+            Write-Verbose "restoring from buildinfo json..." -Verbose
+            $buildInfo = Get-Content -Path $jsonPath | ConvertFrom-Json
+            $releaseTag = $buildInfo.ReleaseTag
+        } else {
+            Write-Verbose "creating from branch counter and metadat.json..." -Verbose
+            $metaDataJsonPath = Join-Path $PSScriptRoot -ChildPath '..\metadata.json'
+            $metadata = Get-Content $metaDataJsonPath | ConvertFrom-Json
+            $versionPart = $metadata.PreviewReleaseTag
+            if ($versionPart -match '-.*$') {
+                $versionPart = $versionPart -replace '-.*$'
+            }
+
+            $releaseTag = "$versionPart-daily$((Get-Date).ToString('yyyyMMdd')).$($env:BRANCHCOUNTER)"
         }
 
-        $releaseTag = "$versionPart-daily$((Get-Date).ToString('yyyyMMdd')).$($env:BRANCHCOUNTER)"
         $vstsCommandString = "vso[task.setvariable variable=$Variable]$releaseTag"
         Write-Verbose -Message "setting $Variable to $releaseTag" -Verbose
         Write-Host -Object "##$vstsCommandString"

--- a/tools/releaseBuild/setReleaseTag.ps1
+++ b/tools/releaseBuild/setReleaseTag.ps1
@@ -90,7 +90,7 @@ if($ReleaseTag -eq 'fromBranch' -or !$ReleaseTag)
             $buildInfo = Get-Content -Path $jsonPath | ConvertFrom-Json
             $releaseTag = $buildInfo.ReleaseTag
         } else {
-            Write-Verbose "creating from branch counter and metadat.json..." -Verbose
+            Write-Verbose "creating from branch counter and metadata.json..." -Verbose
             $metaDataJsonPath = Join-Path $PSScriptRoot -ChildPath '..\metadata.json'
             $metadata = Get-Content $metaDataJsonPath | ConvertFrom-Json
             $versionPart = $metadata.PreviewReleaseTag


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Make sure daily release tag does not change when retrying failures

## PR Context

If the seed that is used for a counter changes for a rerun, the variables are recalculated on rerun.

This PR persists the release tag as an artifact, preventing any change.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
