### PR TITLE
Remove pre-parse for array-based JSON

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -160,22 +160,6 @@ namespace Microsoft.PowerShell.Commands
             error = null;
             try
             {
-                // JsonConvert.DeserializeObject does not throw an exception when an invalid Json array is passed.
-                // This issue is being tracked by https://github.com/JamesNK/Newtonsoft.Json/issues/1930.
-                // To work around this, we need to identify when input is a Json array, and then try to parse it via JArray.Parse().
-
-                // If input starts with '[' (ignoring white spaces).
-                if (Regex.Match(input, @"^\s*\[").Success)
-                {
-                    // JArray.Parse() will throw a JsonException if the array is invalid.
-                    // This will be caught by the catch block below, and then throw an
-                    // ArgumentException - this is done to have same behavior as the JavaScriptSerializer.
-                    JArray.Parse(input);
-
-                    // Please note that if the Json array is valid, we don't do anything,
-                    // we just continue the deserialization.
-                }
-
                 var obj = JsonConvert.DeserializeObject(
                     input,
                     new JsonSerializerSettings

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Json.Tests.ps1
@@ -58,7 +58,15 @@ Describe 'ConvertFrom-Json Unit Tests' -tags "CI" {
             $json | Should -BeOfType Hashtable
         }
     }
-
+    
+	It 'Throws an ArgumentException with an incomplete array with AsHashtable switch set to <AsHashtable>' -TestCase $testCasesWithAndWithoutAsHashtableSwitch {
+        Param($AsHashtable)
+        { ConvertFrom-Json '["1",' -AsHashtable:$AsHashtable } |
+            Should -Throw -ErrorId "System.ArgumentException,Microsoft.PowerShell.Commands.ConvertFromJsonCommand"
+        { ConvertFrom-Json '[' -AsHashtable:$AsHashtable } |
+            Should -Throw -ErrorId "System.ArgumentException,Microsoft.PowerShell.Commands.ConvertFromJsonCommand"
+    }
+	
     It 'Can convert multi-line object with AsHashtable switch set to <AsHashtable>' -TestCases $testCasesWithAndWithoutAsHashtableSwitch {
         Param($AsHashtable)
         $json = @('{"a" :', '"x"}') | ConvertFrom-Json -AsHashtable:$AsHashtable


### PR DESCRIPTION
# PR Summary

Removes a previously-needed check from the convertfrom-json cmdlet. It appears a pre-parsing step was added for json whose root element was an array -- because of some issues with how Newtonsoft handled issues with Arrays in deserializeObject https://github.com/JamesNK/Newtonsoft.Json/issues/1930

Upon further testing this bug is no longer present in Newtonsoft.Json and this preparsing can be removed. This was previously attempted and then rolled back because newtonsoft.json failed when deserializing a `[`. I have no idea why we needed to double parse this to check if the contents were `[` but the tests are passing and the cases previously listed as causing issues are now working.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

It makes ConvertFrom-Json and Invoke-RestMethod  ~50% faster. It does not reduce memory usage because the pre-parsing was immediately tossed out after it occurred.

Benchmark for parsing a 100MB JSON blob whose root element is an array.

Master:

Run Built-in Cmdlet: Hashtable
- Memory Usage: 1079.3671875 MB
- Runtime: 7256.4268 ms

Run Built-in Cmdlet: PSCustomObject
- Memory Usage: 1338.74609375 MB
- Runtime: 10430.8258 ms

ThisPR:

Run Built-in Cmdlet: Hashtable
- Memory Usage: 1077.58203125 MB
- Runtime: 3885.0489 ms

Run Built-in Cmdlet: PSCustomObject
- Memory Usage: 1374.69921875 MB
- Runtime: 6976.1836 ms

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
