### PR TITLE
Test if a command is 'Out-Default' more thoroughly

### DIFF
--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -438,7 +438,7 @@ namespace System.Management.Automation.Host
             {
                 if (TranscriptionData.SystemTranscript == null)
                 {
-                    TranscriptionData.SystemTranscript = PSHostUserInterface.GetSystemTranscriptOption(TranscriptionData.SystemTranscript);
+                    TranscriptionData.SystemTranscript = GetSystemTranscriptOption(TranscriptionData.SystemTranscript);
                     if (TranscriptionData.SystemTranscript != null)
                     {
                         LogTranscriptHeader(null, TranscriptionData.SystemTranscript);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #15651

PowerShell [automatically adds 'Out-Default -Transcript' to the end of pipeline](https://github.com/PowerShell/PowerShell/blob/1f2dc26ab45d07ac0cd90b6a76af946d088d5243/src/System.Management.Automation/engine/hostifaces/LocalPipeline.cs#L325-L335) when it's transcribing and invoked via API. When [`-Transcript`](https://github.com/PowerShell/PowerShell/blob/1f2dc26ab45d07ac0cd90b6a76af946d088d5243/src/System.Management.Automation/FormatAndOutput/out-console/OutConsole.cs#L46-L53) is specified, objects passed through are transcribed but [are not passed ahead to the host](https://github.com/PowerShell/PowerShell/blob/1f2dc26ab45d07ac0cd90b6a76af946d088d5243/src/System.Management.Automation/FormatAndOutput/out-console/ConsoleLineOutput.cs#L337-L343).

The PowerShell sub-kernel actually already adds `Out-Default` to pass output to host, however, [we have to use `Out-Default2` as the name](https://github.com/dotnet/interactive/blob/09d6307ddaea52ea39c41abfa980fd3dce9a25d6/src/Microsoft.DotNet.Interactive.PowerShell/PowerShellKernel.cs#L63-L68) due to a limitation in the native command processor. Since we are using `Out-Default2`, PowerShell believes it doesn't have the `Out-Default` command at the end, and thus adds `Out-Default -Transcript` automatically, which prevents sending anything to the host and hence you don't see output from PowerShell sub-kernel when the transcription is turned on.

This needs to be fixed in the `InvokeHelper()` method, to not just check for the `Out-Default` name, but also check whether the `ImplementingType` is `typeof(OutDefaultCommand)`.

This PR also refactors the code a bit, to calculate `needToAddOutDefault` only if PowerShell is transcribing.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
