### PR TITLE
Fix #12229: ConvertFrom-Json incorrectly handles a set with a first element of empty

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertFromJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertFromJsonCommand.cs
@@ -75,7 +75,7 @@ namespace Microsoft.PowerShell.Commands
 
                 if (_inputObjectBuffer.Count == 1)
                 {
-                    ConvertFromJsonHelper(_inputObjectBuffer[0].Trim(), out error);
+                    ConvertFromJsonHelper(_inputObjectBuffer[0], out error);
                 }
                 else
                 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertFromJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertFromJsonCommand.cs
@@ -72,6 +72,7 @@ namespace Microsoft.PowerShell.Commands
             if (_inputObjectBuffer.Count > 0)
             {
                 ErrorRecord error = null;
+                ArgumentException exception = null;
 
                 if (_inputObjectBuffer.Count == 1)
                 {
@@ -87,13 +88,15 @@ namespace Microsoft.PowerShell.Commands
                         // Try to deserialize the first element.
                         ConvertFromJsonHelper(_inputObjectBuffer[0], out error);
                     }
-                    catch (ArgumentException)
+                    catch (ArgumentException thisError)
                     {
+                        exception = thisError;
                         // The first input string does not represent a complete Json Syntax.
                         // Hence consider the the entire input as a single Json content.
                     }
 
-                    if (error == null)
+                    // We were able to parse the first entry so that means we should parse every entry
+                    if (error != null || exception != null)
                     {
                         for (int index = 1; index < _inputObjectBuffer.Count; index++)
                         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertFromJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertFromJsonCommand.cs
@@ -80,8 +80,8 @@ namespace Microsoft.PowerShell.Commands
                 else
                 {
                     // The logic here is that we try to deserialize the first element and:
-                    // if it fails then we should concatenate all of the elements and convert the lerge blob
-                    // if it succeeds we should deserialize the rest of the elements starting at index 2
+                    //   if it fails then we should concatenate all of the elements and convert the lerge blob
+                    //   if it succeeds we should deserialize the rest of the elements starting at index 2
                     try
                     {
                         // Try to deserialize the first element.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertFromJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertFromJsonCommand.cs
@@ -96,7 +96,7 @@ namespace Microsoft.PowerShell.Commands
                     }
 
                     // We were able to parse the first entry so that means we should parse every entry
-                    if (error != null || exception != null)
+                    if (error == null && exception == null)
                     {
                         for (int index = 1; index < _inputObjectBuffer.Count; index++)
                         {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Json.Tests.ps1
@@ -132,7 +132,7 @@ Describe 'ConvertFrom-Json Unit Tests' -tags "CI" {
         '[ 1 ]' | ConvertFrom-Json -NoEnumerate | ConvertTo-Json -Compress | Should -Be '[1]'
     }
 
-	It 'Properly handles a null first element' {
+	It 'Properly handles an empty first element' {
 		(@('5','','','','','') | convertfrom-json).count | should -be 6
 		(@('','5','','','','') | convertfrom-json).count | should -be 6
 		(@('','','5','','','') | convertfrom-json).count | should -be 6

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Json.Tests.ps1
@@ -132,6 +132,16 @@ Describe 'ConvertFrom-Json Unit Tests' -tags "CI" {
         '[ 1 ]' | ConvertFrom-Json -NoEnumerate | ConvertTo-Json -Compress | Should -Be '[1]'
     }
 
+	It 'Properly handles a null first element' {
+		(@('5','','','','','') | convertfrom-json).count | should -be 6
+		(@('','5','','','','') | convertfrom-json).count | should -be 6
+		(@('','','5','','','') | convertfrom-json).count | should -be 6
+		(@('','','','5','','') | convertfrom-json).count | should -be 6
+		(@('','','','','5','') | convertfrom-json).count | should -be 6
+		(@('','','','','','5') | convertfrom-json).count | should -be 6
+		@('','','{"common":[1,2]}' | ConvertFrom-Json).Length | should -be 3
+	}
+
     It 'Can convert null' {
         'null' | ConvertFrom-Json | Should -Be $null
         $out = '[1, null, 2]' | ConvertFrom-Json


### PR DESCRIPTION
# PR Summary

Fixes https://github.com/PowerShell/PowerShell/issues/12229

Still need to add tests

<!-- Summarize your PR between here and the checklist. -->

## PR Context

Fixes a bug when passing a empty first element in a set to convertfrom-json. It would cause an edge case where an unintended null would get output to the pipeline. 

Description of the bug and the fix: https://github.com/PowerShell/PowerShell/issues/12229#issuecomment-872749829
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
