### PR TITLE
Do not crash when can't create telemetry mutex.

### DIFF
--- a/src/System.Management.Automation/utils/Telemetry.cs
+++ b/src/System.Management.Automation/utils/Telemetry.cs
@@ -835,28 +835,29 @@ namespace Microsoft.PowerShell.Telemetry
 
             // Multiple processes may start simultaneously so we need a system wide
             // way to control access to the file in the case (although remote) when we have
-            // simulataneous shell starts without the persisted file which attempt to create the file.
-            using (var m = new Mutex(true, "CreateUniqueUserId"))
+            // simultaneous shell starts without the persisted file which attempt to create the file.
+            try
             {
                 // TryCreateUniqueIdentifierAndFile shouldn't throw, but the mutex might
+                using var m = new Mutex(true, "CreateUniqueUserId");
+                m.WaitOne();
                 try
                 {
-                    m.WaitOne();
                     if (TryCreateUniqueIdentifierAndFile(uuidPath, out id))
                     {
                         return id;
                     }
                 }
-                catch (Exception)
-                {
-                    // Any problem in generating a uuid will result in no telemetry being sent.
-                    // Try to send the failure in telemetry, but it will have no unique id.
-                    s_telemetryClient.GetMetric(_telemetryFailure, "Detail").TrackValue(1, "mutex");
-                }
                 finally
                 {
                     m.ReleaseMutex();
                 }
+            }
+            catch (Exception)
+            {
+                // Any problem in generating a uuid will result in no telemetry being sent.
+                // Try to send the failure in telemetry, but it will have no unique id.
+                s_telemetryClient.GetMetric(_telemetryFailure, "Detail").TrackValue(1, "mutex");
             }
 
             // something bad happened, turn off telemetry since the unique id wasn't set.


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Do not stop powershell when can't create telemetry mutex.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

Currently powershell crashes on startup if it can't create an instance of `new Mutex`.  It might happen if there's no space on the disk, or if the current user doesn't have permissions to the tmp folder.

Powershell crashes with the following error:

```
Error: failed to execute "pwsh": Process terminated. The type initializer for 'Microsoft.PowerShell.Telemetry.ApplicationInsightsTelemetry' threw an exception.
   at System.Environment.FailFast(System.String, System.Exception)
   at Microsoft.PowerShell.UnmanagedPSEntry.Start(System.String[], Int32)
   at Microsoft.PowerShell.ManagedPSEntry.Main(System.String[])
System.TypeInitializationException: The type initializer for 'Microsoft.PowerShell.Telemetry.ApplicationInsightsTelemetry' threw an exception.
 ---> System.IO.IOException: The system cannot open the device or file specified. : 'CreateUniqueUserId'
   at System.Threading.Mutex.CreateMutexCore(Boolean initiallyOwned, String name, Boolean& createdNew)
   at System.Threading.Mutex..ctor(Boolean initiallyOwned, String name)
   at Microsoft.PowerShell.Telemetry.ApplicationInsightsTelemetry.GetUniqueIdentifier() in /PowerShell/src/System.Management.Automation/utils/Telemetry.cs:line 802
   at Microsoft.PowerShell.Telemetry.ApplicationInsightsTelemetry..cctor() in /PowerShell/src/System.Management.Automation/utils/Telemetry.cs:line 548
   --- End of inner exception stack trace ---
   at Microsoft.PowerShell.Telemetry.ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry(String mode) in /PowerShell/src/System.Management.Automation/utils/Telemetry.cs:line 656
   at Microsoft.PowerShell.ConsoleHost.Start(String bannerText, String helpText) in /PowerShell/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs:line 248
   at Microsoft.PowerShell.UnmanagedPSEntry.Start(String[] args, Int32 argc) in /PowerShell/src/Microsoft.PowerShell.ConsoleHost/host/msh/ManagedEntrance.cs:line 99
```

This exception is thrown from Mutex ctor and isn't properly handled. This change fixes it.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
