### PR TITLE
Highlight using error color the exception Message and underline in PositionMessage for `Get-Error`

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -810,7 +810,12 @@ namespace System.Management.Automation.Runspaces
                             $maxDepth = 10
                             $ellipsis = ""`u{2026}""
                             $resetColor = ''
+                            $errorColor = ''
                             if ($Host.UI.SupportsVirtualTerminal -and ([string]::IsNullOrEmpty($env:__SuppressAnsiEscapeSequences))) {
+                                if ($null -ne $psstyle) {
+                                    $errorColor = $psstyle.Formatting.Error
+                                }
+
                                 $resetColor = [System.Management.Automation.VTUtility]::GetEscapeSequence(
                                     [System.Management.Automation.VTUtility+VT]::Reset
                                 )
@@ -947,6 +952,13 @@ namespace System.Management.Automation.Runspaces
                                             $value = $null
                                             if ([System.Management.Automation.LanguagePrimitives]::TryConvertTo($prop.Value, [string], [ref]$value) -and $value -ne $null)
                                             {
+                                                if ($prop.Name -eq 'PositionMessage') {
+                                                    $value = $value.Insert($value.IndexOf('~'), $errorColor)
+                                                }
+                                                elseif ($prop.Name -eq 'Message') {
+                                                    $value = $errorColor + $value
+                                                }
+
                                                 $isFirstLine = $true
                                                 if ($value.Contains($newline)) {
                                                     # the 3 is to account for ' : '

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
@@ -128,7 +128,7 @@ Describe 'Get-Error tests' -Tag CI {
 
     It 'Get-Error uses Error color for Message and PositionMessage members' -Skip:(!$EnabledExperimentalFeatures.Contains("PSAnsiRendering")) {
 
-        $out = pwsh -noprofile -command '[System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("BypassOutputRedirectionCheck", $true); try { 1/0 } catch { }; Get-Error' | Out-String
+        $out = pwsh -noprofile -command '$PSStyle.OutputRendering = "ANSI"; [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("BypassOutputRedirectionCheck", $true); try { 1/0 } catch { }; Get-Error' | Out-String
 
         # need to escape the open square bracket so the regex works
         $resetColor = $PSStyle.Reset.Replace('[','\[')

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
@@ -127,14 +127,27 @@ Describe 'Get-Error tests' -Tag CI {
     }
 
     It 'Get-Error uses Error color for Message and PositionMessage members' -Skip:(!$EnabledExperimentalFeatures.Contains("PSAnsiRendering")) {
+        $suppressVT = $false
+        if (Test-Path env:/__SuppressAnsiEscapeSequences) {
+            $suppressVT = $true
+            $env:__SuppressAnsiEscapeSequences = $null
+        }
 
-        $out = pwsh -noprofile -command '$PSStyle.OutputRendering = "ANSI"; [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("BypassOutputRedirectionCheck", $true); try { 1/0 } catch { }; Get-Error' | Out-String
+        try {
+            $out = pwsh -noprofile -command '$PSStyle.OutputRendering = "ANSI"; [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("BypassOutputRedirectionCheck", $true); try { 1/0 } catch { }; Get-Error' | Out-String
 
-        # need to escape the open square bracket so the regex works
-        $resetColor = $PSStyle.Reset.Replace('[','\[')
-        $errorColor = $PSStyle.Formatting.Error.Replace('[','\[')
-        $out | Should -Match "Message +: ${resetColor}${errorColor}[A-z]+"
-        # match the position message underline
-        $out | Should -Match ".*?${errorColor}~~~"
+            # need to escape the open square bracket so the regex works
+            $resetColor = $PSStyle.Reset.Replace('[','\[')
+            $errorColor = $PSStyle.Formatting.Error.Replace('[','\[')
+            $out | Should -Match "Message +: ${resetColor}${errorColor}[A-z]+"
+            # match the position message underline
+            $out | Should -Match ".*?${errorColor}~~~"
+        }
+        finally
+        {
+            if ($suppressVT) {
+                $env:__SuppressAnsiEscapeSequences = 1
+            }
+        }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
@@ -127,16 +127,11 @@ Describe 'Get-Error tests' -Tag CI {
     }
 
     It 'Get-Error uses Error color for Message and PositionMessage members' -Skip:(!$EnabledExperimentalFeatures.Contains("PSAnsiRendering")) {
-        try {
-            1/0
-        }
-        catch {
-        }
 
-        $out = $error[0] | Get-Error | Out-String
+        $out = pwsh -noprofile -command '[System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("BypassOutputRedirectionCheck", $true); try { 1/0 } catch { }; Get-Error' | Out-String
 
         # need to escape the open square bracket so the regex works
-        $resetColor = $PSStyle.Reset
+        $resetColor = $PSStyle.Reset.Replace('[','\[')
         $errorColor = $PSStyle.Formatting.Error.Replace('[','\[')
         $out | Should -Match "Message +: ${resetColor}${errorColor}[A-z]+"
         # match the position message underline

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
@@ -125,4 +125,21 @@ Describe 'Get-Error tests' -Tag CI {
 
         $out | Should -BeLikeExactly "*$expectedExceptionType*"
     }
+
+    It 'Get-Error uses Error color for Message and PositionMessage members' -Skip:(!$EnabledExperimentalFeatures.Contains("PSAnsiRendering")) {
+        try {
+            1/0
+        }
+        catch {
+        }
+
+        $out = $error[0] | Get-Error | Out-String
+
+        # need to escape the open square bracket so the regex works
+        $resetColor = $PSStyle.Reset
+        $errorColor = $PSStyle.Formatting.Error.Replace('[','\[')
+        $out | Should -Match "Message +: ${resetColor}${errorColor}[A-z]+"
+        # match the position message underline
+        $out | Should -Match ".*?${errorColor}~~~"
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Suggested on the Community Call by @rkeithhill to help make important parts of the detailed output of `Get-Error` to highlight the Exception/ErrorRecord `Message` as well as the underline for where the error occurred in the `PositionMessage` member.  The change will use the `$PSStyle.Formatting.Error` color to highlight any property called `Message` and the `~~~` underline used in a property called `PositionMessage`.  This means that some members may be highlighted unintentionally, but it seems those would be corner cases.

Example:
![image](https://user-images.githubusercontent.com/11859881/125865467-f9c9ace1-3560-40b2-aeb2-80b9eb12d5c4.png)

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/15783

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
