### PR TITLE
Make warning about MU being required most of the time dynamic

### DIFF
--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -436,7 +436,7 @@
       <Publish Dialog="ExplorerContextMenuDialog" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
       <Publish Dialog="ExplorerContextMenuDialog" Control="Next" Event="NewDialog" Value="MuDialog">1</Publish>
       <Publish Dialog="MuDialog" Control="Back" Event="NewDialog" Value="ExplorerContextMenuDialog">1</Publish>
-      <Publish Dialog="MuDialog" Control="Next" Event="SpawnDialog" Value="MuWarningDlg" Order="1">ENABLE_MU=0 AND USE_MU=1</Publish>
+      <Publish Dialog="MuDialog" Control="Next" Event="SpawnDialog" Value="MuWarningDlg" Order="1">NOT ENABLE_MU AND USE_MU=1</Publish>
       <Publish Dialog="MuDialog" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="2">1</Publish>
 
       <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -354,8 +354,8 @@
       <Control Id="EnableMuCheckBox" Type="CheckBox" X="20" Y="130" Width="290" Height="17" Property="ENABLE_MU" CheckBoxValue="1" Text="Use Microsoft Update when I check for updates (recommended)">
       </Control>
       <Control Id="MuWarningText" Type="Text" X="20" Y="160" Width="290" Height="17" Text="Without Microsoft Update enabled, you will need to use another update solution like WSUS or SCCM in order to receive automatic updates.">
-        <Condition Action="hide"><![CDATA[ENABLE_MU="1"]]></Condition>
-        <Condition Action="show"><![CDATA[ENABLE_MU<>"1"]]></Condition>
+        <Condition Action="hide"><![CDATA[ENABLE_MU="1" OR USE_MU<>"1"]]></Condition>
+        <Condition Action="show"><![CDATA[ENABLE_MU<>"1" AND USE_MU="1"]]></Condition>
       </Control>
       <Control Id="MuFAQ" Type="Hyperlink" X="20" Y="190" Width="214" Height="17">
         <Text><![CDATA[<a href="https://aka.ms/PowerShell-Microsoft-Update-FAQ">See the Microsoft Update FAQ</a>]]></Text>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -359,7 +359,7 @@
         <Condition Action="show"><![CDATA[ENABLE_MU<>"1"]]></Condition>
       </Control>
       <Control Id="MuFAQ" Type="Hyperlink" X="20" Y="190" Width="214" Height="17">
-        <Text><![CDATA[<a href="https://aka.ms/PowerShell-Microsoft-Update-FAQ">See the Microsoft Update FAQ.</a>]]></Text>
+        <Text><![CDATA[<a href="https://aka.ms/PowerShell-Microsoft-Update-FAQ">See the Microsoft Update FAQ</a>]]></Text>
       </Control>
       <Control Id="PrivacyLink" Type="Hyperlink" X="20" Y="210" Width="290" Height="17">
         <Text><![CDATA[<a href="https://aka.ms/PowerShell-Microsoft-Update-Privacy-Statement">Read the Microsoft Update Priacy Statement</a>]]></Text>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -419,7 +419,7 @@
       <Publish Dialog="ExplorerContextMenuDialog" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
       <Publish Dialog="ExplorerContextMenuDialog" Control="Next" Event="NewDialog" Value="MuDialog">1</Publish>
       <Publish Dialog="MuDialog" Control="Back" Event="NewDialog" Value="ExplorerContextMenuDialog">1</Publish>
-      <Publish Dialog="MuDialog" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="2">1</Publish>
+      <Publish Dialog="MuDialog" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
 
       <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
       <Publish Dialog="InstallDirDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -411,6 +411,8 @@
 
       <Property Id="DefaultUIFont" Value="WixUI_Font_Normal" />
       <Property Id="WixUI_Mode" Value="InstallDir" />
+      <PropertyRef Id="ENABLE_MU" />
+      <PropertyRef Id="USE_MU" />
 
       <DialogRef Id="BrowseDlg" />
       <DialogRef Id="DiskCostDlg" />

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -436,7 +436,7 @@
       <Publish Dialog="ExplorerContextMenuDialog" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
       <Publish Dialog="ExplorerContextMenuDialog" Control="Next" Event="NewDialog" Value="MuDialog">1</Publish>
       <Publish Dialog="MuDialog" Control="Back" Event="NewDialog" Value="ExplorerContextMenuDialog">1</Publish>
-      <Publish Dialog="MuDialog" Control="Next" Event="SpawnDialog" Value="MuWarningDlg" Order="1">ENABLE_MU=0 AND USE_MU=1></Publish>
+      <Publish Dialog="MuDialog" Control="Next" Event="SpawnDialog" Value="MuWarningDlg" Order="1">ENABLE_MU=0 AND USE_MU=1</Publish>
       <Publish Dialog="MuDialog" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="2">1</Publish>
 
       <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -352,9 +352,12 @@
       <!-- If the checkboxes are defined first, then they are first in the tab order and can be ticked and unticked using the spacebar -->
       <Control Id="UseMuCheckBox" Type="CheckBox" X="20" Y="100" Width="290" Height="27" Property="USE_MU" Text="Enable updating PowerShell through Microsft Update or WSUS (recommended)"/>
       <Control Id="EnableMuCheckBox" Type="CheckBox" X="20" Y="130" Width="290" Height="17" Property="ENABLE_MU" Text="Use Microsoft Update when I check for updates (recommended)"/>
-      <Control Id="MuWarningText" Type="Text" X="20" Y="160" Width="290" Height="27" Text="Without Microsoft Update enabled, you will need to use another update solution like WSUS or SCCM in order to receive automatic updates."/>
+      <Control Id="MuWarningText" Type="Text" X="20" Y="160" Width="290" Height="17" Text="Without Microsoft Update enabled, you will need to use another update solution like WSUS or SCCM in order to receive automatic updates.">
+        <Condition Action="hide"><![CDATA[ENABLE_MU="1"]]></Condition>
+        <Condition Action="show"><![CDATA[ENABLE_MU<>"1"]]></Condition>
+      </Control>
       <Control Id="MuFAQ" Type="Hyperlink" X="20" Y="190" Width="214" Height="17">
-        <Text><![CDATA[<a href="https://aka.ms/PowerShell-Microsoft-Update-FAQ">See the Microsoft Update FAQ</a>]]></Text>
+        <Text><![CDATA[<a href="https://aka.ms/PowerShell-Microsoft-Update-FAQ">See the Microsoft Update FAQ.</a>]]></Text>
       </Control>
       <Control Id="PrivacyLink" Type="Hyperlink" X="20" Y="210" Width="290" Height="17">
         <Text><![CDATA[<a href="https://aka.ms/PowerShell-Microsoft-Update-Privacy-Statement">Read the Microsoft Update Priacy Statement</a>]]></Text>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -353,7 +353,7 @@
       <Control Id="UseMuCheckBox" Type="CheckBox" X="20" Y="100" Width="290" Height="27" Property="USE_MU" CheckBoxValue="1" Text="Enable updating PowerShell through Microsft Update or WSUS (recommended)"/>
       <Control Id="EnableMuCheckBox" Type="CheckBox" X="20" Y="130" Width="290" Height="17" Property="ENABLE_MU" CheckBoxValue="1" Text="Use Microsoft Update when I check for updates (recommended)">
       </Control>
-      <Control Id="MuWarningText" Type="Text" X="20" Y="160" Width="290" Height="17" Text="Without Microsoft Update enabled, you will need to use another update solution like WSUS or SCCM in order to receive automatic updates.">
+      <Control Id="MuWarningText" Type="Text" X="20" Y="160" Width="290" Height="27" Text="Without Microsoft Update enabled, you will need to use another update solution like WSUS or SCCM in order to receive automatic updates.">
         <Condition Action="hide"><![CDATA[ENABLE_MU="1" OR USE_MU<>"1"]]></Condition>
         <Condition Action="show"><![CDATA[ENABLE_MU<>"1" AND USE_MU="1"]]></Condition>
       </Control>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -441,7 +441,7 @@
       <Publish Dialog="ExplorerContextMenuDialog" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
       <Publish Dialog="ExplorerContextMenuDialog" Control="Next" Event="NewDialog" Value="MuDialog">1</Publish>
       <Publish Dialog="MuDialog" Control="Back" Event="NewDialog" Value="ExplorerContextMenuDialog">1</Publish>
-      <Publish Dialog="MuDialog" Control="Next" Event="SpawnDialog" Value="MuWarningDlg" Order="1">NOT ENABLE_MU AND USE_MU=1</Publish>
+      <Publish Dialog="MuDialog" Control="Next" Event="SpawnDialog" Value="MuWarningDlg" Order="1"><![CDATA[ENABLE_MU<>"1" AND USE_MU="1"]]></Publish>
       <Publish Dialog="MuDialog" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="2">1</Publish>
 
       <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -350,8 +350,8 @@
       <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" TabSkip="yes" />
       <Control Id="Description" Type="Text" X="25" Y="54" Width="280" Height="100" Transparent="yes" NoPrefix="yes" Text="Microsoft Update helps keep your computer secure and up to date for Windows and other Microsoft products, including PowerShell 7. Updates will be delivered based on your current update settings. You can review or change these settings from the Windows Update control panel." TabSkip="yes" />
       <!-- If the checkboxes are defined first, then they are first in the tab order and can be ticked and unticked using the spacebar -->
-      <Control Id="UseMuCheckBox" Type="CheckBox" X="20" Y="100" Width="290" Height="27" Property="USE_MU" CheckBoxValue="0" Text="Enable updating PowerShell through Microsft Update or WSUS (recommended)"/>
-      <Control Id="EnableMuCheckBox" Type="CheckBox" X="20" Y="130" Width="290" Height="17" Property="ENABLE_MU" CheckBoxValue="0" Text="Use Microsoft Update when I check for updates (recommended)">
+      <Control Id="UseMuCheckBox" Type="CheckBox" X="20" Y="100" Width="290" Height="27" Property="USE_MU" CheckBoxValue="1" Text="Enable updating PowerShell through Microsft Update or WSUS (recommended)"/>
+      <Control Id="EnableMuCheckBox" Type="CheckBox" X="20" Y="130" Width="290" Height="17" Property="ENABLE_MU" CheckBoxValue="1" Text="Use Microsoft Update when I check for updates (recommended)">
         <Publish Event="SpawnDialog" Value="MuWarningDlg"><![CDATA[ENABLE_MU<>"1" AND USE_MU="1"]]></Publish>
       </Control>
       <Control Id="MuWarningText" Type="Text" X="20" Y="160" Width="290" Height="17" Text="Without Microsoft Update enabled, you will need to use another update solution like WSUS or SCCM in order to receive automatic updates.">

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -368,6 +368,20 @@
       </Control>
     </Dialog>
   </UI>
+  <!-- MU not enable dialog box -->
+  <UI>
+    <Dialog Id="MuWarningDlg" Width="284" Height="73" Title="Microsoft Update Warning" NoMinimize="yes">
+      <Control Id="Text" Type="Text" X="38" Y="8" Width="240" Height="40" TabSkip="no">
+        <Text>Without Microsoft Update enabled, you will need to use another update solution like WSUS or SCCM in order to receive automatic updates. Are you sure you want to continue?</Text>
+      </Control>
+      <Control Id="Okay" Type="PushButton" X="114" Y="52" Width="56" Height="17" Default="yes"  Cancel="no" Text="OK">
+        <Publish Event="EndDialog" Value="Return">1</Publish>
+      </Control>
+      <Control Id="Cancel" Type="PushButton" X="184" Y="52" Width="56" Height="17" Default="yes"  Cancel="yes" Text="OK">
+        <Publish Event="EndDialog" Value="Return">0</Publish>
+      </Control>
+    </Dialog>
+  </UI>
 </Fragment>
 <!-- Customized version of WixUI_InstallDir, which is necessary to add custom dialogs. https://github.com/wixtoolset/wix3/blob/master/src/ext/UIExtension/wixlib/WixUI_InstallDir.wxs -->
 <Fragment>
@@ -378,6 +392,7 @@
       - WixUI_InstallDirDlg
       - ExplorerContextMenuDialog
       - MuDialog
+      - MuWarningDlg
       - WixUI_VerifyReadyDlg
       - WixUI_DiskCostDlg
       Maintenance dialog sequence:
@@ -419,7 +434,8 @@
       <Publish Dialog="ExplorerContextMenuDialog" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
       <Publish Dialog="ExplorerContextMenuDialog" Control="Next" Event="NewDialog" Value="MuDialog">1</Publish>
       <Publish Dialog="MuDialog" Control="Back" Event="NewDialog" Value="ExplorerContextMenuDialog">1</Publish>
-      <Publish Dialog="MuDialog" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
+      <Publish Dialog="MuDialog" Control="Next" Event="SpawnDialog" Value="MuWarningDlg" Order="1">ENABLE_MU=0 AND USE_MU=1></Publish>
+      <Publish Dialog="MuDialog" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="2">1</Publish>
 
       <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
       <Publish Dialog="InstallDirDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -366,25 +366,9 @@
       <!-- divider and bottom buttons -->
       <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" TabSkip="yes"/>
       <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)"/>
-      <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Cancel="yes" Default="yes" Text="!(loc.WixUINext)">
-        <Publish Event="SpawnDialog" Value="MuWarningDlg"><![CDATA[ENABLE_MU<>"1" AND USE_MU="1"]]></Publish>
-      </Control>
+      <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Cancel="yes" Default="yes" Text="!(loc.WixUINext)"/>
       <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">
         <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
-      </Control>
-    </Dialog>
-  </UI>
-  <!-- MU not enable dialog box -->
-  <UI>
-    <Dialog Id="MuWarningDlg" Width="284" Height="73" Title="Microsoft Update Warning" NoMinimize="yes">
-      <Control Id="Text" Type="Text" X="38" Y="8" Width="240" Height="40" TabSkip="no">
-        <Text>Without Microsoft Update enabled, you will need to use another update solution like WSUS or SCCM in order to receive automatic updates. Are you sure you want to continue?</Text>
-      </Control>
-      <Control Id="Okay" Type="PushButton" X="114" Y="52" Width="56" Height="17" Default="yes"  Cancel="no" Text="Okay">
-        <Publish Event="EndDialog" Value="Return">1</Publish>
-      </Control>
-      <Control Id="Cancel" Type="PushButton" X="184" Y="52" Width="56" Height="17" Default="yes"  Cancel="yes" Text="Cancel">
-        <Publish Event="EndDialog" Value="Return">1</Publish>
       </Control>
     </Dialog>
   </UI>
@@ -398,7 +382,6 @@
       - WixUI_InstallDirDlg
       - ExplorerContextMenuDialog
       - MuDialog
-      - MuWarningDlg
       - WixUI_VerifyReadyDlg
       - WixUI_DiskCostDlg
       Maintenance dialog sequence:

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -400,8 +400,6 @@
 
       <Property Id="DefaultUIFont" Value="WixUI_Font_Normal" />
       <Property Id="WixUI_Mode" Value="InstallDir" />
-      <PropertyRef Id="ENABLE_MU" />
-      <PropertyRef Id="USE_MU" />
 
       <DialogRef Id="BrowseDlg" />
       <DialogRef Id="DiskCostDlg" />

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -350,8 +350,10 @@
       <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" TabSkip="yes" />
       <Control Id="Description" Type="Text" X="25" Y="54" Width="280" Height="100" Transparent="yes" NoPrefix="yes" Text="Microsoft Update helps keep your computer secure and up to date for Windows and other Microsoft products, including PowerShell 7. Updates will be delivered based on your current update settings. You can review or change these settings from the Windows Update control panel." TabSkip="yes" />
       <!-- If the checkboxes are defined first, then they are first in the tab order and can be ticked and unticked using the spacebar -->
-      <Control Id="UseMuCheckBox" Type="CheckBox" X="20" Y="100" Width="290" Height="27" Property="USE_MU" Text="Enable updating PowerShell through Microsft Update or WSUS (recommended)"/>
-      <Control Id="EnableMuCheckBox" Type="CheckBox" X="20" Y="130" Width="290" Height="17" Property="ENABLE_MU" Text="Use Microsoft Update when I check for updates (recommended)"/>
+      <Control Id="UseMuCheckBox" Type="CheckBox" X="20" Y="100" Width="290" Height="27" Property="USE_MU" CheckBoxValue="0" Text="Enable updating PowerShell through Microsft Update or WSUS (recommended)"/>
+      <Control Id="EnableMuCheckBox" Type="CheckBox" X="20" Y="130" Width="290" Height="17" Property="ENABLE_MU" CheckBoxValue="0" Text="Use Microsoft Update when I check for updates (recommended)">
+        <Publish Event="SpawnDialog" Value="MuWarningDlg"><![CDATA[ENABLE_MU<>"1" AND USE_MU="1"]]></Publish>
+      </Control>
       <Control Id="MuWarningText" Type="Text" X="20" Y="160" Width="290" Height="17" Text="Without Microsoft Update enabled, you will need to use another update solution like WSUS or SCCM in order to receive automatic updates.">
         <Condition Action="hide"><![CDATA[ENABLE_MU="1"]]></Condition>
         <Condition Action="show"><![CDATA[ENABLE_MU<>"1"]]></Condition>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -442,7 +442,6 @@
       <Publish Dialog="ExplorerContextMenuDialog" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
       <Publish Dialog="ExplorerContextMenuDialog" Control="Next" Event="NewDialog" Value="MuDialog">1</Publish>
       <Publish Dialog="MuDialog" Control="Back" Event="NewDialog" Value="ExplorerContextMenuDialog">1</Publish>
-      <Publish Dialog="MuDialog" Control="Next" Event="SpawnDialog" Value="MuWarningDlg" Order="1"><![CDATA[ENABLE_MU<>"1" AND USE_MU="1"]]></Publish>
       <Publish Dialog="MuDialog" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="2">1</Publish>
 
       <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>

--- a/assets/wix/Product.wxs
+++ b/assets/wix/Product.wxs
@@ -352,7 +352,6 @@
       <!-- If the checkboxes are defined first, then they are first in the tab order and can be ticked and unticked using the spacebar -->
       <Control Id="UseMuCheckBox" Type="CheckBox" X="20" Y="100" Width="290" Height="27" Property="USE_MU" CheckBoxValue="1" Text="Enable updating PowerShell through Microsft Update or WSUS (recommended)"/>
       <Control Id="EnableMuCheckBox" Type="CheckBox" X="20" Y="130" Width="290" Height="17" Property="ENABLE_MU" CheckBoxValue="1" Text="Use Microsoft Update when I check for updates (recommended)">
-        <Publish Event="SpawnDialog" Value="MuWarningDlg"><![CDATA[ENABLE_MU<>"1" AND USE_MU="1"]]></Publish>
       </Control>
       <Control Id="MuWarningText" Type="Text" X="20" Y="160" Width="290" Height="17" Text="Without Microsoft Update enabled, you will need to use another update solution like WSUS or SCCM in order to receive automatic updates.">
         <Condition Action="hide"><![CDATA[ENABLE_MU="1"]]></Condition>
@@ -367,7 +366,9 @@
       <!-- divider and bottom buttons -->
       <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" TabSkip="yes"/>
       <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)"/>
-      <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Cancel="yes" Default="yes" Text="!(loc.WixUINext)"/>
+      <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Cancel="yes" Default="yes" Text="!(loc.WixUINext)">
+        <Publish Event="SpawnDialog" Value="MuWarningDlg"><![CDATA[ENABLE_MU<>"1" AND USE_MU="1"]]></Publish>
+      </Control>
       <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">
         <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
       </Control>
@@ -379,11 +380,11 @@
       <Control Id="Text" Type="Text" X="38" Y="8" Width="240" Height="40" TabSkip="no">
         <Text>Without Microsoft Update enabled, you will need to use another update solution like WSUS or SCCM in order to receive automatic updates. Are you sure you want to continue?</Text>
       </Control>
-      <Control Id="Okay" Type="PushButton" X="114" Y="52" Width="56" Height="17" Default="yes"  Cancel="no" Text="OK">
+      <Control Id="Okay" Type="PushButton" X="114" Y="52" Width="56" Height="17" Default="yes"  Cancel="no" Text="Okay">
         <Publish Event="EndDialog" Value="Return">1</Publish>
       </Control>
-      <Control Id="Cancel" Type="PushButton" X="184" Y="52" Width="56" Height="17" Default="yes"  Cancel="yes" Text="OK">
-        <Publish Event="EndDialog" Value="Return">0</Publish>
+      <Control Id="Cancel" Type="PushButton" X="184" Y="52" Width="56" Height="17" Default="yes"  Cancel="yes" Text="Cancel">
+        <Publish Event="EndDialog" Value="Return">1</Publish>
       </Control>
     </Dialog>
   </UI>

--- a/test/packaging/windows/msi.tests.ps1
+++ b/test/packaging/windows/msi.tests.ps1
@@ -231,52 +231,6 @@ Describe -Name "Windows MSI" -Fixture {
                 Invoke-MsiExec -Uninstall -MsiPath $msiX64Path
             } | Should -Not -Throw
         }
-
-        It "UseMU should be 1" -Skip:(!(Test-Elevated)) {
-            try {
-                $useMu = 0
-                $useMu = Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\PowerShellCore\ -Name UseMU -ErrorAction SilentlyContinue
-
-                $useMu | Should -Be 1
-            }
-        }
-
-        It "MU should be enabled" -Skip:(!(Test-Elevated)) {
-            if($muEnabled) {
-                Set-ItResult -Skipped -Because "MU already enabled"
-            }
-
-            Invoke-TestAndUploadLogOnFailure -Test {
-                Test-IsMuEnabled | Should -BeTrue -Because "MU should have been enabled"
-            }
-        }
-
-        It "MSI should uninstall without error" -Skip:(!(Test-Elevated)) {
-            {
-                Invoke-MsiExec -Uninstall -MsiPath $msiX64Path
-            } | Should -Not -Throw
-        }
-    }
-
-    Context "USE_MU disabled" {
-        It "MSI should install without error" -Skip:(!(Test-Elevated)) {
-            {
-                Invoke-MsiExec -Install -MsiPath $msiX64Path -Properties @{USE_MU = 0}
-            } | Should -Not -Throw
-        }
-
-        It "UseMU should be 0" -Skip:(!(Test-Elevated)) {
-            Invoke-TestAndUploadLogOnFailure -Test {
-                $useMu = Get-UseMU
-                $useMu | Should -Be 0
-            }
-        }
-
-        It "MSI should uninstall without error" -Skip:(!(Test-Elevated)) {
-            {
-                Invoke-MsiExec -Uninstall -MsiPath $msiX64Path
-            } | Should -Not -Throw
-        }
     }
 
     Context "Add Path enabled" {

--- a/test/packaging/windows/msi.tests.ps1
+++ b/test/packaging/windows/msi.tests.ps1
@@ -231,6 +231,52 @@ Describe -Name "Windows MSI" -Fixture {
                 Invoke-MsiExec -Uninstall -MsiPath $msiX64Path
             } | Should -Not -Throw
         }
+
+        It "UseMU should be 1" -Skip:(!(Test-Elevated)) {
+            try {
+                $useMu = 0
+                $useMu = Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\PowerShellCore\ -Name UseMU -ErrorAction SilentlyContinue
+
+                $useMu | Should -Be 1
+            }
+        }
+
+        It "MU should be enabled" -Skip:(!(Test-Elevated)) {
+            if($muEnabled) {
+                Set-ItResult -Skipped -Because "MU already enabled"
+            }
+
+            Invoke-TestAndUploadLogOnFailure -Test {
+                Test-IsMuEnabled | Should -BeTrue -Because "MU should have been enabled"
+            }
+        }
+
+        It "MSI should uninstall without error" -Skip:(!(Test-Elevated)) {
+            {
+                Invoke-MsiExec -Uninstall -MsiPath $msiX64Path
+            } | Should -Not -Throw
+        }
+    }
+
+    Context "USE_MU disabled" {
+        It "MSI should install without error" -Skip:(!(Test-Elevated)) {
+            {
+                Invoke-MsiExec -Install -MsiPath $msiX64Path -Properties @{USE_MU = 0}
+            } | Should -Not -Throw
+        }
+
+        It "UseMU should be 0" -Skip:(!(Test-Elevated)) {
+            Invoke-TestAndUploadLogOnFailure -Test {
+                $useMu = Get-UseMU
+                $useMu | Should -Be 0
+            }
+        }
+
+        It "MSI should uninstall without error" -Skip:(!(Test-Elevated)) {
+            {
+                Invoke-MsiExec -Uninstall -MsiPath $msiX64Path
+            } | Should -Not -Throw
+        }
     }
 
     Context "Add Path enabled" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The warning now only appears when the first opt-in is checked and not the second.

![2021-07-15_13-48-18 (1)](https://user-images.githubusercontent.com/10873629/125855560-c292a253-01b7-43a0-9ac2-09b7d1a860e1.gif)

## PR Context

Make the warning in #15727 dynamic

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
