### PR TITLE
Make PS-Committee reviewed experimental features stable

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/DebugRunspaceCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/DebugRunspaceCommand.cs
@@ -103,7 +103,6 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Gets or sets a flag that tells PowerShell to automatically perform a BreakAll when the debugger is attached to the remote target.
         /// </summary>
-        [Experimental("Microsoft.PowerShell.Utility.PSManageBreakpointsInRunspace", ExperimentAction.Show)]
         [Parameter]
         public SwitchParameter BreakAll { get; set; }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImportPowerShellDataFile.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImportPowerShellDataFile.cs
@@ -42,7 +42,6 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Gets or sets switch that determines if built-in limits are applied to the data.
         /// </summary>
-        [Experimental("Microsoft.PowerShell.Utility.PSImportPSDataFileSkipLimitCheck", ExperimentAction.Show)]
         [Parameter]
         public SwitchParameter SkipLimitCheck { get; set; }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/PSBreakpointCommandBase.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/PSBreakpointCommandBase.cs
@@ -16,7 +16,6 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Gets or sets the runspace where the breakpoints will be used.
         /// </summary>
-        [Experimental("Microsoft.PowerShell.Utility.PSManageBreakpointsInRunspace", ExperimentAction.Show)]
         [Parameter]
         [ValidateNotNull]
         [Runspace]

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -63,29 +63,26 @@ namespace Microsoft.PowerShell
             SupportsVirtualTerminal = true;
             _isInteractiveTestToolListening = false;
 
-            if (ExperimentalFeature.IsEnabled("PSAnsiRendering"))
+            // check if TERM env var is set
+            // `dumb` means explicitly don't use VT
+            // `xterm-mono` and `xtermm` means support VT, but emit plaintext
+            switch (Environment.GetEnvironmentVariable("TERM"))
             {
-                // check if TERM env var is set
-                // `dumb` means explicitly don't use VT
-                // `xterm-mono` and `xtermm` means support VT, but emit plaintext
-                switch (Environment.GetEnvironmentVariable("TERM"))
-                {
-                    case "dumb":
-                        SupportsVirtualTerminal = false;
-                        break;
-                    case "xterm-mono":
-                    case "xtermm":
-                        PSStyle.Instance.OutputRendering = OutputRendering.PlainText;
-                        break;
-                    default:
-                        break;
-                }
-
-                // widely supported by CLI tools via https://no-color.org/
-                if (Environment.GetEnvironmentVariable("NO_COLOR") != null)
-                {
+                case "dumb":
+                    SupportsVirtualTerminal = false;
+                    break;
+                case "xterm-mono":
+                case "xtermm":
                     PSStyle.Instance.OutputRendering = OutputRendering.PlainText;
-                }
+                    break;
+                default:
+                    break;
+            }
+
+            // widely supported by CLI tools via https://no-color.org/
+            if (Environment.GetEnvironmentVariable("NO_COLOR") != null)
+            {
+                PSStyle.Instance.OutputRendering = OutputRendering.PlainText;
             }
 
             if (SupportsVirtualTerminal)
@@ -1216,7 +1213,7 @@ namespace Microsoft.PowerShell
             }
             else
             {
-                if (SupportsVirtualTerminal && ExperimentalFeature.IsEnabled("PSAnsiRendering"))
+                if (SupportsVirtualTerminal)
                 {
                     WriteLine(Utils.GetFormatStyleString(Utils.FormatStyle.Debug) + StringUtil.Format(ConsoleHostUserInterfaceStrings.DebugFormatString, message) + PSStyle.Instance.Reset);
                 }
@@ -1277,7 +1274,7 @@ namespace Microsoft.PowerShell
             }
             else
             {
-                if (SupportsVirtualTerminal && ExperimentalFeature.IsEnabled("PSAnsiRendering"))
+                if (SupportsVirtualTerminal)
                 {
                     WriteLine(Utils.GetFormatStyleString(Utils.FormatStyle.Verbose) + StringUtil.Format(ConsoleHostUserInterfaceStrings.VerboseFormatString, message) + PSStyle.Instance.Reset);
                 }
@@ -1321,7 +1318,7 @@ namespace Microsoft.PowerShell
             }
             else
             {
-                if (SupportsVirtualTerminal && ExperimentalFeature.IsEnabled("PSAnsiRendering"))
+                if (SupportsVirtualTerminal)
                 {
                     WriteLine(Utils.GetFormatStyleString(Utils.FormatStyle.Warning) + StringUtil.Format(ConsoleHostUserInterfaceStrings.WarningFormatString, message) + PSStyle.Instance.Reset);
                 }
@@ -1393,7 +1390,7 @@ namespace Microsoft.PowerShell
             {
                 if (writer == _parent.ConsoleTextWriter)
                 {
-                    if (SupportsVirtualTerminal && ExperimentalFeature.IsEnabled("PSAnsiRendering"))
+                    if (SupportsVirtualTerminal)
                     {
                         WriteLine(value);
                     }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceProgress.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceProgress.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PowerShell
 
                 _pendingProgress = null;
 
-                if (SupportsVirtualTerminal && ExperimentalFeature.IsEnabled(ExperimentalFeature.PSAnsiProgressFeatureName) && PSStyle.Instance.Progress.UseOSCIndicator)
+                if (SupportsVirtualTerminal && PSStyle.Instance.Progress.UseOSCIndicator)
                 {
                     // OSC sequence to turn off progress indicator
                     // https://github.com/microsoft/terminal/issues/6700
@@ -99,7 +99,7 @@ namespace Microsoft.PowerShell
             {
                 // Update the progress pane only when the timer set up the update flag or WriteProgress is completed.
                 // As a result, we do not block WriteProgress and whole script and eliminate unnecessary console locks and updates.
-                if (SupportsVirtualTerminal && ExperimentalFeature.IsEnabled(ExperimentalFeature.PSAnsiProgressFeatureName) && PSStyle.Instance.Progress.UseOSCIndicator)
+                if (SupportsVirtualTerminal && PSStyle.Instance.Progress.UseOSCIndicator)
                 {
                     int percentComplete = record.PercentComplete;
                     if (percentComplete < 0)
@@ -115,7 +115,7 @@ namespace Microsoft.PowerShell
                 }
 
                 // If VT is not supported, we change ProgressView to classic
-                if (!SupportsVirtualTerminal && ExperimentalFeature.IsEnabled(ExperimentalFeature.PSAnsiProgressFeatureName))
+                if (!SupportsVirtualTerminal)
                 {
                     PSStyle.Instance.Progress.View = ProgressView.Classic;
                 }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressNode.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressNode.cs
@@ -353,7 +353,7 @@ namespace Microsoft.PowerShell
 
         internal static bool IsMinimalProgressRenderingEnabled()
         {
-            return ExperimentalFeature.IsEnabled(ExperimentalFeature.PSAnsiProgressFeatureName) && PSStyle.Instance.Progress.View == ProgressView.Minimal;
+            return PSStyle.Instance.Progress.View == ProgressView.Minimal;
         }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressPane.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressPane.cs
@@ -115,7 +115,7 @@ namespace Microsoft.PowerShell
 
                     // create cleared region to clear progress bar later
                     _savedRegion = tempProgressRegion;
-                    if (ExperimentalFeature.IsEnabled(ExperimentalFeature.PSAnsiProgressFeatureName) && PSStyle.Instance.Progress.View != ProgressView.Minimal)
+                    if (PSStyle.Instance.Progress.View != ProgressView.Minimal)
                     {
                         for (int row = 0; row < rows; row++)
                         {

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/FileSystem_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/FileSystem_format_ps1xml.cs
@@ -42,27 +42,24 @@ namespace System.Management.Automation.Runspaces
         private static IEnumerable<FormatViewDefinition> ViewsOf_FileSystemTypes(CustomControl[] sharedControls)
         {
 #if UNIX
-            if (ExperimentalFeature.IsEnabled("PSUnixFileStat"))
-            {
-                yield return new FormatViewDefinition("childrenWithUnixStat",
-                    TableControl.Create()
-                        .GroupByProperty("PSParentPath", customControl: sharedControls[0])
-                        .AddHeader(Alignment.Left, label: "UnixMode", width: 10)
-                        .AddHeader(Alignment.Left, label: "User", width: 16)
-                        .AddHeader(Alignment.Left, label: "Group", width: 16)
-                        .AddHeader(Alignment.Right, label: "LastWriteTime", width: 18)
-                        .AddHeader(Alignment.Right, label: "Size", width: 14)
-                        .AddHeader(Alignment.Left, label: "Name")
-                        .StartRowDefinition(wrap: true)
-                            .AddPropertyColumn("UnixMode")
-                            .AddPropertyColumn("User")
-                            .AddPropertyColumn("Group")
-                            .AddScriptBlockColumn(scriptBlock: @"'{0:d} {0:HH}:{0:mm}' -f $_.LastWriteTime")
-                            .AddPropertyColumn("Size")
-                            .AddPropertyColumn("NameString")
-                        .EndRowDefinition()
-                    .EndTable());
-            }
+            yield return new FormatViewDefinition("childrenWithUnixStat",
+                TableControl.Create()
+                    .GroupByProperty("PSParentPath", customControl: sharedControls[0])
+                    .AddHeader(Alignment.Left, label: "UnixMode", width: 10)
+                    .AddHeader(Alignment.Left, label: "User", width: 16)
+                    .AddHeader(Alignment.Left, label: "Group", width: 16)
+                    .AddHeader(Alignment.Right, label: "LastWriteTime", width: 18)
+                    .AddHeader(Alignment.Right, label: "Size", width: 14)
+                    .AddHeader(Alignment.Left, label: "Name")
+                    .StartRowDefinition(wrap: true)
+                        .AddPropertyColumn("UnixMode")
+                        .AddPropertyColumn("User")
+                        .AddPropertyColumn("Group")
+                        .AddScriptBlockColumn(scriptBlock: @"'{0:d} {0:HH}:{0:mm}' -f $_.LastWriteTime")
+                        .AddPropertyColumn("Size")
+                        .AddPropertyColumn("NameString")
+                    .EndRowDefinition()
+                .EndTable());
 #endif
 
             yield return new FormatViewDefinition("children",

--- a/src/System.Management.Automation/FormatAndOutput/common/ListWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ListWriter.cs
@@ -222,25 +222,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             {
                 if (k == 0)
                 {
-                    if (ExperimentalFeature.IsEnabled("PSAnsiRendering"))
-                    {
-                        lo.WriteLine(PSStyle.Instance.Formatting.FormatAccent + prependString + PSStyle.Instance.Reset + sc[k]);
-                    }
-                    else
-                    {
-                        lo.WriteLine(prependString + sc[k]);
-                    }
+                    lo.WriteLine(PSStyle.Instance.Formatting.FormatAccent + prependString + PSStyle.Instance.Reset + sc[k]);
                 }
                 else
                 {
-                    if (ExperimentalFeature.IsEnabled("PSAnsiRendering"))
-                    {
-                        lo.WriteLine(padding + PSStyle.Instance.Formatting.FormatAccent + PSStyle.Instance.Reset + sc[k]);
-                    }
-                    else
-                    {
-                        lo.WriteLine(padding + sc[k]);
-                    }
+                    lo.WriteLine(padding + PSStyle.Instance.Formatting.FormatAccent + PSStyle.Instance.Reset + sc[k]);
                 }
             }
         }

--- a/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
@@ -43,7 +43,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         private ScreenInfo _si;
 
         private const char ESC = '\u001b';
-        private const string ResetConsoleVt100Code = "\u001b[m";
 
         private List<string> _header;
 
@@ -156,14 +155,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             {
                 foreach (string line in _header)
                 {
-                    if (ExperimentalFeature.IsEnabled("PSAnsiRendering"))
-                    {
-                        lo.WriteLine(PSStyle.Instance.Formatting.TableHeader + line + PSStyle.Instance.Reset);
-                    }
-                    else
-                    {
-                        lo.WriteLine(line);
-                    }
+                    lo.WriteLine(PSStyle.Instance.Formatting.TableHeader + line + PSStyle.Instance.Reset);
                 }
 
                 return _header.Count;
@@ -241,7 +233,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 foreach (string line in GenerateTableRow(values, currentAlignment, lo.DisplayCells))
                 {
                     generatedRows?.Add(line);
-                    if (ExperimentalFeature.IsEnabled("PSAnsiRendering") && isHeader)
+                    if (isHeader)
                     {
                         lo.WriteLine(PSStyle.Instance.Formatting.TableHeader + line + PSStyle.Instance.Reset);
                     }
@@ -255,7 +247,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             {
                 string line = GenerateRow(values, currentAlignment, dc);
                 generatedRows?.Add(line);
-                if (ExperimentalFeature.IsEnabled("PSAnsiRendering") && isHeader)
+                if (isHeader)
                 {
                     lo.WriteLine(PSStyle.Instance.Formatting.TableHeader + line + PSStyle.Instance.Reset);
                 }
@@ -469,15 +461,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 if (values[k].Contains(ESC))
                 {
                     // Reset the console output if the content of this column contains ESC
-                    if (ExperimentalFeature.IsEnabled("PSAnsiRendering"))
-                    {
-                        // Remove definition of `ResetConsoleVt10Code` when PSAnsiRendering is not experimental
-                        sb.Append(PSStyle.Instance.Reset);
-                    }
-                    else
-                    {
-                        sb.Append(ResetConsoleVt100Code);
-                    }
+                    sb.Append(PSStyle.Instance.Reset);
                 }
             }
 

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -120,9 +120,6 @@ namespace System.Management.Automation
                     name: "PSSubsystemPluginModel",
                     description: "A plugin model for registering and un-registering PowerShell subsystems"),
                 new ExperimentalFeature(
-                    name: "PSAnsiRendering",
-                    description: "Enable $PSStyle variable to control ANSI rendering of strings"),
-                new ExperimentalFeature(
                     name: PSNativeCommandArgumentPassingFeatureName,
                     description: "Use ArgumentList when invoking a native command"),
                 new ExperimentalFeature(

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -111,9 +111,6 @@ namespace System.Management.Automation
                     name: "PSCommandNotFoundSuggestion",
                     description: "Recommend potential commands based on fuzzy search on a CommandNotFoundException"),
                 new ExperimentalFeature(
-                    name: "PSCultureInvariantReplaceOperator",
-                    description: "Use culture invariant to-string convertor for lval in replace operator"),
-                new ExperimentalFeature(
                     name: "PSNativePSPathResolution",
                     description: "Convert PSPath to filesystem path, if possible, for native commands"),
                 new ExperimentalFeature(

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -111,11 +111,6 @@ namespace System.Management.Automation
                 new ExperimentalFeature(
                     name: "PSCommandNotFoundSuggestion",
                     description: "Recommend potential commands based on fuzzy search on a CommandNotFoundException"),
-#if UNIX
-                new ExperimentalFeature(
-                    name: "PSUnixFileStat",
-                    description: "Provide unix permission information for files and directories"),
-#endif
                 new ExperimentalFeature(
                     name: "PSCultureInvariantReplaceOperator",
                     description: "Use culture invariant to-string convertor for lval in replace operator"),

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -21,7 +21,6 @@ namespace System.Management.Automation
         #region Const Members
 
         internal const string EngineSource = "PSEngine";
-        internal const string PSAnsiProgressFeatureName = "PSAnsiProgress";
         internal const string PSNativeCommandArgumentPassingFeatureName = "PSNativeCommandArgumentPassing";
 
         #endregion
@@ -123,9 +122,6 @@ namespace System.Management.Automation
                 new ExperimentalFeature(
                     name: "PSAnsiRendering",
                     description: "Enable $PSStyle variable to control ANSI rendering of strings"),
-                new ExperimentalFeature(
-                    name: PSAnsiProgressFeatureName,
-                    description: "Enable lightweight progress bar that leverages ANSI codes for rendering"),
                 new ExperimentalFeature(
                     name: PSNativeCommandArgumentPassingFeatureName,
                     description: "Use ArgumentList when invoking a native command"),

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -123,9 +123,6 @@ namespace System.Management.Automation
                     name: "PSNativePSPathResolution",
                     description: "Convert PSPath to filesystem path, if possible, for native commands"),
                 new ExperimentalFeature(
-                    name: "PSNotApplyErrorActionToStderr",
-                    description: "Don't have $ErrorActionPreference affect stderr output"),
-                new ExperimentalFeature(
                     name: "PSSubsystemPluginModel",
                     description: "A plugin model for registering and un-registering PowerShell subsystems"),
                 new ExperimentalFeature(

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -2839,7 +2839,7 @@ namespace System.Management.Automation
                 this.PipelineProcessor.LogExecutionError(_thisCommand.MyInvocation, errorRecord);
             }
 
-            if (!(ExperimentalFeature.IsEnabled("PSNotApplyErrorActionToStderr") && isNativeError))
+            if (!isNativeError)
             {
                 this.PipelineProcessor.ExecutionFailed = true;
 

--- a/src/System.Management.Automation/engine/TypeTable_Types_Ps1Xml.cs
+++ b/src/System.Management.Automation/engine/TypeTable_Types_Ps1Xml.cs
@@ -9227,45 +9227,42 @@ namespace System.Management.Automation.Runspaces
 #if UNIX
             #region UnixStat
 
-            if (ExperimentalFeature.IsEnabled("PSUnixFileStat"))
-            {
-                typeName = @"System.IO.FileSystemInfo";
-                typeMembers = _extendedMembers.GetOrAdd(typeName, GetValueFactoryBasedOnInitCapacity(capacity: 1));
+            typeName = @"System.IO.FileSystemInfo";
+            typeMembers = _extendedMembers.GetOrAdd(typeName, GetValueFactoryBasedOnInitCapacity(capacity: 1));
 
-                // Where we have a method to invoke below, first check to be sure that the object is present
-                // to avoid null reference issues
-                newMembers.Add(@"UnixMode");
-                AddMember(
-                    errors,
-                    typeName,
-                    new PSScriptProperty(@"UnixMode", GetScriptBlock(@"if ($this.UnixStat) { $this.UnixStat.GetModeString() }")),
-                    typeMembers,
-                    isOverride: false);
+            // Where we have a method to invoke below, first check to be sure that the object is present
+            // to avoid null reference issues
+            newMembers.Add(@"UnixMode");
+            AddMember(
+                errors,
+                typeName,
+                new PSScriptProperty(@"UnixMode", GetScriptBlock(@"if ($this.UnixStat) { $this.UnixStat.GetModeString() }")),
+                typeMembers,
+                isOverride: false);
 
-                newMembers.Add(@"User");
-                AddMember(
-                    errors,
-                    typeName,
-                    new PSScriptProperty(@"User", GetScriptBlock(@" if ($this.UnixStat) { $this.UnixStat.GetUserName() } ")),
-                    typeMembers,
-                    isOverride: false);
+            newMembers.Add(@"User");
+            AddMember(
+                errors,
+                typeName,
+                new PSScriptProperty(@"User", GetScriptBlock(@" if ($this.UnixStat) { $this.UnixStat.GetUserName() } ")),
+                typeMembers,
+                isOverride: false);
 
-                newMembers.Add(@"Group");
-                AddMember(
-                    errors,
-                    typeName,
-                    new PSScriptProperty(@"Group", GetScriptBlock(@" if ($this.UnixStat) { $this.UnixStat.GetGroupName() } ")),
-                    typeMembers,
-                    isOverride: false);
+            newMembers.Add(@"Group");
+            AddMember(
+                errors,
+                typeName,
+                new PSScriptProperty(@"Group", GetScriptBlock(@" if ($this.UnixStat) { $this.UnixStat.GetGroupName() } ")),
+                typeMembers,
+                isOverride: false);
 
-                newMembers.Add(@"Size");
-                AddMember(
-                    errors,
-                    typeName,
-                    new PSScriptProperty(@"Size", GetScriptBlock(@"$this.UnixStat.Size")),
-                    typeMembers,
-                    isOverride: false);
-            }
+            newMembers.Add(@"Size");
+            AddMember(
+                errors,
+                typeName,
+                new PSScriptProperty(@"Size", GetScriptBlock(@"$this.UnixStat.Size")),
+                typeMembers,
+                isOverride: false);
 
             #endregion
 #endif

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1791,22 +1791,19 @@ namespace System.Management.Automation
         {
             var outputRendering = OutputRendering.Ansi;
 
-            if (ExperimentalFeature.IsEnabled("PSAnsiRendering"))
+            if (supportsVirtualTerminal != false)
             {
-                if (supportsVirtualTerminal != false)
+                switch (PSStyle.Instance.OutputRendering)
                 {
-                    switch (PSStyle.Instance.OutputRendering)
-                    {
-                        case OutputRendering.Automatic:
-                            outputRendering = OutputRendering.Ansi;
-                            break;
-                        case OutputRendering.Host:
-                            outputRendering = isHost ? OutputRendering.Ansi : OutputRendering.PlainText;
-                            break;
-                        default:
-                            outputRendering = PSStyle.Instance.OutputRendering;
-                            break;
-                    }
+                    case OutputRendering.Automatic:
+                        outputRendering = OutputRendering.Ansi;
+                        break;
+                    case OutputRendering.Host:
+                        outputRendering = isHost ? OutputRendering.Ansi : OutputRendering.PlainText;
+                        break;
+                    default:
+                        outputRendering = PSStyle.Instance.OutputRendering;
+                        break;
                 }
             }
 
@@ -1815,25 +1812,22 @@ namespace System.Management.Automation
 
         internal static string GetOutputString(string s, bool isHost, bool? supportsVirtualTerminal = null, bool isOutputRedirected = false)
         {
-            if (ExperimentalFeature.IsEnabled("PSAnsiRendering"))
+            var sd = new ValueStringDecorated(s);
+
+            if (sd.IsDecorated)
             {
-                var sd = new ValueStringDecorated(s);
-
-                if (sd.IsDecorated)
+                var outputRendering = OutputRendering.Ansi;
+                if (InternalTestHooks.BypassOutputRedirectionCheck)
                 {
-                    var outputRendering = OutputRendering.Ansi;
-                    if (InternalTestHooks.BypassOutputRedirectionCheck)
-                    {
-                        isOutputRedirected = false;
-                    }
-
-                    if (isOutputRedirected || ShouldOutputPlainText(isHost, supportsVirtualTerminal))
-                    {
-                        outputRendering = OutputRendering.PlainText;
-                    }
-
-                    s = sd.ToString(outputRendering);
+                    isOutputRedirected = false;
                 }
+
+                if (isOutputRedirected || ShouldOutputPlainText(isHost, supportsVirtualTerminal))
+                {
+                    outputRendering = OutputRendering.PlainText;
+                }
+
+                s = sd.ToString(outputRendering);
             }
 
             return s;
@@ -1862,33 +1856,28 @@ namespace System.Management.Automation
                 return string.Empty;
             }
 
-            if (ExperimentalFeature.IsEnabled("PSAnsiRendering"))
+            PSStyle psstyle = PSStyle.Instance;                
+            switch (formatStyle)
             {
-                PSStyle psstyle = PSStyle.Instance;                
-                switch (formatStyle)
-                {
-                    case FormatStyle.Reset:
-                        return psstyle.Reset;
-                    case FormatStyle.FormatAccent:
-                        return psstyle.Formatting.FormatAccent;
-                    case FormatStyle.TableHeader:
-                        return psstyle.Formatting.TableHeader;
-                    case FormatStyle.ErrorAccent:
-                        return psstyle.Formatting.ErrorAccent;
-                    case FormatStyle.Error:
-                        return psstyle.Formatting.Error;
-                    case FormatStyle.Warning:
-                        return psstyle.Formatting.Warning;
-                    case FormatStyle.Verbose:
-                        return psstyle.Formatting.Verbose;
-                    case FormatStyle.Debug:
-                        return psstyle.Formatting.Debug;
-                    default:
-                        return string.Empty;
-                }
+                case FormatStyle.Reset:
+                    return psstyle.Reset;
+                case FormatStyle.FormatAccent:
+                    return psstyle.Formatting.FormatAccent;
+                case FormatStyle.TableHeader:
+                    return psstyle.Formatting.TableHeader;
+                case FormatStyle.ErrorAccent:
+                    return psstyle.Formatting.ErrorAccent;
+                case FormatStyle.Error:
+                    return psstyle.Formatting.Error;
+                case FormatStyle.Warning:
+                    return psstyle.Formatting.Warning;
+                case FormatStyle.Verbose:
+                    return psstyle.Formatting.Verbose;
+                case FormatStyle.Debug:
+                    return psstyle.Formatting.Debug;
+                default:
+                    return string.Empty;
             }
-
-            return string.Empty;
         }
 
         #endregion

--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -620,13 +620,10 @@ namespace System.Management.Automation.Host
 
                     resultText = resultText.TrimEnd();
 
-                    if (ExperimentalFeature.IsEnabled("PSAnsiRendering"))
+                    var text = new ValueStringDecorated(resultText);
+                    if (text.IsDecorated)
                     {
-                        var text = new ValueStringDecorated(resultText);
-                        if (text.IsDecorated)
-                        {
-                            resultText = text.ToString(OutputRendering.PlainText);
-                        }
+                        resultText = text.ToString(OutputRendering.PlainText);
                     }
 
                     foreach (TranscriptionOption transcript in TranscriptionData.Transcripts.Prepend<TranscriptionOption>(TranscriptionData.SystemTranscript))

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -969,15 +969,7 @@ namespace System.Management.Automation
             IEnumerator list = LanguagePrimitives.GetEnumerator(lval);
             if (list == null)
             {
-                string lvalString;
-                if (ExperimentalFeature.IsEnabled("PSCultureInvariantReplaceOperator"))
-                {
-                    lvalString = PSObject.ToStringParser(context, lval) ?? string.Empty;
-                }
-                else
-                {
-                    lvalString = lval?.ToString() ?? string.Empty;
-                }
+                string lvalString = PSObject.ToStringParser(context, lval) ?? string.Empty;
 
                 return replacer.Replace(lvalString);
             }

--- a/src/System.Management.Automation/engine/remoting/commands/DebugJob.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/DebugJob.cs
@@ -100,7 +100,6 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Gets or sets a flag that tells PowerShell to automatically perform a BreakAll when the debugger is attached to the remote target.
         /// </summary>
-        [Experimental("Microsoft.PowerShell.Utility.PSManageBreakpointsInRunspace", ExperimentAction.Show)]
         [Parameter]
         public SwitchParameter BreakAll { get; set; }
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -2058,7 +2058,7 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>Name if a file or directory, Name -> Target if symlink.</returns>
         public static string NameString(PSObject instance)
         {
-            if (ExperimentalFeature.IsEnabled("PSAnsiRendering") && ExperimentalFeature.IsEnabled("PSAnsiRenderingFileInfo"))
+            if (ExperimentalFeature.IsEnabled("PSAnsiRenderingFileInfo"))
             {
                 if (instance?.BaseObject is FileSystemInfo fileInfo)
                 {

--- a/src/System.Management.Automation/namespaces/ProviderBase.cs
+++ b/src/System.Management.Automation/namespaces/ProviderBase.cs
@@ -1823,7 +1823,7 @@ namespace System.Management.Automation.Provider
 #if UNIX
 
                 // Add a commonstat structure to file system objects
-                if (ExperimentalFeature.IsEnabled("PSUnixFileStat") && ProviderInfo.ImplementingType == typeof(Microsoft.PowerShell.Commands.FileSystemProvider))
+                if (ProviderInfo.ImplementingType == typeof(Microsoft.PowerShell.Commands.FileSystemProvider))
                 {
                     try
                     {

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -1025,12 +1025,10 @@ Describe 'Console host name' -Tag CI {
 Describe 'TERM env var' -Tag CI {
     BeforeAll {
         $oldTERM = $env:TERM
-        $PSDefaultParameterValues.Add('It:Skip', (-not $EnabledExperimentalFeatures.Contains('PSAnsiRendering')))
     }
 
     AfterAll {
         $env:TERM = $oldTERM
-        $PSDefaultParameterValues.Remove('It:Skip')
     }
 
     It 'TERM = "dumb"' {

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -367,7 +367,7 @@ Describe "TabCompletion" -Tags CI {
         }
 
         It 'Should complete Get-ChildItem | <cmd> -View' -TestCases (
-            @{ cmd = 'Format-Table'; expected = "children childrenWithHardlink$(if ($EnabledExperimentalFeatures.Contains('PSUnixFileStat')) { ' childrenWithUnixStat' })" },
+            @{ cmd = 'Format-Table'; expected = 'children childrenWithHardlink childrenWithUnixStat' },
             @{ cmd = 'Format-List'; expected = 'children' },
             @{ cmd = 'Format-Wide'; expected = 'children' },
             @{ cmd = 'Format-Custom'; expected = '' }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -367,7 +367,7 @@ Describe "TabCompletion" -Tags CI {
         }
 
         It 'Should complete Get-ChildItem | <cmd> -View' -TestCases (
-            @{ cmd = 'Format-Table'; expected = "children childrenWithHardlink$(if (!$IsWindows) { 'childrenWithUnixStat' })" },
+            @{ cmd = 'Format-Table'; expected = "children childrenWithHardlink$(if (!$IsWindows) { ' childrenWithUnixStat' })" },
             @{ cmd = 'Format-List'; expected = 'children' },
             @{ cmd = 'Format-Wide'; expected = 'children' },
             @{ cmd = 'Format-Custom'; expected = '' }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -367,7 +367,7 @@ Describe "TabCompletion" -Tags CI {
         }
 
         It 'Should complete Get-ChildItem | <cmd> -View' -TestCases (
-            @{ cmd = 'Format-Table'; expected = 'children childrenWithHardlink childrenWithUnixStat' },
+            @{ cmd = 'Format-Table'; expected = "children childrenWithHardlink$(if (!$IsWindows) { 'childrenWithUnixStat' })" },
             @{ cmd = 'Format-List'; expected = 'children' },
             @{ cmd = 'Format-Wide'; expected = 'children' },
             @{ cmd = 'Format-Custom'; expected = '' }

--- a/test/powershell/Language/Operators/ReplaceOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/ReplaceOperator.Tests.ps1
@@ -85,24 +85,13 @@ Describe "Replace Operator" -Tags CI {
 
     Describe "Culture-invariance tests for -split and -replace" -Tags CI {
         BeforeAll {
-            $skipTest = -not [ExperimentalFeature]::IsEnabled("PSCultureInvariantReplaceOperator")
-            if ($skipTest) {
-                Write-Verbose "Test Suite Skipped. The test suite requires the experimental feature 'PSCultureInvariantReplaceOperator' to be enabled." -Verbose
-                $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
-                $PSDefaultParameterValues["it:skip"] = $true
-            } else {
-                $prevCulture = [cultureinfo]::CurrentCulture
-                # The French culture uses "," as the decimal mark.
-                [cultureinfo]::CurrentCulture = 'fr'
-            }
+            $prevCulture = [cultureinfo]::CurrentCulture
+            # The French culture uses "," as the decimal mark.
+            [cultureinfo]::CurrentCulture = 'fr'
         }
 
         AfterAll {
-            if ($skipTest) {
-                $global:PSDefaultParameterValues = $originalDefaultParameterValues
-            } else {
-                [cultureinfo]::CurrentCulture = $prevCulture
-            }
+            [cultureinfo]::CurrentCulture = $prevCulture
         }
 
         It "-split: LHS stringification is not culture-sensitive" {

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -147,7 +147,7 @@ Describe "Native Command Processor" -tags "Feature" {
         }
     }
 
-    It '$ErrorActionPreference does not apply to redirected stderr output' -Skip:(!$EnabledExperimentalFeatures.Contains('PSNotApplyErrorActionToStderr')) {
+    It '$ErrorActionPreference does not apply to redirected stderr output' {
         pwsh -noprofile -command '$ErrorActionPreference = ''Stop''; testexe -stderr stop 2>$null; ''hello''; $error; $?' | Should -BeExactly 'hello','True'
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/UnixStat.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/UnixStat.Tests.ps1
@@ -2,6 +2,13 @@
 # Licensed under the MIT License.
 Describe "UnixFileSystem additions" -Tag "CI" {
     Context "Basic Validation" {
+        BeforeAll {
+            $PSDefaultParameterValues.Add('It:Skip', $IsWindows)
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues.Remove('It:Skip')
+        }
 
         It "Should include a UnixStat property" {
             $i = Get-Item ${TestDrive}
@@ -17,9 +24,7 @@ Describe "UnixFileSystem additions" -Tag "CI" {
 
     Context "Validation of additional properties on file system objects" {
         BeforeAll {
-            if ( $IsWindows ) {
-                return
-            }
+            $PSDefaultParameterValues.Add('It:Skip', $IsWindows)
 
             $testDir  = "${TestDrive}/TestDir"
             $testFile = "${testDir}/TestFile"
@@ -34,6 +39,10 @@ Describe "UnixFileSystem additions" -Tag "CI" {
                         @{ Mode = '777';  Perm = '-rwxrwxrwx'; Item = "${testFile}" },
                         @{ Mode = '4777'; Perm = '-rwsrwxrwx'; Item = "${testFile}" },
                         @{ Mode = '1777'; Perm = 'drwxrwxrwt'; Item = "${testDir}"  }
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues.Remove('It:Skip')
         }
 
         BeforeEach {
@@ -68,7 +77,8 @@ Describe "UnixFileSystem additions" -Tag "CI" {
 
     Context "Other properties of UnixStat object" {
         BeforeAll {
-            if ( $IsWindows ) {
+            $PSDefaultParameterValues.Add('It:Skip', $IsWindows)
+            if ($IsWindows) {
                 return
             }
 
@@ -94,6 +104,10 @@ Describe "UnixFileSystem additions" -Tag "CI" {
                 @{ Expected = $expectedDirInode; Observed = $Dir.UnixStat.Inode; Title = "DirInode" },
                 @{ Expected = $expectedDirLinkCount; Observed = $Dir.UnixStat.HardlinkCount; Title = "DirHardlinkCount" },
                 @{ Expected = $expectedDirSize; Observed = $Dir.UnixStat.Size; Title = "DirSize" }
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues.Remove('It:Skip')
         }
 
         It "Should have correct values in UnixStat property for '<Title>'" -TestCases $testCases {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/UnixStat.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/UnixStat.Tests.ps1
@@ -1,26 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 Describe "UnixFileSystem additions" -Tag "CI" {
-    # if PSUnixFileStat is converted from an experimental feature, these tests will need to be changed
-    BeforeAll {
-        $experimentalFeatureName = "PSUnixFileStat"
-        $skipTest = -not $EnabledExperimentalFeatures.Contains($experimentalFeatureName)
-        $PSDefaultParameterValues.Add('It:Skip', $skipTest)
-    }
-    AfterAll {
-        $PSDefaultParameterValues.Remove('It:Skip')
-    }
     Context "Basic Validation" {
-
-        It "Should be an experimental feature on non-Windows systems" {
-            $feature = Get-ExperimentalFeature -Name $experimentalFeatureName
-            if ( $IsWindows ) {
-                $feature | Should -BeNullOrEmpty
-            }
-            else {
-                $feature.Name | Should -Be $experimentalFeatureName
-            }
-        }
 
         It "Should include a UnixStat property" {
             $i = Get-Item ${TestDrive}

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-List.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-List.Tests.ps1
@@ -213,12 +213,10 @@ dbda : KM
 
 Describe 'Format-List color tests' {
     BeforeAll {
-        $PSDefaultParameterValues.Add('It:Skip', (-not $EnabledExperimentalFeatures.Contains('PSAnsiRendering')))
         [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('ForceFormatListFixedLabelWidth', $true)
     }
 
     AfterAll {
-        $PSDefaultParameterValues.Remove('It:Skip')
         [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('ForceFormatListFixedLabelWidth', $false)
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
@@ -848,14 +848,6 @@ A Name                                  B
     }
 
 Describe 'Table color tests' {
-    BeforeAll {
-        $PSDefaultParameterValues.Add('It:Skip', (-not $EnabledExperimentalFeatures.Contains('PSAnsiRendering')))
-    }
-
-    AfterAll {
-        $PSDefaultParameterValues.Remove('It:Skip')
-    }
-
     It 'Table header should use FormatAccent' {
         ([pscustomobject]@{foo = 1} | Format-Table | Out-String).Trim() | Should -BeExactly @"
 $($PSStyle.Formatting.FormatAccent)foo$($PSStyle.Reset)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
@@ -126,7 +126,7 @@ Describe 'Get-Error tests' -Tag CI {
         $out | Should -BeLikeExactly "*$expectedExceptionType*"
     }
 
-    It 'Get-Error uses Error color for Message and PositionMessage members' -Skip:(!$EnabledExperimentalFeatures.Contains("PSAnsiRendering")) {
+    It 'Get-Error uses Error color for Message and PositionMessage members' {
         $suppressVT = $false
         if (Test-Path env:/__SuppressAnsiEscapeSequences) {
             $suppressVT = $true

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FormatData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FormatData.Tests.ps1
@@ -25,9 +25,7 @@ Describe "Get-FormatData" -Tags "CI" {
             $format.TypeNames | Should -HaveCount 2
             $format.TypeNames[0] | Should -BeExactly "System.IO.DirectoryInfo"
             $format.TypeNames[1] | Should -BeExactly "System.IO.FileInfo"
-
-            $isUnixStatEnabled = $EnabledExperimentalFeatures -contains 'PSUnixFileStat'
-            $format.FormatViewDefinition | Should -HaveCount ($isUnixStatEnabled ? 5 : 4)
+            $format.FormatViewDefinition | Should -HaveCount 5
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FormatData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FormatData.Tests.ps1
@@ -21,11 +21,19 @@ Describe "Get-FormatData" -Tags "CI" {
         }
         It "Can get format data requiring v5.1+ with <cmd>" -TestCases $cmds {
             param([scriptblock] $cmd)
+
+            if ($IsWindows) {
+                $expectedCount = 4
+            } else {
+                # UnixStat addes extra one
+                $expectedCount = 5
+            }
+
             $format = & $cmd
             $format.TypeNames | Should -HaveCount 2
             $format.TypeNames[0] | Should -BeExactly "System.IO.DirectoryInfo"
             $format.TypeNames[1] | Should -BeExactly "System.IO.FileInfo"
-            $format.FormatViewDefinition | Should -HaveCount 5
+            $format.FormatViewDefinition | Should -HaveCount $expectedCount
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/PowerShellData.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/PowerShellData.tests.ps1
@@ -9,10 +9,6 @@ Describe "Tests for the Import-PowerShellDataFile cmdlet" -Tags "CI" {
         }
         $largePsd1Builder.Append('}')
         Set-Content -Path $largePsd1Path -Value $largePsd1Builder.ToString()
-
-        if ((Get-ExperimentalFeature Microsoft.PowerShell.Utility.PSImportPSDataFileSkipLimitCheck).Enabled -ne $true) {
-            $skipTest = $true
-        }
     }
 
     It "Validates error on a missing path" {
@@ -49,7 +45,7 @@ Describe "Tests for the Import-PowerShellDataFile cmdlet" -Tags "CI" {
         { Import-PowerShellDataFile $largePsd1Path } | Should -Throw -ErrorId 'System.InvalidOperationException,Microsoft.PowerShell.Commands.ImportPowerShellDataFileCommand'
     }
 
-    It 'Succeeds if -NoLimit is used and has more than 500 keys' -Skip:$skipTest {
+    It 'Succeeds if -NoLimit is used and has more than 500 keys' {
         $result = Import-PowerShellDataFile $largePsd1Path -SkipLimitCheck
         $result.Keys.Count | Should -Be 501
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/RunspaceBreakpointManagement.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/RunspaceBreakpointManagement.Tests.ps1
@@ -1,18 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-$FeatureEnabled = $EnabledExperimentalFeatures.Contains('Microsoft.PowerShell.Utility.PSManageBreakpointsInRunspace')
-
 Describe 'Runspace Breakpoint Unit Tests - Feature-Enabled' -Tags 'CI' {
 
     BeforeAll {
-        if (!$FeatureEnabled) {
-            Write-Verbose 'Test series skipped. This series of tests requires the experimental feature ''Microsoft.PowerShell.Utility.PSManageBreakpointsInRunspace'' to be enabled.' -Verbose
-            $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
-            $PSDefaultParameterValues['it:skip'] = $true
-            return
-        }
-
         # Start a job; this will create a runspace in which we can manage breakpoints
         $job = Start-Job -ScriptBlock {
             Set-PSBreakpoint -Command Start-Sleep
@@ -37,11 +28,6 @@ Describe 'Runspace Breakpoint Unit Tests - Feature-Enabled' -Tags 'CI' {
     }
 
     AfterAll {
-        if (!$FeatureEnabled) {
-            $global:PSDefaultParameterValues = $originalDefaultParameterValues
-            return
-        }
-
         # Remove the running job forcibly (whether it has finished or not)
         Remove-Job -Job $job -Force
     }

--- a/test/powershell/engine/ETS/TypeTable.Tests.ps1
+++ b/test/powershell/engine/ETS/TypeTable.Tests.ps1
@@ -18,13 +18,10 @@ Describe "Built-in type information tests" -Tag "CI" {
     }
 
     It "Should have correct number of built-in type items in type table" {
-        $isUnixStatEnabled = $EnabledExperimentalFeatures -contains 'PSUnixFileStat'
         $expected = if ($IsWindows) {
             273
-        } elseif ($isUnixStatEnabled) {
-            272
         } else {
-            271
+            272
         }
         $types.Count | Should -BeExactly $expected
     }

--- a/test/powershell/engine/Formatting/OutputRendering.Tests.ps1
+++ b/test/powershell/engine/Formatting/OutputRendering.Tests.ps1
@@ -3,16 +3,11 @@
 
 Describe 'OutputRendering tests' {
     BeforeAll {
-        $PSDefaultParameterValues.Add('It:Skip', (-not $EnabledExperimentalFeatures.Contains('PSAnsiRendering')))
         $th = New-TestHost
         $rs = [runspacefactory]::Createrunspace($th)
         $rs.open()
         $ps = [powershell]::Create()
         $ps.Runspace = $rs
-    }
-
-    AfterAll {
-        $PSDefaultParameterValues.Remove('It:Skip')
     }
 
     BeforeEach {

--- a/test/powershell/engine/Formatting/PSStyle.Tests.ps1
+++ b/test/powershell/engine/Formatting/PSStyle.Tests.ps1
@@ -3,7 +3,6 @@
 
 Describe 'Tests for $PSStyle automatic variable' {
     BeforeAll {
-        $PSDefaultParameterValues.Add('It:Skip', (-not $EnabledExperimentalFeatures.Contains('PSAnsiRendering')))
         $styleDefaults = @{
             Reset = "`e[0m"
             BlinkOff = "`e[25m"
@@ -80,10 +79,6 @@ Describe 'Tests for $PSStyle automatic variable' {
 
             return $testcases
         }
-    }
-
-    AfterAll {
-        $PSDefaultParameterValues.Remove('It:Skip')
     }
 
     It '$PSStyle has correct default for OutputRendering' {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Each commit makes a feature non-experimental (although one extra due to my filter only looking at .cs files initially...).  Removed the advertising of the experimental feature and any code and tests that checked that the feature is enabled.

To avoid the headache of merge conflicts, I'm submitting this as a single PR.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/15862

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/7917
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
