### PR TITLE
Clean up code regarding `AppDomain.CreateDomain` and `AppDomain.Unload`

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CommandCompletion.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CommandCompletion.cs
@@ -526,74 +526,70 @@ namespace System.Management.Automation
             {
                 var context = LocalPipeline.GetExecutionContextFromTLS();
 
-                bool cleanupModuleAnalysisAppDomain = context.TakeResponsibilityForModuleAnalysisAppDomain();
+                // First, check if a V1/V2 implementation of TabExpansion exists.  If so, the user had overridden
+                // the built-in version, so we should continue to use theirs.
+                int replacementIndex = -1;
+                int replacementLength = -1;
+                List<CompletionResult> results = null;
 
-                try
+                if (NeedToInvokeLegacyTabExpansion(powershell))
                 {
-                    // First, check if a V1/V2 implementation of TabExpansion exists.  If so, the user had overridden
-                    // the built-in version, so we should continue to use theirs.
-                    int replacementIndex = -1;
-                    int replacementLength = -1;
-                    List<CompletionResult> results = null;
+                    var inputAndCursor = GetInputAndCursorFromAst(positionOfCursor);
+                    results = InvokeLegacyTabExpansion(powershell, inputAndCursor.Item1, inputAndCursor.Item2, false, out replacementIndex, out replacementLength);
+                    replacementIndex += inputAndCursor.Item3;
+                }
 
-                    if (NeedToInvokeLegacyTabExpansion(powershell))
+                if (results == null || results.Count == 0)
+                {
+                    /* BROKEN code commented out, fix sometime
+                    // If we were invoked from TabExpansion2, we want to "remove" TabExpansion2 and anything it calls
+                    // from our results.  We do this by faking out the session so that TabExpansion2 isn't anywhere to be found.
+                    MutableTuple tupleForFrameToSkipPast = null;
+                    foreach (var stackEntry in context.Debugger.GetCallStack())
                     {
-                        var inputAndCursor = GetInputAndCursorFromAst(positionOfCursor);
-                        results = InvokeLegacyTabExpansion(powershell, inputAndCursor.Item1, inputAndCursor.Item2, false, out replacementIndex, out replacementLength);
-                        replacementIndex += inputAndCursor.Item3;
+                        dynamic stackEntryAsPSObj = PSObject.AsPSObject(stackEntry);
+                        if (stackEntryAsPSObj.Command.Equals("TabExpansion2", StringComparison.OrdinalIgnoreCase))
+                        {
+                            tupleForFrameToSkipPast = stackEntry.FunctionContext._localsTuple;
+                            break;
+                        }
                     }
 
-                    if (results == null || results.Count == 0)
+                    SessionStateScope scopeToRestore = null;
+                    if (tupleForFrameToSkipPast != null)
                     {
-                        /* BROKEN code commented out, fix sometime
-                        // If we were invoked from TabExpansion2, we want to "remove" TabExpansion2 and anything it calls
-                        // from our results.  We do this by faking out the session so that TabExpansion2 isn't anywhere to be found.
-                        MutableTuple tupleForFrameToSkipPast = null;
-                        foreach (var stackEntry in context.Debugger.GetCallStack())
+                        // Find this tuple in the scope stack.
+                        scopeToRestore = context.EngineSessionState.CurrentScope;
+                        var scope = context.EngineSessionState.CurrentScope;
+                        while (scope != null && scope.LocalsTuple != tupleForFrameToSkipPast)
                         {
-                            dynamic stackEntryAsPSObj = PSObject.AsPSObject(stackEntry);
-                            if (stackEntryAsPSObj.Command.Equals("TabExpansion2", StringComparison.OrdinalIgnoreCase))
-                            {
-                                tupleForFrameToSkipPast = stackEntry.FunctionContext._localsTuple;
-                                break;
-                            }
+                            scope = scope.Parent;
                         }
 
-                        SessionStateScope scopeToRestore = null;
-                        if (tupleForFrameToSkipPast != null)
+                        if (scope != null)
                         {
-                            // Find this tuple in the scope stack.
-                            scopeToRestore = context.EngineSessionState.CurrentScope;
-                            var scope = context.EngineSessionState.CurrentScope;
-                            while (scope != null && scope.LocalsTuple != tupleForFrameToSkipPast)
-                            {
-                                scope = scope.Parent;
-                            }
-
-                            if (scope != null)
-                            {
-                                context.EngineSessionState.CurrentScope = scope.Parent;
-                            }
+                            context.EngineSessionState.CurrentScope = scope.Parent;
                         }
-
-                        try
-                        {
-                        */
-                        var completionAnalysis = new CompletionAnalysis(ast, tokens, positionOfCursor, options);
-                        results = completionAnalysis.GetResults(powershell, out replacementIndex, out replacementLength);
-                        /*
-                        }
-                        finally
-                        {
-                            if (scopeToRestore != null)
-                            {
-                                context.EngineSessionState.CurrentScope = scopeToRestore;
-                            }
-                        }
-                        */
                     }
 
-                    var completionResults = results ?? EmptyCompletionResult;
+                    try
+                    {
+                    */
+                    var completionAnalysis = new CompletionAnalysis(ast, tokens, positionOfCursor, options);
+                    results = completionAnalysis.GetResults(powershell, out replacementIndex, out replacementLength);
+                    /*
+                    }
+                    finally
+                    {
+                        if (scopeToRestore != null)
+                        {
+                            context.EngineSessionState.CurrentScope = scopeToRestore;
+                        }
+                    }
+                    */
+                }
+
+                var completionResults = results ?? EmptyCompletionResult;
 
 #if LEGACYTELEMETRY
                     // no telemetry here. We don't capture tab completion performance.
@@ -601,19 +597,11 @@ namespace System.Management.Automation
                     TelemetryAPI.ReportTabCompletionTelemetry(sw.ElapsedMilliseconds, completionResults.Count,
                         completionResults.Count > 0 ? completionResults[0].ResultType : CompletionResultType.Text);
 #endif
-                    return new CommandCompletion(
-                        new Collection<CompletionResult>(completionResults),
-                        -1,
-                        replacementIndex,
-                        replacementLength);
-                }
-                finally
-                {
-                    if (cleanupModuleAnalysisAppDomain)
-                    {
-                        context.ReleaseResponsibilityForModuleAnalysisAppDomain();
-                    }
-                }
+                return new CommandCompletion(
+                    new Collection<CompletionResult>(completionResults),
+                    -1,
+                    replacementIndex,
+                    replacementLength);
             }
         }
 

--- a/src/System.Management.Automation/engine/CommandDiscovery.cs
+++ b/src/System.Management.Automation/engine/CommandDiscovery.cs
@@ -1053,7 +1053,6 @@ namespace System.Management.Automation
             if (etwEnabled) CommandDiscoveryEventSource.Log.ModuleAutoDiscoveryStart(commandName);
 
             CommandInfo result = null;
-            bool cleanupModuleAnalysisAppDomain = false;
             try
             {
                 // If commandName had a slash, it was module-qualified or path-qualified.
@@ -1075,8 +1074,6 @@ namespace System.Management.Automation
                     {
                         discoveryTracer.WriteLine("Executing non module-qualified search: {0}", commandName);
                         context.CommandDiscovery.RegisterLookupCommandInfoAction("ActiveModuleSearch", commandName);
-
-                        cleanupModuleAnalysisAppDomain = context.TakeResponsibilityForModuleAnalysisAppDomain();
 
                         // Get the available module files, preferring modules from $PSHOME so that user modules don't
                         // override system modules during auto-loading
@@ -1142,10 +1139,6 @@ namespace System.Management.Automation
             finally
             {
                 context.CommandDiscovery.UnregisterLookupCommandInfoAction("ActiveModuleSearch", commandName);
-                if (cleanupModuleAnalysisAppDomain)
-                {
-                    context.ReleaseResponsibilityForModuleAnalysisAppDomain();
-                }
             }
 
             if (etwEnabled) CommandDiscoveryEventSource.Log.ModuleAutoDiscoveryStop(commandName);

--- a/src/System.Management.Automation/engine/ExecutionContext.cs
+++ b/src/System.Management.Automation/engine/ExecutionContext.cs
@@ -205,40 +205,6 @@ namespace System.Management.Automation
         /// </summary>
         internal string ModuleBeingProcessed { get; set; }
 
-        private bool _responsibilityForModuleAnalysisAppDomainOwned;
-
-        internal bool TakeResponsibilityForModuleAnalysisAppDomain()
-        {
-            if (_responsibilityForModuleAnalysisAppDomainOwned)
-            {
-                return false;
-            }
-
-            Diagnostics.Assert(AppDomainForModuleAnalysis == null, "Invalid module analysis app domain state");
-            _responsibilityForModuleAnalysisAppDomainOwned = true;
-            return true;
-        }
-
-        internal void ReleaseResponsibilityForModuleAnalysisAppDomain()
-        {
-            Diagnostics.Assert(_responsibilityForModuleAnalysisAppDomainOwned, "Invalid module analysis app domain state");
-
-            if (AppDomainForModuleAnalysis != null)
-            {
-                AppDomain.Unload(AppDomainForModuleAnalysis);
-                AppDomainForModuleAnalysis = null;
-            }
-
-            _responsibilityForModuleAnalysisAppDomainOwned = false;
-        }
-
-        /// <summary>
-        /// The AppDomain currently being used for module analysis.  It should only be created if needed,
-        /// but various callers need to take responsibility for unloading the domain via
-        /// the TakeResponsibilityForModuleAnalysisAppDomain.
-        /// </summary>
-        internal AppDomain AppDomainForModuleAnalysis { get; set; }
-
         /// <summary>
         /// Authorization manager for this runspace.
         /// </summary>

--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -589,7 +589,6 @@ namespace Microsoft.PowerShell.Commands
             if (!moduleLoaded)
             {
                 PSModuleInfo module = LoadBinaryModule(
-                    trySnapInName: false,
                     moduleName: null,
                     fileName: null,
                     suppliedAssembly,

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -142,6 +142,11 @@ namespace System.Management.Automation.Language
         /// <returns>The <see cref="ScriptBlockAst"/> that represents the input script file.</returns>
         public static ScriptBlockAst ParseInput(string input, string fileName, out Token[] tokens, out ParseError[] errors)
         {
+            if (input is null)
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
+
             Parser parser = new Parser();
             List<Token> tokenList = new List<Token>();
             ScriptBlockAst result;


### PR DESCRIPTION
# PR Summary

Fixes #15535

`AppDomain.CreateAppDomain` and `AppDomain.Unload` were used for binary module analysis originally -- loading the binary module into another `AppDomain` so the analysis doesn't pollute the current app domain. However, the code path was disabled when moving to .NET Core because there has been only one `AppDomain` since the beginning in .NET Core.

That code path was for analyzing a DLL module (without a module manifest `.psd1` file), and it's really not that useful in real world scenarios because all modules should have a module manifest file, which defines what commands are exposed from the module. Therefore, nothing is really affected even though that code path was disabled since 2016.

This cleanup removed that code path that creates an `AppDomain` all together, as well as the relevant code for cleaning up the `AppDomain`.

Also, a simple `NullReferenceException` is fixed in `Parser.ParseInput`.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.