### PR TITLE
Implement RFC 277: native error throwing

### DIFF
--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -22,6 +22,7 @@ namespace System.Management.Automation
 
         internal const string EngineSource = "PSEngine";
         internal const string PSNativeCommandArgumentPassingFeatureName = "PSNativeCommandArgumentPassing";
+        internal const string PSNativeCommandErrorActionPreferenceFeatureName = "PSNativeCommandErrorActionPreference";
 
         #endregion
 
@@ -125,6 +126,9 @@ namespace System.Management.Automation
                 new ExperimentalFeature(
                     name: "PSAnsiRenderingFileInfo",
                     description: "Enable coloring for FileInfo objects"),
+                new ExperimentalFeature(
+                    name: PSNativeCommandErrorActionPreferenceFeatureName,
+                    description: "Native commands with non-zero exit codes issue errors according to $ErrorActionPreference when $PSNativeCommandUseErrorActionPreference is $true"),
             };
 
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4471,7 +4471,7 @@ end {
         internal const ActionPreference DefaultInformationPreference = ActionPreference.SilentlyContinue;
 
         internal const ErrorView DefaultErrorView = ErrorView.ConciseView;
-        internal const bool DefaultNativeCommandUseErrorActionPreference = false;
+        internal const bool DefaultPSNativeCommandUseErrorActionPreference = false;
         internal const bool DefaultWhatIfPreference = false;
         internal const ConfirmImpact DefaultConfirmPreference = ConfirmImpact.High;
 
@@ -4562,9 +4562,9 @@ end {
                 0,
                 RunspaceInit.NestedPromptLevelDescription),
             new SessionStateVariableEntry(
-                SpecialVariables.NativeCommandUseErrorActionPreference,
-                DefaultNativeCommandUseErrorActionPreference,
-                RunspaceInit.NativeCommandUseErrorActionPreferenceDescription),
+                SpecialVariables.PSNativeCommandUseErrorActionPreference,
+                DefaultPSNativeCommandUseErrorActionPreference,
+                RunspaceInit.PSNativeCommandUseErrorActionPreferenceDescription),
             new SessionStateVariableEntry(
                 SpecialVariables.WhatIfPreference,
                 DefaultWhatIfPreference,

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4471,6 +4471,7 @@ end {
         internal const ActionPreference DefaultInformationPreference = ActionPreference.SilentlyContinue;
 
         internal const ErrorView DefaultErrorView = ErrorView.ConciseView;
+        internal const bool DefaultNativeCommandThrowPreference = false;
         internal const bool DefaultWhatIfPreference = false;
         internal const ConfirmImpact DefaultConfirmPreference = ConfirmImpact.High;
 
@@ -4560,6 +4561,10 @@ end {
                 SpecialVariables.NestedPromptLevel,
                 0,
                 RunspaceInit.NestedPromptLevelDescription),
+            new SessionStateVariableEntry(
+                SpecialVariables.NativeCommandThrowPreference,
+                DefaultNativeCommandThrowPreference,
+                RunspaceInit.NativeCommandThrowPreferenceDescription),
             new SessionStateVariableEntry(
                 SpecialVariables.WhatIfPreference,
                 DefaultWhatIfPreference,

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4475,155 +4475,169 @@ end {
         internal const bool DefaultWhatIfPreference = false;
         internal const ConfirmImpact DefaultConfirmPreference = ConfirmImpact.High;
 
-        internal static readonly SessionStateVariableEntry[] BuiltInVariables = new SessionStateVariableEntry[]
+        static InitialSessionState()
         {
-            // Engine variables that should be precreated before running profile
-            // Bug fix for Win7:2202228 Engine halts if initial command fulls up variable table
-            // Anytime a new variable that the engine depends on to run is added, this table
-            // must be updated...
-            new SessionStateVariableEntry(SpecialVariables.LastToken, null, string.Empty),
-            new SessionStateVariableEntry(SpecialVariables.FirstToken, null, string.Empty),
-            new SessionStateVariableEntry(SpecialVariables.StackTrace, null, string.Empty),
+            var builtinVariables = new List<SessionStateVariableEntry>()
+            {
+                // Engine variables that should be precreated before running profile
+                // Bug fix for Win7:2202228 Engine halts if initial command fulls up variable table
+                // Anytime a new variable that the engine depends on to run is added, this table
+                // must be updated...
+                new SessionStateVariableEntry(SpecialVariables.LastToken, null, string.Empty),
+                new SessionStateVariableEntry(SpecialVariables.FirstToken, null, string.Empty),
+                new SessionStateVariableEntry(SpecialVariables.StackTrace, null, string.Empty),
 
-            // Variable which controls the output rendering
-            new SessionStateVariableEntry(
-                SpecialVariables.PSStyle,
-                PSStyle.Instance,
-                RunspaceInit.PSStyleDescription,
-                ScopedItemOptions.None),
+                // Variable which controls the output rendering
+                new SessionStateVariableEntry(
+                    SpecialVariables.PSStyle,
+                    PSStyle.Instance,
+                    RunspaceInit.PSStyleDescription,
+                    ScopedItemOptions.None),
 
-            // Variable which controls the encoding for piping data to a NativeCommand
-            new SessionStateVariableEntry(
-                SpecialVariables.OutputEncoding,
-                Utils.utf8NoBom,
-                RunspaceInit.OutputEncodingDescription,
-                ScopedItemOptions.None,
-                new ArgumentTypeConverterAttribute(typeof(System.Text.Encoding))),
+                // Variable which controls the encoding for piping data to a NativeCommand
+                new SessionStateVariableEntry(
+                    SpecialVariables.OutputEncoding,
+                    Utils.utf8NoBom,
+                    RunspaceInit.OutputEncodingDescription,
+                    ScopedItemOptions.None,
+                    new ArgumentTypeConverterAttribute(typeof(System.Text.Encoding))),
 
-            // Preferences
-            //
-            // NTRAID#Windows Out Of Band Releases-931461-2006/03/13
-            // ArgumentTypeConverterAttribute is applied to these variables,
-            // but this only reaches the global variable.  If these are
-            // redefined in script scope etc, the type conversion
-            // is not applicable.
-            //
-            // Variables typed to ActionPreference
-            new SessionStateVariableEntry(
-                SpecialVariables.ConfirmPreference,
-                DefaultConfirmPreference,
-                RunspaceInit.ConfirmPreferenceDescription,
-                ScopedItemOptions.None,
-                new ArgumentTypeConverterAttribute(typeof(ConfirmImpact))),
-            new SessionStateVariableEntry(
-                SpecialVariables.DebugPreference,
-                DefaultDebugPreference,
-                RunspaceInit.DebugPreferenceDescription,
-                ScopedItemOptions.None,
-                new ArgumentTypeConverterAttribute(typeof(ActionPreference))),
-            new SessionStateVariableEntry(
-                SpecialVariables.ErrorActionPreference,
-                DefaultErrorActionPreference,
-                RunspaceInit.ErrorActionPreferenceDescription,
-                ScopedItemOptions.None,
-                new ArgumentTypeConverterAttribute(typeof(ActionPreference))),
-            new SessionStateVariableEntry(
-                SpecialVariables.ProgressPreference,
-                DefaultProgressPreference,
-                RunspaceInit.ProgressPreferenceDescription,
-                ScopedItemOptions.None,
-                new ArgumentTypeConverterAttribute(typeof(ActionPreference))),
-            new SessionStateVariableEntry(
-                SpecialVariables.VerbosePreference,
-                DefaultVerbosePreference,
-                RunspaceInit.VerbosePreferenceDescription,
-                ScopedItemOptions.None,
-                new ArgumentTypeConverterAttribute(typeof(ActionPreference))),
-            new SessionStateVariableEntry(
-                SpecialVariables.WarningPreference,
-                DefaultWarningPreference,
-                RunspaceInit.WarningPreferenceDescription,
-                ScopedItemOptions.None,
-                new ArgumentTypeConverterAttribute(typeof(ActionPreference))),
-            new SessionStateVariableEntry(
-                SpecialVariables.InformationPreference,
-                DefaultInformationPreference,
-                RunspaceInit.InformationPreferenceDescription,
-                ScopedItemOptions.None,
-                new ArgumentTypeConverterAttribute(typeof(ActionPreference))),
-            new SessionStateVariableEntry(
-                SpecialVariables.ErrorView,
-                DefaultErrorView,
-                RunspaceInit.ErrorViewDescription,
-                ScopedItemOptions.None,
-                new ArgumentTypeConverterAttribute(typeof(ErrorView))),
-            new SessionStateVariableEntry(
-                SpecialVariables.NestedPromptLevel,
-                0,
-                RunspaceInit.NestedPromptLevelDescription),
-            new SessionStateVariableEntry(
-                SpecialVariables.PSNativeCommandUseErrorActionPreference,
-                DefaultPSNativeCommandUseErrorActionPreference,
-                RunspaceInit.PSNativeCommandUseErrorActionPreferenceDescription),
-            new SessionStateVariableEntry(
-                SpecialVariables.WhatIfPreference,
-                DefaultWhatIfPreference,
-                RunspaceInit.WhatIfPreferenceDescription),
-            new SessionStateVariableEntry(
-                FormatEnumerationLimit,
-                DefaultFormatEnumerationLimit,
-                RunspaceInit.FormatEnumerationLimitDescription),
+                // Preferences
+                //
+                // NTRAID#Windows Out Of Band Releases-931461-2006/03/13
+                // ArgumentTypeConverterAttribute is applied to these variables,
+                // but this only reaches the global variable.  If these are
+                // redefined in script scope etc, the type conversion
+                // is not applicable.
+                //
+                // Variables typed to ActionPreference
+                new SessionStateVariableEntry(
+                    SpecialVariables.ConfirmPreference,
+                    DefaultConfirmPreference,
+                    RunspaceInit.ConfirmPreferenceDescription,
+                    ScopedItemOptions.None,
+                    new ArgumentTypeConverterAttribute(typeof(ConfirmImpact))),
+                new SessionStateVariableEntry(
+                    SpecialVariables.DebugPreference,
+                    DefaultDebugPreference,
+                    RunspaceInit.DebugPreferenceDescription,
+                    ScopedItemOptions.None,
+                    new ArgumentTypeConverterAttribute(typeof(ActionPreference))),
+                new SessionStateVariableEntry(
+                    SpecialVariables.ErrorActionPreference,
+                    DefaultErrorActionPreference,
+                    RunspaceInit.ErrorActionPreferenceDescription,
+                    ScopedItemOptions.None,
+                    new ArgumentTypeConverterAttribute(typeof(ActionPreference))),
+                new SessionStateVariableEntry(
+                    SpecialVariables.ProgressPreference,
+                    DefaultProgressPreference,
+                    RunspaceInit.ProgressPreferenceDescription,
+                    ScopedItemOptions.None,
+                    new ArgumentTypeConverterAttribute(typeof(ActionPreference))),
+                new SessionStateVariableEntry(
+                    SpecialVariables.VerbosePreference,
+                    DefaultVerbosePreference,
+                    RunspaceInit.VerbosePreferenceDescription,
+                    ScopedItemOptions.None,
+                    new ArgumentTypeConverterAttribute(typeof(ActionPreference))),
+                new SessionStateVariableEntry(
+                    SpecialVariables.WarningPreference,
+                    DefaultWarningPreference,
+                    RunspaceInit.WarningPreferenceDescription,
+                    ScopedItemOptions.None,
+                    new ArgumentTypeConverterAttribute(typeof(ActionPreference))),
+                new SessionStateVariableEntry(
+                    SpecialVariables.InformationPreference,
+                    DefaultInformationPreference,
+                    RunspaceInit.InformationPreferenceDescription,
+                    ScopedItemOptions.None,
+                    new ArgumentTypeConverterAttribute(typeof(ActionPreference))),
+                new SessionStateVariableEntry(
+                    SpecialVariables.ErrorView,
+                    DefaultErrorView,
+                    RunspaceInit.ErrorViewDescription,
+                    ScopedItemOptions.None,
+                    new ArgumentTypeConverterAttribute(typeof(ErrorView))),
+                new SessionStateVariableEntry(
+                    SpecialVariables.NestedPromptLevel,
+                    0,
+                    RunspaceInit.NestedPromptLevelDescription),
+                new SessionStateVariableEntry(
+                    SpecialVariables.WhatIfPreference,
+                    DefaultWhatIfPreference,
+                    RunspaceInit.WhatIfPreferenceDescription),
+                new SessionStateVariableEntry(
+                    FormatEnumerationLimit,
+                    DefaultFormatEnumerationLimit,
+                    RunspaceInit.FormatEnumerationLimitDescription),
 
-             // variable for PSEmailServer
-            new SessionStateVariableEntry(
-                SpecialVariables.PSEmailServer,
-                string.Empty,
-                RunspaceInit.PSEmailServerDescription),
+                // variable for PSEmailServer
+                new SessionStateVariableEntry(
+                    SpecialVariables.PSEmailServer,
+                    string.Empty,
+                    RunspaceInit.PSEmailServerDescription),
 
-            // Start: Variables which control remoting behavior
-            new SessionStateVariableEntry(
-                Microsoft.PowerShell.Commands.PSRemotingBaseCmdlet.DEFAULT_SESSION_OPTION,
-                new System.Management.Automation.Remoting.PSSessionOption(),
-                RemotingErrorIdStrings.PSDefaultSessionOptionDescription,
-                ScopedItemOptions.None),
-            new SessionStateVariableEntry(
-                SpecialVariables.PSSessionConfigurationName,
-                "http://schemas.microsoft.com/powershell/Microsoft.PowerShell",
-                RemotingErrorIdStrings.PSSessionConfigurationName,
-                ScopedItemOptions.None),
-            new SessionStateVariableEntry(
-                SpecialVariables.PSSessionApplicationName,
-                "wsman",
-                RemotingErrorIdStrings.PSSessionAppName,
-                ScopedItemOptions.None),
-            // End: Variables which control remoting behavior
+                // Start: Variables which control remoting behavior
+                new SessionStateVariableEntry(
+                    Microsoft.PowerShell.Commands.PSRemotingBaseCmdlet.DEFAULT_SESSION_OPTION,
+                    new System.Management.Automation.Remoting.PSSessionOption(),
+                    RemotingErrorIdStrings.PSDefaultSessionOptionDescription,
+                    ScopedItemOptions.None),
+                new SessionStateVariableEntry(
+                    SpecialVariables.PSSessionConfigurationName,
+                    "http://schemas.microsoft.com/powershell/Microsoft.PowerShell",
+                    RemotingErrorIdStrings.PSSessionConfigurationName,
+                    ScopedItemOptions.None),
+                new SessionStateVariableEntry(
+                    SpecialVariables.PSSessionApplicationName,
+                    "wsman",
+                    RemotingErrorIdStrings.PSSessionAppName,
+                    ScopedItemOptions.None),
+                // End: Variables which control remoting behavior
 
-            #region Platform
-            new SessionStateVariableEntry(
-                SpecialVariables.IsLinux,
-                Platform.IsLinux,
-                string.Empty,
-                ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
+                #region Platform
+                new SessionStateVariableEntry(
+                    SpecialVariables.IsLinux,
+                    Platform.IsLinux,
+                    string.Empty,
+                    ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
 
-            new SessionStateVariableEntry(
-                SpecialVariables.IsMacOS,
-                Platform.IsMacOS,
-                string.Empty,
-                ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
+                new SessionStateVariableEntry(
+                    SpecialVariables.IsMacOS,
+                    Platform.IsMacOS,
+                    string.Empty,
+                    ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
 
-            new SessionStateVariableEntry(
-                SpecialVariables.IsWindows,
-                Platform.IsWindows,
-                string.Empty,
-                ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
+                new SessionStateVariableEntry(
+                    SpecialVariables.IsWindows,
+                    Platform.IsWindows,
+                    string.Empty,
+                    ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
 
-            new SessionStateVariableEntry(
-                SpecialVariables.IsCoreCLR,
-                Platform.IsCoreCLR,
-                string.Empty,
-                ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
-            #endregion
-        };
+                new SessionStateVariableEntry(
+                    SpecialVariables.IsCoreCLR,
+                    Platform.IsCoreCLR,
+                    string.Empty,
+                    ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
+                #endregion
+            };
+
+            if (ExperimentalFeature.IsEnabled(ExperimentalFeature.PSNativeCommandErrorActionPreferenceFeatureName))
+            {
+                builtinVariables.Add(
+                    new SessionStateVariableEntry(
+                        SpecialVariables.PSNativeCommandUseErrorActionPreference,
+                        DefaultPSNativeCommandUseErrorActionPreference,
+                        RunspaceInit.PSNativeCommandUseErrorActionPreferenceDescription,
+                        ScopedItemOptions.None,
+                        new ArgumentTypeConverterAttribute(typeof(bool))));
+            }
+
+            BuiltInVariables = builtinVariables.ToArray();
+        }
+
+        internal static readonly SessionStateVariableEntry[] BuiltInVariables;
 
         /// <summary>
         /// Returns a new array of alias entries everytime it's called. This

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4471,7 +4471,7 @@ end {
         internal const ActionPreference DefaultInformationPreference = ActionPreference.SilentlyContinue;
 
         internal const ErrorView DefaultErrorView = ErrorView.ConciseView;
-        internal const bool DefaultNativeCommandThrowPreference = false;
+        internal const bool DefaultNativeCommandUseErrorActionPreference = false;
         internal const bool DefaultWhatIfPreference = false;
         internal const ConfirmImpact DefaultConfirmPreference = ConfirmImpact.High;
 
@@ -4562,9 +4562,9 @@ end {
                 0,
                 RunspaceInit.NestedPromptLevelDescription),
             new SessionStateVariableEntry(
-                SpecialVariables.NativeCommandThrowPreference,
-                DefaultNativeCommandThrowPreference,
-                RunspaceInit.NativeCommandThrowPreferenceDescription),
+                SpecialVariables.NativeCommandUseErrorActionPreference,
+                DefaultNativeCommandUseErrorActionPreference,
+                RunspaceInit.NativeCommandUseErrorActionPreferenceDescription),
             new SessionStateVariableEntry(
                 SpecialVariables.WhatIfPreference,
                 DefaultWhatIfPreference,

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -2819,7 +2819,7 @@ namespace System.Management.Automation
         /// but the command failure will ultimately be
         /// <see cref="System.Management.Automation.ActionPreferenceStopException"/>,
         /// </remarks>
-        internal void _WriteErrorSkipAllowCheck(ErrorRecord errorRecord, ActionPreference? actionPreference = null, bool isNativeError = false)
+        internal void _WriteErrorSkipAllowCheck(ErrorRecord errorRecord, ActionPreference? actionPreference = null, bool isNativeStdErrCall = false)
         {
             ThrowIfStopping();
 
@@ -2839,7 +2839,7 @@ namespace System.Management.Automation
                 this.PipelineProcessor.LogExecutionError(_thisCommand.MyInvocation, errorRecord);
             }
 
-            if (!isNativeError)
+            if (!isNativeStdErrCall)
             {
                 this.PipelineProcessor.ExecutionFailed = true;
 
@@ -2905,7 +2905,7 @@ namespace System.Management.Automation
             // when tracing), so don't add the member again.
 
             // We don't add a note property on messages that comes from stderr stream.
-            if (!isNativeError)
+            if (!isNativeStdErrCall)
             {
                 errorWrap.WriteStream = WriteStreamType.Error;
             }

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -2809,7 +2809,11 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="errorRecord">The error record to write.</param>
         /// <param name="actionPreference">The configured error action preference.</param>
-        /// <param name="isFromNativeStdError">True when this method is called to write from a native command's stderr stream.</param>
+        /// <param name="isFromNativeStdError">
+        /// True when this method is called to write from a native command's stderr stream.
+        /// When errors are written through a native stderr stream, they do not interact with the error preference system,
+        /// but must still present as errors in PowerShell.
+        /// </param>
         /// <exception cref="System.Management.Automation.PipelineStoppedException">
         /// The pipeline has already been terminated, or was terminated
         /// during the execution of this method.

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -2804,8 +2804,12 @@ namespace System.Management.Automation
             _WriteErrorSkipAllowCheck(errorRecord, preference);
         }
 
-        // NOTICE-2004/06/08-JonN 959638
-        // Use this variant to skip the ThrowIfWriteNotPermitted check
+        /// <summary>
+        /// Write an error, skipping the ThrowIfWriteNotPermitted check.
+        /// </summary>
+        /// <param name="errorRecord">The error record to write.</param>
+        /// <param name="actionPreference">The configured error action preference.</param>
+        /// <param name="isFromNativeStdError">True when this method is called to write from a native command's stderr stream.</param>
         /// <exception cref="System.Management.Automation.PipelineStoppedException">
         /// The pipeline has already been terminated, or was terminated
         /// during the execution of this method.
@@ -2819,7 +2823,7 @@ namespace System.Management.Automation
         /// but the command failure will ultimately be
         /// <see cref="System.Management.Automation.ActionPreferenceStopException"/>,
         /// </remarks>
-        internal void _WriteErrorSkipAllowCheck(ErrorRecord errorRecord, ActionPreference? actionPreference = null, bool isNativeStdErrCall = false)
+        internal void _WriteErrorSkipAllowCheck(ErrorRecord errorRecord, ActionPreference? actionPreference = null, bool isFromNativeStdError = false)
         {
             ThrowIfStopping();
 
@@ -2839,7 +2843,7 @@ namespace System.Management.Automation
                 this.PipelineProcessor.LogExecutionError(_thisCommand.MyInvocation, errorRecord);
             }
 
-            if (!isNativeStdErrCall)
+            if (!isFromNativeStdError)
             {
                 this.PipelineProcessor.ExecutionFailed = true;
 
@@ -2905,7 +2909,7 @@ namespace System.Management.Automation
             // when tracing), so don't add the member again.
 
             // We don't add a note property on messages that comes from stderr stream.
-            if (!isNativeStdErrCall)
+            if (!isFromNativeStdError)
             {
                 errorWrap.WriteStream = WriteStreamType.Error;
             }

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -893,11 +893,10 @@ namespace System.Management.Automation
                         return;
                     }
 
-                    ActionPreference errorActionPref =
-                        this.Command.Context.GetEnumPreference(
-                            SpecialVariables.ErrorActionPreferenceVarPath,
-                            ActionPreference.SilentlyContinue,
-                            out _);
+                    ActionPreference errorActionPref = Command.Context.GetEnumPreference(
+                        SpecialVariables.ErrorActionPreferenceVarPath,
+                        ActionPreference.SilentlyContinue,
+                        out _);
 
                     if (errorActionPref != ActionPreference.Ignore)
                     {

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -3,22 +3,22 @@
 
 #pragma warning disable 1634, 1691
 
-using System.Diagnostics;
-using System.IO;
-using System.ComponentModel;
-using System.Text;
 using System.Collections;
-using System.Threading;
-using System.Management.Automation.Internal;
-using System.Management.Automation.Runspaces;
-using System.Xml;
-using System.Runtime.InteropServices;
-using Dbg = System.Management.Automation.Diagnostics;
-using System.Runtime.Serialization;
-using System.Globalization;
-using System.Diagnostics.CodeAnalysis;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Management.Automation.Internal;
+using System.Management.Automation.Runspaces;
+using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading;
+using System.Xml;
+using Dbg = System.Management.Automation.Diagnostics;
 
 namespace System.Management.Automation
 {
@@ -156,13 +156,14 @@ namespace System.Management.Automation
         #region Constructors
 
         /// <summary>
-        /// Constructs a NativeCommandException.
+        /// Initializes a new instance of the <see cref="NativeCommandException"/> class with information on the native
+        /// command, a specified error message and a specified error ID.
         /// </summary>
-        /// <param name="path"></param>
-        /// <param name="exitCode"></param>
-        /// <param name="processId"></param>
-        /// <param name="message"></param>
-        /// <param name="errorId"></param>
+        /// <param name="path">The full path of the native command.</param>
+        /// <param name="exitCode">The exit code returned by the native command.</param>
+        /// <param name="processId">The process ID of the process before it ended.</param>
+        /// <param name="message">The error message.</param>
+        /// <param name="errorId">The error ID.</param>
         internal NativeCommandException(string path, int exitCode, int processId, string message, string errorId)
             : base(message)
         {
@@ -174,12 +175,12 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// This is the default constructor.
+        /// Initializes a new instance of the <see cref="NativeCommandException"/> class.
         /// </summary>
         public NativeCommandException() : base() { }
 
         /// <summary>
-        /// This constructor takes a localized error message.
+        /// Initializes a new instance of the <see cref="NativeCommandException"/> class with a specified error message.
         /// </summary>
         /// <param name="message">
         /// A localized error message.
@@ -187,7 +188,8 @@ namespace System.Management.Automation
         public NativeCommandException(string message) : base(message) { }
 
         /// <summary>
-        /// This constructor takes a localized message and an inner exception.
+        /// Initializes a new instance of the <see cref="NativeCommandException"/> class with a specified error message 
+        /// and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">
         /// Localized error message.
@@ -198,7 +200,7 @@ namespace System.Management.Automation
         public NativeCommandException(string message, Exception innerException) : base(message, innerException) { }
 
         /// <summary>
-        /// This constructor is required by serialization.
+        /// Initializes a new instance of the <see cref="NativeCommandException"/> class with serialized data.
         /// </summary>
         /// <param name="info"></param>
         /// <param name="context"></param>

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -136,7 +136,7 @@ namespace System.Management.Automation
     /// when a native command retuns a non-zero exit code.
     /// </summary>
     [Serializable]
-    public class NativeCommandException : RuntimeException
+    public class NativeCommandExitException : RuntimeException
     {
         /// <summary>
         /// Gets the path of the native command.
@@ -156,7 +156,7 @@ namespace System.Management.Automation
         #region Constructors
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NativeCommandException"/> class with information on the native
+        /// Initializes a new instance of the <see cref="NativeCommandExitException"/> class with information on the native
         /// command, a specified error message and a specified error ID.
         /// </summary>
         /// <param name="path">The full path of the native command.</param>
@@ -164,31 +164,31 @@ namespace System.Management.Automation
         /// <param name="processId">The process ID of the process before it ended.</param>
         /// <param name="message">The error message.</param>
         /// <param name="errorId">The error ID.</param>
-        internal NativeCommandException(string path, int exitCode, int processId, string message, string errorId)
+        internal NativeCommandExitException(string path, int exitCode, int processId, string message, string errorId)
             : base(message)
         {
             SetErrorId(errorId);
             SetErrorCategory(ErrorCategory.NotSpecified);
-            this.Path = path;
-            this.ExitCode = exitCode;
-            this.ProcessId = processId;
+            Path = path;
+            ExitCode = exitCode;
+            ProcessId = processId;
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NativeCommandException"/> class.
+        /// Initializes a new instance of the <see cref="NativeCommandExitException"/> class.
         /// </summary>
-        public NativeCommandException() : base() { }
+        public NativeCommandExitException() : base() { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NativeCommandException"/> class with a specified error message.
+        /// Initializes a new instance of the <see cref="NativeCommandExitException"/> class with a specified error message.
         /// </summary>
         /// <param name="message">
         /// A localized error message.
         /// </param>
-        public NativeCommandException(string message) : base(message) { }
+        public NativeCommandExitException(string message) : base(message) { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NativeCommandException"/> class with a specified error message
+        /// Initializes a new instance of the <see cref="NativeCommandExitException"/> class with a specified error message
         /// and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">
@@ -197,14 +197,14 @@ namespace System.Management.Automation
         /// <param name="innerException">
         /// Inner exception.
         /// </param>
-        public NativeCommandException(string message, Exception innerException) : base(message, innerException) { }
+        public NativeCommandExitException(string message, Exception innerException) : base(message, innerException) { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NativeCommandException"/> class with serialized data.
+        /// Initializes a new instance of the <see cref="NativeCommandExitException"/> class with serialized data.
         /// </summary>
         /// <param name="info"></param>
         /// <param name="context"></param>
-        protected NativeCommandException(SerializationInfo info, StreamingContext context)
+        protected NativeCommandExitException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
             if (info == null)
@@ -212,9 +212,9 @@ namespace System.Management.Automation
                 throw new PSArgumentNullException(nameof(info));
             }
 
-            this.Path = info.GetString(nameof(this.Path));
-            this.ExitCode = info.GetInt32(nameof(this.ExitCode));
-            this.ProcessId = info.GetInt32(nameof(this.ProcessId));
+            Path = info.GetString(nameof(Path));
+            ExitCode = info.GetInt32(nameof(ExitCode));
+            ProcessId = info.GetInt32(nameof(ProcessId));
         }
 
         #endregion Constructors
@@ -233,9 +233,9 @@ namespace System.Management.Automation
 
             base.GetObjectData(info, context);
 
-            info.AddValue(nameof(this.Path), this.Path);
-            info.AddValue(nameof(this.ExitCode), this.ExitCode);
-            info.AddValue(nameof(this.ProcessId), this.ProcessId);
+            info.AddValue(nameof(Path), Path);
+            info.AddValue(nameof(ExitCode), ExitCode);
+            info.AddValue(nameof(ProcessId), ProcessId);
         }
     }
 
@@ -906,7 +906,7 @@ namespace System.Management.Automation
                                 _nativeProcess.ExitCode);
 
                         var exception =
-                            new NativeCommandException(
+                            new NativeCommandExitException(
                                 this.Path,
                                 _nativeProcess.ExitCode,
                                 _nativeProcess.Id,

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -865,15 +865,10 @@ namespace System.Management.Automation
                     this.commandRuntime.PipelineProcessor.ExecutionFailed = true;
 
                     if (!ExperimentalFeature.IsEnabled(ExperimentalFeature.PSNativeCommandErrorActionPreferenceFeatureName)
-                        || !(bool)Command.Context.GetVariableValue(SpecialVariables.PSNativeCommandUseErrorActionPreferenceVarPath))
+                        || !(bool)Command.Context.GetVariableValue(SpecialVariables.PSNativeCommandUseErrorActionPreferenceVarPath, defaultValue: false))
                     {
                         return;
                     }
-
-                    ActionPreference errorActionPref = Command.Context.GetEnumPreference(
-                        SpecialVariables.ErrorActionPreferenceVarPath,
-                        ActionPreference.SilentlyContinue,
-                        out _);
 
                     const string errorId = nameof(CommandBaseStrings.ProgramExitedWithNonZeroCode);
 

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Collections;
 using System.Threading;
 using System.Management.Automation.Internal;
+using System.Management.Automation.Runspaces;
 using System.Xml;
 using System.Runtime.InteropServices;
 using Dbg = System.Management.Automation.Diagnostics;
@@ -766,14 +767,13 @@ namespace System.Management.Automation
                     {
                         this.commandRuntime.PipelineProcessor.ExecutionFailed = true;
 
-                        bool nativeCommandUseErrorActionPref = 
+                        bool nativeCommandUseErrorActionPreference = 
                             this.Command.Context.GetBooleanPreference(
-                                SpecialVariables.NativeCommandUseErrorActionPreferenceVarPath, 
-                                false, 
+                                SpecialVariables.NativeCommandUseErrorActionPreferenceVarPath,
+                                InitialSessionState.DefaultNativeCommandUseErrorActionPreference,
                                 out _);
 
-                        // If $PSNativeCommandUseErrorActionPreference is $true, then evaluate $ErrorActionPreference
-                        if (nativeCommandUseErrorActionPref)
+                        if (nativeCommandUseErrorActionPreference)
                         {
                             ActionPreference errorActionPref =
                                 this.Command.Context.GetEnumPreference(

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -925,7 +925,7 @@ namespace System.Management.Automation
                             errorMsg,
                             errorId);
 
-                        var errorRecord = new ErrorRecord(exception, errorId, ErrorCategory.NotSpecified, null);
+                        var errorRecord = new ErrorRecord(exception, errorId, ErrorCategory.NotSpecified, targetObject: null);
                         this.commandRuntime._WriteErrorSkipAllowCheck(errorRecord);
                     }
                 }

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -884,7 +884,7 @@ namespace System.Management.Automation
                         errorMsg,
                         errorId);
 
-                    var errorRecord = new ErrorRecord(exception, errorId, ErrorCategory.NotSpecified, targetObject: _nativeProcess.ProcessName);
+                    var errorRecord = new ErrorRecord(exception, errorId, ErrorCategory.NotSpecified, targetObject: NativeCommandName);
                     this.commandRuntime._WriteErrorSkipAllowCheck(errorRecord);
                 }
             }

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -169,37 +169,6 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NativeCommandExitException"/> class.
-        /// </summary>
-        public NativeCommandExitException() : base()
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NativeCommandExitException"/> class with a specified error message.
-        /// </summary>
-        /// <param name="message">
-        /// A localized error message.
-        /// </param>
-        public NativeCommandExitException(string message) : base(message)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NativeCommandExitException"/> class with a specified error message
-        /// and a reference to the inner exception that is the cause of this exception.
-        /// </summary>
-        /// <param name="message">
-        /// Localized error message.
-        /// </param>
-        /// <param name="innerException">
-        /// Inner exception.
-        /// </param>
-        public NativeCommandExitException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="NativeCommandExitException"/> class with serialized data.
         /// </summary>
         /// <param name="info"></param>

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -188,7 +188,7 @@ namespace System.Management.Automation
         public NativeCommandException(string message) : base(message) { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NativeCommandException"/> class with a specified error message 
+        /// Initializes a new instance of the <see cref="NativeCommandException"/> class with a specified error message
         /// and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">
@@ -878,8 +878,8 @@ namespace System.Management.Automation
 
                     this.commandRuntime.PipelineProcessor.ExecutionFailed = true;
 
-                    bool nativeCommandUseErrorActionPreference = 
-                        this.Command.Context.GetBooleanPreference(
+                    bool nativeCommandUseErrorActionPreference = ExperimentalFeature.IsEnabled(ExperimentalFeature.PSNativeCommandErrorActionPreferenceFeatureName)
+                        && this.Command.Context.GetBooleanPreference(
                             SpecialVariables.PSNativeCommandUseErrorActionPreferenceVarPath,
                             InitialSessionState.DefaultPSNativeCommandUseErrorActionPreference,
                             out _);
@@ -907,7 +907,7 @@ namespace System.Management.Automation
 
                         var exception =
                             new NativeCommandException(
-                                this.Path, 
+                                this.Path,
                                 _nativeProcess.ExitCode,
                                 _nativeProcess.Id,
                                 errorMsg,

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -131,6 +131,7 @@ namespace System.Management.Automation
         }
     }
 
+    #nullable enable
     /// <summary>
     /// This exception is used by the NativeCommandProcessor to indicate an error
     /// when a native command retuns a non-zero exit code.
@@ -145,21 +146,6 @@ namespace System.Management.Automation
         // it was decided instead to use a fresh type to minimize the chance of conflating the two scenarios:
         // * ApplicationFailedException: PowerShell can not execute an application.
         // * NativeCommandExitException: an application was successfully executed and completed but return non-zero exit code.
-
-        /// <summary>
-        /// Gets the path of the native command.
-        /// </summary>
-        public string Path { get; }
-
-        /// <summary>
-        /// Gets the exit code returned by the native command.
-        /// </summary>
-        public int ExitCode { get; }
-
-        /// <summary>
-        /// Gets the native command's process Id.
-        /// </summary>
-        public int ProcessId { get; }
 
         #region Constructors
 
@@ -245,7 +231,24 @@ namespace System.Management.Automation
             info.AddValue(nameof(ExitCode), ExitCode);
             info.AddValue(nameof(ProcessId), ProcessId);
         }
+
+        /// <summary>
+        /// Gets the path of the native command.
+        /// </summary>
+        public string? Path { get; }
+
+        /// <summary>
+        /// Gets the exit code returned by the native command.
+        /// </summary>
+        public int? ExitCode { get; }
+
+        /// <summary>
+        /// Gets the native command's process Id.
+        /// </summary>
+        public int? ProcessId { get; }
+
     }
+    #nullable restore
 
     /// <summary>
     /// Provides way to create and execute native commands.

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -140,9 +140,11 @@ namespace System.Management.Automation
     {
         // NOTE:
         // When implementing the native error action preference integration,
-        // reusing ApplicationFailedException was contemplated.
-        // However, rather than possibly reusing a type already used in another scenario
-        // it was decided instead to use a fresh type to minimize the chance of conflating the two scenarios.
+        // reusing ApplicationFailedException was rejected.
+        // Instead of reusing the type already used in another scenario
+        // it was decided instead to use a fresh type to minimize the chance of conflating the two scenarios:
+        // * ApplicationFailedException: PowerShell can not execute an application.
+        // * NativeCommandExitException: an application was successfully executed and completed but return non-zero exit code.
 
         /// <summary>
         /// Gets the path of the native command.

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -149,17 +149,17 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets the path of the native command.
         /// </summary>
-        public string Path { get; private set; }
+        public string Path { get; }
 
         /// <summary>
         /// Gets the exit code returned by the native command.
         /// </summary>
-        public int ExitCode { get; private set; }
+        public int ExitCode { get; }
 
         /// <summary>
         /// Gets the native command's process Id.
         /// </summary>
-        public int ProcessId { get; private set; }
+        public int ProcessId { get; }
 
         #region Constructors
 

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -902,19 +902,17 @@ namespace System.Management.Automation
                     {
                         const string errorId = "ProgramFailedToComplete";
 
-                        string errorMsg =
-                            StringUtil.Format(
-                                CommandBaseStrings.ProgramFailedToComplete,
-                                NativeCommandName,
-                                _nativeProcess.ExitCode);
+                        string errorMsg = StringUtil.Format(
+                            CommandBaseStrings.ProgramFailedToComplete,
+                            NativeCommandName,
+                            _nativeProcess.ExitCode);
 
-                        var exception =
-                            new NativeCommandExitException(
-                                Path,
-                                _nativeProcess.ExitCode,
-                                _nativeProcess.Id,
-                                errorMsg,
-                                errorId);
+                        var exception = new NativeCommandExitException(
+                            Path,
+                            _nativeProcess.ExitCode,
+                            _nativeProcess.Id,
+                            errorMsg,
+                            errorId);
 
                         var errorRecord = new ErrorRecord(exception, errorId, ErrorCategory.NotSpecified, null);
                         this.commandRuntime._WriteErrorSkipAllowCheck(errorRecord);

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1214,7 +1214,7 @@ namespace System.Management.Automation
                 ErrorRecord record = outputValue.Data as ErrorRecord;
                 Dbg.Assert(record != null, "ProcessReader should ensure that data is ErrorRecord");
                 record.SetInvocationInfo(this.Command.MyInvocation);
-                this.commandRuntime._WriteErrorSkipAllowCheck(record, isNativeStdErrCall: true);
+                this.commandRuntime._WriteErrorSkipAllowCheck(record, isFromNativeStdError: true);
             }
             else if (outputValue.Stream == MinishellStream.Output)
             {

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -909,25 +909,22 @@ namespace System.Management.Automation
                         ActionPreference.SilentlyContinue,
                         out _);
 
-                    if (errorActionPref != ActionPreference.Ignore)
-                    {
-                        const string errorId = nameof(CommandBaseStrings.ProgramFailedToComplete);
+                    const string errorId = nameof(CommandBaseStrings.ProgramFailedToComplete);
 
-                        string errorMsg = StringUtil.Format(
-                            CommandBaseStrings.ProgramFailedToComplete,
-                            NativeCommandName,
-                            _nativeProcess.ExitCode);
+                    string errorMsg = StringUtil.Format(
+                        CommandBaseStrings.ProgramFailedToComplete,
+                        NativeCommandName,
+                        _nativeProcess.ExitCode);
 
-                        var exception = new NativeCommandExitException(
-                            Path,
-                            _nativeProcess.ExitCode,
-                            _nativeProcess.Id,
-                            errorMsg,
-                            errorId);
+                    var exception = new NativeCommandExitException(
+                        Path,
+                        _nativeProcess.ExitCode,
+                        _nativeProcess.Id,
+                        errorMsg,
+                        errorId);
 
-                        var errorRecord = new ErrorRecord(exception, errorId, ErrorCategory.NotSpecified, targetObject: null);
-                        this.commandRuntime._WriteErrorSkipAllowCheck(errorRecord);
-                    }
+                    var errorRecord = new ErrorRecord(exception, errorId, ErrorCategory.NotSpecified, targetObject: null);
+                    this.commandRuntime._WriteErrorSkipAllowCheck(errorRecord);
                 }
             }
             catch (Win32Exception e)

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -878,10 +878,10 @@ namespace System.Management.Automation
                         ActionPreference.SilentlyContinue,
                         out _);
 
-                    const string errorId = nameof(CommandBaseStrings.ProgramEndsWithNonZeroCode);
+                    const string errorId = nameof(CommandBaseStrings.ProgramExitedWithNonZeroCode);
 
                     string errorMsg = StringUtil.Format(
-                        CommandBaseStrings.ProgramEndsWithNonZeroCode,
+                        CommandBaseStrings.ProgramExitedWithNonZeroCode,
                         NativeCommandName,
                         _nativeProcess.ExitCode);
 

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -884,13 +884,11 @@ namespace System.Management.Automation
 
                     this.commandRuntime.PipelineProcessor.ExecutionFailed = true;
 
-                    bool nativeCommandUseErrorActionPreference = ExperimentalFeature.IsEnabled(ExperimentalFeature.PSNativeCommandErrorActionPreferenceFeatureName)
-                        && this.Command.Context.GetBooleanPreference(
-                            SpecialVariables.PSNativeCommandUseErrorActionPreferenceVarPath,
-                            InitialSessionState.DefaultPSNativeCommandUseErrorActionPreference,
-                            out _);
-
-                    if (!nativeCommandUseErrorActionPreference)
+                    if (!ExperimentalFeature.IsEnabled(ExperimentalFeature.PSNativeCommandErrorActionPreferenceFeatureName)
+                        || !this.Command.Context.GetBooleanPreference(
+                                SpecialVariables.PSNativeCommandUseErrorActionPreferenceVarPath,
+                                InitialSessionState.DefaultPSNativeCommandUseErrorActionPreference,
+                                out _))
                     {
                         return;
                     }

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -909,10 +909,10 @@ namespace System.Management.Automation
                         ActionPreference.SilentlyContinue,
                         out _);
 
-                    const string errorId = nameof(CommandBaseStrings.ProgramFailedToComplete);
+                    const string errorId = nameof(CommandBaseStrings.ProgramEndsWithNonZeroCode);
 
                     string errorMsg = StringUtil.Format(
-                        CommandBaseStrings.ProgramFailedToComplete,
+                        CommandBaseStrings.ProgramEndsWithNonZeroCode,
                         NativeCommandName,
                         _nativeProcess.ExitCode);
 

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -772,8 +772,8 @@ namespace System.Management.Automation
 
                     bool nativeCommandUseErrorActionPreference = 
                         this.Command.Context.GetBooleanPreference(
-                            SpecialVariables.NativeCommandUseErrorActionPreferenceVarPath,
-                            InitialSessionState.DefaultNativeCommandUseErrorActionPreference,
+                            SpecialVariables.PSNativeCommandUseErrorActionPreferenceVarPath,
+                            InitialSessionState.DefaultPSNativeCommandUseErrorActionPreference,
                             out _);
 
                     if (!nativeCommandUseErrorActionPreference)

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -885,7 +885,7 @@ namespace System.Management.Automation
                     this.commandRuntime.PipelineProcessor.ExecutionFailed = true;
 
                     if (!ExperimentalFeature.IsEnabled(ExperimentalFeature.PSNativeCommandErrorActionPreferenceFeatureName)
-                        || !this.Command.Context.GetBooleanPreference(
+                        || !Command.Context.GetBooleanPreference(
                                 SpecialVariables.PSNativeCommandUseErrorActionPreferenceVarPath,
                                 InitialSessionState.DefaultPSNativeCommandUseErrorActionPreference,
                                 out _))
@@ -906,12 +906,12 @@ namespace System.Management.Automation
                         string errorMsg =
                             StringUtil.Format(
                                 CommandBaseStrings.ProgramFailedToComplete,
-                                this.NativeCommandName,
+                                NativeCommandName,
                                 _nativeProcess.ExitCode);
 
                         var exception =
                             new NativeCommandExitException(
-                                this.Path,
+                                Path,
                                 _nativeProcess.ExitCode,
                                 _nativeProcess.Id,
                                 errorMsg,

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -865,10 +865,7 @@ namespace System.Management.Automation
                     this.commandRuntime.PipelineProcessor.ExecutionFailed = true;
 
                     if (!ExperimentalFeature.IsEnabled(ExperimentalFeature.PSNativeCommandErrorActionPreferenceFeatureName)
-                        || !Command.Context.GetBooleanPreference(
-                                SpecialVariables.PSNativeCommandUseErrorActionPreferenceVarPath,
-                                InitialSessionState.DefaultPSNativeCommandUseErrorActionPreference,
-                                out _))
+                        || !(bool)Command.Context.GetVariableValue(SpecialVariables.PSNativeCommandUseErrorActionPreferenceVarPath))
                     {
                         return;
                     }

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -137,15 +137,15 @@ namespace System.Management.Automation
     /// when a native command retuns a non-zero exit code.
     /// </summary>
     [Serializable]
-    public class NativeCommandExitException : RuntimeException
+    public sealed class NativeCommandExitException : RuntimeException
     {
         // NOTE:
         // When implementing the native error action preference integration,
         // reusing ApplicationFailedException was rejected.
-        // Instead of reusing the type already used in another scenario
-        // it was decided instead to use a fresh type to minimize the chance of conflating the two scenarios:
-        // * ApplicationFailedException: PowerShell can not execute an application.
-        // * NativeCommandExitException: an application was successfully executed and completed but return non-zero exit code.
+        // Instead of reusing a type already used in another scenario
+        // it was decided instead to use a fresh type to avoid conflating the two scenarios:
+        // * ApplicationFailedException: PowerShell was not able to complete execution of the application.
+        // * NativeCommandExitException: the application completed execution but returned a non-zero exit code.
 
         #region Constructors
 
@@ -157,7 +157,7 @@ namespace System.Management.Automation
         /// <param name="exitCode">The exit code returned by the native command.</param>
         /// <param name="processId">The process ID of the process before it ended.</param>
         /// <param name="message">The error message.</param>
-        /// <param name="errorId">The error ID.</param>
+        /// <param name="errorId">The PowerShell runtime error ID.</param>
         internal NativeCommandExitException(string path, int exitCode, int processId, string message, string errorId)
             : base(message)
         {
@@ -171,7 +171,9 @@ namespace System.Management.Automation
         /// <summary>
         /// Initializes a new instance of the <see cref="NativeCommandExitException"/> class.
         /// </summary>
-        public NativeCommandExitException() : base() { }
+        public NativeCommandExitException() : base()
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NativeCommandExitException"/> class with a specified error message.
@@ -179,7 +181,9 @@ namespace System.Management.Automation
         /// <param name="message">
         /// A localized error message.
         /// </param>
-        public NativeCommandExitException(string message) : base(message) { }
+        public NativeCommandExitException(string message) : base(message)
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NativeCommandExitException"/> class with a specified error message
@@ -200,7 +204,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="info"></param>
         /// <param name="context"></param>
-        protected NativeCommandExitException(SerializationInfo info, StreamingContext context)
+        private NativeCommandExitException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
             if (info is null)
@@ -242,12 +246,12 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets the exit code returned by the native command.
         /// </summary>
-        public int? ExitCode { get; }
+        public int ExitCode { get; }
 
         /// <summary>
-        /// Gets the native command's process Id.
+        /// Gets the native command's process ID.
         /// </summary>
-        public int? ProcessId { get; }
+        public int ProcessId { get; }
 
     }
     #nullable restore

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -763,7 +763,26 @@ namespace System.Management.Automation
 
                     this.Command.Context.SetVariable(SpecialVariables.LastExitCodeVarPath, _nativeProcess.ExitCode);
                     if (_nativeProcess.ExitCode != 0)
+                    {
                         this.commandRuntime.PipelineProcessor.ExecutionFailed = true;
+
+                        bool nativeCommandThrowPref = 
+                            this.Command.Context.GetBooleanPreference(
+                                SpecialVariables.NativeCommandThrowPreferenceVarPath, 
+                                false, 
+                                out _);
+
+                        if (nativeCommandThrowPref)
+                        {
+                            var nonZeroExitCodeErrorRecord = 
+                                new ErrorRecord(
+                                    exception: new Exception("Native executable returned a non-zero exit code."), 
+                                    errorId: "NativeCommandThrow", 
+                                    errorCategory: ErrorCategory.NotSpecified,
+                                    targetObject: this.NativeCommandName);
+                            this.commandRuntime.ThrowTerminatingError(nonZeroExitCodeErrorRecord);
+                        }
+                    }
                 }
             }
             catch (Win32Exception e)

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -789,7 +789,6 @@ namespace System.Management.Automation
                                         errorId: "NativeCommandThrow", 
                                         errorCategory: ErrorCategory.NotSpecified,
                                         targetObject: this.NativeCommandName);
-                                // this.commandRuntime.ThrowTerminatingError(nonZeroExitCodeErrorRecord);
                                 this.commandRuntime._WriteErrorSkipAllowCheck(errorRecord, isNativeError: true);
                             }
                         }

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -884,7 +884,7 @@ namespace System.Management.Automation
                         errorMsg,
                         errorId);
 
-                    var errorRecord = new ErrorRecord(exception, errorId, ErrorCategory.NotSpecified, targetObject: null);
+                    var errorRecord = new ErrorRecord(exception, errorId, ErrorCategory.NotSpecified, targetObject: _nativeProcess.ProcessName);
                     this.commandRuntime._WriteErrorSkipAllowCheck(errorRecord);
                 }
             }

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -914,7 +914,7 @@ namespace System.Management.Automation
                                 errorId);
 
                         var errorRecord = new ErrorRecord(exception, errorId, ErrorCategory.NotSpecified, null);
-                        this.commandRuntime._WriteErrorSkipAllowCheck(errorRecord, isNativeError: true);
+                        this.commandRuntime._WriteErrorSkipAllowCheck(errorRecord);
                     }
                 }
             }
@@ -1239,7 +1239,7 @@ namespace System.Management.Automation
                 ErrorRecord record = outputValue.Data as ErrorRecord;
                 Dbg.Assert(record != null, "ProcessReader should ensure that data is ErrorRecord");
                 record.SetInvocationInfo(this.Command.MyInvocation);
-                this.commandRuntime._WriteErrorSkipAllowCheck(record, isNativeError: true);
+                this.commandRuntime._WriteErrorSkipAllowCheck(record, isNativeStdErrCall: true);
             }
             else if (outputValue.Stream == MinishellStream.Output)
             {

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -191,7 +191,9 @@ namespace System.Management.Automation
         /// <param name="innerException">
         /// Inner exception.
         /// </param>
-        public NativeCommandExitException(string message, Exception innerException) : base(message, innerException) { }
+        public NativeCommandExitException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NativeCommandExitException"/> class with serialized data.
@@ -201,7 +203,7 @@ namespace System.Management.Automation
         protected NativeCommandExitException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            if (info == null)
+            if (info is null)
             {
                 throw new PSArgumentNullException(nameof(info));
             }
@@ -220,7 +222,7 @@ namespace System.Management.Automation
         /// <param name="context">Streaming context.</param>
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
-            if (info == null)
+            if (info is null)
             {
                 throw new PSArgumentNullException(nameof(info));
             }

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -766,21 +766,32 @@ namespace System.Management.Automation
                     {
                         this.commandRuntime.PipelineProcessor.ExecutionFailed = true;
 
-                        bool nativeCommandThrowPref = 
+                        bool nativeCommandUseErrorActionPref = 
                             this.Command.Context.GetBooleanPreference(
-                                SpecialVariables.NativeCommandThrowPreferenceVarPath, 
+                                SpecialVariables.NativeCommandUseErrorActionPreferenceVarPath, 
                                 false, 
                                 out _);
 
-                        if (nativeCommandThrowPref)
+                        // If $PSNativeCommandUseErrorActionPreference is $true, then evaluate $ErrorActionPreference
+                        if (nativeCommandUseErrorActionPref)
                         {
-                            var nonZeroExitCodeErrorRecord = 
-                                new ErrorRecord(
-                                    exception: new Exception("Native executable returned a non-zero exit code."), 
-                                    errorId: "NativeCommandThrow", 
-                                    errorCategory: ErrorCategory.NotSpecified,
-                                    targetObject: this.NativeCommandName);
-                            this.commandRuntime.ThrowTerminatingError(nonZeroExitCodeErrorRecord);
+                            ActionPreference errorActionPref =
+                                this.Command.Context.GetEnumPreference(
+                                    SpecialVariables.ErrorActionPreferenceVarPath,
+                                    ActionPreference.SilentlyContinue,
+                                    out _);
+
+                            if (errorActionPref != ActionPreference.Ignore)
+                            {
+                                var errorRecord = 
+                                    new ErrorRecord(
+                                        exception: new Exception($"Program {this.NativeCommandName} ended with non-zero exit code {_nativeProcess.ExitCode}"), 
+                                        errorId: "NativeCommandThrow", 
+                                        errorCategory: ErrorCategory.NotSpecified,
+                                        targetObject: this.NativeCommandName);
+                                // this.commandRuntime.ThrowTerminatingError(nonZeroExitCodeErrorRecord);
+                                this.commandRuntime._WriteErrorSkipAllowCheck(errorRecord, isNativeError: true);
+                            }
                         }
                     }
                 }

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -138,6 +138,12 @@ namespace System.Management.Automation
     [Serializable]
     public class NativeCommandExitException : RuntimeException
     {
+        // NOTE:
+        // When implementing the native error action preference integration,
+        // reusing ApplicationFailedException was contemplated.
+        // However, rather than possibly reusing a type already used in another scenario
+        // it was decided instead to use a fresh type to minimize the chance of conflating the two scenarios.
+
         /// <summary>
         /// Gets the path of the native command.
         /// </summary>

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -905,7 +905,7 @@ namespace System.Management.Automation
 
                     if (errorActionPref != ActionPreference.Ignore)
                     {
-                        const string errorId = "ProgramFailedToComplete";
+                        const string errorId = nameof(CommandBaseStrings.ProgramFailedToComplete);
 
                         string errorMsg = StringUtil.Format(
                             CommandBaseStrings.ProgramFailedToComplete,

--- a/src/System.Management.Automation/engine/SpecialVariables.cs
+++ b/src/System.Management.Automation/engine/SpecialVariables.cs
@@ -258,7 +258,7 @@ namespace System.Management.Automation
         internal const string PSNativeCommandUseErrorActionPreference = nameof(PSNativeCommandUseErrorActionPreference);
 
         internal static readonly VariablePath PSNativeCommandUseErrorActionPreferenceVarPath =
-            new VariablePath(PSNativeCommandUseErrorActionPreference);
+            new(PSNativeCommandUseErrorActionPreference);
 
         #endregion Preference Variables
 

--- a/src/System.Management.Automation/engine/SpecialVariables.cs
+++ b/src/System.Management.Automation/engine/SpecialVariables.cs
@@ -255,10 +255,10 @@ namespace System.Management.Automation
 
         internal static readonly VariablePath InformationPreferenceVarPath = new VariablePath(InformationPreference);
 
-        internal const string NativeCommandThrowPreference = "PSNativeCommandThrowPreference";
+        internal const string NativeCommandUseErrorActionPreference = "PSNativeCommandUseErrorActionPreference";
 
-        internal static readonly VariablePath NativeCommandThrowPreferenceVarPath =
-            new VariablePath(NativeCommandThrowPreference);
+        internal static readonly VariablePath NativeCommandUseErrorActionPreferenceVarPath =
+            new VariablePath(NativeCommandUseErrorActionPreference);
 
         #endregion Preference Variables
 
@@ -334,19 +334,19 @@ namespace System.Management.Automation
                                                                     SpecialVariables.WarningPreference,
                                                                     SpecialVariables.InformationPreference,
                                                                     SpecialVariables.ConfirmPreference,
-                                                                    SpecialVariables.NativeCommandThrowPreference,
+                                                                    SpecialVariables.NativeCommandUseErrorActionPreference,
                                                                 };
 
         internal static readonly Type[] PreferenceVariableTypes = 
             {
-                /* DebugPreference */              typeof(ActionPreference),
-                /* VerbosePreference */            typeof(ActionPreference),
-                /* ErrorPreference */              typeof(ActionPreference),
-                /* WhatIfPreference */             typeof(SwitchParameter),
-                /* WarningPreference */            typeof(ActionPreference),
-                /* InformationPreference */        typeof(ActionPreference),
-                /* ConfirmPreference */            typeof(ConfirmImpact),
-                /* NativeCommandThrowPreference */ typeof(SwitchParameter),
+                /* DebugPreference */                       typeof(ActionPreference),
+                /* VerbosePreference */                     typeof(ActionPreference),
+                /* ErrorPreference */                       typeof(ActionPreference),
+                /* WhatIfPreference */                      typeof(SwitchParameter),
+                /* WarningPreference */                     typeof(ActionPreference),
+                /* InformationPreference */                 typeof(ActionPreference),
+                /* ConfirmPreference */                     typeof(ConfirmImpact),
+                /* NativeCommandUseErrorActionPreference */ typeof(SwitchParameter),
             };
 
         // The following variables are created in every session w/ AllScope.  We avoid creating local slots when we

--- a/src/System.Management.Automation/engine/SpecialVariables.cs
+++ b/src/System.Management.Automation/engine/SpecialVariables.cs
@@ -326,7 +326,7 @@ namespace System.Management.Automation
                                                                    /* PSCommandPath */     typeof(string),
                                                                  };
 
-        internal static readonly string[] PreferenceVariables = 
+        internal static readonly string[] PreferenceVariables =
         {
             SpecialVariables.DebugPreference,
             SpecialVariables.VerbosePreference,
@@ -338,7 +338,7 @@ namespace System.Management.Automation
             SpecialVariables.PSNativeCommandUseErrorActionPreference,
         };
 
-        internal static readonly Type[] PreferenceVariableTypes = 
+        internal static readonly Type[] PreferenceVariableTypes =
         {
             /* DebugPreference */                         typeof(ActionPreference),
             /* VerbosePreference */                       typeof(ActionPreference),

--- a/src/System.Management.Automation/engine/SpecialVariables.cs
+++ b/src/System.Management.Automation/engine/SpecialVariables.cs
@@ -255,6 +255,11 @@ namespace System.Management.Automation
 
         internal static readonly VariablePath InformationPreferenceVarPath = new VariablePath(InformationPreference);
 
+        internal const string NativeCommandThrowPreference = "PSNativeCommandThrowPreference";
+
+        internal static readonly VariablePath NativeCommandThrowPreferenceVarPath =
+            new VariablePath(NativeCommandThrowPreference);
+
         #endregion Preference Variables
 
         // Native command argument passing style
@@ -329,17 +334,20 @@ namespace System.Management.Automation
                                                                     SpecialVariables.WarningPreference,
                                                                     SpecialVariables.InformationPreference,
                                                                     SpecialVariables.ConfirmPreference,
+                                                                    SpecialVariables.NativeCommandThrowPreference,
                                                                 };
 
-        internal static readonly Type[] PreferenceVariableTypes = {
-                                                                    /* DebugPreference */       typeof(ActionPreference),
-                                                                    /* VerbosePreference */     typeof(ActionPreference),
-                                                                    /* ErrorPreference */       typeof(ActionPreference),
-                                                                    /* WhatIfPreference */      typeof(SwitchParameter),
-                                                                    /* WarningPreference */     typeof(ActionPreference),
-                                                                    /* InformationPreference */ typeof(ActionPreference),
-                                                                    /* ConfirmPreference */     typeof(ConfirmImpact),
-                                                                  };
+        internal static readonly Type[] PreferenceVariableTypes = 
+            {
+                /* DebugPreference */              typeof(ActionPreference),
+                /* VerbosePreference */            typeof(ActionPreference),
+                /* ErrorPreference */              typeof(ActionPreference),
+                /* WhatIfPreference */             typeof(SwitchParameter),
+                /* WarningPreference */            typeof(ActionPreference),
+                /* InformationPreference */        typeof(ActionPreference),
+                /* ConfirmPreference */            typeof(ConfirmImpact),
+                /* NativeCommandThrowPreference */ typeof(SwitchParameter),
+            };
 
         // The following variables are created in every session w/ AllScope.  We avoid creating local slots when we
         // see an assignment to any of these variables so that they get handled properly (either throwing an exception
@@ -406,5 +414,6 @@ namespace System.Management.Automation
         Warning = 13,
         Information = 14,
         Confirm = 15,
+        NativeCommandThrow = 16,
     }
 }

--- a/src/System.Management.Automation/engine/SpecialVariables.cs
+++ b/src/System.Management.Automation/engine/SpecialVariables.cs
@@ -414,6 +414,6 @@ namespace System.Management.Automation
         Warning = 13,
         Information = 14,
         Confirm = 15,
-        NativeCommandThrow = 16,
+        NativeCommandUseErrorAction = 16,
     }
 }

--- a/src/System.Management.Automation/engine/SpecialVariables.cs
+++ b/src/System.Management.Automation/engine/SpecialVariables.cs
@@ -326,6 +326,9 @@ namespace System.Management.Automation
                                                                    /* PSCommandPath */     typeof(string),
                                                                  };
 
+        // This array and the one below it exist to optimize the way common parameters work in cmdlets/advanced functions.
+        // Common parameters work by setting preference variables in the scope of the cmdlet and restoring the old value afterward.
+        // Preference variables that don't correspond to common cmdlet parameters don't need to be added here.
         internal static readonly string[] PreferenceVariables =
         {
             SpecialVariables.DebugPreference,
@@ -335,7 +338,6 @@ namespace System.Management.Automation
             SpecialVariables.WarningPreference,
             SpecialVariables.InformationPreference,
             SpecialVariables.ConfirmPreference,
-            SpecialVariables.PSNativeCommandUseErrorActionPreference,
         };
 
         internal static readonly Type[] PreferenceVariableTypes =
@@ -347,7 +349,6 @@ namespace System.Management.Automation
             /* WarningPreference */                       typeof(ActionPreference),
             /* InformationPreference */                   typeof(ActionPreference),
             /* ConfirmPreference */                       typeof(ConfirmImpact),
-            /* PSNativeCommandUseErrorActionPreference */ typeof(bool),
         };
 
         // The following variables are created in every session w/ AllScope.  We avoid creating local slots when we

--- a/src/System.Management.Automation/engine/SpecialVariables.cs
+++ b/src/System.Management.Automation/engine/SpecialVariables.cs
@@ -255,10 +255,10 @@ namespace System.Management.Automation
 
         internal static readonly VariablePath InformationPreferenceVarPath = new VariablePath(InformationPreference);
 
-        internal const string NativeCommandUseErrorActionPreference = "PSNativeCommandUseErrorActionPreference";
+        internal const string PSNativeCommandUseErrorActionPreference = nameof(PSNativeCommandUseErrorActionPreference);
 
-        internal static readonly VariablePath NativeCommandUseErrorActionPreferenceVarPath =
-            new VariablePath(NativeCommandUseErrorActionPreference);
+        internal static readonly VariablePath PSNativeCommandUseErrorActionPreferenceVarPath =
+            new VariablePath(PSNativeCommandUseErrorActionPreference);
 
         #endregion Preference Variables
 
@@ -326,28 +326,29 @@ namespace System.Management.Automation
                                                                    /* PSCommandPath */     typeof(string),
                                                                  };
 
-        internal static readonly string[] PreferenceVariables = {
-                                                                    SpecialVariables.DebugPreference,
-                                                                    SpecialVariables.VerbosePreference,
-                                                                    SpecialVariables.ErrorActionPreference,
-                                                                    SpecialVariables.WhatIfPreference,
-                                                                    SpecialVariables.WarningPreference,
-                                                                    SpecialVariables.InformationPreference,
-                                                                    SpecialVariables.ConfirmPreference,
-                                                                    SpecialVariables.NativeCommandUseErrorActionPreference,
-                                                                };
+        internal static readonly string[] PreferenceVariables = 
+        {
+            SpecialVariables.DebugPreference,
+            SpecialVariables.VerbosePreference,
+            SpecialVariables.ErrorActionPreference,
+            SpecialVariables.WhatIfPreference,
+            SpecialVariables.WarningPreference,
+            SpecialVariables.InformationPreference,
+            SpecialVariables.ConfirmPreference,
+            SpecialVariables.PSNativeCommandUseErrorActionPreference,
+        };
 
         internal static readonly Type[] PreferenceVariableTypes = 
-            {
-                /* DebugPreference */                       typeof(ActionPreference),
-                /* VerbosePreference */                     typeof(ActionPreference),
-                /* ErrorPreference */                       typeof(ActionPreference),
-                /* WhatIfPreference */                      typeof(SwitchParameter),
-                /* WarningPreference */                     typeof(ActionPreference),
-                /* InformationPreference */                 typeof(ActionPreference),
-                /* ConfirmPreference */                     typeof(ConfirmImpact),
-                /* NativeCommandUseErrorActionPreference */ typeof(SwitchParameter),
-            };
+        {
+            /* DebugPreference */                         typeof(ActionPreference),
+            /* VerbosePreference */                       typeof(ActionPreference),
+            /* ErrorPreference */                         typeof(ActionPreference),
+            /* WhatIfPreference */                        typeof(SwitchParameter),
+            /* WarningPreference */                       typeof(ActionPreference),
+            /* InformationPreference */                   typeof(ActionPreference),
+            /* ConfirmPreference */                       typeof(ConfirmImpact),
+            /* PSNativeCommandUseErrorActionPreference */ typeof(SwitchParameter),
+        };
 
         // The following variables are created in every session w/ AllScope.  We avoid creating local slots when we
         // see an assignment to any of these variables so that they get handled properly (either throwing an exception
@@ -414,6 +415,6 @@ namespace System.Management.Automation
         Warning = 13,
         Information = 14,
         Confirm = 15,
-        NativeCommandUseErrorAction = 16,
+        PSNativeCommandUseErrorAction = 16,
     }
 }

--- a/src/System.Management.Automation/engine/SpecialVariables.cs
+++ b/src/System.Management.Automation/engine/SpecialVariables.cs
@@ -347,7 +347,7 @@ namespace System.Management.Automation
             /* WarningPreference */                       typeof(ActionPreference),
             /* InformationPreference */                   typeof(ActionPreference),
             /* ConfirmPreference */                       typeof(ConfirmImpact),
-            /* PSNativeCommandUseErrorActionPreference */ typeof(SwitchParameter),
+            /* PSNativeCommandUseErrorActionPreference */ typeof(bool),
         };
 
         // The following variables are created in every session w/ AllScope.  We avoid creating local slots when we

--- a/src/System.Management.Automation/engine/SpecialVariables.cs
+++ b/src/System.Management.Automation/engine/SpecialVariables.cs
@@ -326,9 +326,9 @@ namespace System.Management.Automation
                                                                    /* PSCommandPath */     typeof(string),
                                                                  };
 
-        // This array and the one below it exist to optimize the way common parameters work in cmdlets/advanced functions.
-        // Common parameters work by setting preference variables in the scope of the cmdlet and restoring the old value afterward.
-        // Preference variables that don't correspond to common cmdlet parameters don't need to be added here.
+        // This array and the one below it exist to optimize the way common parameters work in advanced functions.
+        // Common parameters work by setting preference variables in the scope of the function and restoring the old value afterward.
+        // Variables that don't correspond to common cmdlet parameters don't need to be added here.
         internal static readonly string[] PreferenceVariables =
         {
             SpecialVariables.DebugPreference,
@@ -416,6 +416,5 @@ namespace System.Management.Automation
         Warning = 13,
         Information = 14,
         Confirm = 15,
-        PSNativeCommandUseErrorAction = 16,
     }
 }

--- a/src/System.Management.Automation/resources/CommandBaseStrings.resx
+++ b/src/System.Management.Automation/resources/CommandBaseStrings.resx
@@ -157,6 +157,12 @@
     <value>Pause the current pipeline and return to the command prompt. Type "{0}" to resume the pipeline.</value>
   </data>
   <data name="ProgramFailedToComplete" xml:space="preserve">
+    <!-- NOTE:
+      This string was added for the native command error action preference integration feature.
+      ParserStrings already declares a ProgramFailedToExecute string,
+      however that is used for ApplicationFailedExceptions thrown when the NativeCommandProcessor fails in an unexpected way.
+      In this case, we have a more specific error for the native command scenario, so the two are not conflated.
+    -->
     <value>Program "{0}" ended with non-zero exit code {1}.</value>
   </data>
   <data name="ShouldProcessMessage" xml:space="preserve">

--- a/src/System.Management.Automation/resources/CommandBaseStrings.resx
+++ b/src/System.Management.Automation/resources/CommandBaseStrings.resx
@@ -156,7 +156,7 @@
   <data name="PauseHelpMessage" xml:space="preserve">
     <value>Pause the current pipeline and return to the command prompt. Type "{0}" to resume the pipeline.</value>
   </data>
-  <data name="ProgramFailedToComplete" xml:space="preserve">
+  <data name="ProgramEndsWithNonZeroCode" xml:space="preserve">
     <!-- NOTE:
       This string was added for the native command error action preference integration feature.
       ParserStrings already declares a ProgramFailedToExecute string,

--- a/src/System.Management.Automation/resources/CommandBaseStrings.resx
+++ b/src/System.Management.Automation/resources/CommandBaseStrings.resx
@@ -156,7 +156,7 @@
   <data name="PauseHelpMessage" xml:space="preserve">
     <value>Pause the current pipeline and return to the command prompt. Type "{0}" to resume the pipeline.</value>
   </data>
-  <data name="ProgramEndsWithNonZeroCode" xml:space="preserve">
+  <data name="ProgramExitedWithNonZeroCode" xml:space="preserve">
     <!-- NOTE:
       This string was added for the native command error action preference integration feature.
       ParserStrings already declares a ProgramFailedToExecute string,

--- a/src/System.Management.Automation/resources/CommandBaseStrings.resx
+++ b/src/System.Management.Automation/resources/CommandBaseStrings.resx
@@ -163,7 +163,7 @@
       however that is used for ApplicationFailedExceptions thrown when the NativeCommandProcessor fails in an unexpected way.
       In this case, we have a more specific error for the native command scenario, so the two are not conflated.
     -->
-    <value>Program "{0}" ended with non-zero exit code {1}.</value>
+    <value>Program "{0}" ended with non-zero exit code: {1}.</value>
   </data>
   <data name="ShouldProcessMessage" xml:space="preserve">
     <value>Performing the operation "{0}" on target "{1}".</value>

--- a/src/System.Management.Automation/resources/CommandBaseStrings.resx
+++ b/src/System.Management.Automation/resources/CommandBaseStrings.resx
@@ -156,6 +156,9 @@
   <data name="PauseHelpMessage" xml:space="preserve">
     <value>Pause the current pipeline and return to the command prompt. Type "{0}" to resume the pipeline.</value>
   </data>
+  <data name="ProgramFailedToComplete" xml:space="preserve">
+    <value>Program "{0}" ended with non-zero exit code {1}.</value>
+  </data>
   <data name="ShouldProcessMessage" xml:space="preserve">
     <value>Performing the operation "{0}" on target "{1}".</value>
   </data>

--- a/src/System.Management.Automation/resources/RunspaceInit.resx
+++ b/src/System.Management.Automation/resources/RunspaceInit.resx
@@ -186,6 +186,9 @@
   <data name="NestedPromptLevelDescription" xml:space="preserve">
     <value>Dictates what type of prompt should be displayed for the current nesting level</value>
   </data>
+  <data name="NativeCommandThrowPreferenceDescription" xml:space="preserve">
+    <value>If true, native executables that return a non-zero exit code generate a terminating error</value>
+  </data>  
   <data name="WhatIfPreferenceDescription" xml:space="preserve">
     <value>If true, WhatIf is considered to be enabled for all commands.</value>
   </data>

--- a/src/System.Management.Automation/resources/RunspaceInit.resx
+++ b/src/System.Management.Automation/resources/RunspaceInit.resx
@@ -186,8 +186,8 @@
   <data name="NestedPromptLevelDescription" xml:space="preserve">
     <value>Dictates what type of prompt should be displayed for the current nesting level</value>
   </data>
-  <data name="NativeCommandThrowPreferenceDescription" xml:space="preserve">
-    <value>If true, native executables that return a non-zero exit code generate a terminating error</value>
+  <data name="NativeCommandUseErrorActionPreferenceDescription" xml:space="preserve">
+    <value>If true, $ErrorActionPreference applies to native executable non-zero exit codes</value>
   </data>  
   <data name="WhatIfPreferenceDescription" xml:space="preserve">
     <value>If true, WhatIf is considered to be enabled for all commands.</value>

--- a/src/System.Management.Automation/resources/RunspaceInit.resx
+++ b/src/System.Management.Automation/resources/RunspaceInit.resx
@@ -186,7 +186,7 @@
   <data name="NestedPromptLevelDescription" xml:space="preserve">
     <value>Dictates what type of prompt should be displayed for the current nesting level</value>
   </data>
-  <data name="NativeCommandUseErrorActionPreferenceDescription" xml:space="preserve">
+  <data name="PSNativeCommandUseErrorActionPreferenceDescription" xml:space="preserve">
     <value>If true, $ErrorActionPreference applies to native executable non-zero exit codes</value>
   </data>  
   <data name="WhatIfPreferenceDescription" xml:space="preserve">

--- a/src/System.Management.Automation/resources/RunspaceInit.resx
+++ b/src/System.Management.Automation/resources/RunspaceInit.resx
@@ -187,7 +187,7 @@
     <value>Dictates what type of prompt should be displayed for the current nesting level</value>
   </data>
   <data name="PSNativeCommandUseErrorActionPreferenceDescription" xml:space="preserve">
-    <value>If true, $ErrorActionPreference applies to native executable non-zero exit codes</value>
+    <value>If true, $ErrorActionPreference applies to native executables, so that non-zero exit codes will generate cmdlet-style errors governed by error action settings</value>
   </data>
   <data name="WhatIfPreferenceDescription" xml:space="preserve">
     <value>If true, WhatIf is considered to be enabled for all commands.</value>

--- a/src/System.Management.Automation/resources/RunspaceInit.resx
+++ b/src/System.Management.Automation/resources/RunspaceInit.resx
@@ -188,7 +188,7 @@
   </data>
   <data name="PSNativeCommandUseErrorActionPreferenceDescription" xml:space="preserve">
     <value>If true, $ErrorActionPreference applies to native executable non-zero exit codes</value>
-  </data>  
+  </data>
   <data name="WhatIfPreferenceDescription" xml:space="preserve">
     <value>If true, WhatIf is considered to be enabled for all commands.</value>
   </data>

--- a/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
+++ b/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
@@ -51,7 +51,7 @@ Describe 'Native command error handling tests' -Tags 'CI' {
             $stderr = testexe -returncode 1 2>&1
 
             $error[0].FullyQualifiedErrorId | Should -Be 'ProgramFailedToComplete'
-            $stderr[1].Exception.Message | Should -Be "Program `"$exeName`" ended with non-zero exit code 1."
+            $stderr[1].Exception.Message | Should -Be "Program `"$exeName`" ended with non-zero exit code: 1."
         }
 
         It 'Non-zero exit code generates a non-teminating error for $ErrorActionPreference = ''SilentlyContinue''' {

--- a/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
+++ b/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
@@ -39,10 +39,10 @@ Describe 'Native command error handling tests' -Tags 'CI' {
         It 'Non-zero exit code throws teminating error for $ErrorActionPreference = ''Stop''' {
             $ErrorActionPreference = 'Stop'
 
-            { testexe -returncode 1 } | Should -Throw -ErrorId 'ProgramFailedToComplete'
+            { testexe -returncode 1 } | Should -Throw -ErrorId 'ProgramEndsWithNonZeroCode'
 
             $error.Count | Should -Be 1
-            $error[0].FullyQualifiedErrorId | Should -Be 'ProgramFailedToComplete'
+            $error[0].FullyQualifiedErrorId | Should -Be 'ProgramEndsWithNonZeroCode'
         }
 
         It 'Non-zero exit code outputs a non-teminating error for $ErrorActionPreference = ''Continue''' {
@@ -50,7 +50,7 @@ Describe 'Native command error handling tests' -Tags 'CI' {
 
             $stderr = testexe -returncode 1 2>&1
 
-            $error[0].FullyQualifiedErrorId | Should -Be 'ProgramFailedToComplete'
+            $error[0].FullyQualifiedErrorId | Should -Be 'ProgramEndsWithNonZeroCode'
             $stderr[1].Exception.Message | Should -Be "Program `"$exeName`" ended with non-zero exit code: 1."
         }
 
@@ -60,7 +60,7 @@ Describe 'Native command error handling tests' -Tags 'CI' {
             testexe -returncode 1 > $null
 
             $error.Count | Should -Be 1
-            $error[0].FullyQualifiedErrorId | Should -Be 'ProgramFailedToComplete'
+            $error[0].FullyQualifiedErrorId | Should -Be 'ProgramEndsWithNonZeroCode'
         }
 
         It 'Non-zero exit code does not generates an error record for $ErrorActionPreference = ''Ignore''' {

--- a/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
+++ b/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
@@ -6,6 +6,7 @@
 
 Describe 'Native command error handling tests' -Tags 'CI' {
     BeforeAll {
+        $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
         if (-not [ExperimentalFeature]::IsEnabled('PSNativeCommandErrorActionPreference'))
         {
             $PSDefaultParameterValues['It:Skip'] = $true
@@ -23,7 +24,7 @@ Describe 'Native command error handling tests' -Tags 'CI' {
     }
 
     AfterAll {
-        $PSDefaultParameterValues['It:Skip'] = $false
+        $global:PSDefaultParameterValues = $originalDefaultParameterValues
     }
 
     BeforeEach {
@@ -53,7 +54,7 @@ Describe 'Native command error handling tests' -Tags 'CI' {
             $stderr[1].Exception.Message | Should -Be "Program `"$exeName`" ended with non-zero exit code 1."
         }
 
-        It 'Non-zero exit code generrates a non-teminating error for $ErrorActionPreference = ''SilentlyContinue''' {
+        It 'Non-zero exit code generates a non-teminating error for $ErrorActionPreference = ''SilentlyContinue''' {
             $ErrorActionPreference = 'SilentlyContinue'
 
             testexe -returncode 1 > $null

--- a/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
+++ b/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
@@ -1,0 +1,143 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# Functional tests to verify that errors (non-terminating and terminating) appropriately
+# when $PSNativeCommandUseErrorActionPreference is $true
+
+Describe 'Native command error handling tests' -Tags 'CI' {
+    Context 'PSNativeCommandUseErrorActionPreference is $true' {
+        BeforeAll {
+            $pwsh = "$PSHOME/pwsh"
+        }
+        BeforeEach {
+            $PSNativeCommandUseErrorActionPreference = $true
+            $Error.Clear()
+        }
+
+        It 'Non-zero exit code throws teminating error when $ErrorActionPreference = Stop' {
+            $ErrorActionPreference = 'Stop'
+
+            { & $pwsh -noprofile -noninteractive -c "exit 1" } | Should -Throw -ErrorId 'ProgramFailedToComplete'
+
+            $error.Count | Should -Be 1
+            $error[0].FullyQualifiedErrorId | Should -Be 'ProgramFailedToComplete'
+        }
+
+        It 'Non-zero exit code writes a non-teminating error when $ErrorActionPreference = Continue' {
+            $ErrorActionPreference = 'Continue'
+
+            $stderr = & $pwsh -noprofile -noninteractive -c "exit 1" 2>&1
+
+            $error[0].FullyQualifiedErrorId | Should -Be 'ProgramFailedToComplete'
+            $stderr.Exception.Message | Should -Be 'Program "pwsh.exe" ended with non-zero exit code 1.'
+        }
+
+        It 'Non-zero exit code generates a non-teminating error when $ErrorActionPreference = SilentlyContinue' {
+            $ErrorActionPreference = 'SilentlyContinue'
+
+            $stderr = & $pwsh -noprofile -noninteractive -c "exit 1" 2>&1
+
+            $error.Count | Should -Be 1
+            $error[0].FullyQualifiedErrorId | Should -Be 'ProgramFailedToComplete'
+            $stderr | Should -BeNullOrEmpty
+        }
+
+        It 'Non-zero exit code does not generates an error record when $ErrorActionPreference = Ignore' {
+            $ErrorActionPreference = 'Ignore'
+
+            $stderr = & $pwsh -noprofile -noninteractive -c "exit 1" 2>&1
+
+            $LASTEXITCODE | Should -Be 1
+            $error.Count | Should -Be 0
+            $stderr | Should -BeNullOrEmpty
+        }
+
+        It 'Zero exit code generates no error when $ErrorActionPreference = Stop' {
+            $ErrorActionPreference = 'Stop'
+
+            { & $pwsh -noprofile -noninteractive -c "exit 0" } | Should -Not -Throw
+
+            $LASTEXITCODE | Should -Be 0
+            $Error.Count | Should -Be 0
+        }
+
+        It 'Zero exit code generates no error when $ErrorActionPreference = Continue' {
+            $ErrorActionPreference = 'Continue'
+
+            $stderr = & $pwsh -noprofile -noninteractive -c "exit 0" 2>&1
+
+            $LASTEXITCODE | Should -Be 0
+            $Error.Count | Should -Be 0
+            $stderr | Should -BeNullOrEmpty
+        }
+
+        It 'Zero exit code generates no error when $ErrorActionPreference = SilentlyContinue' {
+            $ErrorActionPreference = 'SilentlyContinue'
+
+            $stderr = & $pwsh -noprofile -noninteractive -c "exit 0" 2>&1
+
+            $LASTEXITCODE | Should -Be 0
+            $Error.Count | Should -Be 0
+            $stderr | Should -BeNullOrEmpty
+        }
+
+        It 'Zero exit code generates no error when $ErrorActionPreference = Ignore' {
+            $ErrorActionPreference = 'Ignore'
+
+            $stderr = & $pwsh -noprofile -noninteractive -c "exit 0" 2>&1
+
+            $LASTEXITCODE | Should -Be 0
+            $Error.Count | Should -Be 0
+            $stderr | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'PSNativeCommandUseErrorActionPreference is $false' {
+        BeforeAll {
+            $pwsh = "$PSHOME/pwsh"
+        }
+        BeforeEach {
+            $PSNativeCommandUseErrorActionPreference = $false
+            $Error.Clear()
+        }
+
+        It 'Non-zero exit code generates no error when $ErrorActionPreference = Stop' {
+            $ErrorActionPreference = 'Stop'
+
+            { & $pwsh -noprofile -noninteractive -c "exit 1" } | Should -Not -Throw
+
+            $LASTEXITCODE | Should -Be 1
+            $Error.Count | Should -Be 0
+        }
+
+        It 'Non-zero exit code generates no error when $ErrorActionPreference = Continue' {
+            $ErrorActionPreference = 'Continue'
+
+            $stderr = & $pwsh -noprofile -noninteractive -c "exit 1" 2>&1
+
+            $LASTEXITCODE | Should -Be 1
+            $Error.Count | Should -Be 0
+            $stderr | Should -BeNullOrEmpty
+        }
+
+        It 'Non-zero exit code generates no error when $ErrorActionPreference = SilentlyContinue' {
+            $ErrorActionPreference = 'SilentlyContinue'
+
+            $stderr = & $pwsh -noprofile -noninteractive -c "exit 1" 2>&1
+
+            $LASTEXITCODE | Should -Be 1
+            $Error.Count | Should -Be 0
+            $stderr | Should -BeNullOrEmpty
+        }
+
+        It 'Non-zero exit code generates no error when $ErrorActionPreference = Ignore' {
+            $ErrorActionPreference = 'Ignore'
+
+            $stderr = & $pwsh -noprofile -noninteractive -c "exit 1" 2>&1
+
+            $LASTEXITCODE | Should -Be 1
+            $Error.Count | Should -Be 0
+            $stderr | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
+++ b/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
@@ -43,6 +43,7 @@ Describe 'Native command error handling tests' -Tags 'CI' {
 
             $error.Count | Should -Be 1
             $error[0].FullyQualifiedErrorId | Should -BeExactly 'ProgramExitedWithNonZeroCode'
+            $error[0].TargetObject | Should -BeExactly $exeName
         }
 
         It 'Non-zero exit code outputs a non-teminating error for $ErrorActionPreference = ''Continue''' {
@@ -51,6 +52,7 @@ Describe 'Native command error handling tests' -Tags 'CI' {
             $stderr = testexe -returncode 1 2>&1
 
             $error[0].FullyQualifiedErrorId | Should -BeExactly 'ProgramExitedWithNonZeroCode'
+            $error[0].TargetObject | Should -BeExactly $exeName
             $stderr[1].Exception.Message | Should -BeExactly "Program `"$exeName`" ended with non-zero exit code: 1."
         }
 
@@ -61,6 +63,7 @@ Describe 'Native command error handling tests' -Tags 'CI' {
 
             $error.Count | Should -Be 1
             $error[0].FullyQualifiedErrorId | Should -BeExactly 'ProgramExitedWithNonZeroCode'
+            $error[0].TargetObject | Should -BeExactly $exeName
         }
 
         It 'Non-zero exit code does not generates an error record for $ErrorActionPreference = ''Ignore''' {

--- a/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
+++ b/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
@@ -1,143 +1,102 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-#
+
 # Functional tests to verify that errors (non-terminating and terminating) appropriately
 # when $PSNativeCommandUseErrorActionPreference is $true
 
 Describe 'Native command error handling tests' -Tags 'CI' {
+    BeforeAll {
+        $exeName = $IsWindows ? 'testexe.exe' : 'testexe'
+
+        $errorActionPrefTestCases = @(
+            @{ ErrorActionPref = 'Stop' }
+            @{ ErrorActionPref = 'Continue' }
+            @{ ErrorActionPref = 'SilentlyContinue' }
+            @{ ErrorActionPref = 'Ignore' }
+        )
+    }
+
+    BeforeEach {
+        $Error.Clear()
+    }
+
     Context 'PSNativeCommandUseErrorActionPreference is $true' {
-        BeforeAll {
-            $pwsh = "$PSHOME/pwsh"
-        }
         BeforeEach {
             $PSNativeCommandUseErrorActionPreference = $true
-            $Error.Clear()
         }
 
-        It 'Non-zero exit code throws teminating error when $ErrorActionPreference = Stop' {
+        It 'Non-zero exit code throws teminating error for $ErrorActionPreference = ''Stop''' {
             $ErrorActionPreference = 'Stop'
 
-            { & $pwsh -noprofile -noninteractive -c "exit 1" } | Should -Throw -ErrorId 'ProgramFailedToComplete'
+            { testexe -returncode 1 } | Should -Throw -ErrorId 'ProgramFailedToComplete'
 
             $error.Count | Should -Be 1
             $error[0].FullyQualifiedErrorId | Should -Be 'ProgramFailedToComplete'
         }
 
-        It 'Non-zero exit code writes a non-teminating error when $ErrorActionPreference = Continue' {
+        It 'Non-zero exit code outputs a non-teminating error for $ErrorActionPreference = ''Continue''' {
             $ErrorActionPreference = 'Continue'
 
-            $stderr = & $pwsh -noprofile -noninteractive -c "exit 1" 2>&1
+            $stderr = testexe -returncode 1 2>&1
 
             $error[0].FullyQualifiedErrorId | Should -Be 'ProgramFailedToComplete'
-            $stderr.Exception.Message | Should -Be 'Program "pwsh.exe" ended with non-zero exit code 1.'
+            $stderr[1].Exception.Message | Should -Be "Program `"$exeName`" ended with non-zero exit code 1."
         }
 
-        It 'Non-zero exit code generates a non-teminating error when $ErrorActionPreference = SilentlyContinue' {
+        It 'Non-zero exit code generrates a non-teminating error for $ErrorActionPreference = ''SilentlyContinue''' {
             $ErrorActionPreference = 'SilentlyContinue'
 
-            $stderr = & $pwsh -noprofile -noninteractive -c "exit 1" 2>&1
+            testexe -returncode 1 > $null
 
             $error.Count | Should -Be 1
             $error[0].FullyQualifiedErrorId | Should -Be 'ProgramFailedToComplete'
-            $stderr | Should -BeNullOrEmpty
         }
 
-        It 'Non-zero exit code does not generates an error record when $ErrorActionPreference = Ignore' {
+        It 'Non-zero exit code does not generates an error record for $ErrorActionPreference = ''Ignore''' {
             $ErrorActionPreference = 'Ignore'
 
-            $stderr = & $pwsh -noprofile -noninteractive -c "exit 1" 2>&1
+            testexe -returncode 1 > $null
 
             $LASTEXITCODE | Should -Be 1
             $error.Count | Should -Be 0
-            $stderr | Should -BeNullOrEmpty
         }
 
-        It 'Zero exit code generates no error when $ErrorActionPreference = Stop' {
-            $ErrorActionPreference = 'Stop'
+        It 'Zero exit code generates no error for $ErrorActionPreference = ''<ErrorActionPref>''' -TestCases $errorActionPrefTestCases {
+            param($ErrorActionPref)
 
-            { & $pwsh -noprofile -noninteractive -c "exit 0" } | Should -Not -Throw
+            $ErrorActionPreference = $ErrorActionPref
+
+            if ($ErrorActionPref -eq 'Stop') {
+                { testexe -returncode 0 } | Should -Not -Throw
+            }
+            else {
+                testexe -returncode 0 > $null
+            }
 
             $LASTEXITCODE | Should -Be 0
             $Error.Count | Should -Be 0
-        }
-
-        It 'Zero exit code generates no error when $ErrorActionPreference = Continue' {
-            $ErrorActionPreference = 'Continue'
-
-            $stderr = & $pwsh -noprofile -noninteractive -c "exit 0" 2>&1
-
-            $LASTEXITCODE | Should -Be 0
-            $Error.Count | Should -Be 0
-            $stderr | Should -BeNullOrEmpty
-        }
-
-        It 'Zero exit code generates no error when $ErrorActionPreference = SilentlyContinue' {
-            $ErrorActionPreference = 'SilentlyContinue'
-
-            $stderr = & $pwsh -noprofile -noninteractive -c "exit 0" 2>&1
-
-            $LASTEXITCODE | Should -Be 0
-            $Error.Count | Should -Be 0
-            $stderr | Should -BeNullOrEmpty
-        }
-
-        It 'Zero exit code generates no error when $ErrorActionPreference = Ignore' {
-            $ErrorActionPreference = 'Ignore'
-
-            $stderr = & $pwsh -noprofile -noninteractive -c "exit 0" 2>&1
-
-            $LASTEXITCODE | Should -Be 0
-            $Error.Count | Should -Be 0
-            $stderr | Should -BeNullOrEmpty
         }
     }
 
     Context 'PSNativeCommandUseErrorActionPreference is $false' {
-        BeforeAll {
-            $pwsh = "$PSHOME/pwsh"
-        }
         BeforeEach {
             $PSNativeCommandUseErrorActionPreference = $false
-            $Error.Clear()
         }
 
-        It 'Non-zero exit code generates no error when $ErrorActionPreference = Stop' {
-            $ErrorActionPreference = 'Stop'
+        It 'Non-zero exit code generates no error for $ErrorActionPreference = ''<ErrorActionPref>''' -TestCases $errorActionPrefTestCases {
+            param($ErrorActionPref)
 
-            { & $pwsh -noprofile -noninteractive -c "exit 1" } | Should -Not -Throw
+            $ErrorActionPreference = $ErrorActionPref
+
+            if ($ErrorActionPref -eq 'Stop') {
+                { testexe -returncode 1 } | Should -Not -Throw
+            }
+            else {
+                testexe -returncode 1 > $null
+            }
 
             $LASTEXITCODE | Should -Be 1
             $Error.Count | Should -Be 0
-        }
-
-        It 'Non-zero exit code generates no error when $ErrorActionPreference = Continue' {
-            $ErrorActionPreference = 'Continue'
-
-            $stderr = & $pwsh -noprofile -noninteractive -c "exit 1" 2>&1
-
-            $LASTEXITCODE | Should -Be 1
-            $Error.Count | Should -Be 0
-            $stderr | Should -BeNullOrEmpty
-        }
-
-        It 'Non-zero exit code generates no error when $ErrorActionPreference = SilentlyContinue' {
-            $ErrorActionPreference = 'SilentlyContinue'
-
-            $stderr = & $pwsh -noprofile -noninteractive -c "exit 1" 2>&1
-
-            $LASTEXITCODE | Should -Be 1
-            $Error.Count | Should -Be 0
-            $stderr | Should -BeNullOrEmpty
-        }
-
-        It 'Non-zero exit code generates no error when $ErrorActionPreference = Ignore' {
-            $ErrorActionPreference = 'Ignore'
-
-            $stderr = & $pwsh -noprofile -noninteractive -c "exit 1" 2>&1
-
-            $LASTEXITCODE | Should -Be 1
-            $Error.Count | Should -Be 0
-            $stderr | Should -BeNullOrEmpty
         }
     }
 }

--- a/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
+++ b/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# Functional tests to verify that errors (non-terminating and terminating) appropriately
+# Functional tests to verify that native executables throw errors (non-terminating and terminating) appropriately
 # when $PSNativeCommandUseErrorActionPreference is $true
 
 Describe 'Native command error handling tests' -Tags 'CI' {

--- a/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
+++ b/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
@@ -42,7 +42,7 @@ Describe 'Native command error handling tests' -Tags 'CI' {
             { testexe -returncode 1 } | Should -Throw -ErrorId 'ProgramExitedWithNonZeroCode'
 
             $error.Count | Should -Be 1
-            $error[0].FullyQualifiedErrorId | Should -Be 'ProgramExitedWithNonZeroCode'
+            $error[0].FullyQualifiedErrorId | Should -BeExactly 'ProgramExitedWithNonZeroCode'
         }
 
         It 'Non-zero exit code outputs a non-teminating error for $ErrorActionPreference = ''Continue''' {
@@ -50,8 +50,8 @@ Describe 'Native command error handling tests' -Tags 'CI' {
 
             $stderr = testexe -returncode 1 2>&1
 
-            $error[0].FullyQualifiedErrorId | Should -Be 'ProgramExitedWithNonZeroCode'
-            $stderr[1].Exception.Message | Should -Be "Program `"$exeName`" ended with non-zero exit code: 1."
+            $error[0].FullyQualifiedErrorId | Should -BeExactly 'ProgramExitedWithNonZeroCode'
+            $stderr[1].Exception.Message | Should -BeExactly "Program `"$exeName`" ended with non-zero exit code: 1."
         }
 
         It 'Non-zero exit code generates a non-teminating error for $ErrorActionPreference = ''SilentlyContinue''' {
@@ -60,7 +60,7 @@ Describe 'Native command error handling tests' -Tags 'CI' {
             testexe -returncode 1 > $null
 
             $error.Count | Should -Be 1
-            $error[0].FullyQualifiedErrorId | Should -Be 'ProgramExitedWithNonZeroCode'
+            $error[0].FullyQualifiedErrorId | Should -BeExactly 'ProgramExitedWithNonZeroCode'
         }
 
         It 'Non-zero exit code does not generates an error record for $ErrorActionPreference = ''Ignore''' {

--- a/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
+++ b/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
@@ -77,13 +77,9 @@ Describe 'Native command error handling tests' -Tags 'CI' {
 
             $ErrorActionPreference = $ErrorActionPref
 
-            if ($ErrorActionPref -eq 'Stop') {
-                { testexe -returncode 0 } | Should -Not -Throw
-            }
-            else {
-                testexe -returncode 0 > $null
-            }
+            $output = testexe -returncode 0
 
+            $output | Should -BeExactly '0'
             $LASTEXITCODE | Should -Be 0
             $Error.Count | Should -Be 0
         }

--- a/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
+++ b/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
@@ -39,10 +39,10 @@ Describe 'Native command error handling tests' -Tags 'CI' {
         It 'Non-zero exit code throws teminating error for $ErrorActionPreference = ''Stop''' {
             $ErrorActionPreference = 'Stop'
 
-            { testexe -returncode 1 } | Should -Throw -ErrorId 'ProgramEndsWithNonZeroCode'
+            { testexe -returncode 1 } | Should -Throw -ErrorId 'ProgramExitedWithNonZeroCode'
 
             $error.Count | Should -Be 1
-            $error[0].FullyQualifiedErrorId | Should -Be 'ProgramEndsWithNonZeroCode'
+            $error[0].FullyQualifiedErrorId | Should -Be 'ProgramExitedWithNonZeroCode'
         }
 
         It 'Non-zero exit code outputs a non-teminating error for $ErrorActionPreference = ''Continue''' {
@@ -50,7 +50,7 @@ Describe 'Native command error handling tests' -Tags 'CI' {
 
             $stderr = testexe -returncode 1 2>&1
 
-            $error[0].FullyQualifiedErrorId | Should -Be 'ProgramEndsWithNonZeroCode'
+            $error[0].FullyQualifiedErrorId | Should -Be 'ProgramExitedWithNonZeroCode'
             $stderr[1].Exception.Message | Should -Be "Program `"$exeName`" ended with non-zero exit code: 1."
         }
 
@@ -60,7 +60,7 @@ Describe 'Native command error handling tests' -Tags 'CI' {
             testexe -returncode 1 > $null
 
             $error.Count | Should -Be 1
-            $error[0].FullyQualifiedErrorId | Should -Be 'ProgramEndsWithNonZeroCode'
+            $error[0].FullyQualifiedErrorId | Should -Be 'ProgramExitedWithNonZeroCode'
         }
 
         It 'Non-zero exit code does not generates an error record for $ErrorActionPreference = ''Ignore''' {

--- a/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
+++ b/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
@@ -6,6 +6,12 @@
 
 Describe 'Native command error handling tests' -Tags 'CI' {
     BeforeAll {
+        if (-not [ExperimentalFeature]::IsEnabled('PSNativeCommandErrorActionPreference'))
+        {
+            $PSDefaultParameterValues['It:Skip'] = $true
+            return
+        }
+
         $exeName = $IsWindows ? 'testexe.exe' : 'testexe'
 
         $errorActionPrefTestCases = @(
@@ -14,6 +20,10 @@ Describe 'Native command error handling tests' -Tags 'CI' {
             @{ ErrorActionPref = 'SilentlyContinue' }
             @{ ErrorActionPref = 'Ignore' }
         )
+    }
+
+    AfterAll {
+        $PSDefaultParameterValues['It:Skip'] = $false
     }
 
     BeforeEach {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Continuation of @rkeithhill's work in https://github.com/PowerShell/PowerShell/pull/15757.

Implements error throwing with error action preference integration for native executables, similar to `set -e` scenarios on *nix. 

## PR Context

See on PowerShell/PowerShell-RFC#277.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [x] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [x] Experimental feature name(s): `PSNativeCommandErrorActionPreference`
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
