### PR TITLE
Add support in BasicHtmlWebResponseObject for open-ended input tags

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/BasicHtmlWebResponseObject.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/BasicHtmlWebResponseObject.Common.cs
@@ -219,7 +219,7 @@ namespace Microsoft.PowerShell.Commands
 
             if (s_inputFieldRegex == null)
             {
-                s_inputFieldRegex = new Regex(@"<input\s+[^>]*(/>|>.*?</input>)",
+                s_inputFieldRegex = new Regex(@"<input\s+[^>]*(/?>|>.*?</input>)",
                     RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
             }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -1933,6 +1933,48 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
             $response = Invoke-WebRequest -Uri $dosUri
             $response.Images | Should -Not -BeNullOrEmpty
         }
+
+        $singleInputExpected = @(
+            @{ Name = 'foo'; Value = 'bar' }
+        )
+
+        It 'correctly parses input tag(s) for `<markup>`' -TestCases @(
+            @{
+                Markup = "<input name='foo' value='bar'>";
+                ExpectedFields = $singleInputExpected
+            },
+            @{
+                Markup = "<input name='foo' value='bar'/>";
+                ExpectedFields = $singleInputExpected
+            },
+            @{
+                Markup = "<input name='foo' value='bar'>baz</input>";
+                ExpectedFields = $singleInputExpected
+            }
+            @{
+                Markup = "<input name='item1' value='bar'><input name='item2' value='foo'><input name='item3'></input><input name='item4' value='fu'><input name='item5' value='bahr'/>";
+                ExpectedFields = @(
+                    @{ Name = 'item1'; Value = 'bar'},
+                    @{ Name = 'item2'; Value = 'foo' },
+                    @{ Name = 'item3'; Value = $null },
+                    @{ Name = 'item4'; Value = 'fu' },
+                    @{ Name = 'item5'; Value = 'bahr' }
+                )
+            }
+        ) {
+            param($markup, $expectedFields)
+            $query = @{
+                contenttype = 'text/html'
+                body        = "<html><body>${markup}</body></html>"
+            }
+            $uri = Get-WebListenerUrl -Test 'Response' -Query $query
+            $response = Invoke-WebRequest -Uri $uri -UseBasicParsing
+            $response.Error | Should -BeNullOrEmpty
+            ForEach ($expectedField in $expectedFields) {
+                $actualField = $response.InputFields.FindByName($expectedField.Name)
+                $actualField.Value | Should -Be $expectedField.Value
+            }
+        }
     }
 
     Context "Denial of service" -Tag 'DOS' {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
Per #16126, `BasicHtmlWebResponseObject` didn't fully support valid html for `input` fields. Specifically, for an `Invoke-WebRequest` that returns this valid html:
```html
<html>
    <body>
        <input name="foo" value="bar">
    </body>
</html>
```
would have a null `InputFields` value.

To solve this, I've added an alternative construct to the regular expression (as recommended by the author of the issue) that requires neither a closing slash '/' nor a closing input tag '</input>'.

Additionally, I've created Pester test cases to validate the outcome of the updated expression.
## PR Context

(For reference #15973)

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [x] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
