### PR TITLE
Seal private classes

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimConverter.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimConverter.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PowerShell.Cim
 {
     internal class CimSensitiveValueConverter : IDisposable
     {
-        private class SensitiveString : IDisposable
+        private sealed class SensitiveString : IDisposable
         {
             private GCHandle _gcHandle;
             private string _string;

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/clientSideQuery.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/clientSideQuery.cs
@@ -181,7 +181,7 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
             }
         }
 
-        private class CimInstanceRegularFilter : CimInstancePropertyBasedFilter
+        private sealed class CimInstanceRegularFilter : CimInstancePropertyBasedFilter
         {
             public CimInstanceRegularFilter(string propertyName, IEnumerable allowedPropertyValues, bool wildcardsEnabled, BehaviorOnNoMatch behaviorOnNoMatch)
             {
@@ -247,7 +247,7 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
             }
         }
 
-        private class CimInstanceExcludeFilter : CimInstancePropertyBasedFilter
+        private sealed class CimInstanceExcludeFilter : CimInstancePropertyBasedFilter
         {
             public CimInstanceExcludeFilter(string propertyName, IEnumerable excludedPropertyValues, bool wildcardsEnabled, BehaviorOnNoMatch behaviorOnNoMatch)
             {
@@ -272,7 +272,7 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
             }
         }
 
-        private class CimInstanceMinFilter : CimInstancePropertyBasedFilter
+        private sealed class CimInstanceMinFilter : CimInstancePropertyBasedFilter
         {
             public CimInstanceMinFilter(string propertyName, object minPropertyValue, BehaviorOnNoMatch behaviorOnNoMatch)
             {
@@ -293,7 +293,7 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
             }
         }
 
-        private class CimInstanceMaxFilter : CimInstancePropertyBasedFilter
+        private sealed class CimInstanceMaxFilter : CimInstancePropertyBasedFilter
         {
             public CimInstanceMaxFilter(string propertyName, object minPropertyValue, BehaviorOnNoMatch behaviorOnNoMatch)
             {
@@ -314,7 +314,7 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
             }
         }
 
-        private class CimInstanceAssociationFilter : CimInstanceFilterBase
+        private sealed class CimInstanceAssociationFilter : CimInstanceFilterBase
         {
             public CimInstanceAssociationFilter(BehaviorOnNoMatch behaviorOnNoMatch)
             {

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
@@ -522,7 +522,7 @@ $result
             }
         }
 
-        private class ComputerInfo
+        private sealed class ComputerInfo
         {
             internal string LastBootUpTime;
             internal bool RebootComplete;

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetComputerInfoCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetComputerInfoCommand.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PowerShell.Commands
     public class GetComputerInfoCommand : PSCmdlet
     {
         #region Inner Types
-        private class OSInfoGroup
+        private sealed class OSInfoGroup
         {
             public WmiOperatingSystem os;
             public HotFix[] hotFixes;
@@ -41,7 +41,7 @@ namespace Microsoft.PowerShell.Commands
             public RegWinNtCurrentVersion regCurVer;
         }
 
-        private class SystemInfoGroup
+        private sealed class SystemInfoGroup
         {
             public WmiBaseBoard baseboard;
             public WmiBios bios;
@@ -50,7 +50,7 @@ namespace Microsoft.PowerShell.Commands
             public NetworkAdapter[] networkAdapters;
         }
 
-        private class HyperVInfo
+        private sealed class HyperVInfo
         {
             public bool? Present;
             public bool? VMMonitorModeExtensions;
@@ -59,13 +59,13 @@ namespace Microsoft.PowerShell.Commands
             public bool? DataExecutionPreventionAvailable;
         }
 
-        private class DeviceGuardInfo
+        private sealed class DeviceGuardInfo
         {
             public DeviceGuardSmartStatus status;
             public DeviceGuard deviceGuard;
         }
 
-        private class MiscInfoGroup
+        private sealed class MiscInfoGroup
         {
             public ulong? physicallyInstalledMemory;
             public string timeZone;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -1107,7 +1107,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         // Visit symbols in all namespaces and collect duplicates.
-        private class AllNamedTypeSymbolsVisitor : SymbolVisitor
+        private sealed class AllNamedTypeSymbolsVisitor : SymbolVisitor
         {
             public readonly ConcurrentBag<string> DuplicateSymbols = new();
             public readonly ConcurrentBag<string> UniqueSymbols = new();

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetMember.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetMember.cs
@@ -249,7 +249,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        private class MemberComparer : System.Collections.Generic.IComparer<MemberDefinition>
+        private sealed class MemberComparer : System.Collections.Generic.IComparer<MemberDefinition>
         {
             public int Compare(MemberDefinition first, MemberDefinition second)
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -410,7 +410,7 @@ namespace Microsoft.PowerShell.Commands
         /// A generic circular buffer.
         /// </summary>
         /// <typeparam name="T">The type of items that are buffered.</typeparam>
-        private class CircularBuffer<T> : ICollection<T>
+        private sealed class CircularBuffer<T> : ICollection<T>
         {
             // Ring of items
             private readonly T[] _items;
@@ -627,7 +627,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// A state machine to track display context for each match.
         /// </summary>
-        private class DisplayContextTracker : IContextTracker
+        private sealed class DisplayContextTracker : IContextTracker
         {
             private enum ContextState
             {
@@ -784,12 +784,12 @@ namespace Microsoft.PowerShell.Commands
         /// and other matching lines (since they will appear
         /// as their own match entries.).
         /// </remarks>
-        private class LogicalContextTracker : IContextTracker
+        private sealed class LogicalContextTracker : IContextTracker
         {
             // A union: string | MatchInfo. Needed since
             // context lines could be either proper matches
             // or non-matching lines.
-            private class ContextEntry
+            private sealed class ContextEntry
             {
                 public readonly string Line;
                 public readonly MatchInfo Match;
@@ -989,7 +989,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// A class to track both logical and display contexts.
         /// </summary>
-        private class ContextTracker : IContextTracker
+        private sealed class ContextTracker : IContextTracker
         {
             private readonly IContextTracker _displayTracker;
             private readonly IContextTracker _logicalTracker;
@@ -1058,7 +1058,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// ContextTracker that does not work for the case when pre- and post context is 0.
         /// </summary>
-        private class NoContextTracker : IContextTracker
+        private sealed class NoContextTracker : IContextTracker
         {
             private readonly IList<MatchInfo> _matches = new List<MatchInfo>(1);
 
@@ -1996,7 +1996,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Magic class that works around the limitations on ToString() for FileInfo.
         /// </summary>
-        private class FileinfoToStringAttribute : ArgumentTransformationAttribute
+        private sealed class FileinfoToStringAttribute : ArgumentTransformationAttribute
         {
             public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
@@ -160,7 +160,7 @@ namespace Microsoft.PowerShell.Commands
         /// Keys are strings. Keys are compared with OrdinalIgnoreCase.
         /// </summary>
         /// <typeparam name="TValue">Value type.</typeparam>
-        private class MeasureObjectDictionary<TValue> : Dictionary<string, TValue>
+        private sealed class MeasureObjectDictionary<TValue> : Dictionary<string, TValue>
             where TValue : new()
         {
             /// <summary>
@@ -200,7 +200,7 @@ namespace Microsoft.PowerShell.Commands
         /// what mode we're in.
         /// </summary>
         [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses")]
-        private class Statistics
+        private sealed class Statistics
         {
             // Common properties
             internal int count = 0;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/New-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/New-Object.cs
@@ -416,7 +416,7 @@ namespace Microsoft.PowerShell.Commands
             return result;
         }
 
-        private class ComCreateInfo
+        private sealed class ComCreateInfo
         {
             public object objectCreated;
             public bool success;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -223,7 +223,7 @@ namespace Microsoft.PowerShell.Commands
 
         private SelectObjectQueue _selectObjectQueue;
 
-        private class SelectObjectQueue : Queue<PSObject>
+        private sealed class SelectObjectQueue : Queue<PSObject>
         {
             internal SelectObjectQueue(int first, int last, int skip, int skipLast, bool firstOrLastSpecified)
             {
@@ -324,7 +324,7 @@ namespace Microsoft.PowerShell.Commands
 
         private PSPropertyExpressionFilter _exclusionFilter;
 
-        private class UniquePSObjectHelper
+        private sealed class UniquePSObjectHelper
         {
             internal UniquePSObjectHelper(PSObject o, int notePropertyCount)
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -98,7 +98,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        private class DuplicateMemberHashSet : HashSet<string>
+        private sealed class DuplicateMemberHashSet : HashSet<string>
         {
             public DuplicateMemberHashSet(int capacity)
                 : base(capacity, StringComparer.OrdinalIgnoreCase)

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -2916,7 +2916,7 @@ namespace Microsoft.PowerShell
             {
             }
 
-            protected
+            internal
             ConsoleHostStartupException(
                 System.Runtime.Serialization.SerializationInfo info,
                 System.Runtime.Serialization.StreamingContext context)

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -2322,7 +2322,7 @@ namespace Microsoft.PowerShell
         /// Neither this class' instances nor its static data is threadsafe.  Caller is responsible for ensuring threadsafe
         /// access.
         /// </summary>
-        private class InputLoop
+        private sealed class InputLoop
         {
             internal static void RunNewInputLoop(ConsoleHost parent, bool isNested)
             {
@@ -2902,7 +2902,7 @@ namespace Microsoft.PowerShell
         [Serializable]
         [SuppressMessage("Microsoft.Design", "CA1064:ExceptionsShouldBePublic", Justification =
             "This exception cannot be used outside of the console host application. It is not thrown by a library routine, only by an application.")]
-        private class ConsoleHostStartupException : Exception
+        private sealed class ConsoleHostStartupException : Exception
         {
             internal
             ConsoleHostStartupException()

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -2916,7 +2916,7 @@ namespace Microsoft.PowerShell
             {
             }
 
-            internal
+            private
             ConsoleHostStartupException(
                 System.Runtime.Serialization.SerializationInfo info,
                 System.Runtime.Serialization.StreamingContext context)

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/Executor.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/Executor.cs
@@ -124,7 +124,7 @@ namespace Microsoft.PowerShell
             _parent.ErrorSerializer.Serialize(er);
         }
 
-        private class PipelineFinishedWaitHandle
+        private sealed class PipelineFinishedWaitHandle
         {
             internal PipelineFinishedWaitHandle(Pipeline p)
             {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/PendingProgress.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/PendingProgress.cs
@@ -265,8 +265,7 @@ namespace Microsoft.PowerShell
 #endif
         }
 
-        private
-        class FindOldestNodeVisitor : NodeVisitor
+        private sealed class FindOldestNodeVisitor : NodeVisitor
         {
             internal override
             bool
@@ -366,8 +365,7 @@ namespace Microsoft.PowerShell
                 FindNodeById(sourceId, activityId, out listWhereFound, out indexWhereFound);
         }
 
-        private
-        class FindByIdNodeVisitor : NodeVisitor
+        private sealed class FindByIdNodeVisitor : NodeVisitor
         {
             internal
             FindByIdNodeVisitor(Int64 sourceIdToFind, int activityIdToFind)
@@ -508,8 +506,7 @@ namespace Microsoft.PowerShell
             return found;
         }
 
-        private
-        class AgeAndResetStyleVisitor : NodeVisitor
+        private sealed class AgeAndResetStyleVisitor : NodeVisitor
         {
             internal override
             bool
@@ -666,8 +663,7 @@ namespace Microsoft.PowerShell
             }
         }
 
-        private
-        class HeightTallyer : NodeVisitor
+        private sealed class HeightTallyer : NodeVisitor
         {
             internal HeightTallyer(PSHostRawUserInterface rawUi, int maxHeight, int maxWidth)
             {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/UpdatesNotification.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/UpdatesNotification.cs
@@ -428,7 +428,7 @@ namespace Microsoft.PowerShell
             LTS = 2
         }
 
-        private class Release
+        private sealed class Release
         {
             internal Release(string publishAt, string tagName)
             {

--- a/src/Microsoft.PowerShell.LocalAccounts/LocalAccounts/Sam.cs
+++ b/src/Microsoft.PowerShell.LocalAccounts/LocalAccounts/Sam.cs
@@ -214,7 +214,7 @@ namespace System.Management.Automation.SecurityAccountsManager
         /// Used primarily by the private ThrowOnFailure method when building
         /// Exception objects to throw.
         /// </remarks>
-        private class Context
+        private sealed class Context
         {
             public ContextOperation operation;
             public ContextObjectType type;
@@ -308,7 +308,7 @@ namespace System.Management.Automation.SecurityAccountsManager
         /// AccountInfo is the return type from the private
         /// LookupAccountInfo method.
         /// </remarks>
-        private class AccountInfo
+        private sealed class AccountInfo
         {
             public string AccountName;
             public string DomainName;

--- a/src/Microsoft.PowerShell.ScheduledJob/ScheduledJob.cs
+++ b/src/Microsoft.PowerShell.ScheduledJob/ScheduledJob.cs
@@ -953,7 +953,7 @@ namespace Microsoft.PowerShell.ScheduledJob
         #region Private ResultsInfo class
 
         [Serializable]
-        private class ResultsInfo : ISerializable
+        private sealed class ResultsInfo : ISerializable
         {
             // Private Members
             private Collection<PSObject> _output;

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -848,7 +848,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// Context for the outer scope of the format sequence.
         /// </summary>
-        private class FormatOutputContext : FormatMessagesContextManager.OutputContext
+        private sealed class FormatOutputContext : FormatMessagesContextManager.OutputContext
         {
             /// <summary>
             /// Construct a context to push on the stack.
@@ -917,7 +917,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             protected OutCommandInner InnerCommand { get; }
         }
 
-        private class TableOutputContextBase : GroupOutputContext
+        private sealed class TableOutputContextBase : GroupOutputContext
         {
             /// <summary>
             /// Construct a context to push on the stack.
@@ -1296,7 +1296,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             /// Helper class to accumulate the display values so that when the end
             /// of a line is reached, a full line can be composed.
             /// </summary>
-            private class StringValuesBuffer
+            private sealed class StringValuesBuffer
             {
                 /// <summary>
                 /// Construct the buffer.

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -917,7 +917,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             protected OutCommandInner InnerCommand { get; }
         }
 
-        private sealed class TableOutputContextBase : GroupOutputContext
+        private class TableOutputContextBase : GroupOutputContext
         {
             /// <summary>
             /// Construct a context to push on the stack.

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayResourceManagerCache.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayResourceManagerCache.cs
@@ -142,7 +142,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// Helper class to resolve an assembly name to an assembly reference
         /// The class caches previous results for faster lookup.
         /// </summary>
-        private class AssemblyNameResolver
+        private sealed class AssemblyNameResolver
         {
             /// <summary>
             /// Resolve the assembly name against the set of loaded assemblies.

--- a/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// Information about each column boundaries.
         /// </summary>
-        private class ColumnInfo
+        private sealed class ColumnInfo
         {
             internal int startCol = 0;
             internal int width = 0;
@@ -25,7 +25,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// Class containing information about the tabular layout.
         /// </summary>
-        private class ScreenInfo
+        private sealed class ScreenInfo
         {
             internal int screenColumns = 0;
             internal int screenRows = 0;

--- a/src/System.Management.Automation/FormatAndOutput/out-console/ConsoleLineOutput.cs
+++ b/src/System.Management.Automation/FormatAndOutput/out-console/ConsoleLineOutput.cs
@@ -473,7 +473,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// Object to manage prompting.
         /// </summary>
-        private class PromptHandler
+        private sealed class PromptHandler
         {
             /// <summary>
             /// Prompt handler with the given prompt.

--- a/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
@@ -4047,7 +4047,7 @@ namespace System.Management.Automation
 
         private ReflectionParameterBinder _commonParametersBinder;
 
-        private class DelayedScriptBlockArgument
+        private sealed class DelayedScriptBlockArgument
         {
             // Remember the parameter binder so we know when to invoke the script block
             // and when to use the evaluated argument.

--- a/src/System.Management.Automation/engine/CommandCompletion/CommandCompletion.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CommandCompletion.cs
@@ -1141,7 +1141,7 @@ namespace System.Management.Automation
         /// LastWordFinder implements the algorithm we use to search for the last word in a line of input taken from the console.
         /// This class exists for legacy purposes only - V3 and forward uses a slightly different interface.
         /// </summary>
-        private class LastWordFinder
+        private sealed class LastWordFinder
         {
             internal static string FindLastWord(string sentence, out int replacementIndexOut, out char closingQuote)
             {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -5913,7 +5913,7 @@ namespace System.Management.Automation
         /// This type represents a non-generic type for type name completion. It only contains information that can be
         /// inferred from the full type name.
         /// </summary>
-        private sealed class TypeCompletionInStringFormat : TypeCompletionBase
+        private class TypeCompletionInStringFormat : TypeCompletionBase
         {
             /// <summary>
             /// Get the full type name of the type represented by this instance.
@@ -6056,7 +6056,7 @@ namespace System.Management.Automation
         /// <summary>
         /// This type represents a non-generic type for type name completion. It contains the actual type instance.
         /// </summary>
-        private sealed class TypeCompletion : TypeCompletionBase
+        private class TypeCompletion : TypeCompletionBase
         {
             internal Type Type;
 

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -407,7 +407,7 @@ namespace System.Management.Automation
             return results;
         }
 
-        private class FindFunctionsVisitor : AstVisitor
+        private sealed class FindFunctionsVisitor : AstVisitor
         {
             internal readonly List<FunctionDefinitionAst> FunctionDefinitions = new List<FunctionDefinitionAst>();
 
@@ -4840,7 +4840,7 @@ namespace System.Management.Automation
             }
         }
 
-        private class FindVariablesVisitor : AstVisitor
+        private sealed class FindVariablesVisitor : AstVisitor
         {
             internal Ast Top;
             internal Ast CompletionVariableAst;
@@ -5913,7 +5913,7 @@ namespace System.Management.Automation
         /// This type represents a non-generic type for type name completion. It only contains information that can be
         /// inferred from the full type name.
         /// </summary>
-        private class TypeCompletionInStringFormat : TypeCompletionBase
+        private sealed class TypeCompletionInStringFormat : TypeCompletionBase
         {
             /// <summary>
             /// Get the full type name of the type represented by this instance.
@@ -5992,7 +5992,7 @@ namespace System.Management.Automation
         /// This type represents a generic type for type name completion. It only contains information that can be
         /// inferred from the full type name.
         /// </summary>
-        private class GenericTypeCompletionInStringFormat : TypeCompletionInStringFormat
+        private sealed class GenericTypeCompletionInStringFormat : TypeCompletionInStringFormat
         {
             /// <summary>
             /// Get the number of generic type arguments required by the type represented by this instance.
@@ -6056,7 +6056,7 @@ namespace System.Management.Automation
         /// <summary>
         /// This type represents a non-generic type for type name completion. It contains the actual type instance.
         /// </summary>
-        private class TypeCompletion : TypeCompletionBase
+        private sealed class TypeCompletion : TypeCompletionBase
         {
             internal Type Type;
 
@@ -6109,7 +6109,7 @@ namespace System.Management.Automation
         /// <summary>
         /// This type represents a generic type for type name completion. It contains the actual type instance.
         /// </summary>
-        private class GenericTypeCompletion : TypeCompletion
+        private sealed class GenericTypeCompletion : TypeCompletion
         {
             internal override CompletionResult GetCompletionResult(string keyMatched, string prefix, string suffix)
             {
@@ -6146,7 +6146,7 @@ namespace System.Management.Automation
         /// <summary>
         /// This type represents a namespace for namespace completion.
         /// </summary>
-        private class NamespaceCompletion : TypeCompletionBase
+        private sealed class NamespaceCompletion : TypeCompletionBase
         {
             internal string Namespace;
 
@@ -6168,7 +6168,7 @@ namespace System.Management.Automation
             }
         }
 
-        private class TypeCompletionMapping
+        private sealed class TypeCompletionMapping
         {
             // The Key is the string we'll be searching on.  It could complete to various things.
             internal string Key;
@@ -7234,7 +7234,7 @@ namespace System.Management.Automation
             return defaultChoice;
         }
 
-        private class ItemPathComparer : IComparer<PSObject>
+        private sealed class ItemPathComparer : IComparer<PSObject>
         {
             public int Compare(PSObject x, PSObject y)
             {
@@ -7269,7 +7269,7 @@ namespace System.Management.Automation
             }
         }
 
-        private class CommandNameComparer : IComparer<PSObject>
+        private sealed class CommandNameComparer : IComparer<PSObject>
         {
             public int Compare(PSObject x, PSObject y)
             {

--- a/src/System.Management.Automation/engine/CommandInfo.cs
+++ b/src/System.Management.Automation/engine/CommandInfo.cs
@@ -481,7 +481,7 @@ namespace System.Management.Automation
             return result;
         }
 
-        private class GetMergedCommandParameterMetadataSafelyEventArgs : EventArgs
+        private sealed class GetMergedCommandParameterMetadataSafelyEventArgs : EventArgs
         {
             public MergedCommandParameterMetadata Result;
             public ExceptionDispatchInfo Exception;

--- a/src/System.Management.Automation/engine/CommandParameter.cs
+++ b/src/System.Management.Automation/engine/CommandParameter.cs
@@ -12,14 +12,14 @@ namespace System.Management.Automation
     [DebuggerDisplay("{ParameterName}")]
     internal sealed class CommandParameterInternal
     {
-        private class Parameter
+        private sealed class Parameter
         {
             internal Ast ast;
             internal string parameterName;
             internal string parameterText;
         }
 
-        private class Argument
+        private sealed class Argument
         {
             internal Ast ast;
             internal object value;

--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -1177,7 +1177,7 @@ namespace System.Management.Automation
         }
 
         [DebuggerDisplay("OverloadCandidate: {method.methodDefinition}")]
-        private class OverloadCandidate
+        private sealed class OverloadCandidate
         {
             internal MethodInformation method;
             internal ParameterInformation[] parameters;

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -645,7 +645,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// The comparer to sort CommandInfo objects in the result list.
         /// </summary>
-        private class CommandInfoComparer : IComparer<CommandInfo>
+        private sealed class CommandInfoComparer : IComparer<CommandInfo>
         {
             /// <summary>
             /// Compare two CommandInfo objects first by their command types, and if they

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -362,7 +362,7 @@ namespace System.Management.Automation
         /// implementation of an object when we can't use it's non-generic
         /// implementation.
         /// </summary>
-        private class EnumerableTWrapper : IEnumerable
+        private sealed class EnumerableTWrapper : IEnumerable
         {
             private readonly object _enumerable;
             private readonly Type _enumerableType;
@@ -1889,7 +1889,7 @@ namespace System.Management.Automation
 
         internal class EnumSingleTypeConverter : PSTypeConverter
         {
-            private class EnumHashEntry
+            private sealed class EnumHashEntry
             {
                 internal EnumHashEntry(string[] names, Array values, UInt64 allValues, bool hasNegativeValue, bool hasFlagsAttribute)
                 {
@@ -3684,7 +3684,7 @@ namespace System.Management.Automation
             return ConvertStringToEnum(sbResult.ToString(), resultType, recursion, originalValueToConvert, formatProvider, backupTable);
         }
 
-        private class PSMethodToDelegateConverter
+        private sealed class PSMethodToDelegateConverter
         {
             // Index of the matching overload method.
             private readonly int _matchIndex;
@@ -3744,7 +3744,7 @@ namespace System.Management.Automation
             }
         }
 
-        private class ConvertViaParseMethod
+        private sealed class ConvertViaParseMethod
         {
             // TODO - use an ETS wrapper that generates a dynamic method
             internal MethodInfo parse;
@@ -3810,7 +3810,7 @@ namespace System.Management.Automation
             }
         }
 
-        private class ConvertViaConstructor
+        private sealed class ConvertViaConstructor
         {
             internal Func<object, object> TargetCtorLambda;
 
@@ -3854,7 +3854,7 @@ namespace System.Management.Automation
         /// 1. toType is a closed generic type and it has a constructor that takes IEnumerable[T], ICollection[T] or IList[T]
         /// 2. fromType is System.Array, System.Object[] or it's the same as the element type of toType
         /// </remark>
-        private class ConvertViaIEnumerableConstructor
+        private sealed class ConvertViaIEnumerableConstructor
         {
             internal Func<int, IList> ListCtorLambda;
             internal Func<IList, object> TargetCtorLambda;
@@ -3947,7 +3947,7 @@ namespace System.Management.Automation
             }
         }
 
-        private class ConvertViaNoArgumentConstructor
+        private sealed class ConvertViaNoArgumentConstructor
         {
             private readonly Func<object> _constructor;
 
@@ -4050,7 +4050,7 @@ namespace System.Management.Automation
             }
         }
 
-        private class ConvertViaCast
+        private sealed class ConvertViaCast
         {
             internal MethodInfo cast;
 
@@ -4130,7 +4130,7 @@ namespace System.Management.Automation
             }
         }
 
-        private class ConvertCheckingForCustomConverter
+        private sealed class ConvertCheckingForCustomConverter
         {
             internal PSConverter<object> tryfirstConverter;
             internal PSConverter<object> fallbackConverter;

--- a/src/System.Management.Automation/engine/Modules/RemoteDiscoveryHelper.cs
+++ b/src/System.Management.Automation/engine/Modules/RemoteDiscoveryHelper.cs
@@ -689,7 +689,7 @@ namespace System.Management.Automation
 
             private List<CimModuleFile> _moduleFiles;
 
-            private class CimModuleManifestFile : CimModuleFile
+            private sealed class CimModuleManifestFile : CimModuleFile
             {
                 internal CimModuleManifestFile(string fileName, byte[] rawFileData)
                 {
@@ -705,7 +705,7 @@ namespace System.Management.Automation
                 internal override byte[] RawFileDataCore { get; }
             }
 
-            private class CimModuleImplementationFile : CimModuleFile
+            private sealed class CimModuleImplementationFile : CimModuleFile
             {
                 private readonly CimInstance _baseObject;
 

--- a/src/System.Management.Automation/engine/Modules/ScriptAnalysis.cs
+++ b/src/System.Management.Automation/engine/Modules/ScriptAnalysis.cs
@@ -557,7 +557,7 @@ namespace System.Management.Automation
 
         private static readonly Dictionary<string, ParameterBindingInfo> s_parameterBindingInfoTable;
 
-        private class ParameterBindingInfo
+        private sealed class ParameterBindingInfo
         {
             internal ParameterInfo[] parameterInfo;
         }

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -2318,7 +2318,7 @@ namespace System.Management.Automation
             return new AllowWrite(_thisCommand, permittedToWriteToPipeline);
         }
 
-        private class AllowWrite : IDisposable
+        private sealed class AllowWrite : IDisposable
         {
             /// <summary>
             /// Begin the scope where WriteObject/WriteError is permitted.

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -376,7 +376,7 @@ namespace System.Management.Automation
             }
         }
 
-        private class PSVersionTableComparer : IComparer
+        private sealed class PSVersionTableComparer : IComparer
         {
             public int Compare(object x, object y)
             {

--- a/src/System.Management.Automation/engine/TypeTable.cs
+++ b/src/System.Management.Automation/engine/TypeTable.cs
@@ -1683,7 +1683,7 @@ namespace System.Management.Automation.Runspaces
 
         internal static readonly IEqualityComparer<ConsolidatedString> EqualityComparer = new ConsolidatedStringEqualityComparer();
 
-        private class ConsolidatedStringEqualityComparer : IEqualityComparer<ConsolidatedString>
+        private sealed class ConsolidatedStringEqualityComparer : IEqualityComparer<ConsolidatedString>
         {
             bool IEqualityComparer<ConsolidatedString>.Equals(ConsolidatedString x, ConsolidatedString y)
             {

--- a/src/System.Management.Automation/engine/debugger/Breakpoint.cs
+++ b/src/System.Management.Automation/engine/debugger/Breakpoint.cs
@@ -439,7 +439,7 @@ namespace System.Management.Automation
 
         internal BitArray BreakpointBitArray { get; set; }
 
-        private class CheckBreakpointInScript : AstVisitor
+        private sealed class CheckBreakpointInScript : AstVisitor
         {
             public static bool IsInNestedScriptBlock(Ast ast, LineBreakpoint breakpoint)
             {

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -1575,7 +1575,7 @@ namespace System.Management.Automation
         #region private members
 
         [DebuggerDisplay("{FunctionContext.CurrentPosition}")]
-        private class CallStackInfo
+        private sealed class CallStackInfo
         {
             internal InvocationInfo InvocationInfo { get; set; }
 

--- a/src/System.Management.Automation/engine/hostifaces/ConnectionBase.cs
+++ b/src/System.Management.Automation/engine/hostifaces/ConnectionBase.cs
@@ -670,7 +670,7 @@ namespace System.Management.Automation.Runspaces
         /// </summary>
         private Queue<RunspaceEventQueueItem> _runspaceEventQueue = new Queue<RunspaceEventQueueItem>();
 
-        private class RunspaceEventQueueItem
+        private sealed class RunspaceEventQueueItem
         {
             public RunspaceEventQueueItem(RunspaceStateInfo runspaceStateInfo, RunspaceAvailability currentAvailability, RunspaceAvailability newAvailability)
             {

--- a/src/System.Management.Automation/engine/hostifaces/pipelinebase.cs
+++ b/src/System.Management.Automation/engine/hostifaces/pipelinebase.cs
@@ -768,7 +768,7 @@ namespace System.Management.Automation.Runspaces
         /// </summary>
         private Queue<ExecutionEventQueueItem> _executionEventQueue = new Queue<ExecutionEventQueueItem>();
 
-        private class ExecutionEventQueueItem
+        private sealed class ExecutionEventQueueItem
         {
             public ExecutionEventQueueItem(PipelineStateInfo pipelineStateInfo, RunspaceAvailability currentAvailability, RunspaceAvailability newAvailability)
             {

--- a/src/System.Management.Automation/engine/interpreter/LightCompiler.cs
+++ b/src/System.Management.Automation/engine/interpreter/LightCompiler.cs
@@ -192,7 +192,7 @@ namespace System.Management.Automation.Interpreter
         public bool IsClear;
         private static readonly DebugInfoComparer s_debugComparer = new DebugInfoComparer();
 
-        private class DebugInfoComparer : IComparer<DebugInfo>
+        private sealed class DebugInfoComparer : IComparer<DebugInfo>
         {
             // We allow comparison between int and DebugInfo here
             int IComparer<DebugInfo>.Compare(DebugInfo d1, DebugInfo d2)

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -2200,7 +2200,7 @@ namespace System.Management.Automation.Language
             return Expression.Lambda<Func<FunctionContext, object>>(body, parameters).Compile();
         }
 
-        private class LoopGotoTargets
+        private sealed class LoopGotoTargets
         {
             internal LoopGotoTargets(string label, LabelTarget breakLabel, LabelTarget continueLabel)
             {
@@ -5154,7 +5154,7 @@ namespace System.Management.Automation.Language
         //    }
         //
         // This is a little convoluted because an automatic variable isn't necessarily set.
-        private class AutomaticVarSaver
+        private sealed class AutomaticVarSaver
         {
             private readonly Compiler _compiler;
             private readonly int _automaticVar;

--- a/src/System.Management.Automation/engine/parser/PSType.cs
+++ b/src/System.Management.Automation/engine/parser/PSType.cs
@@ -265,7 +265,7 @@ namespace System.Management.Automation.Language
             }
         }
 
-        private class DefineTypeHelper
+        private sealed class DefineTypeHelper
         {
             private readonly Parser _parser;
             internal readonly TypeDefinitionAst _typeDefinitionAst;
@@ -1007,7 +1007,7 @@ namespace System.Management.Automation.Language
             }
         }
 
-        private class DefineEnumHelper
+        private sealed class DefineEnumHelper
         {
             private readonly Parser _parser;
             private readonly TypeDefinitionAst _enumDefinitionAst;

--- a/src/System.Management.Automation/engine/parser/TypeResolver.cs
+++ b/src/System.Management.Automation/engine/parser/TypeResolver.cs
@@ -673,7 +673,7 @@ namespace System.Management.Automation.Language
 
     internal static class TypeCache
     {
-        private class KeyComparer : IEqualityComparer<Tuple<ITypeName, TypeResolutionState>>
+        private sealed class KeyComparer : IEqualityComparer<Tuple<ITypeName, TypeResolutionState>>
         {
             public bool Equals(Tuple<ITypeName, TypeResolutionState> x,
                                Tuple<ITypeName, TypeResolutionState> y)

--- a/src/System.Management.Automation/engine/parser/VariableAnalysis.cs
+++ b/src/System.Management.Automation/engine/parser/VariableAnalysis.cs
@@ -338,7 +338,7 @@ namespace System.Management.Automation.Language
         // in these cases, we rely on the setter PSVariable.Value to handle those attributes.
         internal const int ForceDynamic = -2;
 
-        private class LoopGotoTargets
+        private sealed class LoopGotoTargets
         {
             internal LoopGotoTargets(string label, Block breakTarget, Block continueTarget)
             {
@@ -354,7 +354,7 @@ namespace System.Management.Automation.Language
             internal Block ContinueTarget { get; }
         }
 
-        private class Block
+        private sealed class Block
         {
             internal readonly List<Ast> _asts = new List<Ast>();
             private readonly List<Block> _successors = new List<Block>();
@@ -439,7 +439,7 @@ namespace System.Management.Automation.Language
             }
         }
 
-        private class AssignmentTarget : Ast
+        private sealed class AssignmentTarget : Ast
         {
             internal readonly ExpressionAst _targetAst;
             internal readonly string _variableName;

--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -1102,7 +1102,7 @@ namespace System.Management.Automation
                             PatternPositionsVisitor patternPositionsForEndOfStringPosition);
         }
 
-        private sealed class QuestionMarkElement : PatternElement
+        private class QuestionMarkElement : PatternElement
         {
             public override void ProcessStringCharacter(
                             char currentStringCharacter,

--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -1001,7 +1001,7 @@ namespace System.Management.Automation
             }
         }
 
-        private class PatternPositionsVisitor : IDisposable
+        private sealed class PatternPositionsVisitor : IDisposable
         {
             private readonly int _lengthOfPattern;
 
@@ -1102,7 +1102,7 @@ namespace System.Management.Automation
                             PatternPositionsVisitor patternPositionsForEndOfStringPosition);
         }
 
-        private class QuestionMarkElement : PatternElement
+        private sealed class QuestionMarkElement : PatternElement
         {
             public override void ProcessStringCharacter(
                             char currentStringCharacter,
@@ -1122,7 +1122,7 @@ namespace System.Management.Automation
             }
         }
 
-        private class LiteralCharacterElement : QuestionMarkElement
+        private sealed class LiteralCharacterElement : QuestionMarkElement
         {
             private readonly char _literalCharacter;
 
@@ -1148,7 +1148,7 @@ namespace System.Management.Automation
             }
         }
 
-        private class BracketExpressionElement : QuestionMarkElement
+        private sealed class BracketExpressionElement : QuestionMarkElement
         {
             private readonly Regex _regex;
 
@@ -1173,7 +1173,7 @@ namespace System.Management.Automation
             }
         }
 
-        private class AsterixElement : PatternElement
+        private sealed class AsterixElement : PatternElement
         {
             public override void ProcessStringCharacter(
                             char currentStringCharacter,
@@ -1197,7 +1197,7 @@ namespace System.Management.Automation
             }
         }
 
-        private class MyWildcardPatternParser : WildcardPatternParser
+        private sealed class MyWildcardPatternParser : WildcardPatternParser
         {
             private readonly List<PatternElement> _patternElements = new List<PatternElement>();
             private CharacterNormalizer _characterNormalizer;

--- a/src/System.Management.Automation/engine/remoting/client/Job.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job.cs
@@ -2048,7 +2048,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Simple throttle operation class for connecting jobs.
         /// </summary>
-        private class ConnectJobOperation : IThrottleOperation
+        private sealed class ConnectJobOperation : IThrottleOperation
         {
             private readonly PSRemotingChildJob _psRemoteChildJob;
 

--- a/src/System.Management.Automation/engine/remoting/client/ThrottlingJob.cs
+++ b/src/System.Management.Automation/engine/remoting/client/ThrottlingJob.cs
@@ -846,7 +846,7 @@ namespace System.Management.Automation
             }
         }
 
-        private class ForwardingHelper : IDisposable
+        private sealed class ForwardingHelper : IDisposable
         {
             // This is higher than 1000 used in
             //      RxExtensionMethods+ToEnumerableObserver<T>.BlockingCollectionCapacity

--- a/src/System.Management.Automation/engine/remoting/client/remotepipeline.cs
+++ b/src/System.Management.Automation/engine/remoting/client/remotepipeline.cs
@@ -42,7 +42,7 @@ namespace System.Management.Automation
         /// </summary>
         private Queue<ExecutionEventQueueItem> _executionEventQueue = new Queue<ExecutionEventQueueItem>();
 
-        private class ExecutionEventQueueItem
+        private sealed class ExecutionEventQueueItem
         {
             public ExecutionEventQueueItem(PipelineStateInfo pipelineStateInfo, RunspaceAvailability currentAvailability, RunspaceAvailability newAvailability)
             {

--- a/src/System.Management.Automation/engine/remoting/commands/ConnectPSSession.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/ConnectPSSession.cs
@@ -487,7 +487,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Throttle class to perform a remoterunspace connect operation.
         /// </summary>
-        private class ConnectRunspaceOperation : IThrottleOperation
+        private sealed class ConnectRunspaceOperation : IThrottleOperation
         {
             private PSSession _session;
             private PSSession _oldSession;

--- a/src/System.Management.Automation/engine/remoting/commands/DisconnectPSSession.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/DisconnectPSSession.cs
@@ -392,7 +392,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Throttle class to perform a remoterunspace disconnect operation.
         /// </summary>
-        private class DisconnectRunspaceOperation : IThrottleOperation
+        private sealed class DisconnectRunspaceOperation : IThrottleOperation
         {
             private readonly PSSession _remoteSession;
             private readonly ObjectStream _writeStream;

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManTransportManager.cs
@@ -305,7 +305,7 @@ namespace System.Management.Automation.Remoting.Client
 
         #region CompletionEventArgs
 
-        private class CompletionEventArgs : EventArgs
+        private sealed class CompletionEventArgs : EventArgs
         {
             internal CompletionEventArgs(CompletionNotification notification)
             {
@@ -2833,7 +2833,7 @@ namespace System.Management.Automation.Remoting.Client
         private readonly string _cmdLine;
         private readonly WSManClientSessionTransportManager _sessnTm;
 
-        private class SendDataChunk
+        private sealed class SendDataChunk
         {
             public SendDataChunk(byte[] data, DataPriorityType type)
             {

--- a/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
@@ -1252,7 +1252,7 @@ namespace System.Management.Automation
             BreakpointManagement,
         }
 
-        private class DebuggerCommandArgument
+        private sealed class DebuggerCommandArgument
         {
             public DebugModes? Mode { get; set; }
 

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -1177,7 +1177,7 @@ namespace System.Management.Automation.Language
 
     internal sealed class PSInvokeDynamicMemberBinder : DynamicMetaObjectBinder
     {
-        private class KeyComparer : IEqualityComparer<PSInvokeDynamicMemberBinderKeyType>
+        private sealed class KeyComparer : IEqualityComparer<PSInvokeDynamicMemberBinderKeyType>
         {
             public bool Equals(PSInvokeDynamicMemberBinderKeyType x, PSInvokeDynamicMemberBinderKeyType y)
             {
@@ -4887,7 +4887,7 @@ namespace System.Management.Automation.Language
     /// </summary>
     internal class PSGetMemberBinder : GetMemberBinder
     {
-        private class KeyComparer : IEqualityComparer<PSGetMemberBinderKeyType>
+        private sealed class KeyComparer : IEqualityComparer<PSGetMemberBinderKeyType>
         {
             public bool Equals(PSGetMemberBinderKeyType x, PSGetMemberBinderKeyType y)
             {
@@ -4911,7 +4911,7 @@ namespace System.Management.Automation.Language
             }
         }
 
-        private class ReservedMemberBinder : PSGetMemberBinder
+        private sealed class ReservedMemberBinder : PSGetMemberBinder
         {
             internal ReservedMemberBinder(string name, bool ignoreCase, bool @static) : base(name, null, ignoreCase, @static, nonEnumerating: false)
             {
@@ -5936,7 +5936,7 @@ namespace System.Management.Automation.Language
     /// </summary>
     internal class PSSetMemberBinder : SetMemberBinder
     {
-        private class KeyComparer : IEqualityComparer<PSSetMemberBinderKeyType>
+        private sealed class KeyComparer : IEqualityComparer<PSSetMemberBinderKeyType>
         {
             public bool Equals(PSSetMemberBinderKeyType x, PSSetMemberBinderKeyType y)
             {
@@ -6519,7 +6519,7 @@ namespace System.Management.Automation.Language
             NonVirtual,
         }
 
-        private class KeyComparer : IEqualityComparer<PSInvokeMemberBinderKeyType>
+        private sealed class KeyComparer : IEqualityComparer<PSInvokeMemberBinderKeyType>
         {
             public bool Equals(PSInvokeMemberBinderKeyType x, PSInvokeMemberBinderKeyType y)
             {
@@ -7509,7 +7509,7 @@ namespace System.Management.Automation.Language
         private readonly bool _publicTypeOnly;
         private int _version;
 
-        private class KeyComparer : IEqualityComparer<Tuple<CallInfo, PSMethodInvocationConstraints, bool>>
+        private sealed class KeyComparer : IEqualityComparer<Tuple<CallInfo, PSMethodInvocationConstraints, bool>>
         {
             public bool Equals(Tuple<CallInfo, PSMethodInvocationConstraints, bool> x,
                                Tuple<CallInfo, PSMethodInvocationConstraints, bool> y)
@@ -7687,7 +7687,7 @@ namespace System.Management.Automation.Language
         private readonly CallInfo _callInfo;
         private readonly PSMethodInvocationConstraints _constraints;
 
-        private class KeyComparer : IEqualityComparer<Tuple<CallInfo, PSMethodInvocationConstraints>>
+        private sealed class KeyComparer : IEqualityComparer<Tuple<CallInfo, PSMethodInvocationConstraints>>
         {
             public bool Equals(Tuple<CallInfo, PSMethodInvocationConstraints> x,
                                Tuple<CallInfo, PSMethodInvocationConstraints> y)

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -1379,7 +1379,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Represent a handler search result.
         /// </summary>
-        private class HandlerSearchResult
+        private sealed class HandlerSearchResult
         {
             internal HandlerSearchResult()
             {

--- a/src/System.Management.Automation/engine/runtime/Operations/VariableOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/VariableOps.cs
@@ -277,7 +277,7 @@ namespace System.Management.Automation
             return null;
         }
 
-        private class UsingResult
+        private sealed class UsingResult
         {
             public object Value { get; set; }
         }

--- a/src/System.Management.Automation/engine/serialization.cs
+++ b/src/System.Management.Automation/engine/serialization.cs
@@ -5639,7 +5639,7 @@ namespace System.Management.Automation
     /// <typeparam name="T">type of dictionary values</typeparam>
     internal class WeakReferenceDictionary<T> : IDictionary<object, T>
     {
-        private class WeakReferenceEqualityComparer : IEqualityComparer<WeakReference>
+        private sealed class WeakReferenceEqualityComparer : IEqualityComparer<WeakReference>
         {
             public bool Equals(WeakReference x, WeakReference y)
             {

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -7369,7 +7369,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Tracks visited files/directories by caching their device IDs and inodes.
         /// </summary>
-        private class InodeTracker
+        private sealed class InodeTracker
         {
             private readonly HashSet<(UInt64, UInt64)> _visitations;
 

--- a/src/System.Management.Automation/utils/tracing/EtwActivity.cs
+++ b/src/System.Management.Automation/utils/tracing/EtwActivity.cs
@@ -103,7 +103,7 @@ namespace System.Management.Automation.Tracing
             /// <summary>
             /// ParentActivityId.
             /// </summary>
-            protected readonly Guid parentActivityId;
+            private readonly Guid parentActivityId;
             private readonly EtwActivity tracer;
 
             /// <summary>

--- a/src/System.Management.Automation/utils/tracing/EtwActivity.cs
+++ b/src/System.Management.Automation/utils/tracing/EtwActivity.cs
@@ -94,7 +94,7 @@ namespace System.Management.Automation.Tracing
         /// This is a helper class that is used to wrap many multi-threading scenarios
         /// and makes correlation event to be logged easily.
         /// </summary>
-        private class CorrelatedCallback
+        private sealed class CorrelatedCallback
         {
             private readonly CallbackNoParameter callbackNoParam;
             private readonly CallbackWithState callbackWithState;

--- a/src/TypeCatalogGen/TypeCatalogGen.cs
+++ b/src/TypeCatalogGen/TypeCatalogGen.cs
@@ -459,7 +459,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Helper class to keep the metadata of a type.
         /// </summary>
-        private class TypeMetadata
+        private sealed class TypeMetadata
         {
             internal readonly string AssemblyName;
             internal readonly bool IsObsolete;

--- a/src/powershell/Program.cs
+++ b/src/powershell/Program.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// Exception to signify an early startup failure.
         /// </summary>
-        private class StartupException : Exception
+        private sealed class StartupException : Exception
         {
             /// <summary>
             /// Construct a new startup exception instance.


### PR DESCRIPTION
Search and replace `private class` -> `private sealed class`.

* Fix [CS0509: Cannot derive from sealed type](https://docs.microsoft.com/dotnet/csharp/misc/cs0509)
* Fix [CS0628: New protected member declared in sealed class](https://docs.microsoft.com/dotnet/csharp/misc/cs0628)

_Contributes to #15110._