### PR TITLE
Fix parsing SemanticVersion build label from version string

### DIFF
--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -720,9 +720,11 @@ namespace System.Management.Automation
                 }
                 else
                 {
-                    // This is a format error.
-                    // Format is 'major.minor.patch+BuildLabel-PreReleaseLabel'
-                    versionSansLabel = version;
+                    // No PreReleaseLabel: preLabel == null
+                    // Format is 'major.minor.patch+BuildLabel'
+                    buildLabel = version.Substring(plusIndex + 1);
+                    versionSansLabel = version.Substring(0, plusIndex);
+                    dashIndex = -1;
                 }
             }
             else

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -720,22 +720,27 @@ namespace System.Management.Automation
                 }
                 else
                 {
-                    // No PreReleaseLabel: preLabel == null
-                    // Format is 'major.minor.patch+BuildLabel'
-                    buildLabel = version.Substring(plusIndex + 1);
-                    versionSansLabel = version.Substring(0, plusIndex);
-                    dashIndex = -1;
+                    // This is a format error.
+                    // Format is 'major.minor.patch+BuildLabel-PreReleaseLabel'
+                    versionSansLabel = version;
                 }
             }
             else
             {
-                if (dashIndex == -1)
+                if (plusIndex == -1)
                 {
                     // Here dashIndex == plusIndex == -1
                     // No preLabel - preLabel == null;
                     // No buildLabel - buildLabel == null;
                     // Format is 'major.minor.patch'
                     versionSansLabel = version;
+                }
+                else if (dashIndex == -1)
+                {
+                    // No PreReleaseLabel: preLabel == null
+                    // Format is 'major.minor.patch+BuildLabel'
+                    buildLabel = version.Substring(plusIndex + 1);
+                    versionSansLabel = version.Substring(0, plusIndex);
                 }
                 else
                 {

--- a/test/powershell/engine/Basic/SemanticVersion.Tests.ps1
+++ b/test/powershell/engine/Basic/SemanticVersion.Tests.ps1
@@ -30,6 +30,14 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
             $v.BuildLabel | Should -Be "BLD.a1-xxx.03"
             $v.ToString() | Should -Be "1.2.3+BLD.a1-xxx.03"
 
+            $v = [SemanticVersion]::new("1.0.0+META")
+            $v.Major | Should -Be 1
+            $v.Minor | Should -Be 0
+            $v.Patch | Should -Be 0
+            $v.PreReleaseLabel | Should -BeNullOrEmpty
+            $v.BuildLabel | Should -Be "META"
+            $v.ToString() | Should -Be "1.0.0+META"
+
             $v = [SemanticVersion]::new("3.0")
             $v.Major | Should -Be 3
             $v.Minor | Should -Be 0

--- a/test/powershell/engine/Basic/SemanticVersion.Tests.ps1
+++ b/test/powershell/engine/Basic/SemanticVersion.Tests.ps1
@@ -22,6 +22,14 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
             $v.BuildLabel | Should -BeNullOrEmpty
             $v.ToString() | Should -Be "1.0.0"
 
+            $v = [SemanticVersion]::new("1.2.3+BLD.a1-xxx.03")
+            $v.Major | Should -Be 1
+            $v.Minor | Should -Be 0
+            $v.Patch | Should -Be 0
+            $v.PreReleaseLabel | Should -BeNullOrEmpty
+            $v.BuildLabel | Should -Be "BLD.a1-xxx.03"
+            $v.ToString() | Should -Be "1.2.3"
+
             $v = [SemanticVersion]::new("3.0")
             $v.Major | Should -Be 3
             $v.Minor | Should -Be 0

--- a/test/powershell/engine/Basic/SemanticVersion.Tests.ps1
+++ b/test/powershell/engine/Basic/SemanticVersion.Tests.ps1
@@ -24,11 +24,11 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
 
             $v = [SemanticVersion]::new("1.2.3+BLD.a1-xxx.03")
             $v.Major | Should -Be 1
-            $v.Minor | Should -Be 0
-            $v.Patch | Should -Be 0
+            $v.Minor | Should -Be 2
+            $v.Patch | Should -Be 3
             $v.PreReleaseLabel | Should -BeNullOrEmpty
             $v.BuildLabel | Should -Be "BLD.a1-xxx.03"
-            $v.ToString() | Should -Be "1.2.3"
+            $v.ToString() | Should -Be "1.2.3+BLD.a1-xxx.03"
 
             $v = [SemanticVersion]::new("3.0")
             $v.Major | Should -Be 3


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Improve the SemanticVersion parsing logic to handle missing cases.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

Parsing semantic version strings of the form `major.minor.patch+release` is broken.

Here is an example from PowerShell 7.2:
```
~/Source> $v1 = [System.Management.Automation.SemanticVersion]::new("1.0.0+META")
MethodInvocationException: Exception calling ".ctor" with "1" argument(s): "Input string was not in a correct format."
```

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
