### PR TITLE
Convert `SessionStateScopeEnumerator` to struct

### DIFF
--- a/src/System.Management.Automation/engine/ScopedItemSearcher.cs
+++ b/src/System.Management.Automation/engine/ScopedItemSearcher.cs
@@ -135,8 +135,6 @@ namespace System.Management.Automation
         public void Dispose()
         {
             _current = default(T);
-            _scopeEnumerable.Dispose();
-            _scopeEnumerable = null;
             _isInitialized = false;
             GC.SuppressFinalize(this);
         }

--- a/src/System.Management.Automation/engine/SessionStateScopeEnumerator.cs
+++ b/src/System.Management.Automation/engine/SessionStateScopeEnumerator.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace System.Management.Automation
 {
-    internal sealed class SessionStateScopeEnumerator : IEnumerator<SessionStateScope>, IEnumerable<SessionStateScope>
+    internal struct SessionStateScopeEnumerator : IEnumerator<SessionStateScope>, IEnumerable<SessionStateScope>
     {
         /// <summary>
         /// Constructs an enumerator for enumerating through the session state scopes
@@ -19,6 +19,7 @@ namespace System.Management.Automation
         {
             Diagnostics.Assert(scope != null, "Caller to verify scope argument");
             _initialScope = scope;
+            _currentEnumeratedScope = null;
         }
 
         /// <summary>
@@ -94,7 +95,7 @@ namespace System.Management.Automation
 
         public void Dispose()
         {
-            Reset();
+            // Nothing to dispose
         }
 
         private readonly SessionStateScope _initialScope;

--- a/src/System.Management.Automation/engine/SessionStateScopeEnumerator.cs
+++ b/src/System.Management.Automation/engine/SessionStateScopeEnumerator.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using System.Collections;
 using System.Collections.Generic;
 
@@ -99,6 +101,6 @@ namespace System.Management.Automation
         }
 
         private readonly SessionStateScope _initialScope;
-        private SessionStateScope _currentEnumeratedScope;
+        private SessionStateScope? _currentEnumeratedScope;
     }
 }


### PR DESCRIPTION
Fix [HLQ006: GetEnumerator() and GetAsyncEnumerator() should return an instance of a value-typed enumerator](https://github.com/NetFabric/NetFabric.Hyperlinq.Analyzer/blob/master/docs/reference/HLQ006_GetEnumeratorReturnType.md)