### PR TITLE
Fix FileSystemProvider to work with volume and pipe paths

### DIFF
--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1292,7 +1292,7 @@ namespace System.Management.Automation
             }
 
             // handle special cases like \\wsl$\ubuntu and \\?\ which aren't a UNC path, but we can say it is so the filesystemprovider can use it
-            if (!networkOnly && (path.StartsWith(WslRootPath, StringComparison.OrdinalIgnoreCase) || path.StartsWith("\\\\?\\")))
+            if (!networkOnly && (path.StartsWith(WslRootPath, StringComparison.OrdinalIgnoreCase) || path.StartsWith("\\\\?\\") || path.StartsWith("\\\\.\\")))
             {
                 return true;
             }

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1291,7 +1291,7 @@ namespace System.Management.Automation
                 return false;
             }
 
-            // handle special cases like \\wsl$\ubuntu and \\?\ which aren't a UNC path, but we can say it is so the filesystemprovider can use it
+            // handle special cases like '\\wsl$\ubuntu', '\\?\', and '\\.\pipe\' which aren't a UNC path, but we can say it is so the filesystemprovider can use it
             if (!networkOnly && (path.StartsWith(WslRootPath, StringComparison.OrdinalIgnoreCase) || path.StartsWith("\\\\?\\") || path.StartsWith("\\\\.\\")))
             {
                 return true;

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1291,8 +1291,8 @@ namespace System.Management.Automation
                 return false;
             }
 
-            // handle special cases like \\wsl$\ubuntu which isn't a UNC path, but we can say it is so the filesystemprovider can use it
-            if (path.StartsWith(WslRootPath, StringComparison.OrdinalIgnoreCase))
+            // handle special cases like \\wsl$\ubuntu and \\?\ which aren't a UNC path, but we can say it is so the filesystemprovider can use it
+            if (path.StartsWith(WslRootPath, StringComparison.OrdinalIgnoreCase) || path.StartsWith("\\\\?\\"))
             {
                 return true;
             }

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1281,7 +1281,7 @@ namespace System.Management.Automation
             return false;
         }
 
-        internal static bool PathIsUnc(string path)
+        internal static bool PathIsUnc(string path, bool networkOnly = false)
         {
 #if UNIX
             return false;
@@ -1292,7 +1292,7 @@ namespace System.Management.Automation
             }
 
             // handle special cases like \\wsl$\ubuntu and \\?\ which aren't a UNC path, but we can say it is so the filesystemprovider can use it
-            if (path.StartsWith(WslRootPath, StringComparison.OrdinalIgnoreCase) || path.StartsWith("\\\\?\\"))
+            if (!networkOnly && (path.StartsWith(WslRootPath, StringComparison.OrdinalIgnoreCase) || path.StartsWith("\\\\?\\")))
             {
                 return true;
             }

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -124,7 +124,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 string exactPath = string.Empty;
                 int itemsToSkip = 0;
-                if (Utils.PathIsUnc(path))
+                if (Utils.PathIsUnc(path) || path.StartsWith("\\\\?\\"))
                 {
                     // With the Split method, a UNC path like \\server\share, we need to skip
                     // trying to enumerate the server and share, so skip the first two empty
@@ -132,20 +132,21 @@ namespace Microsoft.PowerShell.Commands
                     itemsToSkip = 4;
                 }
 
-                foreach (string item in path.Split(StringLiterals.DefaultPathSeparator))
+                var items = path.Split(StringLiterals.DefaultPathSeparator);
+                for (int i = 0; i < items.Length; i++)
                 {
                     if (itemsToSkip-- > 0)
                     {
                         // This handles the UNC server and share and 8.3 short path syntax
-                        exactPath += item + StringLiterals.DefaultPathSeparator;
+                        exactPath += items[i] + StringLiterals.DefaultPathSeparator;
                         continue;
                     }
                     else if (string.IsNullOrEmpty(exactPath))
                     {
                         // This handles the drive letter or / root path start
-                        exactPath = item + StringLiterals.DefaultPathSeparator;
+                        exactPath = items[i] + StringLiterals.DefaultPathSeparator;
                     }
-                    else if (string.IsNullOrEmpty(item))
+                    else if (string.IsNullOrEmpty(items[i]) && i == items.Length - 1)
                     {
                         // This handles the trailing slash case
                         if (!exactPath.EndsWith(StringLiterals.DefaultPathSeparator))
@@ -155,17 +156,17 @@ namespace Microsoft.PowerShell.Commands
 
                         break;
                     }
-                    else if (item.Contains('~'))
+                    else if (items[i].Contains('~'))
                     {
                         // This handles short path names
-                        exactPath += StringLiterals.DefaultPathSeparator + item;
+                        exactPath += StringLiterals.DefaultPathSeparator + items[i];
                     }
                     else
                     {
                         // Use GetFileSystemEntries to get the correct casing of this element
                         try
                         {
-                            var entries = Directory.GetFileSystemEntries(exactPath, item);
+                            var entries = Directory.GetFileSystemEntries(exactPath, items[i]);
                             if (entries.Length > 0)
                             {
                                 exactPath = entries[0];

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -124,7 +124,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 string exactPath = string.Empty;
                 int itemsToSkip = 0;
-                if (Utils.PathIsUnc(path) || path.StartsWith("\\\\?\\"))
+                if (Utils.PathIsUnc(path))
                 {
                     // With the Split method, a UNC path like \\server\share, we need to skip
                     // trying to enumerate the server and share, so skip the first two empty

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -7258,7 +7258,7 @@ namespace Microsoft.PowerShell.Commands
                     return false;
                 }
 
-                if (Utils.PathIsUnc(path))
+                if (Utils.PathIsUnc(path, networkOnly : true))
                 {
                     return true;
                 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -235,6 +235,11 @@ Describe "Get-ChildItem" -Tags "CI" {
             $items[0].Parent | Should -BeExactly "${volume}Windows"
             $items.Count | Should -Be (Get-ChildItem $env:SystemRoot).Count
         }
+
+        It 'Works with Windows pipes' -Skip:(!$IsWindows) {
+            $out = pwsh -noprofile -custompipename myTestPipe { Get-ChildItem \\.\pipe\myTestPipe }
+            $out.Name | Should -BeExactly 'myTestPipe'
+        }
     }
 
     Context 'Env: Provider' {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -228,6 +228,13 @@ Describe "Get-ChildItem" -Tags "CI" {
             $barFiles = Get-ChildItem -Path testdrive:/foo/bar -Recurse
             $barFiles.Count | Should -Be 2
         }
+
+        It 'Works with Windows volume paths' -Skip:(!$IsWindows) {
+            $volume = (Get-Volume -DriveLetter $env:SystemDrive[0]).Path
+            $items = Get-ChildItem -LiteralPath "${volume}Windows"
+            $items[0].Parent | Should -BeExactly "${volume}Windows"
+            $items.Count | Should -Be (Get-ChildItem $env:SystemRoot).Count
+        }
     }
 
     Context 'Env: Provider' {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -233,7 +233,7 @@ Describe "Get-ChildItem" -Tags "CI" {
             $volume = (Get-Volume -DriveLetter $env:SystemDrive[0]).Path
             $items = Get-ChildItem -LiteralPath "${volume}Windows"
             $items[0].Parent | Should -BeExactly "${volume}Windows"
-            $items.Count | Should -Be (Get-ChildItem $env:SystemRoot).Count
+            $items | Should -HaveCount (Get-ChildItem $env:SystemRoot).Count
         }
 
         It 'Works with Windows pipes' -Skip:(!$IsWindows) {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

A change in the FileSystemProvider to get the correct casing for a path regressed working with NTFS volume paths that start with `\\?\` as it's not a UNC path so skips that handling.  Also, the logic for handling a trailing directory separator relied on there to be no content so something like: "c:\\foo\\\\bar" would handle this incorrectly.

Fix is to skip the first parts of the path even if it's not a UNC path, but starts with "\\\\?\\".  Then we only check for empty content if we are at the end of the path to handle trailing separator correctly.

Also supports `\\.\pipe` on Windows

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/15872

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
