### PR TITLE
Add a Windows mode for native commands that allows some commands to use legacy argument passing

### DIFF
--- a/src/System.Management.Automation/engine/CommandBase.cs
+++ b/src/System.Management.Automation/engine/CommandBase.cs
@@ -281,7 +281,7 @@ namespace System.Management.Automation
         /// <summary>Use legacy argument parsing via ProcessStartInfo.Arguments.</summary>
         Legacy = 0,
 
-        /// <summary>Use new style argument parsing via ProcessStartInfo.ArgumentList.</summary>
+        /// <summary>Use new style argument passing via ProcessStartInfo.ArgumentList.</summary>
         Standard = 1,
 
         /// <summary>

--- a/src/System.Management.Automation/engine/CommandBase.cs
+++ b/src/System.Management.Automation/engine/CommandBase.cs
@@ -282,7 +282,13 @@ namespace System.Management.Automation
         Legacy = 0,
 
         /// <summary>Use new style argument parsing via ProcessStartInfo.ArgumentList.</summary>
-        Standard = 1
+        Standard = 1,
+
+        /// <summary>
+        /// Use specific to Windows passing style which is Legacy for selected files on Windows, but
+        /// Standard for everything else. This is the default behavior for Windows.
+        /// </summary>
+        Windows = 2
     }
     #endregion NativeArgumentPassingStyle
 

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -1320,13 +1320,18 @@ namespace System.Management.Automation.Runspaces
 
             // If the PSNativeCommandArgumentPassing feature is enabled, create the variable which controls the behavior
             // Since the BuiltInVariables list is static, and this should be done dynamically
-            // we need to do this here.
+            // we need to do this here. Also, since the defaults are different based on platform we need a
+            // bit more logic.
             if (ExperimentalFeature.IsEnabled("PSNativeCommandArgumentPassing"))
             {
+                NativeArgumentPassingStyle style = NativeArgumentPassingStyle.Standard;
+                if (Platform.IsWindows) {
+                    style = NativeArgumentPassingStyle.Windows;
+                }
                 Variables.Add(
                     new SessionStateVariableEntry(
                         SpecialVariables.NativeArgumentPassing,
-                        NativeArgumentPassingStyle.Standard,
+                        style,
                         RunspaceInit.NativeCommandArgumentPassingDescription,
                         ScopedItemOptions.None,
                         new ArgumentTypeConverterAttribute(typeof(NativeArgumentPassingStyle))));

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -187,7 +187,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets a value indicating whether to use an ArgumentList or string for arguments when invoking a native executable.
         /// </summary>
-        internal bool UseArgumentList
+        internal NativeArgumentPassingStyle ArgumentPassingStyle
         {
             get
             {
@@ -198,16 +198,16 @@ namespace System.Management.Automation
                         // This will default to the new behavior if it is set to anything other than Legacy
                         var preference = LanguagePrimitives.ConvertTo<NativeArgumentPassingStyle>(
                             Context.GetVariableValue(new VariablePath(SpecialVariables.NativeArgumentPassing), NativeArgumentPassingStyle.Standard));
-                        return preference != NativeArgumentPassingStyle.Legacy;
+                        return preference;
                     }
                     catch
                     {
-                        // The value is not convertable send back true
-                        return true;
+                        // The value is not convertable send back Legacy
+                        return NativeArgumentPassingStyle.Legacy;
                     }
                 }
 
-                return false;
+                return NativeArgumentPassingStyle.Legacy;
             }
         }
 
@@ -314,7 +314,7 @@ namespace System.Management.Automation
                         }
                         else
                         {
-                            if (argArrayAst != null && UseArgumentList)
+                            if (argArrayAst != null && ArgumentPassingStyle == NativeArgumentPassingStyle.Standard)
                             {
                                 // We have a literal array, so take the extent, break it on spaces and add them to the argument list.
                                 foreach (string element in argArrayAst.Extent.Text.Split(' ', StringSplitOptions.RemoveEmptyEntries))
@@ -331,7 +331,7 @@ namespace System.Management.Automation
                         }
                     }
                 }
-                else if (UseArgumentList && currentObj != null)
+                else if (ArgumentPassingStyle == NativeArgumentPassingStyle.Standard && currentObj != null)
                 {
                     // add empty strings to arglist, but not nulls
                     AddToArgumentList(parameter, arg);

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -20,6 +20,8 @@ namespace System.Management.Automation
     /// </summary>
     internal class NativeCommandParameterBinder : ParameterBinderBase
     {
+        private readonly VariablePath s_nativeArgumentPassingVarPath = new VariablePath(SpecialVariables.NativeArgumentPassing);
+
         #region ctor
 
         /// <summary>
@@ -197,7 +199,7 @@ namespace System.Management.Automation
                     {
                         // This will default to the new behavior if it is set to anything other than Legacy
                         var preference = LanguagePrimitives.ConvertTo<NativeArgumentPassingStyle>(
-                            Context.GetVariableValue(new VariablePath(SpecialVariables.NativeArgumentPassing), NativeArgumentPassingStyle.Standard));
+                            Context.GetVariableValue(s_nativeArgumentPassingVarPath, NativeArgumentPassingStyle.Standard));
                         return preference;
                     }
                     catch

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinderController.cs
@@ -50,13 +50,13 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Gets a value indicating whether to use the new API for StartInfo.
+        /// Gets the value indicating what type of native argument binding to use.
         /// </summary>
-        internal bool UseArgumentList
+        internal NativeArgumentPassingStyle ArgumentPassingStyle
         {
             get
             {
-                return ((NativeCommandParameterBinder)DefaultParameterBinder).UseArgumentList;
+                return ((NativeCommandParameterBinder)DefaultParameterBinder).ArgumentPassingStyle;
             }
         }
 

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1110,10 +1110,10 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets the ProcessStartInfo for process.
         /// </summary>
-        /// <param name="redirectOutput"></param>
-        /// <param name="redirectError"></param>
-        /// <param name="redirectInput"></param>
-        /// <param name="soloCommand"></param>
+        /// <param name="redirectOutput">A boolean which determines whether the output is to be redirected.</param>
+        /// <param name="redirectError">A boolean which determines whether errors are to be redirected.</param>
+        /// <param name="redirectInput">A boolean which determines whether the input is to be redirected.</param>
+        /// <param name="soloCommand">A boolean which determines whether this is a solo command.</param>
         /// <returns>A ProcessStartInfo object which is the base of the native invocation.</returns>
         private ProcessStartInfo GetProcessStartInfoObject(bool redirectOutput, bool redirectError, bool redirectInput, bool soloCommand)
         {
@@ -1146,19 +1146,30 @@ namespace System.Management.Automation
                 {
                     // Shell doesn't exist on headless SKUs, so documents cannot be associated with an application.
                     // Therefore, we cannot run document in this case.
-                    throw InterpreterError.NewInterpreterException(this.Path, typeof(RuntimeException),
-                        this.Command.InvocationExtent, "CantActivateDocumentInPowerShellCore", ParserStrings.CantActivateDocumentInPowerShellCore, this.Path);
+                    throw InterpreterError.NewInterpreterException(
+                        this.Path,
+                        typeof(RuntimeException),
+                        this.Command.InvocationExtent,
+                        "CantActivateDocumentInPowerShellCore",
+                        ParserStrings.CantActivateDocumentInPowerShellCore,
+                        this.Path);
                 }
 
                 // We only want to ShellExecute something that is standalone...
                 if (!soloCommand)
                 {
-                    throw InterpreterError.NewInterpreterException(this.Path, typeof(RuntimeException),
-                        this.Command.InvocationExtent, "CantActivateDocumentInPipeline", ParserStrings.CantActivateDocumentInPipeline, this.Path);
+                    throw InterpreterError.NewInterpreterException(
+                        this.Path,
+                        typeof(RuntimeException),
+                        this.Command.InvocationExtent,
+                        "CantActivateDocumentInPipeline",
+                        ParserStrings.CantActivateDocumentInPipeline,
+                        this.Path);
                 }
 
                 startInfo.UseShellExecute = true;
             }
+
             return startInfo;
         }
 

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1108,14 +1108,14 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Gets the start info for process.
+        /// Gets the ProcessStartInfo for process.
         /// </summary>
         /// <param name="redirectOutput"></param>
         /// <param name="redirectError"></param>
         /// <param name="redirectInput"></param>
         /// <param name="soloCommand"></param>
-        /// <returns></returns>
-        private ProcessStartInfo GetProcessStartInfo(bool redirectOutput, bool redirectError, bool redirectInput, bool soloCommand)
+        /// <returns>A ProcessStartInfo object which is the base of the native invocation.</returns>
+        private ProcessStartInfo GetProcessStartInfoObject(bool redirectOutput, bool redirectError, bool redirectInput, bool soloCommand)
         {
             ProcessStartInfo startInfo = new ProcessStartInfo();
             startInfo.FileName = this.Path;
@@ -1159,6 +1159,20 @@ namespace System.Management.Automation
 
                 startInfo.UseShellExecute = true;
             }
+            return startInfo;
+        }
+
+        /// <summary>
+        /// Gets the start info for process.
+        /// </summary>
+        /// <param name="redirectOutput"></param>
+        /// <param name="redirectError"></param>
+        /// <param name="redirectInput"></param>
+        /// <param name="soloCommand"></param>
+        /// <returns></returns>
+        private ProcessStartInfo GetProcessStartInfo(bool redirectOutput, bool redirectError, bool redirectInput, bool soloCommand)
+        {
+            ProcessStartInfo startInfo = GetProcessStartInfoObject(redirectOutput, redirectError, redirectInput, soloCommand);
 
             // For minishell value of -outoutFormat parameter depends on value of redirectOutput.
             // So we delay the parameter binding. Do parameter binding for minishell now.

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1145,6 +1145,18 @@ namespace System.Management.Automation
         }
 
         /// <summary>
+        /// Get whether we should treat this executable with special handling and use the legacy passing style.
+        /// </summary>
+        /// <param name="filePath"></param>
+        private bool UseSpecialArgumentPassing(string filePath) =>
+            NativeParameterBinderController.ArgumentPassingStyle switch
+            {
+                NativeArgumentPassingStyle.Legacy => true,
+                NativeArgumentPassingStyle.Windows => ShouldUseLegacyPassingStyle(filePath),
+                _ => false
+            };
+
+        /// <summary>
         /// Gets the ProcessStartInfo for process.
         /// </summary>
         /// <param name="redirectOutput">A boolean that indicates that, when true, output from the process is redirected to a stream, and otherwise is sent to stdout.</param>

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1127,10 +1127,10 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets the ProcessStartInfo for process.
         /// </summary>
-        /// <param name="redirectOutput">A boolean which determines whether the output is to be redirected.</param>
-        /// <param name="redirectError">A boolean which determines whether errors are to be redirected.</param>
-        /// <param name="redirectInput">A boolean which determines whether the input is to be redirected.</param>
-        /// <param name="soloCommand">A boolean which determines whether this is a solo command.</param>
+        /// <param name="redirectOutput">A boolean that indicates that, when true, output from the process is redirected to a stream, and otherwise is sent to stdout.</param>
+        /// <param name="redirectError">A boolean that indicates that, when true, error output from the process is redirected to a stream, and otherwise is sent to stderr.</param>
+        /// <param name="redirectInput">A boolean that indicates that, when true, input to the process is taken from a stream, and otherwise is taken from stdin.</param>
+        /// <param name="soloCommand">A boolean that indicates, when true, that the command to be executed is not part of a pipeline, and otherwise indicates that is is.</param>
         /// <returns>A ProcessStartInfo object which is the base of the native invocation.</returns>
         private ProcessStartInfo GetProcessStartInfoObject(bool redirectOutput, bool redirectError, bool redirectInput, bool soloCommand)
         {

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1217,25 +1217,28 @@ namespace System.Management.Automation
         /// is done on Windows.
         /// </summary>
         /// <param name="filename">string</param>
-        /// <returns>bool</returns>
+        /// <returns>A boolean indicating what passing style should be used.</returns>
         private static bool useLegacyPassingStyle(string filename)
         {
             if (filename == null || filename == string.Empty)
             {
                 return false;
             }
+
             string commandPath = filename.ToLowerInvariant();
+
             // This is the list of files which will trigger Legacy behavior if
             // PSNativeCommandArgumentPassing is set to "Windows".
             // The following native commands have non-standard behavior with regard to argument passing.
-            string[] exceptions = new string[]{
+            string[] exceptions = new string[] {
                 "cmd.exe",
                 "cscript.exe",
                 "wscript.exe",
                 ".bat",
                 ".cmd",
-                ".vbs"};
-            foreach (string exception in exceptions) {
+                ".vbs" };
+            foreach (string exception in exceptions)
+            {
                 if (filename.EndsWith(exception))
                 {
                     return true;

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1288,7 +1288,9 @@ namespace System.Management.Automation
                 "wscript.exe",
                 ".bat",
                 ".cmd",
-                ".vbs"
+                ".vbs",
+                ".wsf",
+                ".js"
                 };
             foreach (string exception in exceptions)
             {

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -427,7 +427,7 @@ namespace System.Management.Automation
             bool soloCommand = this.Command.MyInvocation.PipelineLength == 1;
 
             // Get the start info for the process.
-            ProcessStartInfo startInfo = GetProcessStartInfo(redirectInput, redirectOutput, redirectError, soloCommand);
+            ProcessStartInfo startInfo = GetProcessStartInfo(redirectOutput, redirectError, redirectInput, soloCommand);
 
 #if !UNIX
             string commandPath = this.Path.ToLowerInvariant();
@@ -1165,9 +1165,9 @@ namespace System.Management.Automation
         /// <param name="soloCommand">A boolean that indicates, when true, that the command to be executed is not part of a pipeline, and otherwise indicates that is is.</param>
         /// <returns>A ProcessStartInfo object which is the base of the native invocation.</returns>
         private ProcessStartInfo GetProcessStartInfo(
-            bool redirectInput,
             bool redirectOutput,
             bool redirectError,
+            bool redirectInput,
             bool soloCommand)
         {
             var startInfo = new ProcessStartInfo

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1194,15 +1194,9 @@ namespace System.Management.Automation
         /// Get whether we should treat this executable with special handling and use the legacy passing style.
         /// </summary>
         /// <param name="filePath"></param>
-        private bool UseSpecialArgumentPassing(string filePath)
-        {
-            // We need to check if we're using legacy argument passing or it's a special case.
-            bool useLegacy = NativeParameterBinderController.ArgumentPassingStyle == NativeArgumentPassingStyle.Legacy;
-            bool windowsSpecialCase =
-                NativeParameterBinderController.ArgumentPassingStyle == NativeArgumentPassingStyle.Windows &&
-                UseLegacyPassingStyle(filePath);
-            return (useLegacy || windowsSpecialCase);
-        }
+        private bool UseSpecialArgumentPassing(string filePath) =>
+            NativeParameterBinderController.ArgumentPassingStyle == NativeArgumentPassingStyle.Legacy
+            || (NativeParameterBinderController.ArgumentPassingStyle == NativeArgumentPassingStyle.Windows && UseLegacyPassingStyle(filePath));
 
         /// <summary>
         /// Gets the start info for process.
@@ -1271,12 +1265,10 @@ namespace System.Management.Automation
         /// <returns>A boolean indicating what passing style should be used.</returns>
         private static bool UseLegacyPassingStyle(string filePath)
         {
-            if (filePath == null || filePath == string.Empty)
+            if (string.IsNullOrEmpty(filePath))
             {
                 return false;
             }
-
-            string commandPath = filePath.ToLowerInvariant();
 
             // This is the list of files which will trigger Legacy behavior if
             // PSNativeCommandArgumentPassing is set to "Windows".
@@ -1299,7 +1291,7 @@ namespace System.Management.Automation
                 };
             foreach (string exception in exceptions)
             {
-                if (filePath.EndsWith(exception))
+                if (filePath.EndsWith(exception, StringComparison.OrdinalIgnoreCase))
                 {
                     return true;
                 }

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1267,25 +1267,30 @@ namespace System.Management.Automation
         /// Determine if we have a special file which will change the way native argument passing
         /// is done on Windows. We use legacy behavior for cmd.exe, .bat, .cmd files.
         /// </summary>
-        /// <param name="filename">The file to use when checking how to pass arguments.</param>
+        /// <param name="filePath">The file to use when checking how to pass arguments.</param>
         /// <returns>A boolean indicating what passing style should be used.</returns>
-        private static bool UseLegacyPassingStyle(string filename)
+        private static bool UseLegacyPassingStyle(string filePath)
         {
-            if (filename == null || filename == string.Empty)
+            if (filePath == null || filePath == string.Empty)
             {
                 return false;
             }
 
-            string commandPath = filename.ToLowerInvariant();
+            string commandPath = filePath.ToLowerInvariant();
 
             // This is the list of files which will trigger Legacy behavior if
             // PSNativeCommandArgumentPassing is set to "Windows".
             // The following native commands have non-standard behavior with regard to argument passing.
+            // It's possible (but not likely) that one of the executables could have forward slashes,
+            // so we check for both.
             string[] exceptions = new string[]
                 {
-                "cmd.exe",
-                "cscript.exe",
-                "wscript.exe",
+                "\\cmd.exe",
+                "/cmd.exe",
+                "\\cscript.exe",
+                "/cscript.exe",
+                "\\wscript.exe",
+                "/wscript.exe",
                 ".bat",
                 ".cmd",
                 ".vbs",
@@ -1294,7 +1299,7 @@ namespace System.Management.Automation
                 };
             foreach (string exception in exceptions)
             {
-                if (filename.EndsWith(exception))
+                if (filePath.EndsWith(exception))
                 {
                     return true;
                 }

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -486,8 +486,8 @@ namespace System.Management.Automation
 
                             string oldArguments = startInfo.Arguments;
                             string oldFileName = startInfo.FileName;
+                            // Check to see whether this executable should be using Legacy mode argument parsing
                             bool useSpecialArgumentPassing = UseSpecialArgumentPassing(oldFileName);
-                            // Check to see whether we should be using Legacy mode
                             if (useSpecialArgumentPassing)
                             {
                                 startInfo.Arguments = "\"" + oldFileName + "\" " + startInfo.Arguments;
@@ -1195,8 +1195,12 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="filePath"></param>
         private bool UseSpecialArgumentPassing(string filePath) =>
-            NativeParameterBinderController.ArgumentPassingStyle == NativeArgumentPassingStyle.Legacy
-            || (NativeParameterBinderController.ArgumentPassingStyle == NativeArgumentPassingStyle.Windows && UseLegacyPassingStyle(filePath));
+            NativeParameterBinderController.ArgumentPassingStyle switch
+            {
+                NativeArgumentPassingStyle.Legacy => true,
+                NativeArgumentPassingStyle.Windows => UseLegacyPassingStyle(filePath),
+                _ => false
+            };
 
         /// <summary>
         /// Gets the start info for process.

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1178,7 +1178,7 @@ namespace System.Management.Automation
                 bool useLegacy = NativeParameterBinderController.ArgumentPassingStyle == NativeArgumentPassingStyle.Legacy;
                 bool windowsSpecialCase =
                     NativeParameterBinderController.ArgumentPassingStyle == NativeArgumentPassingStyle.Windows &&
-                    useLegacyPassingStyle(startInfo.FileName);
+                    UseLegacyPassingStyle(startInfo.FileName);
 
                 if (useLegacy || windowsSpecialCase)
                 {
@@ -1214,11 +1214,11 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Determine if we have a special file which will change the way native argument passing
-        /// is done on Windows.
+        /// is done on Windows. We use legacy behavior for cmd.exe, .bat, .cmd files.
         /// </summary>
-        /// <param name="filename">string</param>
+        /// <param name="filename">The file to use when checking how to pass arguments.</param>
         /// <returns>A boolean indicating what passing style should be used.</returns>
-        private static bool useLegacyPassingStyle(string filename)
+        private static bool UseLegacyPassingStyle(string filename)
         {
             if (filename == null || filename == string.Empty)
             {
@@ -1230,13 +1230,15 @@ namespace System.Management.Automation
             // This is the list of files which will trigger Legacy behavior if
             // PSNativeCommandArgumentPassing is set to "Windows".
             // The following native commands have non-standard behavior with regard to argument passing.
-            string[] exceptions = new string[] {
+            string[] exceptions = new string[]
+                {
                 "cmd.exe",
                 "cscript.exe",
                 "wscript.exe",
                 ".bat",
                 ".cmd",
-                ".vbs" };
+                ".vbs"
+                };
             foreach (string exception in exceptions)
             {
                 if (filename.EndsWith(exception))
@@ -1244,6 +1246,7 @@ namespace System.Management.Automation
                     return true;
                 }
             }
+
             return false;
         }
 

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -240,7 +240,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             $LASTEXITCODE | Should -Be 64
         }
 
-        It "Empty space command should succeed" {
+        It "Empty space command should succeed on non-Windows" -skip:$IsWindows {
             & $powershell -noprofile -c '' | Should -BeNullOrEmpty
             $LASTEXITCODE | Should -Be 0
         }

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
@@ -5,10 +5,7 @@ param()
 
 Describe "Behavior is specific for each platform" -tags "CI" {
     BeforeAll {
-        $skipTests = $false
-        if ($EnabledExperimentalFeatures -notcontains 'PSNativeCommandArgumentPassing') {
-            $skipTests = $true
-        }
+        $skipTests = $EnabledExperimentalFeatures -notcontains 'PSNativeCommandArgumentPassing'
     }
     It "PSNativeCommandArgumentPassing is set to 'Windows' on Windows systems" -skip:(-not $IsWindows) {
         $PSNativeCommandArgumentPassing | Should -Be "Windows"
@@ -31,10 +28,8 @@ Describe "Behavior is specific for each platform" -tags "CI" {
 
 Describe "tests for multiple languages and extensions" -tags "CI" {
     AfterAll {
-        if ($EnabledExperimentalFeatures -notcontains 'PSNativeCommandArgumentPassing') {
-            return
-        }
-        if (! $IsWindows ) {
+        if (-not $IsWindows -or
+            $EnabledExperimentalFeatures -notcontains 'PSNativeCommandArgumentPassing') {
             return
         }
         $PSNativeCommandArgumentPassing = $passingStyle
@@ -131,14 +126,8 @@ echo Argument 4 is: ^<%4^>
 
         # determine whether we should skip the tests we just defined
         # doing it in this order ensures that the test output will show each skipped test
-        $skipTests = $false
-        if ($EnabledExperimentalFeatures -notcontains 'PSNativeCommandArgumentPassing') {
-            $skipTests = $true
-            return
-        }
-
-        if (! $IsWindows ) {
-            $skipTests = $true
+        $skipTests = -not $IsWindows -or $EnabledExperimentalFeatures -notcontains 'PSNativeCommandArgumentPassing'
+        if ($skipTests) {
             return
         }
 

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
@@ -21,9 +21,10 @@ Describe "Behavior is specific for each platform" {
         "@echo off`nSET V2=a`necho %V1%" > "$TESTDRIVE\script 2.cmd"
         "@echo off`necho %V1%`necho %V2%" > "$TESTDRIVE\script 3.cmd"
         $result = cmd /c """${TESTDRIVE}\script 1.cmd"" && ""${TESTDRIVE}\script 2.cmd"" && ""${TESTDRIVE}\script 3.cmd"""
-        $result.Count | Should -Be 2
+        $result.Count | Should -Be 3
         $result[0] | Should -Be 1
-        $result[1] | Should Be "a"
+        $result[1] | Should -Be 1
+        $result[2] | Should Be "a"
     }
     
 }

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
@@ -42,7 +42,7 @@ Describe "tests for multiple languages and extensions" -tags "CI" {
     BeforeAll {
         $testCases = @(
             @{
-                Command = ""
+                Command = "cscript.exe"
                 Filename = "test.wsf"
                 ExpectedResults = @(
                     "Argument 0 is: <ab cd>"
@@ -64,7 +64,7 @@ next
 '@
             }
             @{
-                Command = ""
+                Command = "cscript.exe"
                 Filename = "test.vbs"
                 ExpectedResults = @(
                     "Argument 0 is: <ab cd>"

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
@@ -13,7 +13,7 @@ Describe "Behavior is specific for each platform" {
     It "PSNativeCommandArgumentPassing is set to 'Windows' on Windows systems" -skip:(-not $IsWindows) {
         $PSNativeCommandArgumentPassing | Should -Be "Windows"
     }
-    It "PSNativeCommandArgumentPassing is set to 'Standarad' on non-Windows systems" -skip:($IsWindows) {
+    It "PSNativeCommandArgumentPassing is set to 'Standard' on non-Windows systems" -skip:($IsWindows) {
         $PSNativeCommandArgumentPassing | Should -Be "Standard"
     }
     It "Has proper behavior on Windows" -skip:(-not $IsWindows) {

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
@@ -155,12 +155,12 @@ echo Argument 4 is: ^<%4^>
         $scriptPath = Join-Path $TESTDRIVE $Filename
         $Script | out-file -encoding ASCII $scriptPath
         if ($Command) {
-            $results = & $Command $scriptPath  $a 'a"b c"d' a"b c"d "a'b c'd"
+            $results = & $Command $scriptPath  $a 'a"b c"d' a"b c"d "a'b c'd" 2> "${TESTDRIVE}/error.txt"
         }
         else {
             $results = & $scriptPath  $a 'a"b c"d' a"b c"d "a'b c'd" 2> "${TESTDRIVE}/error.txt"
         }
-        $errorContent = Get-Content "${TESTDRIVE}/error.txt"
+        $errorContent = Get-Content "${TESTDRIVE}/error.txt" -ErrorAction Ignore
         $errorContent | Should -BeNullOrEmpty
         $results.Count | Should -Be 4
         $results[0] | Should -Be $ExpectedResults[0]


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR targets a _consistent_ default behavior between PowerShell 5 and PowerShell 7 on Windows for some executables and file types. The behavior is now update to use the legacy behavior for the following files:

 - cmd.exe
- cscript.exe
- wscript.exe
- ending with .bat
- ending with .cmd
- ending with .vbs

This list is table driven, and can be easily altered. I have started with this list as I am familiar with real world issues with them.

The PSNativeArgumentPassing preference value has been expanded to include the new value `Windows`.  When the preference variable is set to `Windows` the above table will be in effect, meaning that invocations of those files will automatically use the `Legacy` style argument passing. If the PSNativeArgumentPassing is set to either `Legacy` or `Standard`, then the additional checks will _not_ take place.

The default behavior is now also platform specific. On Windows platforms, the default setting will be `Windows` and non-Windows platforms will be `Standard`.


<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [x] Experimental feature name(s): PSNativeCommandArgumentPassing
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
