### PR TITLE
Annotating ThrowTerminatingError with [DoesNotReturn]

### DIFF
--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimCommandBase.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimCommandBase.cs
@@ -672,6 +672,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// Throw terminating error
         /// </para>
         /// </summary>
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
         internal void ThrowTerminatingError(Exception exception, string operation)
         {
             ErrorRecord errorRecord = new(exception, operation, ErrorCategory.InvalidOperation, this);

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CmdletOperation.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CmdletOperation.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
             return cmdlet.ShouldProcess(verboseDescription, verboseWarning, caption, out shouldProcessReason);
         }
 
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
         public virtual void ThrowTerminatingError(ErrorRecord errorRecord)
         {
             cmdlet.ThrowTerminatingError(errorRecord);
@@ -115,6 +116,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// Throw terminating error
         /// </para>
         /// </summary>
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
         internal void ThrowTerminatingError(Exception exception, string operation)
         {
             ErrorRecord errorRecord = new(exception, operation, ErrorCategory.InvalidOperation, this);

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseCommand.cs
@@ -22,6 +22,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             _command = command;
         }
 
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
         internal void ThrowTerminatingError(ErrorRecord errorRecord)
         {
             _command.ThrowTerminatingError(errorRecord);

--- a/src/System.Management.Automation/engine/DefaultCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/DefaultCommandRuntime.cs
@@ -230,6 +230,7 @@ namespace System.Management.Automation
         /// if it exists, otherwise throw an invalid operation exception.
         /// </summary>
         /// <param name="errorRecord">The error record to throw.</param>
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
         public void ThrowTerminatingError(ErrorRecord errorRecord)
         {
             if (errorRecord.Exception != null)

--- a/src/System.Management.Automation/engine/ICommandRuntime.cs
+++ b/src/System.Management.Automation/engine/ICommandRuntime.cs
@@ -549,6 +549,7 @@ namespace System.Management.Automation
         /// if any information is to be added. It should encapsulate the
         /// error record into an exception and then throw that exception.
         /// </remarks>
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
         void ThrowTerminatingError(ErrorRecord errorRecord);
         #endregion ThrowTerminatingError
         #endregion misc

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -2055,6 +2055,7 @@ namespace System.Management.Automation
         /// <see cref="System.Management.Automation.Cmdlet.ProcessRecord"/>.
         /// etc.
         /// </remarks>
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
         public void ThrowTerminatingError(ErrorRecord errorRecord)
         {
             ThrowIfStopping();

--- a/src/System.Management.Automation/engine/cmdlet.cs
+++ b/src/System.Management.Automation/engine/cmdlet.cs
@@ -1714,6 +1714,7 @@ namespace System.Management.Automation
         /// <see cref="System.Management.Automation.Cmdlet.ProcessRecord"/>.
         /// etc.
         /// </remarks>
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
         public void ThrowTerminatingError(ErrorRecord errorRecord)
         {
             using (PSTransactionManager.GetEngineProtectionScope())

--- a/src/System.Management.Automation/namespaces/ProviderBase.cs
+++ b/src/System.Management.Automation/namespaces/ProviderBase.cs
@@ -1417,6 +1417,7 @@ namespace System.Management.Automation.Provider
 
         #region ThrowTerminatingError
         /// <Content contentref="System.Management.Automation.Cmdlet.ThrowTerminatingError" />
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
         public void ThrowTerminatingError(ErrorRecord errorRecord)
         {
             using (PSTransactionManager.GetEngineProtectionScope())


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add codeanalysis attribute `[DoesNotReturn]` to `ThrowTerminatingError`

## PR Context

Helps with code that has a return value but calls ThrowTerminatingError. Without it, code analysis suggests it is an error to not return a value in that code path.

## PR Checklist

- [x ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
