### PR TITLE
Enable CA1839: Use 'Environment.ProcessPath'

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -447,7 +447,7 @@ dotnet_diagnostic.CA1838.severity = silent
 
 # CA1839: Use 'Environment.ProcessPath'
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
-dotnet_diagnostic.CA1839.severity = suggestion
+dotnet_diagnostic.CA1839.severity = warning
 
 # CA1840: Use 'Environment.CurrentManagedThreadId'
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840

--- a/test/tools/TestExe/TestExe.cs
+++ b/test/tools/TestExe/TestExe.cs
@@ -64,7 +64,7 @@ namespace TestExe
                 for (uint i = 0; i < num; i++)
                 {
                     Process child = new Process();
-                    child.StartInfo.FileName = Process.GetCurrentProcess().MainModule.FileName;
+                    child.StartInfo.FileName = Environment.ProcessPath;
                     child.StartInfo.Arguments = "-createchildprocess";
                     child.Start();
                 }

--- a/test/xUnit/csharp/test_FileSystemProvider.cs
+++ b/test/xUnit/csharp/test_FileSystemProvider.cs
@@ -115,7 +115,7 @@ namespace PSTests.Parallel
             {
                 directoryObject = new DirectoryInfo(System.Environment.CurrentDirectory);
                 fileObject = new FileInfo(System.Reflection.Assembly.GetEntryAssembly().Location);
-                executableObject = new FileInfo(System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName);
+                executableObject = new FileInfo(Environment.ProcessPath);
             }
 
             Assert.Equal("d----", FileSystemProvider.Mode(PSObject.AsPSObject(directoryObject)).Replace("r", "-"));


### PR DESCRIPTION
Fix #15629.

Enable [CA1839: Use 'Environment.ProcessPath'](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839)
