### PR TITLE
Corrects the Max path condition check while using ChildItem based commands

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -8260,7 +8260,7 @@ namespace Microsoft.PowerShell.Commands
 
             WIN32_FIND_DATA data = default;
             string fullPath = Path.TrimEndingDirectorySeparator(fileInfo.FullName);
-            if (fullPath.Length > MAX_PATH)
+            if (fullPath.Length >= MAX_PATH)
             {
                 fullPath = PathUtils.EnsureExtendedPrefix(fullPath);
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -6,6 +6,7 @@ Describe "Get-ChildItem" -Tags "CI" {
 
         BeforeAll {
             # Create Test data
+            $max_Path = 260
             $item_a = "a3fe710a-31af-4834-bc29-d0b584589838"
             $item_B = "B1B691A9-B7B1-4584-AED7-5259511BEEC4"
             $item_c = "c283d143-2116-4809-bf11-4f7d61613f92"
@@ -13,6 +14,9 @@ Describe "Get-ChildItem" -Tags "CI" {
             $item_E = "EE150FEB-0F21-4AFF-8066-AF59E925810C"
             $item_F = ".F81D8514-8862-4227-B041-0529B1656A43"
             $item_G = "5560A62F-74F1-4FAE-9A23-F4EBD90D2676"
+            $item_H = "5f05ebca-4859-11ec-81d3-0242ac130003"
+            $item_I = "z" * ($max_Path - $TestDrive.FullName.Length - $item_H.Length - 2)
+            $item_J = "32d74aae-9054-4fa7-be97-8c806d10e8b9"
             $null = New-Item -Path $TestDrive -Name $item_a -ItemType "File" -Force
             $null = New-Item -Path $TestDrive -Name $item_B -ItemType "File" -Force
             $null = New-Item -Path $TestDrive -Name $item_c -ItemType "File" -Force
@@ -20,6 +24,7 @@ Describe "Get-ChildItem" -Tags "CI" {
             $null = New-Item -Path $TestDrive -Name $item_E -ItemType "Directory" -Force
             $null = New-Item -Path $TestDrive -Name $item_F -ItemType "File" -Force | ForEach-Object {$_.Attributes = "hidden"}
             $null = New-Item -Path (Join-Path -Path $TestDrive -ChildPath $item_E) -Name $item_G -ItemType "File" -Force
+            $null = New-Item -Path $TestDrive\$item_I\$item_H -Name $item_J -ItemType "Directory" -Force
 
             $searchRoot = Join-Path $TestDrive -ChildPath "TestPS"
             $file1 = Join-Path $searchRoot -ChildPath "D1" -AdditionalChildPath "File1.txt"
@@ -103,16 +108,17 @@ Describe "Get-ChildItem" -Tags "CI" {
         It "Should list files in sorted order" {
             $files = Get-ChildItem -Path $TestDrive
             $files[0].Name     | Should -Be $item_E
-            $files[1].Name     | Should -Be $item_a
-            $files[2].Name     | Should -Be $item_B
-            $files[3].Name     | Should -Be $item_c
-            $files[4].Name     | Should -Be $item_D
+            $files[1].Name     | Should -Be $item_I
+            $files[2].Name     | Should -Be $item_a
+            $files[3].Name     | Should -Be $item_B
+            $files[4].Name     | Should -Be $item_c
+            $files[5].Name     | Should -Be $item_D
         }
 
         It "Should list hidden files as well when 'Force' parameter is used" {
             $files = Get-ChildItem -Path $TestDrive -Force
             $files | Should -Not -BeNullOrEmpty
-            $files.Count | Should -Be 6
+            $files.Count | Should -Be 7
             $files.Name.Contains($item_F) | Should -BeTrue
         }
 
@@ -130,22 +136,22 @@ Describe "Get-ChildItem" -Tags "CI" {
         }
 
         It "Should list items in current directory only with depth set to 0" {
-            (Get-ChildItem -Path $TestDrive -Depth 0).Count | Should -Be 5
-            (Get-ChildItem -Path $TestDrive -Depth 0 -Include *).Count | Should -Be 5
-            (Get-ChildItem -Path $TestDrive -Depth 0 -Exclude IntentionallyNonexistent).Count | Should -Be 5
+            (Get-ChildItem -Path $TestDrive -Depth 0).Count | Should -Be 6
+            (Get-ChildItem -Path $TestDrive -Depth 0 -Include *).Count | Should -Be 6
+            (Get-ChildItem -Path $TestDrive -Depth 0 -Exclude IntentionallyNonexistent).Count | Should -Be 6
         }
 
         It "Should return items recursively when using 'Include' or 'Exclude' parameters" {
-            (Get-ChildItem -Path $TestDrive -Depth 1).Count | Should -Be 6
+            (Get-ChildItem -Path $TestDrive -Depth 1).Count | Should -Be 8
             (Get-ChildItem -Path $TestDrive -Depth 1 -Include $item_G).Count | Should -Be 1
-            (Get-ChildItem -Path $TestDrive -Depth 1 -Exclude $item_a).Count | Should -Be 5
+            (Get-ChildItem -Path $TestDrive -Depth 1 -Exclude $item_a).Count | Should -Be 7
         }
 
         It "Should return items recursively when using 'Include' or 'Exclude' parameters with -LiteralPath" {
             (Get-ChildItem -LiteralPath $TestDrive -Recurse -Exclude *).Count | Should -Be 0
             (Get-ChildItem -LiteralPath $TestDrive -Recurse -Include *.dll).Count | Should -Be (Get-ChildItem $TestDrive -Recurse -Include *.dll).Count
             (Get-ChildItem -LiteralPath $TestDrive -Depth 1 -Include $item_G).Count | Should -Be 1
-            (Get-ChildItem -LiteralPath $TestDrive -Depth 1 -Exclude $item_a).Count | Should -Be 5
+            (Get-ChildItem -LiteralPath $TestDrive -Depth 1 -Exclude $item_a).Count | Should -Be 7
         }
 
         It "get-childitem path wildcard - <title>" -TestCases $PathWildCardTestCases {
@@ -206,6 +212,10 @@ Describe "Get-ChildItem" -Tags "CI" {
             } finally {
                 Set-Location $oldLocation
             }
+        }
+
+        It "Should list the folder present when path length equal to MAX_PATH" {
+            (Get-ChildItem -Path TestDrive:\$item_I -Recurse -Force).Name.Length | Should -BeGreaterThan 0
         }
     }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Fix #16123
Corrects the Max path condition check
Add Pester test for Max path condition check
<!-- Summarize your PR between here and the checklist. -->

## PR Context
This PR will resolve the bug reported in #16123.  Adding pester tests to avoid regression.
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
