### PR TITLE
Use the same temporary home directory when 'HOME' env variable is not set

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -16,6 +16,7 @@ using System.Management.Automation.Host;
 using System.Management.Automation.Internal;
 using System.Management.Automation.Language;
 using System.Management.Automation.Remoting;
+using System.Management.Automation.Remoting.Server;
 using System.Management.Automation.Runspaces;
 using System.Management.Automation.Tracing;
 using System.Reflection;
@@ -193,7 +194,7 @@ namespace Microsoft.PowerShell
                 {
                     ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("ServerMode");
                     ProfileOptimization.StartProfile("StartupProfileData-ServerMode");
-                    System.Management.Automation.Remoting.Server.StdIOProcessMediator.Run(
+                    StdIOProcessMediator.Run(
                         initialCommand: s_cpp.InitialCommand,
                         workingDirectory: s_cpp.WorkingDirectory,
                         configurationName: null);
@@ -203,7 +204,7 @@ namespace Microsoft.PowerShell
                 {
                     ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("SSHServer");
                     ProfileOptimization.StartProfile("StartupProfileData-SSHServerMode");
-                    System.Management.Automation.Remoting.Server.StdIOProcessMediator.Run(
+                    StdIOProcessMediator.Run(
                         initialCommand: s_cpp.InitialCommand,
                         workingDirectory: null,
                         configurationName: null);
@@ -213,7 +214,7 @@ namespace Microsoft.PowerShell
                 {
                     ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("NamedPipe");
                     ProfileOptimization.StartProfile("StartupProfileData-NamedPipeServerMode");
-                    System.Management.Automation.Remoting.RemoteSessionNamedPipeServer.RunServerMode(
+                    RemoteSessionNamedPipeServer.RunServerMode(
                         configurationName: s_cpp.ConfigurationName);
                     exitCode = 0;
                 }
@@ -221,7 +222,7 @@ namespace Microsoft.PowerShell
                 {
                     ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("SocketServerMode");
                     ProfileOptimization.StartProfile("StartupProfileData-SocketServerMode");
-                    System.Management.Automation.Remoting.Server.HyperVSocketMediator.Run(
+                    HyperVSocketMediator.Run(
                         initialCommand: s_cpp.InitialCommand,
                         configurationName: s_cpp.ConfigurationName);
                     exitCode = 0;

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Runtime.InteropServices;
 
 using Microsoft.Win32;
-using Microsoft.Win32.SafeHandles;
 
 namespace System.Management.Automation
 {
@@ -157,10 +156,13 @@ namespace System.Management.Automation
         // Gets the location for cache and config folders.
         internal static readonly string CacheDirectory = Platform.SelectProductNameForDirectory(Platform.XDG_Type.CACHE);
         internal static readonly string ConfigDirectory = Platform.SelectProductNameForDirectory(Platform.XDG_Type.CONFIG);
+
+        private static string s_tempHome = null;
 #else
         // Gets the location for cache and config folders.
         internal static readonly string CacheDirectory = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + @"\Microsoft\PowerShell";
         internal static readonly string ConfigDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Personal) + @"\PowerShell";
+
         private static readonly Lazy<bool> _isStaSupported = new Lazy<bool>(() =>
         {
             // See objbase.h
@@ -199,8 +201,6 @@ namespace System.Management.Automation
             "WSMan.format.ps1xml"
         };
 
-        private static string _tempDirectory = null;
-
         /// <summary>
         /// Some common environment variables used in PS have different
         /// names in different OS platforms.
@@ -214,43 +214,35 @@ namespace System.Management.Automation
 #endif
         }
 
+#if UNIX
         /// <summary>
-        /// Remove the temporary directory created for the current process.
+        /// Get the 'HOME' environment variable or create a temporary home diretory if the environment variable is not set.
         /// </summary>
-        internal static void RemoveTemporaryDirectory()
+        internal static string GetHomeOrCreateTempHome()
         {
-            if (_tempDirectory == null)
+            const string tempHomeFolderName = "pwsh-tmp-98288ff9-5712-4a14-9a11-23693b9cd91a";
+
+            string envHome = Environment.GetEnvironmentVariable("HOME") ?? s_tempHome;
+            if (envHome is not null)
             {
-                return;
+                return envHome;
             }
 
             try
             {
-                Directory.Delete(_tempDirectory, true);
+                s_tempHome = Path.Combine(Path.GetTempPath(), tempHomeFolderName);
+                Directory.CreateDirectory(s_tempHome);
             }
-            catch
+            catch (UnauthorizedAccessException)
             {
-                // ignore if there is a failure
+                // Directory creation may fail if the account doesn't have filesystem permission such as some service accounts.
+                // Return an empty string in this case so the process working directory will be used.
+                s_tempHome = string.Empty;
             }
 
-            _tempDirectory = null;
+            return s_tempHome;
         }
 
-        /// <summary>
-        /// Get a temporary directory to use for the current process.
-        /// </summary>
-        internal static string GetTemporaryDirectory()
-        {
-            if (_tempDirectory != null)
-            {
-                return _tempDirectory;
-            }
-
-            _tempDirectory = PsUtils.GetTemporaryDirectory();
-            return _tempDirectory;
-        }
-
-#if UNIX
         /// <summary>
         /// X Desktop Group configuration type enum.
         /// </summary>
@@ -270,230 +262,100 @@ namespace System.Management.Automation
             DEFAULT
         }
 
-        private static string s_tempHomeDir = null;
-
         /// <summary>
         /// Function for choosing directory location of PowerShell for profile loading.
         /// </summary>
-        public static string SelectProductNameForDirectory(Platform.XDG_Type dirpath)
+        public static string SelectProductNameForDirectory(XDG_Type dirpath)
         {
             // TODO: XDG_DATA_DIRS implementation as per GitHub issue #1060
 
-            string xdgconfighome = System.Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
-            string xdgdatahome = System.Environment.GetEnvironmentVariable("XDG_DATA_HOME");
-            string xdgcachehome = System.Environment.GetEnvironmentVariable("XDG_CACHE_HOME");
-            string envHome = System.Environment.GetEnvironmentVariable(CommonEnvVariableNames.Home);
-            if (envHome == null)
-            {
-                s_tempHomeDir ??= GetTemporaryDirectory();
-                envHome = s_tempHomeDir;
-            }
+            string xdgconfighome = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+            string xdgdatahome = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
+            string xdgcachehome = Environment.GetEnvironmentVariable("XDG_CACHE_HOME");
+            string envHome = GetHomeOrCreateTempHome();
 
             string xdgConfigHomeDefault = Path.Combine(envHome, ".config", "powershell");
             string xdgDataHomeDefault = Path.Combine(envHome, ".local", "share", "powershell");
             string xdgModuleDefault = Path.Combine(xdgDataHomeDefault, "Modules");
             string xdgCacheDefault = Path.Combine(envHome, ".cache", "powershell");
 
-            switch (dirpath)
+            try
             {
-                case Platform.XDG_Type.CONFIG:
-                    // the user has set XDG_CONFIG_HOME corresponding to profile path
-                    if (string.IsNullOrEmpty(xdgconfighome))
-                    {
-                        // xdg values have not been set
-                        return xdgConfigHomeDefault;
-                    }
+                switch (dirpath)
+                {
+                    case XDG_Type.CONFIG:
+                        // Use 'XDG_CONFIG_HOME' if it's set, otherwise use the default path.
+                        return string.IsNullOrEmpty(xdgconfighome)
+                            ? xdgConfigHomeDefault
+                            : Path.Combine(xdgconfighome, "powershell");
 
-                    else
-                    {
-                        return Path.Combine(xdgconfighome, "powershell");
-                    }
-
-                case Platform.XDG_Type.DATA:
-                    // the user has set XDG_DATA_HOME corresponding to module path
-                    if (string.IsNullOrEmpty(xdgdatahome))
-                    {
-                        // create the xdg folder if needed
-                        if (!Directory.Exists(xdgDataHomeDefault))
+                    case XDG_Type.DATA:
+                        // Use 'XDG_DATA_HOME' if it's set, otherwise use the default path.
+                        if (string.IsNullOrEmpty(xdgdatahome))
                         {
-                            try
-                            {
-                                Directory.CreateDirectory(xdgDataHomeDefault);
-                            }
-                            catch (UnauthorizedAccessException)
-                            {
-                                // service accounts won't have permission to create user folder
-                                return GetTemporaryDirectory();
-                            }
+                            // Create the default data directory if it doesn't exist.
+                            Directory.CreateDirectory(xdgDataHomeDefault);
+                            return xdgDataHomeDefault;
                         }
-
-                        return xdgDataHomeDefault;
-                    }
-                    else
-                    {
                         return Path.Combine(xdgdatahome, "powershell");
-                    }
 
-                case Platform.XDG_Type.USER_MODULES:
-                    // the user has set XDG_DATA_HOME corresponding to module path
-                    if (string.IsNullOrEmpty(xdgdatahome))
-                    {
-                        // xdg values have not been set
-                        if (!Directory.Exists(xdgModuleDefault)) // module folder not always guaranteed to exist
+                    case XDG_Type.USER_MODULES:
+                        // Use 'XDG_DATA_HOME' if it's set, otherwise use the default path.
+                        if (string.IsNullOrEmpty(xdgdatahome))
                         {
-                            try
-                            {
-                                Directory.CreateDirectory(xdgModuleDefault);
-                            }
-                            catch (UnauthorizedAccessException)
-                            {
-                                // service accounts won't have permission to create user folder
-                                return GetTemporaryDirectory();
-                            }
+                            Directory.CreateDirectory(xdgModuleDefault);
+                            return xdgModuleDefault;
                         }
-
-                        return xdgModuleDefault;
-                    }
-                    else
-                    {
                         return Path.Combine(xdgdatahome, "powershell", "Modules");
-                    }
 
-                case Platform.XDG_Type.SHARED_MODULES:
-                    return "/usr/local/share/powershell/Modules";
+                    case XDG_Type.SHARED_MODULES:
+                        return "/usr/local/share/powershell/Modules";
 
-                case Platform.XDG_Type.CACHE:
-                    // the user has set XDG_CACHE_HOME
-                    if (string.IsNullOrEmpty(xdgcachehome))
-                    {
-                        // xdg values have not been set
-                        if (!Directory.Exists(xdgCacheDefault)) // module folder not always guaranteed to exist
+                    case XDG_Type.CACHE:
+                        // Use 'XDG_CACHE_HOME' if it's set, otherwise use the default path.
+                        if (string.IsNullOrEmpty(xdgcachehome))
                         {
-                            try
-                            {
-                                Directory.CreateDirectory(xdgCacheDefault);
-                            }
-                            catch (UnauthorizedAccessException)
-                            {
-                                // service accounts won't have permission to create user folder
-                                return GetTemporaryDirectory();
-                            }
+                            Directory.CreateDirectory(xdgCacheDefault);
+                            return xdgCacheDefault;
                         }
 
-                        return xdgCacheDefault;
-                    }
-                    else
-                    {
-                        if (!Directory.Exists(Path.Combine(xdgcachehome, "powershell")))
-                        {
-                            try
-                            {
-                                Directory.CreateDirectory(Path.Combine(xdgcachehome, "powershell"));
-                            }
-                            catch (UnauthorizedAccessException)
-                            {
-                                // service accounts won't have permission to create user folder
-                                return GetTemporaryDirectory();
-                            }
-                        }
+                        string cachePath = Path.Combine(xdgcachehome, "powershell");
+                        Directory.CreateDirectory(cachePath);
+                        return cachePath;
 
-                        return Path.Combine(xdgcachehome, "powershell");
-                    }
+                    case XDG_Type.DEFAULT:
+                        // Use 'xdgConfigHomeDefault' for 'XDG_Type.DEFAULT' and create the directory if it doesn't exist.
+                        Directory.CreateDirectory(xdgConfigHomeDefault);
+                        return xdgConfigHomeDefault;
 
-                case Platform.XDG_Type.DEFAULT:
-                    // default for profile location
-                    return xdgConfigHomeDefault;
-
-                default:
-                    // xdgConfigHomeDefault needs to be created in the edge case that we do not have the folder or it was deleted
-                    // This folder is the default in the event of all other failures for data storage
-                    if (!Directory.Exists(xdgConfigHomeDefault))
-                    {
-                        try
-                        {
-                            Directory.CreateDirectory(xdgConfigHomeDefault);
-                        }
-                        catch
-                        {
-                            Console.Error.WriteLine("Failed to create default data directory: " + xdgConfigHomeDefault);
-                        }
-                    }
-
-                    return xdgConfigHomeDefault;
+                    default:
+                        throw new InvalidOperationException("Unreachable code.");
+                }
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // Directory creation may fail if the account doesn't have filesystem permission such as some service accounts.
+                // Return an empty string in this case so the process working directory will be used.
+                return string.Empty;
             }
         }
 #endif
 
         /// <summary>
-        /// The code is copied from the .NET implementation.
+        /// Mimic 'Environment.GetFolderPath(folder)' on Unix.
         /// </summary>
-        internal static string GetFolderPath(System.Environment.SpecialFolder folder)
+        internal static string GetFolderPath(Environment.SpecialFolder folder)
         {
-            return InternalGetFolderPath(folder);
-        }
-
-        /// <summary>
-        /// The API set 'api-ms-win-shell-shellfolders-l1-1-0.dll' was removed from NanoServer, so we cannot depend on 'SHGetFolderPathW'
-        /// to get the special folder paths. Instead, we need to rely on the basic environment variables to get the special folder paths.
-        /// </summary>
-        /// <returns>
-        /// The path to the specified system special folder, if that folder physically exists on your computer.
-        /// Otherwise, an empty string (string.Empty).
-        /// </returns>
-        private static string InternalGetFolderPath(System.Environment.SpecialFolder folder)
-        {
-            string folderPath = null;
 #if UNIX
-            string envHome = System.Environment.GetEnvironmentVariable(Platform.CommonEnvVariableNames.Home);
-            if (envHome == null)
+            return folder switch
             {
-                envHome = Platform.GetTemporaryDirectory();
-            }
-
-            switch (folder)
-            {
-                case System.Environment.SpecialFolder.ProgramFiles:
-                    folderPath = "/bin";
-                    if (!System.IO.Directory.Exists(folderPath)) { folderPath = null; }
-
-                    break;
-                case System.Environment.SpecialFolder.ProgramFilesX86:
-                    folderPath = "/usr/bin";
-                    if (!System.IO.Directory.Exists(folderPath)) { folderPath = null; }
-
-                    break;
-                case System.Environment.SpecialFolder.System:
-                case System.Environment.SpecialFolder.SystemX86:
-                    folderPath = "/sbin";
-                    if (!System.IO.Directory.Exists(folderPath)) { folderPath = null; }
-
-                    break;
-                case System.Environment.SpecialFolder.Personal:
-                    folderPath = envHome;
-                    break;
-                case System.Environment.SpecialFolder.LocalApplicationData:
-                    folderPath = System.IO.Path.Combine(envHome, ".config");
-                    if (!System.IO.Directory.Exists(folderPath))
-                    {
-                        try
-                        {
-                            System.IO.Directory.CreateDirectory(folderPath);
-                        }
-                        catch (UnauthorizedAccessException)
-                        {
-                            // directory creation may fail if the account doesn't have filesystem permission such as some service accounts
-                            folderPath = string.Empty;
-                        }
-                    }
-
-                    break;
-                default:
-                    throw new NotSupportedException();
-            }
+                Environment.SpecialFolder.ProgramFiles => Directory.Exists("/bin") ? "/bin" : string.Empty,
+                Environment.SpecialFolder.MyDocuments => GetHomeOrCreateTempHome(),
+                _ => throw new NotSupportedException()
+            };
 #else
-            folderPath = System.Environment.GetFolderPath(folder);
+            return Environment.GetFolderPath(folder);
 #endif
-            return folderPath ?? string.Empty;
         }
 
         // Platform methods prefixed NonWindows are:
@@ -558,11 +420,9 @@ namespace System.Management.Automation
             return Unix.NativeMethods.IsSameFileSystemItem(pathOne, pathTwo);
         }
 
-        internal static bool NonWindowsGetInodeData(string path, out System.ValueTuple<UInt64, UInt64> inodeData)
+        internal static bool NonWindowsGetInodeData(string path, out ValueTuple<ulong, ulong> inodeData)
         {
-            UInt64 device = 0UL;
-            UInt64 inode = 0UL;
-            var result = Unix.NativeMethods.GetInodeData(path, out device, out inode);
+            var result = Unix.NativeMethods.GetInodeData(path, out ulong device, out ulong inode);
 
             inodeData = (device, inode);
             return result == 0;
@@ -1036,7 +896,7 @@ namespace System.Management.Automation
                         return invalidPid;
                     }
 
-                    return Int32.Parse(parts[3]);
+                    return int.Parse(parts[3]);
                 }
                 catch (Exception)
                 {
@@ -1145,7 +1005,7 @@ namespace System.Management.Automation
 
                 [DllImport(psLib, CharSet = CharSet.Ansi, SetLastError = true)]
                 internal static extern int GetInodeData([MarshalAs(UnmanagedType.LPStr)] string path,
-                                                        out UInt64 device, out UInt64 inode);
+                                                        out ulong device, out ulong inode);
 
                 /// <summary>
                 /// This is a struct from getcommonstat.h in the native library.

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Runtime.InteropServices;
-
+using System.Management.Automation.Internal;
 using Microsoft.Win32;
 
 namespace System.Management.Automation
@@ -156,8 +156,6 @@ namespace System.Management.Automation
         // Gets the location for cache and config folders.
         internal static readonly string CacheDirectory = Platform.SelectProductNameForDirectory(Platform.XDG_Type.CACHE);
         internal static readonly string ConfigDirectory = Platform.SelectProductNameForDirectory(Platform.XDG_Type.CONFIG);
-
-        private static string s_tempHome = null;
 #else
         // Gets the location for cache and config folders.
         internal static readonly string CacheDirectory = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + @"\Microsoft\PowerShell";
@@ -215,12 +213,14 @@ namespace System.Management.Automation
         }
 
 #if UNIX
+        private static string s_tempHome = null;
+
         /// <summary>
         /// Get the 'HOME' environment variable or create a temporary home diretory if the environment variable is not set.
         /// </summary>
-        internal static string GetHomeOrCreateTempHome()
+        private static string GetHomeOrCreateTempHome()
         {
-            const string tempHomeFolderName = "pwsh-tmp-98288ff9-5712-4a14-9a11-23693b9cd91a";
+            const string tempHomeFolderName = "pwsh-{0}-98288ff9-5712-4a14-9a11-23693b9cd91a";
 
             string envHome = Environment.GetEnvironmentVariable("HOME") ?? s_tempHome;
             if (envHome is not null)
@@ -230,7 +230,7 @@ namespace System.Management.Automation
 
             try
             {
-                s_tempHome = Path.Combine(Path.GetTempPath(), tempHomeFolderName);
+                s_tempHome = Path.Combine(Path.GetTempPath(), StringUtil.Format(tempHomeFolderName, Environment.UserName));
                 Directory.CreateDirectory(s_tempHome);
             }
             catch (UnauthorizedAccessException)

--- a/src/System.Management.Automation/DscSupport/CimDSCParser.cs
+++ b/src/System.Management.Automation/DscSupport/CimDSCParser.cs
@@ -738,12 +738,12 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
 
                 if (!Directory.Exists(systemResourceRoot))
                 {
-                    configSystemPath = Platform.GetFolderPath(Environment.SpecialFolder.System);
+                    configSystemPath = Environment.GetFolderPath(Environment.SpecialFolder.System);
                     systemResourceRoot = Path.Combine(configSystemPath, "Configuration");
                     inboxModulePath = InboxDscResourceModulePath;
                 }
 
-                var programFilesDirectory = Platform.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+                var programFilesDirectory = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
                 Debug.Assert(programFilesDirectory != null, "Program Files environment variable does not exist!");
                 var customResourceRoot = Path.Combine(programFilesDirectory, "WindowsPowerShell\\Configuration");
                 Debug.Assert(Directory.Exists(customResourceRoot), "%ProgramFiles%\\WindowsPowerShell\\Configuration Directory does not exist");

--- a/src/System.Management.Automation/engine/hostifaces/LocalConnection.cs
+++ b/src/System.Management.Automation/engine/hostifaces/LocalConnection.cs
@@ -363,7 +363,7 @@ namespace System.Management.Automation.Runspaces
             }
         }
 
-        private static readonly string s_debugPreferenceCachePath = Path.Combine(Path.Combine(Platform.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "WindowsPowerShell"), "DebugPreference.clixml");
+        private static readonly string s_debugPreferenceCachePath = Path.Combine(Platform.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "WindowsPowerShell", "DebugPreference.clixml");
         private static readonly object s_debugPreferenceLockObject = new object();
 
         /// <summary>
@@ -1241,8 +1241,6 @@ namespace System.Management.Automation.Runspaces
                         RunspaceOpening.Dispose();
                         RunspaceOpening = null;
                     }
-
-                    Platform.RemoveTemporaryDirectory();
 
                     // Dispose the event manager
                     if (this.ExecutionContext != null && this.ExecutionContext.Events != null)

--- a/src/System.Management.Automation/security/SecurityManager.cs
+++ b/src/System.Management.Automation/security/SecurityManager.cs
@@ -328,9 +328,10 @@ namespace Microsoft.PowerShell
                 if (string.Equals(fi.Extension, ".ps1xml", StringComparison.OrdinalIgnoreCase))
                 {
                     string[] trustedDirectories = new string[]
-                        { Platform.GetFolderPath(Environment.SpecialFolder.System),
-                          Platform.GetFolderPath(Environment.SpecialFolder.ProgramFiles)
-                        };
+                    {
+                        Environment.GetFolderPath(Environment.SpecialFolder.System),
+                        Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles)
+                    };
 
                     foreach (string trustedDirectory in trustedDirectories)
                     {

--- a/src/System.Management.Automation/utils/PsUtils.cs
+++ b/src/System.Management.Automation/utils/PsUtils.cs
@@ -83,31 +83,6 @@ namespace System.Management.Automation
             return arch == Architecture.Arm || arch == Architecture.Arm64;
         }
 
-        /// <summary>
-        /// Get a temporary directory to use, needs to be unique to avoid collision.
-        /// </summary>
-        internal static string GetTemporaryDirectory()
-        {
-            string tempDir = string.Empty;
-            string tempPath = Path.GetTempPath();
-            do
-            {
-                tempDir = Path.Combine(tempPath, System.Guid.NewGuid().ToString());
-            }
-            while (Directory.Exists(tempDir));
-
-            try
-            {
-                Directory.CreateDirectory(tempDir);
-            }
-            catch (UnauthorizedAccessException)
-            {
-                tempDir = string.Empty; // will become current working directory
-            }
-
-            return tempDir;
-        }
-
         internal static string GetHostName()
         {
             IPGlobalProperties ipProperties = IPGlobalProperties.GetIPGlobalProperties();

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -664,6 +664,20 @@ namespace StackTest {
         It "Should start if HOME is not defined" -Skip:($IsWindows) {
             bash -c "unset HOME;$powershell -c '1+1'" | Should -BeExactly 2
         }
+
+        It "Same user should use the same temporary HOME directory for different sessions" {
+            $results = bash -c @"
+unset HOME;
+pwsh -c '[System.Management.Automation.Platform]::SelectProductNameForDirectory(\`"default\`")';
+pwsh -c '[System.Management.Automation.Platform]::SelectProductNameForDirectory(\`"default\`")';
+"@
+            $results | Should -HaveCount 2
+            $results[0] | Should -BeExactly $results[1]
+
+            $tempHomeName = "pwsh-{0}-98288ff9-5712-4a14-9a11-23693b9cd91a" -f [System.Environment]::UserName
+            $defaultPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "$tempHomeName/.config/powershell"
+            $results[0] | Should -BeExactly $defaultPath
+        }
     }
 
     Context "PATH environment variable" {

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -665,7 +665,7 @@ namespace StackTest {
             bash -c "unset HOME;$powershell -c '1+1'" | Should -BeExactly 2
         }
 
-        It "Same user should use the same temporary HOME directory for different sessions" {
+        It "Same user should use the same temporary HOME directory for different sessions" -Skip:($IsWindows) {
             $results = bash -c @"
 unset HOME;
 pwsh -c '[System.Management.Automation.Platform]::SelectProductNameForDirectory(\`"default\`")';

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -668,8 +668,8 @@ namespace StackTest {
         It "Same user should use the same temporary HOME directory for different sessions" -Skip:($IsWindows) {
             $results = bash -c @"
 unset HOME;
-pwsh -c '[System.Management.Automation.Platform]::SelectProductNameForDirectory(\`"default\`")';
-pwsh -c '[System.Management.Automation.Platform]::SelectProductNameForDirectory(\`"default\`")';
+$powershell -c '[System.Management.Automation.Platform]::SelectProductNameForDirectory([System.Management.Automation.Platform+XDG_Type]::DEFAULT)';
+$powershell -c '[System.Management.Automation.Platform]::SelectProductNameForDirectory([System.Management.Automation.Platform+XDG_Type]::DEFAULT)';
 "@
             $results | Should -HaveCount 2
             $results[0] | Should -BeExactly $results[1]


### PR DESCRIPTION
# PR Summary

Fix #15299

Use the same temporary home directory for a user account when the environment variable 'HOME' is not set for the user.

The previous solution used for unset `HOME` environment variable was to create a temporary folder and delete if when the Runspace is disposed. However, when `pwsh` exits, `Runspace.Dispose` doesn't get called -- the whole process is being torn down, so no much point to dispose the Runspace anyways. Therefore, every execution of `pwsh` will leave a temporary folder behind.

This PR updates `pwsh` to create and reuse a single temporary home directory for every user account. So executions of `pwsh` by a specific user will only have one temporary home folder created.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
