### PR TITLE
Fix Windows build ZIP packaging

### DIFF
--- a/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
@@ -251,7 +251,7 @@ jobs:
       Write-Host "##$vstsCommandString"
     displayName: Compress signed files
 
-  - powershell: |
+  - pwsh: |
       $runtime = switch ($env:Architecture)
         {
           "x64" { "win7-x64" }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes #16261

## PR Context

Fix shell for calling `PowerShellPackage.ps1` in CI for packaging step.