### PR TITLE
Fix IDisposable implementation in `CommandPathSearch`

### DIFF
--- a/src/System.Management.Automation/engine/CommandPathSearch.cs
+++ b/src/System.Management.Automation/engine/CommandPathSearch.cs
@@ -346,9 +346,12 @@ namespace System.Management.Automation
         /// </summary>
         public void Reset()
         {
+            _lookupPathsEnumerator.Dispose();
             _lookupPathsEnumerator = _lookupPaths.GetEnumerator();
+            _patternEnumerator.Dispose();
             _patternEnumerator = _patterns.GetEnumerator();
             _currentDirectoryResults = Array.Empty<string>();
+            _currentDirectoryResultsEnumerator.Dispose();
             _currentDirectoryResultsEnumerator = _currentDirectoryResults.GetEnumerator();
             _justReset = true;
         }


### PR DESCRIPTION
Fix [CA2213: Disposable fields should be disposed](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213) in `System.Management.Automation.CommandPathSearch`.
