### PR TITLE
Remove Windows PowerShell issue link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Windows PowerShell
-    url: https://windowsserver.uservoice.com/forums/301869-powershell
+    url: https://support.microsoft.com/windows/send-feedback-to-microsoft-with-the-feedback-hub-app-f59187f8-8739-22d6-ba93-f66612949332
     about: Windows PowerShell issues or suggestions.
   - name: Support
     url: https://github.com/PowerShell/PowerShell/blob/master/.github/SUPPORT.md


### PR DESCRIPTION
The linked user voice no longer exists. I suggest removing this option unless we know where we should point Windows PowerShell users. Found by @sdwheeler.
