### PR TITLE
Fix ValidateRange Max Depth Allowed

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
@@ -27,8 +27,6 @@ namespace Microsoft.PowerShell.Commands
 
         private int _depth = 2;
 
-        private const int maxDepthAllowed = 100;
-
         private readonly CancellationTokenSource _cancellationSource = new();
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
@@ -99,23 +99,7 @@ namespace Microsoft.PowerShell.Commands
                 _cancellationSource.Dispose();
             }
         }
-
-        /// <summary>
-        /// Prerequisite checks.
-        /// </summary>
-        protected override void BeginProcessing()
-        {
-            if (_depth > maxDepthAllowed)
-            {
-                string errorMessage = StringUtil.Format(WebCmdletStrings.ReachedMaximumDepthAllowed, maxDepthAllowed);
-                ThrowTerminatingError(new ErrorRecord(
-                                new InvalidOperationException(errorMessage),
-                                "ReachedMaximumDepthAllowed",
-                                ErrorCategory.InvalidOperation,
-                                null));
-            }
-        }
-
+        
         private readonly List<object> _inputObjects = new();
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
@@ -35,7 +35,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the Depth property.
         /// </summary>
         [Parameter]
-        [ValidateRange(0, maxDepthAllowed)]
+        [ValidateRange(0, 100)]
         public int Depth
         {
             get { return _depth; }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
@@ -35,7 +35,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the Depth property.
         /// </summary>
         [Parameter]
-        [ValidateRange(0, int.MaxValue)]
+        [ValidateRange(0, maxDepthAllowed)]
         public int Depth
         {
             get { return _depth; }

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
@@ -237,9 +237,6 @@
   <data name="JsonNetModuleFilesRequired" xml:space="preserve">
     <value>Ensure 'Json.Net.psd1' and 'Newtonsoft.Json.dll' are available in a versioned subdirectory of '{0}'.</value>
   </data>
-  <data name="ReachedMaximumDepthAllowed" xml:space="preserve">
-    <value>The maximum depth allowed for serialization is {0}.</value>
-  </data>
   <data name="JsonDeserializationFailed" xml:space="preserve">
     <value>Conversion from JSON failed with error: {0}</value>
   </data>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
@@ -1670,10 +1670,10 @@ Describe "Json Bug fixes"  -Tags "Feature" {
 
     $testCases = @(
         @{
-            Name = "ConvertTo-Json -Depth 101 throws MaximumAllowedDepthReached when the user specifies a depth greater than 100."
+            Name = "ConvertTo-Json -Depth 101 throws ParameterArgumentValidationError when the user specifies a depth greater than 100."
             NumberOfElements = 10
             MaxDepth = 101
-            FullyQualifiedErrorId = "ReachedMaximumDepthAllowed,Microsoft.PowerShell.Commands.ConvertToJsonCommand"
+            FullyQualifiedErrorId = "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.ConvertToJsonCommand"
             ShouldThrow = $true
         }
         @{


### PR DESCRIPTION
# PR Summary

Replace int.MaxValue with 100 so that parameter validation works as expected.

Remove BeginProcessing method.  No longer required to do a prerequisite check on Max Depth.  Parameter Argument Validation now used.

Update Json Tests.

## PR Context

Fixes #15344

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->