### PR TITLE
Fix NullReferenceException in DSC ClearCache()

### DIFF
--- a/src/System.Management.Automation/DscSupport/JsonDscClassCache.cs
+++ b/src/System.Management.Automation/DscSupport/JsonDscClassCache.cs
@@ -100,7 +100,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal.CrossPlatform
             new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MSFT_BaseConfigurationProviderRegistration", "MSFT_CimConfigurationProviderRegistration", "MSFT_PSConfigurationProviderRegistration" };
 
         /// <summary>
-        /// A collection to prevent circular importing case when Import-DscResource does not have a module specified
+        /// Gets a collection to prevent circular importing case when Import-DscResource does not have a module specified.
         /// </summary>
         private static HashSet<string> CurrentImportDscResourceInvocations
         {

--- a/src/System.Management.Automation/DscSupport/JsonDscClassCache.cs
+++ b/src/System.Management.Automation/DscSupport/JsonDscClassCache.cs
@@ -103,9 +103,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal.CrossPlatform
         /// Gets a collection to prevent circular importing case when Import-DscResource does not have a module specified.
         /// </summary>
         private static HashSet<string> CurrentImportDscResourceInvocations
-        {
-            get => t_currentImportDscResourceInvocations ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        }
+            => t_currentImportDscResourceInvocations ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         [ThreadStatic]
         private static HashSet<string> t_currentImportDscResourceInvocations;


### PR DESCRIPTION
# PR Summary

In a multi-threaded environment there is a NullReferenceException in DSC ClearCache().
This fix is needed for GuestConfig.

## PR Context

Initial values for fields marked with ThreadStaticAttribute should not be used, because such initialization occurs only once, when the class constructor executes, and therefore affects only one thread. Sometimes in a multi-threaded GuestConfig environment this was causing NullReferenceException in `ClearCache()` methods where the ThreadStatic filed `t_currentImportDscResourceInvocations` was accessed.

GuestConfig verified this fix on private binaries.

Side note: the entire section of code, where current fix is, will be removed soon by [`DSC as a subsystem` PR](https://github.com/PowerShell/PowerShell/pull/15127).

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [X] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
