### PR TITLE
Partially revert changes to `src/Microsoft.Management.UI.Internal/`

### DIFF
--- a/src/Microsoft.Management.UI.Internal/HelpWindow/HelpViewModel.cs
+++ b/src/Microsoft.Management.UI.Internal/HelpWindow/HelpViewModel.cs
@@ -4,7 +4,6 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Management.Automation;
 using System.Windows.Documents;
@@ -274,13 +273,11 @@ namespace Microsoft.Management.UI.Internal
         /// <param name="propertyName">Property name.</param>
         private void OnNotifyPropertyChanged(string propertyName)
         {
-            #pragma warning disable IDE1005 // IDE1005: Delegate invocation can be simplified.
             PropertyChangedEventHandler handler = this.PropertyChanged;
             if (handler != null)
             {
                 handler(this, new PropertyChangedEventArgs(propertyName));
             }
-            #pragma warning restore IDE1005s
         }
     }
 }

--- a/src/Microsoft.Management.UI.Internal/HelpWindow/ParagraphBuilder.cs
+++ b/src/Microsoft.Management.UI.Internal/HelpWindow/ParagraphBuilder.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Windows.Documents;
 using System.Windows.Media;
@@ -108,15 +107,10 @@ namespace Microsoft.Management.UI.Internal
                 bool newHighlighted = false;
 
                 ParagraphBuilder.MoveSpanToPosition(ref currentBoldIndex, ref currentBoldSpan, i, this.boldSpans);
-
-                #pragma warning disable IDE0075 // IDE0075: Conditional expression can be simplified
                 newBold = currentBoldSpan == null ? false : currentBoldSpan.Value.Contains(i);
-                #pragma warning restore IDE0075
 
                 ParagraphBuilder.MoveSpanToPosition(ref currentHighlightedIndex, ref currentHighlightedSpan, i, this.highlightedSpans);
-                #pragma warning disable IDE0075 // IDE0075: Conditional expression can be simplified
                 newHighlighted = currentHighlightedSpan == null ? false : currentHighlightedSpan.Value.Contains(i);
-                #pragma warning restore IDE0075
 
                 if (newBold != currentBold || newHighlighted != currentHighlighted)
                 {
@@ -307,13 +301,11 @@ namespace Microsoft.Management.UI.Internal
         /// <param name="propertyName">Property name.</param>
         private void OnNotifyPropertyChanged(string propertyName)
         {
-            #pragma warning disable IDE1005 // IDE1005: Delegate invocation can be simplified.s
             PropertyChangedEventHandler handler = this.PropertyChanged;
             if (handler != null)
             {
                 handler(this, new PropertyChangedEventArgs(propertyName));
             }
-            #pragma warning restore IDE1005
         }
 
         /// <summary>

--- a/src/Microsoft.Management.UI.Internal/ManagementList/Common/DismissiblePopup.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/Common/DismissiblePopup.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Windows;
 using System.Windows.Automation;
 using System.Windows.Controls.Primitives;
@@ -80,7 +79,6 @@ namespace Microsoft.Management.UI.Internal
             }
         }
 
-        [SuppressMessage("Performance", "CA1822: Mark members as static", Justification = "Potential breaking change")]
         private void SetFocus(UIElement element)
         {
             if (element.Focusable)

--- a/src/Microsoft.Management.UI.Internal/ManagementList/Common/ListOrganizerItem.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/Common/ListOrganizerItem.cs
@@ -35,9 +35,7 @@ namespace Microsoft.Management.UI.Internal
         {
             get
             {
-                #pragma warning disable IDE0075 // IDE0075: Conditional expression can be simplified
                 return (this.renameButton != null) ? this.renameButton.IsChecked.Value : false;
-                #pragma warning restore IDE0075
             }
         }
 

--- a/src/Microsoft.Management.UI.Internal/ManagementList/Common/ReadOnlyObservableAsyncCollection.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/Common/ReadOnlyObservableAsyncCollection.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Management.UI.Internal
 {
@@ -98,8 +97,6 @@ namespace Microsoft.Management.UI.Internal
         #endregion IAsyncProgress
 
         #region Private Methods
-
-        #pragma warning disable IDE1005 // IDE1005: Delegate invocation can be simplified.
         private void OnCollectionChanged(NotifyCollectionChangedEventArgs args)
         {
             NotifyCollectionChangedEventHandler eh = this.CollectionChanged;
@@ -119,8 +116,6 @@ namespace Microsoft.Management.UI.Internal
                 eh(this, args);
             }
         }
-
-        #pragma warning restore IDE1005
 
         // forward CollectionChanged events from the base list to our listeners
         private void HandleCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)

--- a/src/Microsoft.Management.UI.Internal/ManagementList/CommonControls/Resizer.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/CommonControls/Resizer.cs
@@ -4,7 +4,6 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -203,7 +202,6 @@ namespace Microsoft.Management.UI.Internal
             return this.GetConstrainedValue(newWidth, this.MaxWidth, this.MinWidth);
         }
 
-        [SuppressMessage("Performance", "CA1822: Mark members as static", Justification = "Potential breaking change")]
         private double GetHorizontalDelta(ResizeGripLocation location, double horzDelta)
         {
             double realDelta;
@@ -221,7 +219,6 @@ namespace Microsoft.Management.UI.Internal
             return realDelta;
         }
 
-        [SuppressMessage("Performance", "CA1822: Mark members as static", Justification = "Potential breaking change")]
         private double GetConstrainedValue(double value, double max, double min)
         {
             return Math.Min(max, Math.Max(value, min));

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/DefaultFilterRuleCustomizationFactory.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/DefaultFilterRuleCustomizationFactory.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 
@@ -197,7 +196,6 @@ namespace Microsoft.Management.UI.Internal
 
         #region Helpers
 
-        [SuppressMessage("Performance", "CA1822: Mark members as static", Justification = "Potential breaking change")]
         private bool TryGetGenericParameterForComparableValueFilterRule(FilterRule rule, out Type genericParameter)
         {
             genericParameter = null;
@@ -219,7 +217,6 @@ namespace Microsoft.Management.UI.Internal
             return true;
         }
 
-        [SuppressMessage("Performance", "CA1822: Mark members as static", Justification = "Potential breaking change")]
         private object GetValueFromValidatingValue(FilterRule rule, string propertyName)
         {
             Debug.Assert(rule != null && !string.IsNullOrEmpty(propertyName), "rule and propertyname are not null");
@@ -239,7 +236,6 @@ namespace Microsoft.Management.UI.Internal
             return property.GetValue(validatingValue, null);
         }
 
-        [SuppressMessage("Performance", "CA1822: Mark members as static", Justification = "Potential breaking change")]
         private void SetValueOnValidatingValue(FilterRule rule, string propertyName, object value)
         {
             Debug.Assert(rule != null && !string.IsNullOrEmpty(propertyName), "rule and propertyname are not null");

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterEvaluator.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterEvaluator.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Management.UI.Internal
 {
@@ -174,8 +173,6 @@ namespace Microsoft.Management.UI.Internal
 
         #region NotifyPropertyChanged
 
-        #pragma warning disable IDE1005 // IDE1005: Delegate invocation can be simplified.
-
         /// <summary>
         /// Notifies listeners that a property has changed.
         /// </summary>
@@ -216,8 +213,6 @@ namespace Microsoft.Management.UI.Internal
                 eh(this, new EventArgs());
             }
         }
-
-        #pragma warning restore IDE1005
 
         private void FilterProvider_FilterExpressionChanged(object sender, EventArgs e)
         {

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/ValidatingValue.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/ValidatingValue.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 namespace Microsoft.Management.UI.Internal
@@ -191,7 +190,6 @@ namespace Microsoft.Management.UI.Internal
             }
         }
 
-        [SuppressMessage("Performance", "CA1822: Mark members as static", Justification = "Potential breaking change")]
         private bool TryGetEnumValue(object rawValue, out T castValue)
         {
             Debug.Assert(rawValue != null, "rawValue not null");

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/AddFilterRulePicker.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/AddFilterRulePicker.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
 using System.Windows.Controls;
 
 namespace Microsoft.Management.UI.Internal
@@ -50,11 +49,9 @@ namespace Microsoft.Management.UI.Internal
 
         partial void OnOkAddFilterRulesCanExecuteImplementation(System.Windows.Input.CanExecuteRoutedEventArgs e)
         {
-            #pragma warning disable IDE0075 // IDE0075: Conditional expression can be simplified
             e.CanExecute = (this.AddFilterRulesCommand != null)
                 ? CommandHelper.CanExecuteCommand(this.AddFilterRulesCommand, null, this.AddFilterRulesCommandTarget)
                 : false;
-            #pragma warning restore IDE0075
         }
 
         partial void OnOkAddFilterRulesExecutedImplementation(System.Windows.Input.ExecutedRoutedEventArgs e)

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/InputFieldBackgroundTextConverter.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/InputFieldBackgroundTextConverter.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 using System.Windows.Data;
@@ -70,7 +69,6 @@ namespace Microsoft.Management.UI.Internal
 
         #region Helpers
 
-        [SuppressMessage("Performance", "CA1822: Mark members as static", Justification = "Potential breaking change")]
         private bool IsOfTypeValidatingValue(object value)
         {
             Debug.Assert(value != null, "not null");
@@ -94,7 +92,6 @@ namespace Microsoft.Management.UI.Internal
             return value.GetType().GetGenericArguments()[0];
         }
 
-        [SuppressMessage("Performance", "CA1822: Mark members as static", Justification = "Potential breaking change")]
         private object GetBackgroundTextForType(Type inputType)
         {
             if (typeof(DateTime) == inputType)

--- a/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/Innerlist.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/Innerlist.cs
@@ -8,7 +8,6 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 using System.Windows;
@@ -402,14 +401,12 @@ namespace Microsoft.Management.UI.Internal
         /// <returns>The exception to be thrown when using Items.</returns>
         private static NotSupportedException GetItemsException()
         {
-            #pragma warning disable IDE1005 // IDE1005: Delegate invocation can be simplified.
             return new NotSupportedException(
                 string.Format(
                     CultureInfo.InvariantCulture,
                     InvariantResources.NotSupportAddingToItems,
                     nameof(InnerList),
                     ItemsControl.ItemsSourceProperty.Name));
-            #pragma warning restore IDE1005s
         }
         #endregion static private methods
 
@@ -608,7 +605,6 @@ namespace Microsoft.Management.UI.Internal
             return entryText.ToString();
         }
 
-        [SuppressMessage("Performance", "CA1822: Mark members as static", Justification = "Potential breaking change")]
         private void SetClipboardWithSelectedItemsText(string text)
         {
             if (string.IsNullOrEmpty(text))

--- a/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/PropertyValueComparer.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/PropertyValueComparer.cs
@@ -6,7 +6,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Management.Automation;
 
 namespace Microsoft.Management.UI.Internal
@@ -89,7 +88,6 @@ namespace Microsoft.Management.UI.Internal
             }
         }
 
-        [SuppressMessage("Performance", "CA1822: Mark members as static", Justification = "Potential breaking change")]
         private int CompareData(object firstValue, object secondValue, StringComparison stringComparison)
         {
             // If both values are null, do nothing; otherwise, if one is null promote the other \\

--- a/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/PropertyValueGetter.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/PropertyValueGetter.cs
@@ -4,7 +4,6 @@
 using System;
 using System.ComponentModel;
 using System.Data;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 namespace Microsoft.Management.UI.Internal
@@ -111,7 +110,6 @@ namespace Microsoft.Management.UI.Internal
             return descriptor;
         }
 
-        [SuppressMessage("Performance", "CA1822: Mark members as static", Justification = "Potential breaking change")]
         private bool TryGetPropertyValueInternal(PropertyDescriptor descriptor, object value, out object propertyValue)
         {
             propertyValue = null;

--- a/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/managementlist.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/managementlist.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
@@ -309,7 +308,6 @@ namespace Microsoft.Management.UI.Internal
 
         #region View Manager Callbacks
 
-        [SuppressMessage("Performance", "CA1822: Mark members as static", Justification = "Potential breaking change")]
         partial void OnSaveViewCanExecuteImplementation(CanExecuteRoutedEventArgs e)
         {
             string viewName = (string)e.Parameter;

--- a/src/Microsoft.Management.UI.Internal/ShowCommand/Controls/ParameterSetControl.xaml.cs
+++ b/src/Microsoft.Management.UI.Internal/ShowCommand/Controls/ParameterSetControl.xaml.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Management.Automation;
 using System.Windows;
@@ -345,7 +344,6 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
         /// Creates a RowDefinition for MainGrid.
         /// </summary>
         /// <returns>Return a RowDefinition object.</returns>
-        [SuppressMessage("Performance", "CA1822: Mark members as static", Justification = "Potential breaking change")]
         private RowDefinition CreateNewRow()
         {
             RowDefinition row = new RowDefinition();
@@ -384,7 +382,6 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
         /// <param name="parameterViewModel">DataContext object.</param>
         /// <param name="rowNumber">Row number.</param>
         /// <returns>Return a Label control.</returns>
-        [SuppressMessage("Performance", "CA1822: Mark members as static", Justification = "Potential breaking change")]
         private Label CreateLabel(ParameterViewModel parameterViewModel, int rowNumber)
         {
             Label label = new Label();

--- a/src/Microsoft.Management.UI.Internal/ShowCommand/ViewModel/AllModulesViewModel.cs
+++ b/src/Microsoft.Management.UI.Internal/ShowCommand/ViewModel/AllModulesViewModel.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Management.Automation;
@@ -80,12 +79,10 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
         /// <param name="commands">Commands to show.</param>
         public AllModulesViewModel(Dictionary<string, ShowCommandModuleInfo> importedModules, IEnumerable<ShowCommandCommandInfo> commands)
         {
-            #pragma warning disable IDE0075 // IDE0075: Conditional expression can be simplified
             if (commands == null || !commands.GetEnumerator().MoveNext())
             {
                 throw new ArgumentNullException("commands");
             }
-            #pragma warning disable IDE0075 // IDE0075: Conditional expression can be simplified
 
             this.Initialization(importedModules, commands, true);
         }
@@ -403,13 +400,11 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
         /// </summary>
         internal void OnRefresh()
         {
-            #pragma warning disable IDE1005 // IDE1005: Delegate invocation can be simplified.
             EventHandler<EventArgs> handler = this.Refresh;
             if (handler != null)
             {
                 handler(this, new EventArgs());
             }
-            #pragma warning restore IDE1005s
         }
 
         #region Private Methods
@@ -598,8 +593,6 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
             this.OnSelectedCommandInSelectedModuleNeedsImportModule(e);
         }
 
-        #pragma warning disable IDE1005 // IDE1005: Delegate invocation can be simplified.
-
         /// <summary>
         /// Triggers SelectedCommandInSelectedModuleNeedsHelp.
         /// </summary>
@@ -661,8 +654,6 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
                 handler(this, new PropertyChangedEventArgs(propertyName));
             }
         }
-
-        #pragma warning restore IDE1005s
         #endregion
     }
 }

--- a/src/Microsoft.Management.UI.Internal/ShowCommand/ViewModel/ModuleViewModel.cs
+++ b/src/Microsoft.Management.UI.Internal/ShowCommand/ViewModel/ModuleViewModel.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
 using System.Management.Automation;
 using System.Windows;
 
@@ -77,8 +76,6 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
             this.commands = new List<CommandViewModel>();
             this.filteredCommands = new ObservableCollection<CommandViewModel>();
 
-            #pragma warning disable IDE0075 // IDE0075: Conditional expression can be simplified
-
             // This check looks to see if the given module name shows up in
             // the set of modules that are known to be imported in the current
             // session.  In remote PowerShell sessions, the core cmdlet module
@@ -89,8 +86,6 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
                 importedModules == null ? true : name.Length == 0 ||
                 importedModules.ContainsKey(name) ||
                 string.Equals("Microsoft.PowerShell.Core", name, StringComparison.OrdinalIgnoreCase);
-
-            #pragma warning restore IDE0075
         }
         #endregion
 
@@ -377,8 +372,6 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
             }
         }
 
-        #pragma warning disable IDE1005 // IDE1005: Delegate invocation can be simplified.
-
         /// <summary>
         /// Callled in response to a GUI event that requires the command to be run.
         /// </summary>
@@ -534,7 +527,5 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
                 handler(this, new PropertyChangedEventArgs(propertyName));
             }
         }
-
-        #pragma warning restore IDE1005
     }
 }

--- a/src/Microsoft.Management.UI.Internal/commandHelpers/OutGridView.cs
+++ b/src/Microsoft.Management.UI.Internal/commandHelpers/OutGridView.cs
@@ -246,7 +246,6 @@ namespace Microsoft.Management.UI.Internal
         /// </summary>
         /// <param name="outputMode">Output mode of the out-gridview.</param>
         /// <returns>A new ManagementList.</returns>
-        [SuppressMessage("Performance", "CA1822: Mark members as static", Justification = "Potential breaking change")]
         private ManagementList CreateManagementList(string outputMode)
         {
             ManagementList newList = new ManagementList();

--- a/src/Microsoft.Management.UI.Internal/commandHelpers/ShowCommandHelper.cs
+++ b/src/Microsoft.Management.UI.Internal/commandHelpers/ShowCommandHelper.cs
@@ -643,9 +643,7 @@ Function PSGetSerializedShowCommandInfo
             ModuleViewModel moduleToSelect = returnValue.Modules.Find(
                 new Predicate<ModuleViewModel>((module) =>
                 {
-                    #pragma warning disable IDE0075 // IDE0075: Conditional expression can be simplified
-                    return module.Name.Equals(selectedModuleNeedingImportModule, StringComparison.OrdinalIgnoreCase);
-                    #pragma warning restore IDE0075
+                    return module.Name.Equals(selectedModuleNeedingImportModule, StringComparison.OrdinalIgnoreCase) ? true : false;
                 }));
 
             if (moduleToSelect == null)
@@ -659,7 +657,7 @@ Function PSGetSerializedShowCommandInfo
                 new Predicate<CommandViewModel>((command) =>
                 {
                     return command.ModuleName.Equals(parentModuleNeedingImportModule, StringComparison.OrdinalIgnoreCase) &&
-                        command.Name.Equals(commandNeedingImportModule, StringComparison.OrdinalIgnoreCase);
+                        command.Name.Equals(commandNeedingImportModule, StringComparison.OrdinalIgnoreCase) ? true : false;
                 }));
 
             if (commandToSelect == null)
@@ -1246,7 +1244,6 @@ Function PSGetSerializedShowCommandInfo
         /// Showing a MessageBox when user type a invalidate command name.
         /// </summary>
         /// <param name="errorString">Error message.</param>
-        [SuppressMessage("Performance", "CA1822: Mark members as static", Justification = "Potential breaking change")]
         private void ShowErrorString(string errorString)
         {
             if (errorString != null && errorString.Trim().Length > 0)


### PR DESCRIPTION
Partially revert 7ead1374072c2664f5830fceb6b281a500196d0a.

#15452 made changes to frozen code to fix the build, but since #15677 we skip analyzers for `src/Microsoft.Management.UI.Internal/Microsoft.PowerShell.GraphicalHost.csproj`

cc: @iSazonov