### PR TITLE
Set locale correctly on Linux CI

### DIFF
--- a/.vsts-ci/linux-daily.yml
+++ b/.vsts-ci/linux-daily.yml
@@ -122,9 +122,6 @@ stages:
       condition: succeededOrFailed()
 
     - pwsh: |
-        Import-Module .\build.psm1
-        Set-CorrectLocale
-
         Import-Module .\tools\ci.psm1
         Restore-PSOptions -PSOptionsPath '$(System.ArtifactsDirectory)\build\psoptions.json'
         Invoke-CITest -Purpose UnelevatedPesterTests -TagSet Others
@@ -132,9 +129,6 @@ stages:
       condition: succeededOrFailed()
 
     - pwsh: |
-        Import-Module .\build.psm1
-        Set-CorrectLocale
-
         Import-Module .\tools\ci.psm1
         Restore-PSOptions -PSOptionsPath '$(System.ArtifactsDirectory)\build\psoptions.json'
         Invoke-CITest -Purpose ElevatedPesterTests -TagSet Others

--- a/.vsts-ci/templates/nix-test.yml
+++ b/.vsts-ci/templates/nix-test.yml
@@ -63,9 +63,6 @@ jobs:
     continueOnError: true
 
   - pwsh: |
-      Import-Module .\build.psm1 -Force
-      Set-CorrectLocale
-
       Import-Module .\tools\ci.psm1
       Restore-PSOptions -PSOptionsPath '$(System.ArtifactsDirectory)\build\psoptions.json'
       $options = (Get-PSOptions)

--- a/tools/ci.psm1
+++ b/tools/ci.psm1
@@ -215,6 +215,9 @@ function Invoke-CITest
         [string] $TagSet
     )
 
+    # Set locale correctly for Linux CIs
+    Set-CorrectLocale
+
     # Pester doesn't allow Invoke-Pester -TagAll@('CI', 'RequireAdminOnWindows') currently
     # https://github.com/pester/Pester/issues/608
     # To work-around it, we exlude all categories, but 'CI' from the list


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes daily CI issues on Linux where help tests fail due to bad locale settings.

Failed Linux daily CI: https://dev.azure.com/powershell/PowerShell/_build/results?buildId=86091&view=results