### PR TITLE
Update analyzers

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -506,6 +506,10 @@ dotnet_diagnostic.CA1845.severity = warning
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
 dotnet_diagnostic.CA1846.severity = warning
 
+# CA1847: Use char literal for a single character lookup
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = warning
+
 # CA2000: Dispose objects before losing scope
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
 dotnet_diagnostic.CA2000.severity = none
@@ -703,6 +707,10 @@ dotnet_diagnostic.CA2250.severity = warning
 # CA2251: Use 'string.Equals'
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
 dotnet_diagnostic.CA2251.severity = warning
+
+# CA2252: This API requires opting into preview features
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2251.severity = none
 
 # CA2300: Do not use insecure deserializer BinaryFormatter
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300

--- a/Analyzers.props
+++ b/Analyzers.props
@@ -1,6 +1,7 @@
 <Project>
   <ItemGroup>
     <PackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" PrivateAssets="all" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.312" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0-rc1.21366.2" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* Update `Microsoft.CodeAnalysis.NetAnalyzers` package to `6.0.0-rc1.21366.2` so new rules are included.
  *  Add new analyzer rules to match https://github.com/dotnet/runtime/commit/4e405a12423e107055874665f81f0c7ff05a03be.
* Update `StyleCop.Analyzers`



