### PR TITLE
Fix the mac build by updating the pool image name

### DIFF
--- a/tools/releaseBuild/azureDevOps/templates/mac-package-build.yml
+++ b/tools/releaseBuild/azureDevOps/templates/mac-package-build.yml
@@ -8,7 +8,7 @@ jobs:
   dependsOn: MacFileSigningJob_${{ parameters.buildArchitecture }}
   condition: succeeded()
   pool:
-    vmImage: internal-macos-10.15
+    vmImage: internal-macos-10.14
   variables:
     # Turn off Homebrew analytics
     - name: HOMEBREW_NO_ANALYTICS

--- a/tools/releaseBuild/azureDevOps/templates/mac-package-build.yml
+++ b/tools/releaseBuild/azureDevOps/templates/mac-package-build.yml
@@ -7,7 +7,8 @@ jobs:
   displayName: Package macOS ${{ parameters.buildArchitecture }}
   dependsOn: MacFileSigningJob_${{ parameters.buildArchitecture }}
   condition: succeeded()
-  pool: Hosted Mac Internal
+  pool:
+    vmImage: internal-macos-10.15
   variables:
     # Turn off Homebrew analytics
     - name: HOMEBREW_NO_ANALYTICS

--- a/tools/releaseBuild/azureDevOps/templates/mac.yml
+++ b/tools/releaseBuild/azureDevOps/templates/mac.yml
@@ -6,7 +6,7 @@ jobs:
   displayName: Build macOS ${{ parameters.buildArchitecture }}
   condition: succeeded()
   pool:
-    vmImage: internal-macos-10.15
+    vmImage: internal-macos-10.14
   variables:
     # Turn off Homebrew analytics
     - name: HOMEBREW_NO_ANALYTICS

--- a/tools/releaseBuild/azureDevOps/templates/mac.yml
+++ b/tools/releaseBuild/azureDevOps/templates/mac.yml
@@ -5,7 +5,8 @@ jobs:
 - job: build_macOS_${{ parameters.buildArchitecture }}
   displayName: Build macOS ${{ parameters.buildArchitecture }}
   condition: succeeded()
-  pool: Hosted Mac Internal
+  pool:
+    vmImage: internal-macos-10.15
   variables:
     # Turn off Homebrew analytics
     - name: HOMEBREW_NO_ANALYTICS


### PR DESCRIPTION
### PR Summary

The old pool name used by macOS build was deprecated. Update to use the new image name.

Validation build: https://dev.azure.com/mscodehub/PowerShellCore/_build/results?buildId=206977&view=results
