### PR TITLE
Fix regression in `Move-Item` to only fallback to CopyAndDelete in specific cases

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -51,6 +51,15 @@ namespace Microsoft.PowerShell.Commands
                                                      ISecurityDescriptorCmdletProvider,
                                                      ICmdletProviderSupportsHelp
     {
+#if UNIX
+        // This is the errno returned by the rename() syscall
+        // when an item is attempted to be renamed across filesystem mount boundaries.
+        private const int MOVE_FAILED_ERROR = 18;
+#else
+        // 0x80070005 ACCESS_DENIED is returned when trying to move files across volumes like DFS
+        private const int MOVE_FAILED_ERROR = -2147024891;
+#endif
+
         // 4MB gives the best results without spiking the resources on the remote connection for file transfers between pssessions.
         // NOTE: The script used to copy file data from session (PSCopyFromSessionHelper) has a
         // maximum fragment size value for security.  If FILETRANSFERSIZE changes make sure the
@@ -6112,22 +6121,42 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="force">If true, force move the directory, overwriting anything at the destination.</param>
         private void MoveDirectoryInfoUnchecked(DirectoryInfo directory, string destinationPath, bool force)
         {
-            try
+            if (!IsSameWindowsVolume(directory.FullName, destinationPath))
             {
-                if (InternalTestHooks.ThrowExdevErrorOnMoveDirectory)
-                {
-                    throw new IOException("Invalid cross-device link");
-                }
-
-                directory.MoveTo(destinationPath);
-            }
-            catch (IOException)
-            {
-                // Rather than try to ascertain whether we can rename a directory ahead of time,
-                // it's both faster and more correct to try to rename it and fall back to copy/deleting it
-                // See also: https://github.com/coreutils/coreutils/blob/439741053256618eb651e6d43919df29625b8714/src/mv.c#L212-L216
                 CopyAndDelete(directory, destinationPath, force);
             }
+            else
+            {
+                try
+                {
+                    if (InternalTestHooks.ThrowExdevErrorOnMoveDirectory)
+                    {
+                        throw new IOException("Invalid cross-device link", hresult: MOVE_FAILED_ERROR);
+                    }
+
+                    directory.MoveTo(destinationPath);
+                }
+                catch (IOException e) when (e.HResult == MOVE_FAILED_ERROR)
+                {
+                    // Rather than try to ascertain whether we can rename a directory ahead of time,
+                    // it's both faster and more correct to try to rename it and fall back to copy/deleting it
+                    // See also: https://github.com/coreutils/coreutils/blob/439741053256618eb651e6d43919df29625b8714/src/mv.c#L212-L216
+                    CopyAndDelete(directory, destinationPath, force);
+                }
+            }
+        }
+
+        private static bool IsSameWindowsVolume(string source, string destination)
+        {
+#if UNIX
+            return true;
+#else
+
+            FileInfo src = new FileInfo(source);
+            FileInfo dest = new FileInfo(destination);
+
+            return src.Directory.Root.Name == dest.Directory.Root.Name;
+#endif
         }
 
         private void CopyAndDelete(DirectoryInfo directory, string destination, bool force)

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -6124,7 +6124,8 @@ namespace Microsoft.PowerShell.Commands
 #if UNIX
             // This is the errno returned by the rename() syscall
             // when an item is attempted to be renamed across filesystem mount boundaries.
-            catch (IOException e) when (e.HResult == 18)
+            // 0x80131620 is returned if the source and destination do not have the same root path
+            catch (IOException e) when (e.HResult == 18 || e.HResult == -2146232800)
 #else
             // 0x80070005 ACCESS_DENIED is returned when trying to move files across volumes like DFS
             // 0x80131620 is returned if the source and destination do not have the same root path

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -54,10 +54,11 @@ namespace Microsoft.PowerShell.Commands
 #if UNIX
         // This is the errno returned by the rename() syscall
         // when an item is attempted to be renamed across filesystem mount boundaries.
-        private const int MOVE_FAILED_ERROR = 18;
+        private readonly List<int> MOVE_FAILED_ERRORS = new(){18};
 #else
         // 0x80070005 ACCESS_DENIED is returned when trying to move files across volumes like DFS
-        private const int MOVE_FAILED_ERROR = -2147024891;
+        // 0x80131620 is returned if the source and destination do not have the same root path
+        private readonly List<int> MOVE_FAILED_ERRORS = new(){-2147024891, -2146232800};
 #endif
 
         // 4MB gives the best results without spiking the resources on the remote connection for file transfers between pssessions.
@@ -6121,42 +6122,22 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="force">If true, force move the directory, overwriting anything at the destination.</param>
         private void MoveDirectoryInfoUnchecked(DirectoryInfo directory, string destinationPath, bool force)
         {
-            if (!IsSameWindowsVolume(directory.FullName, destinationPath))
+            try
             {
+                if (InternalTestHooks.ThrowExdevErrorOnMoveDirectory)
+                {
+                    throw new IOException("Invalid cross-device link", hresult: MOVE_FAILED_ERRORS[0]);
+                }
+
+                directory.MoveTo(destinationPath);
+            }
+            catch (IOException e) when (MOVE_FAILED_ERRORS.Contains(e.HResult))
+            {
+                // Rather than try to ascertain whether we can rename a directory ahead of time,
+                // it's both faster and more correct to try to rename it and fall back to copy/deleting it
+                // See also: https://github.com/coreutils/coreutils/blob/439741053256618eb651e6d43919df29625b8714/src/mv.c#L212-L216
                 CopyAndDelete(directory, destinationPath, force);
             }
-            else
-            {
-                try
-                {
-                    if (InternalTestHooks.ThrowExdevErrorOnMoveDirectory)
-                    {
-                        throw new IOException("Invalid cross-device link", hresult: MOVE_FAILED_ERROR);
-                    }
-
-                    directory.MoveTo(destinationPath);
-                }
-                catch (IOException e) when (e.HResult == MOVE_FAILED_ERROR)
-                {
-                    // Rather than try to ascertain whether we can rename a directory ahead of time,
-                    // it's both faster and more correct to try to rename it and fall back to copy/deleting it
-                    // See also: https://github.com/coreutils/coreutils/blob/439741053256618eb651e6d43919df29625b8714/src/mv.c#L212-L216
-                    CopyAndDelete(directory, destinationPath, force);
-                }
-            }
-        }
-
-        private static bool IsSameWindowsVolume(string source, string destination)
-        {
-#if UNIX
-            return true;
-#else
-
-            FileInfo src = new FileInfo(source);
-            FileInfo dest = new FileInfo(destination);
-
-            return src.Directory.Root.Name == dest.Directory.Root.Name;
-#endif
         }
 
         private void CopyAndDelete(DirectoryInfo directory, string destination, bool force)

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -170,9 +170,14 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
         }
 
         It "Verify Move-Item will not move to an existing file" {
-            { Move-Item -Path $testDir -Destination $testFile -ErrorAction Stop } | Should -Throw -ErrorId 'DirectoryExist,Microsoft.PowerShell.Commands.MoveItemCommand'
-            $error[0].Exception | Should -BeOfType System.IO.IOException
+            $e = { Move-Item -Path $testDir -Destination $testFile -ErrorAction Stop } | Should -Throw -ErrorId 'MoveDirectoryItemIOError,Microsoft.PowerShell.Commands.MoveItemCommand' -PassThru
+            $e.Exception | Should -BeOfType System.IO.IOException
             $testDir | Should -Exist
+        }
+
+        It 'Verify Move-Item fails for non-existing destination path' {
+            $e = { Move-Item -Path $testDir -Destination TestDrive:/0/2/0 -ErrorAction Stop } | Should -Throw -ErrorId 'MoveDirectoryItemIOError,Microsoft.PowerShell.Commands.MoveItemCommand' -PassThru
+            $e.Exception | Should -BeOfType System.IO.IOException
         }
 
         It "Verify Move-Item throws correct error for non-existent source" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -170,7 +170,14 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
         }
 
         It "Verify Move-Item will not move to an existing file" {
-            $e = { Move-Item -Path $testDir -Destination $testFile -ErrorAction Stop } | Should -Throw -ErrorId 'MoveDirectoryItemIOError,Microsoft.PowerShell.Commands.MoveItemCommand' -PassThru
+            if ($IsWindows) {
+                $expectedError = 'MoveDirectoryItemIOError,Microsoft.PowerShell.Commands.MoveItemCommand'
+            }
+            else {
+                $expectedError = 'DirectoryExist,Microsoft.PowerShell.Commands.MoveItemCommand'
+            }
+
+            $e = { Move-Item -Path $testDir -Destination $testFile -ErrorAction Stop } | Should -Throw -ErrorId $expectedError -PassThru
             $e.Exception | Should -BeOfType System.IO.IOException
             $testDir | Should -Exist
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

If Move fails, check if known case before attempting CopyAndDelete:

- if an item is attempted to be renamed across filesystem mount boundaries.
- if the source and destination do not have the same root path

## PR Context

#15077 introduced a regression where it would fall through to CopyAndDelete on any IOException including where the destination doesn't exist (and probably other cases as well).

Fix https://github.com/PowerShell/PowerShell/issues/16000

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
