### PR TITLE
Don't throw exception when trying to resolve a possible link path

### DIFF
--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1112,10 +1112,17 @@ namespace System.Management.Automation
             //  1. When starting a process on Windows, if the 'FileName' is a symbolic link, the immediate link target will automatically be used,
             //     but the OS does not do recursive resolution when the immediate link target is also a symbolic link.
             //  2. Keep the same behavior as before adopting the 'LinkTarget' and 'ResolveLinkTarget' APIs in .NET 6.
-            string linkTarget = File.ResolveLinkTarget(fileName, returnFinalTarget: false)?.FullName;
-            if (linkTarget is not null)
+            try
             {
-                fileName = linkTarget;
+                string linkTarget = File.ResolveLinkTarget(fileName, returnFinalTarget: false)?.FullName;
+                if (linkTarget is not null)
+                {
+                    fileName = linkTarget;
+                }
+            }
+            catch
+            {
+                // Swallow any exception thrown from 'ResolveLinkTarget'. Just use the original file name when it fails.
             }
 
             SHFILEINFO shinfo = new SHFILEINFO();

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1122,7 +1122,9 @@ namespace System.Management.Automation
             }
             catch
             {
-                // Swallow any exception thrown from 'ResolveLinkTarget'. Just use the original file name when it fails.
+                // An exception may be thrown from 'File.ResolveLinkTarget' when it fails to resolve a link path,
+                // for example, when the underlying file system doesn't support reparse points.
+                // Just use the original file name in this case.
             }
 
             SHFILEINFO shinfo = new SHFILEINFO();

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -281,7 +281,7 @@ Describe "Run native command from a mounted FAT-format VHD" -tags @("Feature", "
         diskpart.exe /s $create_vhdx
         Mount-DiskImage -ImagePath $vhdx > $null
 
-        Copy-Item "$env:WinDir\System32\whoami.exe T:\whoami.exe"
+        Copy-Item "$env:WinDir\System32\whoami.exe" T:\whoami.exe
     }
 
     AfterAll {
@@ -292,7 +292,7 @@ Describe "Run native command from a mounted FAT-format VHD" -tags @("Feature", "
     }
 
     It "Should run 'whoami.exe' from FAT file system without error" -Skip:(!$IsWindows) {
-        $expected = "$env:WinDir\System32\whoami.exe"
+        $expected = & "$env:WinDir\System32\whoami.exe"
         $result = T:\whoami.exe
         $result | Should -BeExactly $expected
     }

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -291,7 +291,7 @@ Describe "Run native command from a mounted FAT-format VHD" -tags @("Feature", "
         }
     }
 
-    It "Should run 'whoami.exe' from FAT file system without error" {
+    It "Should run 'whoami.exe' from FAT file system without error" -Skip:(!$IsWindows) {
         $expected = C:\Windows\System32\whoami.exe
         $result = T:\whoami.exe
         $result | Should -BeExactly $expected

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -292,7 +292,7 @@ Describe "Run native command from a mounted FAT-format VHD" -tags @("Feature", "
     }
 
     It "Should run 'whoami.exe' from FAT file system without error" -Skip:(!$IsWindows) {
-        $expected = C:\Windows\System32\whoami.exe
+        $expected = "$env:WinDir\System32\whoami.exe"
         $result = T:\whoami.exe
         $result | Should -BeExactly $expected
     }

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -281,7 +281,7 @@ Describe "Run native command from a mounted FAT-format VHD" -tags @("Feature", "
         diskpart.exe /s $create_vhdx
         Mount-DiskImage -ImagePath $vhdx > $null
 
-        Copy-Item C:\Windows\System32\whoami.exe T:\whoami.exe
+        Copy-Item "$env:WinDir\System32\whoami.exe T:\whoami.exe"
     }
 
     AfterAll {

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -252,3 +252,48 @@ Categories=Application;
         { $dllFile = "$PSHOME\System.Management.Automation.dll"; & $dllFile } | Should -Throw -ErrorId "NativeCommandFailed"
     }
 }
+
+Describe "Run native command from a mounted FAT-format VHD" -tags @("Feature", "RequireAdminOnWindows") {
+    BeforeAll {
+        if (-not $IsWindows) {
+            return;
+        }
+
+        $vhdx = Join-Path -Path $TestDrive -ChildPath ncp.vhdx
+
+        if (Test-Path -Path $vhdx) {
+            Remove-item -Path $vhdx -Force
+        }
+
+        $create_vhdx = Join-Path -Path $TestDrive -ChildPath 'create_vhdx.txt'
+
+        Set-Content -Path $create_vhdx -Force -Value @"
+            create vdisk file="$vhdx" maximum=20 type=fixed
+            select vdisk file="$vhdx"
+            attach vdisk
+            convert mbr
+            create partition primary
+            format fs=fat
+            assign letter="T"
+            detach vdisk
+"@
+
+        diskpart.exe /s $create_vhdx
+        Mount-DiskImage -ImagePath $vhdx > $null
+
+        Copy-Item C:\Windows\System32\whoami.exe T:\whoami.exe
+    }
+
+    AfterAll {
+        if ($IsWindows) {
+            Dismount-DiskImage -ImagePath $vhdx
+            Remove-Item $vhdx, $create_vhdx -Force
+        }
+    }
+
+    It "Should run 'whoami.exe' from FAT file system without error" {
+        $expected = C:\Windows\System32\whoami.exe
+        $result = T:\whoami.exe
+        $result | Should -BeExactly $expected
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #16293
Before #16165, we were using `InternalSymbolicLinkLinkCodeMethods.WinInternalGetTarget` to try resolving a possible link path, and that API never throws -- catch exception and returns null. However, `File.ResolveLinkTarget` throws when there is any error while resolving the link path, e.g. the file system doesn't support reparse point. This caused a regression in 7.2.0-rc1.

The fix is to wrap `File.ResolveLinkTarget` in a try/catch block, and use the original `fileName` when `ResolveLinkTarget` fails.

@iSazonov and @jborean93, thank you both for bring the regression to our attention, and also worked out the test.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
