### PR TITLE
Fix ForEach-Object -Parallel when passing in script block variable

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -685,7 +685,7 @@
         "Type": "nuget",
         "Nuget": {
           "Name": "StyleCop.Analyzers.Unstable",
-          "Version": "1.2.0.354"
+          "Version": "1.2.0.376"
         }
       },
       "DevelopmentDependency": true

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -382,17 +382,6 @@ namespace Microsoft.PowerShell.Commands
         private Exception _taskCollectionException;
         private string _currentLocationPath;
 
-        // List of Foreach-Object command names and aliases.
-        // TODO: Look into using SessionState.Internal.GetAliasTable() to find all user created aliases.
-        //       But update Alias command logic to maintain reverse table that lists all aliases mapping
-        //       to a single command definition, for performance.
-        private static readonly string[] forEachNames = new string[]
-        {
-            "ForEach-Object",
-            "foreach",
-            "%"
-        };
-
         private void InitParallelParameterSet()
         {
             // The following common parameters are not (yet) supported in this parameter set.
@@ -423,8 +412,7 @@ namespace Microsoft.PowerShell.Commands
             _usingValuesMap = ScriptBlockToPowerShellConverter.GetUsingValuesForEachParallel(
                 scriptBlock: Parallel,
                 isTrustedInput: allowUsingExpression,
-                context: this.Context,
-                foreachNames: forEachNames);
+                context: this.Context);
 
             // Validate using values map, which is a map of '$using:' variables referenced in the script.
             // Script block variables are not allowed since their behavior is undefined outside the runspace

--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -192,6 +192,7 @@ namespace System.Management.Automation.PSTasks
         /// <param name="dollarUnderbar">Dollar underbar variable value for script block.</param>
         /// <param name="currentLocationPath">Current working directory.</param>
         /// <param name="job">Job object associated with task.</param>
+        /// </summary>
         public PSJobTask(
             ScriptBlock scriptBlock,
             Dictionary<string, object> usingValuesMap,

--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -192,7 +192,6 @@ namespace System.Management.Automation.PSTasks
         /// <param name="dollarUnderbar">Dollar underbar variable value for script block.</param>
         /// <param name="currentLocationPath">Current working directory.</param>
         /// <param name="job">Job object associated with task.</param>
-        /// </summary>
         public PSJobTask(
             ScriptBlock scriptBlock,
             Dictionary<string, object> usingValuesMap,

--- a/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
+++ b/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
@@ -452,7 +452,7 @@ namespace System.Management.Automation
                 currentParent = currentParent.Parent;
             }
 
-            return foreachNestedCount == 1;
+            return foreachNestedCount <= 1;
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
+++ b/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
@@ -336,6 +336,7 @@ namespace System.Management.Automation
             // Foreach-Object -Parallel call scope. This will filter the using variable map to variables 
             // only within the current (outer) Foreach-Object -Parallel call scope.
             var usingAsts = UsingExpressionAstSearcher.FindAllUsingExpressions(scriptBlock.Ast).ToList();
+            
             // If the scriptblock ast parent is null, then it comes from a scriptblock variable and does
             // not include the initiating Foreach-Object -Parallel command.
             bool astIncludesForEachCommand = scriptBlock.Ast.Parent is not null;

--- a/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
+++ b/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
@@ -336,6 +336,7 @@ namespace System.Management.Automation
             // Foreach-Object -Parallel call scope. This will filter the using variable map to variables 
             // only within the current (outer) Foreach-Object -Parallel call scope.
             var usingAsts = UsingExpressionAstSearcher.FindAllUsingExpressions(scriptBlock.Ast).ToList();
+
             // If the scriptblock ast parent is null, then it comes from a scriptblock variable and does
             // not include the initiating Foreach-Object -Parallel command.
             bool astIncludesForEachCommand = scriptBlock.Ast.Parent is not null;

--- a/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
+++ b/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
@@ -336,6 +336,9 @@ namespace System.Management.Automation
             // Foreach-Object -Parallel call scope. This will filter the using variable map to variables 
             // only within the current (outer) Foreach-Object -Parallel call scope.
             var usingAsts = UsingExpressionAstSearcher.FindAllUsingExpressions(scriptBlock.Ast).ToList();
+            // If the scriptblock ast parent is null, then it comes from a scriptblock variable and does
+            // not include the initiating Foreach-Object -Parallel command.
+            bool astIncludesForEachCommand = scriptBlock.Ast.Parent is not null;
             UsingExpressionAst usingAst = null;
             var usingValueMap = new Dictionary<string, object>(usingAsts.Count);
             Version oldStrictVersion = null;
@@ -352,7 +355,7 @@ namespace System.Management.Automation
                     usingAst = (UsingExpressionAst)usingAsts[i];
                     if (IsInForeachParallelCallingScope(
                         usingAst: usingAst,
-                        astIncludesForEachCommand: scriptBlock.Ast.Parent is not null,
+                        astIncludesForEachCommand: astIncludesForEachCommand,
                         foreachNames: foreachNames))
                     {
                         var value = Compiler.GetExpressionValue(usingAst.SubExpression, isTrustedInput, context);

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
@@ -87,6 +87,101 @@ Describe 'ForEach-Object -Parallel Basic Tests' -Tags 'CI' {
         $usingErrors[0].FullyQualifiedErrorId | Should -BeExactly 'UsingVariableIsUndefined,Microsoft.PowerShell.Commands.ForEachObjectCommand'
     }
 
+    It 'Verifies using variables with passed-in script block object' {
+
+        $var = "Hello"
+        $varArray = "Hello","There"
+        $sBlock = [scriptblock]::Create('$using:var; $using:varArray[1]')
+        $result = 1..1 | ForEach-Object -Parallel $sBlock
+        $result[0] | Should -BeExactly $var
+        $result[1] | Should -BeExactly $varArray[1]
+    }
+
+    It 'Verifies in scope using same-name variables in nested calls for passed-in script block objects' {
+
+        $Test = "Test1"
+        $sBlock = [scriptblock]::Create(@'
+            $using:Test1
+            $Test = "Test2"
+            $sBlock2 = [scriptblock]::Create('$using:Test')
+            1..2 | ForEach-Object -Parallel $sBlock2
+'@)
+        $results = 1..2 | ForEach-Object -Parallel $sBlock
+        $results.Count | Should -BeExactly 6
+        $groups = $results | Group-Object -AsHashTable
+        $groups['Test1'].Count | Should -BeExactly 2
+        $groups['Test2'].Count | Should -BeExactly 4
+    }
+
+    It 'Verifies in scope using same-name variables in nested calls for mixed script block objects' {
+
+        $Test = "Test1"
+        $sBlock = [scriptblock]::Create(@'
+            $using:Test1
+            $Test = "Test2"
+            1..2 | ForEach-Object -Parallel { $using:Test }
+'@)
+        $results = 1..2 | ForEach-Object -Parallel $sBlock
+        $results.Count | Should -BeExactly 6
+        $groups = $results | Group-Object -AsHashTable
+        $groups['Test1'].Count | Should -BeExactly 2
+        $groups['Test2'].Count | Should -BeExactly 4
+    }
+
+    It 'Verifies in scope using different-name variables in nested calls for passed-in script block objects' {
+
+        $Test1 = "Test1"
+        $sBlock = [scriptblock]::Create(@'
+            $using:Test1
+            $Test2 = "Test2"
+            $sBlock2 = [scriptblock]::Create('$using:Test2')
+            1..2 | ForEach-Object -Parallel $sBlock2
+'@)
+        $results = 1..2 | ForEach-Object -Parallel $sBlock
+        $results.Count | Should -BeExactly 6
+        $groups = $results | Group-Object -AsHashTable
+        $groups['Test1'].Count | Should -BeExactly 2
+        $groups['Test2'].Count | Should -BeExactly 4
+    }
+
+    It 'Verifies in scope using different-name variables in nested calls for mixed script block objects' {
+
+        $Test1 = "Test1"
+        $sBlock = [scriptblock]::Create(@'
+            $using:Test1
+            $Test2 = "Test2"
+            1..2 | ForEach-Object -Parallel { $using:Test2 }
+'@)
+        $results = 1..2 | ForEach-Object -Parallel $sBlock
+        $results.Count | Should -BeExactly 6
+        $groups = $results | Group-Object -AsHashTable
+        $groups['Test1'].Count | Should -BeExactly 2
+        $groups['Test2'].Count | Should -BeExactly 4
+    }
+
+    It 'Verifies expected error for out of scope using variable in nested calls for passed-in script block objects' {
+
+        $Test = "TestZ"
+        $sBlock = [scriptblock]::Create(@'
+            $using:Test
+            $sBlock2 = [scriptblock]::Create('$using:Test')
+            1..1 | ForEach-Object -Parallel $sBlock2
+'@)
+        1..1 | ForEach-Object -Parallel $SBlock -ErrorVariable usingErrors 2>$null
+        $usingErrors[0].FullyQualifiedErrorId | Should -BeExactly 'UsingVariableIsUndefined,Microsoft.PowerShell.Commands.ForEachObjectCommand'
+    }
+
+    It 'Verifies expected error for out of scope using variable in nested calls for mixed script block objects' {
+
+        $Test = "TestZ"
+        $sBlock = [scriptblock]::Create(@'
+            $using:Test
+            1..1 | ForEach-Object -Parallel { $using:Test }
+'@)
+        1..1 | ForEach-Object -Parallel $SBlock -ErrorVariable usingErrors 2>$null
+        $usingErrors[0].FullyQualifiedErrorId | Should -BeExactly 'UsingVariableIsUndefined,Microsoft.PowerShell.Commands.ForEachObjectCommand'
+    }
+
     It 'Verifies terminating error streaming' {
 
         $result = 1..1 | ForEach-Object -Parallel { throw 'Terminating Error!'; "Hello" } 2>&1
@@ -150,7 +245,7 @@ Describe 'ForEach-Object -Parallel Basic Tests' -Tags 'CI' {
         $pr[0].StatusDescription | Should -Be Running
         $ps.Dispose()
     }
- 
+
     It 'Verifies information data streaming' {
 
         $actualInformation = 1..1 | ForEach-Object -Parallel { Write-Information "Information!" } 6>&1

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
@@ -99,11 +99,11 @@ Describe 'ForEach-Object -Parallel Basic Tests' -Tags 'CI' {
 
     It 'Verifies in scope using same-name variables in nested calls for passed-in script block objects' {
 
-        $Test = "Test1"
+        $Test1 = "Test1"
         $sBlock = [scriptblock]::Create(@'
             $using:Test1
-            $Test = "Test2"
-            $sBlock2 = [scriptblock]::Create('$using:Test')
+            $Test2 = "Test2"
+            $sBlock2 = [scriptblock]::Create('$using:Test2')
             1..2 | ForEach-Object -Parallel $sBlock2
 '@)
         $results = 1..2 | ForEach-Object -Parallel $sBlock
@@ -115,11 +115,11 @@ Describe 'ForEach-Object -Parallel Basic Tests' -Tags 'CI' {
 
     It 'Verifies in scope using same-name variables in nested calls for mixed script block objects' {
 
-        $Test = "Test1"
+        $Test1 = "Test1"
         $sBlock = [scriptblock]::Create(@'
             $using:Test1
-            $Test = "Test2"
-            1..2 | ForEach-Object -Parallel { $using:Test }
+            $Test2 = "Test2"
+            1..2 | ForEach-Object -Parallel { $using:Test2 }
 '@)
         $results = 1..2 | ForEach-Object -Parallel $sBlock
         $results.Count | Should -BeExactly 6


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This change fixes #16445, where using variables were not being evaluated correctly when the -Parallel script block is passed in as a variable.

## PR Context

ForeEach-Object -Parallel using variable processing walks the script block AST to determine if the using variable was defined in the current scope, and does this by tracking the number of 'ForEach-Object -Parallel' commands in the call chain.
However, the provided script block is different, depending on whether it is passed in as a variable or via parameter binding.

```powershell
$myScript = '"Hello!"'
1 | ForEach-Object -Parallel ([scriptblock]::Create($myScript))
# Script block Ast does not contain the 'ForEach-Object' command in the call chain

1 | ForEach-Object -Parallel { "Hello!" }
# Script block Ast does contain the 'ForEach-Object' command in the call chain
```

This change takes into account the two forms of script blocks

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
