### PR TITLE
increment RC MSI build number by 100

### DIFF
--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -3096,7 +3096,7 @@ function Get-WindowsNames {
     Write-Verbose -Message "Getting Windows Names for ProductName: $ProductName; ProductNameSuffix: $ProductNameSuffix; ProductVersion: $ProductVersion" -Verbose
 
     $ProductSemanticVersion = Get-PackageSemanticVersion -Version $ProductVersion
-    $ProductVersion = Get-PackageVersionAsMajorMinorBuildRevision -Version $ProductVersion
+    $ProductVersion = Get-PackageVersionAsMajorMinorBuildRevision -Version $ProductVersion  -IncrementBuildNumber
 
     $productVersionWithName = $ProductName + '_' + $ProductVersion
     $productSemanticVersionWithName = $ProductName + '-' + $ProductSemanticVersion
@@ -3748,8 +3748,9 @@ function Get-PackageVersionAsMajorMinorBuildRevision
         # Version of the Package
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [string] $Version
-        )
+        [string] $Version,
+        [switch] $IncrementBuildNumber
+    )
 
     Write-Verbose "Extract the version in the form of major.minor[.build[.revision]] for $Version"
     $packageVersionTokens = $Version.Split('-')
@@ -3768,6 +3769,10 @@ function Get-PackageVersionAsMajorMinorBuildRevision
             {
                 # MSIX will fail if it is more characters
                 $packageBuildTokens = $packageBuildTokens.Substring(0,4)
+            }
+
+            if ($packageVersionTokens[1] -match 'rc' -and $IncrementBuildNumber) {
+                $packageBuildTokens = [int]$packageBuildTokens + 100
             }
 
             $packageVersion = $packageVersion + '.' + $packageBuildTokens
@@ -4210,7 +4215,7 @@ function Test-PackageManifest {
     }
 
     Process {
-        Write-Verbose "Processing $($man.files.count) files..." -verbose
+        Write-Verbose "Processing $($man.files) files..." -verbose
         $man.files | ForEach-Object {
             $filePath = Join-Path $PackagePath -childPath $_.fileName
             $checksumObj = $_.checksums | Where-Object {$_.algorithm -eq 'sha256'}

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -4215,7 +4215,7 @@ function Test-PackageManifest {
     }
 
     Process {
-        Write-Verbose "Processing $($man.files) files..." -verbose
+        Write-Verbose "Processing $($man.files.count) files..." -verbose
         $man.files | ForEach-Object {
             $filePath = Join-Path $PackagePath -childPath $_.fileName
             $checksumObj = $_.checksums | Where-Object {$_.algorithm -eq 'sha256'}

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -3096,7 +3096,7 @@ function Get-WindowsNames {
     Write-Verbose -Message "Getting Windows Names for ProductName: $ProductName; ProductNameSuffix: $ProductNameSuffix; ProductVersion: $ProductVersion" -Verbose
 
     $ProductSemanticVersion = Get-PackageSemanticVersion -Version $ProductVersion
-    $ProductVersion = Get-PackageVersionAsMajorMinorBuildRevision -Version $ProductVersion  -IncrementBuildNumber
+    $ProductVersion = Get-PackageVersionAsMajorMinorBuildRevision -Version $ProductVersion -IncrementBuildNumber
 
     $productVersionWithName = $ProductName + '_' + $ProductVersion
     $productSemanticVersionWithName = $ProductName + '-' + $ProductSemanticVersion


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

increment RC MSI build number by 100

## PR Context

If the number is not higher than preview, the RC is detected as a downgrade or obsolete.

Fix issue mentioned in:  https://github.com/PowerShell/PowerShell/discussions/15510

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
