### PR TITLE
Fix race condition between DisconnectAsync and Dispose

### DIFF
--- a/src/System.Management.Automation/engine/remoting/client/RemotingProtocol2.cs
+++ b/src/System.Management.Automation/engine/remoting/client/RemotingProtocol2.cs
@@ -829,7 +829,10 @@ namespace System.Management.Automation.Internal
             {
                 remoteSession?.DisconnectAsync();
             }
-            catch { }
+            catch 
+            {
+                // remoteSession may have already been disposed resulting in unexpected exceptions.
+            }
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/remoting/client/RemotingProtocol2.cs
+++ b/src/System.Management.Automation/engine/remoting/client/RemotingProtocol2.cs
@@ -824,7 +824,12 @@ namespace System.Management.Automation.Internal
         /// <param name="state"></param>
         private void StartDisconnectAsync(object state)
         {
-            RemoteSession?.DisconnectAsync();
+            var remoteSession = RemoteSession;
+            try
+            {
+                remoteSession?.DisconnectAsync();
+            }
+            catch { }
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/remoting/client/RemotingProtocol2.cs
+++ b/src/System.Management.Automation/engine/remoting/client/RemotingProtocol2.cs
@@ -813,7 +813,7 @@ namespace System.Management.Automation.Internal
                     // what thread this callback is made from.  If it was made from a transport
                     // callback event then a deadlock may occur when DisconnectAsync is called on
                     // that same thread.
-                    ThreadPool.QueueUserWorkItem(new WaitCallback(StartDisconnectAsync), RemoteSession);
+                    ThreadPool.QueueUserWorkItem(new WaitCallback(StartDisconnectAsync));
                 }
             }
         }
@@ -822,9 +822,9 @@ namespace System.Management.Automation.Internal
         /// WaitCallback method to start an asynchronous disconnect.
         /// </summary>
         /// <param name="remoteSession"></param>
-        private void StartDisconnectAsync(object remoteSession)
+        private void StartDisconnectAsync(object state)
         {
-            ((ClientRemoteSession)remoteSession).DisconnectAsync();
+            RemoteSession?.DisconnectAsync();
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/remoting/client/RemotingProtocol2.cs
+++ b/src/System.Management.Automation/engine/remoting/client/RemotingProtocol2.cs
@@ -821,7 +821,7 @@ namespace System.Management.Automation.Internal
         /// <summary>
         /// WaitCallback method to start an asynchronous disconnect.
         /// </summary>
-        /// <param name="remoteSession"></param>
+        /// <param name="state"></param>
         private void StartDisconnectAsync(object state)
         {
             RemoteSession?.DisconnectAsync();


### PR DESCRIPTION
# PR Summary
Make `StartDisconnectAsync` running on a background thread able to run after `Dispose` has been invoked. 

## PR Context
There is an inherent race condition in offloading to the `ThreadPool`.
Dispose can run before `RemoteSession.DisconnectAsync`.
This will result in an NRE inside `ClientRemoteSession`.
An unhandled exception in a `ThreadPool` thread crashes the process.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
