### PR TITLE
`ConvertTo-Csv`: Quote fields with quotes and newlines when using `-UseQuotes AsNeeded`

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -881,7 +881,6 @@ namespace Microsoft.PowerShell.Commands
         private readonly BaseCsvWritingCommand.QuoteKind _quoteKind;
         private readonly HashSet<string> _quoteFields;
         private readonly StringBuilder _outputString;
-        private readonly char[] _escapeCharacters;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ExportCsvHelper"/> class.
@@ -895,9 +894,6 @@ namespace Microsoft.PowerShell.Commands
             _quoteKind = quoteKind;
             _quoteFields = quoteFields == null ? null : new HashSet<string>(quoteFields, StringComparer.OrdinalIgnoreCase);
             _outputString = new StringBuilder(128);
-
-            // As per RFC 4180, fields with line breaks, double quotes (the escape character) or delimiter should be escaped
-            _escapeCharacters = new char[] { '"', '\r', '\n', delimiter };
         }
 
         // Name of properties to be written in CSV format
@@ -971,7 +967,8 @@ namespace Microsoft.PowerShell.Commands
                             AppendStringWithEscapeAlways(_outputString, propertyName);
                             break;
                         case BaseCsvWritingCommand.QuoteKind.AsNeeded:
-                            if (propertyName.IndexOfAny(_escapeCharacters) != -1)
+                            
+                            if (propertyName.AsSpan().IndexOfAny(_delimiter, '\n', '"') != -1)
                             {
                                 AppendStringWithEscapeAlways(_outputString, propertyName);
                             }
@@ -1042,7 +1039,7 @@ namespace Microsoft.PowerShell.Commands
                                 AppendStringWithEscapeAlways(_outputString, value);
                                 break;
                             case BaseCsvWritingCommand.QuoteKind.AsNeeded:
-                                if (value != null && value.IndexOfAny(_escapeCharacters) != -1)
+                                if (value != null && value.AsSpan().IndexOfAny(_delimiter, '\n', '"') != -1)
                                 {
                                     AppendStringWithEscapeAlways(_outputString, value);
                                 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -881,6 +881,7 @@ namespace Microsoft.PowerShell.Commands
         private readonly BaseCsvWritingCommand.QuoteKind _quoteKind;
         private readonly HashSet<string> _quoteFields;
         private readonly StringBuilder _outputString;
+        private readonly char[] _escapeCharacters;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ExportCsvHelper"/> class.
@@ -894,6 +895,8 @@ namespace Microsoft.PowerShell.Commands
             _quoteKind = quoteKind;
             _quoteFields = quoteFields == null ? null : new HashSet<string>(quoteFields, StringComparer.OrdinalIgnoreCase);
             _outputString = new StringBuilder(128);
+            // As per RFC 4180, fields with line breaks, double quotes (the escape character) or delimiter should be escaped
+            _escapeCharacters = new Char[] { '"', '\r', '\n', delimiter};
         }
 
         // Name of properties to be written in CSV format
@@ -967,7 +970,7 @@ namespace Microsoft.PowerShell.Commands
                             AppendStringWithEscapeAlways(_outputString, propertyName);
                             break;
                         case BaseCsvWritingCommand.QuoteKind.AsNeeded:
-                            if (propertyName.Contains(_delimiter))
+                            if (propertyName.IndexOfAny(_escapeCharacters) != -1)
                             {
                                 AppendStringWithEscapeAlways(_outputString, propertyName);
                             }
@@ -1038,7 +1041,7 @@ namespace Microsoft.PowerShell.Commands
                                 AppendStringWithEscapeAlways(_outputString, value);
                                 break;
                             case BaseCsvWritingCommand.QuoteKind.AsNeeded:
-                                if (value != null && value.Contains(_delimiter))
+                                if (value != null && value.IndexOfAny(_escapeCharacters) != -1)
                                 {
                                     AppendStringWithEscapeAlways(_outputString, value);
                                 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -895,8 +895,9 @@ namespace Microsoft.PowerShell.Commands
             _quoteKind = quoteKind;
             _quoteFields = quoteFields == null ? null : new HashSet<string>(quoteFields, StringComparer.OrdinalIgnoreCase);
             _outputString = new StringBuilder(128);
+
             // As per RFC 4180, fields with line breaks, double quotes (the escape character) or delimiter should be escaped
-            _escapeCharacters = new Char[] { '"', '\r', '\n', delimiter};
+            _escapeCharacters = new char[] { '"', '\r', '\n', delimiter };
         }
 
         // Name of properties to be written in CSV format

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Csv.Tests.ps1
@@ -173,6 +173,7 @@ Describe "ConvertTo-Csv" -Tags "CI" {
             $result[0] | Should -BeExactly "`"FirstColumn`"rSecond,Column"
             $result[1] | Should -BeExactly "Hello,r`"World`""
         }
+
         It "UseQuotes AsNeeded Escapes Newlines" {
             $testCRLFObject = [pscustomobject]@{ "First`r`nColumn" = "Hello`r`nWorld" };
             $testLFObject = [pscustomobject]@{ "First`nColumn" = "Hello`nWorld" };
@@ -187,6 +188,7 @@ Describe "ConvertTo-Csv" -Tags "CI" {
             $result[0] | Should -BeExactly "`"First`nColumn`""
             $result[1] | Should -BeExactly "`"Hello`nWorld`""
         }
+
         It "UseQuotes AsNeeded Escapes Quotes" {
             $testQuotesObject = [pscustomobject]@{ "First`"Column" = "`"Hello`" World" };
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Csv.Tests.ps1
@@ -41,6 +41,7 @@ Describe "ConvertTo-Csv" -Tags "CI" {
         $Name = "Hello"; $Data = "World";
         $testObject = [pscustomobject]@{ FirstColumn = $Name; SecondColumn = $Data }
         $testNullObject = [pscustomobject]@{ FirstColumn = $Name; SecondColumn = $null }
+        $testQuotesObject = [pscustomobject]@{ FirstColumn = "`"$Name`""; SecondColumn = "`nWorld"}
     }
 
     It "Should Be able to be called without error" {
@@ -127,6 +128,11 @@ Describe "ConvertTo-Csv" -Tags "CI" {
 
             $result[0] | Should -BeExactly "`"FirstColumn`",`"SecondColumn`""
             $result[1] | Should -BeExactly "`"Hello`","
+
+            $result = $testQuotesObject | ConvertTo-Csv -UseQuotes Always -Delimiter ','
+
+            $result[0] | Should -BeExactly "`"FirstColumn`",`"SecondColumn`""
+            $result[1] | Should -BeExactly "`"`"`"Hello`"`"`",`"`nWorld`""
         }
 
         It "UseQuotes Always is default" {
@@ -146,6 +152,8 @@ Describe "ConvertTo-Csv" -Tags "CI" {
 
             $result[0] | Should -BeExactly "FirstColumn,SecondColumn"
             $result[1] | Should -BeExactly "Hello,"
+
+            $result = $testQuotesObject | ConvertTo-Csv -UseQuotes Never
         }
 
         It "UseQuotes AsNeeded" {
@@ -158,6 +166,16 @@ Describe "ConvertTo-Csv" -Tags "CI" {
 
             $result[0] | Should -BeExactly "`"FirstColumn`"rSecondColumn"
             $result[1] | Should -BeExactly "Hellor"
+
+            $result = $testQuotesObject | ConvertTo-Csv -UseQuotes AsNeeded -Delimiter ','
+
+            $result[0] | Should -BeExactly "FirstColumn,SecondColumn"
+            $result[1] | Should -BeExactly "`"`"`"Hello`"`"`",`"`nWorld`""
+
+            $result = $testQuotesObject | ConvertTo-Csv -UseQuotes AsNeeded -Delimiter 'e'
+
+            $result[0] | Should -BeExactly "FirstColumne`"SecondColumn`""
+            $result[1] | Should -BeExactly "`"`"`"Hello`"`"`"e`"`nWorld`""
         }
     }
 }


### PR DESCRIPTION
Fix for issue #9284 - Escape fields that contain quotes and newlines, not just those that contain the delimiter

# PR Summary

This PR fixes the case of CSV fields that include double quotes or newlines in their values. If a Column value contains `"`,`\r`,`\n` or the delimiter then it will be marked as needing to be surrounded by quotes.

This follows [RFC-4180 rules](https://datatracker.ietf.org/doc/html/rfc4180#section-2) as to what characters trigger a field to be quoted (except it allows for different delimiters than the comma). This also follows how `ConvertFrom-Csv` parses input CSV files.

## PR Context

`-UseQuotes AsNeeded` currently only looks for delimiters, which means that the field `Hello,World` will be surrounded in quotes, however the field `Hello"World` would not be surrounded in quotes, causing this kind of embarassing slip-up:

```powershell
$testObj = [pscustomobject]@{ Greet = "Hello"; Me = "`""; Here = "World" };
# Greet Me Here
# ----- -- ----
# Hello "  World

$str = $testObj | convertto-csv -UseQuotes AsNeeded
# Greet,Me,Here
# Hello,",World  <-- Should be 'Hello,"""",World'

$str | convertfrom-csv
# Greet Me     Here
# ----- --     ----
# Hello ,World
```

Newlines are another risk, since they're interpreted as completely different rows.

```powershell
$testObj = [pscustomobject]@{ FirstColumn = "Hello"; SecondColumn = "World`r`nGoodbye" }
FirstColumn,SecondColumn
Hello,World
Goodbye
```

**Performance Caveat:** This version is searching for the existence of 4 characters (using `string.IndexOfAny(chars)` instead of the original 1 (`string.Contains(char)`. Based on my benchmarks this change does have a *miniscule* increase in time for that single operation. However, in my naïve in-memory benchmarks against a 100MB CSV file, using `-UseQuotes AsNeeded` was slightly faster than `-UseQuotes Always` or `-QuoteFields`. My guess is that I didn't need to allocate as much memory for those unneeded quotes.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [X] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [X] Issue filed: [7796](https://github.com/MicrosoftDocs/PowerShell-Docs/issues/7796)
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
