### PR TITLE
Fix CA1846 and CA1845 for using `AsSpan` instead of `Substring`

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -85,7 +85,7 @@ namespace Microsoft.PowerShell
                 if (Environment.GetEnvironmentVariable("NO_COLOR") != null)
                 {
                     PSStyle.Instance.OutputRendering = OutputRendering.PlainText;
-                }   
+                }
             }
 
             if (SupportsVirtualTerminal)
@@ -961,7 +961,7 @@ namespace Microsoft.PowerShell
                     int w = maxWidthInBufferCells - cellCounter;
                     Dbg.Assert(w < e.Current.CellCount, "width remaining should be less than size of word");
 
-                    line.Append(e.Current.Text.Substring(0, w));
+                    line.Append(e.Current.Text.AsSpan(0, w));
 
                     l = line.ToString();
                     Dbg.Assert(RawUI.LengthInBufferCells(l) == maxWidthInBufferCells, "line should exactly fit");
@@ -2019,8 +2019,7 @@ namespace Microsoft.PowerShell
                     var completionResult = commandCompletion.GetNextResult(rlResult == ReadLineResult.endedOnTab);
                     if (completionResult != null)
                     {
-                        completedInput = completionInput.Substring(0, commandCompletion.ReplacementIndex)
-                                         + completionResult.CompletionText;
+                        completedInput = string.Concat(completionInput.AsSpan(0, commandCompletion.ReplacementIndex), completionResult.CompletionText);
                     }
                     else
                     {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressNode.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressNode.cs
@@ -408,7 +408,7 @@ namespace Microsoft.PowerShell
             int maxStatusLength = barWidth - secRemainLength - 1;
             if (maxStatusLength > 0 && StatusDescription.Length > barWidth - secRemainLength)
             {
-                sb.Append(StatusDescription.Substring(0, barWidth - secRemainLength - 1));
+                sb.Append(StatusDescription.AsSpan(0, barWidth - secRemainLength - 1));
                 sb.Append(PSObjectHelper.Ellipsis);
             }
             else

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -1209,7 +1209,7 @@ namespace System.Management.Automation
 
                     if (ret != null && ret.Count > 0)
                     {
-                        string prefix = String.Concat(TokenKind.LParen.Text(), input.AsSpan(0, fakeReplacementIndex));
+                        string prefix = string.Concat(TokenKind.LParen.Text(), input.AsSpan(0, fakeReplacementIndex));
                         foreach (CompletionResult entry in ret)
                         {
                             string completionText = prefix + entry.CompletionText;

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -1209,7 +1209,7 @@ namespace System.Management.Automation
 
                     if (ret != null && ret.Count > 0)
                     {
-                        var prefix = TokenKind.LParen.Text() + input.Substring(0, fakeReplacementIndex);
+                        string prefix = String.Concat(TokenKind.LParen.Text(), input.AsSpan(0, fakeReplacementIndex));
                         foreach (CompletionResult entry in ret)
                         {
                             string completionText = prefix + entry.CompletionText;
@@ -5394,11 +5394,11 @@ namespace System.Management.Automation
 
             return null;
         }
-        
+
         private static List<CompletionResult> CompleteCommentParameterValue(CompletionContext context, string wordToComplete)
         {
             FunctionDefinitionAst foundFunction = GetCommentHelpFunctionTarget(context);
-            
+
             ReadOnlyCollection<ParameterAst> foundParameters = null;
             if (foundFunction is not null)
             {
@@ -5409,7 +5409,7 @@ namespace System.Management.Automation
                 // The helpblock is for a script file
                 foundParameters = scriptAst.ParamBlock?.Parameters;
             }
-            
+
             if (foundParameters is null || foundParameters.Count == 0)
             {
                 return null;
@@ -6531,7 +6531,7 @@ namespace System.Management.Automation
 
             //search for help files for the current culture + en-US as fallback
             var searchPaths = new string[]
-            { 
+            {
                 Path.Combine(userHelpDir, currentCulture),
                 Path.Combine(appHelpDir, currentCulture),
                 Path.Combine(userHelpDir, "en-US"),

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -466,7 +466,7 @@ namespace System.Management.Automation
                     {
                         ProviderInfo fileSystemProvider = context.EngineSessionState.GetSingleProvider(FileSystemProvider.ProviderName);
                         return new StringBuilder(fileSystemProvider.Home)
-                            .Append(path.Substring(1))
+                            .Append(path.AsSpan(1))
                             .Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)
                             .ToString();
                     }

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -1807,7 +1807,8 @@ namespace System.Management.Automation
                 {
                     // Fix up prompt.
                     ++index;
-                    string debugPrompt = "\"[DBG]: " + originalPromptString.Substring(index, originalPromptString.Length - index);
+                    string debugPrompt = String.Concat("\"[DBG]: ", originalPromptString.AsSpan(index, originalPromptString.Length - index));
+
                     defaultPromptInfo.Update(
                         ScriptBlock.Create(debugPrompt), true, ScopedItemOptions.Unspecified);
                 }

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -1807,7 +1807,7 @@ namespace System.Management.Automation
                 {
                     // Fix up prompt.
                     ++index;
-                    string debugPrompt = String.Concat("\"[DBG]: ", originalPromptString.AsSpan(index, originalPromptString.Length - index));
+                    string debugPrompt = string.Concat("\"[DBG]: ", originalPromptString.AsSpan(index, originalPromptString.Length - index));
 
                     defaultPromptInfo.Update(
                         ScriptBlock.Create(debugPrompt), true, ScopedItemOptions.Unspecified);

--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -1262,7 +1262,7 @@ namespace System.Management.Automation.Host
                     Text.StringBuilder splitLabel = new Text.StringBuilder(choices[i].Label.Substring(0, andPos), choices[i].Label.Length);
                     if (andPos + 1 < choices[i].Label.Length)
                     {
-                        splitLabel.Append(choices[i].Label.Substring(andPos + 1));
+                        splitLabel.Append(choices[i].Label.AsSpan(andPos + 1));
                         hotkeysAndPlainLabels[0, i] = CultureInfo.CurrentCulture.TextInfo.ToUpper(choices[i].Label.AsSpan(andPos + 1, 1).Trim().ToString());
                     }
 

--- a/src/System.Management.Automation/help/HelpCommentsParser.cs
+++ b/src/System.Management.Automation/help/HelpCommentsParser.cs
@@ -628,7 +628,7 @@ namespace System.Management.Automation
                     start++;
                 }
 
-                sb.Append(line.Substring(start));
+                sb.Append(line.AsSpan(start));
                 sb.Append('\n');
             }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix CA1846 and CA1845 violations by replacing Substring with AsSpan. 

## PR Context

These violations cause build break when used with .NET 6 Preview 6.

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
