### PR TITLE
Don't serialize to json ETS properties for DateTime and string types

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -679,7 +679,7 @@ namespace Microsoft.PowerShell.Commands
         private static void AppendPsProperties(PSObject psObj, IDictionary receiver, int depth, bool isCustomObject, in ConvertToJsonContext context)
         {
             // if the psObj is a DateTime or String type, we don't serialize any extended or adapted properties
-            if (psObj.BaseObject is DateTime || psObj.BaseObject is string)
+            if (psObj.BaseObject is string || psObj.BaseObject is DateTime)
             {
                 return;
             }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -678,6 +678,12 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="context">The context for the operation.</param>
         private static void AppendPsProperties(PSObject psObj, IDictionary receiver, int depth, bool isCustomObject, in ConvertToJsonContext context)
         {
+            // if the psObj is a DateTime or String type, we don't serialize any extended or adapted properties
+            if (psObj.BaseObject is DateTime || psObj.BaseObject is string)
+            {
+                return;
+            }
+
             // serialize only Extended and Adapted properties..
             PSMemberInfoCollection<PSPropertyInfo> srcPropertiesToSearch =
                 new PSMemberInfoIntegratingCollection<PSPropertyInfo>(psObj,

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
@@ -131,4 +131,16 @@ Describe 'ConvertTo-Json' -tags "CI" {
             $p2.psobject.Properties.Remove('nullstr')
         }
     }
+
+    It 'Should not serialize ETS properties added to DateTime' {
+        $date = "2021-06-24T15:54:06.796999-07:00"
+        $d = [DateTime]::Parse($date)
+        $d | ConvertTo-Json -Compress | Should -BeExactly "`"$date`""
+    }
+
+    It 'Should not serialize ETS properties added to String' {
+        $text = "Hello there"
+        $t = Add-Member -InputObject $text -MemberType NoteProperty -Name text -Value $text -PassThru
+        $t | ConvertTo-Json -Compress | Should -BeExactly "`"$text`""
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
@@ -135,7 +135,10 @@ Describe 'ConvertTo-Json' -tags "CI" {
     It 'Should not serialize ETS properties added to DateTime' {
         $date = "2021-06-24T15:54:06.796999-07:00"
         $d = [DateTime]::Parse($date)
-        $d | ConvertTo-Json -Compress | Should -BeExactly "`"$date`""
+
+        # need to use wildcard here due to some systems may be configured with different culture setting showing time in different format
+        $d | ConvertTo-Json -Compress | Should -BeLike '"2021-06-24T*'
+        $d | ConvertTo-Json | ConvertFrom-Json | Should -Be $d
     }
 
     It 'Should not serialize ETS properties added to String' {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

PowerShell automatically adds extended properties to `DateTime` (specifically `DisplayHint`) objects that is used with formatting.  This is intended to be "internal", but when converted to JSON, those extra properties turn what should be a json datetime to a complex object.  For `string` types, if the user has added extended properties, this can result in recursive serialization behavior.

The @PowerShell/powershell-committee agreed to special case both `DateTime` and `string` types to not serialize any extended properties when converting to JSON.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/5797

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
