### PR TITLE
Reduce the amount of startup banner text

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -690,7 +690,6 @@ namespace Microsoft.PowerShell
                 if (!string.IsNullOrEmpty(bannerText))
                 {
                     hostUI.WriteLine(bannerText);
-                    hostUI.WriteLine();
                 }
 
                 if (UpdatesNotification.CanNotifyUpdates)

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/UpdatesNotification.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/UpdatesNotification.cs
@@ -126,6 +126,7 @@ namespace Microsoft.PowerShell
 
                 string notificationMsg = string.Format(CultureInfo.CurrentCulture, notificationMsgTemplate, releaseTag, notificationColor, resetColor, line2Padding, line3Padding);
 
+                hostUI.WriteLine();
                 hostUI.WriteLine(notificationMsg);
             }
         }

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -118,11 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ShellBannerNonWindowsPowerShell" xml:space="preserve">
-    <value>PowerShell {0}
-Copyright (c) Microsoft Corporation.
-
-https://aka.ms/powershell
-Type 'help' to get help.</value>
+    <value>PowerShell {0}</value>
   </data>
   <data name="PSReadLineDisabledWhenScreenReaderIsActive" xml:space="preserve">
     <value>Warning: PowerShell detected that you might be using a screen reader and has disabled PSReadLine for compatibility purposes. If you want to re-enable it, run 'Import-Module PSReadLine'.</value>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -379,7 +379,7 @@ All parameters are case-insensitive.</value>
 
 -NoLogo | -nol
 
-    Hides the copyright banner at startup of interactive sessions.
+    Hides the banner text at startup of interactive sessions.
 
 -NonInteractive | -noni
 

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -880,7 +880,6 @@ namespace StackTest {
             Wait-UntilTrue -sb { $process.HasExited } -TimeoutInMilliseconds 5000 -IntervalInMilliseconds 250 | Should -BeTrue
 
             $out = @(Get-Content $outputPath)
-            Write-Warning "pwsh output is: '$($out -join '\n')'"
             $out.Count | Should -BeExactly 3
             $out[0] | Should -BeExactly "PowerShell $($PSVersionTable.GitCommitId)"
             $out[1] | Should -MatchExactly $expectedPromptPattern1
@@ -893,7 +892,6 @@ namespace StackTest {
             Wait-UntilTrue -sb { $process.HasExited } -TimeoutInMilliseconds 5000 -IntervalInMilliseconds 250 | Should -BeTrue
 
             $out = @(Get-Content $outputPath)
-            Write-Warning "pwsh output is: '$($out -join '\n')'"
             $out.Count | Should -BeExactly 2
             $out[0] | Should -MatchExactly $expectedPromptPattern1
             $out[1] | Should -MatchExactly $expectedPromptPattern2

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -845,6 +845,11 @@ namespace StackTest {
             $origPSUpdateCheckVal = $env:POWERSHELL_UPDATECHECK
             $env:POWERSHELL_UPDATECHECK = "Off"
 
+            # During some runs of pwsh, the ANSI DECCKM enable(1h)/disable(1l) sequences wind up in the output
+            $escPwd = [regex]::Escape($pwd)
+            $expectedPromptPattern1 = "PS ${escPwd}> (1h)?\`$PSStyle.OutputRendering = 'PlainText'"
+            $expectedPromptPattern2 = "(1l)?PS ${escPwd}> exit"
+
             $spArgs = @{
                 FilePath = $powershell
                 ArgumentList = @("-NoProfile")
@@ -878,8 +883,8 @@ namespace StackTest {
             Write-Warning "pwsh output is: '$($out -join '\n')'"
             $out.Count | Should -BeExactly 3
             $out[0] | Should -BeExactly "PowerShell $($PSVersionTable.GitCommitId)"
-            $out[1] | Should -BeExactly "PS ${pwd}> `$PSStyle.OutputRendering = 'PlainText'"
-            $out[2] | Should -BeExactly "PS ${pwd}> exit"
+            $out[1] | Should -MatchExactly $expectedPromptPattern1
+            $out[2] | Should -MatchExactly $expectedPromptPattern2
         }
         It "Displays only the prompt with -NoLogo" {
             $spArgs["ArgumentList"] += "-NoLogo"
@@ -890,8 +895,8 @@ namespace StackTest {
             $out = @(Get-Content $outputPath)
             Write-Warning "pwsh output is: '$($out -join '\n')'"
             $out.Count | Should -BeExactly 2
-            $out[0] | Should -BeExactly "PS ${pwd}> `$PSStyle.OutputRendering = 'PlainText'"
-            $out[1] | Should -BeExactly "PS ${pwd}> exit"
+            $out[0] | Should -MatchExactly $expectedPromptPattern1
+            $out[1] | Should -MatchExactly $expectedPromptPattern2
         }
     }
 }

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -875,6 +875,7 @@ namespace StackTest {
             Wait-UntilTrue -sb { $process.HasExited } -TimeoutInMilliseconds 5000 -IntervalInMilliseconds 250 | Should -BeTrue
 
             $out = @(Get-Content $outputPath)
+            Write-Host "pwsh output is: '$($out -join '\n')'"
             $out.Count | Should -BeExactly 2
             $out[0] | Should -BeExactly "PowerShell $($PSVersionTable.GitCommitId)"
             $out[1] | Should -BeExactly "PS ${pwd}> exit"
@@ -886,6 +887,7 @@ namespace StackTest {
             Wait-UntilTrue -sb { $process.HasExited } -TimeoutInMilliseconds 5000 -IntervalInMilliseconds 250 | Should -BeTrue
 
             $out = @(Get-Content $outputPath)
+            Write-Host "pwsh output is: '$($out -join '\n')'"
             $out.Count | Should -BeExactly 1
             $out[0] | Should -BeExactly "PS ${pwd}> exit"
         }

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -877,7 +877,7 @@ namespace StackTest {
             Wait-UntilTrue -sb { $process.HasExited } -TimeoutInMilliseconds 5000 -IntervalInMilliseconds 250 | Should -BeTrue
 
             $out = @(Get-Content $outputPath)
-            $out.Count | Should -BeExactly 2
+            $out.Count | Should -Be 2
             $out[0] | Should -BeExactly "PowerShell $($PSVersionTable.GitCommitId)"
             $out[1] | Should -MatchExactly $expectedPromptPattern
         }
@@ -887,7 +887,7 @@ namespace StackTest {
             Wait-UntilTrue -sb { $process.HasExited } -TimeoutInMilliseconds 5000 -IntervalInMilliseconds 250 | Should -BeTrue
 
             $out = @(Get-Content $outputPath)
-            $out.Count | Should -BeExactly 1
+            $out.Count | Should -Be 1
             $out[0] | Should -MatchExactly $expectedPromptPattern
         }
     }

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -856,6 +856,9 @@ namespace StackTest {
             }
         }
         AfterAll {
+            Remove-Item $inputPath -Force -ErrorAction Ignore
+            Remove-Item $outputPath -Force -ErrorAction Ignore
+
             # Restore original value of $env:POWERSHELL_UPDATECHECK
             if ($origUpdateCheckVal) {
                 $env:POWERSHELL_UPDATECHECK = $origUpdateCheckVal

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -837,7 +837,7 @@ namespace StackTest {
     Context "Startup banner text tests" -Tag Slow {
         BeforeAll {
             $inputPath = "Temp:\StartupBannerTest-Input.txt"
-            "exit" > $inputPath
+            "`$PSStyle.OutputRendering = 'PlainText'`nexit" > $inputPath
 
             $outputPath = "Temp:\StartupBannerTest-Output-${Pid}.txt"
 
@@ -876,9 +876,10 @@ namespace StackTest {
 
             $out = @(Get-Content $outputPath)
             Write-Warning "pwsh output is: '$($out -join '\n')'"
-            $out.Count | Should -BeExactly 2
+            $out.Count | Should -BeExactly 3
             $out[0] | Should -BeExactly "PowerShell $($PSVersionTable.GitCommitId)"
-            $out[1] | Should -BeExactly "PS ${pwd}> exit"
+            $out[1] | Should -BeExactly "PS ${pwd}> `$PSStyle.OutputRendering = 'PlainText'"
+            $out[2] | Should -BeExactly "PS ${pwd}> exit"
         }
         It "Displays only the prompt with -NoLogo" {
             $spArgs["ArgumentList"] += "-NoLogo"
@@ -888,8 +889,9 @@ namespace StackTest {
 
             $out = @(Get-Content $outputPath)
             Write-Warning "pwsh output is: '$($out -join '\n')'"
-            $out.Count | Should -BeExactly 1
-            $out[0] | Should -BeExactly "PS ${pwd}> exit"
+            $out.Count | Should -BeExactly 2
+            $out[0] | Should -BeExactly "PS ${pwd}> `$PSStyle.OutputRendering = 'PlainText'"
+            $out[1] | Should -BeExactly "PS ${pwd}> exit"
         }
     }
 }

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -836,13 +836,13 @@ namespace StackTest {
 
     Context "Startup banner text tests" -Tag Slow {
         BeforeAll {
-            $outputPath = Join-Path $env:temp "StartupBannerTest-Output-${Pid}.txt"
-
             $inputPath = Join-Path $env:temp "StartupBannerTest-Input.txt"
             "exit" > $inputPath
 
+            $outputPath = Join-Path $env:temp "StartupBannerTest-Output-${Pid}.txt"
+
             # Not testing update notification banner text here
-            $origUpdateCheckVal = $env:POWERSHELL_UPDATECHECK
+            $origPSUpdateCheckVal = $env:POWERSHELL_UPDATECHECK
             $env:POWERSHELL_UPDATECHECK = "Off"
 
             $spArgs = @{
@@ -859,11 +859,11 @@ namespace StackTest {
             Remove-Item $inputPath -Force -ErrorAction Ignore
             Remove-Item $outputPath -Force -ErrorAction Ignore
 
-            # Restore original value of $env:POWERSHELL_UPDATECHECK
-            if ($origUpdateCheckVal) {
-                $env:POWERSHELL_UPDATECHECK = $origUpdateCheckVal
+            # Restore original value of $env:POWERSHELL_UPDATECHECK or remove it if it didn't exist
+            if ($origPSUpdateCheckVal) {
+                $env:POWERSHELL_UPDATECHECK = $origPSUpdateCheckVal
             }
-            else {
+            elseif (Test-Path Env:\POWERSHELL_UPDATECHECK) {
                 Remove-Item Env:\POWERSHELL_UPDATECHECK -Force
             }
         }
@@ -880,7 +880,7 @@ namespace StackTest {
             $out[1] | Should -BeExactly "PS ${pwd}> exit"
         }
         It "Displays only the prompt with -NoLogo" {
-            $spArgs.ArgumentList += "-NoLogo"
+            $spArgs["ArgumentList"] += "-NoLogo"
 
             $process = Start-Process @spArgs
             Wait-UntilTrue -sb { $process.HasExited } -TimeoutInMilliseconds 5000 -IntervalInMilliseconds 250 | Should -BeTrue

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -875,7 +875,7 @@ namespace StackTest {
             Wait-UntilTrue -sb { $process.HasExited } -TimeoutInMilliseconds 5000 -IntervalInMilliseconds 250 | Should -BeTrue
 
             $out = @(Get-Content $outputPath)
-            Write-Host "pwsh output is: '$($out -join '\n')'"
+            Write-Warning "pwsh output is: '$($out -join '\n')'"
             $out.Count | Should -BeExactly 2
             $out[0] | Should -BeExactly "PowerShell $($PSVersionTable.GitCommitId)"
             $out[1] | Should -BeExactly "PS ${pwd}> exit"
@@ -887,7 +887,7 @@ namespace StackTest {
             Wait-UntilTrue -sb { $process.HasExited } -TimeoutInMilliseconds 5000 -IntervalInMilliseconds 250 | Should -BeTrue
 
             $out = @(Get-Content $outputPath)
-            Write-Host "pwsh output is: '$($out -join '\n')'"
+            Write-Warning "pwsh output is: '$($out -join '\n')'"
             $out.Count | Should -BeExactly 1
             $out[0] | Should -BeExactly "PS ${pwd}> exit"
         }

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -847,8 +847,8 @@ namespace StackTest {
 
             # During some runs of pwsh, the ANSI DECCKM enable(1h)/disable(1l) sequences wind up in the output
             $escPwd = [regex]::Escape($pwd)
-            $expectedPromptPattern1 = "PS ${escPwd}> (1h)?\`$PSStyle.OutputRendering = 'PlainText'"
-            $expectedPromptPattern2 = "(1l)?PS ${escPwd}> exit"
+            $expectedPromptPattern1 = "^PS ${escPwd}> (\x1b\[\?1h)?\`$PSStyle.OutputRendering = 'PlainText'`$"
+            $expectedPromptPattern2 = "^(\x1b\[\?1l)?PS ${escPwd}> exit`$"
 
             $spArgs = @{
                 FilePath = $powershell

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -836,10 +836,10 @@ namespace StackTest {
 
     Context "Startup banner text tests" -Tag Slow {
         BeforeAll {
-            $inputPath = Join-Path $env:temp "StartupBannerTest-Input.txt"
+            $inputPath = "Temp:\StartupBannerTest-Input.txt"
             "exit" > $inputPath
 
-            $outputPath = Join-Path $env:temp "StartupBannerTest-Output-${Pid}.txt"
+            $outputPath = "Temp:\StartupBannerTest-Output-${Pid}.txt"
 
             # Not testing update notification banner text here
             $origPSUpdateCheckVal = $env:POWERSHELL_UPDATECHECK
@@ -863,8 +863,8 @@ namespace StackTest {
             if ($origPSUpdateCheckVal) {
                 $env:POWERSHELL_UPDATECHECK = $origPSUpdateCheckVal
             }
-            elseif (Test-Path Env:\POWERSHELL_UPDATECHECK) {
-                Remove-Item Env:\POWERSHELL_UPDATECHECK -Force
+            else {
+                Remove-Item Env:\POWERSHELL_UPDATECHECK -Force -ErrorAction Ignore
             }
         }
         BeforeEach {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR does not set -nologo as the default, instead it removes the
copyright line, the two "how to get help" lines and two blank lines
around the "how to get help" lines.

The following is the resulting startup banner when there is no update available OR the user has disabled updating checking via the `POWERSHELL_UPDATECHECK` environment variable:

![image](https://user-images.githubusercontent.com/5177512/143382343-dc126f36-bde6-431e-a719-07423f50770d.png)

compare this with the current startup banner:

![image](https://user-images.githubusercontent.com/5177512/143382413-07447d65-10b0-4bff-8189-3010641a0f49.png)

When there is an update available AND the user has not disabled update checking, the reduced startup banner looks like this:

![image](https://user-images.githubusercontent.com/5177512/143382483-977d40c7-3842-48ba-bfad-1b56a3ba43fb.png)

If we decide that we want to keep the `Type 'help' to get help.` text, I propose something like this:

![image](https://user-images.githubusercontent.com/5177512/143382548-92d419f0-4c59-4a74-baf6-0cb9573821b0.png)

![image](https://user-images.githubusercontent.com/5177512/143382557-4024e655-b035-4fad-99f9-36b6399fb297.png)

BTW here are some other startup banners for comparison:

![image](https://user-images.githubusercontent.com/5177512/143386079-a89d6fa1-b2c1-4903-898b-fb5368b20e85.png)

As you can see, bash and nodejs have no startup banner text at all and Python's is a bit wordy.  :-)

## PR Context

Addresses #15644

Regarding documentation impact, I think this would only impact images/text blocks where the PowerShell startup banner is shown.  But what I'm seeing so far in the online help is images of Windows PowerShell startup banner text.  @sdwheeler are there areas of the online help where PowerShell v6/7 startup banner text is shown?

This PR currently leaves the profile timing text as-is.

The PR is meant to give folks a way to test drive a reduced startup banner.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/8476
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
