### PR TITLE
Only allow `-File` to accept `.ps1` scripts on Windows

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -1159,6 +1159,16 @@ namespace Microsoft.PowerShell
                         showHelp: true);
                     return false;
                 }
+#if !UNIX
+                // Only do the .ps1 extension check on Windows since shebang is not supported
+                else if (!Path.GetExtension(_file).Equals(".ps1", StringComparison.OrdinalIgnoreCase))
+                {
+                    SetCommandLineError(
+                        string.Format(CultureInfo.CurrentCulture, CommandLineParameterParserStrings.InvalidFileArgumentExtension, args[i]),
+                        showBanner: false);
+                    return false;
+                }
+#endif
 
                 i++;
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -1161,7 +1161,7 @@ namespace Microsoft.PowerShell
                 }
 #if !UNIX
                 // Only do the .ps1 extension check on Windows since shebang is not supported
-                else if (!_file.EndsWith(".ps1", StringComparison.OrdinalIgnoreCase))
+                if (!_file.EndsWith(".ps1", StringComparison.OrdinalIgnoreCase))
                 {
                     SetCommandLineError(string.Format(CultureInfo.CurrentCulture, CommandLineParameterParserStrings.InvalidFileArgumentExtension, args[i]));
                     return false;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -1163,9 +1163,7 @@ namespace Microsoft.PowerShell
                 // Only do the .ps1 extension check on Windows since shebang is not supported
                 else if (!Path.GetExtension(_file).Equals(".ps1", StringComparison.OrdinalIgnoreCase))
                 {
-                    SetCommandLineError(
-                        string.Format(CultureInfo.CurrentCulture, CommandLineParameterParserStrings.InvalidFileArgumentExtension, args[i]),
-                        showBanner: false);
+                    SetCommandLineError(string.Format(CultureInfo.CurrentCulture, CommandLineParameterParserStrings.InvalidFileArgumentExtension, args[i]));
                     return false;
                 }
 #endif

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -1161,7 +1161,7 @@ namespace Microsoft.PowerShell
                 }
 #if !UNIX
                 // Only do the .ps1 extension check on Windows since shebang is not supported
-                else if (!Path.GetExtension(_file).Equals(".ps1", StringComparison.OrdinalIgnoreCase))
+                else if (!_file.EndsWith(".ps1", StringComparison.OrdinalIgnoreCase))
                 {
                     SetCommandLineError(string.Format(CultureInfo.CurrentCulture, CommandLineParameterParserStrings.InvalidFileArgumentExtension, args[i]));
                     return false;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -1857,6 +1857,7 @@ namespace Microsoft.PowerShell
 
                 Pipeline tempPipeline = exec.CreatePipeline();
                 Command c;
+#if UNIX
                 // if file doesn't have .ps1 extension, we read the contents and treat it as a script to support shebang with no .ps1 extension usage
                 if (!Path.GetExtension(filePath).Equals(".ps1", StringComparison.OrdinalIgnoreCase))
                 {
@@ -1864,6 +1865,7 @@ namespace Microsoft.PowerShell
                     c = new Command(script, isScript: true, useLocalScope: false);
                 }
                 else
+#endif
                 {
                     c = new Command(filePath, false, false);
                 }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -1859,7 +1859,7 @@ namespace Microsoft.PowerShell
                 Command c;
 #if UNIX
                 // if file doesn't have .ps1 extension, we read the contents and treat it as a script to support shebang with no .ps1 extension usage
-                if (!Path.GetExtension(filePath).Equals(".ps1", StringComparison.OrdinalIgnoreCase))
+                if (!filePath.EndsWith(".ps1", StringComparison.OrdinalIgnoreCase))
                 {
                     string script = File.ReadAllText(filePath);
                     c = new Command(script, isScript: true, useLocalScope: false);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

A change was made previously to support shebang on Linux to accept files without requiring .ps1 extension.  However, Windows doesn't support shebang, so we should be consistent with Windows PowerShell and only allow for scripts with .ps1 extension. 

Fix is to update consolehost `-File` parsing path to check if the file has a `.ps1` extension on Windows and return an error.
A bunch of tests had to be updated with the new behavior.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/7904
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
