### PR TITLE
Specify exe path as TargetObect for non-zero exit code ErrorRecord

### DIFF
--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -884,7 +884,7 @@ namespace System.Management.Automation
                         errorMsg,
                         errorId);
 
-                    var errorRecord = new ErrorRecord(exception, errorId, ErrorCategory.NotSpecified, targetObject: NativeCommandName);
+                    var errorRecord = new ErrorRecord(exception, errorId, ErrorCategory.NotSpecified, targetObject: Path);
                     this.commandRuntime._WriteErrorSkipAllowCheck(errorRecord);
                 }
             }

--- a/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
+++ b/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
@@ -14,6 +14,7 @@ Describe 'Native command error handling tests' -Tags 'CI' {
         }
 
         $exeName = $IsWindows ? 'testexe.exe' : 'testexe'
+        $exePath = @(Get-Command $exeName -Type Application)[0].Path
 
         $errorActionPrefTestCases = @(
             @{ ErrorActionPref = 'Stop' }
@@ -43,7 +44,7 @@ Describe 'Native command error handling tests' -Tags 'CI' {
 
             $error.Count | Should -Be 1
             $error[0].FullyQualifiedErrorId | Should -BeExactly 'ProgramExitedWithNonZeroCode'
-            $error[0].TargetObject | Should -BeExactly $exeName
+            $error[0].TargetObject | Should -BeExactly $exePath
         }
 
         It 'Non-zero exit code outputs a non-teminating error for $ErrorActionPreference = ''Continue''' {
@@ -52,7 +53,7 @@ Describe 'Native command error handling tests' -Tags 'CI' {
             $stderr = testexe -returncode 1 2>&1
 
             $error[0].FullyQualifiedErrorId | Should -BeExactly 'ProgramExitedWithNonZeroCode'
-            $error[0].TargetObject | Should -BeExactly $exeName
+            $error[0].TargetObject | Should -BeExactly $exePath
             $stderr[1].Exception.Message | Should -BeExactly "Program `"$exeName`" ended with non-zero exit code: 1."
         }
 
@@ -65,7 +66,7 @@ Describe 'Native command error handling tests' -Tags 'CI' {
             $stderr = testexe -returncode 1 2>&1
 
             $error[0].FullyQualifiedErrorId | Should -BeExactly 'ProgramExitedWithNonZeroCode'
-            $error[0].TargetObject | Should -BeExactly $exeName
+            $error[0].TargetObject | Should -BeExactly $exePath
             $stderr[1].Exception.Message | Should -BeExactly "Program `"$exeName`" ended with non-zero exit code: 1."
         }
 
@@ -76,7 +77,7 @@ Describe 'Native command error handling tests' -Tags 'CI' {
 
             $error.Count | Should -Be 1
             $error[0].FullyQualifiedErrorId | Should -BeExactly 'ProgramExitedWithNonZeroCode'
-            $error[0].TargetObject | Should -BeExactly $exeName
+            $error[0].TargetObject | Should -BeExactly $exePath
         }
 
         It 'Non-zero exit code does not generates an error record for $ErrorActionPreference = ''Ignore''' {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR changes the TargetObject for the ErrorCode to the full native command's path.  This ErrorRecord is generated as part of the experimental feature PSNativeCommandErrorActionPreference.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
Fix #15992

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
