### PR TITLE
Fix a casting error when using `$PSNativeCommandUsesErrorActionPreference`

### DIFF
--- a/src/System.Management.Automation/engine/ExecutionContext.cs
+++ b/src/System.Management.Automation/engine/ExecutionContext.cs
@@ -1562,23 +1562,6 @@ namespace System.Management.Automation
         private void InitializeCommon(AutomationEngine engine, PSHost hostInterface)
         {
             Engine = engine;
-#if !CORECLR// System.AppDomain is not in CoreCLR
-            // Set the assembly resolve handler if it isn't already set...
-            if (!_assemblyEventHandlerSet)
-            {
-                // we only want to set the event handler once for the entire app domain...
-                lock (lockObject)
-                {
-                    // Need to check again inside the lock due to possibility of a race condition...
-                    if (!_assemblyEventHandlerSet)
-                    {
-                        AppDomain currentAppDomain = AppDomain.CurrentDomain;
-                        currentAppDomain.AssemblyResolve += new ResolveEventHandler(PowerShellAssemblyResolveHandler);
-                        _assemblyEventHandlerSet = true;
-                    }
-                }
-            }
-#endif
             Events = new PSLocalEventManager(this);
             transactionManager = new PSTransactionManager();
             _debugger = new ScriptDebugger(this);
@@ -1603,35 +1586,6 @@ namespace System.Management.Automation
         }
 
         private static readonly object lockObject = new object();
-
-#if !CORECLR // System.AppDomain is not in CoreCLR
-        private static bool _assemblyEventHandlerSet = false;
-
-        /// <summary>
-        /// AssemblyResolve event handler that will look in the assembly cache to see
-        /// if the named assembly has been loaded. This is necessary so that assemblies loaded
-        /// with LoadFrom, which are in a different loaded context than Load, can still be used to
-        /// resolve types.
-        /// </summary>
-        /// <param name="sender">The event sender.</param>
-        /// <param name="args">The event args.</param>
-        /// <returns>The resolve assembly or null if not found.</returns>
-        private static Assembly PowerShellAssemblyResolveHandler(object sender, ResolveEventArgs args)
-        {
-            ExecutionContext ecFromTLS = Runspaces.LocalPipeline.GetExecutionContextFromTLS();
-            if (ecFromTLS != null)
-            {
-                if (ecFromTLS.AssemblyCache != null)
-                {
-                    Assembly assembly;
-                    ecFromTLS.AssemblyCache.TryGetValue(args.Name, out assembly);
-                    return assembly;
-                }
-            }
-
-            return null;
-        }
-#endif
     }
 
     /// <summary>

--- a/src/System.Management.Automation/engine/ExecutionContext.cs
+++ b/src/System.Management.Automation/engine/ExecutionContext.cs
@@ -525,9 +525,7 @@ namespace System.Management.Automation
         /// </summary>
         internal object GetVariableValue(VariablePath path, object defaultValue)
         {
-            CmdletProviderContext context;
-            SessionStateScope scope;
-            return EngineSessionState.GetVariableValue(path, out context, out scope) ?? defaultValue;
+            return EngineSessionState.GetVariableValue(path, out _, out _) ?? defaultValue;
         }
 
         /// <summary>
@@ -612,19 +610,15 @@ namespace System.Management.Automation
         /// <returns></returns>
         internal bool GetBooleanPreference(VariablePath preferenceVariablePath, bool defaultPref, out bool defaultUsed)
         {
-            CmdletProviderContext context = null;
-            SessionStateScope scope = null;
-            object val = EngineSessionState.GetVariableValue(preferenceVariablePath, out context, out scope);
-            if (val == null)
+            object val = EngineSessionState.GetVariableValue(preferenceVariablePath, out _, out _);
+            if (val is null)
             {
                 defaultUsed = true;
                 return defaultPref;
             }
 
-            bool converted = defaultPref;
-            defaultUsed = !LanguagePrimitives.TryConvertTo<bool>
-                (val, out converted);
-            return (defaultUsed) ? defaultPref : converted;
+            defaultUsed = !LanguagePrimitives.TryConvertTo(val, out bool converted);
+            return defaultUsed ? defaultPref : converted;
         }
         #endregion GetSetVariable methods
 

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -3250,8 +3250,7 @@ namespace System.Management.Automation
             {
                 if (!IsWhatIfFlagSet && !_isWhatIfPreferenceCached)
                 {
-                    bool defaultUsed = false;
-                    _whatIfFlag = Context.GetBooleanPreference(SpecialVariables.WhatIfPreferenceVarPath, _whatIfFlag, out defaultUsed);
+                    _whatIfFlag = Context.GetBooleanPreference(SpecialVariables.WhatIfPreferenceVarPath, _whatIfFlag, out _);
                     _isWhatIfPreferenceCached = true;
                 }
 

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -20,8 +20,6 @@ namespace System.Management.Automation
     /// </summary>
     internal class NativeCommandParameterBinder : ParameterBinderBase
     {
-        private readonly VariablePath s_nativeArgumentPassingVarPath = new VariablePath(SpecialVariables.NativeArgumentPassing);
-
         #region ctor
 
         /// <summary>
@@ -193,13 +191,13 @@ namespace System.Management.Automation
         {
             get
             {
-                if (ExperimentalFeature.IsEnabled("PSNativeCommandArgumentPassing"))
+                if (ExperimentalFeature.IsEnabled(ExperimentalFeature.PSNativeCommandArgumentPassingFeatureName))
                 {
                     try
                     {
                         // This will default to the new behavior if it is set to anything other than Legacy
                         var preference = LanguagePrimitives.ConvertTo<NativeArgumentPassingStyle>(
-                            Context.GetVariableValue(s_nativeArgumentPassingVarPath, NativeArgumentPassingStyle.Standard));
+                            Context.GetVariableValue(SpecialVariables.NativeArgumentPassingVarPath, NativeArgumentPassingStyle.Standard));
                         return preference;
                     }
                     catch

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -865,7 +865,7 @@ namespace System.Management.Automation
                     this.commandRuntime.PipelineProcessor.ExecutionFailed = true;
 
                     if (!ExperimentalFeature.IsEnabled(ExperimentalFeature.PSNativeCommandErrorActionPreferenceFeatureName)
-                        || !(bool)Command.Context.GetVariableValue(SpecialVariables.PSNativeCommandUseErrorActionPreferenceVarPath, defaultValue: false))
+                        || !Command.Context.GetBooleanPreference(SpecialVariables.PSNativeCommandUseErrorActionPreferenceVarPath, defaultPref: false, out _))
                     {
                         return;
                     }

--- a/src/System.Management.Automation/engine/SpecialVariables.cs
+++ b/src/System.Management.Automation/engine/SpecialVariables.cs
@@ -204,6 +204,7 @@ namespace System.Management.Automation
         internal static readonly VariablePath PSModuleAutoLoadingPreferenceVarPath = new VariablePath("global:" + PSModuleAutoLoading);
 
         #region Platform Variables
+
         internal const string IsLinux = "IsLinux";
 
         internal static readonly VariablePath IsLinuxPath = new VariablePath("IsLinux");
@@ -221,6 +222,7 @@ namespace System.Management.Automation
         internal static readonly VariablePath IsCoreCLRPath = new VariablePath("IsCoreCLR");
 
         #endregion
+
         #region Preference Variables
 
         internal const string DebugPreference = "DebugPreference";
@@ -255,12 +257,12 @@ namespace System.Management.Automation
 
         internal static readonly VariablePath InformationPreferenceVarPath = new VariablePath(InformationPreference);
 
+        #endregion Preference Variables
+
         internal const string PSNativeCommandUseErrorActionPreference = nameof(PSNativeCommandUseErrorActionPreference);
 
         internal static readonly VariablePath PSNativeCommandUseErrorActionPreferenceVarPath =
             new(PSNativeCommandUseErrorActionPreference);
-
-        #endregion Preference Variables
 
         // Native command argument passing style
         internal const string NativeArgumentPassing = "PSNativeCommandArgumentPassing";

--- a/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
+++ b/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
@@ -56,6 +56,19 @@ Describe 'Native command error handling tests' -Tags 'CI' {
             $stderr[1].Exception.Message | Should -BeExactly "Program `"$exeName`" ended with non-zero exit code: 1."
         }
 
+        It "Non-boolean value should not cause type casting error when the native command exited with non-zero code" {
+            $ErrorActionPreference = 'Continue'
+
+            $PSNativeCommandUseErrorActionPreference = 'Yeah'
+            $PSNativeCommandUseErrorActionPreference | Should -BeExactly 'Yeah'
+
+            $stderr = testexe -returncode 1 2>&1
+
+            $error[0].FullyQualifiedErrorId | Should -BeExactly 'ProgramExitedWithNonZeroCode'
+            $error[0].TargetObject | Should -BeExactly $exeName
+            $stderr[1].Exception.Message | Should -BeExactly "Program `"$exeName`" ended with non-zero exit code: 1."
+        }
+
         It 'Non-zero exit code generates a non-teminating error for $ErrorActionPreference = ''SilentlyContinue''' {
             $ErrorActionPreference = 'SilentlyContinue'
 
@@ -170,6 +183,19 @@ Describe 'Native command error handling tests' -Tags 'CI' {
             else {
                 testexe -returncode 1 > $null
             }
+
+            $LASTEXITCODE | Should -Be 1
+            $Error.Count | Should -Be 0
+        }
+
+        It "Non-boolean value should not cause type casting error when the native command exited with non-zero code" {
+            $ErrorActionPreference = 'Continue'
+
+            $PSNativeCommandUseErrorActionPreference = 0
+            $PSNativeCommandUseErrorActionPreference | Should -Be 0
+            $PSNativeCommandUseErrorActionPreference | Should -BeOfType 'System.Int32'
+
+            testexe -returncode 1 > $null
 
             $LASTEXITCODE | Should -Be 1
             $Error.Count | Should -Be 0


### PR DESCRIPTION
# PR Summary

This PR includes the following changes:

1. Move the declaration of the variable `PSNativeArgumentPassing` (from an experimental feature) to `static InitialSessionState`, to be consistent with `PSNativeCommandUsesErrorActionPreference`.
2. Change back to `GetBooleanPreference` to get the value for `PSNativeCommandUsesErrorActionPreference`, because when assigning a value to that variable in a nested scope, the variable won't have the argument transformation attribute and thus can be assigned with arbitrary values. Tests are also added.

    
![image](https://user-images.githubusercontent.com/127450/130705227-6c602b6e-a931-43ea-920e-8d08a9f5deeb.png)


3. Instead of using the string `"PSNativeCommandArgumentPassing"`, use the const variable defined in `ExperimentalFeature`.
4. Instead of using `s_nativeArgumentPassingVarPath`, use the one defined in `SpecialVariables`.
5. A few other simple cleanup changes.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
- **User-facing changes**
    - [x] Not Applicable
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
