### PR TITLE
Revert "Temporary disable Update-Help tests for PackageManagement module"

### DIFF
--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -20,7 +20,7 @@ $powershellCoreModules = @(
     "Microsoft.PowerShell.Security"
     "Microsoft.PowerShell.Utility"
     "Microsoft.WsMan.Management"
-    # "PackageManagement" - tracking issue https://github.com/PowerShell/PowerShell/issues/15654
+    "PackageManagement"
 #    "PowershellGet"
 )
 


### PR DESCRIPTION
Reverts PowerShell/PowerShell#15661.

Fixes https://github.com/PowerShell/PowerShell/issues/15654.