### PR TITLE
Add mu opt out to MSI install

### DIFF
--- a/.vsts-ci/windows/templates/windows-packaging.yml
+++ b/.vsts-ci/windows/templates/windows-packaging.yml
@@ -32,5 +32,4 @@ jobs:
       Import-Module .\tools\ci.psm1
       New-CodeCoverageAndTestPackage
       Invoke-CIFinish -Runtime win7-${{ parameters.architecture }} -channel ${{ parameters.channel }}
-    errorActionPreference: continue
     displayName: Build and Test Package

--- a/.vsts-ci/windows/templates/windows-packaging.yml
+++ b/.vsts-ci/windows/templates/windows-packaging.yml
@@ -32,4 +32,5 @@ jobs:
       Import-Module .\tools\ci.psm1
       New-CodeCoverageAndTestPackage
       Invoke-CIFinish -Runtime win7-${{ parameters.architecture }} -channel ${{ parameters.channel }}
+    errorActionPreference: continue
     displayName: Build and Test Package

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -410,8 +410,8 @@
 
       <Property Id="DefaultUIFont" Value="WixUI_Font_Normal" />
       <Property Id="WixUI_Mode" Value="InstallDir" />
-      <Property Id="WixUI_ENABLE_MU" Value="ENABLE_MU" />
-      <Property Id="WixUI_USE_MU" Value="USE_MU" />
+      <PropertyRef Id="ENABLE_MU" />
+      <PropertyRef Id="USE_MU" />
 
       <DialogRef Id="BrowseDlg" />
       <DialogRef Id="DiskCostDlg" />
@@ -435,7 +435,7 @@
       <Publish Dialog="ExplorerContextMenuDialog" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
       <Publish Dialog="ExplorerContextMenuDialog" Control="Next" Event="NewDialog" Value="MuDialog">1</Publish>
       <Publish Dialog="MuDialog" Control="Back" Event="NewDialog" Value="ExplorerContextMenuDialog">1</Publish>
-      <Publish Dialog="MuDialog" Control="Next" Event="SpawnDialog" Value="MuWarningDlg" Order="1">WixUI_ENABLE_MU=0 AND WixUI_USE_MU=1></Publish>
+      <Publish Dialog="MuDialog" Control="Next" Event="SpawnDialog" Value="MuWarningDlg" Order="1">ENABLE_MU=0 AND USE_MU=1></Publish>
       <Publish Dialog="MuDialog" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="2">1</Publish>
 
       <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -410,8 +410,8 @@
 
       <Property Id="DefaultUIFont" Value="WixUI_Font_Normal" />
       <Property Id="WixUI_Mode" Value="InstallDir" />
-      <PropertyRef Id="ENABLE_MU" />
-      <PropertyRef Id="USE_MU" />
+      <Property Id="WixUI_ENABLE_MU" Value="ENABLE_MU" />
+      <Property Id="WixUI_USE_MU" Value="USE_MU" />
 
       <DialogRef Id="BrowseDlg" />
       <DialogRef Id="DiskCostDlg" />
@@ -435,7 +435,7 @@
       <Publish Dialog="ExplorerContextMenuDialog" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
       <Publish Dialog="ExplorerContextMenuDialog" Control="Next" Event="NewDialog" Value="MuDialog">1</Publish>
       <Publish Dialog="MuDialog" Control="Back" Event="NewDialog" Value="ExplorerContextMenuDialog">1</Publish>
-      <Publish Dialog="MuDialog" Control="Next" Event="SpawnDialog" Value="MuWarningDlg" Order="1">ENABLE_MU=0 AND USE_MU=1></Publish>
+      <Publish Dialog="MuDialog" Control="Next" Event="SpawnDialog" Value="MuWarningDlg" Order="1">WixUI_ENABLE_MU=0 AND WixUI_USE_MU=1></Publish>
       <Publish Dialog="MuDialog" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="2">1</Publish>
 
       <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -308,7 +308,7 @@
  <UI>
     <Property Id="REGISTER_MANIFEST" Value="1" />
     <Property Id="ADD_PATH" Value="1" />
-    <Dialog Id="ExplorerContextMenuDialog" Width="370" Height="310" Title="!(loc.ExitDialog_Title)">
+    <Dialog Id="ExplorerContextMenuDialog" Width="370" Height="270" Title="!(loc.ExitDialog_Title)">
       <!-- Banner -->
       <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="yes" Text="!(loc.InstallDirDlgBannerBitmap)"/>
       <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes" Text="{\WixUI_Font_Title}Optional Actions" TabSkip="yes" />
@@ -320,17 +320,17 @@
       <Control Id="EnablePSRemotingCheckBox" Type="CheckBox" X="20" Y="100" Width="290" Height="17" Property="ENABLE_PSREMOTING" CheckBoxValue="0" Text="Enable $(var.ProductName) remoting"/>
       <Control Id="ContextMenuOpenPowerShell" Type="CheckBox" X="20" Y="120" Width="290" Height="17" Property="ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL" CheckBoxValue="0" Text="Add '$(var.ExplorerContextSubMenuDialogText)' context menus to Explorer"/>
       <Control Id="ContextMenuRunPowerShell" Type="CheckBox" X="20" Y="140" Width="290" Height="17" Property="ADD_FILE_CONTEXT_MENU_RUNPOWERSHELL" CheckBoxValue="0" Text="Add '$(var.PowerShellFileContextSubMenuDialogText)' context menu for PowerShell files"/>
-      <Control Id="LicenseLink" Type="Hyperlink" X="20" Y="230" Width="214" Height="17">
+      <Control Id="LicenseLink" Type="Hyperlink" X="20" Y="190" Width="214" Height="17">
         <Text><![CDATA[<a href="https://github.com/PowerShell/PowerShell/blob/master/LICENSE.txt">The application is distributed under the MIT license.</a>]]></Text>
       </Control>
-      <Control Id="TpnLink" Type="Hyperlink" X="20" Y="250" Width="290" Height="17">
+      <Control Id="TpnLink" Type="Hyperlink" X="20" Y="210" Width="290" Height="17">
         <Text><![CDATA[<a href="https://github.com/PowerShell/PowerShell/blob/master/ThirdPartyNotices.txt">Please review the ThirdPartyNotices.txt</a>]]></Text>
       </Control>
       <!-- divider and bottom buttons -->
-      <Control Id="BottomLine" Type="Line" X="0" Y="254" Width="370" Height="0" TabSkip="yes"/>
-      <Control Id="Back" Type="PushButton" X="180" Y="283" Width="56" Height="17" Text="!(loc.WixUIBack)"/>
-      <Control Id="Next" Type="PushButton" X="236" Y="283" Width="56" Height="17" Cancel="yes" Default="yes" Text="!(loc.WixUINext)"/>
-      <Control Id="Cancel" Type="PushButton" X="304" Y="283" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">
+      <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" TabSkip="yes"/>
+      <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)"/>
+      <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Cancel="yes" Default="yes" Text="!(loc.WixUINext)"/>
+      <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">
         <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
       </Control>
     </Dialog>
@@ -341,12 +341,12 @@
 <Fragment>
  <UI>
     <Property Id="USE_MU" Value="1" />
-    <Dialog Id="MuDialog" Width="370" Height="310" Title="!(loc.ExitDialog_Title)">
+    <Dialog Id="MuDialog" Width="370" Height="270" Title="!(loc.ExitDialog_Title)">
       <!-- Banner -->
       <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="yes" Text="!(loc.InstallDirDlgBannerBitmap)"/>
-      <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes" Text="{\WixUI_Font_Title}Use Microsoft Update to help keep your computer secure and up to date" TabSkip="yes" />
-      <Control Id="Description" Type="Text" X="25" Y="23" Width="280" Height="15" Transparent="yes" NoPrefix="yes" Text="Microsoft Update helps keep your computer secure and up to date for Windows and other Microsoft products, including PowerShell 7. Updates will be delivered based on your current update settings. You can review or change these settings from the Windows Update control panel." TabSkip="yes" />
+      <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="30" Transparent="yes" NoPrefix="yes" Text="{\WixUI_Font_Title}Use Microsoft Update to help keep your computer secure and up to date" TabSkip="yes" />
       <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" TabSkip="yes" />
+      <Control Id="Description" Type="Text" X="25" Y="54" Width="280" Height="100" Transparent="yes" NoPrefix="yes" Text="Microsoft Update helps keep your computer secure and up to date for Windows and other Microsoft products, including PowerShell 7. Updates will be delivered based on your current update settings. You can review or change these settings from the Windows Update control panel." TabSkip="yes" />
       <!-- If the checkboxes are defined first, then they are first in the tab order and can be ticked and unticked using the spacebar -->
       <Control Id="UseMuRadioButtonGroup" Type="RadioButtonGroup" X="20" Y="160" Width="290" Height="30" Property="USE_MU">
         <RadioButtonGroup Property="USE_MU">
@@ -361,10 +361,10 @@
         <Text><![CDATA[<a href="http://go.microsoft.com/fwlink/?LinkID=57190">Read the Microsoft Update Priacy Statement.</a>]]></Text>
       </Control>
       <!-- divider and bottom buttons -->
-      <Control Id="BottomLine" Type="Line" X="0" Y="254" Width="370" Height="0" TabSkip="yes"/>
-      <Control Id="Back" Type="PushButton" X="180" Y="283" Width="56" Height="17" Text="!(loc.WixUIBack)"/>
-      <Control Id="Next" Type="PushButton" X="236" Y="283" Width="56" Height="17" Cancel="yes" Default="yes" Text="!(loc.WixUINext)"/>
-      <Control Id="Cancel" Type="PushButton" X="304" Y="283" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">
+      <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" TabSkip="yes"/>
+      <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)"/>
+      <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Cancel="yes" Default="yes" Text="!(loc.WixUINext)"/>
+      <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">
         <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
       </Control>
     </Dialog>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -367,6 +367,20 @@
       </Control>
     </Dialog>
   </UI>
+  <!-- MU not enable dialog box -->
+  <UI>
+    <Dialog Id="MuWarningDlg" Width="284" Height="73" Title="Microsoft Update Warning" NoMinimize="yes">
+      <Control Id="Text" Type="Text" X="38" Y="8" Width="240" Height="40" TabSkip="no">
+        <Text>Without Microsoft Update enabled, you will need to use another update solution like WSUS or SCCM in order to receive automatic updates. Are you sure you want to continue?</Text>
+      </Control>
+      <Control Id="Okay" Type="PushButton" X="114" Y="52" Width="56" Height="17" Default="yes"  Cancel="no" Text="OK">
+        <Publish Event="EndDialog" Value="Return">1</Publish>
+      </Control>
+      <Control Id="Cancel" Type="PushButton" X="184" Y="52" Width="56" Height="17" Default="yes"  Cancel="yes" Text="OK">
+        <Publish Event="EndDialog" Value="Return">0</Publish>
+      </Control>
+    </Dialog>
+  </UI>
 </Fragment>
 <!-- Customized version of WixUI_InstallDir, which is necessary to add custom dialogs. https://github.com/wixtoolset/wix3/blob/master/src/ext/UIExtension/wixlib/WixUI_InstallDir.wxs -->
 <Fragment>
@@ -377,6 +391,7 @@
       - WixUI_InstallDirDlg
       - ExplorerContextMenuDialog
       - MuDialog
+      - MuWarningDlg
       - WixUI_VerifyReadyDlg
       - WixUI_DiskCostDlg
       Maintenance dialog sequence:
@@ -418,7 +433,8 @@
       <Publish Dialog="ExplorerContextMenuDialog" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
       <Publish Dialog="ExplorerContextMenuDialog" Control="Next" Event="NewDialog" Value="MuDialog">1</Publish>
       <Publish Dialog="MuDialog" Control="Back" Event="NewDialog" Value="ExplorerContextMenuDialog">1</Publish>
-      <Publish Dialog="MuDialog" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
+      <Publish Dialog="MuDialog" Control="Next" Event="SpawnDialog" Value="MuWarningDlg" Order="1"><![CDATA[ENABLE_MU = 0 AND USE_MU = 1]]></Publish>
+      <Publish Dialog="MuDialog" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="2">1</Publish>
 
       <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
       <Publish Dialog="InstallDirDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -52,8 +52,6 @@
     <Property Id="ARPPRODUCTICON" Value="PowerShellExe.ico" />
     <!-- Set properties for add/remove programs -->
     <Property Id="ARPHELPLINK" Value="$(var.InfoURL)" />
-    <Property Id="USE_MU" Value="1" />
-    <Property Id="ENABLE_MU" Value="1" />
     <!-- custom images -->
     <WixVariable Id="WixUIBannerBmp" Value="assets\wix\WixUIBannerBmp.png" />
     <WixVariable Id="WixUIDialogBmp" Value="assets\wix\WixUIDialogBmp.png" />
@@ -343,6 +341,8 @@
 <!-- Microsoft Update Menu Dialog -->
 <Fragment>
  <UI>
+    <Property Id="USE_MU" Value="1" />
+    <Property Id="ENABLE_MU" Value="1" />
     <Dialog Id="MuDialog" Width="370" Height="270" Title="!(loc.ExitDialog_Title)">
       <!-- Banner -->
       <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="yes" Text="!(loc.InstallDirDlgBannerBitmap)"/>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -355,7 +355,7 @@
         <Text><![CDATA[<a href="https://aka.ms/PowerShell-Microsoft-Update-FAQ">See the Microsoft Update FAQ.</a>]]></Text>
       </Control>
       <Control Id="PrivacyLink" Type="Hyperlink" X="20" Y="170" Width="290" Height="17">
-        <Text><![CDATA[<a href="http://go.microsoft.com/fwlink/?LinkID=57190">Read the Microsoft Update Priacy Statement.</a>]]></Text>
+        <Text><![CDATA[<a href="https://aka.ms/PowerShell-Microsoft-Update-Privacy-Statement">Read the Microsoft Update Priacy Statement.</a>]]></Text>
       </Control>
       <!-- divider and bottom buttons -->
       <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" TabSkip="yes"/>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -349,12 +349,12 @@
       <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" TabSkip="yes" />
       <Control Id="Description" Type="Text" X="25" Y="54" Width="280" Height="100" Transparent="yes" NoPrefix="yes" Text="Microsoft Update helps keep your computer secure and up to date for Windows and other Microsoft products, including PowerShell 7. Updates will be delivered based on your current update settings. You can review or change these settings from the Windows Update control panel." TabSkip="yes" />
       <!-- If the checkboxes are defined first, then they are first in the tab order and can be ticked and unticked using the spacebar -->
-      <Control Id="UseMuCheckBox" Type="CheckBox" X="20" Y="100" Width="290" Height="50" Property="USE_MU" CheckBoxValue="0" Text="Enable updating PowerShell through Microsft Update or WSUS (recommended)"/>
-      <Control Id="EnableMuCheckBox" Type="CheckBox" X="20" Y="130" Width="290" Height="50" Property="ENABLE_MU" CheckBoxValue="0" Text="Use Microsoft Update when I check for updates (recommended)"/>
-      <Control Id="MuFAQ" Type="Hyperlink" X="20" Y="150" Width="214" Height="17">
+      <Control Id="UseMuCheckBox" Type="CheckBox" X="20" Y="100" Width="290" Height="27" Property="USE_MU" CheckBoxValue="0" Text="Enable updating PowerShell through Microsft Update or WSUS (recommended)"/>
+      <Control Id="EnableMuCheckBox" Type="CheckBox" X="20" Y="130" Width="290" Height="17" Property="ENABLE_MU" CheckBoxValue="0" Text="Use Microsoft Update when I check for updates (recommended)"/>
+      <Control Id="MuFAQ" Type="Hyperlink" X="20" Y="190" Width="214" Height="17">
         <Text><![CDATA[<a href="https://aka.ms/PowerShell-Microsoft-Update-FAQ">See the Microsoft Update FAQ.</a>]]></Text>
       </Control>
-      <Control Id="PrivacyLink" Type="Hyperlink" X="20" Y="170" Width="290" Height="17">
+      <Control Id="PrivacyLink" Type="Hyperlink" X="20" Y="210" Width="290" Height="17">
         <Text><![CDATA[<a href="https://aka.ms/PowerShell-Microsoft-Update-Privacy-Statement">Read the Microsoft Update Priacy Statement.</a>]]></Text>
       </Control>
       <!-- divider and bottom buttons -->

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -193,15 +193,12 @@
             <Component Id="MURegistryEntries">
               <!-- Create registry key to allow opt-out of MU servicing without opting out of MU completely.  -->
               <RegistryKey Root="HKLM" Key="Software\Microsoft\PowerShellCore" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="no">
-                  <RegistryValue Type="integer" Value="[USE_MU]" Name="UseMU"/>
+                  <RegistryValue Type="integer" Value="[USE_MU]" Name="UseMU"  KeyPath="yes"/>
               </RegistryKey>
             </Component>
             <Component Id="RegistryEntries">
               <!-- create key for easy detection of a particular version of a powershell core package
                     The upgrade code is used in the key because it will change when we allow SxS       -->
-              <RegistryKey Root="HKLM" Key="Software\Microsoft\PowerShellCore" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
-                  <RegistryValue Type="integer" Value="[USE_MU]" Name="UseMU" KeyPath="yes"/>
-              </RegistryKey>
               <RegistryKey Root="HKLM" Key="Software\Microsoft\PowerShellCore\InstalledVersions\$(var.UpgradeCode)" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
                   <RegistryValue Type="string" Value="$(var.ProductSemanticVersion)" Name="SemanticVersion" KeyPath="yes"/>
                   <RegistryValue Type="string" Value="[VersionFolder]" Name="InstallLocation" />

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -340,6 +340,7 @@
 <!-- Microsoft Update Menu Dialog -->
 <Fragment>
  <UI>
+    <Property Id="USE_MU" Value="1" />
     <Dialog Id="MuDialog" Width="370" Height="310" Title="!(loc.ExitDialog_Title)">
       <!-- Banner -->
       <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="yes" Text="!(loc.InstallDirDlgBannerBitmap)"/>
@@ -347,11 +348,10 @@
       <Control Id="Description" Type="Text" X="25" Y="23" Width="280" Height="15" Transparent="yes" NoPrefix="yes" Text="Microsoft Update helps keep your computer secure and up to date for Windows and other Microsoft products, including PowerShell 7. Updates will be delivered based on your current update settings. You can review or change these settings from the Windows Update control panel." TabSkip="yes" />
       <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" TabSkip="yes" />
       <!-- If the checkboxes are defined first, then they are first in the tab order and can be ticked and unticked using the spacebar -->
-      <Control Id="UseMuCheckBox" Type="CheckBox" X="20" Y="160" Width="290" Height="17" Property="USE_MU" CheckBoxValue="1" Text="Update using Microsoft Update"/>
-      <Control Id="UseMuRadioButtonGroup" Type="RadioButtonGroup" X="20" Y="160" Width="290" Height="200" Property="USE_MU">
+      <Control Id="UseMuRadioButtonGroup" Type="RadioButtonGroup" X="20" Y="160" Width="290" Height="30" Property="USE_MU">
         <RadioButtonGroup Property="USE_MU">
-          <RadioButton Value="0" X="0" Y="0" Width="200" Height="10" Text="Use Microsoft Update when I check for updates (recommended)" />
-          <RadioButton Value="1" X="0" Y="20" Width="200" Height="10" Text="I don’t want to use Microsoft Update." />
+          <RadioButton Value="1" X="0" Y="0" Width="200" Height="10" Text="Use Microsoft Update when I check for updates (recommended)" />
+          <RadioButton Value="0" X="0" Y="20" Width="200" Height="10" Text="I don’t want to use Microsoft Update." />
         </RadioButtonGroup>
       </Control>
       <Control Id="MuFAQ" Type="Hyperlink" X="20" Y="230" Width="214" Height="17">

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -433,7 +433,7 @@
       <Publish Dialog="ExplorerContextMenuDialog" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
       <Publish Dialog="ExplorerContextMenuDialog" Control="Next" Event="NewDialog" Value="MuDialog">1</Publish>
       <Publish Dialog="MuDialog" Control="Back" Event="NewDialog" Value="ExplorerContextMenuDialog">1</Publish>
-      <Publish Dialog="MuDialog" Control="Next" Event="SpawnDialog" Value="MuWarningDlg" Order="1">ENABLE_MU="0" AND USE_MU="1"></Publish>
+      <Publish Dialog="MuDialog" Control="Next" Event="SpawnDialog" Value="MuWarningDlg" Order="1">ENABLE_MU=0 AND USE_MU=1></Publish>
       <Publish Dialog="MuDialog" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="2">1</Publish>
 
       <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -435,7 +435,7 @@
       <Publish Dialog="ExplorerContextMenuDialog" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
       <Publish Dialog="ExplorerContextMenuDialog" Control="Next" Event="NewDialog" Value="MuDialog">1</Publish>
       <Publish Dialog="MuDialog" Control="Back" Event="NewDialog" Value="ExplorerContextMenuDialog">1</Publish>
-      <Publish Dialog="MuDialog" Control="Next" Event="SpawnDialog" Value="MuWarningDlg" Order="1">ENABLE_MU=0 AND USE_MU=1></Publish>
+      <Publish Dialog="MuDialog" Control="Next" Event="SpawnDialog" Value="MuWarningDlg" Order="1">ENABLE_MU=0 AND USE_MU=1</Publish>
       <Publish Dialog="MuDialog" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="2">1</Publish>
 
       <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -433,7 +433,7 @@
       <Publish Dialog="ExplorerContextMenuDialog" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
       <Publish Dialog="ExplorerContextMenuDialog" Control="Next" Event="NewDialog" Value="MuDialog">1</Publish>
       <Publish Dialog="MuDialog" Control="Back" Event="NewDialog" Value="ExplorerContextMenuDialog">1</Publish>
-      <Publish Dialog="MuDialog" Control="Next" Event="SpawnDialog" Value="MuWarningDlg" Order="1"><![CDATA[ENABLE_MU = 0 AND USE_MU = 1]]></Publish>
+      <Publish Dialog="MuDialog" Control="Next" Event="SpawnDialog" Value="MuWarningDlg" Order="1">ENABLE_MU<>"1" AND USE_MU="1"></Publish>
       <Publish Dialog="MuDialog" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="2">1</Publish>
 
       <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
@@ -445,7 +445,7 @@
       <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Property="_BrowseProperty" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
       <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Event="SpawnDialog" Value="BrowseDlg" Order="2">1</Publish>
 
-      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="ExplorerContextMenuDialog" Order="1">NOT Installed</Publish>
+      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MuDialog" Order="1">NOT Installed</Publish>
       <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="2">Installed AND NOT PATCH</Publish>
       <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">Installed AND PATCH</Publish>
 

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -353,8 +353,8 @@
       <Control Id="UseMuCheckBox" Type="CheckBox" X="20" Y="100" Width="290" Height="27" Property="USE_MU" CheckBoxValue="0" Text="Enable updating PowerShell through Microsft Update or WSUS (recommended)"/>
       <Control Id="EnableMuCheckBox" Type="CheckBox" X="20" Y="130" Width="290" Height="17" Property="ENABLE_MU" CheckBoxValue="0" Text="Use Microsoft Update when I check for updates (recommended)"/>
       <Control Id="MuWarningText" Type="Text" X="20" Y="160" Width="290" Height="17" Text="Without Microsoft Update enabled, you will need to use another update solution like WSUS or SCCM in order to receive automatic updates.">
-        <Condition Action="hide"><![CDATA[ENABLE_MU="1" OR USE_MU="0"]]></Condition>
-        <Condition Action="show"><![CDATA[ENABLE_MU="0" AND USE_MU="1"]]></Condition>
+        <Condition Action="hide"><![CDATA[ENABLE_MU="1" OR USE_MU<>"1"]]></Condition>
+        <Condition Action="show"><![CDATA[ENABLE_MU<>"1" AND USE_MU="1"]]></Condition>
       </Control>
       <Control Id="MuFAQ" Type="Hyperlink" X="20" Y="190" Width="214" Height="17">
         <Text><![CDATA[<a href="https://aka.ms/PowerShell-Microsoft-Update-FAQ">See the Microsoft Update FAQ.</a>]]></Text>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -351,7 +351,9 @@
       <Control Id="Description" Type="Text" X="25" Y="54" Width="280" Height="100" Transparent="yes" NoPrefix="yes" Text="Microsoft Update helps keep your computer secure and up to date for Windows and other Microsoft products, including PowerShell 7. Updates will be delivered based on your current update settings. You can review or change these settings from the Windows Update control panel." TabSkip="yes" />
       <!-- If the checkboxes are defined first, then they are first in the tab order and can be ticked and unticked using the spacebar -->
       <Control Id="UseMuCheckBox" Type="CheckBox" X="20" Y="100" Width="290" Height="27" Property="USE_MU" CheckBoxValue="0" Text="Enable updating PowerShell through Microsft Update or WSUS (recommended)"/>
-      <Control Id="EnableMuCheckBox" Type="CheckBox" X="20" Y="130" Width="290" Height="17" Property="ENABLE_MU" CheckBoxValue="0" Text="Use Microsoft Update when I check for updates (recommended)"/>
+      <Control Id="EnableMuCheckBox" Type="CheckBox" X="20" Y="130" Width="290" Height="17" Property="ENABLE_MU" CheckBoxValue="0" Text="Use Microsoft Update when I check for updates (recommended)">
+        <Publish Event="SpawnDialog" Value="MuWarningDlg"><![CDATA[ENABLE_MU<>"1" AND USE_MU="1"]]></Publish>
+      </Control>
       <Control Id="MuWarningText" Type="Text" X="20" Y="160" Width="290" Height="17" Text="Without Microsoft Update enabled, you will need to use another update solution like WSUS or SCCM in order to receive automatic updates.">
         <Condition Action="hide"><![CDATA[ENABLE_MU="1" OR USE_MU<>"1"]]></Condition>
         <Condition Action="show"><![CDATA[ENABLE_MU<>"1" AND USE_MU="1"]]></Condition>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -148,6 +148,7 @@
     <Feature Id="ProductFeature" Title="PowerShell" Level="1">
       <ComponentGroupRef Id="ApplicationFiles"/>
       <ComponentRef Id="ApplicationProgramsMenuShortcut"/>
+      <ComponentRef Id="MURegistryEntries"/>
       <ComponentRef Id="RegistryEntries"/>
       <ComponentRef Id="SharedRegistryEntries"/>
       <ComponentRef Id="SetPath"/>
@@ -192,7 +193,7 @@
             <Component Id="MURegistryEntries">
               <!-- Create registry key to allow opt-out of MU servicing without opting out of MU completely.  -->
               <RegistryKey Root="HKLM" Key="Software\Microsoft\PowerShellCore" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="no">
-                  <RegistryValue Type="integer" Value="[USE_MU]" Name="UseMU" KeyPath="yes"/>
+                  <RegistryValue Type="integer" Value="[USE_MU]" Name="UseMU"/>
               </RegistryKey>
             </Component>
             <Component Id="RegistryEntries">

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -350,17 +350,21 @@
       <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" TabSkip="yes" />
       <Control Id="Description" Type="Text" X="25" Y="54" Width="280" Height="100" Transparent="yes" NoPrefix="yes" Text="Microsoft Update helps keep your computer secure and up to date for Windows and other Microsoft products, including PowerShell 7. Updates will be delivered based on your current update settings. You can review or change these settings from the Windows Update control panel." TabSkip="yes" />
       <!-- If the checkboxes are defined first, then they are first in the tab order and can be ticked and unticked using the spacebar -->
-      <Control Id="UseMuCheckBox" Type="CheckBox" X="20" Y="100" Width="290" Height="27" Property="USE_MU" CheckBoxValue="0" Text="Enable updating PowerShell through Microsft Update or WSUS (recommended)"/>
-      <Control Id="EnableMuCheckBox" Type="CheckBox" X="20" Y="130" Width="290" Height="17" Property="ENABLE_MU" CheckBoxValue="0" Text="Use Microsoft Update when I check for updates (recommended)">
+      <Control Id="UseMuCheckBox" Type="CheckBox" X="20" Y="100" Width="290" Height="27" Property="USE_MU" Text="Enable updating PowerShell through Microsft Update or WSUS (recommended)"/>
+      <Control Id="EnableMuCheckBox" Type="CheckBox" X="20" Y="130" Width="290" Height="17" Property="ENABLE_MU" Text="Use Microsoft Update when I check for updates (recommended)">
         <Publish Event="SpawnDialog" Value="MuWarningDlg"><![CDATA[ENABLE_MU<>"1" AND USE_MU="1"]]></Publish>
       </Control>
       <Control Id="MuWarningText" Type="Text" X="20" Y="160" Width="290" Height="17" Text="Without Microsoft Update enabled, you will need to use another update solution like WSUS or SCCM in order to receive automatic updates.">
         <Condition Action="hide"><![CDATA[ENABLE_MU="1" OR NOT USE_MU]]></Condition>
         <Condition Action="show"><![CDATA[NOT ENABLE_MU AND USE_MU="1"]]></Condition>
       </Control>
-      <Control Id="MuFAQ" Type="Hyperlink" X="20" Y="190" Width="214" Height="17">
-        <Text><![CDATA[<a href="https://aka.ms/PowerShell-Microsoft-Update-FAQ">See the Microsoft Update FAQ.</a>]]></Text>
+      <Control Id="MuWarningText2" Type="Edit" X="20" Y="190" Width="290" Height="17" Text="2-Without Microsoft Update enabled, you will need to use another update solution like WSUS or SCCM in order to receive automatic updates.">
+        <Condition Action="hide"><![CDATA[ENABLE_MU="1"]]></Condition>
+        <Condition Action="show"><![CDATA[ENABLE_MU<>"1"]]></Condition>
       </Control>
+      <!--Control Id="MuFAQ" Type="Hyperlink" X="20" Y="190" Width="214" Height="17">
+        <Text><![CDATA[<a href="https://aka.ms/PowerShell-Microsoft-Update-FAQ">See the Microsoft Update FAQ.</a>]]></Text>
+      </Control-->
       <Control Id="PrivacyLink" Type="Hyperlink" X="20" Y="210" Width="290" Height="17">
         <Text><![CDATA[<a href="https://aka.ms/PowerShell-Microsoft-Update-Privacy-Statement">Read the Microsoft Update Priacy Statement.</a>]]></Text>
       </Control>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -396,8 +396,6 @@
 
       <Property Id="DefaultUIFont" Value="WixUI_Font_Normal" />
       <Property Id="WixUI_Mode" Value="InstallDir" />
-      <PropertyRef Id="ENABLE_MU" />
-      <PropertyRef Id="USE_MU" />
 
       <DialogRef Id="BrowseDlg" />
       <DialogRef Id="DiskCostDlg" />

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -352,6 +352,10 @@
       <!-- If the checkboxes are defined first, then they are first in the tab order and can be ticked and unticked using the spacebar -->
       <Control Id="UseMuCheckBox" Type="CheckBox" X="20" Y="100" Width="290" Height="27" Property="USE_MU" CheckBoxValue="0" Text="Enable updating PowerShell through Microsft Update or WSUS (recommended)"/>
       <Control Id="EnableMuCheckBox" Type="CheckBox" X="20" Y="130" Width="290" Height="17" Property="ENABLE_MU" CheckBoxValue="0" Text="Use Microsoft Update when I check for updates (recommended)"/>
+      <Control Id="MuWarningText" Type="Text" X="20" Y="160" Width="290" Height="17" Text="Without Microsoft Update enabled, you will need to use another update solution like WSUS or SCCM in order to receive automatic updates.">
+        <Condition Action="hide"><![CDATA[ENABLE_MU="1" OR USE_MU="0"]]></Condition>
+        <Condition Action="show"><![CDATA[ENABLE_MU="0" AND USE_MU="1"]]></Condition>
+      </Control>
       <Control Id="MuFAQ" Type="Hyperlink" X="20" Y="190" Width="214" Height="17">
         <Text><![CDATA[<a href="https://aka.ms/PowerShell-Microsoft-Update-FAQ">See the Microsoft Update FAQ.</a>]]></Text>
       </Control>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -351,20 +351,11 @@
       <Control Id="Description" Type="Text" X="25" Y="54" Width="280" Height="100" Transparent="yes" NoPrefix="yes" Text="Microsoft Update helps keep your computer secure and up to date for Windows and other Microsoft products, including PowerShell 7. Updates will be delivered based on your current update settings. You can review or change these settings from the Windows Update control panel." TabSkip="yes" />
       <!-- If the checkboxes are defined first, then they are first in the tab order and can be ticked and unticked using the spacebar -->
       <Control Id="UseMuCheckBox" Type="CheckBox" X="20" Y="100" Width="290" Height="27" Property="USE_MU" Text="Enable updating PowerShell through Microsft Update or WSUS (recommended)"/>
-      <Control Id="EnableMuCheckBox" Type="CheckBox" X="20" Y="130" Width="290" Height="17" Property="ENABLE_MU" Text="Use Microsoft Update when I check for updates (recommended)">
-        <Publish Event="SpawnDialog" Value="MuWarningDlg"><![CDATA[ENABLE_MU<>"1" AND USE_MU="1"]]></Publish>
-      </Control>
-      <Control Id="MuWarningText" Type="Text" X="20" Y="160" Width="290" Height="17" Text="Without Microsoft Update enabled, you will need to use another update solution like WSUS or SCCM in order to receive automatic updates.">
-        <Condition Action="hide"><![CDATA[ENABLE_MU="1" OR NOT USE_MU]]></Condition>
-        <Condition Action="show"><![CDATA[NOT ENABLE_MU AND USE_MU="1"]]></Condition>
-      </Control>
-      <Control Id="MuWarningText2" Type="Edit" X="20" Y="190" Width="290" Height="17" Text="2-Without Microsoft Update enabled, you will need to use another update solution like WSUS or SCCM in order to receive automatic updates.">
-        <Condition Action="hide"><![CDATA[ENABLE_MU="1"]]></Condition>
-        <Condition Action="show"><![CDATA[ENABLE_MU<>"1"]]></Condition>
-      </Control>
-      <!--Control Id="MuFAQ" Type="Hyperlink" X="20" Y="190" Width="214" Height="17">
+      <Control Id="EnableMuCheckBox" Type="CheckBox" X="20" Y="130" Width="290" Height="17" Property="ENABLE_MU" Text="Use Microsoft Update when I check for updates (recommended)"/>
+      <Control Id="MuWarningText" Type="Text" X="20" Y="160" Width="290" Height="27" Text="Without Microsoft Update enabled, you will need to use another update solution like WSUS or SCCM in order to receive automatic updates."/>
+      <Control Id="MuFAQ" Type="Hyperlink" X="20" Y="190" Width="214" Height="17">
         <Text><![CDATA[<a href="https://aka.ms/PowerShell-Microsoft-Update-FAQ">See the Microsoft Update FAQ.</a>]]></Text>
-      </Control-->
+      </Control>
       <Control Id="PrivacyLink" Type="Hyperlink" X="20" Y="210" Width="290" Height="17">
         <Text><![CDATA[<a href="https://aka.ms/PowerShell-Microsoft-Update-Privacy-Statement">Read the Microsoft Update Priacy Statement.</a>]]></Text>
       </Control>
@@ -374,20 +365,6 @@
       <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Cancel="yes" Default="yes" Text="!(loc.WixUINext)"/>
       <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">
         <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
-      </Control>
-    </Dialog>
-  </UI>
-  <!-- MU not enable dialog box -->
-  <UI>
-    <Dialog Id="MuWarningDlg" Width="284" Height="73" Title="Microsoft Update Warning" NoMinimize="yes">
-      <Control Id="Text" Type="Text" X="38" Y="8" Width="240" Height="40" TabSkip="no">
-        <Text>Without Microsoft Update enabled, you will need to use another update solution like WSUS or SCCM in order to receive automatic updates. Are you sure you want to continue?</Text>
-      </Control>
-      <Control Id="Okay" Type="PushButton" X="114" Y="52" Width="56" Height="17" Default="yes"  Cancel="no" Text="OK">
-        <Publish Event="EndDialog" Value="Return">1</Publish>
-      </Control>
-      <Control Id="Cancel" Type="PushButton" X="184" Y="52" Width="56" Height="17" Default="yes"  Cancel="yes" Text="OK">
-        <Publish Event="EndDialog" Value="Return">0</Publish>
       </Control>
     </Dialog>
   </UI>
@@ -401,7 +378,6 @@
       - WixUI_InstallDirDlg
       - ExplorerContextMenuDialog
       - MuDialog
-      - MuWarningDlg
       - WixUI_VerifyReadyDlg
       - WixUI_DiskCostDlg
       Maintenance dialog sequence:
@@ -445,7 +421,6 @@
       <Publish Dialog="ExplorerContextMenuDialog" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
       <Publish Dialog="ExplorerContextMenuDialog" Control="Next" Event="NewDialog" Value="MuDialog">1</Publish>
       <Publish Dialog="MuDialog" Control="Back" Event="NewDialog" Value="ExplorerContextMenuDialog">1</Publish>
-      <Publish Dialog="MuDialog" Control="Next" Event="SpawnDialog" Value="MuWarningDlg" Order="1">NOT ENABLE_MU AND USE_MU=1</Publish>
       <Publish Dialog="MuDialog" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="2">1</Publish>
 
       <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -191,9 +191,10 @@
               <Environment Id="PowerShellDistributionChannel" Action="create" Name="POWERSHELL_DISTRIBUTION_CHANNEL" Permanent="no" System="yes" Value="MSI:[WINDOWS_PRODUCT_NAME]"/>
             </Component>
             <Component Id="MURegistryEntries">
+              <Condition>USE_MU=1</Condition>
               <!-- Create registry key to allow opt-out of MU servicing without opting out of MU completely.  -->
-              <RegistryKey Root="HKLM" Key="Software\Microsoft\PowerShellCore" Action="create">
-                  <RegistryValue Type="integer" Value="[USE_MU]" Name="UseMU"  KeyPath="yes"/>
+              <RegistryKey Root="HKLM" Key="Software\Microsoft\PowerShellCore" Action="create" ForceCreateOnInstall="yes">
+                  <RegistryValue Type="integer" Value="1" Name="UseMU"  KeyPath="yes"/>
               </RegistryKey>
             </Component>
             <Component Id="RegistryEntries">

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -349,8 +349,8 @@
       <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" TabSkip="yes" />
       <Control Id="Description" Type="Text" X="25" Y="54" Width="280" Height="100" Transparent="yes" NoPrefix="yes" Text="Microsoft Update helps keep your computer secure and up to date for Windows and other Microsoft products, including PowerShell 7. Updates will be delivered based on your current update settings. You can review or change these settings from the Windows Update control panel." TabSkip="yes" />
       <!-- If the checkboxes are defined first, then they are first in the tab order and can be ticked and unticked using the spacebar -->
-      <Control Id="UseMuCheckBox" Type="CheckBox" X="20" Y="140" Width="290" Height="50" Property="ADD_PATH" CheckBoxValue="0" Text="Enable updating PowerShell through Microsft Update or WSUS (recommended)"/>
-      <Control Id="EnableMuCheckBox" Type="CheckBox" X="20" Y="180" Width="290" Height="50" Property="ADD_PATH" CheckBoxValue="0" Text="Use Microsoft Update when I check for updates (recommended)"/>
+      <Control Id="UseMuCheckBox" Type="CheckBox" X="20" Y="140" Width="290" Height="50" Property="USE_MU" CheckBoxValue="0" Text="Enable updating PowerShell through Microsft Update or WSUS (recommended)"/>
+      <Control Id="EnableMuCheckBox" Type="CheckBox" X="20" Y="180" Width="290" Height="50" Property="ENABLE_MU" CheckBoxValue="0" Text="Use Microsoft Update when I check for updates (recommended)"/>
       <Control Id="MuFAQ" Type="Hyperlink" X="20" Y="230" Width="214" Height="17">
         <Text><![CDATA[<a href="https://aka.ms/PowerShell-Microsoft-Update-FAQ">See the Microsoft Update FAQ.</a>]]></Text>
       </Control>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -52,6 +52,8 @@
     <Property Id="ARPPRODUCTICON" Value="PowerShellExe.ico" />
     <!-- Set properties for add/remove programs -->
     <Property Id="ARPHELPLINK" Value="$(var.InfoURL)" />
+    <Property Id="USE_MU" Value="1" />
+    <Property Id="ENABLE_MU" Value="1" />
     <!-- custom images -->
     <WixVariable Id="WixUIBannerBmp" Value="assets\wix\WixUIBannerBmp.png" />
     <WixVariable Id="WixUIDialogBmp" Value="assets\wix\WixUIDialogBmp.png" />
@@ -341,8 +343,6 @@
 <!-- Microsoft Update Menu Dialog -->
 <Fragment>
  <UI>
-    <Property Id="USE_MU" Value="1" />
-    <Property Id="ENABLE_MU" Value="1" />
     <Dialog Id="MuDialog" Width="370" Height="270" Title="!(loc.ExitDialog_Title)">
       <!-- Banner -->
       <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="yes" Text="!(loc.InstallDirDlgBannerBitmap)"/>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -104,7 +104,7 @@
         <![CDATA[NOT Installed AND (ENABLE_PSREMOTING=1)]]>
       </Custom>
       <Custom Action="EnableMU" After="InstallFiles">
-        <![CDATA[NOT Installed AND (USE_MU=1)]]>
+        <![CDATA[NOT Installed AND (ENABLE_MU=1)]]>
       </Custom>
     </InstallExecuteSequence>
     <UI>
@@ -341,6 +341,7 @@
 <Fragment>
  <UI>
     <Property Id="USE_MU" Value="1" />
+    <Property Id="ENABLE_MU" Value="1" />
     <Dialog Id="MuDialog" Width="370" Height="270" Title="!(loc.ExitDialog_Title)">
       <!-- Banner -->
       <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="yes" Text="!(loc.InstallDirDlgBannerBitmap)"/>
@@ -348,12 +349,8 @@
       <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" TabSkip="yes" />
       <Control Id="Description" Type="Text" X="25" Y="54" Width="280" Height="100" Transparent="yes" NoPrefix="yes" Text="Microsoft Update helps keep your computer secure and up to date for Windows and other Microsoft products, including PowerShell 7. Updates will be delivered based on your current update settings. You can review or change these settings from the Windows Update control panel." TabSkip="yes" />
       <!-- If the checkboxes are defined first, then they are first in the tab order and can be ticked and unticked using the spacebar -->
-      <Control Id="UseMuRadioButtonGroup" Type="RadioButtonGroup" X="20" Y="160" Width="290" Height="30" Property="USE_MU">
-        <RadioButtonGroup Property="USE_MU">
-          <RadioButton Value="1" X="0" Y="0" Width="200" Height="10" Text="Use Microsoft Update when I check for updates (recommended)" />
-          <RadioButton Value="0" X="0" Y="20" Width="200" Height="10" Text="I don’t want to use Microsoft Update." />
-        </RadioButtonGroup>
-      </Control>
+      <Control Id="UseMuCheckBox" Type="CheckBox" X="20" Y="140" Width="290" Height="50" Property="ADD_PATH" CheckBoxValue="0" Text="Enable updating PowerShell through Microsft Update or WSUS (recommended)"/>
+      <Control Id="EnableMuCheckBox" Type="CheckBox" X="20" Y="180" Width="290" Height="50" Property="ADD_PATH" CheckBoxValue="0" Text="Use Microsoft Update when I check for updates (recommended)"/>
       <Control Id="MuFAQ" Type="Hyperlink" X="20" Y="230" Width="214" Height="17">
         <Text><![CDATA[<a href="https://aka.ms/PowerShell-Microsoft-Update-FAQ">See the Microsoft Update FAQ.</a>]]></Text>
       </Control>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -349,12 +349,12 @@
       <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" TabSkip="yes" />
       <Control Id="Description" Type="Text" X="25" Y="54" Width="280" Height="100" Transparent="yes" NoPrefix="yes" Text="Microsoft Update helps keep your computer secure and up to date for Windows and other Microsoft products, including PowerShell 7. Updates will be delivered based on your current update settings. You can review or change these settings from the Windows Update control panel." TabSkip="yes" />
       <!-- If the checkboxes are defined first, then they are first in the tab order and can be ticked and unticked using the spacebar -->
-      <Control Id="UseMuCheckBox" Type="CheckBox" X="20" Y="140" Width="290" Height="50" Property="USE_MU" CheckBoxValue="0" Text="Enable updating PowerShell through Microsft Update or WSUS (recommended)"/>
-      <Control Id="EnableMuCheckBox" Type="CheckBox" X="20" Y="180" Width="290" Height="50" Property="ENABLE_MU" CheckBoxValue="0" Text="Use Microsoft Update when I check for updates (recommended)"/>
-      <Control Id="MuFAQ" Type="Hyperlink" X="20" Y="230" Width="214" Height="17">
+      <Control Id="UseMuCheckBox" Type="CheckBox" X="20" Y="100" Width="290" Height="50" Property="USE_MU" CheckBoxValue="0" Text="Enable updating PowerShell through Microsft Update or WSUS (recommended)"/>
+      <Control Id="EnableMuCheckBox" Type="CheckBox" X="20" Y="130" Width="290" Height="50" Property="ENABLE_MU" CheckBoxValue="0" Text="Use Microsoft Update when I check for updates (recommended)"/>
+      <Control Id="MuFAQ" Type="Hyperlink" X="20" Y="150" Width="214" Height="17">
         <Text><![CDATA[<a href="https://aka.ms/PowerShell-Microsoft-Update-FAQ">See the Microsoft Update FAQ.</a>]]></Text>
       </Control>
-      <Control Id="PrivacyLink" Type="Hyperlink" X="20" Y="250" Width="290" Height="17">
+      <Control Id="PrivacyLink" Type="Hyperlink" X="20" Y="170" Width="290" Height="17">
         <Text><![CDATA[<a href="http://go.microsoft.com/fwlink/?LinkID=57190">Read the Microsoft Update Priacy Statement.</a>]]></Text>
       </Control>
       <!-- divider and bottom buttons -->

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -192,7 +192,7 @@
             </Component>
             <Component Id="MURegistryEntries">
               <!-- Create registry key to allow opt-out of MU servicing without opting out of MU completely.  -->
-              <RegistryKey Root="HKLM" Key="Software\Microsoft\PowerShellCore" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="no">
+              <RegistryKey Root="HKLM" Key="Software\Microsoft\PowerShellCore" Action="create">
                   <RegistryValue Type="integer" Value="[USE_MU]" Name="UseMU"  KeyPath="yes"/>
               </RegistryKey>
             </Component>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -410,6 +410,8 @@
 
       <Property Id="DefaultUIFont" Value="WixUI_Font_Normal" />
       <Property Id="WixUI_Mode" Value="InstallDir" />
+      <PropertyRef Id="ENABLE_MU" />
+      <PropertyRef Id="USE_MU" />
 
       <DialogRef Id="BrowseDlg" />
       <DialogRef Id="DiskCostDlg" />

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -354,10 +354,10 @@
       <Control Id="EnableMuCheckBox" Type="CheckBox" X="20" Y="130" Width="290" Height="17" Property="ENABLE_MU" Text="Use Microsoft Update when I check for updates (recommended)"/>
       <Control Id="MuWarningText" Type="Text" X="20" Y="160" Width="290" Height="27" Text="Without Microsoft Update enabled, you will need to use another update solution like WSUS or SCCM in order to receive automatic updates."/>
       <Control Id="MuFAQ" Type="Hyperlink" X="20" Y="190" Width="214" Height="17">
-        <Text><![CDATA[<a href="https://aka.ms/PowerShell-Microsoft-Update-FAQ">See the Microsoft Update FAQ.</a>]]></Text>
+        <Text><![CDATA[<a href="https://aka.ms/PowerShell-Microsoft-Update-FAQ">See the Microsoft Update FAQ</a>]]></Text>
       </Control>
       <Control Id="PrivacyLink" Type="Hyperlink" X="20" Y="210" Width="290" Height="17">
-        <Text><![CDATA[<a href="https://aka.ms/PowerShell-Microsoft-Update-Privacy-Statement">Read the Microsoft Update Priacy Statement.</a>]]></Text>
+        <Text><![CDATA[<a href="https://aka.ms/PowerShell-Microsoft-Update-Privacy-Statement">Read the Microsoft Update Priacy Statement</a>]]></Text>
       </Control>
       <!-- divider and bottom buttons -->
       <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" TabSkip="yes"/>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -435,7 +435,7 @@
       <Publish Dialog="ExplorerContextMenuDialog" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
       <Publish Dialog="ExplorerContextMenuDialog" Control="Next" Event="NewDialog" Value="MuDialog">1</Publish>
       <Publish Dialog="MuDialog" Control="Back" Event="NewDialog" Value="ExplorerContextMenuDialog">1</Publish>
-      <Publish Dialog="MuDialog" Control="Next" Event="SpawnDialog" Value="MuWarningDlg" Order="1">ENABLE_MU=0 AND USE_MU=1</Publish>
+      <Publish Dialog="MuDialog" Control="Next" Event="SpawnDialog" Value="MuWarningDlg" Order="1">NOT ENABLE_MU AND USE_MU=1</Publish>
       <Publish Dialog="MuDialog" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="2">1</Publish>
 
       <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -84,6 +84,16 @@
                   Execute="deferred"
                   Return="ignore"
                   Impersonate="no" />
+    <SetProperty Id="EnableMU"
+                 Before="EnableMU"
+                 Sequence="execute"
+                 Value="&quot;[VersionFolder]pwsh.exe&quot; -NoProfile -ExecutionPolicy Bypass -Command &quot;$null=(New-Object -ComObject Microsoft.Update.ServiceManager).AddService2('7971f918-a847-4430-9279-4a52d1efe18d', 7, '')&quot;" />
+    <CustomAction Id="EnableMU"
+                  BinaryKey="WixCA"
+                  DllEntry="CAQuietExec"
+                  Execute="deferred"
+                  Return="ignore"
+                  Impersonate="no" />
     <InstallExecuteSequence>
       <!-- Do not remove shortcuts on upgrade to preserve user shortcuts pinned to Taskbar, see https://stackoverflow.com/a/33402698/1810304 -->
       <RemoveShortcuts>Installed AND NOT UPGRADINGPRODUCTCODE</RemoveShortcuts>
@@ -92,6 +102,9 @@
       </Custom>
       <Custom Action="EnablePSRemoting" After="InstallFiles">
         <![CDATA[NOT Installed AND (ENABLE_PSREMOTING=1)]]>
+      </Custom>
+      <Custom Action="EnableMU" After="InstallFiles">
+        <![CDATA[NOT Installed AND (USE_MU=1)]]>
       </Custom>
     </InstallExecuteSequence>
     <UI>
@@ -176,9 +189,18 @@
               <!-- Should retain component GUID since this is a shared, non-file, non-registry resource. -->
               <Environment Id="PowerShellDistributionChannel" Action="create" Name="POWERSHELL_DISTRIBUTION_CHANNEL" Permanent="no" System="yes" Value="MSI:[WINDOWS_PRODUCT_NAME]"/>
             </Component>
+            <Component Id="MURegistryEntries">
+              <!-- Create registry key to allow opt-out of MU servicing without opting out of MU completely.  -->
+              <RegistryKey Root="HKLM" Key="Software\Microsoft\PowerShellCore" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="no">
+                  <RegistryValue Type="integer" Value="[USE_MU]" Name="UseMU" KeyPath="yes"/>
+              </RegistryKey>
+            </Component>
             <Component Id="RegistryEntries">
               <!-- create key for easy detection of a particular version of a powershell core package
                     The upgrade code is used in the key because it will change when we allow SxS       -->
+              <RegistryKey Root="HKLM" Key="Software\Microsoft\PowerShellCore" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
+                  <RegistryValue Type="integer" Value="[USE_MU]" Name="UseMU" KeyPath="yes"/>
+              </RegistryKey>
               <RegistryKey Root="HKLM" Key="Software\Microsoft\PowerShellCore\InstalledVersions\$(var.UpgradeCode)" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
                   <RegistryValue Type="string" Value="$(var.ProductSemanticVersion)" Name="SemanticVersion" KeyPath="yes"/>
                   <RegistryValue Type="string" Value="[VersionFolder]" Name="InstallLocation" />
@@ -288,7 +310,7 @@
  <UI>
     <Property Id="REGISTER_MANIFEST" Value="1" />
     <Property Id="ADD_PATH" Value="1" />
-    <Dialog Id="ExplorerContextMenuDialog" Width="370" Height="270" Title="!(loc.ExitDialog_Title)">
+    <Dialog Id="ExplorerContextMenuDialog" Width="370" Height="310" Title="!(loc.ExitDialog_Title)">
       <!-- Banner -->
       <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="yes" Text="!(loc.InstallDirDlgBannerBitmap)"/>
       <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes" Text="{\WixUI_Font_Title}Optional Actions" TabSkip="yes" />
@@ -300,23 +322,56 @@
       <Control Id="EnablePSRemotingCheckBox" Type="CheckBox" X="20" Y="100" Width="290" Height="17" Property="ENABLE_PSREMOTING" CheckBoxValue="0" Text="Enable $(var.ProductName) remoting"/>
       <Control Id="ContextMenuOpenPowerShell" Type="CheckBox" X="20" Y="120" Width="290" Height="17" Property="ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL" CheckBoxValue="0" Text="Add '$(var.ExplorerContextSubMenuDialogText)' context menus to Explorer"/>
       <Control Id="ContextMenuRunPowerShell" Type="CheckBox" X="20" Y="140" Width="290" Height="17" Property="ADD_FILE_CONTEXT_MENU_RUNPOWERSHELL" CheckBoxValue="0" Text="Add '$(var.PowerShellFileContextSubMenuDialogText)' context menu for PowerShell files"/>
-      <Control Id="LicenseLink" Type="Hyperlink" X="20" Y="190" Width="214" Height="17">
+      <Control Id="LicenseLink" Type="Hyperlink" X="20" Y="230" Width="214" Height="17">
         <Text><![CDATA[<a href="https://github.com/PowerShell/PowerShell/blob/master/LICENSE.txt">The application is distributed under the MIT license.</a>]]></Text>
       </Control>
-      <Control Id="TpnLink" Type="Hyperlink" X="20" Y="210" Width="290" Height="17">
+      <Control Id="TpnLink" Type="Hyperlink" X="20" Y="250" Width="290" Height="17">
         <Text><![CDATA[<a href="https://github.com/PowerShell/PowerShell/blob/master/ThirdPartyNotices.txt">Please review the ThirdPartyNotices.txt</a>]]></Text>
       </Control>
       <!-- divider and bottom buttons -->
-      <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" TabSkip="yes"/>
-      <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)"/>
-      <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Cancel="yes" Default="yes" Text="!(loc.WixUINext)"/>
-      <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">
+      <Control Id="BottomLine" Type="Line" X="0" Y="254" Width="370" Height="0" TabSkip="yes"/>
+      <Control Id="Back" Type="PushButton" X="180" Y="283" Width="56" Height="17" Text="!(loc.WixUIBack)"/>
+      <Control Id="Next" Type="PushButton" X="236" Y="283" Width="56" Height="17" Cancel="yes" Default="yes" Text="!(loc.WixUINext)"/>
+      <Control Id="Cancel" Type="PushButton" X="304" Y="283" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">
         <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
       </Control>
     </Dialog>
   </UI>
 </Fragment>
 
+<!-- Microsoft Update Menu Dialog -->
+<Fragment>
+ <UI>
+    <Dialog Id="MuDialog" Width="370" Height="310" Title="!(loc.ExitDialog_Title)">
+      <!-- Banner -->
+      <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="yes" Text="!(loc.InstallDirDlgBannerBitmap)"/>
+      <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes" Text="{\WixUI_Font_Title}Use Microsoft Update to help keep your computer secure and up to date" TabSkip="yes" />
+      <Control Id="Description" Type="Text" X="25" Y="23" Width="280" Height="15" Transparent="yes" NoPrefix="yes" Text="Microsoft Update helps keep your computer secure and up to date for Windows and other Microsoft products, including PowerShell 7. Updates will be delivered based on your current update settings. You can review or change these settings from the Windows Update control panel." TabSkip="yes" />
+      <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" TabSkip="yes" />
+      <!-- If the checkboxes are defined first, then they are first in the tab order and can be ticked and unticked using the spacebar -->
+      <Control Id="UseMuCheckBox" Type="CheckBox" X="20" Y="160" Width="290" Height="17" Property="USE_MU" CheckBoxValue="1" Text="Update using Microsoft Update"/>
+      <Control Id="UseMuRadioButtonGroup" Type="RadioButtonGroup" X="20" Y="160" Width="290" Height="200" Property="USE_MU">
+        <RadioButtonGroup Property="USE_MU">
+          <RadioButton Value="0" X="0" Y="0" Width="200" Height="10" Text="Use Microsoft Update when I check for updates (recommended)" />
+          <RadioButton Value="1" X="0" Y="20" Width="200" Height="10" Text="I don’t want to use Microsoft Update." />
+        </RadioButtonGroup>
+      </Control>
+      <Control Id="MuFAQ" Type="Hyperlink" X="20" Y="230" Width="214" Height="17">
+        <Text><![CDATA[<a href="https://aka.ms/PowerShell-Microsoft-Update-FAQ">See the Microsoft Update FAQ.</a>]]></Text>
+      </Control>
+      <Control Id="PrivacyLink" Type="Hyperlink" X="20" Y="250" Width="290" Height="17">
+        <Text><![CDATA[<a href="http://go.microsoft.com/fwlink/?LinkID=57190">Read the Microsoft Update Priacy Statement.</a>]]></Text>
+      </Control>
+      <!-- divider and bottom buttons -->
+      <Control Id="BottomLine" Type="Line" X="0" Y="254" Width="370" Height="0" TabSkip="yes"/>
+      <Control Id="Back" Type="PushButton" X="180" Y="283" Width="56" Height="17" Text="!(loc.WixUIBack)"/>
+      <Control Id="Next" Type="PushButton" X="236" Y="283" Width="56" Height="17" Cancel="yes" Default="yes" Text="!(loc.WixUINext)"/>
+      <Control Id="Cancel" Type="PushButton" X="304" Y="283" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">
+        <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
+      </Control>
+    </Dialog>
+  </UI>
+</Fragment>
 <!-- Customized version of WixUI_InstallDir, which is necessary to add custom dialogs. https://github.com/wixtoolset/wix3/blob/master/src/ext/UIExtension/wixlib/WixUI_InstallDir.wxs -->
 <Fragment>
   <UI Id="CustomWixUI_InstallDir">
@@ -325,6 +380,7 @@
       - WixUI_WelcomeDlg
       - WixUI_InstallDirDlg
       - ExplorerContextMenuDialog
+      - MuDialog
       - WixUI_VerifyReadyDlg
       - WixUI_DiskCostDlg
       Maintenance dialog sequence:
@@ -364,7 +420,9 @@
       <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">Installed AND PATCH</Publish>
 
       <Publish Dialog="ExplorerContextMenuDialog" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
-      <Publish Dialog="ExplorerContextMenuDialog" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
+      <Publish Dialog="ExplorerContextMenuDialog" Control="Next" Event="NewDialog" Value="MuDialog">1</Publish>
+      <Publish Dialog="MuDialog" Control="Back" Event="NewDialog" Value="ExplorerContextMenuDialog">1</Publish>
+      <Publish Dialog="MuDialog" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
 
       <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
       <Publish Dialog="InstallDirDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -433,7 +433,7 @@
       <Publish Dialog="ExplorerContextMenuDialog" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
       <Publish Dialog="ExplorerContextMenuDialog" Control="Next" Event="NewDialog" Value="MuDialog">1</Publish>
       <Publish Dialog="MuDialog" Control="Back" Event="NewDialog" Value="ExplorerContextMenuDialog">1</Publish>
-      <Publish Dialog="MuDialog" Control="Next" Event="SpawnDialog" Value="MuWarningDlg" Order="1">ENABLE_MU<>"1" AND USE_MU="1"></Publish>
+      <Publish Dialog="MuDialog" Control="Next" Event="SpawnDialog" Value="MuWarningDlg" Order="1">ENABLE_MU="0" AND USE_MU="1"></Publish>
       <Publish Dialog="MuDialog" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="2">1</Publish>
 
       <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -355,8 +355,8 @@
         <Publish Event="SpawnDialog" Value="MuWarningDlg"><![CDATA[ENABLE_MU<>"1" AND USE_MU="1"]]></Publish>
       </Control>
       <Control Id="MuWarningText" Type="Text" X="20" Y="160" Width="290" Height="17" Text="Without Microsoft Update enabled, you will need to use another update solution like WSUS or SCCM in order to receive automatic updates.">
-        <Condition Action="hide"><![CDATA[ENABLE_MU="1" OR USE_MU<>"1"]]></Condition>
-        <Condition Action="show"><![CDATA[ENABLE_MU<>"1" AND USE_MU="1"]]></Condition>
+        <Condition Action="hide"><![CDATA[ENABLE_MU="1" OR NOT USE_MU]]></Condition>
+        <Condition Action="show"><![CDATA[NOT ENABLE_MU AND USE_MU="1"]]></Condition>
       </Control>
       <Control Id="MuFAQ" Type="Hyperlink" X="20" Y="190" Width="214" Height="17">
         <Text><![CDATA[<a href="https://aka.ms/PowerShell-Microsoft-Update-FAQ">See the Microsoft Update FAQ.</a>]]></Text>

--- a/test/packaging/windows/msi.tests.ps1
+++ b/test/packaging/windows/msi.tests.ps1
@@ -120,42 +120,6 @@ Describe -Name "Windows MSI" -Fixture {
         $error.Clear()
     }
 
-    Context "Enable_MU disabled" {
-        It "MSI should install without error" -Skip:(!(Test-Elevated)) {
-            if($muEnabled) {
-                Set-ItResult -Skipped -Because "MU already enabled"
-            }
-            {
-                Invoke-MsiExec -Install -MsiPath $msiX64Path -Properties @{Enable_MU = 0}
-            } | Should -Not -Throw
-        }
-
-        # Doesn't work in azDO hosts
-        It "MU should be disabled" -Pending {
-            if($muEnabled) {
-                Set-ItResult -Skipped -Because "MU already enabled"
-            }
-
-            Test-IsMuEnabled | Should -BeFalse -Because "MU should not have been enabled"
-        }
-
-        It "UseMU should be 1" -Skip:(!(Test-Elevated)) {
-            Invoke-TestAndUploadLogOnFailure -Test {
-                $useMu = Get-UseMU
-                $useMu | Should -Be 1
-            }
-        }
-
-        It "MSI should uninstall without error" -Skip:(!(Test-Elevated)) {
-            if($muEnabled) {
-                Set-ItResult -Skipped -Because "MU already enabled"
-            }
-            {
-                Invoke-MsiExec -Uninstall -MsiPath $msiX64Path
-            } | Should -Not -Throw
-        }
-    }
-
     Context "Upgrade code" {
         BeforeAll {
             Write-Verbose "cr-$channel-$runtime" -Verbose
@@ -241,17 +205,6 @@ Describe -Name "Windows MSI" -Fixture {
             }
         }
 
-        # Doesn't work in azDO hosts
-        It "MU should be enabled" -Pending {
-            if($muEnabled) {
-                Set-ItResult -Skipped -Because "MU already enabled"
-            }
-
-            Invoke-TestAndUploadLogOnFailure -Test {
-                Test-IsMuEnabled | Should -BeTrue -Because "MU should have been enabled"
-            }
-        }
-
         It "MSI should uninstall without error" -Skip:(!(Test-Elevated)) {
             {
                 Invoke-MsiExec -Uninstall -MsiPath $msiX64Path
@@ -270,17 +223,6 @@ Describe -Name "Windows MSI" -Fixture {
             Invoke-TestAndUploadLogOnFailure -Test {
                 $useMu = Get-UseMU
                 $useMu | Should -Be 0
-            }
-        }
-
-        # Doesn't work in azDO hosts
-        It "MU should be enabled" -Pending {
-            if($muEnabled) {
-                Set-ItResult -Skipped -Because "MU already enabled"
-            }
-
-            Invoke-TestAndUploadLogOnFailure -Test {
-                Test-IsMuEnabled | Should -BeTrue -Because "MU should have been enabled"
             }
         }
 

--- a/test/packaging/windows/msi.tests.ps1
+++ b/test/packaging/windows/msi.tests.ps1
@@ -78,7 +78,7 @@ Describe -Name "Windows MSI" -Fixture {
             }
 
             $argumentList = "$switch $MsiPath /quiet /l*vx $msiLog $additionalOptions"
-            Write-Verbose -Message "running msiexec $argumentList" -Verbose
+            Write-Verbose -Message "running msiexec $argumentList"
             $msiExecProcess = Start-Process msiexec.exe -Wait -ArgumentList $argumentList -NoNewWindow -PassThru
             if ($msiExecProcess.ExitCode -ne 0) {
                 $exitCode = $msiExecProcess.ExitCode

--- a/test/packaging/windows/msi.tests.ps1
+++ b/test/packaging/windows/msi.tests.ps1
@@ -40,8 +40,13 @@ Describe -Name "Windows MSI" -Fixture {
 
         function Get-UseMU {
             $useMu = 0
+            $key = 'HKLM:\SOFTWARE\Microsoft\PowerShellCore\'
+            if ($runtime -like '*x86*') {
+                $key = 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\PowerShellCore\'
+            }
+
             try {
-                $useMu = Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\PowerShellCore\ -Name UseMU -ErrorAction SilentlyContinue
+                $useMu = Get-ItemPropertyValue -Path $key -Name UseMU -ErrorAction SilentlyContinue
             } catch {}
 
             return $useMu

--- a/test/packaging/windows/msi.tests.ps1
+++ b/test/packaging/windows/msi.tests.ps1
@@ -55,6 +55,7 @@ Describe -Name "Windows MSI" -Fixture {
             }
 
             $argumentList = "$switch $MsiPath /quiet /l*vx $msiLog $additionalOptions"
+            Write-Verbose -Message "running msiexec $argumentList" -Verbose
             $msiExecProcess = Start-Process msiexec.exe -Wait -ArgumentList $argumentList -NoNewWindow -PassThru
             if ($msiExecProcess.ExitCode -ne 0) {
                 $exitCode = $msiExecProcess.ExitCode
@@ -212,7 +213,8 @@ Describe -Name "Windows MSI" -Fixture {
         }
 
         It "UseMU should be 1" -Skip:(!(Test-Elevated)) {
-            $useMu = Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\PowerShellCore\ -Name UseMU
+            $useMu = 0
+            $useMu = Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\PowerShellCore\ -Name UseMU -ErrorAction Ignore
 
             $useMu | Should -Be 1
         }
@@ -234,7 +236,8 @@ Describe -Name "Windows MSI" -Fixture {
         }
 
         It "UseMU should be 0" -Skip:(!(Test-Elevated)) {
-            $useMu = Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\PowerShellCore\ -Name UseMU
+            $useMu = 0
+            $useMu = Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\PowerShellCore\ -Name UseMU -ErrorAction Ignore
 
             $useMu | Should -Be 0
         }

--- a/test/packaging/windows/msi.tests.ps1
+++ b/test/packaging/windows/msi.tests.ps1
@@ -125,7 +125,8 @@ Describe -Name "Windows MSI" -Fixture {
             } | Should -Not -Throw
         }
 
-        It "MU should be disabled" -Skip:(!(Test-Elevated)) {
+        # Doesn't work in azDO hosts
+        It "MU should be disabled" -Pending {
             if($muEnabled) {
                 Set-ItResult -Skipped -Because "MU already enabled"
             }
@@ -235,7 +236,8 @@ Describe -Name "Windows MSI" -Fixture {
             }
         }
 
-        It "MU should be enabled" -Skip:(!(Test-Elevated)) {
+        # Doesn't work in azDO hosts
+        It "MU should be enabled" -Pending {
             if($muEnabled) {
                 Set-ItResult -Skipped -Because "MU already enabled"
             }
@@ -266,7 +268,8 @@ Describe -Name "Windows MSI" -Fixture {
             }
         }
 
-        It "MU should be enabled" -Skip:(!(Test-Elevated)) {
+        # Doesn't work in azDO hosts
+        It "MU should be enabled" -Pending {
             if($muEnabled) {
                 Set-ItResult -Skipped -Because "MU already enabled"
             }

--- a/test/packaging/windows/msi.tests.ps1
+++ b/test/packaging/windows/msi.tests.ps1
@@ -38,6 +38,15 @@ Describe -Name "Windows MSI" -Fixture {
             }
         }
 
+        function Get-UseMU {
+            $useMu = 0
+            try {
+                $useMu = Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\PowerShellCore\ -Name UseMU -ErrorAction SilentlyContinue
+            } catch {}
+
+            return $useMu
+        }
+
         function Invoke-Msiexec {
             param(
                 [Parameter(ParameterSetName = 'Install', Mandatory)]
@@ -122,6 +131,13 @@ Describe -Name "Windows MSI" -Fixture {
             }
 
             Test-IsMuEnabled | Should -BeFalse -Because "MU should not have been enabled"
+        }
+
+        It "UseMU should be 1" -Skip:(!(Test-Elevated)) {
+            Invoke-TestAndUploadLogOnFailure -Test {
+                $useMu = Get-UseMU
+                $useMu | Should -Be 1
+            }
         }
 
         It "MSI should uninstall without error" -Skip:(!(Test-Elevated)) {
@@ -214,9 +230,7 @@ Describe -Name "Windows MSI" -Fixture {
 
         It "UseMU should be 1" -Skip:(!(Test-Elevated)) {
             Invoke-TestAndUploadLogOnFailure -Test {
-                $useMu = 0
-                $useMu = Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\PowerShellCore\ -Name UseMU -ErrorAction SilentlyContinue
-
+                $useMu = Get-UseMU
                 $useMu | Should -Be 1
             }
         }
@@ -247,10 +261,18 @@ Describe -Name "Windows MSI" -Fixture {
 
         It "UseMU should be 0" -Skip:(!(Test-Elevated)) {
             Invoke-TestAndUploadLogOnFailure -Test {
-                $useMu = 0
-                $useMu = Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\PowerShellCore\ -Name UseMU -ErrorAction SilentlyContinue
-
+                $useMu = Get-UseMU
                 $useMu | Should -Be 0
+            }
+        }
+
+        It "MU should be enabled" -Skip:(!(Test-Elevated)) {
+            if($muEnabled) {
+                Set-ItResult -Skipped -Because "MU already enabled"
+            }
+
+            Invoke-TestAndUploadLogOnFailure -Test {
+                Test-IsMuEnabled | Should -BeTrue -Because "MU should have been enabled"
             }
         }
 

--- a/test/packaging/windows/msi.tests.ps1
+++ b/test/packaging/windows/msi.tests.ps1
@@ -92,14 +92,6 @@ Describe -Name "Windows MSI" -Fixture {
         $error.Clear()
     }
 
-    AfterEach {
-        if ($error.Count -ne 0 -and !$uploadedLog) {
-            Copy-Item -Path $msiLog -Destination $env:temp -Force
-            Write-Verbose "MSI log is at $env:temp\msilog.txt" -Verbose
-            $uploadedLog = $true
-        }
-    }
-
     Context "Enable_MU disabled" {
         It "MSI should install without error" -Skip:(!(Test-Elevated)) {
             if($muEnabled) {
@@ -213,10 +205,16 @@ Describe -Name "Windows MSI" -Fixture {
         }
 
         It "UseMU should be 1" -Skip:(!(Test-Elevated)) {
-            $useMu = 0
-            $useMu = Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\PowerShellCore\ -Name UseMU -ErrorAction Ignore
+            try {
+                $useMu = 0
+                $useMu = Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\PowerShellCore\ -Name UseMU -ErrorAction Ignore
 
-            $useMu | Should -Be 1
+                $useMu | Should -Be 1
+            }
+            catch {
+                Send-VstsLogFile -Path $msiLog
+                throw
+            }
         }
 
         It "MU should be enabled" -Skip:(!(Test-Elevated)) {

--- a/test/packaging/windows/msi.tests.ps1
+++ b/test/packaging/windows/msi.tests.ps1
@@ -3,6 +3,7 @@
 
 Describe -Name "Windows MSI" -Fixture {
     BeforeAll {
+        Set-StrictMode -Off
         function Test-Elevated {
             [CmdletBinding()]
             [OutputType([bool])]
@@ -81,9 +82,15 @@ Describe -Name "Windows MSI" -Fixture {
         }
         $uploadedLog = $false
     }
+
+    AfterAll {
+        Set-StrictMode -Verbose 3.0
+    }
+
     BeforeEach {
         $error.Clear()
     }
+
     AfterEach {
         if ($error.Count -ne 0 -and !$uploadedLog) {
             Copy-Item -Path $msiLog -Destination $env:temp -Force

--- a/test/packaging/windows/msi.tests.ps1
+++ b/test/packaging/windows/msi.tests.ps1
@@ -194,7 +194,7 @@ Describe -Name "Windows MSI" -Fixture {
     Context "Add Path disabled" {
         It "MSI should install without error" -Skip:(!(Test-Elevated)) {
             {
-                Invoke-MsiExec -Install -MsiPath $msiX64Path -Properties @{ADD_PATH = 0}
+                Invoke-MsiExec -Install -MsiPath $msiX64Path -Properties @{ADD_PATH = 0; USE_MU = 1; ENABLE_MU = 1}
             } | Should -Not -Throw
         }
 

--- a/test/packaging/windows/msi.tests.ps1
+++ b/test/packaging/windows/msi.tests.ps1
@@ -198,12 +198,6 @@ Describe -Name "Windows MSI" -Fixture {
             $psPath | Should -BeNullOrEmpty
         }
 
-        It "MSI should uninstall without error" -Skip:(!(Test-Elevated)) {
-            {
-                Invoke-MsiExec -Uninstall -MsiPath $msiX64Path
-            } | Should -Not -Throw
-        }
-
         It "UseMU should be 1" -Skip:(!(Test-Elevated)) {
             try {
                 $useMu = 0
@@ -224,6 +218,12 @@ Describe -Name "Windows MSI" -Fixture {
 
             Test-IsMuEnabled | Should -BeTrue -Because "MU should have been enabled"
         }
+
+        It "MSI should uninstall without error" -Skip:(!(Test-Elevated)) {
+            {
+                Invoke-MsiExec -Uninstall -MsiPath $msiX64Path
+            } | Should -Not -Throw
+        }
     }
 
     Context "USE_MU disabled" {
@@ -235,7 +235,7 @@ Describe -Name "Windows MSI" -Fixture {
 
         It "UseMU should be 0" -Skip:(!(Test-Elevated)) {
             $useMu = 0
-            $useMu = Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\PowerShellCore\ -Name UseMU -ErrorAction Ignore
+            $useMu = Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\PowerShellCore\ -Name UseMU -ErrorAction SilentlyContinue
 
             $useMu | Should -Be 0
         }

--- a/test/packaging/windows/msi.tests.ps1
+++ b/test/packaging/windows/msi.tests.ps1
@@ -84,7 +84,7 @@ Describe -Name "Windows MSI" -Fixture {
     }
 
     AfterAll {
-        Set-StrictMode -Verbose 3.0
+        Set-StrictMode -Version 3.0
     }
 
     BeforeEach {

--- a/test/tools/Modules/HelpersCommon/HelpersCommon.psm1
+++ b/test/tools/Modules/HelpersCommon/HelpersCommon.psm1
@@ -219,22 +219,21 @@ function Send-VstsLogFile {
         }
     }
 
+    $newName = ([System.Io.Path]::GetRandomFileName() + "-$LogName.txt")
     if($Contents)
     {
-        $logFile = Join-Path -Path $logFolder -ChildPath ([System.Io.Path]::GetRandomFileName() + "-$LogName.txt")
-        $name = Split-Path -Leaf -Path $logFile
+        $logFile = Join-Path -Path $logFolder -ChildPath $newName
 
         $Contents | Out-File -path $logFile -Encoding ascii
     }
     else
     {
-        $name = Split-Path -Leaf -Path $path
-        $logFile = Join-Path -Path $logFolder -ChildPath ([System.Io.Path]::GetRandomFileName() + '-' + $name)
+        $logFile = Join-Path -Path $logFolder -ChildPath $newName
         Copy-Item -Path $Path -Destination $logFile
     }
 
-    Write-Host "##vso[artifact.upload containerfolder=$name;artifactname=$name]$logFile"
-    Write-Verbose "Log file captured as $name" -Verbose
+    Write-Host "##vso[artifact.upload containerfolder=$newName;artifactname=$newName]$logFile"
+    Write-Verbose "Log file captured as $newName" -Verbose
 }
 
 # Tests if the Linux or macOS user is root

--- a/tools/ci.psm1
+++ b/tools/ci.psm1
@@ -546,23 +546,21 @@ function Invoke-CIFinish
         Start-PSBuild -Restore -Runtime win-arm64 -PSModuleRestore -Configuration 'Release' -ReleaseTag $releaseTag
         $arm64Package = Start-PSPackage -Type zip -WindowsRuntime win-arm64 -ReleaseTag $releaseTag -SkipReleaseChecks
         $artifacts.Add($arm64Package)
-
+    }
+    finally {
         $pushedAllArtifacts = $true
 
         $artifacts | ForEach-Object {
             Write-Log -Message "Pushing $_ as CI artifact"
-            if(Test-Path $_)
-            {
+            if (Test-Path $_) {
                 Push-Artifact -Path $_ -Name 'artifacts'
-            }
-            else
-            {
+            } else {
                 $pushedAllArtifacts = $false
                 Write-Warning "Artifact $_ does not exist."
             }
         }
-        if(!$pushedAllArtifacts)
-        {
+
+        if (!$pushedAllArtifacts) {
             throw "Some artifacts did not exist!"
         }
     }

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -3278,7 +3278,8 @@ function Start-MsiBuild {
     Write-Log "running light..."
     # suppress ICE61, because we allow same version upgrades
     # suppress ICE57, this suppresses an error caused by our shortcut not being installed per user
-    Start-NativeExecution -VerboseOutputOnError {& $wixPaths.wixLightExePath -sice:ICE61 -sice:ICE57 -out $msiLocationPath -pdbout $msiPdbLocationPath $objectPaths $extensionArgs }
+    # suppress ICE40, REINSTALLMODE is defined in the Property table.
+    Start-NativeExecution -VerboseOutputOnError {& $wixPaths.wixLightExePath -sice:ICE61 -sice:ICE40 -sice:ICE57 -out $msiLocationPath -pdbout $msiPdbLocationPath $objectPaths $extensionArgs }
 
     foreach($file in $objectPaths)
     {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

![image](https://user-images.githubusercontent.com/10873629/125687903-f36b25ae-756a-40f1-8d07-6768f8cbb6dc.png)


FAQ link goes to https://aka.ms/PowerShell-Microsoft-Update-FAQ
privacy link goes to: https://aka.ms/PowerShell-Microsoft-Update-Privacy-Statement 

I will make the warning about needing MU or WSUS dynamic in a later PR.  the draft, #15776, is already open for this, but we want to get the USE_MU code in as soon as possible.

## PR Context

resolves #6118
https://github.com/MicrosoftDocs/PowerShell-Docs/issues/7787

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
