### PR TITLE
Make sure GA revision increases from RC/Preview releases

### DIFF
--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -49,13 +49,15 @@
       <ReleaseTagSemVersionPrereleaseNamePart>$([System.Text.RegularExpressions.Regex]::Match($(ReleaseTag), $(RegexReleaseTag)).Groups[6].Value)</ReleaseTagSemVersionPrereleaseNamePart>
       <!-- Increment revision 100 for rc releases -->
       <RCIncrementValue>100</RCIncrementValue>
+      <!-- Increment revision 500 for GA releases -->
+      <GAIncrementValue>500</GAIncrementValue>
       <ReleaseTagSemVersionPart Condition = "'$(ReleaseTagSemVersionPrereleaseNamePart)' == 'rc'">$([MSBuild]::Add($(ReleaseTagSemVersionPart), $(RCIncrementValue)))</ReleaseTagSemVersionPart>
       <!-- Create the internal version -->
       <PSCoreBuildVersion>$(ReleaseTag)</PSCoreBuildVersion>
       <!-- Create the version if we have a pre-release -->
       <PSCoreFileVersion Condition = "'$(ReleaseTagSemVersionPart)' != ''">$(ReleaseTagVersionPart).$(ReleaseTagSemVersionPart)</PSCoreFileVersion>
       <!-- Create the version if we have a release build -->
-      <PSCoreFileVersion Condition = "'$(PSCoreFileVersion)' == ''">$(ReleaseTagVersionPart)</PSCoreFileVersion>
+      <PSCoreFileVersion Condition = "'$(PSCoreFileVersion)' == ''">$(ReleaseTagVersionPart).$(GAIncrementValue)</PSCoreFileVersion>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/test/packaging/windows/msi.tests.ps1
+++ b/test/packaging/windows/msi.tests.ps1
@@ -86,6 +86,8 @@ Describe -Name "Windows MSI" -Fixture {
         BeforeAll {
             Write-Verbose "cr-$channel-$runtime" -Verbose
             $pwshPath = Join-Path $env:ProgramFiles -ChildPath "PowerShell"
+            $pwshx86Path = Join-Path ${env:ProgramFiles(x86)} -ChildPath "PowerShell"
+
             switch ("$channel-$runtime") {
                 "preview-win7-x64" {
                     $versionPath = Join-Path -Path $pwshPath -ChildPath '7-preview'
@@ -98,12 +100,12 @@ Describe -Name "Windows MSI" -Fixture {
                     $msiUpgradeCode = '31ab5147-9a97-4452-8443-d9709f0516e1'
                 }
                 "preview-win7-x86" {
-                    $versionPath = Join-Path -Path $pwshPath -ChildPath '7-preview'
+                    $versionPath = Join-Path -Path $pwshx86Path -ChildPath '7-preview'
                     $revisionRange = 0, 99
                     $msiUpgradeCode = '86abcfbd-1ccc-4a88-b8b2-0facfde29094'
                 }
                 "stable-win7-x86" {
-                    $versionPath = Join-Path -Path $pwshPath -ChildPath '7'
+                    $versionPath = Join-Path -Path $pwshx86Path -ChildPath '7'
                     $revisionRange = 500, 500
                     $msiUpgradeCode = '1d00683b-0f84-4db8-a64f-2f98ad42fe06'
                 }
@@ -132,6 +134,7 @@ Describe -Name "Windows MSI" -Fixture {
         It "Revision should be in correct range" -Skip:(!(Test-Elevated)) {
             $pwshDllPath = Join-Path -Path $versionPath -ChildPath "pwsh.dll"
             [version] $version = (Get-ChildItem $pwshDllPath).VersionInfo.FileVersion
+            Write-Verbose "pwsh.dll version: $version" -Verbose
             $version.Revision | Should -BeGreaterOrEqual $revisionRange[0] -Because "$channel revision should between $($revisionRange[0]) and $($revisionRange[1])"
             $version.Revision | Should -BeLessOrEqual $revisionRange[1] -Because "$channel revision should between $($revisionRange[0]) and $($revisionRange[1])"
         }

--- a/test/packaging/windows/msi.tests.ps1
+++ b/test/packaging/windows/msi.tests.ps1
@@ -85,17 +85,26 @@ Describe -Name "Windows MSI" -Fixture {
     Context "Upgrade code" {
         BeforeAll {
             Write-Verbose "cr-$channel-$runtime" -Verbose
+            $pwshPath = Join-Path $env:ProgramFiles -ChildPath "PowerShell"
             switch ("$channel-$runtime") {
                 "preview-win7-x64" {
+                    $versionPath = Join-Path -Path $pwshPath -ChildPath '7-preview'
+                    $revisionRange = 0, 99
                     $msiUpgradeCode = '39243d76-adaf-42b1-94fb-16ecf83237c8'
                 }
                 "stable-win7-x64" {
+                    $versionPath = Join-Path -Path $pwshPath -ChildPath '7'
+                    $revisionRange = 500, 500
                     $msiUpgradeCode = '31ab5147-9a97-4452-8443-d9709f0516e1'
                 }
                 "preview-win7-x86" {
+                    $versionPath = Join-Path -Path $pwshPath -ChildPath '7-preview'
+                    $revisionRange = 0, 99
                     $msiUpgradeCode = '86abcfbd-1ccc-4a88-b8b2-0facfde29094'
                 }
                 "stable-win7-x86" {
+                    $versionPath = Join-Path -Path $pwshPath -ChildPath '7'
+                    $revisionRange = 500, 500
                     $msiUpgradeCode = '1d00683b-0f84-4db8-a64f-2f98ad42fe06'
                 }
                 default {
@@ -118,6 +127,13 @@ Describe -Name "Windows MSI" -Fixture {
         It "Upgrade code should be correct" -Skip:(!(Test-Elevated)) {
             $result = @(Get-CimInstance -Query "SELECT Value FROM Win32_Property WHERE Property='UpgradeCode' and Value = '{$msiUpgradeCode}'")
             $result.Count | Should -Be 1 -Because "Query should return 1 result if Upgrade code is for $runtime $channel"
+        }
+
+        It "Revision should be in correct range" -Skip:(!(Test-Elevated)) {
+            $pwshDllPath = Join-Path -Path $versionPath -ChildPath "pwsh.dll"
+            [version] $version = (Get-ChildItem $pwshDllPath).VersionInfo.FileVersion
+            $version.Revision | Should -BeGreaterOrEqual $revisionRange[0] -Because "$channel revision should between $($revisionRange[0]) and $($revisionRange[1])"
+            $version.Revision | Should -BeLessOrEqual $revisionRange[1] -Because "$channel revision should between $($revisionRange[0]) and $($revisionRange[1])"
         }
 
         It "MSI should uninstall without error" -Skip:(!(Test-Elevated)) {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Make sure GA revision increases from RC/Preview releases
- Fix revision to 500 for all GA releases
- Add tests to verify expected revisions

## PR Context

Make sure GA revision increases from RC/Preview releases. 
This allows SDK builds using preview to work against GA builds.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
