### PR TITLE
print a new line on exit

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -2686,6 +2686,9 @@ namespace Microsoft.PowerShell
                         _parent._isRunningPromptLoop = false;
                     }
                 }
+#if UNIX
+                ui.WriteLine();
+#endif
             }
 
             internal void BlockCommandOutput()

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -527,7 +527,7 @@ export $envVarName='$guid'
             $process.StandardOutput.ReadLine() | Should -Be "PS> 1+2`b3"
             $process.StandardOutput.ReadLine() | Should -Be "4"
             $process.StandardInput.Close()
-            $process.StandardOutput.ReadToEnd() | Should -Be "PS> "
+            $process.StandardOutput.ReadToEnd() | Should -Be "PS> `n"
             EnsureChildHasExited $process
         }
 
@@ -541,7 +541,7 @@ export $envVarName='$guid'
             $process.StandardOutput.ReadLine() | Should -Be "PS> 1+2"
             $process.StandardOutput.ReadLine() | Should -Be "3"
             $process.StandardInput.Close()
-            $process.StandardOutput.ReadToEnd() | Should -Be "PS> "
+            $process.StandardOutput.ReadToEnd() | Should -Be "PS> `n"
             EnsureChildHasExited $process
         }
 
@@ -554,7 +554,7 @@ export $envVarName='$guid'
             $process.StandardOutput.ReadLine() | Should -Be "PS> 1+1"
             $process.StandardOutput.ReadLine() | Should -Be "2"
             $process.StandardInput.Close()
-            $process.StandardOutput.ReadToEnd() | Should -Be "PS> "
+            $process.StandardOutput.ReadToEnd() | Should -Be "PS> `n"
             EnsureChildHasExited $process
         }
 
@@ -601,7 +601,7 @@ foo
             $process.StandardInput.Write("exit`n")
             $process.StandardOutput.ReadLine() | Should -Be "PS>> exit"
             $process.StandardInput.Close()
-            $process.StandardOutput.ReadToEnd() | Should -Be "PS> "
+            $process.StandardOutput.ReadToEnd() | Should -Be "`nPS> `n"
             EnsureChildHasExited $process
         }
     }


### PR DESCRIPTION
When quitting the shell with ^D, a new line is not print in Unix:

    mcroce@t490s:~$ pwsh
    PowerShell 7.2.0
    Copyright (c) Microsoft Corporation.

    https://aka.ms/powershell
    Type 'help' to get help.

    PS /home/mcroce> mcroce@t490s:~$

Do it to keep the behaviour consistent with other Unix shell.
Fixes PowerShell/PSReadLine#5092

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
