### PR TITLE
Avoid Linq `Single` when `Count` is known

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/ExtrinsicMethodInvocationJob.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/ExtrinsicMethodInvocationJob.cs
@@ -105,7 +105,7 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
 
             if (cmdletOutput.Count == 1)
             {
-                var singleOutputParameter = cmdletOutput.Values.Single();
+                var singleOutputParameter = cmdletOutput.Values.First();
                 if (singleOutputParameter.Value == null)
                 {
                     return;

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/clientSideQuery.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/clientSideQuery.cs
@@ -202,7 +202,7 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
 
                 if (valueBehaviors.Count == 1)
                 {
-                    this.BehaviorOnNoMatch = valueBehaviors.Single();
+                    this.BehaviorOnNoMatch = valueBehaviors.First();
                 }
                 else
                 {

--- a/src/System.Management.Automation/cimSupport/cmdletization/ScriptWriter.cs
+++ b/src/System.Management.Automation/cimSupport/cmdletization/ScriptWriter.cs
@@ -1983,7 +1983,7 @@ Microsoft.PowerShell.Core\Export-ModuleMember -Function '{1}' -Alias '*'
             }
             else if (queryParameterSets.Count == 1)
             {
-                commandMetadata.DefaultParameterSetName = queryParameterSets.Single();
+                commandMetadata.DefaultParameterSetName = queryParameterSets[0];
             }
 
             AddPassThruParameter(commonParameters, instanceCmdlet);


### PR DESCRIPTION
Fix [HLQ005: Avoid use of `Single()`, `SingleOrDefault()`, `SingleAsync()` and `SingleOrDefaultAsync()` operations](https://github.com/NetFabric/NetFabric.Hyperlinq.Analyzer/blob/master/docs/reference/HLQ005_AvoidSingle.md)