### PR TITLE
Enable redirection to variables with experimental feature PSRedirectToVariable

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
@@ -710,6 +710,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 return _append;
             }
+
             set
             {
                 _append = value;
@@ -751,7 +752,7 @@ namespace Microsoft.PowerShell.Commands
                 _valueList = new List<object>();
                 var currentValue = Context.SessionState.PSVariable.Get(Name[0]);
                 if (currentValue != null) {
-                    if (currentValue.Value is IList)
+                    if (currentValue.Value is IList<object>)
                     {
                         _valueList.AddRange(currentValue.Value as IList<object>);
                     }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
@@ -700,6 +700,24 @@ namespace Microsoft.PowerShell.Commands
 
         private bool _passThru;
 
+        /// <summary>
+        /// Append to the variable if it exists
+        /// </summary>
+        [Parameter]
+        public SwitchParameter Append
+        {
+            get
+            {
+                return _append;
+            }
+            set
+            {
+                _append = value;
+            }
+        }
+
+        private bool _append;
+
         private bool _nameIsFormalParameter;
         private bool _valueIsFormalParameter;
         #endregion parameters
@@ -717,6 +735,31 @@ namespace Microsoft.PowerShell.Commands
             if (Value != AutomationNull.Value)
             {
                 _valueIsFormalParameter = true;
+            }
+
+            if (_append)
+            {
+                // create the list here and add to it if it has a value
+                // but if they have more than one name, produce an error
+                if (Name.Length != 1)
+                {
+                    ErrorRecord er = new ErrorRecord(new InvalidOperationException(), "SetVariableAppend", ErrorCategory.InvalidOperation, Name);
+                    er.ErrorDetails = new ErrorDetails("SetVariable");
+                    er.ErrorDetails.RecommendedAction = "Use a single variable rather than a collection";
+                    ThrowTerminatingError(er);
+                }
+                _valueList = new List<object>();
+                var currentValue = Context.SessionState.PSVariable.Get(Name[0]);
+                if (currentValue != null) {
+                    if (currentValue.Value is IList)
+                    {
+                        _valueList.AddRange(currentValue.Value as IList<object>);
+                    }
+                    else
+                    {
+                        _valueList.Add(currentValue.Value);
+                    }
+                }
             }
         }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
@@ -713,7 +713,14 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _append = value;
+                if (ExperimentalFeature.IsEnabled("PSRedirectToVariable"))
+                {
+                    _append = value;
+                }
+                else
+                {
+                    throw new ArgumentException("ExperimentalFeature 'PSRedirectToVariable' is not enabled");
+                }
             }
         }
 
@@ -744,10 +751,10 @@ namespace Microsoft.PowerShell.Commands
                 // but if they have more than one name, produce an error
                 if (Name.Length != 1)
                 {
-                    ErrorRecord er = new ErrorRecord(new InvalidOperationException(), "SetVariableAppend", ErrorCategory.InvalidOperation, Name);
-                    er.ErrorDetails = new ErrorDetails("SetVariable");
-                    er.ErrorDetails.RecommendedAction = "Use a single variable rather than a collection";
-                    ThrowTerminatingError(er);
+                    ErrorRecord appendVariableError = new ErrorRecord(new InvalidOperationException(), "SetVariableAppend", ErrorCategory.InvalidOperation, Name);
+                    appendVariableError.ErrorDetails = new ErrorDetails("SetVariable");
+                    appendVariableError.ErrorDetails.RecommendedAction = "Use a single variable rather than a collection";
+                    ThrowTerminatingError(appendVariableError);
                 }
                 _valueList = new List<object>();
                 var currentValue = Context.SessionState.PSVariable.Get(Name[0]);

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -25,6 +25,7 @@ namespace System.Management.Automation
         internal const string PSNativeCommandErrorActionPreferenceFeatureName = "PSNativeCommandErrorActionPreference";
         internal const string PSRemotingSSHTransportErrorHandling = "PSRemotingSSHTransportErrorHandling";
         internal const string PSCleanBlockFeatureName = "PSCleanBlock";
+        internal const string PSRedirectToVariable = "PSRedirectToVariable";
 
         #endregion
 
@@ -134,6 +135,9 @@ namespace System.Management.Automation
                 new ExperimentalFeature(
                     name: PSCleanBlockFeatureName,
                     description: "Add support of a 'Clean' block to functions and script cmdlets for easy resource cleanup"),
+                new ExperimentalFeature(
+                    name: PSRedirectToVariable,
+                    description: "Add support for redirecting to the variable drive"),
             };
 
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -1164,27 +1164,53 @@ namespace System.Management.Automation
                 return new Pipe { NullPipe = true };
             }
 
-            CommandProcessorBase commandProcessor = context.CreateCommand("out-file", false);
-            Diagnostics.Assert(commandProcessor != null, "CreateCommand returned null");
+            // determine whether we're trying to set a variable by inspecting the file path
+            // if we can determine that it's a variable, we'll use Set-Variable rather than Out-File
+            ProviderInfo p;
+            PSDriveInfo d;
+            CommandProcessorBase commandProcessor;
+            var name = context.SessionState.Path.GetUnresolvedProviderPathFromPSPath(File, out p, out d);
 
-            // Previously, we mandated Unicode encoding here
-            // Now, We can take what ever has been set if PSDefaultParameterValues
-            // Unicode is still the default, but now may be overridden
-
-            var cpi = CommandParameterInternal.CreateParameterWithArgument(
-                /*parameterAst*/null, "Filepath", "-Filepath:",
-                /*argumentAst*/null, File,
-                false);
-            commandProcessor.AddParameter(cpi);
-
-            if (this.Appending)
+            if (p.NameEquals(context.ProviderNames.Variable))
             {
-                cpi = CommandParameterInternal.CreateParameterWithArgument(
-                    /*parameterAst*/null, "Append", "-Append:",
-                    /*argumentAst*/null, true,
+                commandProcessor = context.CreateCommand("Set-Variable", false);
+                Diagnostics.Assert(commandProcessor != null, "CreateCommand returned null");
+                var cpi = CommandParameterInternal.CreateParameterWithArgument(
+                    /*parameterAst*/null, "Name", "-Name:",
+                    /*argumentAst*/null, name,
                     false);
                 commandProcessor.AddParameter(cpi);
+
+                if (this.Appending)
+                {
+                    commandProcessor.AddParameter(CommandParameterInternal.CreateParameter("Append","-Append",null));
+                }
             }
+            else
+            {
+                commandProcessor = context.CreateCommand("out-file", false);
+                Diagnostics.Assert(commandProcessor != null, "CreateCommand returned null");
+
+                // Previously, we mandated Unicode encoding here
+                // Now, We can take what ever has been set if PSDefaultParameterValues
+                // Unicode is still the default, but now may be overridden
+
+                var cpi = CommandParameterInternal.CreateParameterWithArgument(
+                    /*parameterAst*/null, "Filepath", "-Filepath:",
+                    /*argumentAst*/null, File,
+                    false);
+                commandProcessor.AddParameter(cpi);
+
+                if (this.Appending)
+                {
+                    cpi = CommandParameterInternal.CreateParameterWithArgument(
+                        /*parameterAst*/null, "Append", "-Append:",
+                        /*argumentAst*/null, true,
+                        false);
+                    commandProcessor.AddParameter(cpi);
+                }
+            }
+
 
             PipelineProcessor = new PipelineProcessor();
             PipelineProcessor.Add(commandProcessor);

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -1171,7 +1171,7 @@ namespace System.Management.Automation
             CommandProcessorBase commandProcessor;
             var name = context.SessionState.Path.GetUnresolvedProviderPathFromPSPath(File, out p, out d);
 
-            if (ExperimentalFeature.IsEnabled("PSRedirectToVariable") && p.NameEquals(context.ProviderNames.Variable))
+            if (ExperimentalFeature.IsEnabled("PSRedirectToVariable") && p != null && p.NameEquals(context.ProviderNames.Variable))
             {
                 commandProcessor = context.CreateCommand("Set-Variable", false);
                 Diagnostics.Assert(commandProcessor != null, "CreateCommand returned null");

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -1183,7 +1183,7 @@ namespace System.Management.Automation
 
                 if (this.Appending)
                 {
-                    commandProcessor.AddParameter(CommandParameterInternal.CreateParameter("Append","-Append",null));
+                    commandProcessor.AddParameter(CommandParameterInternal.CreateParameter("Append", "-Append", null));
                 }
             }
             else
@@ -1210,7 +1210,6 @@ namespace System.Management.Automation
                     commandProcessor.AddParameter(cpi);
                 }
             }
-
 
             PipelineProcessor = new PipelineProcessor();
             PipelineProcessor.Add(commandProcessor);

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -1171,7 +1171,7 @@ namespace System.Management.Automation
             CommandProcessorBase commandProcessor;
             var name = context.SessionState.Path.GetUnresolvedProviderPathFromPSPath(File, out p, out d);
 
-            if (p.NameEquals(context.ProviderNames.Variable))
+            if (ExperimentalFeature.IsEnabled("PSRedirectToVariable") && p.NameEquals(context.ProviderNames.Variable))
             {
                 commandProcessor = context.CreateCommand("Set-Variable", false);
                 Diagnostics.Assert(commandProcessor != null, "CreateCommand returned null");

--- a/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
+++ b/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
@@ -124,9 +124,15 @@ Describe "File redirection should have 'DoComplete' called on the underlying pip
     }
 }
 
-Describe "Redirection and Set-Variable -append tests" {
+Describe "Redirection and Set-Variable -append tests" -tags CI {
     Context "variable redirection should work" {
         BeforeAll {
+            if ( $EnabledExperimentalFeatures -contains "PSRedirectToVariable" ) {
+                $skipTest = $false
+            }
+            else {
+                $skipTest = $true
+            }
             $testCases = @{ Name = "Variable should be created"; scriptBlock = { 1..3>variable:a }; Validation = { ($a -join "") | Should -Be ((1..3) -join "") } },
                 @{ Name = "variable should be appended"; scriptBlock = {1..3>variable:a; 4..6>>variable:a}; Validation = { ($a -join "") | Should -Be ((1..6) -join "")}},
                 @{ Name = "variable should maintain type"; scriptBlock = {@{one=1}>variable:a};Validation = {$a | Should -BeOfType [hashtable]}},
@@ -214,7 +220,7 @@ Describe "Redirection and Set-Variable -append tests" {
 
 
         }
-        It "<name>" -TestCases $testCases {
+        It "<name>" -TestCases $testCases -skip:$skipTest {
             param ( $scriptBlock, $validation )
             . $scriptBlock
             . $validation

--- a/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
+++ b/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
@@ -123,3 +123,101 @@ Describe "File redirection should have 'DoComplete' called on the underlying pip
         $errorContent | Should -Match "CommandNotFoundException,Microsoft.PowerShell.Commands.GetCommandCommand"
     }
 }
+
+Describe "Redirection and Set-Variable -append tests" {
+    Context "variable redirection should work" {
+        BeforeAll {
+            $testCases = @{ Name = "Variable should be created"; scriptBlock = { 1..3>variable:a }; Validation = { ($a -join "") | Should -Be ((1..3) -join "") } },
+                @{ Name = "variable should be appended"; scriptBlock = {1..3>variable:a; 4..6>>variable:a}; Validation = { ($a -join "") | Should -Be ((1..6) -join "")}},
+                @{ Name = "variable should maintain type"; scriptBlock = {@{one=1}>variable:a};Validation = {$a | Should -BeOfType [hashtable]}},
+                @{
+                    Name = "variable should maintain type for multiple objects"
+                    scriptBlock = {@{one=1}>variable:a;@{two=2}>>variable:a;1>>variable:a;"string">>variable:a}
+                    Validation = {
+                        $a.count | Should -Be 4
+                        ,$a | Should -BeOfType [array]
+                        $a[0] | Should -BeOfType [hashtable]
+                        $a[1] | Should -BeOfType [hashtable]
+                        $a[2] | Should -BeOfType [int]
+                        $a[3] | Should -BeOfType [string]
+                        $a[0].one | Should -Be 1
+                        $a[1].two | Should -Be 2
+                        $a[2] | Should -Be 1
+                        $a[3] | Should -Be "string"
+                        }
+                    },
+                 @{ Name = "Error stream should be redirectable"
+                     scriptBlock = { write-error bad 2>variable:a}
+                     validation = {
+                        $a |Should -BeOfType [System.Management.Automation.ErrorRecord]
+                        $a.Exception.Message | Should -BeExactly "bad"
+                        }
+                     },
+                 @{ Name = "Warning stream should be redirectable"
+                     scriptBlock = { write-warning warn 3>variable:a}
+                     validation = {
+                        $a |Should -BeOfType [System.Management.Automation.WarningRecord]
+                        $a.Message | Should -BeExactly "warn"
+                        }
+                     },
+                 @{ Name = "Verbose stream should be redirectable"
+                     scriptBlock = { write-verbose -verbose verb 4>variable:a}
+                     validation = {
+                        $a |Should -BeOfType [System.Management.Automation.VerboseRecord]
+                        $a.Message | Should -BeExactly "verb"
+                        }
+                     },
+                 @{ Name = "Debug stream should be redirectable" 
+                     scriptBlock = { write-debug -debug deb 5>variable:a}
+                     validation = {
+                        $a |Should -BeOfType [System.Management.Automation.DebugRecord]
+                        $a.Message | Should -BeExactly "deb"
+                        }
+                     },
+                 @{ Name = "Information stream should be redirectable"
+                     scriptBlock = { write-information info 6>variable:a}
+                     validation = {
+                         $a |Should -BeOfType [System.Management.Automation.InformationRecord]
+                         $a.MessageData | Should -BeExactly "info"
+                         }
+                     },
+                 @{ Name = "Complex redirection should be supported"
+                     scriptBlock = {
+                        . {
+                            write-error bad
+                            write-information info
+                            } *>variable:a
+                        }
+                    validation = {
+                        $a.Count | Should -Be 2
+                        $a[0] | Should -BeOfType [System.Management.Automation.ErrorRecord]
+                        $a[0].Exception.Message | Should -Be "bad"
+                        $a[1] |Should -BeOfType [System.Management.Automation.InformationRecord]
+                        $a[1].MessageData | Should -BeExactly "info"
+                        }
+                    },
+                  @{
+                    Name = "multiple redirections should work"
+                     scriptBlock = {
+                        . {
+                            write-error bad
+                            write-information info
+                            } 2>variable:e 6>variable:i
+                        }
+                     validation = {
+                        $e | Should -BeOfType [System.Management.Automation.ErrorRecord]
+                        $e.Exception.Message | Should -Be "bad"
+                        $i | Should -BeOfType [System.Management.Automation.InformationRecord]
+                        $i.MessageData | Should -BeExactly "info"
+                     }
+                 }
+
+
+        }
+        It "<name>" -TestCases $testCases {
+            param ( $scriptBlock, $validation )
+            . $scriptBlock
+            . $validation
+        }
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageRestriction.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageRestriction.Tests.ps1
@@ -460,7 +460,7 @@ try
             $rs.Open()
             $pl = $rs.CreatePipeline('"Hello" > c:\temp\foo.txt')
 
-            $e = { $pl.Invoke() } | Should -Throw -ErrorId "CmdletInvocationException"
+            $e = { $pl.Invoke() } | Should -Throw -ErrorId "DriveNotFoundException"
 
             $rs.Dispose()
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This enables streams to be redirected to a variable.
Also, a new parameter for Set-Variable is available `-append`
this is a treatment for #12754

## PR Context

Currently, it is very difficult to capture alternative streams and retain their object nature. Streams may be redirected to a file, but that will be only the text representation. This PR allows the following syntax to be supported.

```powershell
PS> write-warning "This is a warning"
WARNING: This is a warning
PS> write-warning "This is a warning" 3>variable:mywarning
PS> $mywarning|fl -for *

WARNING: FullyQualifiedWarningId : 
WARNING: Message                 : This is a warning
WARNING: InvocationInfo          : System.Management.Automation.InvocationInfo
WARNING: PipelineIterationInfo   : {0, 0, 0}
WARNING: 
```

multiple redirections are also supported:

```powershell
PS> .{ write-warning warn!; write-verbose -verbose verbose!; write-information Info! } 3>variable:v1 4>variable:v2 6>variable:v3
PS> .{ $v1;$v2;$v3}|fl -for *                                                                                                   

WARNING: FullyQualifiedWarningId : 
WARNING: Message                 : warn!
WARNING: InvocationInfo          : System.Management.Automation.InvocationInfo
WARNING: PipelineIterationInfo   : {0, 0}
WARNING: 
VERBOSE: Message               : verbose!
VERBOSE: InvocationInfo        : System.Management.Automation.InvocationInfo
VERBOSE: PipelineIterationInfo : {0, 0}
VERBOSE: 
MessageData     : Info!
Source          : Write-Information
TimeGenerated   : 11/20/2021 10:59:06 AM
Tags            : {}
User            : james
Computer        : computername
ProcessId       : 71896
NativeThreadId  : 16548359
ManagedThreadId : 23
```

A side effect of this change is that the following is also possible:
```powershell
PS> get-date > variable:dd
PS> $dd

Saturday, November 20, 2021 11:04:23 AM
```

but should be discouraged as it is not performant.

Additionally, a new parameter is available for `Set-Variable`. The `-Append` parameter will append to a variable when a value is piped to it.

```powershell
PS> set-variable -Name v1 -Value 1
PS> $v1
1
PS> 2 | set-variable -Name v1 -Append
PS> $v1
1
2
```

If attempting to append to multiple variables, an error will be produced.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [x] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [x] Experimental feature name(s): PSRedirectToVariable
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
