### PR TITLE
Add `exec` cmdlet for bash compatibility

### DIFF
--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -26,6 +26,7 @@ namespace System.Management.Automation
         internal const string PSRemotingSSHTransportErrorHandling = "PSRemotingSSHTransportErrorHandling";
         internal const string PSCleanBlockFeatureName = "PSCleanBlock";
         internal const string PSAMSIMethodInvocationLogging = "PSAMSIMethodInvocationLogging";
+        internal const string PSExecFeatureName = "PSExec";
 
         #endregion
 
@@ -138,6 +139,9 @@ namespace System.Management.Automation
                 new ExperimentalFeature(
                     name: PSAMSIMethodInvocationLogging,
                     description: "Provides AMSI notification of .NET method invocations."),
+                new ExperimentalFeature(
+                    name: PSExecFeatureName,
+                    description: "Add 'exec' built-in command on Linux and macOS"),
             };
 
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4146,6 +4146,14 @@ End
 }
         ";
 
+        internal static string GetExecFunctionText()
+        {
+            return @"
+                param($command)
+                & $command @args
+            ";
+        }
+
         /// <summary>
         /// This is the default function to use for clear-host.
         /// </summary>
@@ -4822,6 +4830,7 @@ end {
            // Functions that don't require full language mode
             SessionStateFunctionEntry.GetDelayParsedFunctionEntry("cd..", "Set-Location ..", isProductCode: true, languageMode: systemLanguageMode),
             SessionStateFunctionEntry.GetDelayParsedFunctionEntry("cd\\", "Set-Location \\", isProductCode: true, languageMode: systemLanguageMode),
+            SessionStateFunctionEntry.GetDelayParsedFunctionEntry("exec", GetExecFunctionText(), isProductCode: true, languageMode: systemLanguageMode),
             // Win8: 320909. Retaining the original definition to ensure backward compatability.
             SessionStateFunctionEntry.GetDelayParsedFunctionEntry("Pause",
                 string.Concat("$null = Read-Host '", CodeGeneration.EscapeSingleQuotedStringContent(RunspaceInit.PauseDefinitionString), "'"), isProductCode: true, languageMode: systemLanguageMode),

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4150,7 +4150,10 @@ End
         {
             return @"
                 param($command)
-                & $command @args
+
+                if ($null -ne $command) {
+                    & $command @args
+                }
             ";
         }
 

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4802,10 +4802,12 @@ end {
                     new SessionStateAliasEntry("sls", "Select-String"),
                 };
 
+#if UNIX
                 if (ExperimentalFeature.IsEnabled(ExperimentalFeature.PSExecFeatureName))
                 {
                     builtInAliases.Add(new SessionStateAliasEntry("exec", "Switch-Process"));
                 }
+#endif
 
                 return builtInAliases.ToArray();
             }

--- a/src/System.Management.Automation/engine/Modules/SwitchProcessCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/SwitchProcessCommand.cs
@@ -58,7 +58,11 @@ namespace Microsoft.PowerShell.Commands
             }
 
             var execArgs = new string?[WithCommand.Length + 1];
-            for (int i = 0; i < WithCommand.Length; i++)
+
+            // execv convention is the first arg is the program name
+            execArgs[0] = command.Name;
+
+            for (int i = 1; i < WithCommand.Length; i++)
             {
                 execArgs[i] = WithCommand[i].ToString();
             }
@@ -85,7 +89,7 @@ namespace Microsoft.PowerShell.Commands
                     )
                 );
             }
-        }        
+        }
 
         /// <summary>
         /// The `execv` POSIX syscall we use to exec /bin/sh.

--- a/src/System.Management.Automation/engine/Modules/SwitchProcessCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/SwitchProcessCommand.cs
@@ -24,13 +24,13 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Get or set the command and arguments to replace the current pwsh process.
         /// </summary>
-        [Parameter(Position = 0, Mandatory = false, ValueFromPipeline = true, ValueFromRemainingArguments = true)]
+        [Parameter(Position = 0, Mandatory = false, ValueFromRemainingArguments = true)]
         public string[] WithCommand { get; set; } = Array.Empty<string>();
 
         /// <summary>
-        /// For each record, execute it, and push the results into the success stream.
+        /// Execute the command and arguments
         /// </summary>
-        protected override void ProcessRecord()
+        protected override void EndProcessing()
         {
             if (WithCommand.Length == 0)
             {

--- a/src/System.Management.Automation/engine/Modules/SwitchProcessCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/SwitchProcessCommand.cs
@@ -80,7 +80,8 @@ namespace Microsoft.PowerShell.Commands
                             string.Format(
                                 System.Globalization.CultureInfo.InvariantCulture,
                                 CommandBaseStrings.ExecFailed,
-                                Marshal.GetLastPInvokeError()
+                                Marshal.GetLastPInvokeError(),
+                                string.Join(" ", WithCommand)
                             )
                         ),
                         "ExecutionFailed",

--- a/src/System.Management.Automation/engine/Modules/SwitchProcessCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/SwitchProcessCommand.cs
@@ -18,7 +18,7 @@ namespace Microsoft.PowerShell.Commands
     /// Implements a cmdlet that allows use of execv API.
     /// </summary>
     [Experimental(ExperimentalFeature.PSExecFeatureName, ExperimentAction.Show)]
-    [Cmdlet(VerbsCommon.Switch, "Process", HelpUri = "https://replace")]
+    [Cmdlet(VerbsCommon.Switch, "Process", HelpUri = "https://go.microsoft.com/fwlink/?linkid=2181448")]
     public sealed class SwitchProcessCommand : PSCmdlet
     {
         /// <summary>

--- a/src/System.Management.Automation/engine/Modules/SwitchProcessCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/SwitchProcessCommand.cs
@@ -39,7 +39,7 @@ namespace Microsoft.PowerShell.Commands
 
             // execv requires command to be full path so resolve command to first match
             var command = this.SessionState.InvokeCommand.GetCommand(WithCommand[0], CommandTypes.Application);
-            if (command == null)
+            if (command is null)
             {
                 ThrowTerminatingError(
                     new ErrorRecord(

--- a/src/System.Management.Automation/engine/Modules/SwitchProcessCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/SwitchProcessCommand.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerShell.Commands
     public sealed class SwitchProcessCommand : PSCmdlet
     {
         /// <summary>
-        /// Command to execute.
+        /// Get or set the command and arguments to replace the current pwsh process.
         /// </summary>
         [Parameter(Position = 0, Mandatory = false, ValueFromPipeline = true, ValueFromRemainingArguments = true)]
         public string[] WithCommand { get; set; } = Array.Empty<string>();

--- a/src/System.Management.Automation/engine/Modules/SwitchProcessCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/SwitchProcessCommand.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Runtime.InteropServices;
+
+using Dbg = System.Management.Automation.Diagnostics;
+
+#if UNIX
+
+namespace Microsoft.PowerShell.Commands
+{
+    /// <summary>
+    /// Implements a cmdlet that allows use of execv API
+    /// </summary>
+    [Experimental(ExperimentalFeature.PSExecFeatureName, ExperimentAction.Show)]
+    [Cmdlet(VerbsCommon.Switch, "Process", HelpUri = "https://replace")]
+    public sealed class SwitchProcessCommand : PSCmdlet
+    {
+        /// <summary>
+        /// Command to execute.
+        /// </summary>
+        [Parameter(Position = 0, Mandatory = false, ValueFromPipeline = true, ValueFromRemainingArguments = true)]
+        public string[] WithCommand { get; set; } = Array.Empty<string>();
+
+        /// <summary>
+        /// For each record, execute it, and push the results into the success stream.
+        /// </summary>
+        protected override void ProcessRecord()
+        {
+            if (WithCommand.Length == 0)
+            {
+                return;
+            }
+
+            // execv requires command to be full path so resolve command to first match
+            var command = this.SessionState.InvokeCommand.GetCommand(WithCommand[0], CommandTypes.Application);
+            if (command == null)
+            {
+                ThrowTerminatingError(
+                    new ErrorRecord(
+                        new CommandNotFoundException(
+                            string.Format(
+                                System.Globalization.CultureInfo.InvariantCulture,
+                                CommandBaseStrings.NativeCommandNotFound,
+                                command
+                            )
+                        ),
+                        "CommandNotFound",
+                        ErrorCategory.InvalidArgument,
+                        WithCommand
+                    )
+                );
+            }
+
+            var execArgs = new string?[WithCommand.Length + 1];
+            for (int i = 0; i < WithCommand.Length; i++)
+            {
+                execArgs[i] = WithCommand[i].ToString();
+            }
+
+            // need null terminator at end
+            execArgs[execArgs.Length - 1] = null;
+
+            int exitCode = Exec(command.Source, execArgs);
+
+            if (exitCode < 0)
+            {
+                ThrowTerminatingError(
+                    new ErrorRecord(
+                        new Exception(
+                            string.Format(
+                                System.Globalization.CultureInfo.InvariantCulture,
+                                CommandBaseStrings.ExecFailed,
+                                Marshal.GetLastPInvokeError()
+                            )
+                        ),
+                        "ExecutionFailed",
+                        ErrorCategory.InvalidOperation,
+                        WithCommand
+                    )
+                );
+            }
+        }        
+
+        /// <summary>
+        /// The `execv` POSIX syscall we use to exec /bin/sh.
+        /// </summary>
+        /// <param name="path">The path to the executable to exec.</param>
+        /// <param name="args">
+        /// The arguments to send through to the executable.
+        /// Array must have its final element be null.
+        /// </param>
+        /// <returns>
+        /// An exit code if exec failed, but if successful the calling process will be overwritten.
+        /// </returns>
+        [DllImport("libc",
+            EntryPoint = "execv",
+            CallingConvention = CallingConvention.Cdecl,
+            CharSet = CharSet.Ansi,
+            SetLastError = true)]
+        private static extern int Exec(string path, string?[] args);
+    }
+}
+
+#endif

--- a/src/System.Management.Automation/engine/Modules/SwitchProcessCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/SwitchProcessCommand.cs
@@ -15,7 +15,7 @@ using Dbg = System.Management.Automation.Diagnostics;
 namespace Microsoft.PowerShell.Commands
 {
     /// <summary>
-    /// Implements a cmdlet that allows use of execv API
+    /// Implements a cmdlet that allows use of execv API.
     /// </summary>
     [Experimental(ExperimentalFeature.PSExecFeatureName, ExperimentAction.Show)]
     [Cmdlet(VerbsCommon.Switch, "Process", HelpUri = "https://replace")]

--- a/src/System.Management.Automation/engine/Modules/SwitchProcessCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/SwitchProcessCommand.cs
@@ -64,7 +64,7 @@ namespace Microsoft.PowerShell.Commands
 
             for (int i = 1; i < WithCommand.Length; i++)
             {
-                execArgs[i] = WithCommand[i].ToString();
+                execArgs[i] = WithCommand[i];
             }
 
             // need null terminator at end

--- a/src/System.Management.Automation/resources/CommandBaseStrings.resx
+++ b/src/System.Management.Automation/resources/CommandBaseStrings.resx
@@ -223,7 +223,7 @@ Reviewed by TArcher on 2010-07-20
     <value>The {0} is obsolete. {1}</value>
   </data>
   <data name="ExecFailed" xml:space="preserve">
-    <value>Exec call failed with errorno: {0}</value>
+    <value>Exec call failed with errorno: {0}.</value>
   </data>
   <data name="NativeCommandNotFound" xml:space="preserve">
     <value>Command '{0}' was not found.  The specified command must be an executable.</value>

--- a/src/System.Management.Automation/resources/CommandBaseStrings.resx
+++ b/src/System.Management.Automation/resources/CommandBaseStrings.resx
@@ -226,6 +226,6 @@ Reviewed by TArcher on 2010-07-20
     <value>Exec call failed with errorno {0} for command line: {1}</value>
   </data>
   <data name="NativeCommandNotFound" xml:space="preserve">
-    <value>Command '{0}' was not found.  The specified command must be an executable.</value>
+    <value>Command '{0}' was not found. The specified command must be an executable.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/CommandBaseStrings.resx
+++ b/src/System.Management.Automation/resources/CommandBaseStrings.resx
@@ -223,7 +223,7 @@ Reviewed by TArcher on 2010-07-20
     <value>The {0} is obsolete. {1}</value>
   </data>
   <data name="ExecFailed" xml:space="preserve">
-    <value>Exec call failed with errorno: {0}.</value>
+    <value>Exec call failed with errorno {0} for command line: {1}</value>
   </data>
   <data name="NativeCommandNotFound" xml:space="preserve">
     <value>Command '{0}' was not found.  The specified command must be an executable.</value>

--- a/src/System.Management.Automation/resources/CommandBaseStrings.resx
+++ b/src/System.Management.Automation/resources/CommandBaseStrings.resx
@@ -222,4 +222,10 @@ Reviewed by TArcher on 2010-07-20
   <data name="UseOfDeprecatedCommandWarning" xml:space="preserve">
     <value>The {0} is obsolete. {1}</value>
   </data>
+  <data name="ExecFailed" xml:space="preserve">
+    <value>Exec call failed with errorno: {0}</value>
+  </data>
+  <data name="NativeCommandNotFound" xml:space="preserve">
+    <value>Command '{0}' was not found.  The specified command must be an executable.</value>
+  </data>
 </root>

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Exec.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Exec.Tests.ps1
@@ -43,6 +43,7 @@ Describe 'Switch-Process tests for Unix' -Tags 'CI' {
 
     It 'Exec will replace the process' {
         $sleep = Get-Command sleep -CommandType Application
+        write-verbose -verbose ($sleep | fl | out-string)
         $p = start-process pwsh -ArgumentList "-noprofile -command exec $($sleep.Source) 90" -PassThru
         Wait-UntilTrue {
             ($p | Get-Process).Name -eq 'sleep'

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Exec.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Exec.Tests.ps1
@@ -42,8 +42,7 @@ Describe 'Switch-Process tests for Unix' -Tags 'CI' {
     }
 
     It 'Exec will replace the process' {
-        $sleep = Get-Command sleep -CommandType Application
-        write-verbose -verbose ($sleep | fl | out-string)
+        $sleep = Get-Command sleep -CommandType Application | Select-Object -First 1
         $p = start-process pwsh -ArgumentList "-noprofile -command exec $($sleep.Source) 90" -PassThru
         Wait-UntilTrue {
             ($p | Get-Process).Name -eq 'sleep'

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Exec.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Exec.Tests.ps1
@@ -43,7 +43,7 @@ Describe 'Switch-Process tests for Unix' -Tags 'CI' {
 
     It 'Exec will replace the process' {
         $sleep = Get-Command sleep -CommandType Application | Select-Object -First 1
-        $p = start-process pwsh -ArgumentList "-noprofile -command exec $($sleep.Source) 90" -PassThru
+        $p = Start-Process pwsh -ArgumentList "-noprofile -command exec $($sleep.Source) 90" -PassThru
         Wait-UntilTrue {
             ($p | Get-Process).Name -eq 'sleep'
         } -timeout 60000 -interval 100 | Should -BeTrue

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Exec.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Exec.Tests.ps1
@@ -1,20 +1,66 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Describe 'Exec function tests' {
+Describe 'Switch-Process tests for Unix' {
+    BeforeAll {
+        $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
+        if (-not [ExperimentalFeature]::IsEnabled('PSExec') -or $IsWindows)
+        {
+            $PSDefaultParameterValues['It:Skip'] = $true
+            return
+        }
+    }
+
+    AfterAll {
+        $global:PSDefaultParameterValues = $originalDefaultParameterValues
+    }
+
+    It 'Exec alias should map to Switch-Process' {
+        $alias = Get-Command exec
+        $alias | Should -BeOfType [System.Management.Automation.AliasInfo]
+        $alias.Definition | Should -BeExactly 'Switch-Process'
+    }
+
     It 'Exec by itself does nothing' {
         exec | Should -BeNullOrEmpty
     }
 
-    It 'Exec should run a command line: <command>' -TestCases @(
-        @{ command = 'get-command -verb invoke' }
-        @{ command = 'get-module' }
-        @{ command = 'write-output (1+1)' }
-    ) {
-        param($command)
+    It 'Exec given a cmdlet should fail' {
+        { exec Get-Command } | Should -Throw -ErrorId 'CommandNotFound,Microsoft.PowerShell.Commands.SwitchProcessCommand'
+    }
 
-        $a = Invoke-Expression "exec $command"
-        $b = Invoke-Expression $command
-        Compare-Object -ReferenceObject $a -DifferenceObject $b | Should -BeNullOrEmpty
+    It 'Exec given an exe should work' {
+        $id, $uname = pwsh -noprofile -noexit -outputformat text -command { $pid; exec uname }
+        { Get-Process -Id $id -ErrorAction Stop } | Should -Throw -ErrorId 'NoProcessFoundForGivenId,Microsoft.PowerShell.Commands.GetProcessCommand'
+        $uname | Should -BeExactly (uname)
+    }
+
+    It 'Exec given an exe and arguments should work' {
+        $id, $uname = pwsh -noprofile -noexit -outputformat text -command { $pid; exec uname -a }
+        { Get-Process -Id $id -ErrorAction Stop } | Should -Throw -ErrorId 'NoProcessFoundForGivenId,Microsoft.PowerShell.Commands.GetProcessCommand'
+        $uname | Should -BeExactly (uname -a)
+    }
+}
+
+Describe 'Switch-Process for Windows' {
+    BeforeAll {
+        $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
+        if (-not $IsWindows)
+        {
+            $PSDefaultParameterValues['It:Skip'] = $true
+            return
+        }
+    }
+
+    AfterAll {
+        $global:PSDefaultParameterValues = $originalDefaultParameterValues
+    }
+
+    It 'Switch-Process should not be available' {
+        { Get-Command -Name Switch-Process } | Should -Throw -ErrorId 'CommandNotFoundException,Microsoft.PowerShell.Commands.GetCommandCommand'
+    }
+
+    It 'Exec alias should not be available' {
+        { Get-Alias -Name exec } | Should -Throw -ErrorId 'CommandNotFoundException,Microsoft.PowerShell.Commands.GetCommandCommand'
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Exec.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Exec.Tests.ps1
@@ -43,7 +43,7 @@ Describe 'Switch-Process tests for Unix' -Tags 'CI' {
 
     It 'Exec will replace the process' {
         $sleep = Get-Command sleep -CommandType Application
-        $p = start-process pwsh -ArgumentList '-noprofile','-command','exec',$sleep.Source,'90' -PassThru
+        $p = start-process pwsh -ArgumentList "-noprofile -command exec $($sleep.Source) 90" -PassThru
         Wait-UntilTrue {
             ($p | Get-Process).Name -eq 'sleep'
         } -timeout 60000 -interval 100 | Should -BeTrue

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Exec.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Exec.Tests.ps1
@@ -1,0 +1,20 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe 'Exec function tests' {
+    It 'Exec by itself does nothing' {
+        exec | Should -BeNullOrEmpty
+    }
+
+    It 'Exec should run a command line: <command>' -TestCases @(
+        @{ command = 'get-command -verb invoke' }
+        @{ command = 'get-module' }
+        @{ command = 'write-output (1+1)' }
+    ) {
+        param($command)
+
+        $a = Invoke-Expression "exec $command"
+        $b = Invoke-Expression $command
+        Compare-Object -ReferenceObject $a -DifferenceObject $b | Should -BeNullOrEmpty
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Exec.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Exec.Tests.ps1
@@ -65,10 +65,10 @@ Describe 'Switch-Process for Windows' {
     }
 
     It 'Switch-Process should not be available' {
-        { Get-Command -Name Switch-Process } | Should -Throw -ErrorId 'CommandNotFoundException,Microsoft.PowerShell.Commands.GetCommandCommand'
+        Get-Command -Name Switch-Process -ErrorAction Ignore | Should -BeNullOrEmpty
     }
 
     It 'Exec alias should not be available' {
-        { Get-Alias -Name exec } | Should -Throw -ErrorId 'CommandNotFoundException,Microsoft.PowerShell.Commands.GetCommandCommand'
+        Get-Alias -Name exec -ErrorAction Ignore | Should -BeNullOrEmpty
     }
 }

--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -16,7 +16,8 @@ $script:cmdletsToSkip = @(
     "Get-ExperimentalFeature",
     "Enable-ExperimentalFeature",
     "Disable-ExperimentalFeature",
-    "Get-PSSubsystem"
+    "Get-PSSubsystem",
+    "Switch-Process"
 )
 
 function UpdateHelpFromLocalContentPath {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Some native unix command will shell out to run something (like `ssh`) and uses the bash built-in `exec` to spawn a new process that replaces the current one.  This fails when PowerShell is the default shell as `exec` is not a valid command.  
This is affecting some known scripts like `copy-ssh-id` or some subcommands of AzCLI.

Since `Replace` is not a valid verb, I decided to use `Switch`.  Also, the other "Process" cmdlets are in the ManagementModule, but this is not related to those cmdlets and is really a Core cmdlet expected to be part of a Unix shell.

This PR adds a new `Switch-Process` cmdlet aliased to `exec` that calls `execv()` function to provide similar behavior as POSIX shells.  This is not intended to have parity with the `exec` built-in function in POSIX shells (like how file descriptors are handled), but should cover most cases.  This cmdlet only shows up for non-Windows systems.

We should consider backporting to 7.2 (as LTS release) for this reason, but should wait on sufficient user feedback in 7.3.

This may conflict with a user defined function called `exec` on non-Windows systems, but this seems necessary and uncommon.  @PowerShell/powershell-committee  had previously decided this was acceptable.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/4691

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [x] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [x] Experimental feature name(s): `PSExec`
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/8349
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
