### PR TITLE
Seal `ClientRemotePowerShell`

### DIFF
--- a/src/System.Management.Automation/engine/remoting/client/ClientRemotePowerShell.cs
+++ b/src/System.Management.Automation/engine/remoting/client/ClientRemotePowerShell.cs
@@ -938,28 +938,15 @@ namespace System.Management.Automation.Runspaces.Internal
         #region IDisposable
 
         /// <summary>
-        /// Public interface for dispose.
+        /// Release all resources.
         /// </summary>
         public void Dispose()
         {
-            Dispose(true);
-
-            GC.SuppressFinalize(this);
+            // inputstream.Dispose();
+            // outputstream.Dispose();
+            // errorstream.Dispose();
         }
 
-        /// <summary>
-        /// Release all resources.
-        /// </summary>
-        /// <param name="disposing">If true, release all managed resources.</param>
-        private void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                // inputstream.Dispose();
-                // outputstream.Dispose();
-                // errorstream.Dispose();
-            }
-        }
         #endregion IDisposable
     }
 

--- a/src/System.Management.Automation/engine/remoting/client/ClientRemotePowerShell.cs
+++ b/src/System.Management.Automation/engine/remoting/client/ClientRemotePowerShell.cs
@@ -907,16 +907,16 @@ namespace System.Management.Automation.Runspaces.Internal
         private ObjectStreamBase inputstream;
         private ObjectStreamBase errorstream;
         private PSInformationalBuffers informationalBuffers;
-        private PowerShell shell;
-        private Guid clientRunspacePoolId;
+        private readonly PowerShell shell;
+        private readonly Guid clientRunspacePoolId;
         private bool noInput;
         private PSInvocationSettings settings;
         private ObjectStreamBase outputstream;
-        private string computerName;
+        private readonly string computerName;
         private ClientPowerShellDataStructureHandler dataStructureHandler;
         private bool stopCalled = false;
         private PSHost hostToUse;
-        private RemoteRunspacePoolInternal runspacePool;
+        private readonly RemoteRunspacePoolInternal runspacePool;
 
         private const string WRITE_DEBUG_LINE = "WriteDebugLine";
         private const string WRITE_VERBOSE_LINE = "WriteVerboseLine";

--- a/src/System.Management.Automation/engine/remoting/client/ClientRemotePowerShell.cs
+++ b/src/System.Management.Automation/engine/remoting/client/ClientRemotePowerShell.cs
@@ -902,28 +902,28 @@ namespace System.Management.Automation.Runspaces.Internal
 
         #endregion Private Methods
 
-        #region Protected Members
+        #region Private Fields
 
-        protected ObjectStreamBase inputstream;
-        protected ObjectStreamBase errorstream;
-        protected PSInformationalBuffers informationalBuffers;
-        protected PowerShell shell;
-        protected Guid clientRunspacePoolId;
-        protected bool noInput;
-        protected PSInvocationSettings settings;
-        protected ObjectStreamBase outputstream;
-        protected string computerName;
-        protected ClientPowerShellDataStructureHandler dataStructureHandler;
-        protected bool stopCalled = false;
-        protected PSHost hostToUse;
-        protected RemoteRunspacePoolInternal runspacePool;
+        private ObjectStreamBase inputstream;
+        private ObjectStreamBase errorstream;
+        private PSInformationalBuffers informationalBuffers;
+        private PowerShell shell;
+        private Guid clientRunspacePoolId;
+        private bool noInput;
+        private PSInvocationSettings settings;
+        private ObjectStreamBase outputstream;
+        private string computerName;
+        private ClientPowerShellDataStructureHandler dataStructureHandler;
+        private bool stopCalled = false;
+        private PSHost hostToUse;
+        private RemoteRunspacePoolInternal runspacePool;
 
-        protected const string WRITE_DEBUG_LINE = "WriteDebugLine";
-        protected const string WRITE_VERBOSE_LINE = "WriteVerboseLine";
-        protected const string WRITE_WARNING_LINE = "WriteWarningLine";
-        protected const string WRITE_PROGRESS = "WriteProgress";
+        private const string WRITE_DEBUG_LINE = "WriteDebugLine";
+        private const string WRITE_VERBOSE_LINE = "WriteVerboseLine";
+        private const string WRITE_WARNING_LINE = "WriteWarningLine";
+        private const string WRITE_PROGRESS = "WriteProgress";
 
-        protected bool initialized = false;
+        private bool initialized = false;
         /// <summary>
         /// This queue is for the state change events that resulted in closing the underlying
         /// datastructure handler. We cannot send the state back to the upper layers until
@@ -933,7 +933,7 @@ namespace System.Management.Automation.Runspaces.Internal
 
         private PSConnectionRetryStatus _connectionRetryStatus = PSConnectionRetryStatus.None;
 
-        #endregion Protected Members
+        #endregion Private Fields
 
         #region IDisposable
 
@@ -951,7 +951,7 @@ namespace System.Management.Automation.Runspaces.Internal
         /// Release all resources.
         /// </summary>
         /// <param name="disposing">If true, release all managed resources.</param>
-        protected void Dispose(bool disposing)
+        private void Dispose(bool disposing)
         {
             if (disposing)
             {

--- a/src/System.Management.Automation/engine/remoting/client/ClientRemotePowerShell.cs
+++ b/src/System.Management.Automation/engine/remoting/client/ClientRemotePowerShell.cs
@@ -15,7 +15,7 @@ namespace System.Management.Automation.Runspaces.Internal
     /// PowerShell client side proxy base which handles invocation
     /// of powershell on a remote machine.
     /// </summary>
-    internal class ClientRemotePowerShell : IDisposable
+    internal sealed class ClientRemotePowerShell : IDisposable
     {
         #region Tracer
 


### PR DESCRIPTION
Seal internal `System.Management.Automation.Runspaces.Internal.ClientRemotePowerShell` class as it not meant to be derived from.

The motivation of this PR is this comment by @PaulHigin in https://github.com/PowerShell/PowerShell/pull/11820#discussion_r452404781. Sealing the class enables fixing the disposable implementation as previously attempted in #11820.

_Contributes to #15110._
