### PR TITLE
Enable CA2213: Disposable fields should be disposed

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -593,7 +593,7 @@ dotnet_diagnostic.CA2211.severity = warning
 
 # CA2213: Disposable fields should be disposed
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
-dotnet_diagnostic.CA2213.severity = none
+dotnet_diagnostic.CA2213.severity = warning
 
 # CA2214: Do not call overridable methods in constructors
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimChildJobBase.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimChildJobBase.cs
@@ -166,7 +166,9 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
         private const int MaxRetryDelayMs = 15 * 1000;
         private const int MinRetryDelayMs = 100;
 
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private Timer _sleepAndRetryTimer;
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
 
         private void SleepAndRetry_OnWakeup(object state)
         {

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -2183,8 +2183,10 @@ namespace Microsoft.PowerShell.Commands
         }
 
 #if UNIX
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private StreamWriter _outputWriter;
         private StreamWriter _errorWriter;
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
 
         private void StdOutputHandler(object sendingProcess, DataReceivedEventArgs outLine)
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
+++ b/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
@@ -2,7 +2,8 @@
   <Import Project="..\..\PowerShell.Common.props" />
   <PropertyGroup>
     <Description>PowerShell's Microsoft.PowerShell.Commands.Utility project</Description>
-    <NoWarn>$(NoWarn);CS1570;CA1416</NoWarn>
+    <!-- CA2213: https://github.com/PowerShell/PowerShell/issues/15803 -->
+    <NoWarn>$(NoWarn);CS1570;CA1416;CA2213</NoWarn>
     <AssemblyName>Microsoft.PowerShell.Commands.Utility</AssemblyName>
   </PropertyGroup>
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -24,7 +24,9 @@ namespace Microsoft.PowerShell.Commands
     {
         #region Data
 
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private readonly Stream _originalStreamToProxy;
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
         private bool _isInitialized = false;
         private readonly Cmdlet _ownerCmdlet;
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/XmlCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/XmlCommands.cs
@@ -670,7 +670,9 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// XmlReader used to read file.
         /// </summary>
+#pragma warning disable CA2213 // Disposable fields should be disposed
         internal XmlReader _xr;
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
 
         private static XmlReader CreateXmlReader(Stream stream)
         {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -2976,13 +2976,17 @@ namespace Microsoft.PowerShell
         private bool _shouldEndSession;
         private int _beginApplicationNotifyCount;
 
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private readonly ConsoleTextWriter _consoleWriter;
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
         private WrappedSerializer _outputSerializer;
         private WrappedSerializer _errorSerializer;
         private bool _displayDebuggerBanner;
         private DebuggerStopEventArgs _debuggerStopEventArgs;
         private bool _inPushedConfiguredSession;
+#pragma warning disable CA2213 // Disposable fields should be disposed
         internal Pipeline runningCmd;
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
 
         // The ConsoleHost class is a singleton.  Note that there is not a thread-safety issue with these statics as there can
         // only be one console host per process.

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseCommand.cs
@@ -228,7 +228,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// Reference to the implementation command that this class
         /// is wrapping.
         /// </summary>
+#pragma warning disable CA2213 // Disposable fields should be disposed
         internal ImplementationCommandBase implementation = null;
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
 
         #region IDisposable Implementation
 

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -1066,7 +1066,9 @@ namespace System.Management.Automation
             return traceResult(result);
         }
 
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private IEnumerator<CmdletInfo>? _matchingCmdlet;
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
 
         [return: NotNullIfNotNull("result")]
         private static CmdletInfo? traceResult(CmdletInfo? result)
@@ -1492,7 +1494,9 @@ namespace System.Management.Automation
         /// The enumerator that uses the Path to
         /// search for commands.
         /// </summary>
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private CommandPathSearch? _pathSearcher;
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
 
         /// <summary>
         /// The execution context instance for the current engine...
@@ -1658,12 +1662,16 @@ namespace System.Management.Automation
         /// <summary>
         /// An enumerator of the matching aliases.
         /// </summary>
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private IEnumerator<AliasInfo>? _matchingAlias;
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
 
         /// <summary>
         /// An enumerator of the matching functions.
         /// </summary>
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private IEnumerator<CommandInfo?>? _matchingFunctionEnumerator;
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
 
         /// <summary>
         /// The CommandInfo that references the command that matches the pattern.

--- a/src/System.Management.Automation/engine/DscResourceSearcher.cs
+++ b/src/System.Management.Automation/engine/DscResourceSearcher.cs
@@ -30,7 +30,9 @@ namespace System.Management.Automation
         private readonly string _resourceName = null;
         private readonly ExecutionContext _context = null;
         private DscResourceInfo _currentMatch = null;
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private IEnumerator<DscResourceInfo> _matchingResource = null;
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
         private Collection<DscResourceInfo> _matchingResourceList = null;
 
         #endregion

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -376,7 +376,9 @@ namespace Microsoft.PowerShell.Commands
         private PSTaskDataStreamWriter _taskDataStreamWriter;
         private Dictionary<string, object> _usingValuesMap;
         private Timer _taskTimer;
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private PSTaskJob _taskJob;
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
         private PSDataCollection<System.Management.Automation.PSTasks.PSTask> _taskCollection;
         private Exception _taskCollectionException;
         private string _currentLocationPath;

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -2357,7 +2357,9 @@ namespace System.Management.Automation
             // There is no finalizer, by design.  This class relies on always
             // being disposed and always following stack semantics.
 
+#pragma warning disable CA2213 // Disposable fields should be disposed
             private readonly PipelineProcessor _pp = null;
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
             private readonly InternalCommand _wasPermittedToWrite = null;
             private readonly bool _wasPermittedToWriteToPipeline = false;
             private readonly Thread _wasPermittedToWriteThread = null;

--- a/src/System.Management.Automation/engine/PSClassSearcher.cs
+++ b/src/System.Management.Automation/engine/PSClassSearcher.cs
@@ -36,7 +36,9 @@ namespace System.Management.Automation
         private readonly string _className = null;
         private readonly ExecutionContext _context = null;
         private PSClassInfo _currentMatch = null;
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private IEnumerator<PSClassInfo> _matchingClass = null;
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
         private Collection<PSClassInfo> _matchingClassList = null;
         private readonly bool _useWildCards = false;
         private readonly Dictionary<string, PSModuleInfo> _moduleInfoCache = null;

--- a/src/System.Management.Automation/engine/SessionStateFunctionAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateFunctionAPIs.cs
@@ -47,7 +47,7 @@ namespace System.Management.Automation
             Dictionary<string, FunctionInfo> result =
                 new Dictionary<string, FunctionInfo>(StringComparer.OrdinalIgnoreCase);
 
-            foreach (SessionStateScope scope in scopeEnumerator)
+            foreach (var scope in scopeEnumerator)
             {
                 foreach (FunctionInfo entry in scope.FunctionTable.Values)
                 {

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -1689,7 +1689,9 @@ namespace System.Management.Automation
         private DebuggerCommandProcessor _commandProcessor = new DebuggerCommandProcessor();
         private InvocationInfo _currentInvocationInfo;
         private bool _inBreakpoint;
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private PowerShell _psDebuggerCommand;
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
 
         // Job debugger integration.
         private bool _nestedDebuggerStop;

--- a/src/System.Management.Automation/engine/hostifaces/ConnectionBase.cs
+++ b/src/System.Management.Automation/engine/hostifaces/ConnectionBase.cs
@@ -685,7 +685,9 @@ namespace System.Management.Automation.Runspaces
         }
 
         // This is to notify once runspace has been opened (RunspaceState.Opened)
+#pragma warning disable CA2213 // Disposable fields should be disposed
         internal ManualResetEventSlim RunspaceOpening = new ManualResetEventSlim(false);
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
 
         /// <summary>
         /// Set the new runspace state.
@@ -986,7 +988,9 @@ namespace System.Management.Automation.Runspaces
             return _currentlyRunningPipeline;
         }
 
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private Pipeline _currentlyRunningPipeline = null;
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
 
         /// <summary>
         /// This method stops all the pipelines which are nested

--- a/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
@@ -1937,7 +1937,9 @@ namespace System.Management.Automation
             }
         }
 
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private RunspacePool _runspacePool = null;
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
 
         /// <summary>
         /// Gets the associated Runspace or RunspacePool for this PowerShell

--- a/src/System.Management.Automation/engine/remoting/client/Job.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job.cs
@@ -3826,7 +3826,9 @@ namespace System.Management.Automation
         #region Private Members
 
         // helper associated with this job object
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private readonly RemotePipeline _remotePipeline = null;
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
 
         // object used for synchronization
         protected object SyncObject = new object();

--- a/src/System.Management.Automation/engine/remoting/client/Job2.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job2.cs
@@ -526,7 +526,9 @@ namespace System.Management.Automation
         // count of number of child jobs which stopped
         private int _stoppedChildJobsCount = 0;
 
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private readonly PowerShellTraceSource _tracer = PowerShellTraceSourceFactory.GetTraceSource();
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
         private readonly PSDataCollection<ErrorRecord> _executionError = new PSDataCollection<ErrorRecord>();
 
         private PSEventManager _eventManager;

--- a/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
+++ b/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
@@ -44,7 +44,9 @@ namespace System.Management.Automation
 
         // the following two variables have been added for supporting
         // the Invoke-Command | Invoke-Command scenario
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private InvokeCommandCommand _currentInvokeCommand = null;
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
         private long _currentLocalPipelineId = 0;
 
         /// <summary>
@@ -1793,7 +1795,9 @@ namespace System.Management.Automation
         #region Members
 
         private readonly RemoteRunspace _runspace;
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private PowerShell _psDebuggerCommand;
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
         private bool _remoteDebugSupported;
         private bool _isActive;
         private int _breakpointCount;

--- a/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
@@ -2018,7 +2018,9 @@ namespace Microsoft.PowerShell.Commands
         private PSInvokeExpressionSyncJob _job;
 
         // used for streaming behavior for local invocations
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private SteppablePipeline _steppablePipeline;
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
 
         private bool _pipelineinvoked = false;    // if pipeline has been invoked
         private bool _inputStreamClosed = false;

--- a/src/System.Management.Automation/engine/remoting/commands/ReceiveJob.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/ReceiveJob.cs
@@ -314,7 +314,9 @@ namespace Microsoft.PowerShell.Commands
         private bool _isStopping;
         private bool _isDisposed;
         private readonly ReaderWriterLockSlim _resultsReaderWriterLock = new ReaderWriterLockSlim();
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private readonly PowerShellTraceSource _tracer = PowerShellTraceSourceFactory.GetTraceSource();
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
         private readonly ManualResetEvent _writeExistingData = new ManualResetEvent(true);
         private readonly PSDataCollection<PSStreamObject> _results = new PSDataCollection<PSStreamObject>();
         private bool _holdingResultsRef;

--- a/src/System.Management.Automation/engine/remoting/common/RemoteSessionHyperVSocket.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RemoteSessionHyperVSocket.cs
@@ -138,7 +138,9 @@ namespace System.Management.Automation.Remoting
         #region Members
 
         private readonly object _syncObject;
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private readonly PowerShellTraceSource _tracer = PowerShellTraceSourceFactory.GetTraceSource();
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
 
         #endregion
 
@@ -337,7 +339,9 @@ namespace System.Management.Automation.Remoting
         #region Members
 
         private readonly object _syncObject;
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private readonly PowerShellTraceSource _tracer = PowerShellTraceSourceFactory.GetTraceSource();
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
 
         private static readonly ManualResetEvent s_connectDone =
                 new ManualResetEvent(false);

--- a/src/System.Management.Automation/engine/remoting/common/RemoteSessionNamedPipe.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RemoteSessionNamedPipe.cs
@@ -341,7 +341,9 @@ namespace System.Management.Automation.Remoting
         #region Members
 
         private readonly object _syncObject;
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private readonly PowerShellTraceSource _tracer = PowerShellTraceSourceFactory.GetTraceSource();
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
 
         private const string _threadName = "IPC Listener Thread";
         private const int _namedPipeBufferSizeForRemoting = 32768;
@@ -1007,7 +1009,9 @@ namespace System.Management.Automation.Remoting
         #region Members
 
         private NamedPipeClientStream _clientPipeStream;
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private readonly PowerShellTraceSource _tracer = PowerShellTraceSourceFactory.GetTraceSource();
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
 
         protected string _pipeName;
 

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -479,7 +479,9 @@ namespace System.Management.Automation.Remoting.Client
         private readonly Timer _closeTimeOutTimer;
 
         protected OutOfProcessTextWriter stdInWriter;
+#pragma warning disable CA2213 // Disposable fields should be disposed
         protected PowerShellTraceSource _tracer;
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
 
         #endregion
 
@@ -1592,7 +1594,9 @@ namespace System.Management.Automation.Remoting.Client
         private StreamReader _stdOutReader;
         private StreamReader _stdErrReader;
         private bool _connectionEstablished;
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private Timer _connectionTimer;
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
 
         private const string _threadName = "SSHTransport Reader Thread";
 

--- a/src/System.Management.Automation/utils/ObjectReader.cs
+++ b/src/System.Management.Automation/utils/ObjectReader.cs
@@ -488,7 +488,9 @@ namespace System.Management.Automation.Internal
     {
         #region Private Data
 
+#pragma warning disable CA2213 // Disposable fields should be disposed
         private readonly PSDataCollectionEnumerator<T> _enumerator;
+#pragma warning restore CA2213 // https://github.com/PowerShell/PowerShell/issues/15803
 
         #endregion
 


### PR DESCRIPTION
Enable [CA2213: Disposable fields should be disposed](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213)

* Suppress existing violations with `#pragma warning disable`
* Disable at project level for `Microsoft.PowerShell.Commands.Utility` due to error that was not suppressible with `#pragma`:

```
CSC : error CA2213: 'FrontEndCommandBase' contains field 'implementation' that is of IDisposable type 'ImplementationCommandBase', but it is never disposed. Change the Dispose method on 'FrontEndCommandBase' to call Close or Dispose on this field. [X:\src\Microsoft.PowerShell.Commands.Utility\Microsoft.PowerShell.Commands.Utility.csproj]
```

_Contributes to #15803._

Related issue: https://github.com/dotnet/roslyn-analyzers/issues/4407

cc: @iSazonov