### PR TITLE
Invoke-Command: improve handling of variables with $using: expression

### DIFF
--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -1261,7 +1261,7 @@ namespace System.Management.Automation.Language
                 var varAst = ast as VariableExpressionAst;
                 if (varAst != null)
                 {
-                    var varPath = varAst.VariablePath;
+                    VariablePath varPath = varAst.VariablePath;
                     string varName = varPath.IsDriveQualified ? $"{varPath.DriveName}_{varPath.UnqualifiedPath}" : $"{varPath.UnqualifiedPath}";
                     string varSign = varAst.Splatted ? "@" : "$";
                     string newVarName = varSign + UsingExpressionAst.UsingPrefix + varName;
@@ -2330,7 +2330,7 @@ namespace System.Management.Automation.Language
                 // We are done processing the current ParameterAst
                 if (astStartOffset >= endOffset) { break; }
 
-                var varPath = varAst.VariablePath;
+                VariablePath varPath = varAst.VariablePath;
                 string varName = varPath.IsDriveQualified ? $"{varPath.DriveName}_{varPath.UnqualifiedPath}" : $"{varPath.UnqualifiedPath}";
                 string varSign = varAst.Splatted ? "@" : "$";
                 string newVarName = varSign + UsingExpressionAst.UsingPrefix + varName;

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -1261,7 +1261,8 @@ namespace System.Management.Automation.Language
                 var varAst = ast as VariableExpressionAst;
                 if (varAst != null)
                 {
-                    string varName = varAst.VariablePath.UserPath;
+                    var varPath = varAst.VariablePath;
+                    string varName = varPath.IsDriveQualified ? $"{varPath.DriveName}_{varPath.UnqualifiedPath}" : $"{varPath.UnqualifiedPath}";
                     string varSign = varAst.Splatted ? "@" : "$";
                     string newVarName = varSign + UsingExpressionAst.UsingPrefix + varName;
 
@@ -2329,7 +2330,8 @@ namespace System.Management.Automation.Language
                 // We are done processing the current ParameterAst
                 if (astStartOffset >= endOffset) { break; }
 
-                string varName = varAst.VariablePath.UserPath;
+                var varPath = varAst.VariablePath;
+                string varName = varPath.IsDriveQualified ? $"{varPath.DriveName}_{varPath.UnqualifiedPath}" : $"{varPath.UnqualifiedPath}";
                 string varSign = varAst.Splatted ? "@" : "$";
                 string newVarName = varSign + UsingExpressionAst.UsingPrefix + varName;
 

--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -2374,7 +2374,7 @@ namespace Microsoft.PowerShell.Commands
 
                 foreach (var varAst in usingVariables)
                 {
-                    var varPath = varAst.VariablePath;
+                    VariablePath varPath = varAst.VariablePath;
                     string varName = varPath.IsDriveQualified ? $"{varPath.DriveName}_{varPath.UnqualifiedPath}" : $"{varPath.UnqualifiedPath}";
                     string paramName = UsingExpressionAst.UsingPrefix + varName;
                     string paramNameWithDollar = "$" + paramName;

--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -2374,7 +2374,8 @@ namespace Microsoft.PowerShell.Commands
 
                 foreach (var varAst in usingVariables)
                 {
-                    string varName = varAst.VariablePath.UserPath;
+                    var varPath = varAst.VariablePath;
+                    string varName = varPath.IsDriveQualified ? $"{varPath.DriveName}_{varPath.UnqualifiedPath}" : $"{varPath.UnqualifiedPath}";
                     string paramName = UsingExpressionAst.UsingPrefix + varName;
                     string paramNameWithDollar = "$" + paramName;
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR improves `Invoke-Command`'s handling of cases that combine `$using:` expressions with variable namespace notation when the `-ComputerName` parameter is used.
Fixes #9204
Fixes #16019 

## PR Context

When the `-ComputerName` parameter is used, `Invoke-Command` is unable to check which version of PowerShell is available on the remote computer and assumes v2.0. Because PowerShell 2.0 can't parse `$using:` expressions, the `ScriptBlock` is modified before sending, with `$using:` variables renamed to replace the `$using:` expression with `$__using_`.  Currently, the code that renames these variables doesn't check whether the variable path is qualified.  In cases where variable namespace notation is used, this code produces variable names like `$__using_env:foo`, preventing the remote computer from parsing the variables correctly.  The changes in this PR add handling for qualified variable paths, producing variable names like `$__using_env_foo`

This PR does not fix all issues with the handling of `$using:` expressions.  Variable names that include special characters still aren't parsed correctly, for instance.  Since a user technically _could_ name a variable `$__using_env_foo`, this might be considered an ["unlikely grey area" breaking change](https://github.com/PowerShell/PowerShell/blob/master/docs/dev-process/breaking-change-contract.md). Long-term, it might be worth reconsidering how `Invoke-Command` handles the `-ComputerName` parameter; always falling back to v2.0 seems unnecessarily restrictive.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
