### PR TITLE
Enable CA1812: Avoid uninstantiated internal classes

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -346,7 +346,7 @@ dotnet_diagnostic.CA1810.severity = none
 
 # CA1812: Avoid uninstantiated internal classes
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
-dotnet_diagnostic.CA1812.severity = none
+dotnet_diagnostic.CA1812.severity = warning
 
 # CA1813: Avoid unsealed attributes
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Join-String.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Join-String.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Management.Automation;
@@ -159,6 +160,10 @@ namespace Microsoft.PowerShell.Commands.Utility
         }
     }
 
+    [SuppressMessage(
+        "Microsoft.Performance",
+        "CA1812:AvoidUninstantiatedInternalClasses",
+        Justification = "Class is instantiated through late-bound reflection")]
     internal class JoinItemCompleter : IArgumentCompleter
     {
         public IEnumerable<CompletionResult> CompleteArgument(


### PR DESCRIPTION
Enable [CA1812: Avoid uninstantiated internal classes](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812)

Add suppression for classes instantiated with `System.Activator.CreateInstance`.