### PR TITLE
Fix ErrorActionPreference not being respected from throw site when reset in finally block

### DIFF
--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -1651,6 +1651,15 @@ namespace System.Management.Automation
             }
             else if (ExceptionCannotBeStoppedContinuedOrIgnored(rte, context))
             {
+                // If we throw this error but don't mark it for prompt suppression
+                // it might be recaught later when the error action preference has changed.
+                // Instead we need to mark it here to preserve the EAP semantics from
+                // where it was originally thrown
+                if (preference == ActionPreference.Stop)
+                {
+                    rte.SuppressPromptInInterpreter = true;
+                }
+
                 throw rte;
             }
             else if (preference == ActionPreference.Inquire && !rte.SuppressPromptInInterpreter)

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -1667,21 +1667,19 @@ namespace System.Management.Automation
                 preference = InquireForActionPreference(rte.Message, context);
             }
 
-            if ((preference == ActionPreference.SilentlyContinue) ||
-                (preference == ActionPreference.Ignore))
+            switch (preference)
             {
-                return;
-            }
+                case ActionPreference.SilentlyContinue:
+                case ActionPreference.Ignore:
+                    return;
 
-            if (preference == ActionPreference.Stop)
-            {
-                // The interpreter prompt CommandBaseStrings:InquireHalt
-                // should be suppressed when this flag is set.  This will be set
-                // when this prompt has already occurred and Break was chosen,
-                // or for ActionPreferenceStopException in all cases.
-                rte.SuppressPromptInInterpreter = true;
-
-                throw rte;
+                case ActionPreference.Stop:
+                    // The interpreter prompt CommandBaseStrings:InquireHalt
+                    // should be suppressed when this flag is set.  This will be set
+                    // when this prompt has already occurred and Break was chosen,
+                    // or for ActionPreferenceStopException in all cases.
+                    rte.SuppressPromptInInterpreter = true;
+                    throw rte;
             }
 
             if (!anyTrapHandlers && rte.WasThrownFromThrowStatement)

--- a/test/powershell/Language/Scripting/ActionPreference.Tests.ps1
+++ b/test/powershell/Language/Scripting/ActionPreference.Tests.ps1
@@ -209,6 +209,9 @@ Describe "Tests for (error, warning, etc) action preference" -Tags "CI" {
     }
 
     It 'Correctly interprets ErrorActionPreference on Write-Error when it''s reset in a finally block' {
+        $completedCommand = $false
+        $completedFinally = $false
+
         try
         {
             $oldEAP = $ErrorActionPreference
@@ -217,10 +220,12 @@ Describe "Tests for (error, warning, etc) action preference" -Tags "CI" {
             try
             {
                 Write-Error 'error'
+                $completedCommand = $true
             }
             finally
             {
                 $ErrorActionPreference = $oldEAP
+                $completedFinally = $true
             }
         }
         catch
@@ -230,9 +235,14 @@ Describe "Tests for (error, warning, etc) action preference" -Tags "CI" {
 
         $err.FullyQualifiedErrorId | Should -BeExactly 'Microsoft.PowerShell.Commands.WriteErrorException'
         $err.Exception.Message | Should -BeExactly 'error'
+        $completedCommand | Should -BeFalse
+        $completedFinally | Should -BeTrue
     }
 
     It 'Correctly interprets ErrorActionPreference on a parameter binding error when it''s reset in a finally block' {
+        $completedCommand = $false
+        $completedFinally = $false
+
         try
         {
             $oldEAP = $ErrorActionPreference
@@ -241,10 +251,12 @@ Describe "Tests for (error, warning, etc) action preference" -Tags "CI" {
             try
             {
                 Get-Process -Banana
+                $completedCommand = $true
             }
             finally
             {
                 $ErrorActionPreference = $oldEAP
+                $completedFinally = $true
             }
         }
         catch
@@ -256,6 +268,8 @@ Describe "Tests for (error, warning, etc) action preference" -Tags "CI" {
         $err.CategoryInfo.Activity | Should -BeExactly 'Get-Process'
         $err.CategoryInfo.Category | Should -BeExactly 'InvalidArgument'
         $err.CategoryInfo.Reason   | Should -BeExactly 'ParameterBindingException'
+        $completedCommand | Should -BeFalse
+        $completedFinally | Should -BeTrue
     }
 }
 

--- a/test/powershell/Language/Scripting/ActionPreference.Tests.ps1
+++ b/test/powershell/Language/Scripting/ActionPreference.Tests.ps1
@@ -253,7 +253,8 @@ Describe "Tests for (error, warning, etc) action preference" -Tags "CI" {
         }
 
         $err.FullyQualifiedErrorId | Should -BeExactly 'NamedParameterNotFound,Microsoft.PowerShell.Commands.GetProcessCommand'
-        $err.CategoryInfo.Activity | Should -BeExactly 'InvalidArgument'
+        $err.CategoryInfo.Activity | Should -BeExactly 'Get-Process'
+        $err.CategoryInfo.Category | Should -BeExactly 'InvalidArgument'
         $err.CategoryInfo.Reason   | Should -BeExactly 'ParameterBindingException'
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes https://github.com/PowerShell/PowerShell/issues/15726.

When an error is thrown due to `$ErrorActionPreference = 'Stop'`, we now mark it at the first opportunity to prevent having the action preference re-interpreted at a later stage (so that a finally block changing the value won't cause the error to be quietly downgraded). 

Labelled as a breaking change because the existing behaviour is observable, but I think is a bucket-3 corner case behaviour that users would experience as a bug. Of note is that ordinary errors written with the `WriteError()` API will exhibit the correct behaviour, and this change just ensures that all other errors behave the same way.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
