### PR TITLE
Retrieve productVersion using informational version attribute in AmsiUtils.Init()

### DIFF
--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -78,7 +78,7 @@ namespace System.Management.Automation
             s_psVersionTable = new PSVersionHashTable(StringComparer.OrdinalIgnoreCase);
 
             Assembly currentAssembly = typeof(PSVersionInfo).Assembly;
-            string productVersion = currentAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+            ProductVersion = currentAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
 
             // Get 'GitCommitId' and 'PSVersion' from the 'productVersion' assembly attribute.
             //
@@ -93,11 +93,11 @@ namespace System.Management.Automation
             //      productVersion = '6.0.0 SHA: f1ec9...'                    convert to GitCommitId = 'v6.0.0'
             //                                                                           PSVersion   = '6.0.0'
             string rawGitCommitId;
-            string mainVersion = productVersion.Substring(0, productVersion.IndexOf(' '));
+            string mainVersion = ProductVersion.Substring(0, ProductVersion.IndexOf(' '));
 
-            if (productVersion.Contains(" Commits: "))
+            if (ProductVersion.Contains(" Commits: "))
             {
-                rawGitCommitId = productVersion.Replace(" Commits: ", "-").Replace(" SHA: ", "-g");
+                rawGitCommitId = ProductVersion.Replace(" Commits: ", "-").Replace(" SHA: ", "-g");
             }
             else
             {
@@ -181,6 +181,8 @@ namespace System.Management.Automation
                 return s_psVersion;
             }
         }
+
+        internal static string ProductVersion { get; }
 
         internal static string GitCommitId
         {

--- a/src/System.Management.Automation/security/SecuritySupport.cs
+++ b/src/System.Management.Automation/security/SecuritySupport.cs
@@ -856,7 +856,6 @@ namespace Microsoft.PowerShell.Commands
 
 namespace System.Management.Automation
 {
-    using System.Reflection;
     using System.Security.Cryptography.Pkcs;
 
     /// <summary>
@@ -1343,9 +1342,7 @@ namespace System.Management.Automation
 
             lock (s_amsiLockObject)
             {
-                Assembly currentAssembly = typeof(AmsiUtils).Assembly;
-                string productVersion = currentAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
-                string hostname = string.Concat("PowerShell_", Environment.ProcessPath, "_", productVersion);
+                string hostname = string.Concat("PowerShell_", Environment.ProcessPath, "_", PSVersionInfo.ProductVersion);
 
                 AppDomain.CurrentDomain.ProcessExit += CurrentDomain_ProcessExit;
 

--- a/src/System.Management.Automation/security/SecuritySupport.cs
+++ b/src/System.Management.Automation/security/SecuritySupport.cs
@@ -1349,6 +1349,7 @@ namespace System.Management.Automation
                 }
                 catch (Exception)
                 {
+                    // Fall back to 'Process.ProcessName' in case 'Environment.ProcessPath' throws exception.
                     Process currentProcess = Process.GetCurrentProcess();
                     appName = string.Concat("PowerShell_", currentProcess.ProcessName, ".exe_", PSVersionInfo.ProductVersion);
                 }

--- a/src/System.Management.Automation/security/SecuritySupport.cs
+++ b/src/System.Management.Automation/security/SecuritySupport.cs
@@ -1342,11 +1342,11 @@ namespace System.Management.Automation
 
             lock (s_amsiLockObject)
             {
-                string hostname = string.Concat("PowerShell_", Environment.ProcessPath, "_", PSVersionInfo.ProductVersion);
+                string appName = string.Concat("PowerShell_", Environment.ProcessPath, "_", PSVersionInfo.ProductVersion);
 
                 AppDomain.CurrentDomain.ProcessExit += CurrentDomain_ProcessExit;
 
-                var hr = AmsiNativeMethods.AmsiInitialize(hostname, ref s_amsiContext);
+                var hr = AmsiNativeMethods.AmsiInitialize(appName, ref s_amsiContext);
                 if (!Utils.Succeeded(hr))
                 {
                     s_amsiInitFailed = true;

--- a/src/System.Management.Automation/security/SecuritySupport.cs
+++ b/src/System.Management.Automation/security/SecuritySupport.cs
@@ -1342,7 +1342,16 @@ namespace System.Management.Automation
 
             lock (s_amsiLockObject)
             {
-                string appName = string.Concat("PowerShell_", Environment.ProcessPath, "_", PSVersionInfo.ProductVersion);
+                string appName;
+                try
+                {
+                    appName = string.Concat("PowerShell_", Environment.ProcessPath, "_", PSVersionInfo.ProductVersion);
+                }
+                catch (Exception)
+                {
+                    Process currentProcess = Process.GetCurrentProcess();
+                    appName = string.Concat("PowerShell_", currentProcess.ProcessName, ".exe_", PSVersionInfo.ProductVersion);
+                }
 
                 AppDomain.CurrentDomain.ProcessExit += CurrentDomain_ProcessExit;
 

--- a/test/powershell/Host/Startup.Tests.ps1
+++ b/test/powershell/Host/Startup.Tests.ps1
@@ -67,7 +67,6 @@ Describe "Validate start of console host" -Tag CI {
         if ($IsWindows) {
             $allowedAssemblies += @(
                 'Microsoft.PowerShell.CoreCLR.Eventing.dll'
-                'System.Diagnostics.FileVersionInfo.dll'
                 'System.DirectoryServices.dll'
                 'System.Management.dll'
                 'System.Security.Claims.dll'


### PR DESCRIPTION
# PR Summary

This PR slightly improves PowerShell start-up performance on Windows by using `AssemblyInformationalVersionAttribute` in `AmsiUtils.Init` to retrieve PowerShell product version instead of `ProcessModule.FileVersionInfo`, which is notably slower.
Also, the code that handled possible errors coming from `ProcessModule.FileVersionInfo` has been removed.

Here is the startup performance difference before and after the PR (launched `Measure-Command { .\pwsh -noprofile -c exit }` 15 times on a Release build):

**master branch:**
356,89, 357,19, 356,40, 362,44, 354,41, 355,71, 359,56, 358,05, 350,51, 365,41, 356,74, 357,24, 357,06, 353,06, 353,05
Best: 350,51 ms
Worst: 365,41 ms
Average: **356,91 ms**

**This PR:**
358,31, 347,59, 350,51, 352,66, 348,42, 351,90, 350,34, 354,94, 351,55, 339,00, 344,30, 345,26, 347,64, 351,45, 343,43
Best: 339,00 ms
Worst: 358,31 ms
Average: **349,15 ms**

Contributes to #14268.

## PR Context

This chance for optimization has been discovered by @iSazonov in https://github.com/PowerShell/PowerShell/pull/14332#issuecomment-739549844.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository.
