### PR TITLE
add support for comparing various .NET Runtimes performance

### DIFF
--- a/test/perf/benchmarks/README.md
+++ b/test/perf/benchmarks/README.md
@@ -24,12 +24,12 @@ This folder contains micro benchmarks that test the performance of PowerShell En
 You can run the benchmarks directly using `dotnet run` in this directory:
 1. To run the benchmarks in Interactive Mode, where you will be asked which benchmark(s) to run:
    ```
-   dotnet run -c release
+   dotnet run -c Release
    ```
 
 2. To list all available benchmarks ([read more](https://github.com/dotnet/performance/blob/main/docs/benchmarkdotnet.md#Listing-the-Benchmarks)):
    ```
-   dotnet run -c release --list [flat/tree]
+   dotnet run -c Release --list [flat/tree]
    ```
 
 3. To filter the benchmarks using a glob pattern applied to `namespace.typeName.methodName` ([read more](https://github.com/dotnet/performance/blob/main/docs/benchmarkdotnet.md#Filtering-the-Benchmarks)]):

--- a/test/perf/benchmarks/powershell-perf.csproj
+++ b/test/perf/benchmarks/powershell-perf.csproj
@@ -12,16 +12,22 @@
     <NoWarn>$(NoWarn);CS8002</NoWarn>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
 
-    <!-- To run benchmarks targeting a specific package version, set the version to 'PERF_TARGET_VERSION' as an environment variable.
-         Do not try passing in the value using '/property:' at command line, because
-           1. 'dotnet run' doesn't respect '/property:' arguments;
-           2. BenchmarkDotnet generates temporary project files that reference to this .csproj file,
-              and '/property:' arguments won't be forwarded when building those temp projects. -->
-    <PerfTargetVersion>$(PERF_TARGET_VERSION)</PerfTargetVersion>
-
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
+
+    <!-- Test.Common.props sets TargetFramework to net6.0, we need to clear this value to be able to target multiple TFMs -->
+    <TargetFramework></TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;net5.0;net6.0</TargetFrameworks>
+    
+    <!-- To run benchmarks targeting a specific package version, set the version to 'PERF_TARGET_VERSION' as an environment variable.
+     Do not try passing in the value using '/property:' at command line, because
+       1. 'dotnet run' doesn't respect '/property:' arguments;
+       2. BenchmarkDotnet generates temporary project files that reference to this .csproj file,
+          and '/property:' arguments won't be forwarded when building those temp projects. -->
+    <PerfTargetVersion>$(PERF_TARGET_VERSION)</PerfTargetVersion>
+    <PerfTargetVersion Condition="'$(PerfTargetVersion)' == '' AND '$(TargetFramework)' == 'net5.0'">7.1.3</PerfTargetVersion>
+    <PerfTargetVersion Condition="'$(PerfTargetVersion)' == '' AND '$(TargetFramework)' == 'netcoreapp2.1'">6.2.7</PerfTargetVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -33,7 +39,7 @@
   <ItemGroup>
     <ProjectReference Include="../dotnet-tools/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj" />
   </ItemGroup>
-
+  
   <ItemGroup Condition="'$(PerfTargetVersion)' == ''">
     <ProjectReference Include="../../../src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj" />
     <ProjectReference Include="../../../src/Microsoft.PowerShell.Commands.Diagnostics/Microsoft.PowerShell.Commands.Diagnostics.csproj" />
@@ -41,6 +47,13 @@
 
   <ItemGroup Condition="'$(PerfTargetVersion)' != ''">
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="$(PerfTargetVersion)" />
+    <PackageReference Include="Microsoft.PowerShell.Commands.Diagnostics" Version="$(PerfTargetVersion)" />
+    <PackageReference Include="Microsoft.PowerShell.Commands.Management" Version="$(PerfTargetVersion)" />
+    <PackageReference Include="Microsoft.PowerShell.Commands.Utility" Version="$(PerfTargetVersion)" />
+    <PackageReference Include="Microsoft.PowerShell.Security" Version="$(PerfTargetVersion)" />
+    <PackageReference Include="System.Management.Automation" Version="$(PerfTargetVersion)" />
+    <PackageReference Include="Microsoft.PowerShell.ConsoleHost" Version="$(PerfTargetVersion)" />
+    <PackageReference Include="Microsoft.PowerShell.CoreCLR.Eventing" Version="$(PerfTargetVersion)" />
   </ItemGroup>
 
 </Project>

--- a/test/perf/benchmarks/powershell-perf.csproj
+++ b/test/perf/benchmarks/powershell-perf.csproj
@@ -42,7 +42,7 @@
   <ItemGroup>
     <ProjectReference Include="../dotnet-tools/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(PerfTargetVersion)' == ''">
     <ProjectReference Include="../../../src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj" />
     <ProjectReference Include="../../../src/Microsoft.PowerShell.Commands.Diagnostics/Microsoft.PowerShell.Commands.Diagnostics.csproj" />

--- a/test/perf/benchmarks/powershell-perf.csproj
+++ b/test/perf/benchmarks/powershell-perf.csproj
@@ -24,8 +24,8 @@
     <PerfTargetVersion>$(PERF_TARGET_VERSION)</PerfTargetVersion>
 
     <!-- Test.Common.props sets TargetFramework to net6.0, we need to clear this value to be able to target multiple TFMs.
-         But only when PERF_TARGET_VERSION was not specified. When it it is specified, a specific version is being benchmarked
-         And this version can be benchmarked only against single runtime version. -->
+         But only when PERF_TARGET_VERSION was not specified. When it is specified, a specific version is being benchmarked
+         and this version can be benchmarked only against single runtime version (because Microsoft.PowerShell.SDK targets a single TFM). -->
     <TargetFramework Condition="'$(PerfTargetVersion)' == ''"></TargetFramework>
     <TargetFrameworks Condition="'$(TargetFramework)' == ''">netcoreapp2.1;net5.0;net6.0</TargetFrameworks>
 

--- a/test/perf/benchmarks/powershell-perf.csproj
+++ b/test/perf/benchmarks/powershell-perf.csproj
@@ -16,16 +16,19 @@
     <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
 
-    <!-- Test.Common.props sets TargetFramework to net6.0, we need to clear this value to be able to target multiple TFMs -->
-    <TargetFramework></TargetFramework>
-    <TargetFrameworks>netcoreapp2.1;net5.0;net6.0</TargetFrameworks>
-    
     <!-- To run benchmarks targeting a specific package version, set the version to 'PERF_TARGET_VERSION' as an environment variable.
      Do not try passing in the value using '/property:' at command line, because
        1. 'dotnet run' doesn't respect '/property:' arguments;
        2. BenchmarkDotnet generates temporary project files that reference to this .csproj file,
           and '/property:' arguments won't be forwarded when building those temp projects. -->
     <PerfTargetVersion>$(PERF_TARGET_VERSION)</PerfTargetVersion>
+
+    <!-- Test.Common.props sets TargetFramework to net6.0, we need to clear this value to be able to target multiple TFMs.
+         But only when PERF_TARGET_VERSION was not specified. When it it is specified, a specific version is being benchmarked
+         And this version can be benchmarked only against single runtime version. -->
+    <TargetFramework Condition="'$(PerfTargetVersion)' == ''"></TargetFramework>
+    <TargetFrameworks Condition="'$(TargetFramework)' == ''">netcoreapp2.1;net5.0;net6.0</TargetFrameworks>
+
     <PerfTargetVersion Condition="'$(PerfTargetVersion)' == '' AND '$(TargetFramework)' == 'net5.0'">7.1.3</PerfTargetVersion>
     <PerfTargetVersion Condition="'$(PerfTargetVersion)' == '' AND '$(TargetFramework)' == 'netcoreapp2.1'">6.2.7</PerfTargetVersion>
   </PropertyGroup>

--- a/test/perf/benchmarks/powershell-perf.csproj
+++ b/test/perf/benchmarks/powershell-perf.csproj
@@ -17,20 +17,20 @@
     <DebugSymbols>true</DebugSymbols>
 
     <!-- To run benchmarks targeting a specific package version, set the version to 'PERF_TARGET_VERSION' as an environment variable.
-     Do not try passing in the value using '/property:' at command line, because
-       1. 'dotnet run' doesn't respect '/property:' arguments;
-       2. BenchmarkDotnet generates temporary project files that reference to this .csproj file,
-          and '/property:' arguments won't be forwarded when building those temp projects. -->
+      Do not try passing in the value using '/property:' at command line, because
+        1. 'dotnet run' doesn't respect '/property:' arguments;
+        2. BenchmarkDotnet generates temporary project files that reference to this .csproj file,
+           and '/property:' arguments won't be forwarded when building those temp projects. -->
     <PerfTargetVersion>$(PERF_TARGET_VERSION)</PerfTargetVersion>
 
     <!-- Test.Common.props sets TargetFramework to net6.0, we need to clear this value to be able to target multiple TFMs.
-         But only when PERF_TARGET_VERSION was not specified. When it is specified, a specific version is being benchmarked
-         and this version can be benchmarked only against single runtime version (because Microsoft.PowerShell.SDK targets a single TFM). -->
+      But we do it only when 'PERF_TARGET_VERSION' was not specified. When it is specified, a specific version is being benchmarked
+      and this version can be benchmarked only against single runtime version (because 'Microsoft.PowerShell.SDK' targets a single TFM). -->
     <TargetFramework Condition="'$(PerfTargetVersion)' == ''"></TargetFramework>
-    <TargetFrameworks Condition="'$(TargetFramework)' == ''">netcoreapp2.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFramework)' == ''">netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
 
     <PerfTargetVersion Condition="'$(PerfTargetVersion)' == '' AND '$(TargetFramework)' == 'net5.0'">7.1.3</PerfTargetVersion>
-    <PerfTargetVersion Condition="'$(PerfTargetVersion)' == '' AND '$(TargetFramework)' == 'netcoreapp2.1'">6.2.7</PerfTargetVersion>
+    <PerfTargetVersion Condition="'$(PerfTargetVersion)' == '' AND '$(TargetFramework)' == 'netcoreapp3.1'">7.0.6</PerfTargetVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -49,14 +49,17 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(PerfTargetVersion)' != ''">
+    <!-- We have to specify all package references explicitly due to a .NET SDK bug: https://github.com/dotnet/sdk/issues/17013
+      If the project references project A which references project B and we want to reference their packages for different TFMs,
+      we have to explicitly reference package A and B. -->
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="$(PerfTargetVersion)" />
     <PackageReference Include="Microsoft.PowerShell.Commands.Diagnostics" Version="$(PerfTargetVersion)" />
     <PackageReference Include="Microsoft.PowerShell.Commands.Management" Version="$(PerfTargetVersion)" />
     <PackageReference Include="Microsoft.PowerShell.Commands.Utility" Version="$(PerfTargetVersion)" />
-    <PackageReference Include="Microsoft.PowerShell.Security" Version="$(PerfTargetVersion)" />
-    <PackageReference Include="System.Management.Automation" Version="$(PerfTargetVersion)" />
     <PackageReference Include="Microsoft.PowerShell.ConsoleHost" Version="$(PerfTargetVersion)" />
+    <PackageReference Include="Microsoft.PowerShell.Security" Version="$(PerfTargetVersion)" />
     <PackageReference Include="Microsoft.PowerShell.CoreCLR.Eventing" Version="$(PerfTargetVersion)" />
+    <PackageReference Include="System.Management.Automation" Version="$(PerfTargetVersion)" />
   </ItemGroup>
 
 </Project>

--- a/test/perf/perf.psm1
+++ b/test/perf/perf.psm1
@@ -36,6 +36,9 @@ function Start-Benchmarking
         [ValidateSet('flat', 'tree')]
         [string] $List,
 
+        [ValidateSet('netcoreapp2.1', 'net5.0', 'net6.0')]
+        [string] $TargetFramework = 'net6.0',
+
         [string[]] $Filter = '*',
         [string] $Artifacts,
         [switch] $KeepFiles
@@ -61,8 +64,10 @@ function Start-Benchmarking
             $savedOFS = $OFS; $OFS = $null
 
             if ($TargetPSVersion) {
-                Write-Log -message "Run benchmarks targeting the 'Microsoft.PowerShell.SDK' version $TargetPSVersion..."
+                Write-Log -message "Run benchmarks targeting $TargetFramework and the 'Microsoft.PowerShell.SDK' version $TargetPSVersion..."
                 $env:PERF_TARGET_VERSION = $TargetPSVersion
+            } elseif ($TargetFramework -ne "net6.0") {
+                Write-Log -message "Run benchmarks targeting $TargetFramework and the corresponding 'Microsoft.PowerShell.SDK' version..."
             } else {
                 Write-Log -message "Run benchmarks targeting the current PowerShell code base..."
             }
@@ -71,7 +76,7 @@ function Start-Benchmarking
             if ($List) { $runArgs += '--list', $List }
             if ($KeepFiles) { $runArgs += "--keepFiles" }
 
-            dotnet run -c release --filter $Filter --artifacts $Artifacts --envVars POWERSHELL_TELEMETRY_OPTOUT:1 $runArgs
+            dotnet run -c release -f $TargetFramework --filter $Filter --artifacts $Artifacts --envVars POWERSHELL_TELEMETRY_OPTOUT:1 $runArgs
 
             if (Test-Path $Artifacts) {
                 Write-Log -message "`nBenchmark artifacts can be found at $Artifacts"

--- a/test/perf/perf.psm1
+++ b/test/perf/perf.psm1
@@ -14,8 +14,14 @@ function Start-Benchmarking
     The version of 'Microsoft.PowerShell.SDK' package that we want the benchmark to target.
     The supported versions are 7.0.x and above, including preview versions.
 
+    .PARAMETER TargetFramework
+    The target framework to run benchmarks against.
+
     .PARAMETER List
     List the available benchmarks, in either 'flat' or 'tree' views.
+
+    .PARAMETER Runtime
+    Run benchmarks against multiple .NET runtimes.
 
     .PARAMETER Filter
     One or more wildcard patterns to filter the benchmarks to be executed or to be listed.
@@ -26,18 +32,25 @@ function Start-Benchmarking
     .PARAMETER KeepFiles
     Indicates to keep all temporary files produced for running benchmarks.
     #>
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'Default')]
     param(
+        [Parameter(ParameterSetName = 'Default')]
         [ValidatePattern(
             '^7\.(0|1|2)\.\d+(-preview\.\d{1,2})?$',
             ErrorMessage = 'The package version is invalid or not supported')]
         [string] $TargetPSVersion,
 
+        [Parameter(ParameterSetName = 'Default')]
+        [ValidateSet('netcoreapp3.1', 'net5.0', 'net6.0')]
+        [string] $TargetFramework = 'net6.0',
+
+        [Parameter(ParameterSetName = 'Default')]
         [ValidateSet('flat', 'tree')]
         [string] $List,
 
-        [ValidateSet('netcoreapp2.1', 'net5.0', 'net6.0')]
-        [string] $TargetFramework = 'net6.0',
+        [Parameter(Mandatory, ParameterSetName = 'Runtimes')]
+        [ValidateSet('netcoreapp3.1', 'net5.0', 'net6.0')]
+        [string[]] $Runtime,
 
         [string[]] $Filter = '*',
         [string] $Artifacts,
@@ -56,6 +69,34 @@ function Start-Benchmarking
         if (Test-Path -Path $Artifacts) {
             Remove-Item -Path $Artifacts -Recurse -Force -ErrorAction Stop
         }
+
+        if ($TargetPSVersion) {
+            ## Validate the specified 'TargetPSVersion' and 'TargetFramework' are compatible.
+            $TargetFramework -match '\d.\d' > $null
+            $targetDotNetVersion = $Matches[0]
+
+            $minimalDotNetVersion = switch -Wildcard ($TargetPSVersion) {
+                '7.0.*' { '3.1' }
+                '7.1.*' { '5.0' }
+                '7.2.*' { '6.0' }
+            }
+
+            if ($targetDotNetVersion -lt $minimalDotNetVersion) {
+                $dotnetVer = $minimalDotNetVersion -eq '3.1' ? 'netcoreapp3.1' : "net$minimalDotNetVersion"
+                throw "The '$TargetPSVersion' version of 'Microsoft.PowerShell.SDK' requires '$dotnetVer' as the minimal target framework."
+            }
+        }
+
+        if ($Runtime) {
+            ## Remove duplicate values.
+            $hash = [ordered]@{}
+            foreach ($item in $Runtime) {
+                if (-not $hash.Contains($item)) {
+                    $hash.Add($item, $null)
+                }
+            }
+            $Runtime = $hash.Keys
+        }
     }
 
     End {
@@ -63,20 +104,36 @@ function Start-Benchmarking
             Push-Location -Path "$PSScriptRoot/benchmarks"
             $savedOFS = $OFS; $OFS = $null
 
-            if ($TargetPSVersion) {
-                Write-Log -message "Run benchmarks targeting $TargetFramework and the 'Microsoft.PowerShell.SDK' version $TargetPSVersion..."
-                $env:PERF_TARGET_VERSION = $TargetPSVersion
-            } elseif ($TargetFramework -ne "net6.0") {
-                Write-Log -message "Run benchmarks targeting $TargetFramework and the corresponding 'Microsoft.PowerShell.SDK' version..."
-            } else {
-                Write-Log -message "Run benchmarks targeting the current PowerShell code base..."
-            }
+            ## Aggregate BDN arguments.
+            $runArgs = @('--filter')
+            foreach ($entry in $Filter) { $runArgs += $entry }
+            $runArgs += '--artifacts', $Artifacts
+            $runArgs += '--envVars', 'POWERSHELL_TELEMETRY_OPTOUT:1'
 
-            $runArgs = @()
             if ($List) { $runArgs += '--list', $List }
             if ($KeepFiles) { $runArgs += "--keepFiles" }
 
-            dotnet run -c Release -f $TargetFramework --filter $Filter --artifacts $Artifacts --envVars POWERSHELL_TELEMETRY_OPTOUT:1 $runArgs
+            if ($PSCmdlet.ParameterSetName -eq 'Default') {
+                if ($TargetPSVersion) {
+                    Write-Log -message "Run benchmarks targeting '$TargetFramework' and the 'Microsoft.PowerShell.SDK' version '$TargetPSVersion' ..."
+                    $env:PERF_TARGET_VERSION = $TargetPSVersion
+                }
+                elseif ($TargetFramework -eq 'net6.0') {
+                    Write-Log -message "Run benchmarks targeting the current PowerShell code base ..."
+                }
+                else {
+                    Write-Log -message "Run benchmarks targeting '$TargetFramework' and the corresponding latest version of 'Microsoft.PowerShell.SDK' ..."
+                }
+
+                ## Use 'Release' instead of 'release' (note the capital case) because BDN uses 'Release' when building the auto-generated
+                ## project, and MSBuild somehow recognizes 'release' and 'Release' as two different configurations and thus will rebuild
+                ## all dependencies unnecessarily.
+                dotnet run -c Release -f $TargetFramework $runArgs
+            }
+            else {
+                Write-Log -message "Run benchmarks targeting multiple .NET runtimes: $Runtime ..."
+                dotnet run -c Release -f net6.0 --runtimes $Runtime $runArgs
+            }
 
             if (Test-Path $Artifacts) {
                 Write-Log -message "`nBenchmark artifacts can be found at $Artifacts"
@@ -147,7 +204,7 @@ function Compare-BenchmarkResult
         if ($Noise) { $runArgs += "--noise $Noise" }
         if ($Top -gt 0) { $runArgs += "--top $Top" }
 
-        dotnet run -c release --base $BaseResultPath --diff $DiffResultPath --threshold $Threshold "$runArgs"
+        dotnet run -c Release --base $BaseResultPath --diff $DiffResultPath --threshold $Threshold "$runArgs"
     }
     finally {
         $OFS = $savedOFS

--- a/test/perf/perf.psm1
+++ b/test/perf/perf.psm1
@@ -76,7 +76,7 @@ function Start-Benchmarking
             if ($List) { $runArgs += '--list', $List }
             if ($KeepFiles) { $runArgs += "--keepFiles" }
 
-            dotnet run -c release -f $TargetFramework --filter $Filter --artifacts $Artifacts --envVars POWERSHELL_TELEMETRY_OPTOUT:1 $runArgs
+            dotnet run -c Release -f $TargetFramework --filter $Filter --artifacts $Artifacts --envVars POWERSHELL_TELEMETRY_OPTOUT:1 $runArgs
 
             if (Test-Path $Artifacts) {
                 Write-Log -message "`nBenchmark artifacts can be found at $Artifacts"


### PR DESCRIPTION
# PR Summary

This PR adds support for comparing the performance of various .NET Runtimes.

The users can specify a single `TargetFramework` using `dotnet run` or `Start-Benchmarking`:

```cmd
Start-Benchmarking -Filter *using* -TargetFramework net5.0
dotnet run -c Release -f net5.0 --filter *using*
```

![image](https://user-images.githubusercontent.com/6011991/117952343-624f9580-b315-11eb-8840-ce63cc8135a5.png)

Or multiple target framework monikers using `dotnet run`:

```cmd
dotnet run -c Release --filter Engine.Parsing.UsingStatement -f netcoreapp2.1 --runtimes netcoreapp2.1 net5.0 net6.0
```

![image](https://user-images.githubusercontent.com/6011991/117952128-24527180-b315-11eb-9b96-76b8e18b0dde.png)

For more information please refer to [BenchmarkDotNet docs](https://github.com/dotnet/BenchmarkDotNet/blob/master/docs/articles/configs/toolchains.md#toolchains)

## PR Context

https://github.com/dotnet/sdk/issues/17013

To get it working I had to:

* clear `TargetFramework`  as  `Test.Common.props` sets `TargetFramework` to `net6.0`. This was mandatory to be able to target multiple TFMs.
* specify all package references in explicit way. It seems to be some kind of SDK/MSBuild limitation. If the project references project `A` which references project `B` and we want to reference their **packages** for different TFMs, we have to explicitly reference package `A` **and** `B`. Referencing just `A` gives errors about missing `B`.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
- **User-facing changes**
    - [x] Not Applicable
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively

@daxian-dbw @adityapatwardhan PTAL