### PR TITLE
Does PSStyle early initialization less expensive

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -35,7 +35,7 @@ namespace System.Management.Automation
         /// <summary>Classic rendering of progress.</summary>
         Classic = 1,
     }
-    
+
     #region PSStyle
     /// <summary>
     /// Contains configuration for how PowerShell renders text.
@@ -365,7 +365,7 @@ namespace System.Management.Automation
                 get => _error;
                 set => _error = ValidateNoContent(value);
             }
-            
+
             private string _error = "\x1b[31;1m";
 
             /// <summary>
@@ -397,7 +397,7 @@ namespace System.Management.Automation
             {
                 get => _debug;
                 set => _debug = ValidateNoContent(value);
-            }   
+            }
 
             private string _debug = "\x1b[33;1m";
         }
@@ -465,6 +465,16 @@ namespace System.Management.Automation
                 public void Add(string extension, string decoration)
                 {
                     _extensionDictionary.Add(ValidateExtension(extension), ValidateNoContent(decoration));
+                }
+
+                /// <summary>
+                /// Add new extension and decoration to dictionary without validation.
+                /// </summary>
+                /// <param name="extension">Extension to add.</param>
+                /// <param name="decoration">ANSI string value to add.</param>
+                internal void AddWithoutValidate(string extension, string decoration)
+                {
+                    _extensionDictionary.Add(extension, decoration);
                 }
 
                 /// <summary>
@@ -543,19 +553,19 @@ namespace System.Management.Automation
                 Extension = new FileExtensionDictionary();
 
                 // archives
-                Extension.Add(".zip", "\x1b[31;1m");
-                Extension.Add(".tgz", "\x1b[31;1m");
-                Extension.Add(".gz", "\x1b[31;1m");
-                Extension.Add(".tar", "\x1b[31;1m");
-                Extension.Add(".nupkg", "\x1b[31;1m");
-                Extension.Add(".cab", "\x1b[31;1m");
-                Extension.Add(".7z", "\x1b[31;1m");
+                Extension.AddWithoutValidate(".zip", "\x1b[31;1m");
+                Extension.AddWithoutValidate(".tgz", "\x1b[31;1m");
+                Extension.AddWithoutValidate(".gz", "\x1b[31;1m");
+                Extension.AddWithoutValidate(".tar", "\x1b[31;1m");
+                Extension.AddWithoutValidate(".nupkg", "\x1b[31;1m");
+                Extension.AddWithoutValidate(".cab", "\x1b[31;1m");
+                Extension.AddWithoutValidate(".7z", "\x1b[31;1m");
 
                 // powershell
-                Extension.Add(".ps1", "\x1b[33;1m");
-                Extension.Add(".psd1", "\x1b[33;1m");
-                Extension.Add(".psm1", "\x1b[33;1m");
-                Extension.Add(".ps1xml", "\x1b[33;1m");
+                Extension.AddWithoutValidate(".ps1", "\x1b[33;1m");
+                Extension.AddWithoutValidate(".psd1", "\x1b[33;1m");
+                Extension.AddWithoutValidate(".psm1", "\x1b[33;1m");
+                Extension.AddWithoutValidate(".ps1xml", "\x1b[33;1m");
             }
         }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -472,7 +472,7 @@ namespace System.Management.Automation
                 /// </summary>
                 /// <param name="extension">Extension to add.</param>
                 /// <param name="decoration">ANSI string value to add.</param>
-                internal void AddWithoutValidate(string extension, string decoration)
+                internal void AddWithoutValidation(string extension, string decoration)
                 {
                     _extensionDictionary.Add(extension, decoration);
                 }
@@ -553,19 +553,19 @@ namespace System.Management.Automation
                 Extension = new FileExtensionDictionary();
 
                 // archives
-                Extension.AddWithoutValidate(".zip", "\x1b[31;1m");
-                Extension.AddWithoutValidate(".tgz", "\x1b[31;1m");
-                Extension.AddWithoutValidate(".gz", "\x1b[31;1m");
-                Extension.AddWithoutValidate(".tar", "\x1b[31;1m");
-                Extension.AddWithoutValidate(".nupkg", "\x1b[31;1m");
-                Extension.AddWithoutValidate(".cab", "\x1b[31;1m");
-                Extension.AddWithoutValidate(".7z", "\x1b[31;1m");
+                Extension.AddWithoutValidation(".zip", "\x1b[31;1m");
+                Extension.AddWithoutValidation(".tgz", "\x1b[31;1m");
+                Extension.AddWithoutValidation(".gz", "\x1b[31;1m");
+                Extension.AddWithoutValidation(".tar", "\x1b[31;1m");
+                Extension.AddWithoutValidation(".nupkg", "\x1b[31;1m");
+                Extension.AddWithoutValidation(".cab", "\x1b[31;1m");
+                Extension.AddWithoutValidation(".7z", "\x1b[31;1m");
 
                 // powershell
-                Extension.AddWithoutValidate(".ps1", "\x1b[33;1m");
-                Extension.AddWithoutValidate(".psd1", "\x1b[33;1m");
-                Extension.AddWithoutValidate(".psm1", "\x1b[33;1m");
-                Extension.AddWithoutValidate(".ps1xml", "\x1b[33;1m");
+                Extension.AddWithoutValidation(".ps1", "\x1b[33;1m");
+                Extension.AddWithoutValidation(".psd1", "\x1b[33;1m");
+                Extension.AddWithoutValidation(".psm1", "\x1b[33;1m");
+                Extension.AddWithoutValidation(".ps1xml", "\x1b[33;1m");
             }
         }
 
@@ -698,7 +698,7 @@ namespace System.Management.Automation
 
         private static string ValidateNoContent(string text)
         {
-            var decorartedString = new StringDecorated(text);
+            var decorartedString = new ValueStringDecorated(text);
             if (decorartedString.ContentLength > 0)
             {
                 throw new ArgumentException(string.Format(PSStyleStrings.TextContainsContent, decorartedString.ToString(OutputRendering.PlainText)));


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Improve startup scenario. It is a perf regression after #13758.

Before the PR:
![image](https://user-images.githubusercontent.com/22290914/139193609-2f84e932-3bdb-4992-9457-136ac94b09ab.png)



## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
