### PR TITLE
DotNetTypeAdapter - treat init-only properties as non-settable

### DIFF
--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -4067,7 +4067,8 @@ namespace System.Management.Automation
         /// <returns>True if the property is settable.</returns>
         protected override bool PropertyIsSettable(PSProperty property)
         {
-            return !((PropertyCacheEntry)property.adapterData).readOnly && !((PropertyCacheEntry)property.adapterData).initOnly;
+            PropertyCacheEntry adapterData = (PropertyCacheEntry)property.adapterData;
+            return !adapterData.readOnly && !adapterData.initOnly;
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -2790,7 +2790,7 @@ namespace System.Management.Automation
                     this.isStatic = propertySetter.IsStatic;
                     foreach (Type requiredCustomModifier in propertySetter.ReturnParameter.GetRequiredCustomModifiers())
                     {
-                        if (!requiredCustomModifier.IsNested && requiredCustomModifier.Name == "IsExternalInit" && requiredCustomModifier.Namespace == "System.Runtime.CompilerServices")
+                        if (!requiredCustomModifier.IsNested && requiredCustomModifier.FullName == "System.Runtime.CompilerServices.IsExternalInit")
                         {
                             this.initOnly = true;
                             break;

--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -2788,7 +2788,7 @@ namespace System.Management.Automation
                 if (propertySetter != null && (propertySetter.IsPublic || propertySetter.IsFamily))
                 {
                     this.isStatic = propertySetter.IsStatic;
-                    foreach (var requiredCustomModifier in propertySetter.ReturnParameter.GetRequiredCustomModifiers())
+                    foreach (Type requiredCustomModifier in propertySetter.ReturnParameter.GetRequiredCustomModifiers())
                     {
                         if (!requiredCustomModifier.IsNested && requiredCustomModifier.Name == "IsExternalInit" && requiredCustomModifier.Namespace == "System.Runtime.CompilerServices")
                         {

--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -2790,7 +2790,7 @@ namespace System.Management.Automation
                     this.isStatic = propertySetter.IsStatic;
                     foreach (Type requiredCustomModifier in propertySetter.ReturnParameter.GetRequiredCustomModifiers())
                     {
-                        if (!requiredCustomModifier.IsNested && requiredCustomModifier.FullName == "System.Runtime.CompilerServices.IsExternalInit")
+                        if (requiredCustomModifier.FullName == "System.Runtime.CompilerServices.IsExternalInit")
                         {
                             this.initOnly = true;
                             break;

--- a/test/powershell/engine/ETS/Adapter.Tests.ps1
+++ b/test/powershell/engine/ETS/Adapter.Tests.ps1
@@ -236,7 +236,7 @@ public class InitOnlyTestClass
 
         It "Init-only properties are not settable via ETS" {
             $iotc = [InitOnlyTestClass]@{ Value = 123 }
-            { $iotc.Value = 456 } | Should -Throw -ErrorId PropertyAssignmentException -ExpectedMessage "'Value' is a ReadOnly property."
+            { $iotc.Value = 456 } | Should -Throw -ErrorId PropertyAssignmentException
         }
     }
 

--- a/test/powershell/engine/ETS/Adapter.Tests.ps1
+++ b/test/powershell/engine/ETS/Adapter.Tests.ps1
@@ -236,7 +236,7 @@ public class InitOnlyTestClass
 
         It "Init-only properties are not settable via ETS" {
             $iotc = [InitOnlyTestClass]@{ Value = 123 }
-            { $iotc.Value = 456 } | Should -Throw -ExceptionType ([System.InvalidOperationException])
+            { $iotc.Value = 456 } | Should -Throw -ErrorId PropertyAssignmentException -ExpectedMessage "'Value' is a ReadOnly property."
         }
     }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR modifies the .NET type adapter to respect [the `IsExternalInit` modifier](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/init#metadata-encoding) on property setters. 

`IsExternalInit` is the mechanism through which the C# 9.0 specification implements support for init-only setters - properties that can only be set during instantiation, after which they're considered read-only by the compiler.

By inspecting the property setter's return parameter we can similarly discover the `IsExternalInit` modifier on runtime types, and change the behavior of ETS to reject attempts to set init-only properties by having `Adapter.PropertyIsSettable()` reflect whether the modifier was found.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

As reported in https://github.com/PowerShell/PowerShell/issues/13819, PowerShell has no current facility for detecting init-only 
 properties, and what the C# compiler would now treat as read-only properties are suddenly writable/settable at runtime:

```
PS ~> $PSVersionTable['PSVersion'] -as [string]
7.2.0
PS ~> Add-Type @'
>> public class InitOnlyValue {public long Value {get; init;}}
>> '@
PS ~> $value = [InitOnlyValue]@{ Value = 123 }
PS ~> $value

Value
-----
  123

PS ~> $value.Value = 456
PS ~> $value

Value
-----
  456

PS ~> $value |Get-Member -MemberType Properties

   TypeName: InitOnlyValue

Name  MemberType Definition
----  ---------- ----------
Value Property   long Value {get;set;}

```

After we apply the changes in this PR, PowerShell's behavior reflects that of [C#](https://github.com/dotnet/roslyn/blob/2da789af0f404e15871b6e6e17706185a2707ab4/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs#L1931-L1966) (and [VB.NET](https://github.com/dotnet/roslyn/commit/0a39566fae0541423aa4c7ad3e0cae584f5dcd5c)):

```
PS ~> $value = [InitOnlyValue]@{ Value = 123 }
PS ~> $value

Value
-----
  123

PS ~> $value.Value = 456
InvalidOperation: 'Value' is a ReadOnly property.
PS ~> $value |Get-Member -MemberType Property

   TypeName: InitOnlyValue

Name  MemberType Definition
----  ---------- ----------
Value Property   long Value {get;}
```

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
