### PR TITLE
Fix retrieving dynamic parameters from provider even if globbed path returns no results

### DIFF
--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -4681,7 +4681,7 @@ namespace System.Management.Automation
                 }
             }
 
-            if (providerPath != null)
+            if (providerInstance != null)
             {
                 // Get the dynamic parameters for the first resolved path
                 return CopyItemDynamicParameters(providerInstance, providerPath, destination, recurse, newContext);
@@ -4732,10 +4732,6 @@ namespace System.Management.Automation
             Dbg.Diagnostics.Assert(
                 providerInstance != null,
                 "Caller should validate providerInstance before calling this method");
-
-            Dbg.Diagnostics.Assert(
-                path != null,
-                "Caller should validate path before calling this method");
 
             Dbg.Diagnostics.Assert(
                 context != null,

--- a/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
+++ b/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
@@ -258,6 +258,9 @@ Describe "Parameter Binding Tests" -Tags "CI" {
 
     It 'Dynamic parameter is found even if globbed path does not exist' {
         $guid = New-Guid
+
+        # This test verifies that the ErrorRecord is coming from parameter validation on a dynamic parameter
+        # instead of an error indicating that the dynamic parameter is not found
         { Copy-Item "~\$guid*" -Destination ~ -ToSession $null } | Should -Throw -ErrorId 'ParameterArgumentValidationError'
     }
 

--- a/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
+++ b/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
@@ -256,6 +256,11 @@ Describe "Parameter Binding Tests" -Tags "CI" {
         DynamicParamTest -PipelineVariable bar | ForEach-Object { $bar } | Should -Be "hi"
     }
 
+    It 'Dynamic parameter is found even if globbed path does not exist' {
+        $guid = New-Guid
+        { Copy-Item "~\$guid*" -Destination ~ -ToSession $null } | Should -Throw -ErrorId 'ParameterArgumentValidationError'
+    }
+
     Context "PipelineVariable Behaviour" {
 
         BeforeAll {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The problem only occurs with a cmdlet that relies on a provider and the path has a wildcard that returns no results.  The simple repro is:

```powershell
$s = New-PSSession .
copy-item c:\foo* -Destination ~ -ToSession $s
```

You'll get a parameter binding error that `-ToSession` is not a valid parameter.  What's happening is that the parameter binder uses the path to find a provider.  It correctly finds the filesystem provider and then uses that to glob the wildcard for results.  Since the wildcard doesn't match any results, the logic incorrectly skips binding dynamic parameters, so the user gets an unhelpful error message.

The fix is to not require that globbing returns any results, just that a provider was returned.  Then I removed an assertion checking that the path is not null.  I looked through the source code for implementations of `CopyItemDynamicParameters()` and the FileSystemProvider doesn't even use the path so it doesn't matter if it's null or not.  The other cases already check if path is null and handles it so the assertion is not necessary even if it only affects debug builds.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/6527

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
