### PR TITLE
Fix `CA1052` in `TypeCatalogGen`

### DIFF
--- a/src/TypeCatalogGen/TypeCatalogGen.cs
+++ b/src/TypeCatalogGen/TypeCatalogGen.cs
@@ -27,7 +27,7 @@ using System.Text;
 
 namespace Microsoft.PowerShell.CoreCLR
 {
-    public class TypeCatalogGen
+    public static class TypeCatalogGen
     {
         // Help messages
         private const string Param_TargetCSharpFilePath = "TargetCSharpFilePath";

--- a/src/TypeCatalogGen/TypeCatalogGen.csproj
+++ b/src/TypeCatalogGen/TypeCatalogGen.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <Description>Generates CorePsTypeCatalog.cs given powershell.inc</Description>
     <TargetFramework>net6.0</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>TypeCatalogGen</AssemblyName>
     <OutputType>Exe</OutputType>
     <TieredCompilation>true</TieredCompilation>


### PR DESCRIPTION
* Fix [CA1052: Static holder types should be Static or NotInheritable](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052) in `Microsoft.PowerShell.CoreCLR.TypeCatalogGen`
* Enable `TreatWarningsAsErrors` for `TypeCatalogGen.csproj`

In #15775, we missed a warning as `TreatWarningsAsErrors` was not enabled.

Again, possible breaking public API change (Unlikely Grey Area), however instantiating the class has no obvious utility and furthermore the API doesn't appear to be publicly documented.