### PR TITLE
Clean up crossgen related build scripts also generate native symbols for R2R images

### DIFF
--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -138,6 +138,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
     <PublishReadyToRun Condition=" '$(Configuration)' != 'Debug' ">true</PublishReadyToRun>
+    <PublishReadyToRunEmitSymbols>true</PublishReadyToRunEmitSymbols>
 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/build.psm1
+++ b/build.psm1
@@ -314,8 +314,6 @@ function Start-PSBuild {
         [ValidateSet('Debug', 'Release', 'CodeCoverage', '')] # We might need "Checked" as well
         [string]$Configuration,
 
-        [switch]$CrossGen,
-
         [ValidatePattern("^v\d+\.\d+\.\d+(-\w+(\.\d{1,2})?)?$")]
         [ValidateNotNullOrEmpty()]
         [string]$ReleaseTag,
@@ -343,10 +341,6 @@ function Start-PSBuild {
     }
 
     if ($ForMinimalSize) {
-        if ($CrossGen) {
-            throw "Build for the minimal size requires the minimal disk footprint, so `CrossGen` is not allowed"
-        }
-
         if ($Runtime -and "linux-x64", "win7-x64", "osx-x64" -notcontains $Runtime) {
             throw "Build for the minimal size is enabled only for following runtimes: 'linux-x64', 'win7-x64', 'osx-x64'"
         }
@@ -414,7 +408,6 @@ Fix steps:
 
     # set output options
     $OptionsArguments = @{
-        CrossGen=$CrossGen
         Output=$Output
         Runtime=$Runtime
         Configuration=$Configuration
@@ -525,12 +518,6 @@ Fix steps:
             Write-Log -message "Run dotnet $Arguments from $PWD"
             Start-NativeExecution { dotnet $Arguments }
             Write-Log -message "PowerShell output: $($Options.Output)"
-
-            if ($CrossGen) {
-                # fxdependent package cannot be CrossGen'ed
-                Start-CrossGen -PublishPath $publishPath -Runtime $script:Options.Runtime
-                Write-Log -message "pwsh.exe with ngen binaries is available at: $($Options.Output)"
-            }
         } else {
             $globalToolSrcFolder = Resolve-Path (Join-Path $Options.Top "../Microsoft.PowerShell.GlobalTool.Shim") | Select-Object -ExpandProperty Path
 
@@ -833,8 +820,6 @@ function New-PSOptions {
                      "win7-x86")]
         [string]$Runtime,
 
-        [switch]$CrossGen,
-
         # Accept a path to the output directory
         # If not null or empty, name of the executable will be appended to
         # this path, otherwise, to the default path, and then the full path
@@ -940,7 +925,6 @@ function New-PSOptions {
                 -RootInfo ([PSCustomObject]$RootInfo) `
                 -Top $Top `
                 -Runtime $Runtime `
-                -Crossgen $Crossgen.IsPresent `
                 -Configuration $Configuration `
                 -PSModuleRestore $PSModuleRestore.IsPresent `
                 -Framework $Framework `
@@ -2353,211 +2337,6 @@ function script:Start-NativeExecution
     }
 }
 
-function Start-CrossGen {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory= $true)]
-        [ValidateNotNullOrEmpty()]
-        [String]
-        $PublishPath,
-
-        [Parameter(Mandatory=$true)]
-        [ValidateSet("alpine-x64",
-                     "linux-arm",
-                     "linux-arm64",
-                     "linux-x64",
-                     "osx-arm64",
-                     "osx-x64",
-                     "win-arm",
-                     "win-arm64",
-                     "win7-x64",
-                     "win7-x86")]
-        [string]
-        $Runtime
-    )
-
-    function New-CrossGenAssembly {
-        param (
-            [Parameter(Mandatory = $true)]
-            [ValidateNotNullOrEmpty()]
-            [String[]]
-            $AssemblyPath,
-
-            [Parameter(Mandatory = $true)]
-            [ValidateNotNullOrEmpty()]
-            [String]
-            $CrossgenPath,
-
-            [Parameter(Mandatory = $true)]
-            [ValidateSet("alpine-x64",
-                "linux-arm",
-                "linux-arm64",
-                "linux-x64",
-                "osx-arm64",
-                "osx-x64",
-                "win-arm",
-                "win-arm64",
-                "win7-x64",
-                "win7-x86")]
-            [string]
-            $Runtime
-        )
-
-        $platformAssembliesPath = Split-Path $AssemblyPath[0] -Parent
-
-        $targetOS, $targetArch = $Runtime -split '-'
-
-        # Special cases where OS / Arch does not conform with runtime names
-        switch ($Runtime) {
-            'alpine-x64' {
-                $targetOS = 'linux'
-                $targetArch = 'x64'
-             }
-            'win-arm' {
-                $targetOS = 'windows'
-                $targetArch = 'arm'
-            }
-            'win-arm64' {
-                $targetOS = 'windows'
-                $targetArch = 'arm64'
-            }
-            'win7-x64' {
-                $targetOS = 'windows'
-                $targetArch = 'x64'
-            }
-            'win7-x86' {
-                $targetOS = 'windows'
-                $targetArch = 'x86'
-            }
-        }
-
-        $generatePdb = $targetos -eq 'windows'
-
-        # The path to folder must end with directory separator
-        $dirSep = [System.IO.Path]::DirectorySeparatorChar
-        $platformAssembliesPath = if (-not $platformAssembliesPath.EndsWith($dirSep)) { $platformAssembliesPath + $dirSep }
-
-        Start-NativeExecution {
-            $crossgen2Params = @(
-                "-r"
-                $platformAssembliesPath
-                "--out-near-input"
-                "--single-file-compilation"
-                "-O"
-                "--targetos"
-                $targetOS
-                "--targetarch"
-                $targetArch
-            )
-
-            if ($generatePdb) {
-                $crossgen2Params += "--pdb"
-            }
-
-            $crossgen2Params += $AssemblyPath
-
-            & $CrossgenPath $crossgen2Params
-        }
-    }
-
-    if (-not (Test-Path $PublishPath)) {
-        throw "Path '$PublishPath' does not exist."
-    }
-
-    # Get the path to crossgen
-    $crossGenExe = if ($environment.IsWindows) { "crossgen2.exe" } else { "crossgen2" }
-
-    # The crossgen tool is only published for these particular runtimes
-    $crossGenRuntime = if ($environment.IsWindows) {
-        # for windows the tool architecture is the host machine architecture, so it is always x64.
-        # we can cross compile for x86, arm and arm64
-        "win-x64"
-    } else {
-        $Runtime
-    }
-
-    if (-not $crossGenRuntime) {
-        throw "crossgen is not available for this platform"
-    }
-
-    $dotnetRuntimeVersion = $script:Options.Framework -replace 'net'
-
-    # Get the CrossGen.exe for the correct runtime with the latest version
-    $crossGenPath = Get-ChildItem $script:Environment.nugetPackagesRoot $crossGenExe -Recurse | `
-                        Where-Object { $_.FullName -match $crossGenRuntime } | `
-                        Where-Object { $_.FullName -match $dotnetRuntimeVersion } | `
-                        Where-Object { (Split-Path $_.FullName -Parent).EndsWith('tools') } | `
-                        Sort-Object -Property FullName -Descending | `
-                        Select-Object -First 1 | `
-                        ForEach-Object { $_.FullName }
-    if (-not $crossGenPath) {
-        throw "Unable to find latest version of crossgen2.exe. 'Please run Start-PSBuild -Clean' first, and then try again."
-    }
-    Write-Verbose "Matched CrossGen2.exe: $crossGenPath" -Verbose
-
-    # Common assemblies used by Add-Type or assemblies with high JIT and no pdbs to crossgen
-    $commonAssembliesForAddType = @(
-        "Microsoft.CodeAnalysis.CSharp.dll"
-        "Microsoft.CodeAnalysis.dll"
-        "System.Linq.Expressions.dll"
-        "Microsoft.CSharp.dll"
-        "System.Runtime.Extensions.dll"
-        "System.Linq.dll"
-        "System.Collections.Concurrent.dll"
-        "System.Collections.dll"
-        "Newtonsoft.Json.dll"
-        "System.IO.FileSystem.dll"
-        "System.Diagnostics.Process.dll"
-        "System.Threading.Tasks.Parallel.dll"
-        "System.Security.AccessControl.dll"
-        "System.Text.Encoding.CodePages.dll"
-        "System.Private.Uri.dll"
-        "System.Threading.dll"
-        "System.Security.Principal.Windows.dll"
-        "System.Console.dll"
-        "Microsoft.Win32.Registry.dll"
-        "System.IO.Pipes.dll"
-        "System.Diagnostics.FileVersionInfo.dll"
-        "System.Collections.Specialized.dll"
-        "Microsoft.ApplicationInsights.dll"
-    )
-
-    $fullAssemblyList = $commonAssembliesForAddType
-
-    $assemblyFullPaths = @()
-    $assemblyFullPaths += foreach ($assemblyName in $fullAssemblyList) {
-        Join-Path $PublishPath $assemblyName
-    }
-
-    New-CrossGenAssembly -CrossgenPath $crossGenPath -AssemblyPath $assemblyFullPaths -Runtime $Runtime
-
-    #
-    # With the latest dotnet.exe, the default load context is only able to load TPAs, and TPA
-    # only contains IL assembly names. In order to make the default load context able to load
-    # the NI PS assemblies, we need to replace the IL PS assemblies with the corresponding NI
-    # PS assemblies, but with the same IL assembly names.
-    #
-    Write-Verbose "PowerShell Ngen assemblies have been generated. Deploying ..." -Verbose
-    foreach ($assemblyName in $fullAssemblyList) {
-
-        # Remove the IL assembly and its symbols.
-        $assemblyPath = Join-Path $PublishPath $assemblyName
-        $symbolsPath = [System.IO.Path]::ChangeExtension($assemblyPath, ".pdb")
-
-        Remove-Item $assemblyPath -Force -ErrorAction Stop
-
-        # Rename the corresponding ni.dll assembly to be the same as the IL assembly
-        $niAssemblyPath = [System.IO.Path]::ChangeExtension($assemblyPath, "ni.dll")
-        Rename-Item $niAssemblyPath $assemblyPath -Force -ErrorAction Stop
-
-        # No symbols are available for Microsoft.CodeAnalysis.CSharp.dll, Microsoft.CodeAnalysis.dll,
-        # Microsoft.CodeAnalysis.VisualBasic.dll, and Microsoft.CSharp.dll.
-        if ($commonAssembliesForAddType -notcontains $assemblyName) {
-            Remove-Item $symbolsPath -Force -ErrorAction Stop
-        }
-    }
-}
-
 # Cleans the PowerShell repo - everything but the root folder
 function Clear-PSRepo
 {
@@ -3080,7 +2859,6 @@ function Restore-PSOptions {
                     -RootInfo $options.RootInfo `
                     -Top $options.Top `
                     -Runtime $options.Runtime `
-                    -Crossgen $options.Crossgen `
                     -Configuration $options.Configuration `
                     -PSModuleRestore $options.PSModuleRestore `
                     -Framework $options.Framework `
@@ -3103,10 +2881,6 @@ function New-PSOptionsObject
         [Parameter(Mandatory)]
         [String]
         $Runtime,
-
-        [Parameter(Mandatory)]
-        [Bool]
-        $CrossGen,
 
         [Parameter(Mandatory)]
         [String]
@@ -3136,7 +2910,6 @@ function New-PSOptionsObject
         Framework = $Framework
         Runtime = $Runtime
         Output = $Output
-        CrossGen = $CrossGen
         PSModuleRestore = $PSModuleRestore
         ForMinimalSize = $ForMinimalSize
     }

--- a/tools/ci.psm1
+++ b/tools/ci.psm1
@@ -99,7 +99,7 @@ function Invoke-CIBuild
         Start-PSBuild -Configuration 'CodeCoverage' -PSModuleRestore -CI -ReleaseTag $releaseTag
     }
 
-    Start-PSBuild -CrossGen -PSModuleRestore -Configuration 'Release' -CI -ReleaseTag $releaseTag
+    Start-PSBuild -PSModuleRestore -Configuration 'Release' -CI -ReleaseTag $releaseTag
     Save-PSOptions
 
     $options = (Get-PSOptions)
@@ -470,7 +470,7 @@ function Invoke-CIFinish
                 $prereleaseIteration = (get-date).Day
                 $preReleaseVersion = "$previewPrefix-$previewLabel.$prereleaseIteration"
                 # Build clean before backing to remove files from testing
-                Start-PSBuild -CrossGen -PSModuleRestore -Configuration 'Release' -ReleaseTag $preReleaseVersion -Clean -Runtime $Runtime -output $buildFolder -PSOptionsPath "${buildFolder}/psoptions.json"
+                Start-PSBuild -PSModuleRestore -Configuration 'Release' -ReleaseTag $preReleaseVersion -Clean -Runtime $Runtime -output $buildFolder -PSOptionsPath "${buildFolder}/psoptions.json"
                 $options = Get-PSOptions
                 # Remove symbol files.
                 $filter = Join-Path -Path (Split-Path $options.Output) -ChildPath '*.pdb'
@@ -481,7 +481,7 @@ function Invoke-CIFinish
                 $releaseTagParts = $releaseTag.split('.')
                 $preReleaseVersion = $releaseTagParts[0]+ ".9.9"
                 Write-Verbose "newPSReleaseTag: $preReleaseVersion" -Verbose
-                Start-PSBuild -CrossGen -PSModuleRestore -Configuration 'Release' -ReleaseTag $preReleaseVersion -Clean -Runtime $Runtime -output $buildFolder -PSOptionsPath "${buildFolder}/psoptions.json"
+                Start-PSBuild -PSModuleRestore -Configuration 'Release' -ReleaseTag $preReleaseVersion -Clean -Runtime $Runtime -output $buildFolder -PSOptionsPath "${buildFolder}/psoptions.json"
                 $options = Get-PSOptions
                 # Remove symbol files.
                 $filter = Join-Path -Path (Split-Path $options.Output) -ChildPath '*.pdb'

--- a/tools/releaseBuild/Images/GenericLinuxFiles/PowerShellPackage.ps1
+++ b/tools/releaseBuild/Images/GenericLinuxFiles/PowerShellPackage.ps1
@@ -63,7 +63,6 @@ function BuildPackages {
         } else {
             # make the artifact name unique
             $projectAssetsZipName = "linuxProjectAssets-$((Get-Date).Ticks)-symbols.zip"
-            $buildParams.Add("Crossgen", $true)
         }
 
         Start-PSBuild @buildParams @releaseTagParam
@@ -89,7 +88,6 @@ function BuildPackages {
             Remove-Item -Path $binDir -Recurse -Force
 
             ## Build 'min-size' and create 'tar.gz' package for it.
-            $buildParams['Crossgen'] = $false
             $buildParams['ForMinimalSize'] = $true
             Start-PSBuild @buildParams @releaseTagParam
             Start-PSPackage -Type min-size @releaseTagParam -LTS:$LTS

--- a/tools/releaseBuild/Images/microsoft_powershell_windowsservercore/PowerShellPackage.ps1
+++ b/tools/releaseBuild/Images/microsoft_powershell_windowsservercore/PowerShellPackage.ps1
@@ -97,7 +97,6 @@ try
     {
         Write-Verbose "Starting powershell build for RID: $Runtime and ReleaseTag: $ReleaseTag ..." -Verbose
         $buildParams = @{
-            CrossGen = !$ForMinimalSize -and $Runtime -notmatch "arm" -and $Runtime -notlike "fxdependent*"
             ForMinimalSize = $ForMinimalSize
         }
 

--- a/tools/releaseBuild/macOS/PowerShellPackageVsts.ps1
+++ b/tools/releaseBuild/macOS/PowerShellPackageVsts.ps1
@@ -104,15 +104,14 @@ try {
     }
 
     if ($Build) {
-        $runCrossgen = $Runtime -eq 'osx-x64'
         if ($Symbols) {
-            Start-PSBuild -Clean -Configuration 'Release' -Crossgen:$runCrossgen -NoPSModuleRestore @releaseTagParam -Runtime $Runtime
+            Start-PSBuild -Clean -Configuration 'Release' -NoPSModuleRestore @releaseTagParam -Runtime $Runtime
             $pspackageParams['Type']='zip'
             $pspackageParams['IncludeSymbols']=$Symbols.IsPresent
             Write-Verbose "Starting powershell packaging(zip)..." -Verbose
             Start-PSPackage @pspackageParams @releaseTagParam
         } else {
-            Start-PSBuild -Configuration 'Release' -Crossgen:$runCrossgen -PSModuleRestore @releaseTagParam -Runtime $Runtime
+            Start-PSBuild -Configuration 'Release' -PSModuleRestore @releaseTagParam -Runtime $Runtime
             Start-PSPackage @pspackageParams @releaseTagParam
             switch ($ExtraPackage) {
                 "tar" { Start-PSPackage -Type tar @pspackageParams @releaseTagParam }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Supersede #16265

The .NET team has confirmed that ALL .NET 6 runtime assemblies should be R2R images. See https://github.com/dotnet/runtime/issues/60779 for details.
During my verification, I found some runtime assemblies that are not R2R images, but it turns out that is by design because those assemblies as pure façade assemblies. See https://github.com/dotnet/runtime/issues/60782 for details.

I have also verified that `<PublishReadyToRun>true</PublishReadyToRun>` actually crossgen'ed all the package assemblies pwsh depends on, including all that in the [$commonAssembliesForAddType](https://github.com/PowerShell/PowerShell/blob/e5d27d139c59a94931bf7767b7e17a4b3bc65d00/build.psm1#L2499-L2523) array today. The following is the pdb generated for those crossgen'ed assemblies.

```
InputObject                                           SideIndicator
-----------                                           -------------
Markdig.Signed.ni.pdb                                 =>
Microsoft.ApplicationInsights.ni.pdb                  =>
Microsoft.CodeAnalysis.CSharp.ni.pdb                  =>
Microsoft.CodeAnalysis.ni.pdb                         =>
Microsoft.Extensions.ObjectPool.ni.pdb                =>
Microsoft.Management.Infrastructure.CimCmdlets.ni.pdb =>
Microsoft.Management.Infrastructure.Native.ni.pdb     =>
Microsoft.Management.Infrastructure.ni.pdb            =>
Microsoft.PowerShell.Commands.Diagnostics.ni.pdb      =>
Microsoft.PowerShell.Commands.Management.ni.pdb       =>
Microsoft.PowerShell.Commands.Utility.ni.pdb          =>
Microsoft.PowerShell.ConsoleHost.ni.pdb               =>
Microsoft.PowerShell.CoreCLR.Eventing.ni.pdb          =>
Microsoft.PowerShell.GraphicalHost.ni.pdb             =>
Microsoft.PowerShell.MarkdownRender.ni.pdb            =>
Microsoft.PowerShell.Security.ni.pdb                  =>
Microsoft.WSMan.Management.ni.pdb                     =>
Microsoft.WSMan.Runtime.ni.pdb                        =>
Namotion.Reflection.ni.pdb                            =>
Newtonsoft.Json.ni.pdb                                =>
NJsonSchema.ni.pdb                                    =>
pwsh.ni.pdb                                           =>
System.ComponentModel.Composition.ni.pdb              =>
System.ComponentModel.Composition.Registration.ni.pdb =>
System.Data.Odbc.ni.pdb                               =>
System.Data.OleDb.ni.pdb                              =>
System.Data.SqlClient.ni.pdb                          =>
System.DirectoryServices.AccountManagement.ni.pdb     =>
System.DirectoryServices.Protocols.ni.pdb             =>
System.IO.Ports.ni.pdb                                =>
System.Management.Automation.ni.pdb                   =>
System.Management.ni.pdb                              =>
System.Net.Http.WinHttpHandler.ni.pdb                 =>
System.Private.ServiceModel.ni.pdb                    =>
System.Reflection.Context.ni.pdb                      =>
System.Runtime.Caching.ni.pdb                         =>
System.ServiceModel.Syndication.ni.pdb                =>
System.ServiceProcess.ServiceController.ni.pdb        =>
System.Speech.ni.pdb                                  =>
```

Given all above, we should just remove the `Start-CrossGen` code, and also remove the `-CrossGen` switch parameter from `Start-PSBuild`, because we have `<PublishReadyToRun Condition=" '$(Configuration)' != 'Debug' ">true</PublishReadyToRun>` in `PowerShell.Common.props` file, so unless explicitly disabling R2R (for `fxdependent*` and `minSize` packages), our build will generate R2R images for release builds.

Also add `<PublishReadyToRunEmitSymbols>true</PublishReadyToRunEmitSymbols>` to generate the native symbols for the R2R images when publishing R2R, because [profiler needs the symbols generated by `<PublishReadyToRunEmitSymbols>` to examine the R2R files](https://docs.microsoft.com/en-us/dotnet/core/deploying/ready-to-run#symbol-generation-for-use-with-profilers). However, those symbols are only useful for profiling the startup scenario of PowerShell because PowerShell enables tiered compilation which will overwrite the R2R code.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.