### PR TITLE
Add validation to `$PSStyle` to reject printable text as ANSI escape sequence

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -2127,7 +2127,7 @@ namespace System.Management.Automation.Runspaces
                         .AddItemScriptBlock(@"""$($_.ErrorAccent)$($_.ErrorAccent.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "ErrorAccent")
                         .AddItemScriptBlock(@"""$($_.Error)$($_.Error.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "Error")
                         .AddItemScriptBlock(@"""$($_.Warning)$($_.Warning.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "Warning")
-                        .AddItemScriptBlock(@"""$($_.Verbose)$($_.Verbose.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "Formatting.Verbose")
+                        .AddItemScriptBlock(@"""$($_.Verbose)$($_.Verbose.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "Verbose")
                         .AddItemScriptBlock(@"""$($_.Debug)$($_.Debug.Replace(""""`e"""",'`e'))$($PSStyle.Reset)""", label: "Debug")
                     .EndEntry()
                 .EndList());

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -443,37 +443,58 @@ namespace System.Management.Automation
             private string _executable = "\x1b[32;1m";
 
             /// <summary>
-            /// Custom dictionary handling validation of content.
+            /// Custom dictionary handling validation of extension and content.
             /// </summary>
-            public class AnsiDictionary : Dictionary<string, string>
+            public class FileExtensionDictionary : Dictionary<string, string>
             {
                 /// <summary>
-                /// Initializes a new instance of the <see cref="AnsiDictionary"/> class.
+                /// Initializes a new instance of the <see cref="FileExtensionDictionary"/> class.
                 /// </summary>
-                public AnsiDictionary() : base(StringComparer.OrdinalIgnoreCase) { }
+                public FileExtensionDictionary() : base(StringComparer.OrdinalIgnoreCase) { }
 
                 /// <summary>
-                /// Addnew entry to dictionary.
+                /// Add new extension and decoration to dictionary.
                 /// </summary>
-                /// <param name="key">Key to add.</param>
-                /// <param name="value">ANSI string value to add.</param>
-                public new void Add(string key, string value)
+                /// <param name="extension">Extension to add.</param>
+                /// <param name="decoration">ANSI string value to add.</param>
+                public new void Add(string extension, string decoration)
                 {
-                    base.Add(key, ValidateNoContent(value));
+                    // if extension doesn't start with a dot, add one
+                    if (!extension.StartsWith("."))
+                    {
+                        extension = "." + extension;
+                    }
+
+                    base.Add(extension, ValidateNoContent(decoration));
+                }
+
+                /// <summary>
+                /// Remove an extension from dictionary.
+                /// </summary>
+                /// <param name="extension">Extension to remove.</param>
+                public new void Remove(string extension)
+                {
+                    // if extension doesn't start with a dot, add one
+                    if (!extension.StartsWith("."))
+                    {
+                        extension = "." + extension;
+                    }
+
+                    base.Remove(extension);
                 }
             }
 
             /// <summary>
             /// Gets the style for archive.
             /// </summary>
-            public AnsiDictionary Extension { get; }
+            public FileExtensionDictionary Extension { get; }
 
             /// <summary>
             /// Initializes a new instance of the <see cref="FileInfoFormatting"/> class.
             /// </summary>
             public FileInfoFormatting()
             {
-                Extension = new AnsiDictionary();
+                Extension = new FileExtensionDictionary();
 
                 // archives
                 Extension.Add(".zip", "\x1b[31;1m");

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -512,7 +512,12 @@ namespace System.Management.Automation
                 /// <returns>True if the dictionary contains the specified extension, otherwise false.</returns>
                 public bool ContainsKey(string extension)
                 {
-                    return _extensionDictionary.ContainsKey(extension);
+                    if (string.IsNullOrEmpty(extension))
+                    {
+                        return false;
+                    }
+
+                    return _extensionDictionary.ContainsKey(ValidateExtension(extension));
                 }
 
                 /// <summary>

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -309,9 +309,9 @@ namespace System.Management.Automation
                 
                 set
                 {
-                    if (value < 0)
+                    if (value < 18)
                     {
-                        value = 0;
+                        throw new ArgumentOutOfRangeException(nameof(MaxWidth), PSStyleStrings.ProgressWidthTooSmall);
                     }
 
                     _maxWidth = value;

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Management.Automation.Internal;
 
 namespace System.Management.Automation
 {
@@ -281,12 +282,43 @@ namespace System.Management.Automation
             /// <summary>
             /// Gets or sets the style for progress bar.
             /// </summary>
-            public string Style { get; set; } = "\x1b[33;1m";
+            public string Style
+            {
+                get
+                {
+                    return _style;
+                } 
+
+                set
+                {
+                    _style = ValidateNoContent(value);
+                }
+            }
+
+            private string _style = "\x1b[33;1m";
 
             /// <summary>
             /// Gets or sets the max width of the progress bar.
             /// </summary>
-            public int MaxWidth { get; set; } = 120;
+            public int MaxWidth
+            {
+                get
+                {
+                    return _maxWidth;
+                } 
+                
+                set
+                {
+                    if (value < 0)
+                    {
+                        value = 0;
+                    }
+
+                    _maxWidth = value;
+                }
+            }
+
+            private int _maxWidth = 120;
 
             /// <summary>
             /// Gets or sets the view for progress bar.
@@ -307,37 +339,128 @@ namespace System.Management.Automation
             /// <summary>
             /// Gets or sets the accent style for formatting.
             /// </summary>
-            public string FormatAccent { get; set; } = "\x1b[32;1m";
+            public string FormatAccent
+            {
+                get
+                {
+                    return _formatAccent;
+                }
+
+                set
+                {
+                    _formatAccent = ValidateNoContent(value);
+                }
+            }
+
+            private string _formatAccent = "\x1b[32;1m";
 
             /// <summary>
             /// Gets or sets the style for table headers.
             /// </summary>
-            public string TableHeader { get; set; } = "\x1b[32;1m";
+            public string TableHeader
+            {
+                get
+                {
+                    return _tableHeader;
+                }
+
+                set
+                {
+                    _tableHeader = ValidateNoContent(value);
+                }
+            }
+
+            private string _tableHeader = "\x1b[32;1m";
 
             /// <summary>
             /// Gets or sets the accent style for errors.
             /// </summary>
-            public string ErrorAccent { get; set; } = "\x1b[36;1m";
+            public string ErrorAccent
+            {
+                get
+                {
+                    return _errorAccent;
+                }
+
+                set
+                {
+                    _errorAccent = ValidateNoContent(value);
+                }
+            }
+
+            private string _errorAccent = "\x1b[36;1m";
 
             /// <summary>
             /// Gets or sets the style for error messages.
             /// </summary>
-            public string Error { get; set; } = "\x1b[31;1m";
+            public string Error
+            {
+                get
+                {
+                    return _error;
+                }
+
+                set
+                {
+                    _error = ValidateNoContent(value);
+                }
+            }
+            
+            private string _error = "\x1b[31;1m";
 
             /// <summary>
             /// Gets or sets the style for warning messages.
             /// </summary>
-            public string Warning { get; set; } = "\x1b[33;1m";
+            public string Warning
+            {
+                get
+                {
+                    return _warning;
+                }
+
+                set
+                {
+                    _warning = ValidateNoContent(value);
+                }
+            }
+
+            private string _warning = "\x1b[33;1m";
 
             /// <summary>
             /// Gets or sets the style for verbose messages.
             /// </summary>
-            public string Verbose { get; set; } = "\x1b[33;1m";
+            public string Verbose
+            {
+                get
+                {
+                    return _verbose;
+                }
+
+                set
+                {
+                    _verbose = ValidateNoContent(value);
+                }
+            }
+
+            private string _verbose = "\x1b[33;1m";
 
             /// <summary>
             /// Gets or sets the style for debug messages.
             /// </summary>
-            public string Debug { get; set; } = "\x1b[33;1m";
+            public string Debug
+            {
+                get
+                {
+                    return _debug;
+                }
+
+                set
+                {
+                    _debug = ValidateNoContent(value);
+                }
+            }
+
+            private string _debug = "\x1b[33;1m";
         }
 
         /// <summary>
@@ -348,29 +471,89 @@ namespace System.Management.Automation
             /// <summary>
             /// Gets or sets the style for directories.
             /// </summary>
-            public string Directory { get; set; } = "\x1b[44;1m";
+            public string Directory
+            {
+                get
+                {
+                    return _directory;
+                }
+
+                set
+                {
+                    _directory = ValidateNoContent(value);
+                }
+            }
+
+            private string _directory = "\x1b[44;1m";
 
             /// <summary>
             /// Gets or sets the style for symbolic links.
             /// </summary>
-            public string SymbolicLink { get; set; } = "\x1b[36;1m";
+            public string SymbolicLink
+            {
+                get
+                {
+                    return _symbolicLink;
+                }
+
+                set
+                {
+                    _symbolicLink = ValidateNoContent(value);
+                }
+            }
+
+            private string _symbolicLink = "\x1b[36;1m";
 
             /// <summary>
             /// Gets or sets the style for executables.
             /// </summary>
-            public string Executable { get; set; } = "\x1b[32;1m";
+            public string Executable
+            {
+                get
+                {
+                    return _executable;
+                }
+
+                set
+                {
+                    _executable = ValidateNoContent(value);
+                }
+            }
+
+            private string _executable = "\x1b[32;1m";
+
+            /// <summary>
+            /// Custom dictionary handling validation of content.
+            /// </summary>
+            public class AnsiDictionary : Dictionary<string, string>
+            {
+                /// <summary>
+                /// Constructor for AnsiDictionary.
+                /// </summary>
+                public AnsiDictionary() : base(StringComparer.OrdinalIgnoreCase){}
+
+                /// <summary>
+                /// Addnew entry to dictionary.
+                /// </summary>
+                /// <param name="key">Key to add</param>
+                /// <param name="value">ANSI string value to add</param>
+                public new void Add(string key, string value)
+                {
+                    base.Add(key, ValidateNoContent(value));
+                }
+            }
 
             /// <summary>
             /// Gets the style for archive.
             /// </summary>
-            public Dictionary<string, string> Extension { get; }
+            public AnsiDictionary Extension { get; }
 
             /// <summary>
             /// Initializes a new instance of the <see cref="FileInfoFormatting"/> class.
             /// </summary>
             public FileInfoFormatting()
             {
-                Extension = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                Extension = new AnsiDictionary();
 
                 // archives
                 Extension.Add(".zip", "\x1b[31;1m");
@@ -514,6 +697,17 @@ namespace System.Management.Automation
             Foreground = new ForegroundColor();
             Background = new BackgroundColor();
             FileInfo = new FileInfoFormatting();
+        }
+
+        private static string ValidateNoContent(string text)
+        {
+            var decorartedString = new StringDecorated(text);
+            if (decorartedString.ContentLength > 0)
+            {
+                throw new InvalidOperationException(string.Format(PSStyleStrings.TextContainsContent, decorartedString.ToString(OutputRendering.PlainText)));
+            }
+
+            return text;
         }
 
         /// <summary>

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -446,7 +446,7 @@ namespace System.Management.Automation
             /// <summary>
             /// Custom dictionary handling validation of extension and content.
             /// </summary>
-            public sealed class FileExtensionDictionary : IEnumerable
+            public sealed class FileExtensionDictionary
             {
                 private static string ValidateExtension(string extension)
                 {
@@ -485,15 +485,6 @@ namespace System.Management.Automation
                 public void Clear()
                 {
                     _extensionDictionary.Clear();
-                }
-
-                /// <summary>
-                /// Gets the enumerator for the dictionary.
-                /// </summary>
-                /// <returns>The enumerator for the dictionary.</returns>
-                public IEnumerator GetEnumerator()
-                {
-                    return _extensionDictionary.GetEnumerator();
                 }
 
                 /// <summary>

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -459,7 +459,7 @@ namespace System.Management.Automation
                 /// <param name="decoration">ANSI string value to add.</param>
                 public new void Add(string extension, string decoration)
                 {
-                    if (!extension.StartsWith("."))
+                    if (!extension.StartsWith('.'))
                     {
                         throw new ArgumentException(PSStyleStrings.ExtensionNotStartingWithPeriod);
                     }
@@ -473,7 +473,7 @@ namespace System.Management.Automation
                 /// <param name="extension">Extension to remove.</param>
                 public new void Remove(string extension)
                 {
-                    if (!extension.StartsWith("."))
+                    if (!extension.StartsWith('.'))
                     {
                         throw new ArgumentException(PSStyleStrings.ExtensionNotStartingWithPeriod);
                     }

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -528,15 +528,15 @@ namespace System.Management.Automation
             public class AnsiDictionary : Dictionary<string, string>
             {
                 /// <summary>
-                /// Constructor for AnsiDictionary.
+                /// Initializes a new instance of the <see cref="AnsiDictionary"/> class.
                 /// </summary>
-                public AnsiDictionary() : base(StringComparer.OrdinalIgnoreCase){}
+                public AnsiDictionary() : base(StringComparer.OrdinalIgnoreCase) { }
 
                 /// <summary>
                 /// Addnew entry to dictionary.
                 /// </summary>
-                /// <param name="key">Key to add</param>
-                /// <param name="value">ANSI string value to add</param>
+                /// <param name="key">Key to add.</param>
+                /// <param name="value">ANSI string value to add.</param>
                 public new void Add(string key, string value)
                 {
                     base.Add(key, ValidateNoContent(value));

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -458,7 +458,7 @@ namespace System.Management.Automation
                     return extension;
                 }
 
-                private readonly Dictionary<string, string> _extensionDictionary = new();
+                private readonly Dictionary<string, string> _extensionDictionary = new(StringComparer.OrdinalIgnoreCase);
 
                 /// <summary>
                 /// Add new extension and decoration to dictionary.
@@ -521,7 +521,7 @@ namespace System.Management.Automation
                 /// <returns>True if the dictionary contains the specified extension, otherwise false.</returns>
                 public bool ContainsKey(string extension)
                 {
-                    return _extensionDictionary.ContainsKey(ValidateExtension(extension));
+                    return _extensionDictionary.ContainsKey(extension);
                 }
 
                 /// <summary>

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -445,7 +445,7 @@ namespace System.Management.Automation
             /// <summary>
             /// Custom dictionary handling validation of extension and content.
             /// </summary>
-            public class FileExtensionDictionary : Dictionary<string, string>
+            public sealed class FileExtensionDictionary : Dictionary<string, string>
             {
                 /// <summary>
                 /// Initializes a new instance of the <see cref="FileExtensionDictionary"/> class.
@@ -459,10 +459,9 @@ namespace System.Management.Automation
                 /// <param name="decoration">ANSI string value to add.</param>
                 public new void Add(string extension, string decoration)
                 {
-                    // if extension doesn't start with a dot, add one
                     if (!extension.StartsWith("."))
                     {
-                        extension = "." + extension;
+                        throw new ArgumentException(PSStyleStrings.ExtensionNotStartingWithPeriod);
                     }
 
                     base.Add(extension, ValidateNoContent(decoration));
@@ -474,10 +473,9 @@ namespace System.Management.Automation
                 /// <param name="extension">Extension to remove.</param>
                 public new void Remove(string extension)
                 {
-                    // if extension doesn't start with a dot, add one
                     if (!extension.StartsWith("."))
                     {
-                        extension = "." + extension;
+                        throw new ArgumentException(PSStyleStrings.ExtensionNotStartingWithPeriod);
                     }
 
                     base.Remove(extension);

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -284,15 +284,8 @@ namespace System.Management.Automation
             /// </summary>
             public string Style
             {
-                get
-                {
-                    return _style;
-                } 
-
-                set
-                {
-                    _style = ValidateNoContent(value);
-                }
+                get => _style;
+                set => _style = ValidateNoContent(value);
             }
 
             private string _style = "\x1b[33;1m";
@@ -302,13 +295,10 @@ namespace System.Management.Automation
             /// </summary>
             public int MaxWidth
             {
-                get
-                {
-                    return _maxWidth;
-                } 
-                
+                get => _maxWidth;
                 set
                 {
+                    // Width less than 18 does not render correctly due to the different parts of the progress bar.
                     if (value < 18)
                     {
                         throw new ArgumentOutOfRangeException(nameof(MaxWidth), PSStyleStrings.ProgressWidthTooSmall);
@@ -341,15 +331,8 @@ namespace System.Management.Automation
             /// </summary>
             public string FormatAccent
             {
-                get
-                {
-                    return _formatAccent;
-                }
-
-                set
-                {
-                    _formatAccent = ValidateNoContent(value);
-                }
+                get => _formatAccent;
+                set => _formatAccent = ValidateNoContent(value);
             }
 
             private string _formatAccent = "\x1b[32;1m";
@@ -359,15 +342,8 @@ namespace System.Management.Automation
             /// </summary>
             public string TableHeader
             {
-                get
-                {
-                    return _tableHeader;
-                }
-
-                set
-                {
-                    _tableHeader = ValidateNoContent(value);
-                }
+                get => _tableHeader;
+                set => _tableHeader = ValidateNoContent(value);
             }
 
             private string _tableHeader = "\x1b[32;1m";
@@ -377,15 +353,8 @@ namespace System.Management.Automation
             /// </summary>
             public string ErrorAccent
             {
-                get
-                {
-                    return _errorAccent;
-                }
-
-                set
-                {
-                    _errorAccent = ValidateNoContent(value);
-                }
+                get => _errorAccent;
+                set => _errorAccent = ValidateNoContent(value);
             }
 
             private string _errorAccent = "\x1b[36;1m";
@@ -395,15 +364,8 @@ namespace System.Management.Automation
             /// </summary>
             public string Error
             {
-                get
-                {
-                    return _error;
-                }
-
-                set
-                {
-                    _error = ValidateNoContent(value);
-                }
+                get => _error;
+                set => _error = ValidateNoContent(value);
             }
             
             private string _error = "\x1b[31;1m";
@@ -413,15 +375,8 @@ namespace System.Management.Automation
             /// </summary>
             public string Warning
             {
-                get
-                {
-                    return _warning;
-                }
-
-                set
-                {
-                    _warning = ValidateNoContent(value);
-                }
+                get => _warning;
+                set => _warning = ValidateNoContent(value);
             }
 
             private string _warning = "\x1b[33;1m";
@@ -431,15 +386,8 @@ namespace System.Management.Automation
             /// </summary>
             public string Verbose
             {
-                get
-                {
-                    return _verbose;
-                }
-
-                set
-                {
-                    _verbose = ValidateNoContent(value);
-                }
+                get => _verbose;
+                set => _verbose = ValidateNoContent(value);
             }
 
             private string _verbose = "\x1b[33;1m";
@@ -449,16 +397,9 @@ namespace System.Management.Automation
             /// </summary>
             public string Debug
             {
-                get
-                {
-                    return _debug;
-                }
-
-                set
-                {
-                    _debug = ValidateNoContent(value);
-                }
-            }
+                get => _debug;
+                set => _debug = ValidateNoContent(value);
+            }   
 
             private string _debug = "\x1b[33;1m";
         }
@@ -473,15 +414,8 @@ namespace System.Management.Automation
             /// </summary>
             public string Directory
             {
-                get
-                {
-                    return _directory;
-                }
-
-                set
-                {
-                    _directory = ValidateNoContent(value);
-                }
+                get => _directory;
+                set => _directory = ValidateNoContent(value);
             }
 
             private string _directory = "\x1b[44;1m";
@@ -491,15 +425,8 @@ namespace System.Management.Automation
             /// </summary>
             public string SymbolicLink
             {
-                get
-                {
-                    return _symbolicLink;
-                }
-
-                set
-                {
-                    _symbolicLink = ValidateNoContent(value);
-                }
+                get => _symbolicLink;
+                set => _symbolicLink = ValidateNoContent(value);
             }
 
             private string _symbolicLink = "\x1b[36;1m";
@@ -509,15 +436,8 @@ namespace System.Management.Automation
             /// </summary>
             public string Executable
             {
-                get
-                {
-                    return _executable;
-                }
-
-                set
-                {
-                    _executable = ValidateNoContent(value);
-                }
+                get => _executable;
+                set => _executable = ValidateNoContent(value);
             }
 
             private string _executable = "\x1b[32;1m";

--- a/src/System.Management.Automation/resources/PSStyleStrings.resx
+++ b/src/System.Management.Automation/resources/PSStyleStrings.resx
@@ -61,4 +61,7 @@
   <data name="TextContainsContent" xml:space="preserve">
     <value>The specified string contains printable content when it should only contain ANSI escape sequences: {0}</value>
   </data>
+  <data name="ProgressWidthTooSmall" xml:space="preserve">
+    <value>The MaxWidth for the Progress rendering must be at least 18 to render correctly.</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/resources/PSStyleStrings.resx
+++ b/src/System.Management.Automation/resources/PSStyleStrings.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="https://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="https://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="TextContainsContent" xml:space="preserve">
+    <value>The specified string contains printable content when it should only contain ANSI escape sequences: {0}</value>
+  </data>
+</root>

--- a/src/System.Management.Automation/resources/PSStyleStrings.resx
+++ b/src/System.Management.Automation/resources/PSStyleStrings.resx
@@ -64,4 +64,7 @@
   <data name="ProgressWidthTooSmall" xml:space="preserve">
     <value>The MaxWidth for the Progress rendering must be at least 18 to render correctly.</value>
   </data>
+  <data name="ExtensionNotStartingWithPeriod" xml:space="preserve">
+    <value>When adding or removing extensions, the extension must start with a period.</value>
+  </data>
 </root>

--- a/test/powershell/engine/Formatting/PSStyle.Tests.ps1
+++ b/test/powershell/engine/Formatting/PSStyle.Tests.ps1
@@ -204,6 +204,16 @@ Describe 'Tests for $PSStyle automatic variable' {
     }
 
     It 'Should fail adding extension formatting with printable characters' {
-        { $PSStyle.FileInfo.Extension.Add('.md', 'hello') } | Should -Throw
+        { $PSStyle.FileInfo.Extension.Add('.md', 'hello') } | Should -Throw -ErrorId 'InvalidOperationException'
+    }
+
+    It 'Should fail if MaxWidth is less than 18' {
+        $maxWidth = $PSStyle.Progress.MaxWidth
+        try {
+            { $PSStyle.Progress.MaxWidth = 17 } | Should -Throw -ErrorId 'ExceptionWhenSetting'
+        }
+        finally {
+            $PSStyle.Progress.MaxWidth = $maxWidth
+        }
     }
 }

--- a/test/powershell/engine/Formatting/PSStyle.Tests.ps1
+++ b/test/powershell/engine/Formatting/PSStyle.Tests.ps1
@@ -207,25 +207,22 @@ Describe 'Tests for $PSStyle automatic variable' {
         { $PSStyle.FileInfo.Extension.Add('.md', 'hello') } | Should -Throw -ErrorId 'InvalidOperationException'
     }
 
-    It 'Should add and remove extension: <extension>' -TestCases @(
-        @{ extension = '.myext' }
-        @{ extension = 'myext' }
-    ) {
-        param ($extension)
-
-        if ($extension.StartsWith('.')) {
-            $fullExtension = $extension
-        }
-        else {
-            $fullExtension = '.' + $extension
-        }
-
-        $PSStyle.FileInfo.Extension.Keys | Should -Not -Contain $fullextension
+    It 'Should add and remove extension' {
+        $extension = '.mytest'
+        $PSStyle.FileInfo.Extension.Keys | Should -Not -Contain $extension
         $PSStyle.FileInfo.Extension.Add($extension, $PSStyle.Foreground.Blue)
 
-        $PSStyle.FileInfo.Extension[$fullextension] | Should -Be $PSStyle.Foreground.Blue
+        $PSStyle.FileInfo.Extension[$extension] | Should -Be $PSStyle.Foreground.Blue
         $PSStyle.FileInfo.Extension.Remove($extension)
-        $PSStyle.FileInfo.Extension.Keys | Should -Not -Contain $fullextension
+        $PSStyle.FileInfo.Extension.Keys | Should -Not -Contain $extension
+    }
+
+    It 'Should fail to add extension does not start with a period' {
+        { $PSStyle.FileInfo.Extension.Add('mytest', $PSStyle.Foreground.Blue) } | Should -Throw -ErrorId 'ArgumentException'
+    }
+
+    It 'Should fail to remove extension does not start with a period' {
+        { $PSStyle.FileInfo.Extension.Remove('zip') } | Should -Throw -ErrorId 'ArgumentException'
     }
 
     It 'Should fail if MaxWidth is less than 18' {

--- a/test/powershell/engine/Formatting/PSStyle.Tests.ps1
+++ b/test/powershell/engine/Formatting/PSStyle.Tests.ps1
@@ -207,8 +207,31 @@ Describe 'Tests for $PSStyle automatic variable' {
         { $PSStyle.FileInfo.Extension.Add('.md', 'hello') } | Should -Throw -ErrorId 'InvalidOperationException'
     }
 
+    It 'Should add and remove extension: <extension>' -TestCases @(
+        @{ extension = '.myext' }
+        @{ extension = 'myext' }
+    ) {
+        param ($extension)
+
+        if ($extension.StartsWith('.')) {
+            $fullExtension = $extension
+        }
+        else {
+            $fullExtension = '.' + $extension
+        }
+
+        $PSStyle.FileInfo.Extension.Keys | Should -Not -Contain $fullextension
+        $PSStyle.FileInfo.Extension.Add($extension, $PSStyle.Foreground.Blue)
+
+        $PSStyle.FileInfo.Extension[$fullextension] | Should -Be $PSStyle.Foreground.Blue
+        $PSStyle.FileInfo.Extension.Remove($extension)
+        $PSStyle.FileInfo.Extension.Keys | Should -Not -Contain $fullextension
+    }
+
     It 'Should fail if MaxWidth is less than 18' {
         $maxWidth = $PSStyle.Progress.MaxWidth
+
+        # minimum allowed width is 18 as less than that doesn't render correctly
         try {
             { $PSStyle.Progress.MaxWidth = 17 } | Should -Throw -ErrorId 'ExceptionWhenSetting'
         }

--- a/test/powershell/engine/Formatting/PSStyle.Tests.ps1
+++ b/test/powershell/engine/Formatting/PSStyle.Tests.ps1
@@ -204,7 +204,7 @@ Describe 'Tests for $PSStyle automatic variable' {
     }
 
     It 'Should fail adding extension formatting with printable characters' {
-        { $PSStyle.FileInfo.Extension.Add('.md', 'hello') } | Should -Throw -ErrorId 'InvalidOperationException'
+        { $PSStyle.FileInfo.Extension.Add('.md', 'hello') } | Should -Throw -ErrorId 'ArgumentException'
     }
 
     It 'Should add and remove extension' {

--- a/test/powershell/engine/Formatting/PSStyle.Tests.ps1
+++ b/test/powershell/engine/Formatting/PSStyle.Tests.ps1
@@ -165,4 +165,45 @@ Describe 'Tests for $PSStyle automatic variable' {
             $PSStyle.Formatting.TableHeader = $old
         }
     }
+
+    It 'Should fail if setting formatting contains printable characters: <member>.<submember>' -TestCases @(
+        @{ Submember = 'Reset' }
+        @{ Submember = 'BlinkOff' }
+        @{ Submember = 'Blink' }
+        @{ Submember = 'BoldOff' }
+        @{ Submember = 'Bold' }
+        @{ Submember = 'HiddenOff' }
+        @{ Submember = 'Hidden' }
+        @{ Submember = 'ItalicOff' }
+        @{ Submember = 'Italic' }
+        @{ Submember = 'UnderlineOff' }
+        @{ Submember = 'Underline' }
+        @{ Submember = 'StrikethroughOff' }
+        @{ Submember = 'Strikethrough' }
+        @{ Member = 'Formatting'; Submember = 'FormatAccent' }
+        @{ Member = 'Formatting'; Submember = 'TableHeader' }
+        @{ Member = 'Formatting'; Submember = 'ErrorAccent' }
+        @{ Member = 'Formatting'; Submember = 'Error' }
+        @{ Member = 'Formatting'; Submember = 'Warning' }
+        @{ Member = 'Formatting'; Submember = 'Verbose' }
+        @{ Member = 'Formatting'; Submember = 'Debug' }
+        @{ Member = 'Progress'; Submember = 'Style' }
+        @{ Member = 'FileInfo'; Submember = 'Directory' }
+        @{ Member = 'FileInfo'; Submember = 'SymbolicLink' }
+        @{ Member = 'FileInfo'; Submember = 'Executable' }
+        @{ Member = 'FileInfo'; Submember = 'Hidden' }
+    ) {
+        param ($member, $submember)
+
+        if ($null -ne $member) {
+            { $PSStyle.$member.$submember = $PSStyle.Foreground.Red + 'hello' } | Should -Throw
+        }
+        else {
+            { $PSStyle.$submember = $PSStyle.Foreground.Red + 'hello' } | Should -Throw
+        }
+    }
+
+    It 'Should fail adding extension formatting with printable characters' {
+        { $PSStyle.FileInfo.Extension.Add('.md', 'hello') } | Should -Throw
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Currently, if you set custom formatting like `$PSStyle.Formatting.Error` and include printable characters (that is text other than an ANSI escape sequence), this can mess up the formatting which expects the formatting string to not take up any buffercells.  The change is to add validation that the set text is only decoration and does not include characters that would print on screen as plain text.

Also added validation to `Add()` and `Remove()` to require period prefix which is used during formatting.

Also fixed an error in the formatting which incorrectly prefixed `Verbose` as `Formatting.Verbose` in the output.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
