### PR TITLE
Fix CA2243: Attribute string literals should parse correctly

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -635,7 +635,7 @@ dotnet_diagnostic.CA2242.severity = suggestion
 
 # CA2243: Attribute string literals should parse correctly
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
-dotnet_diagnostic.CA2243.severity = none
+dotnet_diagnostic.CA2243.severity = warning
 
 # CA2244: Do not duplicate indexed element initializations
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/RemoveAliasCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/RemoveAliasCommand.cs
@@ -9,7 +9,7 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// The implementation of the "Remove-Alias" cmdlet.
     /// </summary>
-    [Cmdlet(VerbsCommon.Remove, "Alias", DefaultParameterSetName = "Default", HelpUri = "")]
+    [Cmdlet(VerbsCommon.Remove, "Alias", DefaultParameterSetName = "Default", HelpUri = "https://go.microsoft.com/fwlink/?linkid=2097127")]
     [Alias("ral")]
     public class RemoveAliasCommand : PSCmdlet
     {

--- a/test/powershell/engine/Help/assets/HelpURI/V2Cmdlets.csv
+++ b/test/powershell/engine/Help/assets/HelpURI/V2Cmdlets.csv
@@ -159,6 +159,7 @@ Register-EngineEvent,https://go.microsoft.com/fwlink/?linkid=2097128
 Register-ObjectEvent,https://go.microsoft.com/fwlink/?linkid=2096714
 Register-PSSessionConfiguration,https://go.microsoft.com/fwlink/?linkid=2096793
 Register-WmiEvent,https://go.microsoft.com/fwlink/?LinkID=135245
+Remove-Alias,https://go.microsoft.com/fwlink/?linkid=2097127
 Remove-Computer,https://go.microsoft.com/fwlink/?LinkID=135246
 Remove-Event,https://go.microsoft.com/fwlink/?linkid=2096715
 Remove-EventLog,https://go.microsoft.com/fwlink/?LinkID=135248


### PR DESCRIPTION
cc: @iSazonov 

* Fix #15625
* Enable [CA2243: Attribute string literals should parse correctly](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243)