### PR TITLE
Fix ConvertTo-SecureString with key regression due to .NET breaking change

### DIFF
--- a/src/System.Management.Automation/security/SecureStringHelper.cs
+++ b/src/System.Management.Automation/security/SecureStringHelper.cs
@@ -321,7 +321,7 @@ namespace Microsoft.PowerShell
             }
             finally
             {
-                Array.Clear(keyBlob, 0, keyBlob.Length);
+                Array.Clear(keyBlob);
             }
         }
 

--- a/src/System.Management.Automation/security/SecureStringHelper.cs
+++ b/src/System.Management.Automation/security/SecureStringHelper.cs
@@ -364,7 +364,7 @@ namespace Microsoft.PowerShell
                     }
                     finally
                     {
-                        Array.Clear(decryptedData, 0, decryptedData.Length);
+                        Array.Clear(decryptedData);
                     }
                 }
             }

--- a/src/System.Management.Automation/security/SecureStringHelper.cs
+++ b/src/System.Management.Automation/security/SecureStringHelper.cs
@@ -231,7 +231,7 @@ namespace Microsoft.PowerShell
             }
             finally
             {
-                Array.Clear(keyBlob, 0, keyBlob.Length);
+                Array.Clear(keyBlob);
             }
         }
 

--- a/src/System.Management.Automation/security/SecureStringHelper.cs
+++ b/src/System.Management.Automation/security/SecureStringHelper.cs
@@ -269,7 +269,7 @@ namespace Microsoft.PowerShell
                 byte[] data = GetData(input);
                 try
                 {
-                    using (var encryptor = aes.CreateEncryptor(key, iv))
+                    using (ICryptoTransform encryptor = aes.CreateEncryptor(key, iv))
                     using (var sourceStream = new MemoryStream(data))
                     using (var encryptedStream = new MemoryStream())
                     {

--- a/src/System.Management.Automation/security/SecureStringHelper.cs
+++ b/src/System.Management.Automation/security/SecureStringHelper.cs
@@ -345,7 +345,7 @@ namespace Microsoft.PowerShell
             //
             using (var aes = Aes.Create())
             {
-                using (var decryptor = aes.CreateDecryptor(key, IV ?? aes.IV))
+                using (ICryptoTransform decryptor = aes.CreateDecryptor(key, IV ?? aes.IV))
                 using (var encryptedStream = new MemoryStream(ByteArrayFromString(input)))
                 using (var targetStream = new MemoryStream())
                 {

--- a/src/System.Management.Automation/security/SecureStringHelper.cs
+++ b/src/System.Management.Automation/security/SecureStringHelper.cs
@@ -258,7 +258,7 @@ namespace Microsoft.PowerShell
             //
             using (Aes aes = Aes.Create())
             {
-                if (iv == null)
+                if (iv is null)
                 {
                     iv = aes.IV;
                 }

--- a/src/System.Management.Automation/security/SecureStringHelper.cs
+++ b/src/System.Management.Automation/security/SecureStringHelper.cs
@@ -217,8 +217,6 @@ namespace Microsoft.PowerShell
         /// <returns>A string (see summary).</returns>
         internal static EncryptionResult Encrypt(SecureString input, SecureString key)
         {
-            EncryptionResult output = null;
-
             //
             // get clear text key from the SecureString key
             //
@@ -227,14 +225,14 @@ namespace Microsoft.PowerShell
             //
             // encrypt the data
             //
-            output = Encrypt(input, keyBlob);
-
-            //
-            // clear the clear text key
-            //
-            Array.Clear(keyBlob, 0, keyBlob.Length);
-
-            return output;
+            try
+            {
+                return Encrypt(input, keyBlob);
+            }
+            finally
+            {
+                Array.Clear(keyBlob, 0, keyBlob.Length);
+            }
         }
 
         /// <summary>
@@ -254,48 +252,46 @@ namespace Microsoft.PowerShell
             Utils.CheckSecureStringArg(input, "input");
             Utils.CheckKeyArg(key, "key");
 
-            byte[] encryptedData = null;
-            MemoryStream ms = null;
-            ICryptoTransform encryptor = null;
-            CryptoStream cs = null;
-
             //
             // prepare the crypto stuff. Initialization Vector is
             // randomized by default.
             //
-            Aes aes = Aes.Create();
-            if (iv == null)
-                iv = aes.IV;
-
-            encryptor = aes.CreateEncryptor(key, iv);
-            ms = new MemoryStream();
-
-            using (cs = new CryptoStream(ms, encryptor, CryptoStreamMode.Write))
+            using (Aes aes = Aes.Create())
             {
+                if (iv == null)
+                {
+                    iv = aes.IV;
+                }
+
                 //
                 // get clear text data from the input SecureString
                 //
                 byte[] data = GetData(input);
+                try
+                {
+                    using (var encryptor = aes.CreateEncryptor(key, iv))
+                    using (var sourceStream = new MemoryStream(data))
+                    using (var encryptedStream = new MemoryStream())
+                    {
+                        //
+                        // encrypt it
+                        //
+                        using (var cryptoStream = new CryptoStream(encryptedStream, encryptor, CryptoStreamMode.Write))
+                        {
+                            sourceStream.CopyTo(cryptoStream);
+                        }
 
-                //
-                // encrypt it
-                //
-                cs.Write(data, 0, data.Length);
-                cs.FlushFinalBlock();
-
-                //
-                // clear the clear text data array
-                //
-                Array.Clear(data, 0, data.Length);
-
-                //
-                // convert the encrypted blob to a string
-                //
-                encryptedData = ms.ToArray();
-
-                EncryptionResult output = new EncryptionResult(ByteArrayToString(encryptedData), Convert.ToBase64String(iv));
-
-                return output;
+                        //
+                        // return encrypted data
+                        //
+                        byte[] encryptedData = encryptedStream.ToArray();
+                        return new EncryptionResult(ByteArrayToString(encryptedData), Convert.ToBase64String(iv));
+                    }
+                }
+                finally
+                {
+                    Array.Clear(data, 0, data.Length);
+                }
             }
         }
 
@@ -311,8 +307,6 @@ namespace Microsoft.PowerShell
         /// <returns>SecureString .</returns>
         internal static SecureString Decrypt(string input, SecureString key, byte[] IV)
         {
-            SecureString output = null;
-
             //
             // get clear text key from the SecureString key
             //
@@ -321,14 +315,14 @@ namespace Microsoft.PowerShell
             //
             // decrypt the data
             //
-            output = Decrypt(input, keyBlob, IV);
-
-            //
-            // clear the clear text key
-            //
-            Array.Clear(keyBlob, 0, keyBlob.Length);
-
-            return output;
+            try
+            {
+                return Decrypt(input, keyBlob, IV);
+            }
+            finally
+            {
+                Array.Clear(keyBlob, 0, keyBlob.Length);
+            }
         }
 
         /// <summary>
@@ -346,44 +340,33 @@ namespace Microsoft.PowerShell
             Utils.CheckArgForNullOrEmpty(input, "input");
             Utils.CheckKeyArg(key, "key");
 
-            byte[] decryptedData = null;
-            byte[] encryptedData = null;
-            SecureString s = null;
-
             //
             // prepare the crypto stuff
             //
-            Aes aes = Aes.Create();
-            encryptedData = ByteArrayFromString(input);
-
-            var decryptor = aes.CreateDecryptor(key, IV ?? aes.IV);
-
-            MemoryStream ms = new MemoryStream(encryptedData);
-
-            using (CryptoStream cs = new CryptoStream(ms, decryptor, CryptoStreamMode.Read))
+            using (var aes = Aes.Create())
             {
-                byte[] tempDecryptedData = new byte[encryptedData.Length];
-
-                int numBytesRead = 0;
-
-                //
-                // decrypt the data
-                //
-                numBytesRead = cs.Read(tempDecryptedData, 0,
-                                       tempDecryptedData.Length);
-
-                decryptedData = new byte[numBytesRead];
-
-                for (int i = 0; i < numBytesRead; i++)
+                using (var decryptor = aes.CreateDecryptor(key, IV ?? aes.IV))
+                using (var encryptedStream = new MemoryStream(ByteArrayFromString(input)))
+                using (var targetStream = new MemoryStream())
                 {
-                    decryptedData[i] = tempDecryptedData[i];
+                    //
+                    // decrypt the data and return as SecureString
+                    //
+                    using (var sourceStream = new CryptoStream(encryptedStream, decryptor, CryptoStreamMode.Read))
+                    {
+                        sourceStream.CopyTo(targetStream);
+                    }
+
+                    byte[] decryptedData = targetStream.ToArray();
+                    try
+                    {
+                        return New(decryptedData);
+                    }
+                    finally
+                    {
+                        Array.Clear(decryptedData, 0, decryptedData.Length);
+                    }
                 }
-
-                s = New(decryptedData);
-                Array.Clear(decryptedData, 0, decryptedData.Length);
-                Array.Clear(tempDecryptedData, 0, tempDecryptedData.Length);
-
-                return s;
             }
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1
@@ -11,12 +11,12 @@ Describe "SecureString conversion tests" -Tags "CI" {
         $string.ToCharArray() | ForEach-Object { $securestring.AppendChar($_) }
     }
 
-    It "using null arguments to ConvertFrom-SecureString produces an exception" {
+    It "Using null arguments to ConvertFrom-SecureString produces an exception" {
         { ConvertFrom-SecureString -SecureString $null -Key $null } |
             Should -Throw -ErrorId "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.ConvertFromSecureStringCommand"
     }
 
-    It "using a bad key produces an exception" {
+    It "Using a bad key produces an exception" {
         $badkey = [byte[]]@(1,2)
         { ConvertFrom-SecureString -SecureString $secureString -Key $badkey } |
             Should -Throw -ErrorId "Argument,Microsoft.PowerShell.Commands.ConvertFromSecureStringCommand"
@@ -27,9 +27,18 @@ Describe "SecureString conversion tests" -Tags "CI" {
         $ss | Should -BeOfType SecureString
     }
 
-    It "can convert back from a secure string" {
+    It "Can convert back from a secure string" {
         $ss1 = ConvertTo-SecureString -AsPlainText -Force $string
         $ss2 = ConvertFrom-SecureString $ss1 | ConvertTo-SecureString
         $ss2 | ConvertFrom-SecureString -AsPlainText | Should -Be $string
+    }
+
+    It "Can encode secure string with key" {
+        $testString = '[8Chars][8Chars][Not8]'
+        $key = [System.Text.Encoding]::UTF8.GetBytes("1234"*8)
+        $ss1 = $testString | ConvertTo-SecureString -AsPlainText -Force
+        $encodedStr = $ss1 | ConvertFrom-SecureString -Key $key
+        $ss2 = $encodedStr | ConvertTo-SecureString -Key $key
+        $ss2 | ConvertFrom-SecureString -AsPlainText | Should -BeExactly $testString
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR fixes a regression in ConvertTo-SecureString found and reported by this [Issue](https://github.com/PowerShell/PowerShell/issues/16047).
Fix #16047.

## PR Context

This regression was caused by the change of behavior in the .NET CryptoStream.Read() method.  Previously, the Read method would synchronously read entire stream contents into the provided buffer, until the buffer was filled or the stream ended.  It was recently changed to read available data and return before the buffer is filled or the stream ended, breaking the existing code which would now read only partial stream contents.

Instead of performing multiple reads to ensure all stream content is obtained, this change uses an alternative common pattern to copy entire stream contents.  It also takes care to dispose all disposable objects and zero out clear-text buffers.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
