### PR TITLE
Kill native processes in pipeline when pipeline is Disposed on Unix

### DIFF
--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1018,12 +1018,16 @@ namespace System.Management.Automation
 
             try
             {
-                // Kill the process if it's already created
-                // Dispose is not sufficient as it just closes redirection handles
-                // but the process can continue
                 if (_nativeProcess != null)
                 {
+                    // on Unix, we need to kill the process to ensure it terminates as Dispose() merely
+                    // closes the redirected streams and the processs does not exit on macOS.  However,
+                    // on Windows, a winexe like notepad should continue running so we don't want to kill it.
+#if UNIX
                     _nativeProcess.Kill();
+#else
+                    _nativeProcess.Dispose();
+#endif
                 }
             }
             catch (Exception)

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1024,10 +1024,16 @@ namespace System.Management.Automation
                     // closes the redirected streams and the processs does not exit on macOS.  However,
                     // on Windows, a winexe like notepad should continue running so we don't want to kill it.
 #if UNIX
-                    _nativeProcess.Kill();
-#else
-                    _nativeProcess.Dispose();
+                    try
+                    {
+                        _nativeProcess.Kill();
+                    }
+                    catch
+                    {
+                        // Ignore all exception since it is cleanup.
+                    }
 #endif
+                    _nativeProcess.Dispose();
                 }
             }
             catch (Exception)

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1018,10 +1018,12 @@ namespace System.Management.Automation
 
             try
             {
-                // Dispose the process if it's already created
+                // Kill the process if it's already created
+                // Dispose is not sufficient as it just closes redirection handles
+                // but the process can continue
                 if (_nativeProcess != null)
                 {
-                    _nativeProcess.Dispose();
+                    _nativeProcess.Kill();
                 }
             }
             catch (Exception)

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -43,6 +43,12 @@ Describe 'native commands with pipeline' -tags 'Feature' {
             $result[0] | Should -Match "pwsh"
         }
     }
+
+    It 'native command should be killed when pipeline is disposed' -Skip:($IsWindows) {
+        $yes = (Get-Process 'yes' -ErrorAction Ignore).Count
+        yes | Select-Object -First 2
+        (Get-Process 'yes' -ErrorAction Ignore).Count | Should -Be $yes
+    }
 }
 
 Describe "Native Command Processor" -tags "Feature" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Currently, when the Pipeline is being cleaned up, we call Process.Dispose() with the intent to kill any running processes.  However, [Dispose() only closes the redirected streams](https://github.com/dotnet/runtime/issues/51594#issuecomment-823648869) and thus has different behavior on Windows, Linux, and macOS.  On Linux, it appears that the processes will be killed by the OS.  However, on macOS, the process continues to run in the background.  On Windows, because of the difference of exe vs winexe (graphical apps), we can't forcibly kill the process as starting `notepad` would be killed instantly so we leave it as Dispose().

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
