### PR TITLE
WIP: Don't specify `paramName` for `ArgumentNullException` in properties

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/SessionBasedWrapper.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/SessionBasedWrapper.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PowerShell.Cmdletization
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException();
                 }
 
                 _session = value;

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
@@ -1090,7 +1090,7 @@ namespace Microsoft.PowerShell.Commands
         public string Name
         {
             get => _name;
-            set => _name = value ?? throw PSTraceSource.NewArgumentNullException(nameof(value));
+            set => _name = value ?? throw PSTraceSource.NewArgumentNullException();
         }
 
         /// <summary>
@@ -1100,7 +1100,7 @@ namespace Microsoft.PowerShell.Commands
         public string PSProvider
         {
             get => _provider;
-            set => _provider = value ?? throw PSTraceSource.NewArgumentNullException(nameof(value));
+            set => _provider = value ?? throw PSTraceSource.NewArgumentNullException();
         }
 
         /// <summary>
@@ -1112,7 +1112,7 @@ namespace Microsoft.PowerShell.Commands
         public string Root
         {
             get => _root;
-            set => _root = value ?? throw PSTraceSource.NewArgumentNullException(nameof(value));
+            set => _root = value ?? throw PSTraceSource.NewArgumentNullException();
         }
 
         /// <summary>
@@ -1122,7 +1122,7 @@ namespace Microsoft.PowerShell.Commands
         public string Description
         {
             get => _description;
-            set => _description = value ?? throw PSTraceSource.NewArgumentNullException(nameof(value));
+            set => _description = value ?? throw PSTraceSource.NewArgumentNullException();
         }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -1285,7 +1285,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 // null check is not needed (because of ValidateNotNullOrEmpty),
                 // but we have to include it to silence OACR
-                _includeStrings = value ?? throw PSTraceSource.NewArgumentNullException(nameof(value));
+                _includeStrings = value ?? throw PSTraceSource.NewArgumentNullException();
 
                 _include = new WildcardPattern[_includeStrings.Length];
                 for (int i = 0; i < _includeStrings.Length; i++)
@@ -1312,7 +1312,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 // null check is not needed (because of ValidateNotNullOrEmpty),
                 // but we have to include it to silence OACR
-                _excludeStrings = value ?? throw PSTraceSource.NewArgumentNullException("value");
+                _excludeStrings = value ?? throw PSTraceSource.NewArgumentNullException();
 
                 _exclude = new WildcardPattern[_excludeStrings.Length];
                 for (int i = 0; i < _excludeStrings.Length; i++)
@@ -1384,7 +1384,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 // null check is not needed (because of ValidateNotNullOrEmpty),
                 // but we have to include it to silence OACR
-                _context = value ?? throw PSTraceSource.NewArgumentNullException("value");
+                _context = value ?? throw PSTraceSource.NewArgumentNullException();
 
                 if (_context.Length == 1)
                 {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostRawUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostRawUserInterface.cs
@@ -831,7 +831,7 @@ namespace Microsoft.PowerShell
                 }
                 else
                 {
-                    throw PSTraceSource.NewArgumentNullException("value");
+                    throw PSTraceSource.NewArgumentNullException();
                 }
             }
         }

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -289,7 +289,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException();
                 }
 
                 _parameterNames = value;
@@ -319,7 +319,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException();
                 }
 
                 // if '...CimInstance#Win32_Process' is specified, then exclude '...CimInstance'

--- a/src/System.Management.Automation/engine/PseudoParameters.cs
+++ b/src/System.Management.Automation/engine/PseudoParameters.cs
@@ -116,7 +116,7 @@ namespace System.Management.Automation
             {
                 if (value == null)
                 {
-                    throw PSTraceSource.NewArgumentNullException("value");
+                    throw PSTraceSource.NewArgumentNullException();
                 }
 
                 _parameterType = value;

--- a/src/System.Management.Automation/engine/hostifaces/ChoiceDescription.cs
+++ b/src/System.Management.Automation/engine/hostifaces/ChoiceDescription.cs
@@ -126,7 +126,7 @@ namespace System.Management.Automation.Host
             {
                 if (value == null)
                 {
-                    throw PSTraceSource.NewArgumentNullException("value");
+                    throw PSTraceSource.NewArgumentNullException();
                 }
 
                 this.helpMessage = value;

--- a/src/System.Management.Automation/engine/hostifaces/FieldDescription.cs
+++ b/src/System.Management.Automation/engine/hostifaces/FieldDescription.cs
@@ -198,7 +198,7 @@ namespace System.Management.Automation.Host
             {
                 if (value == null)
                 {
-                    throw PSTraceSource.NewArgumentNullException("value");
+                    throw PSTraceSource.NewArgumentNullException();
                 }
 
                 label = value;
@@ -230,7 +230,7 @@ namespace System.Management.Automation.Host
             {
                 if (value == null)
                 {
-                    throw PSTraceSource.NewArgumentNullException("value");
+                    throw PSTraceSource.NewArgumentNullException();
                 }
 
                 helpMessage = value;

--- a/src/System.Management.Automation/engine/lang/scriptblock.cs
+++ b/src/System.Management.Automation/engine/lang/scriptblock.cs
@@ -716,7 +716,7 @@ namespace System.Management.Automation
             {
                 if (value == null)
                 {
-                    throw PSTraceSource.NewArgumentNullException(nameof(value));
+                    throw PSTraceSource.NewArgumentNullException();
                 }
 
                 SessionStateInternal = value.Internal;

--- a/src/System.Management.Automation/engine/remoting/client/Job2.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job2.cs
@@ -105,7 +105,7 @@ namespace System.Management.Automation
             {
                 if (value == null)
                 {
-                    throw PSTraceSource.NewArgumentNullException("value");
+                    throw PSTraceSource.NewArgumentNullException();
                 }
 
                 lock (_syncobject)

--- a/src/System.Management.Automation/engine/remoting/client/JobSourceAdapter.cs
+++ b/src/System.Management.Automation/engine/remoting/client/JobSourceAdapter.cs
@@ -188,7 +188,7 @@ namespace System.Management.Automation
             set
             {
                 if (value == null)
-                    throw new PSArgumentNullException("value");
+                    throw new PSArgumentNullException();
                 _name = value;
             }
         }

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -168,7 +168,7 @@ namespace System.Management.Automation.Runspaces
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException();
                 }
 
                 _culture = value;
@@ -191,7 +191,7 @@ namespace System.Management.Automation.Runspaces
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException();
                 }
 
                 _uiCulture = value;
@@ -403,7 +403,7 @@ namespace System.Management.Automation.Runspaces
             {
                 if (value == null)
                 {
-                    throw PSTraceSource.NewArgumentNullException("value");
+                    throw PSTraceSource.NewArgumentNullException();
                 }
 
                 UpdateUri(value);
@@ -610,7 +610,7 @@ namespace System.Management.Automation.Runspaces
             {
                 if (value == null)
                 {
-                    throw PSTraceSource.NewArgumentNullException("value");
+                    throw PSTraceSource.NewArgumentNullException();
                 }
 
                 _thumbPrint = value;

--- a/src/System.Management.Automation/namespaces/ProviderBase.cs
+++ b/src/System.Management.Automation/namespaces/ProviderBase.cs
@@ -139,7 +139,7 @@ namespace System.Management.Automation.Provider
             {
                 if (value == null)
                 {
-                    throw PSTraceSource.NewArgumentNullException("value");
+                    throw PSTraceSource.NewArgumentNullException();
                 }
 
                 // Check that the provider supports the use of credentials

--- a/src/System.Management.Automation/namespaces/SessionStateProviderBase.cs
+++ b/src/System.Management.Automation/namespaces/SessionStateProviderBase.cs
@@ -694,7 +694,7 @@ namespace Microsoft.PowerShell.Commands
             if (newItem == null)
             {
                 ArgumentNullException argException =
-                    PSTraceSource.NewArgumentNullException("value");
+                    PSTraceSource.NewArgumentNullException(nameof(newItem));
 
                 WriteError(
                     new ErrorRecord(

--- a/src/System.Management.Automation/utils/MshTraceSource.cs
+++ b/src/System.Management.Automation/utils/MshTraceSource.cs
@@ -217,6 +217,8 @@ namespace System.Management.Automation
 
         #region TraceFlags.New*Exception methods/helpers
 
+        internal static PSArgumentNullException NewArgumentNullException() => new PSArgumentNullException();
+
         /// <summary>
         /// Traces the Message and StackTrace properties of the exception
         /// and returns the new exception. This is not allowed to call other


### PR DESCRIPTION
Specifying `value` as a `paramName` for `ArgumentException` in properties does not add any value over the stack trace.

_Follow-up to https://github.com/PowerShell/PowerShell/pull/15604#discussion_r655238211._