### PR TITLE
Avoid possible `InvalidOperationException` in `NewPSSessionOptionCommand.MaximumRedirection`

### DIFF
--- a/src/System.Management.Automation/engine/remoting/commands/NewPSSessionOptionCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/NewPSSessionOptionCommand.cs
@@ -29,9 +29,8 @@ namespace Microsoft.PowerShell.Commands
         [Parameter]
         public int MaximumRedirection
         {
-            get { return _maximumRedirection.Value; }
-
-            set { _maximumRedirection = value; }
+            get => _maximumRedirection ?? -1;
+            set => _maximumRedirection = value;
         }
 
         private int? _maximumRedirection;

--- a/src/System.Management.Automation/engine/remoting/commands/NewPSSessionOptionCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/NewPSSessionOptionCommand.cs
@@ -29,7 +29,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter]
         public int MaximumRedirection
         {
-            get => _maximumRedirection ?? -1;
+            get => _maximumRedirection ?? 0;
             set => _maximumRedirection = value;
         }
 


### PR DESCRIPTION
Specify a default value rather then allowing `_maximumRedirection.Value` to throw the exception.