### PR TITLE
Add wget as a dependency for installation script

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -1995,6 +1995,9 @@ function Start-PSBootstrap {
                 # Build tools
                 $Deps += "cmake"
 
+                # wget for downloading dotnet
+                $Deps += "wget"
+
                 # .NET Core required runtime libraries
                 $Deps += "openssl"
 

--- a/build.psm1
+++ b/build.psm1
@@ -2005,7 +2005,7 @@ function Start-PSBootstrap {
                 # ignore exitcode, because they may be already installed
                 Start-NativeExecution ([ScriptBlock]::Create("$PackageManager install $Deps")) -IgnoreExitcode
             } elseif ($environment.IsLinux -and $environment.IsAlpine) {
-                $Deps += 'libunwind', 'libcurl', 'bash', 'cmake', 'clang', 'build-base', 'git', 'curl'
+                $Deps += 'libunwind', 'libcurl', 'bash', 'cmake', 'clang', 'build-base', 'git', 'curl', 'wget'
 
                 Start-NativeExecution {
                     Invoke-Expression "apk add $Deps"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add wget as a dependency for installation script.

## PR Context

When building PowerShell with `build.psm1` module, if `wget` is not installed bootstrap process would fail on macOS.
```pwsh
PS /Users/nik/Development/PowerShell> Start-PSBootstrap
Installing PowerShell build dependencies
Updating Homebrew...
==> Auto-updated Homebrew!
Updated 1 tap (homebrew/cask).
==> Updated Casks
Updated 8 casks.

Warning: Treating cmake as a formula. For the cask, use homebrew/cask/cmake
Warning: cmake 3.21.3_1 is already installed and up-to-date.
To reinstall 3.21.3_1, run:
  brew reinstall cmake
Warning: openssl@3 3.0.0_1 is already installed and up-to-date.
To reinstall 3.0.0_1, run:
  brew reinstall openssl@3
WARNING: Could not find 'dotnet', appending /Users/nik/.dotnet to PATH.
WARNING: Still could not find 'dotnet', restoring PATH.
dotnet not present.  Installing dotnet.
Get-Command: /Users/nik/Development/PowerShell/build.psm1:1774:17
Line |
1774 |  …     $wget = Get-Command -Name wget -CommandType Application -TotalCou …
     |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | The term 'wget' is not recognized as a name of a cmdlet, function, script file, or executable program. Check the spelling
     | of the name, or if a path was included, verify that the path is correct and try again.
```

## After the changes

```pwsh
PS /Users/nik/Development/PowerShell> Start-PSBootstrap         
Installing PowerShell build dependencies
Warning: Treating cmake as a formula. For the cask, use homebrew/cask/cmake
Warning: cmake 3.21.3_1 is already installed and up-to-date.
To reinstall 3.21.3_1, run:
  brew reinstall cmake
Warning: openssl@3 3.0.0_1 is already installed and up-to-date.
To reinstall 3.0.0_1, run:
  brew reinstall openssl@3
Warning: Building wget from source as the bottle needs:
...
dotnet not present.  Installing dotnet.
--2021-10-25 23:08:36--  https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/uninstall/dotnet-uninstall-pkgs.sh
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.109.133, 185.199.111.133, 185.199.110.133, ...
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.109.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 1191 (1.2K) [text/plain]
Saving to: ‘dotnet-uninstall-pkgs.sh’
...
```
