### PR TITLE
Make `Measure-Object` ignore missing properties unless running in strict mode

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
@@ -820,7 +820,7 @@ namespace Microsoft.PowerShell.Commands
                 Statistics stat = _statistics[propertyName];
                 if (stat.count == 0 && Property != null)
                 {
-                    if (Context.EngineSessionState.CurrentScope.StrictModeVersion?.Major != 0) 
+                    if (Context.IsStrictVersion(2))
                     {
                         string errorId = (IsMeasuringGeneric) ? "GenericMeasurePropertyNotFound" : "TextMeasurePropertyNotFound";
                         WritePropertyNotFoundError(propertyName, errorId);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
@@ -820,11 +820,12 @@ namespace Microsoft.PowerShell.Commands
                 Statistics stat = _statistics[propertyName];
                 if (stat.count == 0 && Property != null)
                 {
-                    // Why are there two different ids for this error?
-                    string errorId = (IsMeasuringGeneric) ? "GenericMeasurePropertyNotFound" : "TextMeasurePropertyNotFound";
-                    if (Context.EngineSessionState.CurrentScope.StrictModeVersion?.Major != 0) {
+                    if (Context.EngineSessionState.CurrentScope.StrictModeVersion?.Major != 0) 
+                    {
+                        string errorId = (IsMeasuringGeneric) ? "GenericMeasurePropertyNotFound" : "TextMeasurePropertyNotFound";
                         WritePropertyNotFoundError(propertyName, errorId);
                     }
+                    
                     continue;
                 }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
@@ -792,9 +792,9 @@ namespace Microsoft.PowerShell.Commands
         {
             Diagnostics.Assert(Property != null, "no property and no InputObject should have been addressed");
             ErrorRecord errorRecord = new(
-                    PSTraceSource.NewArgumentException("Property"),
+                    PSTraceSource.NewArgumentException(propertyName),
                     errorId,
-                    ErrorCategory.InvalidArgument,
+                    ErrorCategory.ObjectNotFound,
                     null);
             errorRecord.ErrorDetails = new ErrorDetails(
                 this, "MeasureObjectStrings", "PropertyNotFound", propertyName);
@@ -822,7 +822,9 @@ namespace Microsoft.PowerShell.Commands
                 {
                     // Why are there two different ids for this error?
                     string errorId = (IsMeasuringGeneric) ? "GenericMeasurePropertyNotFound" : "TextMeasurePropertyNotFound";
-                    WritePropertyNotFoundError(propertyName, errorId);
+                    if (Context.EngineSessionState.CurrentScope.StrictModeVersion?.Major != 0) {
+                        WritePropertyNotFoundError(propertyName, errorId);
+                    }
                     continue;
                 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Measure-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Measure-Object.Tests.ps1
@@ -196,16 +196,16 @@ Describe "Measure-Object" -Tags "CI" {
             $propertyName = "Length"
         }
 
+        AfterAll {
+            Set-StrictMode -off
+        }
+
         It "Should not throw an invalid property error when not in StrictMode" {
             { Set-StrictMode -off; Get-Item $testEmptyFolder | Measure-Object $propertyName -ErrorAction Stop -sum } | Should -Not -Throw
         }
 
         It "Should throw an invalid property error when in StrictMode" {
             { Set-StrictMode -version 3.0; Get-Item $testEmptyFolder | Measure-Object $propertyName -ErrorAction Stop -sum } | Should -Throw -ErrorId 'GenericMeasurePropertyNotFound,Microsoft.PowerShell.Commands.MeasureObjectCommand'
-        }
-
-        AfterAll {
-            Set-StrictMode -off
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Measure-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Measure-Object.Tests.ps1
@@ -189,6 +189,29 @@ Describe "Measure-Object" -Tags "CI" {
         }
     }
 
+    Context "Empty folder tests" {
+        BeforeAll {
+            $repoPath = Join-Path -Path $TESTDRIVE -ChildPath "my_folder"
+            $testEmptyFolder = New-Item $repoPath -ItemType "directory"
+            $propertyName = "Length"
+        }
+
+        It "Should not throw an invalid property error when not in StrictMode" {
+            { Set-StrictMode -off; Get-Item $testEmptyFolder | Measure-Object $propertyName -ErrorAction Stop -sum } | Should -Not -Throw
+        }
+    
+        It "Should throw an invalid property error when in StrictMode" {
+            Set-StrictMode -version 3.0
+            Get-Item $testEmptyFolder | Measure-Object -ErrorVariable Err $propertyName -sum -ErrorAction SilentlyContinue
+            $Err.count | Should -Be 1
+            $Err[0].FullyQualifiedErrorId | Should -BeExactly "GenericMeasurePropertyNotFound,Microsoft.PowerShell.Commands.MeasureObjectCommand"
+        }
+
+        AfterAll {
+            Set-StrictMode -off
+        }
+    }
+
     Context "String tests" {
         BeforeAll {
             $nl = [Environment]::NewLine

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Measure-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Measure-Object.Tests.ps1
@@ -199,12 +199,9 @@ Describe "Measure-Object" -Tags "CI" {
         It "Should not throw an invalid property error when not in StrictMode" {
             { Set-StrictMode -off; Get-Item $testEmptyFolder | Measure-Object $propertyName -ErrorAction Stop -sum } | Should -Not -Throw
         }
-    
+
         It "Should throw an invalid property error when in StrictMode" {
-            Set-StrictMode -version 3.0
-            Get-Item $testEmptyFolder | Measure-Object -ErrorVariable Err $propertyName -sum -ErrorAction SilentlyContinue
-            $Err.count | Should -Be 1
-            $Err[0].FullyQualifiedErrorId | Should -BeExactly "GenericMeasurePropertyNotFound,Microsoft.PowerShell.Commands.MeasureObjectCommand"
+            { Set-StrictMode -version 3.0; Get-Item $testEmptyFolder | Measure-Object $propertyName -ErrorAction Stop -sum } | Should -Throw -ErrorId 'GenericMeasurePropertyNotFound,Microsoft.PowerShell.Commands.MeasureObjectCommand'
         }
 
         AfterAll {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

When using Measure-Object on an empty folder, the "Length" property is invalid. When in StrictMode, an error is thrown when the requested property is not found. The error message is also updated to include the specific property that is not found. The invalid property is simply ignored when not in StrictMode.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

Fixes issue #14449
Unless in StrictMode, missing properties are typically ignored by other commands, so the Measure-Object command should do the same. This pull-request updates the Measure-Object command to only throw a property not found error when in StrictMode and ignores the property not found when not in StrictMode. This functionality is now consistent with other PowerShell commands.

## PR Steps to Reproduce

my_folder is an empty directory

**When StrictMode is off: no error**
Set-StrictMode -off
gi my_folder | measure Length -sum

**When StrictMode is on: error message**
Set-StrictMode -Version 3.0
gi my_folder | measure Length -sum

Measure-Object: Cannot process argument because the value of argument “Length” is not valid. Change the value of the “Length” argument and run the operation again.

## PR Changed Files

Measure-Object.cs
-Bug fix: changed "Property" to propertyName, the actual name of the property argument
-WritePropertyNotFoundError(propertyName, errorId) only called when in StrictMode

Measure-Object.Tests.ps1
-Added 2 empty folder tests where Measure-Object command is used on an empty folder
-When not in StrictMode, no error should be thrown
-When in StrictMode, error should be thrown

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
