### PR TITLE
Add new analyzer rules

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -336,7 +336,7 @@ dotnet_diagnostic.CA1837.severity = warning
 dotnet_diagnostic.CA1838.severity = silent
 
 # CA1839: Use 'Environment.ProcessPath'
-dotnet_diagnostic.CA1839.severity = silent
+dotnet_diagnostic.CA1839.severity = suggestion
 
 # CA1840: Use 'Environment.CurrentManagedThreadId'
 dotnet_diagnostic.CA1840.severity = silent

--- a/.globalconfig
+++ b/.globalconfig
@@ -1068,7 +1068,7 @@ dotnet_diagnostic.IDE2001.severity = warning
 dotnet_diagnostic.IDE2002.severity = warning
 
 # IDE2003: ConsecutiveStatementPlacement
-dotnet_diagnostic.IDE2003.severity = silent
+dotnet_diagnostic.IDE2003.severity = warning
 
 # IDE2004: BlankLineNotAllowedAfterConstructorInitializerColon
 dotnet_diagnostic.IDE2004.severity = silent

--- a/.globalconfig
+++ b/.globalconfig
@@ -498,7 +498,7 @@ dotnet_diagnostic.CA2248.severity = suggestion
 dotnet_diagnostic.CA2249.severity = warning
 
 # CA2250: Use 'ThrowIfCancellationRequested'
-dotnet_diagnostic.CA2250.severity = silent
+dotnet_diagnostic.CA2250.severity = warning
 
 # CA2251: Use 'string.Equals'
 dotnet_diagnostic.CA2251.severity = silent

--- a/.globalconfig
+++ b/.globalconfig
@@ -342,7 +342,7 @@ dotnet_diagnostic.CA1839.severity = suggestion
 dotnet_diagnostic.CA1840.severity = warning
 
 # CA1841: Prefer Dictionary.Contains methods
-dotnet_diagnostic.CA1841.severity = silent
+dotnet_diagnostic.CA1841.severity = warning
 
 # CA1842: Do not use 'WhenAll' with a single task
 dotnet_diagnostic.CA1842.severity = silent

--- a/.globalconfig
+++ b/.globalconfig
@@ -1059,7 +1059,7 @@ dotnet_diagnostic.IDE1007.severity = silent
 dotnet_diagnostic.IDE1008.severity = silent
 
 # IDE2000: MultipleBlankLines
-dotnet_diagnostic.IDE2000.severity = silent
+dotnet_diagnostic.IDE2000.severity = warning
 
 # IDE2001: EmbeddedStatementsMustBeOnTheirOwnLine
 dotnet_diagnostic.IDE2001.severity = silent

--- a/.globalconfig
+++ b/.globalconfig
@@ -1026,7 +1026,7 @@ dotnet_diagnostic.IDE0090.severity = suggestion
 dotnet_diagnostic.IDE0100.severity = warning
 
 # IDE0110: RemoveUnnecessaryDiscard
-dotnet_diagnostic.IDE0110.severity = silent
+dotnet_diagnostic.IDE0110.severity = suggestion
 
 # IDE0120: SimplifyLINQExpression
 dotnet_diagnostic.IDE0120.severity = silent

--- a/.globalconfig
+++ b/.globalconfig
@@ -777,7 +777,7 @@ dotnet_diagnostic.IL3000.severity = warning
 dotnet_diagnostic.IL3001.severity = warning
 
 # IL3002: Using member with RequiresAssemblyFilesAttribute can break functionality when embedded in a single-file app
-dotnet_diagnostic.IL3002.severity = silent
+dotnet_diagnostic.IL3002.severity = warning
 
 # IDE0001: SimplifyNames
 dotnet_diagnostic.IDE0001.severity = silent

--- a/.globalconfig
+++ b/.globalconfig
@@ -357,7 +357,7 @@ dotnet_diagnostic.CA1844.severity = warning
 dotnet_diagnostic.CA1845.severity = warning
 
 # CA1846: Prefer 'AsSpan' over 'Substring'
-dotnet_diagnostic.CA1846.severity = silent
+dotnet_diagnostic.CA1846.severity = warning
 
 # CA2000: Dispose objects before losing scope
 dotnet_diagnostic.CA2000.severity = none

--- a/.globalconfig
+++ b/.globalconfig
@@ -345,7 +345,7 @@ dotnet_diagnostic.CA1840.severity = warning
 dotnet_diagnostic.CA1841.severity = warning
 
 # CA1842: Do not use 'WhenAll' with a single task
-dotnet_diagnostic.CA1842.severity = silent
+dotnet_diagnostic.CA1842.severity = warning
 
 # CA1843: Do not use 'WaitAll' with a single task
 dotnet_diagnostic.CA1843.severity = silent

--- a/.globalconfig
+++ b/.globalconfig
@@ -501,7 +501,7 @@ dotnet_diagnostic.CA2249.severity = warning
 dotnet_diagnostic.CA2250.severity = warning
 
 # CA2251: Use 'string.Equals'
-dotnet_diagnostic.CA2251.severity = silent
+dotnet_diagnostic.CA2251.severity = warning
 
 # CA2300: Do not use insecure deserializer BinaryFormatter
 dotnet_diagnostic.CA2300.severity = none

--- a/.globalconfig
+++ b/.globalconfig
@@ -2,7 +2,7 @@ is_global = true
 
 # CA1000: Do not declare static members on generic types
 dotnet_diagnostic.CA1000.severity = warning
-dotnet_code_quality.ca1000.api_surface = all
+dotnet_code_quality.CA1000.api_surface = all
 
 # CA1001: Types that own disposable fields should be disposable
 dotnet_diagnostic.CA1001.severity = silent
@@ -12,7 +12,7 @@ dotnet_diagnostic.CA1002.severity = none
 
 # CA1003: Use generic event handler instances
 dotnet_diagnostic.CA1003.severity = warning
-dotnet_code_quality.ca1003.api_surface = private, internal
+dotnet_code_quality.CA1003.api_surface = private, internal
 
 # CA1005: Avoid excessive parameters on generic types
 dotnet_diagnostic.CA1005.severity = none
@@ -25,7 +25,7 @@ dotnet_diagnostic.CA1010.severity = silent
 
 # CA1012: Abstract types should not have public constructors
 dotnet_diagnostic.CA1012.severity = warning
-dotnet_code_quality.ca1012.api_surface = all
+dotnet_code_quality.CA1012.api_surface = all
 
 # CA1014: Mark assemblies with CLSCompliant
 dotnet_diagnostic.CA1014.severity = none
@@ -101,7 +101,7 @@ dotnet_diagnostic.CA1051.severity = silent
 
 # CA1052: Static holder types should be Static or NotInheritable
 dotnet_diagnostic.CA1052.severity = warning
-dotnet_code_quality.ca1052.api_surface = private, internal
+dotnet_code_quality.CA1052.api_surface = private, internal
 
 # CA1054: URI-like parameters should not be strings
 dotnet_diagnostic.CA1054.severity = none
@@ -282,7 +282,7 @@ dotnet_diagnostic.CA1821.severity = warning
 
 # CA1822: Mark members as static
 dotnet_diagnostic.CA1822.severity = warning
-dotnet_code_quality.ca1822.api_surface = private
+dotnet_code_quality.CA1822.api_surface = private
 
 # CA1823: Avoid unused private fields
 dotnet_diagnostic.CA1823.severity = none

--- a/.globalconfig
+++ b/.globalconfig
@@ -1,1620 +1,2158 @@
 is_global = true
 
 # CA1000: Do not declare static members on generic types
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
 dotnet_diagnostic.CA1000.severity = warning
 dotnet_code_quality.CA1000.api_surface = all
 
 # CA1001: Types that own disposable fields should be disposable
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
 dotnet_diagnostic.CA1001.severity = silent
 
 # CA1002: Do not expose generic lists
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
 dotnet_diagnostic.CA1002.severity = none
 
 # CA1003: Use generic event handler instances
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
 dotnet_diagnostic.CA1003.severity = warning
 dotnet_code_quality.CA1003.api_surface = private, internal
 
 # CA1005: Avoid excessive parameters on generic types
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
 dotnet_diagnostic.CA1005.severity = none
 
 # CA1008: Enums should have zero value
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
 dotnet_diagnostic.CA1008.severity = none
 
 # CA1010: Generic interface should also be implemented
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
 dotnet_diagnostic.CA1010.severity = silent
 
 # CA1012: Abstract types should not have public constructors
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
 dotnet_diagnostic.CA1012.severity = warning
 dotnet_code_quality.CA1012.api_surface = all
 
 # CA1014: Mark assemblies with CLSCompliant
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
 dotnet_diagnostic.CA1014.severity = none
 
 # CA1016: Mark assemblies with assembly version
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
 dotnet_diagnostic.CA1016.severity = warning
 
 # CA1017: Mark assemblies with ComVisible
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
 dotnet_diagnostic.CA1017.severity = none
 
 # CA1018: Mark attributes with AttributeUsageAttribute
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
 dotnet_diagnostic.CA1018.severity = warning
 
 # CA1019: Define accessors for attribute arguments
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
 dotnet_diagnostic.CA1019.severity = none
 
 # CA1021: Avoid out parameters
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
 dotnet_diagnostic.CA1021.severity = none
 
 # CA1024: Use properties where appropriate
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
 dotnet_diagnostic.CA1024.severity = none
 
 # CA1027: Mark enums with FlagsAttribute
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
 dotnet_diagnostic.CA1027.severity = none
 
 # CA1028: Enum Storage should be Int32
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
 dotnet_diagnostic.CA1028.severity = none
 
 # CA1030: Use events where appropriate
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
 dotnet_diagnostic.CA1030.severity = none
 
 # CA1031: Do not catch general exception types
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
 dotnet_diagnostic.CA1031.severity = none
 
 # CA1032: Implement standard exception constructors
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
 dotnet_diagnostic.CA1032.severity = none
 
 # CA1033: Interface methods should be callable by child types
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
 dotnet_diagnostic.CA1033.severity = none
 
 # CA1034: Nested types should not be visible
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
 dotnet_diagnostic.CA1034.severity = none
 
 # CA1036: Override methods on comparable types
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
 dotnet_diagnostic.CA1036.severity = silent
 
 # CA1040: Avoid empty interfaces
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
 dotnet_diagnostic.CA1040.severity = none
 
 # CA1041: Provide ObsoleteAttribute message
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
 dotnet_diagnostic.CA1041.severity = warning
 
 # CA1043: Use Integral Or String Argument For Indexers
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
 dotnet_diagnostic.CA1043.severity = none
 
 # CA1044: Properties should not be write only
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
 dotnet_diagnostic.CA1044.severity = none
 
 # CA1045: Do not pass types by reference
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
 dotnet_diagnostic.CA1045.severity = none
 
 # CA1046: Do not overload equality operator on reference types
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
 dotnet_diagnostic.CA1046.severity = none
 
 # CA1047: Do not declare protected member in sealed type
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
 dotnet_diagnostic.CA1047.severity = warning
 
 # CA1050: Declare types in namespaces
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
 dotnet_diagnostic.CA1050.severity = warning
 
 # CA1051: Do not declare visible instance fields
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
 dotnet_diagnostic.CA1051.severity = silent
 
 # CA1052: Static holder types should be Static or NotInheritable
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
 dotnet_diagnostic.CA1052.severity = warning
 dotnet_code_quality.CA1052.api_surface = private, internal
 
 # CA1054: URI-like parameters should not be strings
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
 dotnet_diagnostic.CA1054.severity = none
 
 # CA1055: URI-like return values should not be strings
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
 dotnet_diagnostic.CA1055.severity = none
 
 # CA1056: URI-like properties should not be strings
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
 dotnet_diagnostic.CA1056.severity = none
 
 # CA1058: Types should not extend certain base types
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
 dotnet_diagnostic.CA1058.severity = none
 
 # CA1060: Move pinvokes to native methods class
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
 dotnet_diagnostic.CA1060.severity = none
 
 # CA1061: Do not hide base class methods
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
 dotnet_diagnostic.CA1061.severity = warning
 
 # CA1062: Validate arguments of public methods
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
 dotnet_diagnostic.CA1062.severity = none
 
 # CA1063: Implement IDisposable Correctly
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
 dotnet_diagnostic.CA1063.severity = none
 
 # CA1064: Exceptions should be public
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
 dotnet_diagnostic.CA1064.severity = none
 
 # CA1065: Do not raise exceptions in unexpected locations
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
 dotnet_diagnostic.CA1065.severity = warning
 
 # CA1066: Implement IEquatable when overriding Object.Equals
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
 dotnet_diagnostic.CA1066.severity = none
 
 # CA1067: Override Object.Equals(object) when implementing IEquatable<T>
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
 dotnet_diagnostic.CA1067.severity = suggestion
 
 # CA1068: CancellationToken parameters must come last
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
 dotnet_diagnostic.CA1068.severity = warning
 
 # CA1069: Enums values should not be duplicated
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
 dotnet_diagnostic.CA1069.severity = suggestion
 
 # CA1070: Do not declare event fields as virtual
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
 dotnet_diagnostic.CA1070.severity = warning
 
 # CA1200: Avoid using cref tags with a prefix
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
 dotnet_diagnostic.CA1200.severity = silent
 
 # CA1303: Do not pass literals as localized parameters
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
 dotnet_diagnostic.CA1303.severity = none
 
 # CA1304: Specify CultureInfo
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
 dotnet_diagnostic.CA1304.severity = silent
 
 # CA1305: Specify IFormatProvider
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
 dotnet_diagnostic.CA1305.severity = silent
 
 # CA1307: Specify StringComparison for clarity
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
 dotnet_diagnostic.CA1307.severity = none
 
 # CA1308: Normalize strings to uppercase
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
 dotnet_diagnostic.CA1308.severity = none
 
 # CA1309: Use ordinal string comparison
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
 dotnet_diagnostic.CA1309.severity = silent
 
 # CA1310: Specify StringComparison for correctness
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
 dotnet_diagnostic.CA1310.severity = silent
 
 # CA1401: P/Invokes should not be visible
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
 dotnet_diagnostic.CA1401.severity = suggestion
 
 # CA1416: Validate platform compatibility
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
 dotnet_diagnostic.CA1416.severity = warning
 
 # CA1417: Do not use 'OutAttribute' on string parameters for P/Invokes
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
 dotnet_diagnostic.CA1417.severity = warning
 
 # CA1418: Use valid platform string
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
 dotnet_diagnostic.CA1418.severity = warning
 
 # CA1501: Avoid excessive inheritance
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
 dotnet_diagnostic.CA1501.severity = none
 
 # CA1502: Avoid excessive complexity
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
 dotnet_diagnostic.CA1502.severity = none
 
 # CA1505: Avoid unmaintainable code
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
 dotnet_diagnostic.CA1505.severity = none
 
 # CA1506: Avoid excessive class coupling
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
 dotnet_diagnostic.CA1506.severity = none
 
 # CA1507: Use nameof to express symbol names
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
 dotnet_diagnostic.CA1507.severity = suggestion
 
 # CA1508: Avoid dead conditional code
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
 dotnet_diagnostic.CA1508.severity = none
 
 # CA1509: Invalid entry in code metrics rule specification file
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
 dotnet_diagnostic.CA1509.severity = none
 
 # CA1700: Do not name enum values 'Reserved'
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
 dotnet_diagnostic.CA1700.severity = none
 
 # CA1707: Identifiers should not contain underscores
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
 dotnet_diagnostic.CA1707.severity = silent
 
 # CA1708: Identifiers should differ by more than case
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
 dotnet_diagnostic.CA1708.severity = silent
 
 # CA1710: Identifiers should have correct suffix
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
 dotnet_diagnostic.CA1710.severity = silent
 
 # CA1711: Identifiers should not have incorrect suffix
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
 dotnet_diagnostic.CA1711.severity = silent
 
 # CA1712: Do not prefix enum values with type name
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
 dotnet_diagnostic.CA1712.severity = silent
 
 # CA1713: Events should not have 'Before' or 'After' prefix
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
 dotnet_diagnostic.CA1713.severity = none
 
 # CA1715: Identifiers should have correct prefix
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
 dotnet_diagnostic.CA1715.severity = silent
 
 # CA1716: Identifiers should not match keywords
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
 dotnet_diagnostic.CA1716.severity = silent
 
 # CA1720: Identifier contains type name
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
 dotnet_diagnostic.CA1720.severity = silent
 
 # CA1721: Property names should not match get methods
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
 dotnet_diagnostic.CA1721.severity = none
 
 # CA1724: Type names should not match namespaces
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
 dotnet_diagnostic.CA1724.severity = none
 
 # CA1725: Parameter names should match base declaration
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
 dotnet_diagnostic.CA1725.severity = silent
 
 # CA1801: Review unused parameters
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
 dotnet_diagnostic.CA1801.severity = none
 
 # CA1802: Use literals where appropriate
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
 dotnet_diagnostic.CA1802.severity = none
 
 # CA1805: Do not initialize unnecessarily
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
 dotnet_diagnostic.CA1805.severity = suggestion
 
 # CA1806: Do not ignore method results
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
 dotnet_diagnostic.CA1806.severity = suggestion
 
 # CA1810: Initialize reference type static fields inline
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
 dotnet_diagnostic.CA1810.severity = none
 
 # CA1812: Avoid uninstantiated internal classes
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
 dotnet_diagnostic.CA1812.severity = none
 
 # CA1813: Avoid unsealed attributes
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
 dotnet_diagnostic.CA1813.severity = none
 
 # CA1814: Prefer jagged arrays over multidimensional
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
 dotnet_diagnostic.CA1814.severity = none
 
 # CA1815: Override equals and operator equals on value types
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
 dotnet_diagnostic.CA1815.severity = none
 
 # CA1816: Dispose methods should call SuppressFinalize
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
 dotnet_diagnostic.CA1816.severity = warning
 
 # CA1819: Properties should not return arrays
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
 dotnet_diagnostic.CA1819.severity = none
 
 # CA1820: Test for empty strings using string length
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
 dotnet_diagnostic.CA1820.severity = none
 
 # CA1821: Remove empty Finalizers
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
 dotnet_diagnostic.CA1821.severity = warning
 
 # CA1822: Mark members as static
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
 dotnet_diagnostic.CA1822.severity = warning
 dotnet_code_quality.CA1822.api_surface = private
 
 # CA1823: Avoid unused private fields
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
 dotnet_diagnostic.CA1823.severity = none
 
 # CA1824: Mark assemblies with NeutralResourcesLanguageAttribute
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
 dotnet_diagnostic.CA1824.severity = warning
 
 # CA1825: Avoid zero-length array allocations
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
 dotnet_diagnostic.CA1825.severity = warning
 
 # CA1826: Do not use Enumerable methods on indexable collections
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
 dotnet_diagnostic.CA1826.severity = warning
 
 # CA1827: Do not use Count() or LongCount() when Any() can be used
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
 dotnet_diagnostic.CA1827.severity = warning
 
 # CA1828: Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
 dotnet_diagnostic.CA1828.severity = warning
 
 # CA1829: Use Length/Count property instead of Count() when available
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
 dotnet_diagnostic.CA1829.severity = warning
 
 # CA1830: Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
 dotnet_diagnostic.CA1830.severity = warning
 
 # CA1831: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
 dotnet_diagnostic.CA1831.severity = warning
 
 # CA1832: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
 dotnet_diagnostic.CA1832.severity = warning
 
 # CA1833: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
 dotnet_diagnostic.CA1833.severity = warning
 
 # CA1834: Consider using 'StringBuilder.Append(char)' when applicable
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
 dotnet_diagnostic.CA1834.severity = warning
 
 # CA1835: Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
 dotnet_diagnostic.CA1835.severity = suggestion
 
 # CA1836: Prefer IsEmpty over Count
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
 dotnet_diagnostic.CA1836.severity = warning
 
 # CA1837: Use 'Environment.ProcessId'
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
 dotnet_diagnostic.CA1837.severity = warning
 
 # CA1838: Avoid 'StringBuilder' parameters for P/Invokes
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
 dotnet_diagnostic.CA1838.severity = silent
 
 # CA1839: Use 'Environment.ProcessPath'
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
 dotnet_diagnostic.CA1839.severity = suggestion
 
 # CA1840: Use 'Environment.CurrentManagedThreadId'
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
 dotnet_diagnostic.CA1840.severity = warning
 
 # CA1841: Prefer Dictionary.Contains methods
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
 dotnet_diagnostic.CA1841.severity = warning
 
 # CA1842: Do not use 'WhenAll' with a single task
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
 dotnet_diagnostic.CA1842.severity = warning
 
 # CA1843: Do not use 'WaitAll' with a single task
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
 dotnet_diagnostic.CA1843.severity = warning
 
 # CA1844: Provide memory-based overrides of async methods when subclassing 'Stream'
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
 dotnet_diagnostic.CA1844.severity = warning
 
 # CA1845: Use span-based 'string.Concat'
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
 dotnet_diagnostic.CA1845.severity = warning
 
 # CA1846: Prefer 'AsSpan' over 'Substring'
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
 dotnet_diagnostic.CA1846.severity = warning
 
 # CA2000: Dispose objects before losing scope
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
 dotnet_diagnostic.CA2000.severity = none
 
 # CA2002: Do not lock on objects with weak identity
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
 dotnet_diagnostic.CA2002.severity = none
 
 # CA2007: Consider calling ConfigureAwait on the awaited task
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
 dotnet_diagnostic.CA2007.severity = none
 
 # CA2008: Do not create tasks without passing a TaskScheduler
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
 dotnet_diagnostic.CA2008.severity = none
 
 # CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
 dotnet_diagnostic.CA2009.severity = warning
 
 # CA2011: Avoid infinite recursion
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
 dotnet_diagnostic.CA2011.severity = warning
 
 # CA2012: Use ValueTasks correctly
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
 dotnet_diagnostic.CA2012.severity = warning
 
 # CA2013: Do not use ReferenceEquals with value types
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
 dotnet_diagnostic.CA2013.severity = warning
 
 # CA2014: Do not use stackalloc in loops
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
 dotnet_diagnostic.CA2014.severity = warning
 
 # CA2015: Do not define finalizers for types derived from MemoryManager<T>
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
 dotnet_diagnostic.CA2015.severity = warning
 
 # CA2016: Forward the 'CancellationToken' parameter to methods that take one
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
 dotnet_diagnostic.CA2016.severity = suggestion
 
 # CA2100: Review SQL queries for security vulnerabilities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
 dotnet_diagnostic.CA2100.severity = none
 
 # CA2101: Specify marshaling for P/Invoke string arguments
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
 dotnet_diagnostic.CA2101.severity = suggestion
 
 # CA2109: Review visible event handlers
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
 dotnet_diagnostic.CA2109.severity = none
 
 # CA2119: Seal methods that satisfy private interfaces
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
 dotnet_diagnostic.CA2119.severity = none
 
 # CA2153: Do Not Catch Corrupted State Exceptions
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
 dotnet_diagnostic.CA2153.severity = none
 
 # CA2200: Rethrow to preserve stack details
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
 dotnet_diagnostic.CA2200.severity = warning
 
 # CA2201: Do not raise reserved exception types
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
 dotnet_diagnostic.CA2201.severity = silent
 
 # CA2207: Initialize value type static fields inline
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
 dotnet_diagnostic.CA2207.severity = warning
 
 # CA2208: Instantiate argument exceptions correctly
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
 dotnet_diagnostic.CA2208.severity = suggestion
 
 # CA2211: Non-constant fields should not be visible
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
 dotnet_diagnostic.CA2211.severity = warning
 
 # CA2213: Disposable fields should be disposed
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
 dotnet_diagnostic.CA2213.severity = none
 
 # CA2214: Do not call overridable methods in constructors
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
 dotnet_diagnostic.CA2214.severity = none
 
 # CA2215: Dispose methods should call base class dispose
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
 dotnet_diagnostic.CA2215.severity = silent
 
 # CA2216: Disposable types should declare finalizer
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
 dotnet_diagnostic.CA2216.severity = warning
 
 # CA2217: Do not mark enums with FlagsAttribute
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
 dotnet_diagnostic.CA2217.severity = none
 
 # CA2218: Override GetHashCode on overriding Equals
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2218
 dotnet_diagnostic.CA2218.severity = suggestion
 
 # CA2219: Do not raise exceptions in finally clauses
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
 dotnet_diagnostic.CA2219.severity = suggestion
 
 # CA2224: Override Equals on overloading operator equals
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2224
 dotnet_diagnostic.CA2224.severity = suggestion
 
 # CA2225: Operator overloads have named alternates
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
 dotnet_diagnostic.CA2225.severity = none
 
 # CA2226: Operators should have symmetrical overloads
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
 dotnet_diagnostic.CA2226.severity = none
 
 # CA2227: Collection properties should be read only
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
 dotnet_diagnostic.CA2227.severity = none
 
 # CA2229: Implement serialization constructors
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
 dotnet_diagnostic.CA2229.severity = silent
 
 # CA2231: Overload operator equals on overriding value type Equals
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
 dotnet_diagnostic.CA2231.severity = suggestion
 
 # CA2234: Pass system uri objects instead of strings
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
 dotnet_diagnostic.CA2234.severity = none
 
 # CA2235: Mark all non-serializable fields
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
 dotnet_diagnostic.CA2235.severity = none
 
 # CA2237: Mark ISerializable types with serializable
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
 dotnet_diagnostic.CA2237.severity = none
 
 # CA2241: Provide correct arguments to formatting methods
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
 dotnet_diagnostic.CA2241.severity = suggestion
 
 # CA2242: Test for NaN correctly
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
 dotnet_diagnostic.CA2242.severity = suggestion
 
 # CA2243: Attribute string literals should parse correctly
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
 dotnet_diagnostic.CA2243.severity = none
 
 # CA2244: Do not duplicate indexed element initializations
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
 dotnet_diagnostic.CA2244.severity = suggestion
 
 # CA2245: Do not assign a property to itself
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
 dotnet_diagnostic.CA2245.severity = suggestion
 
 # CA2246: Assigning symbol and its member in the same statement
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
 dotnet_diagnostic.CA2246.severity = suggestion
 
 # CA2247: Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
 dotnet_diagnostic.CA2247.severity = warning
 
 # CA2248: Provide correct 'enum' argument to 'Enum.HasFlag'
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
 dotnet_diagnostic.CA2248.severity = suggestion
 
 # CA2249: Consider using 'string.Contains' instead of 'string.IndexOf'
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
 dotnet_diagnostic.CA2249.severity = warning
 
 # CA2250: Use 'ThrowIfCancellationRequested'
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
 dotnet_diagnostic.CA2250.severity = warning
 
 # CA2251: Use 'string.Equals'
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
 dotnet_diagnostic.CA2251.severity = warning
 
 # CA2300: Do not use insecure deserializer BinaryFormatter
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
 dotnet_diagnostic.CA2300.severity = none
 
 # CA2301: Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
 dotnet_diagnostic.CA2301.severity = none
 
 # CA2302: Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
 dotnet_diagnostic.CA2302.severity = none
 
 # CA2305: Do not use insecure deserializer LosFormatter
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
 dotnet_diagnostic.CA2305.severity = none
 
 # CA2310: Do not use insecure deserializer NetDataContractSerializer
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
 dotnet_diagnostic.CA2310.severity = none
 
 # CA2311: Do not deserialize without first setting NetDataContractSerializer.Binder
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
 dotnet_diagnostic.CA2311.severity = none
 
 # CA2312: Ensure NetDataContractSerializer.Binder is set before deserializing
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
 dotnet_diagnostic.CA2312.severity = none
 
 # CA2315: Do not use insecure deserializer ObjectStateFormatter
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
 dotnet_diagnostic.CA2315.severity = none
 
 # CA2321: Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
 dotnet_diagnostic.CA2321.severity = none
 
 # CA2322: Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
 dotnet_diagnostic.CA2322.severity = none
 
 # CA2326: Do not use TypeNameHandling values other than None
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
 dotnet_diagnostic.CA2326.severity = none
 
 # CA2327: Do not use insecure JsonSerializerSettings
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
 dotnet_diagnostic.CA2327.severity = none
 
 # CA2328: Ensure that JsonSerializerSettings are secure
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
 dotnet_diagnostic.CA2328.severity = none
 
 # CA2329: Do not deserialize with JsonSerializer using an insecure configuration
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
 dotnet_diagnostic.CA2329.severity = none
 
 # CA2330: Ensure that JsonSerializer has a secure configuration when deserializing
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
 dotnet_diagnostic.CA2330.severity = none
 
 # CA2350: Do not use DataTable.ReadXml() with untrusted data
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
 dotnet_diagnostic.CA2350.severity = none
 
 # CA2351: Do not use DataSet.ReadXml() with untrusted data
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
 dotnet_diagnostic.CA2351.severity = none
 
 # CA2352: Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
 dotnet_diagnostic.CA2352.severity = none
 
 # CA2353: Unsafe DataSet or DataTable in serializable type
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
 dotnet_diagnostic.CA2353.severity = none
 
 # CA2354: Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
 dotnet_diagnostic.CA2354.severity = none
 
 # CA2355: Unsafe DataSet or DataTable type found in deserializable object graph
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
 dotnet_diagnostic.CA2355.severity = none
 
 # CA2356: Unsafe DataSet or DataTable type in web deserializable object graph
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
 dotnet_diagnostic.CA2356.severity = none
 
 # CA2361: Ensure autogenerated class containing DataSet.ReadXml() is not used with untrusted data
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
 dotnet_diagnostic.CA2361.severity = none
 
 # CA2362: Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
 dotnet_diagnostic.CA2362.severity = none
 
 # CA3001: Review code for SQL injection vulnerabilities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
 dotnet_diagnostic.CA3001.severity = none
 
 # CA3002: Review code for XSS vulnerabilities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
 dotnet_diagnostic.CA3002.severity = none
 
 # CA3003: Review code for file path injection vulnerabilities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
 dotnet_diagnostic.CA3003.severity = none
 
 # CA3004: Review code for information disclosure vulnerabilities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
 dotnet_diagnostic.CA3004.severity = none
 
 # CA3005: Review code for LDAP injection vulnerabilities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
 dotnet_diagnostic.CA3005.severity = none
 
 # CA3006: Review code for process command injection vulnerabilities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
 dotnet_diagnostic.CA3006.severity = none
 
 # CA3007: Review code for open redirect vulnerabilities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
 dotnet_diagnostic.CA3007.severity = none
 
 # CA3008: Review code for XPath injection vulnerabilities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
 dotnet_diagnostic.CA3008.severity = none
 
 # CA3009: Review code for XML injection vulnerabilities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
 dotnet_diagnostic.CA3009.severity = none
 
 # CA3010: Review code for XAML injection vulnerabilities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
 dotnet_diagnostic.CA3010.severity = none
 
 # CA3011: Review code for DLL injection vulnerabilities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
 dotnet_diagnostic.CA3011.severity = none
 
 # CA3012: Review code for regex injection vulnerabilities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
 dotnet_diagnostic.CA3012.severity = none
 
 # CA3061: Do Not Add Schema By URL
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
 dotnet_diagnostic.CA3061.severity = silent
 
 # CA3075: Insecure DTD processing in XML
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
 dotnet_diagnostic.CA3075.severity = silent
 
 # CA3076: Insecure XSLT script processing.
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
 dotnet_diagnostic.CA3076.severity = silent
 
 # CA3077: Insecure Processing in API Design, XmlDocument and XmlTextReader
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
 dotnet_diagnostic.CA3077.severity = silent
 
 # CA3147: Mark Verb Handlers With Validate Antiforgery Token
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
 dotnet_diagnostic.CA3147.severity = silent
 
 # CA5350: Do Not Use Weak Cryptographic Algorithms
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
 dotnet_diagnostic.CA5350.severity = silent
 
 # CA5351: Do Not Use Broken Cryptographic Algorithms
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
 dotnet_diagnostic.CA5351.severity = silent
 
 # CA5358: Review cipher mode usage with cryptography experts
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
 dotnet_diagnostic.CA5358.severity = none
 
 # CA5359: Do Not Disable Certificate Validation
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
 dotnet_diagnostic.CA5359.severity = silent
 
 # CA5360: Do Not Call Dangerous Methods In Deserialization
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
 dotnet_diagnostic.CA5360.severity = silent
 
 # CA5361: Do Not Disable SChannel Use of Strong Crypto
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
 dotnet_diagnostic.CA5361.severity = none
 
 # CA5362: Potential reference cycle in deserialized object graph
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
 dotnet_diagnostic.CA5362.severity = none
 
 # CA5363: Do Not Disable Request Validation
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
 dotnet_diagnostic.CA5363.severity = silent
 
 # CA5364: Do Not Use Deprecated Security Protocols
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
 dotnet_diagnostic.CA5364.severity = silent
 
 # CA5365: Do Not Disable HTTP Header Checking
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
 dotnet_diagnostic.CA5365.severity = silent
 
 # CA5366: Use XmlReader For DataSet Read Xml
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
 dotnet_diagnostic.CA5366.severity = silent
 
 # CA5367: Do Not Serialize Types With Pointer Fields
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
 dotnet_diagnostic.CA5367.severity = none
 
 # CA5368: Set ViewStateUserKey For Classes Derived From Page
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
 dotnet_diagnostic.CA5368.severity = silent
 
 # CA5369: Use XmlReader For Deserialize
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
 dotnet_diagnostic.CA5369.severity = silent
 
 # CA5370: Use XmlReader For Validating Reader
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
 dotnet_diagnostic.CA5370.severity = silent
 
 # CA5371: Use XmlReader For Schema Read
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
 dotnet_diagnostic.CA5371.severity = silent
 
 # CA5372: Use XmlReader For XPathDocument
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
 dotnet_diagnostic.CA5372.severity = silent
 
 # CA5373: Do not use obsolete key derivation function
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
 dotnet_diagnostic.CA5373.severity = silent
 
 # CA5374: Do Not Use XslTransform
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
 dotnet_diagnostic.CA5374.severity = silent
 
 # CA5375: Do Not Use Account Shared Access Signature
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
 dotnet_diagnostic.CA5375.severity = none
 
 # CA5376: Use SharedAccessProtocol HttpsOnly
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
 dotnet_diagnostic.CA5376.severity = none
 
 # CA5377: Use Container Level Access Policy
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
 dotnet_diagnostic.CA5377.severity = none
 
 # CA5378: Do not disable ServicePointManagerSecurityProtocols
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
 dotnet_diagnostic.CA5378.severity = none
 
 # CA5379: Do Not Use Weak Key Derivation Function Algorithm
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
 dotnet_diagnostic.CA5379.severity = silent
 
 # CA5380: Do Not Add Certificates To Root Store
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
 dotnet_diagnostic.CA5380.severity = none
 
 # CA5381: Ensure Certificates Are Not Added To Root Store
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
 dotnet_diagnostic.CA5381.severity = none
 
 # CA5382: Use Secure Cookies In ASP.Net Core
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
 dotnet_diagnostic.CA5382.severity = none
 
 # CA5383: Ensure Use Secure Cookies In ASP.Net Core
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
 dotnet_diagnostic.CA5383.severity = none
 
 # CA5384: Do Not Use Digital Signature Algorithm (DSA)
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
 dotnet_diagnostic.CA5384.severity = silent
 
 # CA5385: Use Rivest–Shamir–Adleman (RSA) Algorithm With Sufficient Key Size
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
 dotnet_diagnostic.CA5385.severity = silent
 
 # CA5386: Avoid hardcoding SecurityProtocolType value
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
 dotnet_diagnostic.CA5386.severity = none
 
 # CA5387: Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
 dotnet_diagnostic.CA5387.severity = none
 
 # CA5388: Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
 dotnet_diagnostic.CA5388.severity = none
 
 # CA5389: Do Not Add Archive Item's Path To The Target File System Path
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
 dotnet_diagnostic.CA5389.severity = none
 
 # CA5390: Do not hard-code encryption key
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
 dotnet_diagnostic.CA5390.severity = none
 
 # CA5391: Use antiforgery tokens in ASP.NET Core MVC controllers
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
 dotnet_diagnostic.CA5391.severity = none
 
 # CA5392: Use DefaultDllImportSearchPaths attribute for P/Invokes
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
 dotnet_diagnostic.CA5392.severity = none
 
 # CA5393: Do not use unsafe DllImportSearchPath value
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
 dotnet_diagnostic.CA5393.severity = none
 
 # CA5394: Do not use insecure randomness
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
 dotnet_diagnostic.CA5394.severity = none
 
 # CA5395: Miss HttpVerb attribute for action methods
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
 dotnet_diagnostic.CA5395.severity = none
 
 # CA5396: Set HttpOnly to true for HttpCookie
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
 dotnet_diagnostic.CA5396.severity = none
 
 # CA5397: Do not use deprecated SslProtocols values
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
 dotnet_diagnostic.CA5397.severity = silent
 
 # CA5398: Avoid hardcoded SslProtocols values
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
 dotnet_diagnostic.CA5398.severity = none
 
 # CA5399: HttpClients should enable certificate revocation list checks
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
 dotnet_diagnostic.CA5399.severity = none
 
 # CA5400: Ensure HttpClient certificate revocation list check is not disabled
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
 dotnet_diagnostic.CA5400.severity = none
 
 # CA5401: Do not use CreateEncryptor with non-default IV
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
 dotnet_diagnostic.CA5401.severity = none
 
 # CA5402: Use CreateEncryptor with the default IV 
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
 dotnet_diagnostic.CA5402.severity = none
 
 # CA5403: Do not hard-code certificate
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
 dotnet_diagnostic.CA5403.severity = none
 
 # IL3000: Avoid using accessing Assembly file path when publishing as a single-file
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
 dotnet_diagnostic.IL3000.severity = warning
 
 # IL3001: Avoid using accessing Assembly file path when publishing as a single-file
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
 dotnet_diagnostic.IL3001.severity = warning
 
 # IL3002: Using member with RequiresAssemblyFilesAttribute can break functionality when embedded in a single-file app
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3002
 dotnet_diagnostic.IL3002.severity = warning
 
 # IDE0001: SimplifyNames
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0001
 dotnet_diagnostic.IDE0001.severity = silent
 
 # IDE0002: SimplifyMemberAccess
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0002
 dotnet_diagnostic.IDE0002.severity = silent
 
 # IDE0003: RemoveQualification
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0003
 dotnet_diagnostic.IDE0003.severity = silent
 
 # IDE0004: RemoveUnnecessaryCast
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0004
 dotnet_diagnostic.IDE0004.severity = silent
 
 # IDE0005: RemoveUnnecessaryImports
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0005
 dotnet_diagnostic.IDE0005.severity = silent
 
 # IDE0006: IntellisenseBuildFailed
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0006
 dotnet_diagnostic.IDE0006.severity = silent
 
 # IDE0007: UseImplicitType
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0007
 dotnet_diagnostic.IDE0007.severity = silent
 
 # IDE0008: UseExplicitType
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0008
 dotnet_diagnostic.IDE0008.severity = silent
 
 # IDE0009: AddQualification
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0009
 dotnet_diagnostic.IDE0009.severity = silent
 
 # IDE0010: PopulateSwitchStatement
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0010
 dotnet_diagnostic.IDE0010.severity = silent
 
 # IDE0011: AddBraces
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0011
 dotnet_diagnostic.IDE0011.severity = silent
 
 # IDE0016: UseThrowExpression
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0016
 dotnet_diagnostic.IDE0016.severity = silent
 
 # IDE0017: UseObjectInitializer
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0017
 dotnet_diagnostic.IDE0017.severity = silent
 
 # IDE0018: InlineDeclaration
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0018
 dotnet_diagnostic.IDE0018.severity = silent
 
 # IDE0019: InlineAsTypeCheck
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0019
 dotnet_diagnostic.IDE0019.severity = silent
 
 # IDE0020: InlineIsTypeCheck
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0020
 dotnet_diagnostic.IDE0020.severity = silent
 
 # IDE0021: UseExpressionBodyForConstructors
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0021
 dotnet_diagnostic.IDE0021.severity = silent
 
 # IDE0022: UseExpressionBodyForMethods
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0022
 dotnet_diagnostic.IDE0022.severity = silent
 
 # IDE0023: UseExpressionBodyForConversionOperators
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0023
 dotnet_diagnostic.IDE0023.severity = silent
 
 # IDE0024: UseExpressionBodyForOperators
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0024
 dotnet_diagnostic.IDE0024.severity = silent
 
 # IDE0025: UseExpressionBodyForProperties
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0025
 dotnet_diagnostic.IDE0025.severity = silent
 
 # IDE0026: UseExpressionBodyForIndexers
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0026
 dotnet_diagnostic.IDE0026.severity = silent
 
 # IDE0027: UseExpressionBodyForAccessors
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0027
 dotnet_diagnostic.IDE0027.severity = silent
 
 # IDE0028: UseCollectionInitializer
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0028
 dotnet_diagnostic.IDE0028.severity = silent
 
 # IDE0029: UseCoalesceExpression
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0029
 dotnet_diagnostic.IDE0029.severity = silent
 
 # IDE0030: UseCoalesceExpressionForNullable
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0030
 dotnet_diagnostic.IDE0030.severity = silent
 
 # IDE0031: UseNullPropagation
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0031
 dotnet_diagnostic.IDE0031.severity = warning
 
 # IDE0032: UseAutoProperty
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0032
 dotnet_diagnostic.IDE0032.severity = silent
 
 # IDE0033: UseExplicitTupleName
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0033
 dotnet_diagnostic.IDE0033.severity = silent
 
 # IDE0034: UseDefaultLiteral
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0034
 dotnet_diagnostic.IDE0034.severity = silent
 
 # IDE0035: RemoveUnreachableCode
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0035
 dotnet_diagnostic.IDE0035.severity = silent
 
 # IDE0036: OrderModifiers
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0036
 dotnet_diagnostic.IDE0036.severity = warning
 
 # IDE0037: UseInferredMemberName
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0037
 dotnet_diagnostic.IDE0037.severity = silent
 
 # IDE0038: InlineIsTypeWithoutNameCheck
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0038
 dotnet_diagnostic.IDE0038.severity = silent
 
 # IDE0039: UseLocalFunction
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0039
 dotnet_diagnostic.IDE0039.severity = silent
 
 # IDE0040: AddAccessibilityModifiers
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0040
 dotnet_diagnostic.IDE0040.severity = warning
 
 # IDE0041: UseIsNullCheck
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0041
 dotnet_diagnostic.IDE0041.severity = warning
 
 # IDE0042: UseDeconstruction
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0042
 dotnet_diagnostic.IDE0042.severity = silent
 
 # IDE0043: ValidateFormatString
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0043
 dotnet_diagnostic.IDE0043.severity = silent
 
 # IDE0044: MakeFieldReadonly
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044
 dotnet_diagnostic.IDE0044.severity = silent
 
 # IDE0045: UseConditionalExpressionForAssignment
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0045
 dotnet_diagnostic.IDE0045.severity = silent
 
 # IDE0046: UseConditionalExpressionForReturn
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0046
 dotnet_diagnostic.IDE0046.severity = silent
 
 # IDE0047: RemoveUnnecessaryParentheses
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0047
 dotnet_diagnostic.IDE0047.severity = silent
 
 # IDE0048: AddRequiredParentheses
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0048
 dotnet_diagnostic.IDE0048.severity = suggestion
 
 # IDE0049: PreferBuiltInOrFrameworkType
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0049
 dotnet_diagnostic.IDE0049.severity = silent
 
 # IDE0050: ConvertAnonymousTypeToTuple
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0050
 dotnet_diagnostic.IDE0050.severity = silent
 
 # IDE0051: RemoveUnusedMembers
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0051
 dotnet_diagnostic.IDE0051.severity = silent
 
 # IDE0052: RemoveUnreadMembers
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0052
 dotnet_diagnostic.IDE0052.severity = silent
 
 # IDE0053: UseExpressionBodyForLambdaExpressions
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0053
 dotnet_diagnostic.IDE0053.severity = silent
 
 # IDE0054: UseCompoundAssignment
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0054
 dotnet_diagnostic.IDE0054.severity = warning
 
 # IDE0055: Formatting
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055
 dotnet_diagnostic.IDE0055.severity = silent
 
 # IDE0056: UseIndexOperator
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0056
 dotnet_diagnostic.IDE0056.severity = silent
 
 # IDE0057: UseRangeOperator
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0057
 dotnet_diagnostic.IDE0057.severity = silent
 
 # IDE0058: ExpressionValueIsUnused
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058
 dotnet_diagnostic.IDE0058.severity = silent
 
 # IDE0059: ValueAssignedIsUnused
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0059
 dotnet_diagnostic.IDE0059.severity = silent
 
 # IDE0060: UnusedParameter
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0060
 dotnet_diagnostic.IDE0060.severity = silent
 
 # IDE0061: UseExpressionBodyForLocalFunctions
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0061
 dotnet_diagnostic.IDE0061.severity = silent
 
 # IDE0062: MakeLocalFunctionStatic
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0062
 dotnet_diagnostic.IDE0062.severity = warning
 
 # IDE0063: UseSimpleUsingStatement
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0063
 dotnet_diagnostic.IDE0063.severity = silent
 
 # IDE0064: MakeStructFieldsWritable
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0064
 dotnet_diagnostic.IDE0064.severity = warning
 
 # IDE0065: MoveMisplacedUsingDirectives
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0065
 dotnet_diagnostic.IDE0065.severity = silent
 
 # IDE0066: ConvertSwitchStatementToExpression
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0066
 dotnet_diagnostic.IDE0066.severity = silent
 
 # IDE0067: DisposeObjectsBeforeLosingScope
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0067
 dotnet_diagnostic.IDE0067.severity = silent
 
 # IDE0068: UseRecommendedDisposePattern
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0068
 dotnet_diagnostic.IDE0068.severity = silent
 
 # IDE0069: DisposableFieldsShouldBeDisposed
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0069
 dotnet_diagnostic.IDE0069.severity = silent
 
 # IDE0070: UseSystemHashCode
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0070
 dotnet_diagnostic.IDE0070.severity = silent
 
 # IDE0071: SimplifyInterpolation
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0071
 dotnet_diagnostic.IDE0071.severity = silent
 
 # IDE0072: PopulateSwitchExpression
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0072
 dotnet_diagnostic.IDE0072.severity = silent
 
 # IDE0073: FileHeaderMismatch
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0073
 dotnet_diagnostic.IDE0073.severity = suggestion
 
 # IDE0074: UseCoalesceCompoundAssignment
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0074
 dotnet_diagnostic.IDE0074.severity = warning
 
 # IDE0075: SimplifyConditionalExpression
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0075
 dotnet_diagnostic.IDE0075.severity = warning
 
 # IDE0076: InvalidSuppressMessageAttribute
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0076
 dotnet_diagnostic.IDE0076.severity = warning
 
 # IDE0077: LegacyFormatSuppressMessageAttribute
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0077
 dotnet_diagnostic.IDE0077.severity = warning
 
 # IDE0078: UsePatternCombinators
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0078
 dotnet_diagnostic.IDE0078.severity = silent
 
 # IDE0079: RemoveUnnecessarySuppression
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0079
 dotnet_diagnostic.IDE0079.severity = silent
 
 # IDE0080: RemoveConfusingSuppressionForIsExpression
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0080
 dotnet_diagnostic.IDE0080.severity = silent
 
 # IDE0081: RemoveUnnecessaryByVal
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0081
 dotnet_diagnostic.IDE0081.severity = silent
 
 # IDE0082: ConvertTypeOfToNameOf
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0082
 dotnet_diagnostic.IDE0082.severity = warning
 
 # IDE0083: UseNotPattern
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0083
 dotnet_diagnostic.IDE0083.severity = silent
 
 # IDE0084: UseIsNotExpression
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0084
 dotnet_diagnostic.IDE0084.severity = silent
 
 # IDE0090: UseNew
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0090
 dotnet_diagnostic.IDE0090.severity = suggestion
 
 # IDE0100: RemoveRedundantEquality
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0100
 dotnet_diagnostic.IDE0100.severity = warning
 
 # IDE0110: RemoveUnnecessaryDiscard
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0110
 dotnet_diagnostic.IDE0110.severity = suggestion
 
 # IDE0120: SimplifyLINQExpression
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0120
 dotnet_diagnostic.IDE0120.severity = warning
 
 # IDE0130: NamespaceDoesNotMatchFolderStructure
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0130
 dotnet_diagnostic.IDE0130.severity = suggestion
 
 # IDE1001: AnalyzerChanged
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1001
 dotnet_diagnostic.IDE1001.severity = silent
 
 # IDE1002: AnalyzerDependencyConflict
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1002
 dotnet_diagnostic.IDE1002.severity = silent
 
 # IDE1003: MissingAnalyzerReference
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1003
 dotnet_diagnostic.IDE1003.severity = silent
 
 # IDE1004: ErrorReadingRuleset
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1004
 dotnet_diagnostic.IDE1004.severity = silent
 
 # IDE1005: InvokeDelegateWithConditionalAccess
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1005
 dotnet_diagnostic.IDE1005.severity = warning
 
 # IDE1006: NamingRule
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1006
 dotnet_diagnostic.IDE1006.severity = silent
 
 # IDE1007: UnboundIdentifier
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1007
 dotnet_diagnostic.IDE1007.severity = silent
 
 # IDE1008: UnboundConstructor
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1008
 dotnet_diagnostic.IDE1008.severity = silent
 
 # IDE2000: MultipleBlankLines
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2000
 dotnet_diagnostic.IDE2000.severity = warning
 
 # IDE2001: EmbeddedStatementsMustBeOnTheirOwnLine
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2001
 dotnet_diagnostic.IDE2001.severity = warning
 
 # IDE2002: ConsecutiveBracesMustNotHaveBlankLinesBetweenThem
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2002
 dotnet_diagnostic.IDE2002.severity = warning
 
 # IDE2003: ConsecutiveStatementPlacement
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2003
 dotnet_diagnostic.IDE2003.severity = warning
 
 # IDE2004: BlankLineNotAllowedAfterConstructorInitializerColon
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2004
 dotnet_diagnostic.IDE2004.severity = warning
 
 # SA0001: XML comment analysis disabled
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0001.md
 dotnet_diagnostic.SA0001.severity = none
 
 # SA0002: Invalid settings file
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0002.md
 dotnet_diagnostic.SA0002.severity = none
 
 # SA1000: Keywords should be spaced correctly
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1000.md
 dotnet_diagnostic.SA1000.severity = warning
 
 # SA1001: Commas should be spaced correctly
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1001.md
 dotnet_diagnostic.SA1001.severity = warning
 
 # SA1002: Semicolons should be spaced correctly
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1002.md
 dotnet_diagnostic.SA1002.severity = warning
 
 # SA1003: Symbols should be spaced correctly
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1003.md
 dotnet_diagnostic.SA1003.severity = warning
 
 # SA1004: Documentation lines should begin with single space
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1004.md
 dotnet_diagnostic.SA1004.severity = none
 
 # SA1005: Single line comments should begin with single space
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1005.md
 dotnet_diagnostic.SA1005.severity = none
 
 # SA1006: Preprocessor keywords should not be preceded by space
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1006.md
 dotnet_diagnostic.SA1006.severity = warning
 
 # SA1007: Operator keyword should be followed by space
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1007.md
 dotnet_diagnostic.SA1007.severity = warning
 
 # SA1008: Opening parenthesis should be spaced correctly
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1008.md
 dotnet_diagnostic.SA1008.severity = warning
 
 # SA1009: Closing parenthesis should be spaced correctly
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1009.md
 dotnet_diagnostic.SA1009.severity = none
 
 # SA1010: Opening square brackets should be spaced correctly
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1010.md
 dotnet_diagnostic.SA1010.severity = none
 
 # SA1011: Closing square brackets should be spaced correctly
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1011.md
 dotnet_diagnostic.SA1011.severity = none
 
 # SA1012: Opening braces should be spaced correctly
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1012.md
 dotnet_diagnostic.SA1012.severity = none
 
 # SA1013: Closing braces should be spaced correctly
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1013.md
 dotnet_diagnostic.SA1013.severity = none
 
 # SA1014: Opening generic brackets should be spaced correctly
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1014.md
 dotnet_diagnostic.SA1014.severity = none
 
 # SA1015: Closing generic brackets should be spaced correctly
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1015.md
 dotnet_diagnostic.SA1015.severity = none
 
 # SA1016: Opening attribute brackets should be spaced correctly
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1016.md
 dotnet_diagnostic.SA1016.severity = none
 
 # SA1017: Closing attribute brackets should be spaced correctly
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1017.md
 dotnet_diagnostic.SA1017.severity = none
 
 # SA1018: Nullable type symbols should be spaced correctly
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1018.md
 dotnet_diagnostic.SA1018.severity = none
 
 # SA1019: Member access symbols should be spaced correctly
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1019.md
 dotnet_diagnostic.SA1019.severity = none
 
 # SA1020: Increment decrement symbols should be spaced correctly
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1020.md
 dotnet_diagnostic.SA1020.severity = none
 
 # SA1021: Negative signs should be spaced correctly
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1021.md
 dotnet_diagnostic.SA1021.severity = none
 
 # SA1022: Positive signs should be spaced correctly
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1022.md
 dotnet_diagnostic.SA1022.severity = none
 
 # SA1023: Dereference and access of symbols should be spaced correctly
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1023.md
 dotnet_diagnostic.SA1023.severity = none
 
 # SA1024: Colons Should Be Spaced Correctly
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1024.md
 dotnet_diagnostic.SA1024.severity = none
 
 # SA1025: Code should not contain multiple whitespace in a row
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1025.md
 dotnet_diagnostic.SA1025.severity = none
 
 # SA1026: Code should not contain space after new or stackalloc keyword in implicitly typed array allocation
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1026.md
 dotnet_diagnostic.SA1026.severity = none
 
 # SA1027: Use tabs correctly
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1027.md
 dotnet_diagnostic.SA1027.severity = none
 
 # SA1028: Code should not contain trailing whitespace
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1028.md
 dotnet_diagnostic.SA1028.severity = none
 
 # SA1100: Do not prefix calls with base unless local implementation exists
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1100.md
 dotnet_diagnostic.SA1100.severity = none
 
 # SA1101: Prefix local calls with this
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1101.md
 dotnet_diagnostic.SA1101.severity = none
 
 # SA1102: Query clause should follow previous clause
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1102.md
 dotnet_diagnostic.SA1102.severity = none
 
 # SA1103: Query clauses should be on separate lines or all on one line
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1103.md
 dotnet_diagnostic.SA1103.severity = none
 
 # SA1104: Query clause should begin on new line when previous clause spans multiple lines
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1104.md
 dotnet_diagnostic.SA1104.severity = none
 
 # SA1105: Query clauses spanning multiple lines should begin on own line
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1105.md
 dotnet_diagnostic.SA1105.severity = none
 
 # SA1106: Code should not contain empty statements
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1106.md
 dotnet_diagnostic.SA1106.severity = warning
 
 # SA1107: Code should not contain multiple statements on one line
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1107.md
 dotnet_diagnostic.SA1107.severity = none
 
 # SA1108: Block statements should not contain embedded comments
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1108.md
 dotnet_diagnostic.SA1108.severity = none
 
 # SA1110: Opening parenthesis or bracket should be on declaration line
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1110.md
 dotnet_diagnostic.SA1110.severity = none
 
 # SA1111: Closing parenthesis should be on line of last parameter
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1111.md
 dotnet_diagnostic.SA1111.severity = none
 
 # SA1112: Closing parenthesis should be on line of opening parenthesis
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1112.md
 dotnet_diagnostic.SA1112.severity = none
 
 # SA1113: Comma should be on the same line as previous parameter
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1113.md
 dotnet_diagnostic.SA1113.severity = none
 
 # SA1114: Parameter list should follow declaration
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1114.md
 dotnet_diagnostic.SA1114.severity = none
 
 # SA1115: Parameter should follow comma
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1115.md
 dotnet_diagnostic.SA1115.severity = none
 
 # SA1116: Split parameters should start on line after declaration
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1116.md
 dotnet_diagnostic.SA1116.severity = none
 
 # SA1117: Parameters should be on same line or separate lines
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1117.md
 dotnet_diagnostic.SA1117.severity = none
 
 # SA1118: Parameter should not span multiple lines
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1118.md
 dotnet_diagnostic.SA1118.severity = none
 
 # SA1119: Statement should not use unnecessary parenthesis
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1119.md
 dotnet_diagnostic.SA1119.severity = none
 
 # SA1120: Comments should contain text
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1120.md
 dotnet_diagnostic.SA1120.severity = none
 
 # SA1121: Use built-in type alias
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1121.md
 dotnet_diagnostic.SA1121.severity = none
 
 # SA1122: Use string.Empty for empty strings
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1122.md
 dotnet_diagnostic.SA1122.severity = warning
 
 # SA1123: Do not place regions within elements
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1123.md
 dotnet_diagnostic.SA1123.severity = none
 
 # SA1124: Do not use regions
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1124.md
 dotnet_diagnostic.SA1124.severity = none
 
 # SA1125: Use shorthand for nullable types
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1125.md
 dotnet_diagnostic.SA1125.severity = none
 
 # SA1127: Generic type constraints should be on their own line
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1127.md
 dotnet_diagnostic.SA1127.severity = none
 
 # SA1128: Put constructor initializers on their own line
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1128.md
 dotnet_diagnostic.SA1128.severity = none
 
 # SA1129: Do not use default value type constructor
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1129.md
 dotnet_diagnostic.SA1129.severity = none
 
 # SA1130: Use lambda syntax
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1130.md
 dotnet_diagnostic.SA1130.severity = none
 
 # SA1131: Use readable conditions
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1131.md
 dotnet_diagnostic.SA1131.severity = warning
 
 # SA1132: Do not combine fields
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1132.md
 dotnet_diagnostic.SA1132.severity = none
 
 # SA1133: Do not combine attributes
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1133.md
 dotnet_diagnostic.SA1133.severity = none
 
 # SA1134: Attributes should not share line
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1134.md
 dotnet_diagnostic.SA1134.severity = none
 
 # SA1135: Using directives should be qualified
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1135.md
 dotnet_diagnostic.SA1135.severity = none
 
 # SA1136: Enum values should be on separate lines
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1136.md
 dotnet_diagnostic.SA1136.severity = none
 
 # SA1137: Elements should have the same indentation
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1137.md
 dotnet_diagnostic.SA1137.severity = none
 
 # SA1139: Use literal suffix notation instead of casting
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1139.md
 dotnet_diagnostic.SA1139.severity = none
 
 # SA1141: Use tuple syntax
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1141.md
 dotnet_diagnostic.SA1141.severity = none
 
 # SA1142: Refer to tuple fields by name
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1142.md
 dotnet_diagnostic.SA1142.severity = none
 
 # SA1200: Using directives should be placed correctly
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1200.md
 dotnet_diagnostic.SA1200.severity = none
 
 # SA1201: Elements should appear in the correct order
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1201.md
 dotnet_diagnostic.SA1201.severity = none
 
 # SA1202: Elements should be ordered by access
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1202.md
 dotnet_diagnostic.SA1202.severity = none
 
 # SA1203: Constants should appear before fields
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1203.md
 dotnet_diagnostic.SA1203.severity = none
 
 # SA1204: Static elements should appear before instance elements
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1204.md
 dotnet_diagnostic.SA1204.severity = none
 
 # SA1205: Partial elements should declare access
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1205.md
 dotnet_diagnostic.SA1205.severity = warning
 
 # SA1206: Declaration keywords should follow order
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1206.md
 dotnet_diagnostic.SA1206.severity = none
 
 # SA1207: Protected should come before internal
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1207.md
 dotnet_diagnostic.SA1207.severity = none
 
 # SA1208: System using directives should be placed before other using directives
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1208.md
 dotnet_diagnostic.SA1208.severity = none
 
 # SA1209: Using alias directives should be placed after other using directives
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1209.md
 dotnet_diagnostic.SA1209.severity = none
 
 # SA1210: Using directives should be ordered alphabetically by namespace
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1210.md
 dotnet_diagnostic.SA1210.severity = none
 
 # SA1211: Using alias directives should be ordered alphabetically by alias name
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1211.md
 dotnet_diagnostic.SA1211.severity = none
 
 # SA1212: Property accessors should follow order
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1212.md
 dotnet_diagnostic.SA1212.severity = warning
 
 # SA1213: Event accessors should follow order
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1213.md
 dotnet_diagnostic.SA1213.severity = warning
 
 # SA1214: Readonly fields should appear before non-readonly fields
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1214.md
 dotnet_diagnostic.SA1214.severity = none
 
 # SA1216: Using static directives should be placed at the correct location
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1216.md
 dotnet_diagnostic.SA1216.severity = warning
 
 # SA1217: Using static directives should be ordered alphabetically
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1217.md
 dotnet_diagnostic.SA1217.severity = warning
 
 # SA1300: Element should begin with upper-case letter
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
 dotnet_diagnostic.SA1300.severity = none
 
 # SA1302: Interface names should begin with I
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1302.md
 dotnet_diagnostic.SA1302.severity = none
 
 # SA1303: Const field names should begin with upper-case letter
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md
 dotnet_diagnostic.SA1303.severity = none
 
 # SA1304: Non-private readonly fields should begin with upper-case letter
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1304.md
 dotnet_diagnostic.SA1304.severity = none
 
 # SA1305: Field names should not use Hungarian notation
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1305.md
 dotnet_diagnostic.SA1305.severity = none
 
 # SA1306: Field names should begin with lower-case letter
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md
 dotnet_diagnostic.SA1306.severity = none
 
 # SA1307: Accessible fields should begin with upper-case letter
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1307.md
 dotnet_diagnostic.SA1307.severity = none
 
 # SA1308: Variable names should not be prefixed
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1308.md
 dotnet_diagnostic.SA1308.severity = none
 
 # SA1309: Field names should not begin with underscore
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1309.md
 dotnet_diagnostic.SA1309.severity = none
 
 # SA1310: Field names should not contain underscore
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1310.md
 dotnet_diagnostic.SA1310.severity = none
 
 # SA1311: Static readonly fields should begin with upper-case letter
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md
 dotnet_diagnostic.SA1311.severity = none
 
 # SA1312: Variable names should begin with lower-case letter
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1312.md
 dotnet_diagnostic.SA1312.severity = none
 
 # SA1313: Parameter names should begin with lower-case letter
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1313.md
 dotnet_diagnostic.SA1313.severity = none
 
 # SA1314: Type parameter names should begin with T
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1314.md
 dotnet_diagnostic.SA1314.severity = warning
 
 # SA1316: Tuple element names should use correct casing
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1316.md
 dotnet_diagnostic.SA1316.severity = none
 
 # SA1400: Access modifier should be declared
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1400.md
 dotnet_diagnostic.SA1400.severity = none
 
 # SA1401: Fields should be private
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md
 dotnet_diagnostic.SA1401.severity = none
 
 # SA1402: File may only contain a single type
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1402.md
 dotnet_diagnostic.SA1402.severity = none
 
 # SA1403: File may only contain a single namespace
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1403.md
 dotnet_diagnostic.SA1403.severity = none
 
 # SA1404: Code analysis suppression should have justification
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1404.md
 dotnet_diagnostic.SA1404.severity = none
 
 # SA1405: Debug.Assert should provide message text
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1405.md
 dotnet_diagnostic.SA1405.severity = none
 
 # SA1406: Debug.Fail should provide message text
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1406.md
 dotnet_diagnostic.SA1406.severity = none
 
 # SA1407: Arithmetic expressions should declare precedence
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1407.md
 dotnet_diagnostic.SA1407.severity = none
 
 # SA1408: Conditional expressions should declare precedence
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1408.md
 dotnet_diagnostic.SA1408.severity = none
 
 # SA1410: Remove delegate parenthesis when possible
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1410.md
 dotnet_diagnostic.SA1410.severity = none
 
 # SA1411: Attribute constructor should not use unnecessary parenthesis
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1411.md
 dotnet_diagnostic.SA1411.severity = none
 
 # SA1412: Store files as UTF-8 with byte order mark
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1412.md
 dotnet_diagnostic.SA1412.severity = none
 
 # SA1413: Use trailing comma in multi-line initializers
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1413.md
 dotnet_diagnostic.SA1413.severity = none
 
 # SA1414: Tuple types in signatures should have element names
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1414.md
 dotnet_diagnostic.SA1414.severity = none
 
 # SA1500: Braces for multi-line statements should not share line
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1500.md
 dotnet_diagnostic.SA1500.severity = none
 
 # SA1501: Statement should not be on a single line
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1501.md
 dotnet_diagnostic.SA1501.severity = none
 
 # SA1502: Element should not be on a single line
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1502.md
 dotnet_diagnostic.SA1502.severity = none
 
 # SA1503: Braces should not be omitted
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1503.md
 dotnet_diagnostic.SA1503.severity = none
 
 # SA1504: All accessors should be single-line or multi-line
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1504.md
 dotnet_diagnostic.SA1504.severity = warning
 
 # SA1505: Opening braces should not be followed by blank line
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1505.md
 dotnet_diagnostic.SA1505.severity = none
 
 # SA1506: Element documentation headers should not be followed by blank line
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1506.md
 dotnet_diagnostic.SA1506.severity = none
 
 # SA1507: Code should not contain multiple blank lines in a row
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1507.md
 dotnet_diagnostic.SA1507.severity = warning
 
 # SA1508: Closing braces should not be preceded by blank line
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1508.md
 dotnet_diagnostic.SA1508.severity = none
 
 # SA1509: Opening braces should not be preceded by blank line
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1509.md
 dotnet_diagnostic.SA1509.severity = none
 
 # SA1510: Chained statement blocks should not be preceded by blank line
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1510.md
 dotnet_diagnostic.SA1510.severity = none
 
 # SA1511: While-do footer should not be preceded by blank line
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1511.md
 dotnet_diagnostic.SA1511.severity = none
 
 # SA1512: Single-line comments should not be followed by blank line
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1512.md
 dotnet_diagnostic.SA1512.severity = none
 
 # SA1513: Closing brace should be followed by blank line
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1513.md
 dotnet_diagnostic.SA1513.severity = none
 
 # SA1514: Element documentation header should be preceded by blank line
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1514.md
 dotnet_diagnostic.SA1514.severity = none
 
 # SA1515: Single-line comment should be preceded by blank line
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1515.md
 dotnet_diagnostic.SA1515.severity = none
 
 # SA1516: Elements should be separated by blank line
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1516.md
 dotnet_diagnostic.SA1516.severity = warning
 
 # SA1517: Code should not contain blank lines at start of file
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1517.md
 dotnet_diagnostic.SA1517.severity = warning
 
 # SA1518: Use line endings correctly at end of file
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1518.md
 dotnet_diagnostic.SA1518.severity = warning
 
 # SA1519: Braces should not be omitted from multi-line child statement
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1519.md
 dotnet_diagnostic.SA1519.severity = none
 
 # SA1520: Use braces consistently
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1520.md
 dotnet_diagnostic.SA1520.severity = none
 
 # SA1600: Elements should be documented
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1600.md
 dotnet_diagnostic.SA1600.severity = none
 
 # SA1601: Partial elements should be documented
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1601.md
 dotnet_diagnostic.SA1601.severity = none
 
 # SA1602: Enumeration items should be documented
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1602.md
 dotnet_diagnostic.SA1602.severity = none
 
 # SA1604: Element documentation should have summary
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1604.md
 dotnet_diagnostic.SA1604.severity = none
 
 # SA1605: Partial element documentation should have summary
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1605.md
 dotnet_diagnostic.SA1605.severity = none
 
 # SA1606: Element documentation should have summary text
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1606.md
 dotnet_diagnostic.SA1606.severity = none
 
 # SA1607: Partial element documentation should have summary text
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1607.md
 dotnet_diagnostic.SA1607.severity = none
 
 # SA1608: Element documentation should not have default summary
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1608.md
 dotnet_diagnostic.SA1608.severity = none
 
 # SA1609: Property documentation should have value
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1609.md
 dotnet_diagnostic.SA1609.severity = none
 
 # SA1610: Property documentation should have value text
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1610.md
 dotnet_diagnostic.SA1610.severity = none
 
 # SA1611: Element parameters should be documented
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1611.md
 dotnet_diagnostic.SA1611.severity = none
 
 # SA1612: Element parameter documentation should match element parameters
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1612.md
 dotnet_diagnostic.SA1612.severity = none
 
 # SA1613: Element parameter documentation should declare parameter name
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1613.md
 dotnet_diagnostic.SA1613.severity = none
 
 # SA1614: Element parameter documentation should have text
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1614.md
 dotnet_diagnostic.SA1614.severity = none
 
 # SA1615: Element return value should be documented
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1615.md
 dotnet_diagnostic.SA1615.severity = none
 
 # SA1616: Element return value documentation should have text
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1616.md
 dotnet_diagnostic.SA1616.severity = none
 
 # SA1617: Void return value should not be documented
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1617.md
 dotnet_diagnostic.SA1617.severity = none
 
 # SA1618: Generic type parameters should be documented
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1618.md
 dotnet_diagnostic.SA1618.severity = none
 
 # SA1619: Generic type parameters should be documented partial class
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1619.md
 dotnet_diagnostic.SA1619.severity = none
 
 # SA1620: Generic type parameter documentation should match type parameters
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1620.md
 dotnet_diagnostic.SA1620.severity = none
 
 # SA1621: Generic type parameter documentation should declare parameter name
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1621.md
 dotnet_diagnostic.SA1621.severity = none
 
 # SA1622: Generic type parameter documentation should have text
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1622.md
 dotnet_diagnostic.SA1622.severity = none
 
 # SA1623: Property summary documentation should match accessors
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1623.md
 dotnet_diagnostic.SA1623.severity = none
 
 # SA1624: Property summary documentation should omit accessor with restricted access
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1624.md
 dotnet_diagnostic.SA1624.severity = none
 
 # SA1625: Element documentation should not be copied and pasted
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1625.md
 dotnet_diagnostic.SA1625.severity = none
 
 # SA1626: Single-line comments should not use documentation style slashes
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1626.md
 dotnet_diagnostic.SA1626.severity = none
 
 # SA1627: Documentation text should not be empty
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1627.md
 dotnet_diagnostic.SA1627.severity = none
 
 # SA1629: Documentation text should end with a period
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1629.md
 dotnet_diagnostic.SA1629.severity = none
 
 # SA1633: File should have header
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1633.md
 dotnet_diagnostic.SA1633.severity = none
 
 # SA1634: File header should show copyright
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1634.md
 dotnet_diagnostic.SA1634.severity = none
 
 # SA1635: File header should have copyright text
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1635.md
 dotnet_diagnostic.SA1635.severity = none
 
 # SA1636: File header copyright text should match
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1636.md
 dotnet_diagnostic.SA1636.severity = none
 
 # SA1637: File header should contain file name
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1637.md
 dotnet_diagnostic.SA1637.severity = none
 
 # SA1638: File header file name documentation should match file name
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1638.md
 dotnet_diagnostic.SA1638.severity = none
 
 # SA1639: File header should have summary
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1639.md
 dotnet_diagnostic.SA1639.severity = none
 
 # SA1640: File header should have valid company text
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1640.md
 dotnet_diagnostic.SA1640.severity = none
 
 # SA1641: File header company name text should match
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1641.md
 dotnet_diagnostic.SA1641.severity = none
 
 # SA1642: Constructor summary documentation should begin with standard text
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1642.md
 dotnet_diagnostic.SA1642.severity = none
 
 # SA1643: Destructor summary documentation should begin with standard text
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1643.md
 dotnet_diagnostic.SA1643.severity = warning
 
 # SA1648: inheritdoc should be used with inheriting class
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1648.md
 dotnet_diagnostic.SA1648.severity = none
 
 # SA1649: File name should match first type name
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1649.md
 dotnet_diagnostic.SA1649.severity = none
 
 # SA1651: Do not use placeholder elements
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1651.md
 dotnet_diagnostic.SA1651.severity = none
 
 # SX1101: Do not prefix local calls with 'this.'
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1101.md
 dotnet_diagnostic.SX1101.severity = none
 
 # SX1309: Field names should begin with underscore
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309.md
 dotnet_diagnostic.SX1309.severity = none
 
 # SX1309S: Static field names should begin with underscore
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309S.md
 dotnet_diagnostic.SX1309S.severity = none

--- a/.globalconfig
+++ b/.globalconfig
@@ -1023,7 +1023,7 @@ dotnet_diagnostic.IDE0084.severity = silent
 dotnet_diagnostic.IDE0090.severity = suggestion
 
 # IDE0100: RemoveRedundantEquality
-dotnet_diagnostic.IDE0100.severity = silent
+dotnet_diagnostic.IDE0100.severity = warning
 
 # IDE0110: RemoveUnnecessaryDiscard
 dotnet_diagnostic.IDE0110.severity = silent

--- a/.globalconfig
+++ b/.globalconfig
@@ -182,7 +182,7 @@ dotnet_diagnostic.CA1416.severity = warning
 dotnet_diagnostic.CA1417.severity = warning
 
 # CA1418: Use valid platform string
-dotnet_diagnostic.CA1418.severity = silent
+dotnet_diagnostic.CA1418.severity = warning
 
 # CA1501: Avoid excessive inheritance
 dotnet_diagnostic.CA1501.severity = none

--- a/.globalconfig
+++ b/.globalconfig
@@ -339,7 +339,7 @@ dotnet_diagnostic.CA1838.severity = silent
 dotnet_diagnostic.CA1839.severity = suggestion
 
 # CA1840: Use 'Environment.CurrentManagedThreadId'
-dotnet_diagnostic.CA1840.severity = silent
+dotnet_diagnostic.CA1840.severity = warning
 
 # CA1841: Prefer Dictionary.Contains methods
 dotnet_diagnostic.CA1841.severity = silent

--- a/.globalconfig
+++ b/.globalconfig
@@ -348,7 +348,7 @@ dotnet_diagnostic.CA1841.severity = warning
 dotnet_diagnostic.CA1842.severity = warning
 
 # CA1843: Do not use 'WaitAll' with a single task
-dotnet_diagnostic.CA1843.severity = silent
+dotnet_diagnostic.CA1843.severity = warning
 
 # CA1844: Provide memory-based overrides of async methods when subclassing 'Stream'
 dotnet_diagnostic.CA1844.severity = silent

--- a/.globalconfig
+++ b/.globalconfig
@@ -1032,7 +1032,7 @@ dotnet_diagnostic.IDE0110.severity = suggestion
 dotnet_diagnostic.IDE0120.severity = warning
 
 # IDE0130: NamespaceDoesNotMatchFolderStructure
-dotnet_diagnostic.IDE0130.severity = silent
+dotnet_diagnostic.IDE0130.severity = suggestion
 
 # IDE1001: AnalyzerChanged
 dotnet_diagnostic.IDE1001.severity = silent

--- a/.globalconfig
+++ b/.globalconfig
@@ -1020,7 +1020,7 @@ dotnet_diagnostic.IDE0083.severity = silent
 dotnet_diagnostic.IDE0084.severity = silent
 
 # IDE0090: UseNew
-dotnet_diagnostic.IDE0090.severity = silent
+dotnet_diagnostic.IDE0090.severity = suggestion
 
 # IDE0100: RemoveRedundantEquality
 dotnet_diagnostic.IDE0100.severity = silent

--- a/.globalconfig
+++ b/.globalconfig
@@ -354,7 +354,7 @@ dotnet_diagnostic.CA1843.severity = warning
 dotnet_diagnostic.CA1844.severity = warning
 
 # CA1845: Use span-based 'string.Concat'
-dotnet_diagnostic.CA1845.severity = silent
+dotnet_diagnostic.CA1845.severity = warning
 
 # CA1846: Prefer 'AsSpan' over 'Substring'
 dotnet_diagnostic.CA1846.severity = silent

--- a/.globalconfig
+++ b/.globalconfig
@@ -351,7 +351,7 @@ dotnet_diagnostic.CA1842.severity = warning
 dotnet_diagnostic.CA1843.severity = warning
 
 # CA1844: Provide memory-based overrides of async methods when subclassing 'Stream'
-dotnet_diagnostic.CA1844.severity = silent
+dotnet_diagnostic.CA1844.severity = warning
 
 # CA1845: Use span-based 'string.Concat'
 dotnet_diagnostic.CA1845.severity = silent

--- a/.globalconfig
+++ b/.globalconfig
@@ -1065,7 +1065,7 @@ dotnet_diagnostic.IDE2000.severity = warning
 dotnet_diagnostic.IDE2001.severity = warning
 
 # IDE2002: ConsecutiveBracesMustNotHaveBlankLinesBetweenThem
-dotnet_diagnostic.IDE2002.severity = silent
+dotnet_diagnostic.IDE2002.severity = warning
 
 # IDE2003: ConsecutiveStatementPlacement
 dotnet_diagnostic.IDE2003.severity = silent

--- a/.globalconfig
+++ b/.globalconfig
@@ -1062,7 +1062,7 @@ dotnet_diagnostic.IDE1008.severity = silent
 dotnet_diagnostic.IDE2000.severity = warning
 
 # IDE2001: EmbeddedStatementsMustBeOnTheirOwnLine
-dotnet_diagnostic.IDE2001.severity = silent
+dotnet_diagnostic.IDE2001.severity = warning
 
 # IDE2002: ConsecutiveBracesMustNotHaveBlankLinesBetweenThem
 dotnet_diagnostic.IDE2002.severity = silent

--- a/.globalconfig
+++ b/.globalconfig
@@ -1071,7 +1071,7 @@ dotnet_diagnostic.IDE2002.severity = warning
 dotnet_diagnostic.IDE2003.severity = warning
 
 # IDE2004: BlankLineNotAllowedAfterConstructorInitializerColon
-dotnet_diagnostic.IDE2004.severity = silent
+dotnet_diagnostic.IDE2004.severity = warning
 
 # SA0001: XML comment analysis disabled
 dotnet_diagnostic.SA0001.severity = none

--- a/.globalconfig
+++ b/.globalconfig
@@ -1029,7 +1029,7 @@ dotnet_diagnostic.IDE0100.severity = warning
 dotnet_diagnostic.IDE0110.severity = suggestion
 
 # IDE0120: SimplifyLINQExpression
-dotnet_diagnostic.IDE0120.severity = silent
+dotnet_diagnostic.IDE0120.severity = warning
 
 # IDE0130: NamespaceDoesNotMatchFolderStructure
 dotnet_diagnostic.IDE0130.severity = silent

--- a/.globalconfig
+++ b/.globalconfig
@@ -181,6 +181,9 @@ dotnet_diagnostic.CA1416.severity = warning
 # CA1417: Do not use 'OutAttribute' on string parameters for P/Invokes
 dotnet_diagnostic.CA1417.severity = warning
 
+# CA1418: Use valid platform string
+dotnet_diagnostic.CA1418.severity = silent
+
 # CA1501: Avoid excessive inheritance
 dotnet_diagnostic.CA1501.severity = none
 
@@ -332,6 +335,30 @@ dotnet_diagnostic.CA1837.severity = warning
 # CA1838: Avoid 'StringBuilder' parameters for P/Invokes
 dotnet_diagnostic.CA1838.severity = silent
 
+# CA1839: Use 'Environment.ProcessPath'
+dotnet_diagnostic.CA1839.severity = silent
+
+# CA1840: Use 'Environment.CurrentManagedThreadId'
+dotnet_diagnostic.CA1840.severity = silent
+
+# CA1841: Prefer Dictionary.Contains methods
+dotnet_diagnostic.CA1841.severity = silent
+
+# CA1842: Do not use 'WhenAll' with a single task
+dotnet_diagnostic.CA1842.severity = silent
+
+# CA1843: Do not use 'WaitAll' with a single task
+dotnet_diagnostic.CA1843.severity = silent
+
+# CA1844: Provide memory-based overrides of async methods when subclassing 'Stream'
+dotnet_diagnostic.CA1844.severity = silent
+
+# CA1845: Use span-based 'string.Concat'
+dotnet_diagnostic.CA1845.severity = silent
+
+# CA1846: Prefer 'AsSpan' over 'Substring'
+dotnet_diagnostic.CA1846.severity = silent
+
 # CA2000: Dispose objects before losing scope
 dotnet_diagnostic.CA2000.severity = none
 
@@ -469,6 +496,12 @@ dotnet_diagnostic.CA2248.severity = suggestion
 
 # CA2249: Consider using 'string.Contains' instead of 'string.IndexOf'
 dotnet_diagnostic.CA2249.severity = warning
+
+# CA2250: Use 'ThrowIfCancellationRequested'
+dotnet_diagnostic.CA2250.severity = silent
+
+# CA2251: Use 'string.Equals'
+dotnet_diagnostic.CA2251.severity = silent
 
 # CA2300: Do not use insecure deserializer BinaryFormatter
 dotnet_diagnostic.CA2300.severity = none
@@ -743,6 +776,9 @@ dotnet_diagnostic.IL3000.severity = warning
 # IL3001: Avoid using accessing Assembly file path when publishing as a single-file
 dotnet_diagnostic.IL3001.severity = warning
 
+# IL3002: Using member with RequiresAssemblyFilesAttribute can break functionality when embedded in a single-file app
+dotnet_diagnostic.IL3002.severity = silent
+
 # IDE0001: SimplifyNames
 dotnet_diagnostic.IDE0001.severity = silent
 
@@ -983,6 +1019,21 @@ dotnet_diagnostic.IDE0083.severity = silent
 # IDE0084: UseIsNotExpression
 dotnet_diagnostic.IDE0084.severity = silent
 
+# IDE0090: UseNew
+dotnet_diagnostic.IDE0090.severity = silent
+
+# IDE0100: RemoveRedundantEquality
+dotnet_diagnostic.IDE0100.severity = silent
+
+# IDE0110: RemoveUnnecessaryDiscard
+dotnet_diagnostic.IDE0110.severity = silent
+
+# IDE0120: SimplifyLINQExpression
+dotnet_diagnostic.IDE0120.severity = silent
+
+# IDE0130: NamespaceDoesNotMatchFolderStructure
+dotnet_diagnostic.IDE0130.severity = silent
+
 # IDE1001: AnalyzerChanged
 dotnet_diagnostic.IDE1001.severity = silent
 
@@ -1006,6 +1057,21 @@ dotnet_diagnostic.IDE1007.severity = silent
 
 # IDE1008: UnboundConstructor
 dotnet_diagnostic.IDE1008.severity = silent
+
+# IDE2000: MultipleBlankLines
+dotnet_diagnostic.IDE2000.severity = silent
+
+# IDE2001: EmbeddedStatementsMustBeOnTheirOwnLine
+dotnet_diagnostic.IDE2001.severity = silent
+
+# IDE2002: ConsecutiveBracesMustNotHaveBlankLinesBetweenThem
+dotnet_diagnostic.IDE2002.severity = silent
+
+# IDE2003: ConsecutiveStatementPlacement
+dotnet_diagnostic.IDE2003.severity = silent
+
+# IDE2004: BlankLineNotAllowedAfterConstructorInitializerColon
+dotnet_diagnostic.IDE2004.severity = silent
 
 # SA0001: XML comment analysis disabled
 dotnet_diagnostic.SA0001.severity = none


### PR DESCRIPTION
Fix #15498

* Enable [IL3002: Using member with RequiresAssemblyFilesAttribute can break functionality when embedded in a single-file app](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3002).
* Enable [CA1418: Use valid platform string](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418).
* Enable [CA1839: Use 'Environment.ProcessPath'](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839) as _suggestion_.
  * Issue: **#15629**.
* Enable [CA1840: Use 'Environment.CurrentManagedThreadId'](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840).
* Enable [CA1841: Prefer Dictionary.Contains methods](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841).
* Enable [CA1842: Do not use 'WhenAll' with a single task](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842).
* Enable [CA1843: Do not use 'WhenAll' with a single task](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843).
* Enable [CA1844: Provide memory-based overrides of async methods when subclassing 'Stream'](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844).
* Enable [CA1845: Use span-based 'string.Concat'](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845).
* Enable [CA1846: Prefer 'AsSpan' over 'Substring'](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846).
* Enable [CA2250: Use 'ThrowIfCancellationRequested'](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250).
* Enable [CA2251: Use 'string.Equals'](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251).
* Enable [IDE0090: UseNew](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0090) as _suggestion_.
  * Issue: **#15627**.
* Enable [IDE0100: RemoveRedundantEquality](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0100).
* Enable [IDE0110: RemoveUnnecessaryDiscard](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0110) as _suggestion_.
  * Issue: **#15630**.
* Enable [IDE0120: SimplifyLINQExpression](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0120)
* Enable [IDE0130: NamespaceDoesNotMatchFolderStructure](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0130) as _suggestion_.
  * Issue: **#15631**.
* Enable [IDE2000: MultipleBlankLines](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2000)
* Enable [IDE2001: EmbeddedStatementsMustBeOnTheirOwnLine](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2001)
* Enable [IDE2002: ConsecutiveBracesMustNotHaveBlankLinesBetweenThem](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2002)
* Enable [IDE2003: ConsecutiveStatementPlacement](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2003)
* Enable [IDE2004: BlankLineNotAllowedAfterConstructorInitializerColon](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2004)
