### PR TITLE
Use new JSON Streaming methods for Invoke-RestMethod

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -192,7 +192,7 @@ namespace Microsoft.PowerShell.Commands
             try
             {
                 ErrorRecord error;
-                obj = JsonObject.ConvertFromJson(stream, AsHashtable, out error);
+                obj = JsonObject.ConvertFromJsonStream(stream, AsHashtable, out error);
 
                 if (obj == null)
                 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -160,22 +160,6 @@ namespace Microsoft.PowerShell.Commands
             error = null;
             try
             {
-                // JsonConvert.DeserializeObject does not throw an exception when an invalid Json array is passed.
-                // This issue is being tracked by https://github.com/JamesNK/Newtonsoft.Json/issues/1930.
-                // To work around this, we need to identify when input is a Json array, and then try to parse it via JArray.Parse().
-
-                // If input starts with '[' (ignoring white spaces).
-                if (Regex.Match(input, @"^\s*\[").Success)
-                {
-                    // JArray.Parse() will throw a JsonException if the array is invalid.
-                    // This will be caught by the catch block below, and then throw an
-                    // ArgumentException - this is done to have same behavior as the JavaScriptSerializer.
-                    JArray.Parse(input);
-
-                    // Please note that if the Json array is valid, we don't do anything,
-                    // we just continue the deserialization.
-                }
-
                 var obj = JsonConvert.DeserializeObject(
                     input,
                     new JsonSerializerSettings

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -263,7 +263,6 @@ namespace Microsoft.PowerShell.Commands
                 default:
                     return thisObject;
             }
-            
         }
 
         // This function is a clone of PopulateFromDictionary using JObject as an input.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -118,9 +118,9 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="error">An error record if the conversion failed.</param>
         /// <returns>A PSObject.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", Justification = "Preferring Json over JSON")]
-        public static object ConvertFromJson(StreamReader stream, out ErrorRecord error)
+        public static object ConvertFromJsonStream(StreamReader stream, out ErrorRecord error)
         {
-            return ConvertFromJson(stream, returnHashtable: false, out error);
+            return ConvertFromJsonStream(stream, returnHashtable: false, out error);
         }
 
         /// <summary>
@@ -146,9 +146,9 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>A <see cref="System.Management.Automation.PSObject"/> or a <see cref="System.Collections.Hashtable"/>
         /// if the <paramref name="returnHashtable"/> parameter is true.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", Justification = "Preferring Json over JSON")]
-        public static object ConvertFromJson(StreamReader stream, bool returnHashtable, out ErrorRecord error)
+        public static object ConvertFromJsonStream(StreamReader stream, bool returnHashtable, out ErrorRecord error)
         {
-            return ConvertFromJson(stream, returnHashtable, maxDepth: 1024, out error);
+            return ConvertFromJsonStream(stream, returnHashtable, maxDepth: 1024, out error);
         }
 
         /// <summary>
@@ -171,6 +171,24 @@ namespace Microsoft.PowerShell.Commands
         /// Convert a JSON string back to an object of type <see cref="System.Management.Automation.PSObject"/> or
         /// <see cref="System.Collections.Hashtable"/> depending on parameter <paramref name="returnHashtable"/>.
         /// </summary>
+        /// <param name="input">The JSON text to convert.</param>
+        /// <param name="returnHashtable">True if the result should be returned as a <see cref="System.Collections.Hashtable"/>
+        /// instead of a <see cref="System.Management.Automation.PSObject"/>.</param>
+        /// <param name="maxDepth">The max depth allowed when deserializing the json input. Set to null for no maximum.</param>
+        /// <param name="error">An error record if the conversion failed.</param>
+        /// <returns>A <see cref="System.Management.Automation.PSObject"/> or a <see cref="System.Collections.Hashtable"/>
+        /// if the <paramref name="returnHashtable"/> parameter is true.</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", Justification = "Preferring Json over JSON")]
+        public static object ConvertFromJson(string input, bool returnHashtable, int? maxDepth, out ErrorRecord error)
+        {
+            StreamReader thisStream = new StreamReader(new MemoryStream(System.Text.Encoding.UTF8.GetBytes(input)));
+            return ConvertFromJsonStream(thisStream, returnHashtable, maxDepth, out error);
+        }
+
+        /// <summary>
+        /// Convert a JSON string back to an object of type <see cref="System.Management.Automation.PSObject"/> or
+        /// <see cref="System.Collections.Hashtable"/> depending on parameter <paramref name="returnHashtable"/>.
+        /// </summary>
         /// <param name="stream">The JSON text to convert.</param>
         /// <param name="returnHashtable">True if the result should be returned as a <see cref="System.Collections.Hashtable"/>
         /// instead of a <see cref="System.Management.Automation.PSObject"/>.</param>
@@ -179,7 +197,7 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>A <see cref="System.Management.Automation.PSObject"/> or a <see cref="System.Collections.Hashtable"/>
         /// if the <paramref name="returnHashtable"/> parameter is true.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", Justification = "Preferring Json over JSON")]
-        public static object ConvertFromJson(StreamReader stream, bool returnHashtable, int? maxDepth, out ErrorRecord error)
+        public static object ConvertFromJsonStream(StreamReader stream, bool returnHashtable, int? maxDepth, out ErrorRecord error)
         {
             if (stream == null)
             {
@@ -239,24 +257,6 @@ namespace Microsoft.PowerShell.Commands
                 // the same as JavaScriptSerializer does
                 throw new ArgumentException(msg, je);
             }
-        }
-
-        /// <summary>
-        /// Convert a JSON string back to an object of type <see cref="System.Management.Automation.PSObject"/> or
-        /// <see cref="System.Collections.Hashtable"/> depending on parameter <paramref name="returnHashtable"/>.
-        /// </summary>
-        /// <param name="input">The JSON text to convert.</param>
-        /// <param name="returnHashtable">True if the result should be returned as a <see cref="System.Collections.Hashtable"/>
-        /// instead of a <see cref="System.Management.Automation.PSObject"/>.</param>
-        /// <param name="maxDepth">The max depth allowed when deserializing the json input. Set to null for no maximum.</param>
-        /// <param name="error">An error record if the conversion failed.</param>
-        /// <returns>A <see cref="System.Management.Automation.PSObject"/> or a <see cref="System.Collections.Hashtable"/>
-        /// if the <paramref name="returnHashtable"/> parameter is true.</returns>
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", Justification = "Preferring Json over JSON")]
-        public static object ConvertFromJson(string input, bool returnHashtable, int? maxDepth, out ErrorRecord error)
-        {
-            StreamReader thisStream = new StreamReader(new MemoryStream(System.Text.Encoding.UTF8.GetBytes(input)));
-            return ConvertFromJson(thisStream, returnHashtable, maxDepth, out error);
         }
 
         private static List<object> DeserializeRootArrayHelper(JsonReader reader, JsonSerializer serializer, bool returnHashtable, out ErrorRecord error)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -221,10 +221,11 @@ namespace Microsoft.PowerShell.Commands
                         throw new ArgumentException(errorMsg);
                     }
 
+                    // if we processed an array let's return the array
+                    // If we did not process the array we can return the first (and only) object in our result arraylist
                     if (isArray)
                     {
                         return result.ToArray();
-
                     }
                     else if (result.Count >= 1)
                     {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -161,7 +161,6 @@ namespace Microsoft.PowerShell.Commands
             error = null;
             try
             {
-
                 var serializer = new JsonSerializer();
 
                 serializer.TypeNameHandling = TypeNameHandling.None;
@@ -174,6 +173,7 @@ namespace Microsoft.PowerShell.Commands
                     bool isArray = false;
 
                     var readResult = reader.Read();
+
                     // If the first token in our file is an array let's read in that token so that our next token is an object or a primitive.
                     // This will allow newtonsoft to deserialize the incoming json one object at a time instead of doing the whole object at once.
                     if (reader.TokenType == JsonToken.StartArray)
@@ -181,6 +181,7 @@ namespace Microsoft.PowerShell.Commands
                         isArray = true;
                         reader.Read();
                     }
+
                     System.Collections.ArrayList result = new System.Collections.ArrayList();
 
                     do
@@ -205,7 +206,8 @@ namespace Microsoft.PowerShell.Commands
                                 result.Add(thisObject);
                                 break;
                         }
-                    } while (reader.Read());
+                    } 
+                    while (reader.Read());
 
                     // Earlier we stripped off the start of the array. Here we want to make sure that if we were handling an array that we ended with an EndArray token.
                     if (isArray && reader.TokenType != JsonToken.EndArray)
@@ -222,6 +224,7 @@ namespace Microsoft.PowerShell.Commands
                     if (isArray)
                     {
                         return result.ToArray();
+
                     }
                     else if (result.Count >= 1)
                     {
@@ -232,7 +235,6 @@ namespace Microsoft.PowerShell.Commands
                         return null;
                     }
                 }
-
             }
             catch (JsonException je)
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -114,6 +114,18 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Convert a Json string back to an object of type PSObject.
         /// </summary>
+        /// <param name="stream">The json text to convert.</param>
+        /// <param name="error">An error record if the conversion failed.</param>
+        /// <returns>A PSObject.</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", Justification = "Preferring Json over JSON")]
+        public static object ConvertFromJson(StreamReader stream, out ErrorRecord error)
+        {
+            return ConvertFromJson(stream, returnHashtable: false, out error);
+        }
+
+        /// <summary>
+        /// Convert a Json string back to an object of type PSObject.
+        /// </summary>
         /// <param name="input">The json text to convert.</param>
         /// <param name="error">An error record if the conversion failed.</param>
         /// <returns>A PSObject.</returns>
@@ -124,15 +136,19 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Convert a Json string back to an object of type PSObject.
+        /// Convert a Json string back to an object of type <see cref="System.Management.Automation.PSObject"/> or
+        /// <see cref="System.Collections.Hashtable"/> depending on parameter <paramref name="returnHashtable"/>.
         /// </summary>
         /// <param name="stream">The json text to convert.</param>
+        /// <param name="returnHashtable">True if the result should be returned as a <see cref="System.Collections.Hashtable"/>
+        /// instead of a <see cref="System.Management.Automation.PSObject"/></param>
         /// <param name="error">An error record if the conversion failed.</param>
-        /// <returns>A PSObject.</returns>
+        /// <returns>A <see cref="System.Management.Automation.PSObject"/> or a <see cref="System.Collections.Hashtable"/>
+        /// if the <paramref name="returnHashtable"/> parameter is true.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", Justification = "Preferring Json over JSON")]
-        public static object ConvertFromJson(StreamReader stream, out ErrorRecord error)
+        public static object ConvertFromJson(StreamReader stream, bool returnHashtable, out ErrorRecord error)
         {
-            return ConvertFromJson(stream, returnHashtable: false, out error);
+            return ConvertFromJson(stream, returnHashtable, maxDepth: 1024, out error);
         }
 
         /// <summary>
@@ -149,21 +165,6 @@ namespace Microsoft.PowerShell.Commands
         public static object ConvertFromJson(string input, bool returnHashtable, out ErrorRecord error)
         {
             return ConvertFromJson(input, returnHashtable, maxDepth: 1024, out error);
-        }
-        /// <summary>
-        /// Convert a Json string back to an object of type <see cref="System.Management.Automation.PSObject"/> or
-        /// <see cref="System.Collections.Hashtable"/> depending on parameter <paramref name="returnHashtable"/>.
-        /// </summary>
-        /// <param name="stream">The json text to convert.</param>
-        /// <param name="returnHashtable">True if the result should be returned as a <see cref="System.Collections.Hashtable"/>
-        /// instead of a <see cref="System.Management.Automation.PSObject"/></param>
-        /// <param name="error">An error record if the conversion failed.</param>
-        /// <returns>A <see cref="System.Management.Automation.PSObject"/> or a <see cref="System.Collections.Hashtable"/>
-        /// if the <paramref name="returnHashtable"/> parameter is true.</returns>
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", Justification = "Preferring Json over JSON")]
-        public static object ConvertFromJson(StreamReader stream, bool returnHashtable, out ErrorRecord error)
-        {
-            return ConvertFromJson(stream, returnHashtable, maxDepth: 1024, out error);
         }
 
         /// <summary>
@@ -254,7 +255,7 @@ namespace Microsoft.PowerShell.Commands
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", Justification = "Preferring Json over JSON")]
         public static object ConvertFromJson(string input, bool returnHashtable, int? maxDepth, out ErrorRecord error)
         {
-            StreamReader thisStream = new StreamReader(new MemoryStream(System.Text.Encoding.Default.GetBytes(input)));
+            StreamReader thisStream = new StreamReader(new MemoryStream(System.Text.Encoding.UTF8.GetBytes(input)));
             return ConvertFromJson(thisStream, returnHashtable, maxDepth, out error);
         }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -546,7 +546,6 @@ namespace Microsoft.PowerShell.Commands
         #endregion ConvertFromJson
 
         #region ConvertToJson
-
         /// <summary>
         /// Convert an object to JSON string.
         /// </summary>
@@ -557,6 +556,7 @@ namespace Microsoft.PowerShell.Commands
                 // Pre-process the object so that it serializes the same, except that properties whose
                 // values cannot be evaluated are treated as having the value null.
                 _maxDepthWarningWritten = false;
+                object preprocessedObject = ProcessValue(objectToProcess, currentDepth: 0, in context);
                 var jsonSettings = new JsonSerializerSettings
                 {
                     // This TypeNameHandling setting is required to be secure.
@@ -575,36 +575,7 @@ namespace Microsoft.PowerShell.Commands
                     jsonSettings.Formatting = Formatting.Indented;
                 }
 
-                Type typ = objectToProcess.GetType();
-                
-                if (context.CompressOutput && typ.IsArray)
-                {
-                    System.Text.StringBuilder thisWriter = new System.Text.StringBuilder();
-
-                    thisWriter.Append('[');
-
-                    object[] objectToProcessArray = (object[])objectToProcess;
-
-                    for (int i = 0; i < objectToProcessArray.Length; i++)
-                    {
-                        object preprocessedObject = ProcessValue(objectToProcessArray[i], currentDepth: 0, in context);
-                        thisWriter.Append(JsonConvert.SerializeObject(preprocessedObject, jsonSettings));
-
-                        if (i != (objectToProcessArray.Length - 1))
-                        {
-                            thisWriter.Append(',');
-                        }
-                    }
-                    
-                    thisWriter.Append(']');
-
-                    return thisWriter.ToString();
-                }
-                else
-                {
-                    object preprocessedObject = ProcessValue(objectToProcess, currentDepth: 0, in context);
-                    return JsonConvert.SerializeObject(preprocessedObject, jsonSettings);
-                } 
+                return JsonConvert.SerializeObject(preprocessedObject, jsonSettings);
             }
             catch (OperationCanceledException)
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -477,12 +477,6 @@ namespace Microsoft.PowerShell.Commands
             return result;
         }
 
-        /*
-        private static object ProcessValue (object obj)
-        {
-            if (obj is )
-        }
-        */
         #endregion ConvertFromJson
 
         #region ConvertToJson


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR is a "child" PR to: https://github.com/PowerShell/PowerShell/pull/15695

This PR is in good shape but needs tests for the additional parameter on invoke-restmethod for -ashashtable

Essentially if the streaming approach from that PR is approved we can make new methods which take a stream directly instead of the string body. We can then wire up invoke-restmethod so that it takes the response stream and sends it directly to newtonsoft.

This should improve all use-cases of invoke-restmethod but will particularly improve cases where the source API has an array as its root element.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

This should greatly reduce the memory usage of the invoke-restmethod cmdlets and somewhat reduce the execution time/cpu time.

Benchmarks for a 100MB JSON Response with Array root element (Time to first byte from the API is about 8s so for realistic times subtract 8000ms from each runtime number)

7.1.3:
- Memory Usage: **1597 MB**
- Runtime: **20679.9797 ms**
- Est Runtime: **12679.9797 ms**

ThisPR:
- Memory Usage: 718.55 MB
- Runtime: 16323.1985 ms
- Est Runtime: 8323.1985 ms

ThisPR -AsHashtable:
- Memory Usage: **415.41 MB**
- Runtime: **13592.6211 ms**
- Est Runtime: **5592.6211 ms**

Benchmarks for a 100MB JSON response with Object root element
7.1.3
- Memory Usage: 1672.84765625 MB
- Runtime: 12771.3602 ms
- Est Runtime: 12771.3602 ms

This PR:
- Memory Usage: 1489.90625 MB
- Runtime: 12222.5628 ms

This PR -AsHashtable
- Memory Usage: 1146.078125 MB
- Runtime: 11367.9809 ms


Benchmarks for a 12MB JSON Response
7.1.3:
- Memory Usage: 268.9921875 MB
- Runtime: 2553.9797 ms

ThisPR:
- Memory Usage: 100.05078125 MB
- Runtime: 1950.1985 ms

Runtime is misleading as I am hitting a real API

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
