### PR TITLE
Fix completions inside the param block

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -154,7 +154,10 @@ namespace System.Management.Automation
                 inputAst,
                 ast => IsCursorWithinOrJustAfterExtent(positionForAstSearch, ast.Extent),
                 searchNestedScriptBlocks: true).ToList();
-
+            if (relatedAsts[^1].Extent.Text.StartsWith("param", StringComparison.OrdinalIgnoreCase) && relatedAsts[^1] is NamedBlockAst namedBlock && namedBlock.Unnamed)
+            {
+                relatedAsts.RemoveAt(relatedAsts.Count - 1);
+            }
             Diagnostics.Assert(tokenAtCursor == null || tokenBeforeCursor == null, "Only one of these tokens can be non-null");
 
             return new AstAnalysisContext(tokenAtCursor, tokenBeforeCursor, relatedAsts, replacementIndex);
@@ -395,11 +398,6 @@ namespace System.Management.Automation
 
             var tokenAtCursor = completionContext.TokenAtCursor;
             Ast lastAst = completionContext.RelatedAsts[^1];
-            if (lastAst.Extent.Text.StartsWith("param", StringComparison.OrdinalIgnoreCase) && lastAst is NamedBlockAst namedBlock && namedBlock.Unnamed)
-            {
-                completionContext.RelatedAsts.RemoveAt(completionContext.RelatedAsts.Count - 1);
-                lastAst = completionContext.RelatedAsts[^1];
-            }
             List<CompletionResult> result = null;
             if (tokenAtCursor != null)
             {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -394,7 +394,12 @@ namespace System.Management.Automation
             replacementLength = -1;
 
             var tokenAtCursor = completionContext.TokenAtCursor;
-            var lastAst = completionContext.RelatedAsts.Last();
+            Ast lastAst = completionContext.RelatedAsts[^1];
+            if (lastAst.Extent.Text.StartsWith("param", StringComparison.OrdinalIgnoreCase) && lastAst is NamedBlockAst namedBlock && namedBlock.Unnamed)
+            {
+                completionContext.RelatedAsts.RemoveAt(completionContext.RelatedAsts.Count - 1);
+                lastAst = completionContext.RelatedAsts[^1];
+            }
             List<CompletionResult> result = null;
             if (tokenAtCursor != null)
             {

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1707,6 +1707,18 @@ function MyFunction ($param1, $param2)
             $res = TabExpansion2 -cursorColumn $CursorIndex -inputScript $TestString.Remove($CursorIndex, 1)
             $res.CompletionMatches.CompletionText | Should -BeExactly $Expected
         }
+        It 'Should complete parameter in param block' {
+            $res = TabExpansion2 -inputScript 'Param($Param1=(Get-ChildItem -))' -cursorColumn 30
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly '-Path'
+        }
+        It 'Should complete member in param block' {
+            $res = TabExpansion2 -inputScript 'Param($Param1=($PSVersionTable.))' -cursorColumn 31
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly 'Count'
+        }
+        It 'Should complete attribute argument in param block' {
+            $res = TabExpansion2 -inputScript 'Param([Parameter()]$Param1)' -cursorColumn 17
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly 'Position'
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Fixes https://github.com/PowerShell/PowerShell/issues/15300
where various completions don't work inside the param block if there's not an explicit begin/process/end block following the param block.
This is fixed by removing the implicit NamedBlockAst from the relatedAsts list.  
As mentioned in the issue, this is just the easiest solution to the problem. Another approach would be to update all of the different code paths to account for this seemingly unrelated Ast being last in the relatedAsts list.  
All tests pass and I haven't been able to find something that breaks with this approach.
<!-- Summarize your PR between here and the checklist. -->
## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
