### PR TITLE
Ensure locale is set correctly on Linux in CI

### DIFF
--- a/.vsts-ci/linux-daily.yml
+++ b/.vsts-ci/linux-daily.yml
@@ -122,6 +122,9 @@ stages:
       condition: succeededOrFailed()
 
     - pwsh: |
+        Import-Module .\build.psm1
+        Set-CorrectLocale
+
         Import-Module .\tools\ci.psm1
         Restore-PSOptions -PSOptionsPath '$(System.ArtifactsDirectory)\build\psoptions.json'
         Invoke-CITest -Purpose UnelevatedPesterTests -TagSet Others
@@ -129,6 +132,9 @@ stages:
       condition: succeededOrFailed()
 
     - pwsh: |
+        Import-Module .\build.psm1
+        Set-CorrectLocale
+
         Import-Module .\tools\ci.psm1
         Restore-PSOptions -PSOptionsPath '$(System.ArtifactsDirectory)\build\psoptions.json'
         Invoke-CITest -Purpose ElevatedPesterTests -TagSet Others

--- a/.vsts-ci/templates/nix-test.yml
+++ b/.vsts-ci/templates/nix-test.yml
@@ -64,16 +64,7 @@ jobs:
 
   - pwsh: |
       Import-Module .\build.psm1 -Force
-      $environment = Get-EnvironmentInformation
-      $isUbuntu20 = $environment.IsUbuntu -and $environment.IsUbuntu20
-      if ($isUbuntu20) {
-        $env:LC_ALL='en_US.UTF-8'
-        $env:LANG='en_US.UTF-8'
-        sudo locale-gen $LANG
-        sudo update-locale
-      }
-
-      locale
+      Set-CorrectLocale
 
       Import-Module .\tools\ci.psm1
       Restore-PSOptions -PSOptionsPath '$(System.ArtifactsDirectory)\build\psoptions.json'

--- a/build.psm1
+++ b/build.psm1
@@ -3386,3 +3386,23 @@ function New-NugetConfigFile
 
     Set-Content -Path (Join-Path $Destination 'nuget.config') -Value $content -Force
 }
+
+function Set-CorrectLocale
+{
+    if (-not $IsLinux)
+    {
+        return
+    }
+
+    $environment = Get-EnvironmentInformation
+    if ($environment.IsUbuntu -and $environment.IsUbuntu20)
+    {
+        $env:LC_ALL = 'en_US.UTF-8'
+        $env:LANG = 'en_US.UTF-8'
+        sudo locale-gen $env:LANG
+        sudo update-locale
+    }
+
+    # Output the locale to log it
+    locale
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes daily CI issues on Linux where help tests fail due to bad locale settings.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
