### PR TITLE
Add SuppressMessageAttribute type accelerator for System.Diagnostics.CodeAnalysis.SuppressMessageAttribute

### DIFF
--- a/src/System.Management.Automation/engine/parser/TypeResolver.cs
+++ b/src/System.Management.Automation/engine/parser/TypeResolver.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 #if !UNIX
 using System.DirectoryServices;
 #endif
@@ -773,6 +774,7 @@ namespace System.Management.Automation
                     { typeof(sbyte),                                       new[] { "sbyte" } },
                     { typeof(string),                                      new[] { "string" } },
                     { typeof(SupportsWildcardsAttribute),                  new[] { "SupportsWildcards" } },
+                    { typeof(SuppressMessageAttribute),                    new[] { "SuppressMessageAttribute" } },
                     { typeof(SwitchParameter),                             new[] { "switch" } },
                     { typeof(CultureInfo),                                 new[] { "cultureinfo" } },
                     { typeof(BigInteger),                                  new[] { "bigint" } },

--- a/test/powershell/Language/Parser/TypeAccelerator.Tests.ps1
+++ b/test/powershell/Language/Parser/TypeAccelerator.Tests.ps1
@@ -408,14 +408,10 @@ Describe "Type accelerators" -Tags "CI" {
                 }
             )
 
-            if ( !$IsWindows )
-            {
-                $totalAccelerators = 99
-            }
-            else
-            {
-                $totalAccelerators = 104
+            [int] $totalAccelerators = 100
 
+            if ( $IsWindows )
+            {
                 $extraFullPSAcceleratorTestCases = @(
                     @{
                         Accelerator = 'adsi'
@@ -438,6 +434,7 @@ Describe "Type accelerators" -Tags "CI" {
                         Type        = [System.Management.ManagementObjectSearcher]
                     }
                 )
+                $totalAccelerators += $extraFullPSAcceleratorTestCases.Count
             }
         }
 

--- a/test/powershell/Language/Parser/TypeAccelerator.Tests.ps1
+++ b/test/powershell/Language/Parser/TypeAccelerator.Tests.ps1
@@ -215,6 +215,10 @@ Describe "Type accelerators" -Tags "CI" {
                     Type        = [System.Management.Automation.SupportsWildcardsAttribute]
                 }
                 @{
+                    Accelerator = 'SuppressMessageAttribute'
+                    Type        = [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute]
+                }
+                @{
                     Accelerator = 'switch'
                     Type        = [System.Management.Automation.SwitchParameter]
                 }


### PR DESCRIPTION
# PR Summary

Implements #14784

I observed though that when using this type accelerator for PowerShell versions without this type accelerator, `PSScriptAnalyzer` (PSSA) does not throw but just ignored the attribute, I initially expected it to throw an error, not sure it this is what the behavior of PSSA should be and if this should be improved. I'd suggest to let PSSA emit a warning if it encounters that in an old PS version and in order to get it highlighted in the editor, PSSA should probably emit a diagnosticrecord as well on those versions similar to how it does for parsererrors

## PR Context

See linked issue. Because this type is long and uses for PSSA suppressions.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
