### PR TITLE
Remove duplicate remote server mediator code

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -193,7 +193,20 @@ namespace Microsoft.PowerShell
                 {
                     ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("ServerMode");
                     ProfileOptimization.StartProfile("StartupProfileData-ServerMode");
-                    System.Management.Automation.Remoting.Server.OutOfProcessMediator.Run(s_cpp.InitialCommand, s_cpp.WorkingDirectory);
+                    System.Management.Automation.Remoting.Server.StdIOProcessMediator.Run(
+                        initialCommand: s_cpp.InitialCommand,
+                        workingDirectory: s_cpp.WorkingDirectory,
+                        configurationName: null);
+                    exitCode = 0;
+                }
+                else if (s_cpp.SSHServerMode)
+                {
+                    ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("SSHServer");
+                    ProfileOptimization.StartProfile("StartupProfileData-SSHServerMode");
+                    System.Management.Automation.Remoting.Server.StdIOProcessMediator.Run(
+                        initialCommand: s_cpp.InitialCommand,
+                        workingDirectory: null,
+                        configurationName: null);
                     exitCode = 0;
                 }
                 else if (s_cpp.NamedPipeServerMode)
@@ -201,22 +214,16 @@ namespace Microsoft.PowerShell
                     ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("NamedPipe");
                     ProfileOptimization.StartProfile("StartupProfileData-NamedPipeServerMode");
                     System.Management.Automation.Remoting.RemoteSessionNamedPipeServer.RunServerMode(
-                        s_cpp.ConfigurationName);
-                    exitCode = 0;
-                }
-                else if (s_cpp.SSHServerMode)
-                {
-                    ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("SSHServer");
-                    ProfileOptimization.StartProfile("StartupProfileData-SSHServerMode");
-                    System.Management.Automation.Remoting.Server.SSHProcessMediator.Run(s_cpp.InitialCommand);
+                        configurationName: s_cpp.ConfigurationName);
                     exitCode = 0;
                 }
                 else if (s_cpp.SocketServerMode)
                 {
                     ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("SocketServerMode");
                     ProfileOptimization.StartProfile("StartupProfileData-SocketServerMode");
-                    System.Management.Automation.Remoting.Server.HyperVSocketMediator.Run(s_cpp.InitialCommand,
-                        s_cpp.ConfigurationName);
+                    System.Management.Automation.Remoting.Server.HyperVSocketMediator.Run(
+                        initialCommand: s_cpp.InitialCommand,
+                        configurationName: s_cpp.ConfigurationName);
                     exitCode = 0;
                 }
                 else

--- a/src/System.Management.Automation/engine/remoting/server/OutOfProcServerMediator.cs
+++ b/src/System.Management.Automation/engine/remoting/server/OutOfProcServerMediator.cs
@@ -72,14 +72,6 @@ namespace System.Management.Automation.Remoting.Server
         {
             try
             {
-#if !CORECLR
-                // CurrentUICulture is not available in Thread Class in CSS
-                // WinBlue: 621775. Thread culture is not properly set
-                // for local background jobs causing experience differences
-                // between local console and local background jobs.
-                Thread.CurrentThread.CurrentUICulture = Microsoft.PowerShell.NativeCultureResolver.UICulture;
-                Thread.CurrentThread.CurrentCulture = Microsoft.PowerShell.NativeCultureResolver.Culture;
-#endif
                 string data = state as string;
                 OutOfProcessUtils.ProcessData(data, callbacks);
             }
@@ -423,28 +415,6 @@ namespace System.Management.Automation.Remoting.Server
         }
 
         #endregion
-
-        #region Static Methods
-
-        internal static void AppDomainUnhandledException(object sender, UnhandledExceptionEventArgs args)
-        {
-            // args can never be null.
-            Exception exception = (Exception)args.ExceptionObject;
-            // log the exception to crimson event logs
-            PSEtwLog.LogOperationalError(PSEventId.AppDomainUnhandledException,
-                PSOpcode.Close, PSTask.None,
-                PSKeyword.UseAlwaysOperational,
-                exception.GetType().ToString(), exception.Message,
-                exception.StackTrace);
-
-            PSEtwLog.LogAnalyticError(PSEventId.AppDomainUnhandledException_Analytic,
-                    PSOpcode.Close, PSTask.None,
-                    PSKeyword.ManagedPlugin | PSKeyword.UseAlwaysAnalytic,
-                    exception.GetType().ToString(), exception.Message,
-                    exception.StackTrace);
-        }
-
-        #endregion
     }
 
     internal sealed class StdIOProcessMediator : OutOfProcessMediatorBase
@@ -510,10 +480,6 @@ namespace System.Management.Automation.Remoting.Server
                 s_singletonInstance = new StdIOProcessMediator();
             }
 
-#if !CORECLR
-            // Setup unhandled exception to log events.
-            AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(AppDomainUnhandledException);
-#endif
             s_singletonInstance.Start(
                 initialCommand: initialCommand,
                 cryptoHelper: new PSRemotingCryptoHelperServer(),
@@ -587,10 +553,6 @@ namespace System.Management.Automation.Remoting.Server
                 s_singletonInstance = new NamedPipeProcessMediator(namedPipeServer);
             }
 
-#if !CORECLR
-            // AppDomain is not available in CoreCLR
-            AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(AppDomainUnhandledException);
-#endif
             s_singletonInstance.Start(
                 initialCommand: initialCommand,
                 cryptoHelper: new PSRemotingCryptoHelperServer(),
@@ -680,11 +642,6 @@ namespace System.Management.Automation.Remoting.Server
             {
                 s_instance = new HyperVSocketMediator();
             }
-
-#if !CORECLR
-            // AppDomain is not available in CoreCLR
-            AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(AppDomainUnhandledException);
-#endif
 
             s_instance.Start(
                 initialCommand: initialCommand,


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR removes duplicate server mediator classes, and refactors code to use a single mediator for StdIO based connections.
It also fixes parameter arguments so that configuration name is passed in correctly.

## PR Context

There used to be two separate server mediator derivations, one each for OutOfProc and SSH transports.  They both use StdIO for communication, but SSH had special code to deal with .NET implementation inconsistencies.  But .NET addressed the issues and now both class derivations operate identically.  So this PR creates a single StdIOProcessMediator class for both uses.

I also found a bug where the 'configurationName' parameter was not passed in correctly for HyperV mediators.  I fixed the issues, but it turns out that the code path is not being used for PowerShellDirect VM connections, but I am not sure about container connections.  
Actually, neither of these code paths are used because currently PowerShellDirect only works with WindowsPowerShell.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
