### PR TITLE
Add tests for ConvertFrom-Json

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
@@ -373,9 +373,8 @@ Describe "Json Tests" -Tags "Feature" {
 	"date-y-should-parse-as-string": "September 2008"
 }
 "@
-			foreach ($AsHashtableOption in @($True, $false)) {
-				$result = ConvertFrom-Json $json -AsHashtable:$AsHashtableOption
-
+			foreach ($asHashtableOption in @($True, $false)) {
+				$result = ConvertFrom-Json $json -AsHashtable:$asHashtableOption
 
 				$result."date-s-should-parse-as-datetime".ToString("d") | Should -Be "9/22/2008"
 				$result."date-s-should-parse-as-datetime".ToString("D") | Should -Be "Monday, September 22, 2008"
@@ -544,7 +543,6 @@ Describe "Json Tests" -Tags "Feature" {
 			$result.Tags[0] | Should -Be "laboris"
 			$result.Tags | Should -Be @("laboris", "voluptate", "amet", "ad", "velit", "ipsum", "do")
 			
-			
 			$result.Friends | Should -Beoftype [pscustomobject]
 			$result.Friends[0].id | Should -Be 0
 			$result.Friends[0].name | Should -Be "Renee Holden"
@@ -552,8 +550,6 @@ Describe "Json Tests" -Tags "Feature" {
 			$result.Friends[1].name | Should -Be "Bennett Dixon"
 			$result.Friends[2].id | Should -Be 2
 			$result.Friends[2].name | Should -Be "Emilia Holder"
-			$result.Tags.count | Should -Be 7 
-			$result.Tags | Should -Be @("laboris", "voluptate", "amet", "ad", "velit", "ipsum", "do")
 		}
 		
 		It "ConvertFrom-Json chooses the appropriate number type" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
@@ -345,6 +345,110 @@ Describe "Json Tests" -Tags "Feature" {
             ValidateSampleObject -result $result -hasEmbeddedSampleObject
         }
 
+		It "ConvertFrom-Json correctly processes datetimes vs strings using newtonsoft conventions" {
+			# Create all the various "standard" date formats from a source date 2008-09-22T14:01:54.9571247Z
+			# Then we deserialize them and verify which ones newtonsoft decides to make into datetimes and which ones newtonsoft keeps as strings
+			# For the ones that are datetimes, make sure they retain all of the various formats correctly
+			# for the ones that are strings just verify that they are actually strings.
+
+			$json = @"
+{
+	"date-s-should-parse-as-datetime": "2008-09-22T14:01:54",
+	"date-upperO-should-parse-as-datetime": "2008-09-22T14:01:54.9571247Z",
+	
+	"date-o-should-parse-as-string": "2019-12-17T06:14:06 +06:00",
+	"date-upperD-should-parse-as-string": "Monday, September 22, 2008",
+	"date-f-should-parse-as-string": "Monday, September 22, 2008 2:01 PM",
+	"date-upperF-should-parse-as-string": "Monday, September 22, 2008 2:01:54 PM",
+	"date-g-should-parse-as-string": "9/22/2008 2:01 PM",
+	"date-upperG-should-parse-as-string": "9/22/2008 2:01:54 PM",
+	"date-m-should-parse-as-string": "September 22",
+	"date-upperM-should-parse-as-string": "September 22",
+	"date-upperR-should-parse-as-string": "Mon, 22 Sep 2008 14:01:54 GMT",
+	"date-t-should-parse-as-string": "2:01 PM",
+	"date-upperT-should-parse-as-string": "2:01:54 PM",
+	"date-u-should-parse-as-string": "2008-09-22 14:01:54Z",
+	"date-upperU-should-parse-as-string": "Monday, September 22, 2008 2:01:54 PM",
+	"date-upperY-should-parse-as-string": "September 2008",
+	"date-y-should-parse-as-string": "September 2008"
+}
+"@
+			foreach ($AsHashtableOption in @($True, $false)) {
+				$object = ConvertFrom-Json $json -AsHashtable:$AsHashtableOption
+
+
+				$Object."date-s-should-parse-as-datetime".ToString("d") | should -be "9/22/2008"
+				$Object."date-s-should-parse-as-datetime".ToString("D") | should -be "Monday, September 22, 2008"
+				$Object."date-s-should-parse-as-datetime".ToString("f") | should -be "Monday, September 22, 2008 2:01 PM"
+				$Object."date-s-should-parse-as-datetime".ToString("F") | should -be "Monday, September 22, 2008 2:01:54 PM"
+				$Object."date-s-should-parse-as-datetime".ToString("g") | should -be "9/22/2008 2:01 PM"
+				$Object."date-s-should-parse-as-datetime".ToString("G") | should -be "9/22/2008 2:01:54 PM"
+				$Object."date-s-should-parse-as-datetime".ToString("m") | should -be "September 22"
+				$Object."date-s-should-parse-as-datetime".ToString("M") | should -be "September 22"
+				$Object."date-s-should-parse-as-datetime".ToString("o") | should -be "2008-09-22T14:01:54.0000000"
+				$Object."date-s-should-parse-as-datetime".ToString("O") | should -be "2008-09-22T14:01:54.0000000"
+				$Object."date-s-should-parse-as-datetime".ToString("R") | should -be "Mon, 22 Sep 2008 14:01:54 GMT"
+				$Object."date-s-should-parse-as-datetime".ToString("s") | should -be "2008-09-22T14:01:54"
+				$Object."date-s-should-parse-as-datetime".ToString("t") | should -be "2:01 PM"
+				$Object."date-s-should-parse-as-datetime".ToString("T") | should -be "2:01:54 PM"
+				$Object."date-s-should-parse-as-datetime".ToString("u") | should -be "2008-09-22 14:01:54Z"
+				$Object."date-s-should-parse-as-datetime".ToString("U") | should -be "Monday, September 22, 2008 7:01:54 PM"
+				$Object."date-s-should-parse-as-datetime".ToString("Y") | should -be "September 2008"
+				$Object."date-s-should-parse-as-datetime".ToString("y") | should -be "September 2008"
+				$Object."date-s-should-parse-as-datetime" | should -beoftype [DateTime]
+				
+				$Object."date-upperO-should-parse-as-datetime".ToString("d") | should -be "9/22/2008"
+				$Object."date-upperO-should-parse-as-datetime".ToString("D") | should -be "Monday, September 22, 2008"
+				$Object."date-upperO-should-parse-as-datetime".ToString("f") | should -be "Monday, September 22, 2008 2:01 PM"
+				$Object."date-upperO-should-parse-as-datetime".ToString("F") | should -be "Monday, September 22, 2008 2:01:54 PM"
+				$Object."date-upperO-should-parse-as-datetime".ToString("g") | should -be "9/22/2008 2:01 PM"
+				$Object."date-upperO-should-parse-as-datetime".ToString("G") | should -be "9/22/2008 2:01:54 PM"
+				$Object."date-upperO-should-parse-as-datetime".ToString("m") | should -be "September 22"
+				$Object."date-upperO-should-parse-as-datetime".ToString("M") | should -be "September 22"
+				$Object."date-upperO-should-parse-as-datetime".ToString("o") | should -be "2008-09-22T14:01:54.9571247Z"
+				$Object."date-upperO-should-parse-as-datetime".ToString("O") | should -be "2008-09-22T14:01:54.9571247Z"
+				$Object."date-upperO-should-parse-as-datetime".ToString("R") | should -be "Mon, 22 Sep 2008 14:01:54 GMT"
+				$Object."date-upperO-should-parse-as-datetime".ToString("s") | should -be "2008-09-22T14:01:54"
+				$Object."date-upperO-should-parse-as-datetime".ToString("t") | should -be "2:01 PM"
+				$Object."date-upperO-should-parse-as-datetime".ToString("T") | should -be "2:01:54 PM"
+				$Object."date-upperO-should-parse-as-datetime".ToString("u") | should -be "2008-09-22 14:01:54Z"
+				$Object."date-upperO-should-parse-as-datetime".ToString("U") | should -be "Monday, September 22, 2008 2:01:54 PM"
+				$Object."date-upperO-should-parse-as-datetime".ToString("Y") | should -be "September 2008"
+				$Object."date-upperO-should-parse-as-datetime".ToString("y") | should -be "September 2008"
+				$Object."date-upperO-should-parse-as-datetime" | should -beoftype [DateTime]
+				
+				$Object."date-o-should-parse-as-string" | should -be "2019-12-17T06:14:06 +06:00"
+				$Object."date-o-should-parse-as-string" | should -beoftype [String]
+				$Object."date-f-should-parse-as-string" | should -be "Monday, September 22, 2008 2:01 PM"
+				$Object."date-f-should-parse-as-string" | should -beoftype [String]
+				$Object."date-g-should-parse-as-string" | should -be "9/22/2008 2:01 PM"
+				$Object."date-g-should-parse-as-string" | should -beoftype [String]
+				$Object."date-m-should-parse-as-string" | should -be "September 22"
+				$Object."date-m-should-parse-as-string" | should -beoftype [String]
+				$Object."date-upperM-should-parse-as-string" | should -be "September 22"
+				$Object."date-upperM-should-parse-as-string" | should -beoftype [String]
+				$Object."date-t-should-parse-as-string" | should -be "2:01 PM"
+				$Object."date-t-should-parse-as-string" | should -beoftype [String]
+				$Object."date-u-should-parse-as-string" | should -be "2008-09-22 14:01:54Z"
+				$Object."date-u-should-parse-as-string" | should -beoftype [String]
+				$Object."date-upperD-should-parse-as-string" | should -be "Monday, September 22, 2008"
+				$Object."date-upperD-should-parse-as-string" | should -beoftype [String]
+				$Object."date-upperF-should-parse-as-string" | should -be "Monday, September 22, 2008 2:01:54 PM"
+				$Object."date-upperF-should-parse-as-string" | should -beoftype [String]
+				$Object."date-upperG-should-parse-as-string" | should -be "9/22/2008 2:01:54 PM"
+				$Object."date-upperG-should-parse-as-string" | should -beoftype [String]
+				$Object."date-upperR-should-parse-as-string" | should -be "Mon, 22 Sep 2008 14:01:54 GMT"
+				$Object."date-upperR-should-parse-as-string" | should -beoftype [String]
+				$Object."date-upperT-should-parse-as-string" | should -be "2:01:54 PM"
+				$Object."date-upperT-should-parse-as-string" | should -beoftype [String]
+				$Object."date-upperU-should-parse-as-string" | should -be "Monday, September 22, 2008 2:01:54 PM"
+				$Object."date-upperU-should-parse-as-string" | should -beoftype [String]
+				$Object."date-upperY-should-parse-as-string" | should -be "September 2008"
+				$Object."date-upperY-should-parse-as-string" | should -beoftype [String]
+				$Object."date-y-should-parse-as-string" | should -be "September 2008"
+				$Object."date-y-should-parse-as-string" | should -beoftype [String]
+			}
+		}
         It "ConvertFrom-Json with special characters" {
 
             $json = '{"SampleValue":"\"\\\b\f\n\r\t\u4321\uD7FF"}'

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
@@ -376,6 +376,10 @@ Describe "Json Tests" -Tags "Feature" {
 			foreach ($asHashtableOption in @($True, $false)) {
 				$result = ConvertFrom-Json $json -AsHashtable:$asHashtableOption
 
+                # If the timezone is not specified in the input string newtonsoft assumes the system timezone.
+                # this means that some tests will fail locally but work on the build farm and vice-versa.
+                # this is used to force the datetime into UTC without changing the value so 4PM Central becomes 4PM UTC instead of becoming 10PM UTC
+                $result."date-s-should-parse-as-datetime" = [datetime]::SpecifyKind($result."date-s-should-parse-as-datetime", [System.DateTimeKind]::Utc)
 				$result."date-s-should-parse-as-datetime".ToString("d") | Should -Be "9/22/2008"
 				$result."date-s-should-parse-as-datetime".ToString("D") | Should -Be "Monday, September 22, 2008"
 				$result."date-s-should-parse-as-datetime".ToString("f") | Should -Be "Monday, September 22, 2008 2:01 PM"
@@ -384,18 +388,19 @@ Describe "Json Tests" -Tags "Feature" {
 				$result."date-s-should-parse-as-datetime".ToString("G") | Should -Be "9/22/2008 2:01:54 PM"
 				$result."date-s-should-parse-as-datetime".ToString("m") | Should -Be "September 22"
 				$result."date-s-should-parse-as-datetime".ToString("M") | Should -Be "September 22"
-				$result."date-s-should-parse-as-datetime".ToString("o") | Should -Be "2008-09-22T14:01:54.0000000"
-				$result."date-s-should-parse-as-datetime".ToString("O") | Should -Be "2008-09-22T14:01:54.0000000"
+				$result."date-s-should-parse-as-datetime".ToString("o") | Should -Be "2008-09-22T14:01:54.0000000Z"
+				$result."date-s-should-parse-as-datetime".ToString("O") | Should -Be "2008-09-22T14:01:54.0000000Z"
 				$result."date-s-should-parse-as-datetime".ToString("R") | Should -Be "Mon, 22 Sep 2008 14:01:54 GMT"
 				$result."date-s-should-parse-as-datetime".ToString("s") | Should -Be "2008-09-22T14:01:54"
 				$result."date-s-should-parse-as-datetime".ToString("t") | Should -Be "2:01 PM"
 				$result."date-s-should-parse-as-datetime".ToString("T") | Should -Be "2:01:54 PM"
 				$result."date-s-should-parse-as-datetime".ToString("u") | Should -Be "2008-09-22 14:01:54Z"
-				$result."date-s-should-parse-as-datetime".ToString("U") | Should -Be "Monday, September 22, 2008 7:01:54 PM"
+				$result."date-s-should-parse-as-datetime".ToString("U") | Should -Be "Monday, September 22, 2008 2:01:54 PM"
 				$result."date-s-should-parse-as-datetime".ToString("Y") | Should -Be "September 2008"
 				$result."date-s-should-parse-as-datetime".ToString("y") | Should -Be "September 2008"
 				$result."date-s-should-parse-as-datetime" | Should -Beoftype [DateTime]
 				
+                $result."date-upperO-should-parse-as-datetime" = [datetime]::SpecifyKind($result."date-upperO-should-parse-as-datetime", [System.DateTimeKind]::Utc)
 				$result."date-upperO-should-parse-as-datetime".ToString("d") | Should -Be "9/22/2008"
 				$result."date-upperO-should-parse-as-datetime".ToString("D") | Should -Be "Monday, September 22, 2008"
 				$result."date-upperO-should-parse-as-datetime".ToString("f") | Should -Be "Monday, September 22, 2008 2:01 PM"
@@ -579,8 +584,8 @@ Describe "Json Tests" -Tags "Feature" {
 			ConvertFrom-Json -InputObject 500000000000.0000000000000001 | should -beoftype [double]
 			
 			# these tests also pass because precision is lost during conversion/powershell handling
-			ConvertFrom-Json -InputObject "50000000000000000000000000000000000.0000000000000001" | should -be "50000000000000000000000000000000000"
-			ConvertFrom-Json -InputObject 50000000000000000000000000000000000.0000000000000001 | should -be 50000000000000000000000000000000000
+			ConvertFrom-Json -InputObject "50000000000000000000000000000000000.0000000000000001" | should -be "5E+34"
+			ConvertFrom-Json -InputObject 50000000000000000000000000000000000.0000000000000001 | should -be "5E+34"
 			
 			ConvertFrom-Json -InputObject "50000000000000000000000000000000000.0000000000000001" | should -beoftype [double]
 			ConvertFrom-Json -InputObject 50000000000000000000000000000000000.0000000000000001 | should -beoftype [double]

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
@@ -563,14 +563,41 @@ Describe "Json Tests" -Tags "Feature" {
 			ConvertFrom-Json -InputObject 5 | should -be 5
 			ConvertFrom-Json -InputObject "5" | should -beoftype [int64]
 			ConvertFrom-Json -InputObject 5 | should -beoftype [int64]
+			ConvertFrom-Json -InputObject 5000000000000 | should -be 5000000000000
+			ConvertFrom-Json -InputObject "5000000000000" | should -be "5000000000000"
 			ConvertFrom-Json -InputObject "5000000000000" | should -beoftype [int64]
 			ConvertFrom-Json -InputObject 5000000000000 | should -beoftype [int64]
+			ConvertFrom-Json -InputObject "5.0" | should -be 5
+			ConvertFrom-Json -InputObject "5.0" | should -be 5.0
+			ConvertFrom-Json -InputObject 5.0 | should -be 5
+			ConvertFrom-Json -InputObject 5.0 | should -be 5.0
 			ConvertFrom-Json -InputObject "5.0" | should -beoftype [double]
 			ConvertFrom-Json -InputObject 5.0 | should -beoftype [double]
+			
+			# The decimal is lost but only when this is quoted
+			ConvertFrom-Json -InputObject "500000000000.0000000000000001" | should -be "500000000000"
+			
+			# Counter intuitively all four of these tests pass because precision is lost on both sides of the test, likely due to powershell number handling
+			ConvertFrom-Json -InputObject 500000000000.0000000000000001 | should -be 500000000000
+			ConvertFrom-Json -InputObject 500000000000.0000000000000001 | should -be 500000000000.0000000000000001
+			ConvertFrom-Json -InputObject 500000000000 | should -be 500000000000.0000000000000001
+			ConvertFrom-Json -InputObject 500000000000 | should -be 500000000000
+			
 			ConvertFrom-Json -InputObject "500000000000.0000000000000001" | should -beoftype [double]
 			ConvertFrom-Json -InputObject 500000000000.0000000000000001 | should -beoftype [double]
+			
+			# these tests also pass because precision is lost during conversion/powershell handling
+			ConvertFrom-Json -InputObject "50000000000000000000000000000000000.0000000000000001" | should -be "50000000000000000000000000000000000"
+			ConvertFrom-Json -InputObject 50000000000000000000000000000000000.0000000000000001 | should -be 50000000000000000000000000000000000
+			
 			ConvertFrom-Json -InputObject "50000000000000000000000000000000000.0000000000000001" | should -beoftype [double]
 			ConvertFrom-Json -InputObject 50000000000000000000000000000000000.0000000000000001 | should -beoftype [double]
+			
+			
+			ConvertFrom-Json -InputObject "50000000000000000000000000000000000" | should -be 50000000000000000000000000000000000
+			ConvertFrom-Json -InputObject 50000000000000000000000000000000000 | should -be 50000000000000000000000000000000000
+			ConvertFrom-Json -InputObject "50000000000000000000000000000000000" | should -beoftype [BigInt]
+			ConvertFrom-Json -InputObject 50000000000000000000000000000000000 | should -beoftype [BigInt]
 		}
 		
         It "ConvertFrom-Json with special characters" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
@@ -449,6 +449,115 @@ Describe "Json Tests" -Tags "Feature" {
 				$Object."date-y-should-parse-as-string" | should -beoftype [String]
 			}
 		}
+		
+		It "ConvertFrom-Json properly parses complex objects" {
+			$json = @"
+{
+"_id": "60dd3ea9253016932039a0a2",
+"index": 0,
+"guid": "429b96a7-24e3-47de-a93b-f44a346c5ac9",
+"isActive": false,
+"balance": "$2,039.72",
+"picture": "http://placehold.it/32x32",
+"age": 35,
+"eyeColor": "green",
+"name": "Rhodes Roberson",
+"gender": "male",
+"company": "INSECTUS",
+"email": "rhodesroberson@insectus.com",
+"phone": "+1 (883) 561-3999",
+"address": "931 Kings Place, Hartsville/Hartley, Federated States Of Micronesia, 9344",
+"about": "Ipsum pariatur nisi eiusmod aliquip in cupidatat. Deserunt non sit anim consectetur consectetur incididunt elit qui id proident nostrud. Consectetur pariatur et adipisicing aliquip fugiat fugiat Lorem reprehenderit laboris magna. Duis veniam irure amet ex minim eiusmod et laborum non elit. Dolor enim Lorem occaecat nisi consectetur mollit laborum anim velit et. Irure aliquip eiusmod anim proident ex ea duis deserunt aute amet adipisicing nisi nostrud. Minim ipsum fugiat consequat mollit fugiat tempor fugiat.",
+"registered": "2019-12-17T06:14:06 +06:00",
+"latitude": 51.890798,
+"longitude": -47.522764,
+"tags": [
+  "laboris",
+  "voluptate",
+  "amet",
+  "ad",
+  "velit",
+  "ipsum",
+  "do"
+],
+"friends": [
+  {
+	"id": 0,
+	"name": "Renee Holden"
+  },
+  {
+	"id": 1,
+	"name": "Bennett Dixon"
+  },
+  {
+	"id": 2,
+	"name": "Emilia Holder"
+  }
+],
+"greeting": "Hello, Rhodes Roberson! You have 9 unread messages.",
+"favoriteFruit": "banana"
+}
+"@
+			$Object = ConvertFrom-Json $Json
+			$Object."about"| should -be "Ipsum pariatur nisi eiusmod aliquip in cupidatat. Deserunt non sit anim consectetur consectetur incididunt elit qui id proident nostrud. Consectetur pariatur et adipisicing aliquip fugiat fugiat Lorem reprehenderit laboris magna. Duis veniam irure amet ex minim eiusmod et laborum non elit. Dolor enim Lorem occaecat nisi consectetur mollit laborum anim velit et. Irure aliquip eiusmod anim proident ex ea duis deserunt aute amet adipisicing nisi nostrud. Minim ipsum fugiat consequat mollit fugiat tempor fugiat."
+			$Object."about" | should -beoftype [String]
+			$Object."address"| should -be "931 Kings Place, Hartsville/Hartley, Federated States Of Micronesia, 9344"
+			$Object."address" | should -beoftype [String]
+			$Object."age" | should -beoftype [Int64]
+			$Object."balance"| should -be ",039.72"
+			$Object."balance" | should -beoftype [String]
+			$Object."company"| should -be "INSECTUS"
+			$Object."company" | should -beoftype [String]
+			$Object."email"| should -be "rhodesroberson@insectus.com"
+			$Object."email" | should -beoftype [String]
+			$Object."eyeColor"| should -be "green"
+			$Object."eyeColor" | should -beoftype [String]
+			$Object."favoriteFruit"| should -be "banana"
+			$Object."favoriteFruit" | should -beoftype [String]
+			$Object."gender"| should -be "male"
+			$Object."gender" | should -beoftype [String]
+			$Object."greeting"| should -be "Hello, Rhodes Roberson! You have 9 unread messages."
+			$Object."greeting" | should -beoftype [String]
+			$Object."guid"| should -be "429b96a7-24e3-47de-a93b-f44a346c5ac9"
+			$Object."guid" | should -beoftype [String]
+			$Object."index" | should -beoftype [Int64]
+			$Object."isActive"| should -be False
+			$Object."isActive" | should -beoftype [Boolean]
+			$Object."latitude"| should -be 51.890798
+			$Object."latitude" | should -beoftype [Double]
+			$Object."longitude"| should -be -47.522764
+			$Object."longitude" | should -beoftype [Double]
+			$Object."name"| should -be "Rhodes Roberson"
+			$Object."name" | should -beoftype [String]
+			$Object."phone"| should -be "+1 (883) 561-3999"
+			$Object."phone" | should -beoftype [String]
+			$Object."picture"| should -be "http://placehold.it/32x32"
+			$Object."picture" | should -beoftype [String]
+			$Object."registered"| should -be "2019-12-17T06:14:06 +06:00"
+			$Object."registered" | should -beoftype [String]
+			$Object."_id"| should -be "60dd3ea9253016932039a0a2"
+			$Object."_id" | should -beoftype [String]
+			
+			$Object.Tags | should -beoftype [string]
+			
+			$Object.Tags.count | should -be 7 
+			$Object.Tags[0] | should -be "laboris"
+			$Object.Tags | Should -be @("laboris", "voluptate", "amet", "ad", "velit", "ipsum", "do")
+			
+			
+			$Object.Friends | should -beoftype [pscustomobject]
+			$Object.Friends[0].id | should -be 0
+			$Object.Friends[0].name | should -be "Renee Holden"
+			$Object.Friends[1].id | should -be 0
+			$Object.Friends[1].name | should -be "Bennett Dixon"
+			$Object.Friends[2].id | should -be 0
+			$Object.Friends[2].name | should -be "Emilia Holder"
+			$Object.Tags.count | should -be 7 
+			$Object.Tags | Should -be @("laboris", "voluptate", "amet", "ad", "velit", "ipsum", "do")
+			
+			
+		}
+		
         It "ConvertFrom-Json with special characters" {
 
             $json = '{"SampleValue":"\"\\\b\f\n\r\t\u4321\uD7FF"}'

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
@@ -373,7 +373,7 @@ Describe "Json Tests" -Tags "Feature" {
 	"date-y-should-parse-as-string": "September 2008"
 }
 "@
-			foreach ($asHashtableOption in @($True, $false)) {
+			foreach ($asHashtableOption in @($True, $False)) {
 				$result = ConvertFrom-Json $json -AsHashtable:$asHashtableOption
 
                 # If the timezone is not specified in the input string newtonsoft assumes the system timezone.
@@ -398,7 +398,7 @@ Describe "Json Tests" -Tags "Feature" {
 				$result."date-s-should-parse-as-datetime".ToString("U") | Should -Be "Monday, September 22, 2008 2:01:54 PM"
 				$result."date-s-should-parse-as-datetime".ToString("Y") | Should -Be "September 2008"
 				$result."date-s-should-parse-as-datetime".ToString("y") | Should -Be "September 2008"
-				$result."date-s-should-parse-as-datetime" | Should -Beoftype [DateTime]
+				$result."date-s-should-parse-as-datetime" | Should -BeOfType [DateTime]
 				
                 $result."date-upperO-should-parse-as-datetime" = [datetime]::SpecifyKind($result."date-upperO-should-parse-as-datetime", [System.DateTimeKind]::Utc)
 				$result."date-upperO-should-parse-as-datetime".ToString("d") | Should -Be "9/22/2008"
@@ -419,38 +419,38 @@ Describe "Json Tests" -Tags "Feature" {
 				$result."date-upperO-should-parse-as-datetime".ToString("U") | Should -Be "Monday, September 22, 2008 2:01:54 PM"
 				$result."date-upperO-should-parse-as-datetime".ToString("Y") | Should -Be "September 2008"
 				$result."date-upperO-should-parse-as-datetime".ToString("y") | Should -Be "September 2008"
-				$result."date-upperO-should-parse-as-datetime" | Should -Beoftype [DateTime]
+				$result."date-upperO-should-parse-as-datetime" | Should -BeOfType [DateTime]
 				
 				$result."date-o-should-parse-as-string" | Should -Be "2019-12-17T06:14:06 +06:00"
-				$result."date-o-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-o-should-parse-as-string" | Should -BeOfType [String]
 				$result."date-f-should-parse-as-string" | Should -Be "Monday, September 22, 2008 2:01 PM"
-				$result."date-f-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-f-should-parse-as-string" | Should -BeOfType [String]
 				$result."date-g-should-parse-as-string" | Should -Be "9/22/2008 2:01 PM"
-				$result."date-g-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-g-should-parse-as-string" | Should -BeOfType [String]
 				$result."date-m-should-parse-as-string" | Should -Be "September 22"
-				$result."date-m-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-m-should-parse-as-string" | Should -BeOfType [String]
 				$result."date-upperM-should-parse-as-string" | Should -Be "September 22"
-				$result."date-upperM-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-upperM-should-parse-as-string" | Should -BeOfType [String]
 				$result."date-t-should-parse-as-string" | Should -Be "2:01 PM"
-				$result."date-t-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-t-should-parse-as-string" | Should -BeOfType [String]
 				$result."date-u-should-parse-as-string" | Should -Be "2008-09-22 14:01:54Z"
-				$result."date-u-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-u-should-parse-as-string" | Should -BeOfType [String]
 				$result."date-upperD-should-parse-as-string" | Should -Be "Monday, September 22, 2008"
-				$result."date-upperD-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-upperD-should-parse-as-string" | Should -BeOfType [String]
 				$result."date-upperF-should-parse-as-string" | Should -Be "Monday, September 22, 2008 2:01:54 PM"
-				$result."date-upperF-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-upperF-should-parse-as-string" | Should -BeOfType [String]
 				$result."date-upperG-should-parse-as-string" | Should -Be "9/22/2008 2:01:54 PM"
-				$result."date-upperG-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-upperG-should-parse-as-string" | Should -BeOfType [String]
 				$result."date-upperR-should-parse-as-string" | Should -Be "Mon, 22 Sep 2008 14:01:54 GMT"
-				$result."date-upperR-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-upperR-should-parse-as-string" | Should -BeOfType [String]
 				$result."date-upperT-should-parse-as-string" | Should -Be "2:01:54 PM"
-				$result."date-upperT-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-upperT-should-parse-as-string" | Should -BeOfType [String]
 				$result."date-upperU-should-parse-as-string" | Should -Be "Monday, September 22, 2008 2:01:54 PM"
-				$result."date-upperU-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-upperU-should-parse-as-string" | Should -BeOfType [String]
 				$result."date-upperY-should-parse-as-string" | Should -Be "September 2008"
-				$result."date-upperY-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-upperY-should-parse-as-string" | Should -BeOfType [String]
 				$result."date-y-should-parse-as-string" | Should -Be "September 2008"
-				$result."date-y-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-y-should-parse-as-string" | Should -BeOfType [String]
 			}
 		}
 		
@@ -504,51 +504,51 @@ Describe "Json Tests" -Tags "Feature" {
 "@
 			$result = ConvertFrom-Json $Json
 			$result."about"| Should -BeExactly "Ipsum pariatur nisi eiusmod aliquip in cupidatat. Deserunt non sit anim consectetur consectetur incididunt elit qui id proident nostrud. Consectetur pariatur et adipisicing aliquip fugiat fugiat Lorem reprehenderit laboris magna. Duis veniam irure amet ex minim eiusmod et laborum non elit. Dolor enim Lorem occaecat nisi consectetur mollit laborum anim velit et. Irure aliquip eiusmod anim proident ex ea duis deserunt aute amet adipisicing nisi nostrud. Minim ipsum fugiat consequat mollit fugiat tempor fugiat."
-			$result."about" | Should -Beoftype [String]
+			$result."about" | Should -BeOfType [String]
 			$result."address"| Should -BeExactly "931 Kings Place, Hartsville/Hartley, Federated States Of Micronesia, 9344"
-			$result."address" | Should -Beoftype [String]
-			$result."age" | Should -Beoftype [Int64]
+			$result."address" | Should -BeOfType [String]
+			$result."age" | Should -BeOfType [Int64]
 			$result."balance"| Should -BeExactly ",039.72"
-			$result."balance" | Should -Beoftype [String]
+			$result."balance" | Should -BeOfType [String]
 			$result."company"| Should -BeExactly "INSECTUS"
-			$result."company" | Should -Beoftype [String]
+			$result."company" | Should -BeOfType [String]
 			$result."email"| Should -BeExactly "rhodesroberson@insectus.com"
-			$result."email" | Should -Beoftype [String]
+			$result."email" | Should -BeOfType [String]
 			$result."eyeColor"| Should -BeExactly "green"
-			$result."eyeColor" | Should -Beoftype [String]
+			$result."eyeColor" | Should -BeOfType [String]
 			$result."favoriteFruit"| Should -BeExactly "banana"
-			$result."favoriteFruit" | Should -Beoftype [String]
+			$result."favoriteFruit" | Should -BeOfType [String]
 			$result."gender"| Should -BeExactly "male"
-			$result."gender" | Should -Beoftype [String]
+			$result."gender" | Should -BeOfType [String]
 			$result."greeting"| Should -BeExactly "Hello, Rhodes Roberson! You have 9 unread messages."
-			$result."greeting" | Should -Beoftype [String]
+			$result."greeting" | Should -BeOfType [String]
 			$result."guid"| Should -BeExactly "429b96a7-24e3-47de-a93b-f44a346c5ac9"
-			$result."guid" | Should -Beoftype [String]
-			$result."index" | Should -Beoftype [Int64]
+			$result."guid" | Should -BeOfType [String]
+			$result."index" | Should -BeOfType [Int64]
 			$result."isActive"| Should -Be False
-			$result."isActive" | Should -Beoftype [Boolean]
+			$result."isActive" | Should -BeOfType [Boolean]
 			$result."latitude"| Should -Be 51.890798
-			$result."latitude" | Should -Beoftype [Double]
+			$result."latitude" | Should -BeOfType [Double]
 			$result."longitude"| Should -Be -47.522764
-			$result."longitude" | Should -Beoftype [Double]
+			$result."longitude" | Should -BeOfType [Double]
 			$result."name"| Should -BeExactly "Rhodes Roberson"
-			$result."name" | Should -Beoftype [String]
+			$result."name" | Should -BeOfType [String]
 			$result."phone"| Should -BeExactly "+1 (883) 561-3999"
-			$result."phone" | Should -Beoftype [String]
+			$result."phone" | Should -BeOfType [String]
 			$result."picture"| Should -BeExactly "http://placehold.it/32x32"
-			$result."picture" | Should -Beoftype [String]
+			$result."picture" | Should -BeOfType [String]
 			$result."registered"| Should -BeExactly "2019-12-17T06:14:06 +06:00"
-			$result."registered" | Should -Beoftype [String]
+			$result."registered" | Should -BeOfType [String]
 			$result."_id"| Should -BeExactly "60dd3ea9253016932039a0a2"
-			$result."_id" | Should -Beoftype [String]
+			$result."_id" | Should -BeOfType [String]
 			
-			$result.Tags | Should -Beoftype [string]
+			$result.Tags | Should -BeOfType [string]
 			
 			$result.Tags.count | Should -Be 7 
 			$result.Tags[0] | Should -BeExactly "laboris"
 			$result.Tags | Should -Be @("laboris", "voluptate", "amet", "ad", "velit", "ipsum", "do")
 			
-			$result.Friends | Should -Beoftype [pscustomobject]
+			$result.Friends | Should -BeOfType [pscustomobject]
 			$result.Friends[0].id | Should -Be 0
 			$result.Friends[0].name | Should -BeExactly "Renee Holden"
 			$result.Friends[1].id | Should -Be 1
@@ -558,43 +558,43 @@ Describe "Json Tests" -Tags "Feature" {
 		}
 		
 		It "ConvertFrom-Json chooses the appropriate number type" {
-			ConvertFrom-Json -InputObject "5" | should -be 5
-			ConvertFrom-Json -InputObject 5 | should -be 5
-			ConvertFrom-Json -InputObject "5" | should -beoftype [int64]
-			ConvertFrom-Json -InputObject 5 | should -beoftype [int64]
-			ConvertFrom-Json -InputObject 5000000000000 | should -be 5000000000000
-			ConvertFrom-Json -InputObject "5000000000000" | should -be "5000000000000"
-			ConvertFrom-Json -InputObject "5000000000000" | should -beoftype [int64]
-			ConvertFrom-Json -InputObject 5000000000000 | should -beoftype [int64]
-			ConvertFrom-Json -InputObject "5.0" | should -be 5.0
-			ConvertFrom-Json -InputObject 5.0 | should -be 5.0
-			ConvertFrom-Json -InputObject "5.0" | should -beoftype [double]
-			ConvertFrom-Json -InputObject 5.0 | should -beoftype [double]
+			ConvertFrom-Json -InputObject "5" | should -Be 5
+			ConvertFrom-Json -InputObject 5 | should -Be 5
+			ConvertFrom-Json -InputObject "5" | should -BeOfType [int64]
+			ConvertFrom-Json -InputObject 5 | should -BeOfType [int64]
+			ConvertFrom-Json -InputObject 5000000000000 | should -Be 5000000000000
+			ConvertFrom-Json -InputObject "5000000000000" | should -Be "5000000000000"
+			ConvertFrom-Json -InputObject "5000000000000" | should -BeOfType [int64]
+			ConvertFrom-Json -InputObject 5000000000000 | should -BeOfType [int64]
+			ConvertFrom-Json -InputObject "5.0" | should -Be 5.0
+			ConvertFrom-Json -InputObject 5.0 | should -Be 5.0
+			ConvertFrom-Json -InputObject "5.0" | should -BeOfType [double]
+			ConvertFrom-Json -InputObject 5.0 | should -BeOfType [double]
 			
 			# The decimal is lost but only when this is quoted
-			ConvertFrom-Json -InputObject "500000000000.0000000000000001" | should -be "500000000000"
+			ConvertFrom-Json -InputObject "500000000000.0000000000000001" | should -Be "500000000000"
 			
 			# Counter intuitively all four of these tests pass because precision is lost on both sides of the test, likely due to powershell number handling
-			ConvertFrom-Json -InputObject 500000000000.0000000000000001 | should -be 500000000000
-			ConvertFrom-Json -InputObject 500000000000.0000000000000001 | should -be 500000000000.0000000000000001
-			ConvertFrom-Json -InputObject 500000000000 | should -be 500000000000.0000000000000001
-			ConvertFrom-Json -InputObject 500000000000 | should -be 500000000000
+			ConvertFrom-Json -InputObject 500000000000.0000000000000001 | should -Be 500000000000
+			ConvertFrom-Json -InputObject 500000000000.0000000000000001 | should -Be 500000000000.0000000000000001
+			ConvertFrom-Json -InputObject 500000000000 | should -Be 500000000000.0000000000000001
+			ConvertFrom-Json -InputObject 500000000000 | should -Be 500000000000
 			
-			ConvertFrom-Json -InputObject "500000000000.0000000000000001" | should -beoftype [double]
-			ConvertFrom-Json -InputObject 500000000000.0000000000000001 | should -beoftype [double]
+			ConvertFrom-Json -InputObject "500000000000.0000000000000001" | should -BeOfType [double]
+			ConvertFrom-Json -InputObject 500000000000.0000000000000001 | should -BeOfType [double]
 			
 			# these tests also pass because precision is lost during conversion/powershell handling
-			ConvertFrom-Json -InputObject "50000000000000000000000000000000000.0000000000000001" | should -be "5E+34"
-			ConvertFrom-Json -InputObject 50000000000000000000000000000000000.0000000000000001 | should -be "5E+34"
+			ConvertFrom-Json -InputObject "50000000000000000000000000000000000.0000000000000001" | should -Be "5E+34"
+			ConvertFrom-Json -InputObject 50000000000000000000000000000000000.0000000000000001 | should -Be "5E+34"
 			
-			ConvertFrom-Json -InputObject "50000000000000000000000000000000000.0000000000000001" | should -beoftype [double]
-			ConvertFrom-Json -InputObject 50000000000000000000000000000000000.0000000000000001 | should -beoftype [double]
+			ConvertFrom-Json -InputObject "50000000000000000000000000000000000.0000000000000001" | should -BeOfType [double]
+			ConvertFrom-Json -InputObject 50000000000000000000000000000000000.0000000000000001 | should -BeOfType [double]
 			
 			
-			ConvertFrom-Json -InputObject "50000000000000000000000000000000000" | should -be 50000000000000000000000000000000000
-			ConvertFrom-Json -InputObject 50000000000000000000000000000000000 | should -be 50000000000000000000000000000000000
-			ConvertFrom-Json -InputObject "50000000000000000000000000000000000" | should -beoftype [BigInt]
-			ConvertFrom-Json -InputObject 50000000000000000000000000000000000 | should -beoftype [BigInt]
+			ConvertFrom-Json -InputObject "50000000000000000000000000000000000" | should -Be 50000000000000000000000000000000000
+			ConvertFrom-Json -InputObject 50000000000000000000000000000000000 | should -Be 50000000000000000000000000000000000
+			ConvertFrom-Json -InputObject "50000000000000000000000000000000000" | should -BeOfType [BigInt]
+			ConvertFrom-Json -InputObject 50000000000000000000000000000000000 | should -BeOfType [BigInt]
 		}
 		
         It "ConvertFrom-Json with special characters" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
@@ -503,26 +503,26 @@ Describe "Json Tests" -Tags "Feature" {
 }
 "@
 			$result = ConvertFrom-Json $Json
-			$result."about"| Should -Be "Ipsum pariatur nisi eiusmod aliquip in cupidatat. Deserunt non sit anim consectetur consectetur incididunt elit qui id proident nostrud. Consectetur pariatur et adipisicing aliquip fugiat fugiat Lorem reprehenderit laboris magna. Duis veniam irure amet ex minim eiusmod et laborum non elit. Dolor enim Lorem occaecat nisi consectetur mollit laborum anim velit et. Irure aliquip eiusmod anim proident ex ea duis deserunt aute amet adipisicing nisi nostrud. Minim ipsum fugiat consequat mollit fugiat tempor fugiat."
+			$result."about"| Should -BeExactly "Ipsum pariatur nisi eiusmod aliquip in cupidatat. Deserunt non sit anim consectetur consectetur incididunt elit qui id proident nostrud. Consectetur pariatur et adipisicing aliquip fugiat fugiat Lorem reprehenderit laboris magna. Duis veniam irure amet ex minim eiusmod et laborum non elit. Dolor enim Lorem occaecat nisi consectetur mollit laborum anim velit et. Irure aliquip eiusmod anim proident ex ea duis deserunt aute amet adipisicing nisi nostrud. Minim ipsum fugiat consequat mollit fugiat tempor fugiat."
 			$result."about" | Should -Beoftype [String]
-			$result."address"| Should -Be "931 Kings Place, Hartsville/Hartley, Federated States Of Micronesia, 9344"
+			$result."address"| Should -BeExactly "931 Kings Place, Hartsville/Hartley, Federated States Of Micronesia, 9344"
 			$result."address" | Should -Beoftype [String]
 			$result."age" | Should -Beoftype [Int64]
-			$result."balance"| Should -Be ",039.72"
+			$result."balance"| Should -BeExactly ",039.72"
 			$result."balance" | Should -Beoftype [String]
-			$result."company"| Should -Be "INSECTUS"
+			$result."company"| Should -BeExactly "INSECTUS"
 			$result."company" | Should -Beoftype [String]
-			$result."email"| Should -Be "rhodesroberson@insectus.com"
+			$result."email"| Should -BeExactly "rhodesroberson@insectus.com"
 			$result."email" | Should -Beoftype [String]
-			$result."eyeColor"| Should -Be "green"
+			$result."eyeColor"| Should -BeExactly "green"
 			$result."eyeColor" | Should -Beoftype [String]
-			$result."favoriteFruit"| Should -Be "banana"
+			$result."favoriteFruit"| Should -BeExactly "banana"
 			$result."favoriteFruit" | Should -Beoftype [String]
-			$result."gender"| Should -Be "male"
+			$result."gender"| Should -BeExactly "male"
 			$result."gender" | Should -Beoftype [String]
-			$result."greeting"| Should -Be "Hello, Rhodes Roberson! You have 9 unread messages."
+			$result."greeting"| Should -BeExactly "Hello, Rhodes Roberson! You have 9 unread messages."
 			$result."greeting" | Should -Beoftype [String]
-			$result."guid"| Should -Be "429b96a7-24e3-47de-a93b-f44a346c5ac9"
+			$result."guid"| Should -BeExactly "429b96a7-24e3-47de-a93b-f44a346c5ac9"
 			$result."guid" | Should -Beoftype [String]
 			$result."index" | Should -Beoftype [Int64]
 			$result."isActive"| Should -Be False
@@ -531,30 +531,30 @@ Describe "Json Tests" -Tags "Feature" {
 			$result."latitude" | Should -Beoftype [Double]
 			$result."longitude"| Should -Be -47.522764
 			$result."longitude" | Should -Beoftype [Double]
-			$result."name"| Should -Be "Rhodes Roberson"
+			$result."name"| Should -BeExactly "Rhodes Roberson"
 			$result."name" | Should -Beoftype [String]
-			$result."phone"| Should -Be "+1 (883) 561-3999"
+			$result."phone"| Should -BeExactly "+1 (883) 561-3999"
 			$result."phone" | Should -Beoftype [String]
-			$result."picture"| Should -Be "http://placehold.it/32x32"
+			$result."picture"| Should -BeExactly "http://placehold.it/32x32"
 			$result."picture" | Should -Beoftype [String]
-			$result."registered"| Should -Be "2019-12-17T06:14:06 +06:00"
+			$result."registered"| Should -BeExactly "2019-12-17T06:14:06 +06:00"
 			$result."registered" | Should -Beoftype [String]
-			$result."_id"| Should -Be "60dd3ea9253016932039a0a2"
+			$result."_id"| Should -BeExactly "60dd3ea9253016932039a0a2"
 			$result."_id" | Should -Beoftype [String]
 			
 			$result.Tags | Should -Beoftype [string]
 			
 			$result.Tags.count | Should -Be 7 
-			$result.Tags[0] | Should -Be "laboris"
+			$result.Tags[0] | Should -BeExactly "laboris"
 			$result.Tags | Should -Be @("laboris", "voluptate", "amet", "ad", "velit", "ipsum", "do")
 			
 			$result.Friends | Should -Beoftype [pscustomobject]
 			$result.Friends[0].id | Should -Be 0
-			$result.Friends[0].name | Should -Be "Renee Holden"
+			$result.Friends[0].name | Should -BeExactly "Renee Holden"
 			$result.Friends[1].id | Should -Be 1
-			$result.Friends[1].name | Should -Be "Bennett Dixon"
+			$result.Friends[1].name | Should -BeExactly "Bennett Dixon"
 			$result.Friends[2].id | Should -Be 2
-			$result.Friends[2].name | Should -Be "Emilia Holder"
+			$result.Friends[2].name | Should -BeExactly "Emilia Holder"
 		}
 		
 		It "ConvertFrom-Json chooses the appropriate number type" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
@@ -374,79 +374,79 @@ Describe "Json Tests" -Tags "Feature" {
 }
 "@
 			foreach ($AsHashtableOption in @($True, $false)) {
-				$object = ConvertFrom-Json $json -AsHashtable:$AsHashtableOption
+				$result = ConvertFrom-Json $json -AsHashtable:$AsHashtableOption
 
 
-				$Object."date-s-should-parse-as-datetime".ToString("d") | should -be "9/22/2008"
-				$Object."date-s-should-parse-as-datetime".ToString("D") | should -be "Monday, September 22, 2008"
-				$Object."date-s-should-parse-as-datetime".ToString("f") | should -be "Monday, September 22, 2008 2:01 PM"
-				$Object."date-s-should-parse-as-datetime".ToString("F") | should -be "Monday, September 22, 2008 2:01:54 PM"
-				$Object."date-s-should-parse-as-datetime".ToString("g") | should -be "9/22/2008 2:01 PM"
-				$Object."date-s-should-parse-as-datetime".ToString("G") | should -be "9/22/2008 2:01:54 PM"
-				$Object."date-s-should-parse-as-datetime".ToString("m") | should -be "September 22"
-				$Object."date-s-should-parse-as-datetime".ToString("M") | should -be "September 22"
-				$Object."date-s-should-parse-as-datetime".ToString("o") | should -be "2008-09-22T14:01:54.0000000"
-				$Object."date-s-should-parse-as-datetime".ToString("O") | should -be "2008-09-22T14:01:54.0000000"
-				$Object."date-s-should-parse-as-datetime".ToString("R") | should -be "Mon, 22 Sep 2008 14:01:54 GMT"
-				$Object."date-s-should-parse-as-datetime".ToString("s") | should -be "2008-09-22T14:01:54"
-				$Object."date-s-should-parse-as-datetime".ToString("t") | should -be "2:01 PM"
-				$Object."date-s-should-parse-as-datetime".ToString("T") | should -be "2:01:54 PM"
-				$Object."date-s-should-parse-as-datetime".ToString("u") | should -be "2008-09-22 14:01:54Z"
-				$Object."date-s-should-parse-as-datetime".ToString("U") | should -be "Monday, September 22, 2008 7:01:54 PM"
-				$Object."date-s-should-parse-as-datetime".ToString("Y") | should -be "September 2008"
-				$Object."date-s-should-parse-as-datetime".ToString("y") | should -be "September 2008"
-				$Object."date-s-should-parse-as-datetime" | should -beoftype [DateTime]
+				$result."date-s-should-parse-as-datetime".ToString("d") | Should -Be "9/22/2008"
+				$result."date-s-should-parse-as-datetime".ToString("D") | Should -Be "Monday, September 22, 2008"
+				$result."date-s-should-parse-as-datetime".ToString("f") | Should -Be "Monday, September 22, 2008 2:01 PM"
+				$result."date-s-should-parse-as-datetime".ToString("F") | Should -Be "Monday, September 22, 2008 2:01:54 PM"
+				$result."date-s-should-parse-as-datetime".ToString("g") | Should -Be "9/22/2008 2:01 PM"
+				$result."date-s-should-parse-as-datetime".ToString("G") | Should -Be "9/22/2008 2:01:54 PM"
+				$result."date-s-should-parse-as-datetime".ToString("m") | Should -Be "September 22"
+				$result."date-s-should-parse-as-datetime".ToString("M") | Should -Be "September 22"
+				$result."date-s-should-parse-as-datetime".ToString("o") | Should -Be "2008-09-22T14:01:54.0000000"
+				$result."date-s-should-parse-as-datetime".ToString("O") | Should -Be "2008-09-22T14:01:54.0000000"
+				$result."date-s-should-parse-as-datetime".ToString("R") | Should -Be "Mon, 22 Sep 2008 14:01:54 GMT"
+				$result."date-s-should-parse-as-datetime".ToString("s") | Should -Be "2008-09-22T14:01:54"
+				$result."date-s-should-parse-as-datetime".ToString("t") | Should -Be "2:01 PM"
+				$result."date-s-should-parse-as-datetime".ToString("T") | Should -Be "2:01:54 PM"
+				$result."date-s-should-parse-as-datetime".ToString("u") | Should -Be "2008-09-22 14:01:54Z"
+				$result."date-s-should-parse-as-datetime".ToString("U") | Should -Be "Monday, September 22, 2008 7:01:54 PM"
+				$result."date-s-should-parse-as-datetime".ToString("Y") | Should -Be "September 2008"
+				$result."date-s-should-parse-as-datetime".ToString("y") | Should -Be "September 2008"
+				$result."date-s-should-parse-as-datetime" | Should -Beoftype [DateTime]
 				
-				$Object."date-upperO-should-parse-as-datetime".ToString("d") | should -be "9/22/2008"
-				$Object."date-upperO-should-parse-as-datetime".ToString("D") | should -be "Monday, September 22, 2008"
-				$Object."date-upperO-should-parse-as-datetime".ToString("f") | should -be "Monday, September 22, 2008 2:01 PM"
-				$Object."date-upperO-should-parse-as-datetime".ToString("F") | should -be "Monday, September 22, 2008 2:01:54 PM"
-				$Object."date-upperO-should-parse-as-datetime".ToString("g") | should -be "9/22/2008 2:01 PM"
-				$Object."date-upperO-should-parse-as-datetime".ToString("G") | should -be "9/22/2008 2:01:54 PM"
-				$Object."date-upperO-should-parse-as-datetime".ToString("m") | should -be "September 22"
-				$Object."date-upperO-should-parse-as-datetime".ToString("M") | should -be "September 22"
-				$Object."date-upperO-should-parse-as-datetime".ToString("o") | should -be "2008-09-22T14:01:54.9571247Z"
-				$Object."date-upperO-should-parse-as-datetime".ToString("O") | should -be "2008-09-22T14:01:54.9571247Z"
-				$Object."date-upperO-should-parse-as-datetime".ToString("R") | should -be "Mon, 22 Sep 2008 14:01:54 GMT"
-				$Object."date-upperO-should-parse-as-datetime".ToString("s") | should -be "2008-09-22T14:01:54"
-				$Object."date-upperO-should-parse-as-datetime".ToString("t") | should -be "2:01 PM"
-				$Object."date-upperO-should-parse-as-datetime".ToString("T") | should -be "2:01:54 PM"
-				$Object."date-upperO-should-parse-as-datetime".ToString("u") | should -be "2008-09-22 14:01:54Z"
-				$Object."date-upperO-should-parse-as-datetime".ToString("U") | should -be "Monday, September 22, 2008 2:01:54 PM"
-				$Object."date-upperO-should-parse-as-datetime".ToString("Y") | should -be "September 2008"
-				$Object."date-upperO-should-parse-as-datetime".ToString("y") | should -be "September 2008"
-				$Object."date-upperO-should-parse-as-datetime" | should -beoftype [DateTime]
+				$result."date-upperO-should-parse-as-datetime".ToString("d") | Should -Be "9/22/2008"
+				$result."date-upperO-should-parse-as-datetime".ToString("D") | Should -Be "Monday, September 22, 2008"
+				$result."date-upperO-should-parse-as-datetime".ToString("f") | Should -Be "Monday, September 22, 2008 2:01 PM"
+				$result."date-upperO-should-parse-as-datetime".ToString("F") | Should -Be "Monday, September 22, 2008 2:01:54 PM"
+				$result."date-upperO-should-parse-as-datetime".ToString("g") | Should -Be "9/22/2008 2:01 PM"
+				$result."date-upperO-should-parse-as-datetime".ToString("G") | Should -Be "9/22/2008 2:01:54 PM"
+				$result."date-upperO-should-parse-as-datetime".ToString("m") | Should -Be "September 22"
+				$result."date-upperO-should-parse-as-datetime".ToString("M") | Should -Be "September 22"
+				$result."date-upperO-should-parse-as-datetime".ToString("o") | Should -Be "2008-09-22T14:01:54.9571247Z"
+				$result."date-upperO-should-parse-as-datetime".ToString("O") | Should -Be "2008-09-22T14:01:54.9571247Z"
+				$result."date-upperO-should-parse-as-datetime".ToString("R") | Should -Be "Mon, 22 Sep 2008 14:01:54 GMT"
+				$result."date-upperO-should-parse-as-datetime".ToString("s") | Should -Be "2008-09-22T14:01:54"
+				$result."date-upperO-should-parse-as-datetime".ToString("t") | Should -Be "2:01 PM"
+				$result."date-upperO-should-parse-as-datetime".ToString("T") | Should -Be "2:01:54 PM"
+				$result."date-upperO-should-parse-as-datetime".ToString("u") | Should -Be "2008-09-22 14:01:54Z"
+				$result."date-upperO-should-parse-as-datetime".ToString("U") | Should -Be "Monday, September 22, 2008 2:01:54 PM"
+				$result."date-upperO-should-parse-as-datetime".ToString("Y") | Should -Be "September 2008"
+				$result."date-upperO-should-parse-as-datetime".ToString("y") | Should -Be "September 2008"
+				$result."date-upperO-should-parse-as-datetime" | Should -Beoftype [DateTime]
 				
-				$Object."date-o-should-parse-as-string" | should -be "2019-12-17T06:14:06 +06:00"
-				$Object."date-o-should-parse-as-string" | should -beoftype [String]
-				$Object."date-f-should-parse-as-string" | should -be "Monday, September 22, 2008 2:01 PM"
-				$Object."date-f-should-parse-as-string" | should -beoftype [String]
-				$Object."date-g-should-parse-as-string" | should -be "9/22/2008 2:01 PM"
-				$Object."date-g-should-parse-as-string" | should -beoftype [String]
-				$Object."date-m-should-parse-as-string" | should -be "September 22"
-				$Object."date-m-should-parse-as-string" | should -beoftype [String]
-				$Object."date-upperM-should-parse-as-string" | should -be "September 22"
-				$Object."date-upperM-should-parse-as-string" | should -beoftype [String]
-				$Object."date-t-should-parse-as-string" | should -be "2:01 PM"
-				$Object."date-t-should-parse-as-string" | should -beoftype [String]
-				$Object."date-u-should-parse-as-string" | should -be "2008-09-22 14:01:54Z"
-				$Object."date-u-should-parse-as-string" | should -beoftype [String]
-				$Object."date-upperD-should-parse-as-string" | should -be "Monday, September 22, 2008"
-				$Object."date-upperD-should-parse-as-string" | should -beoftype [String]
-				$Object."date-upperF-should-parse-as-string" | should -be "Monday, September 22, 2008 2:01:54 PM"
-				$Object."date-upperF-should-parse-as-string" | should -beoftype [String]
-				$Object."date-upperG-should-parse-as-string" | should -be "9/22/2008 2:01:54 PM"
-				$Object."date-upperG-should-parse-as-string" | should -beoftype [String]
-				$Object."date-upperR-should-parse-as-string" | should -be "Mon, 22 Sep 2008 14:01:54 GMT"
-				$Object."date-upperR-should-parse-as-string" | should -beoftype [String]
-				$Object."date-upperT-should-parse-as-string" | should -be "2:01:54 PM"
-				$Object."date-upperT-should-parse-as-string" | should -beoftype [String]
-				$Object."date-upperU-should-parse-as-string" | should -be "Monday, September 22, 2008 2:01:54 PM"
-				$Object."date-upperU-should-parse-as-string" | should -beoftype [String]
-				$Object."date-upperY-should-parse-as-string" | should -be "September 2008"
-				$Object."date-upperY-should-parse-as-string" | should -beoftype [String]
-				$Object."date-y-should-parse-as-string" | should -be "September 2008"
-				$Object."date-y-should-parse-as-string" | should -beoftype [String]
+				$result."date-o-should-parse-as-string" | Should -Be "2019-12-17T06:14:06 +06:00"
+				$result."date-o-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-f-should-parse-as-string" | Should -Be "Monday, September 22, 2008 2:01 PM"
+				$result."date-f-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-g-should-parse-as-string" | Should -Be "9/22/2008 2:01 PM"
+				$result."date-g-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-m-should-parse-as-string" | Should -Be "September 22"
+				$result."date-m-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-upperM-should-parse-as-string" | Should -Be "September 22"
+				$result."date-upperM-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-t-should-parse-as-string" | Should -Be "2:01 PM"
+				$result."date-t-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-u-should-parse-as-string" | Should -Be "2008-09-22 14:01:54Z"
+				$result."date-u-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-upperD-should-parse-as-string" | Should -Be "Monday, September 22, 2008"
+				$result."date-upperD-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-upperF-should-parse-as-string" | Should -Be "Monday, September 22, 2008 2:01:54 PM"
+				$result."date-upperF-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-upperG-should-parse-as-string" | Should -Be "9/22/2008 2:01:54 PM"
+				$result."date-upperG-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-upperR-should-parse-as-string" | Should -Be "Mon, 22 Sep 2008 14:01:54 GMT"
+				$result."date-upperR-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-upperT-should-parse-as-string" | Should -Be "2:01:54 PM"
+				$result."date-upperT-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-upperU-should-parse-as-string" | Should -Be "Monday, September 22, 2008 2:01:54 PM"
+				$result."date-upperU-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-upperY-should-parse-as-string" | Should -Be "September 2008"
+				$result."date-upperY-should-parse-as-string" | Should -Beoftype [String]
+				$result."date-y-should-parse-as-string" | Should -Be "September 2008"
+				$result."date-y-should-parse-as-string" | Should -Beoftype [String]
 			}
 		}
 		
@@ -498,64 +498,62 @@ Describe "Json Tests" -Tags "Feature" {
 "favoriteFruit": "banana"
 }
 "@
-			$Object = ConvertFrom-Json $Json
-			$Object."about"| should -be "Ipsum pariatur nisi eiusmod aliquip in cupidatat. Deserunt non sit anim consectetur consectetur incididunt elit qui id proident nostrud. Consectetur pariatur et adipisicing aliquip fugiat fugiat Lorem reprehenderit laboris magna. Duis veniam irure amet ex minim eiusmod et laborum non elit. Dolor enim Lorem occaecat nisi consectetur mollit laborum anim velit et. Irure aliquip eiusmod anim proident ex ea duis deserunt aute amet adipisicing nisi nostrud. Minim ipsum fugiat consequat mollit fugiat tempor fugiat."
-			$Object."about" | should -beoftype [String]
-			$Object."address"| should -be "931 Kings Place, Hartsville/Hartley, Federated States Of Micronesia, 9344"
-			$Object."address" | should -beoftype [String]
-			$Object."age" | should -beoftype [Int64]
-			$Object."balance"| should -be ",039.72"
-			$Object."balance" | should -beoftype [String]
-			$Object."company"| should -be "INSECTUS"
-			$Object."company" | should -beoftype [String]
-			$Object."email"| should -be "rhodesroberson@insectus.com"
-			$Object."email" | should -beoftype [String]
-			$Object."eyeColor"| should -be "green"
-			$Object."eyeColor" | should -beoftype [String]
-			$Object."favoriteFruit"| should -be "banana"
-			$Object."favoriteFruit" | should -beoftype [String]
-			$Object."gender"| should -be "male"
-			$Object."gender" | should -beoftype [String]
-			$Object."greeting"| should -be "Hello, Rhodes Roberson! You have 9 unread messages."
-			$Object."greeting" | should -beoftype [String]
-			$Object."guid"| should -be "429b96a7-24e3-47de-a93b-f44a346c5ac9"
-			$Object."guid" | should -beoftype [String]
-			$Object."index" | should -beoftype [Int64]
-			$Object."isActive"| should -be False
-			$Object."isActive" | should -beoftype [Boolean]
-			$Object."latitude"| should -be 51.890798
-			$Object."latitude" | should -beoftype [Double]
-			$Object."longitude"| should -be -47.522764
-			$Object."longitude" | should -beoftype [Double]
-			$Object."name"| should -be "Rhodes Roberson"
-			$Object."name" | should -beoftype [String]
-			$Object."phone"| should -be "+1 (883) 561-3999"
-			$Object."phone" | should -beoftype [String]
-			$Object."picture"| should -be "http://placehold.it/32x32"
-			$Object."picture" | should -beoftype [String]
-			$Object."registered"| should -be "2019-12-17T06:14:06 +06:00"
-			$Object."registered" | should -beoftype [String]
-			$Object."_id"| should -be "60dd3ea9253016932039a0a2"
-			$Object."_id" | should -beoftype [String]
+			$result = ConvertFrom-Json $Json
+			$result."about"| Should -Be "Ipsum pariatur nisi eiusmod aliquip in cupidatat. Deserunt non sit anim consectetur consectetur incididunt elit qui id proident nostrud. Consectetur pariatur et adipisicing aliquip fugiat fugiat Lorem reprehenderit laboris magna. Duis veniam irure amet ex minim eiusmod et laborum non elit. Dolor enim Lorem occaecat nisi consectetur mollit laborum anim velit et. Irure aliquip eiusmod anim proident ex ea duis deserunt aute amet adipisicing nisi nostrud. Minim ipsum fugiat consequat mollit fugiat tempor fugiat."
+			$result."about" | Should -Beoftype [String]
+			$result."address"| Should -Be "931 Kings Place, Hartsville/Hartley, Federated States Of Micronesia, 9344"
+			$result."address" | Should -Beoftype [String]
+			$result."age" | Should -Beoftype [Int64]
+			$result."balance"| Should -Be ",039.72"
+			$result."balance" | Should -Beoftype [String]
+			$result."company"| Should -Be "INSECTUS"
+			$result."company" | Should -Beoftype [String]
+			$result."email"| Should -Be "rhodesroberson@insectus.com"
+			$result."email" | Should -Beoftype [String]
+			$result."eyeColor"| Should -Be "green"
+			$result."eyeColor" | Should -Beoftype [String]
+			$result."favoriteFruit"| Should -Be "banana"
+			$result."favoriteFruit" | Should -Beoftype [String]
+			$result."gender"| Should -Be "male"
+			$result."gender" | Should -Beoftype [String]
+			$result."greeting"| Should -Be "Hello, Rhodes Roberson! You have 9 unread messages."
+			$result."greeting" | Should -Beoftype [String]
+			$result."guid"| Should -Be "429b96a7-24e3-47de-a93b-f44a346c5ac9"
+			$result."guid" | Should -Beoftype [String]
+			$result."index" | Should -Beoftype [Int64]
+			$result."isActive"| Should -Be False
+			$result."isActive" | Should -Beoftype [Boolean]
+			$result."latitude"| Should -Be 51.890798
+			$result."latitude" | Should -Beoftype [Double]
+			$result."longitude"| Should -Be -47.522764
+			$result."longitude" | Should -Beoftype [Double]
+			$result."name"| Should -Be "Rhodes Roberson"
+			$result."name" | Should -Beoftype [String]
+			$result."phone"| Should -Be "+1 (883) 561-3999"
+			$result."phone" | Should -Beoftype [String]
+			$result."picture"| Should -Be "http://placehold.it/32x32"
+			$result."picture" | Should -Beoftype [String]
+			$result."registered"| Should -Be "2019-12-17T06:14:06 +06:00"
+			$result."registered" | Should -Beoftype [String]
+			$result."_id"| Should -Be "60dd3ea9253016932039a0a2"
+			$result."_id" | Should -Beoftype [String]
 			
-			$Object.Tags | should -beoftype [string]
+			$result.Tags | Should -Beoftype [string]
 			
-			$Object.Tags.count | should -be 7 
-			$Object.Tags[0] | should -be "laboris"
-			$Object.Tags | Should -be @("laboris", "voluptate", "amet", "ad", "velit", "ipsum", "do")
-			
-			
-			$Object.Friends | should -beoftype [pscustomobject]
-			$Object.Friends[0].id | should -be 0
-			$Object.Friends[0].name | should -be "Renee Holden"
-			$Object.Friends[1].id | should -be 1
-			$Object.Friends[1].name | should -be "Bennett Dixon"
-			$Object.Friends[2].id | should -be 2
-			$Object.Friends[2].name | should -be "Emilia Holder"
-			$Object.Tags.count | should -be 7 
-			$Object.Tags | Should -be @("laboris", "voluptate", "amet", "ad", "velit", "ipsum", "do")
+			$result.Tags.count | Should -Be 7 
+			$result.Tags[0] | Should -Be "laboris"
+			$result.Tags | Should -Be @("laboris", "voluptate", "amet", "ad", "velit", "ipsum", "do")
 			
 			
+			$result.Friends | Should -Beoftype [pscustomobject]
+			$result.Friends[0].id | Should -Be 0
+			$result.Friends[0].name | Should -Be "Renee Holden"
+			$result.Friends[1].id | Should -Be 1
+			$result.Friends[1].name | Should -Be "Bennett Dixon"
+			$result.Friends[2].id | Should -Be 2
+			$result.Friends[2].name | Should -Be "Emilia Holder"
+			$result.Tags.count | Should -Be 7 
+			$result.Tags | Should -Be @("laboris", "voluptate", "amet", "ad", "velit", "ipsum", "do")
 		}
 		
 		It "ConvertFrom-Json chooses the appropriate number type" {
@@ -567,9 +565,7 @@ Describe "Json Tests" -Tags "Feature" {
 			ConvertFrom-Json -InputObject "5000000000000" | should -be "5000000000000"
 			ConvertFrom-Json -InputObject "5000000000000" | should -beoftype [int64]
 			ConvertFrom-Json -InputObject 5000000000000 | should -beoftype [int64]
-			ConvertFrom-Json -InputObject "5.0" | should -be 5
 			ConvertFrom-Json -InputObject "5.0" | should -be 5.0
-			ConvertFrom-Json -InputObject 5.0 | should -be 5
 			ConvertFrom-Json -InputObject 5.0 | should -be 5.0
 			ConvertFrom-Json -InputObject "5.0" | should -beoftype [double]
 			ConvertFrom-Json -InputObject 5.0 | should -beoftype [double]

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
@@ -548,14 +548,29 @@ Describe "Json Tests" -Tags "Feature" {
 			$Object.Friends | should -beoftype [pscustomobject]
 			$Object.Friends[0].id | should -be 0
 			$Object.Friends[0].name | should -be "Renee Holden"
-			$Object.Friends[1].id | should -be 0
+			$Object.Friends[1].id | should -be 1
 			$Object.Friends[1].name | should -be "Bennett Dixon"
-			$Object.Friends[2].id | should -be 0
+			$Object.Friends[2].id | should -be 2
 			$Object.Friends[2].name | should -be "Emilia Holder"
 			$Object.Tags.count | should -be 7 
 			$Object.Tags | Should -be @("laboris", "voluptate", "amet", "ad", "velit", "ipsum", "do")
 			
 			
+		}
+		
+		It "ConvertFrom-Json chooses the appropriate number type" {
+			ConvertFrom-Json -InputObject "5" | should -be 5
+			ConvertFrom-Json -InputObject 5 | should -be 5
+			ConvertFrom-Json -InputObject "5" | should -beoftype [int64]
+			ConvertFrom-Json -InputObject 5 | should -beoftype [int64]
+			ConvertFrom-Json -InputObject "5000000000000" | should -beoftype [int64]
+			ConvertFrom-Json -InputObject 5000000000000 | should -beoftype [int64]
+			ConvertFrom-Json -InputObject "5.0" | should -beoftype [double]
+			ConvertFrom-Json -InputObject 5.0 | should -beoftype [double]
+			ConvertFrom-Json -InputObject "500000000000.0000000000000001" | should -beoftype [double]
+			ConvertFrom-Json -InputObject 500000000000.0000000000000001 | should -beoftype [double]
+			ConvertFrom-Json -InputObject "50000000000000000000000000000000000.0000000000000001" | should -beoftype [double]
+			ConvertFrom-Json -InputObject 50000000000000000000000000000000000.0000000000000001 | should -beoftype [double]
 		}
 		
         It "ConvertFrom-Json with special characters" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The current json tests do not adequately test datetimes and integers and while there are some unit tests for primitives there are no "large object" tests. I created a little test generator to take an object and produce tests using the various formats.

The datetime tests also do specific things in the case that newtonsoft chooses to convert the json string into a datetime versus when it does not.

The complex object test makes sure that our unit tests apply even when the object is large, with a variety of types and with nested arrays and objects.

The number tests make sure that we properly capture when newtonsoft decides to give us int64 vs double vs bigint objects.

This will make it apparent when changes to the deserializer cause a difference in behavior for datetime , numbers or complex objects.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

Improve test coverage for json cmdlets.  These tests document current behavior and do not have an opinion on what **correct** behavior looks like. These will help with a future move to system.text.json in understanding where the differences in deserialization are.

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
