### PR TITLE
Fix '-PipelineVariable' to set variable in the right scope

### DIFF
--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -993,13 +993,13 @@ namespace System.Management.Automation
             if (ReferenceEquals(_pipelineVarReference, varToUse))
             {
                 // The returned variable is the exact same instance, which means we set a new variable.
-                // In this case, we will try removing the pipeline varaible in the end.
+                // In this case, we will try removing the pipeline variable in the end.
                 _shouldRemovePipelineVariable = true;
             }
             else
             {
                 // A variable with the same name already exists in the same scope and it was returned.
-                // In this case, we update the reference and don't remove the varaible in the end.
+                // In this case, we update the reference and don't remove the variable in the end.
                 _pipelineVarReference = (PSVariable)varToUse;
             }
 

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -988,7 +988,7 @@ namespace System.Management.Automation
             _state.PSVariable.Set(_pipelineVarReference);
 
             // Get the reference again in case that we need to re-use an existing one from the same scope.
-            // In the case that an existing variable from the same scope is used, don't attemtp to remove
+            // In the case that an existing variable from the same scope is used, don't attempt to remove
             // the pipeline varaible in the end.
             PSVariable varToUse = _state.PSVariable.Get(PipelineVariable);
             _shouldRemovePipelineVariable = ReferenceEquals(_pipelineVarReference, varToUse);
@@ -1005,7 +1005,7 @@ namespace System.Management.Automation
         {
             if (_shouldRemovePipelineVariable)
             {
-                // Remove pipeline varaiable when a pipeline is being torn down.
+                // Remove pipeline variable when a pipeline is being torn down.
                 _state.PSVariable.Remove(PipelineVariable);
             }
         }

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -985,14 +985,14 @@ namespace System.Management.Automation
 
             // Create the pipeline variable
             _pipelineVarReference = new PSVariable(PipelineVariable);
-            _state.PSVariable.Set(_pipelineVarReference);
+            var varToUse = (PSVariable)_state.Internal.SetVariable(
+                _pipelineVarReference,
+                force: false,
+                CommandOrigin.Internal);
 
-            // Get the reference again in case that we need to re-use an existing one from the same scope.
-            // In the case that an existing variable from the same scope is used, don't attempt to remove
-            // the pipeline varaible in the end.
-            PSVariable varToUse = _state.PSVariable.Get(PipelineVariable);
+            // The returned variable to be used could be an existing one from the same scope.
+            // In that case, don't attempt to remove the pipeline varaible in the end.
             _shouldRemovePipelineVariable = ReferenceEquals(_pipelineVarReference, varToUse);
-
             _pipelineVarReference = varToUse;
 
             if (_thisCommand is not PSScriptCmdlet)

--- a/src/System.Management.Automation/engine/pipeline.cs
+++ b/src/System.Management.Automation/engine/pipeline.cs
@@ -1298,7 +1298,7 @@ namespace System.Management.Automation.Internal
                         // pipeline failure and continue disposing cmdlets.
                         try
                         {
-                            var commandRuntime = commandProcessor.CommandRuntime;
+                            MshCommandRuntime commandRuntime = commandProcessor.CommandRuntime;
                             if (commandProcessor is CommandProcessor && commandProcessor.Command is not PSScriptCmdlet)
                             {
                                 // Only a cmdlet can have variable lists defined via the common parameters.

--- a/src/System.Management.Automation/engine/pipeline.cs
+++ b/src/System.Management.Automation/engine/pipeline.cs
@@ -1298,16 +1298,21 @@ namespace System.Management.Automation.Internal
                         // pipeline failure and continue disposing cmdlets.
                         try
                         {
-                            MshCommandRuntime commandRuntime = commandProcessor.CommandRuntime;
-                            if (commandProcessor is CommandProcessor && commandProcessor.Command is not PSScriptCmdlet)
+                            // Only cmdlets can have variables defined via the common parameters.
+                            // We handle the cleanup of those variables only if we need to.
+                            if (commandProcessor is CommandProcessor)
                             {
-                                // Only a cmdlet can have variable lists defined via the common parameters.
-                                // We only need to take care of binary cmdlet here, because for script cmdlet,
-                                // the variable lists were already removed when exiting a scope.
-                                commandRuntime.RemoveVariableListsInPipe();
+                                if (commandProcessor.Command is not PSScriptCmdlet)
+                                {
+                                    // For script cmdlets, the variable lists were already removed when exiting a scope.
+                                    // So we only need to take care of binary cmdlets here.
+                                    commandProcessor.CommandRuntime.RemoveVariableListsInPipe();
+                                }
+
+                                // Remove the pipeline variable if we need to.
+                                commandProcessor.CommandRuntime.RemovePipelineVariable();
                             }
 
-                            commandRuntime.RemovePipelineVariable();
                             commandProcessor.Dispose();
                         }
                         // 2005/04/13-JonN: The only vaguely plausible reason

--- a/src/System.Management.Automation/engine/pipeline.cs
+++ b/src/System.Management.Automation/engine/pipeline.cs
@@ -1298,7 +1298,16 @@ namespace System.Management.Automation.Internal
                         // pipeline failure and continue disposing cmdlets.
                         try
                         {
-                            commandProcessor.CommandRuntime.RemoveVariableListsInPipe();
+                            var commandRuntime = commandProcessor.CommandRuntime;
+                            if (commandProcessor is CommandProcessor && commandProcessor.Command is not PSScriptCmdlet)
+                            {
+                                // Only a cmdlet can have variable lists defined via the common parameters.
+                                // We only need to take care of binary cmdlet here, because for script cmdlet,
+                                // the variable lists were already removed when exiting a scope.
+                                commandRuntime.RemoveVariableListsInPipe();
+                            }
+
+                            commandRuntime.RemovePipelineVariable();
                             commandProcessor.Dispose();
                         }
                         // 2005/04/13-JonN: The only vaguely plausible reason


### PR DESCRIPTION
# PR Summary

Fix #16155

Fix '-PipelineVariable' to set variable in the right scope and to not remove the pipeline variable at the end of pipeline when it's actually using an already existing variable.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
