### PR TITLE
Update the vmImage and PowerShell root directory for macOS builds

### DIFF
--- a/tools/releaseBuild/azureDevOps/templates/cloneToOfficialPath.yml
+++ b/tools/releaseBuild/azureDevOps/templates/cloneToOfficialPath.yml
@@ -1,7 +1,10 @@
+parameters:
+  nativePathRoot: ''
+
 steps:
   - powershell: |
       $dirSeparatorChar = [system.io.path]::DirectorySeparatorChar
-      $nativePath = "${env:HOME}${dirSeparatorChar}PowerShell"
+      $nativePath = "${{parameters.nativePathRoot }}${dirSeparatorChar}PowerShell"
       Write-Host "##vso[task.setvariable variable=PowerShellRoot]$nativePath"
 
       if ((Test-Path "$nativePath")) {

--- a/tools/releaseBuild/azureDevOps/templates/mac-package-build.yml
+++ b/tools/releaseBuild/azureDevOps/templates/mac-package-build.yml
@@ -112,7 +112,7 @@ jobs:
   - pwsh: |
       # Add -SkipReleaseChecks as a mitigation to unblock release.
       # macos-10.15 does not allow creating a folder under root. Hence, moving the folder.
-      $(Build.SourcesDirectory)/tools/releaseBuild/macOS/PowerShellPackageVsts.ps1 -ReleaseTag $(ReleaseTagVar) -Destination $(System.ArtifactsDirectory) -location $(PowerShellRoot) -ArtifactName macosPkgResults -BuildZip $(BuildPackagePath) -ExtraPackage "tar" -Runtime 'osx-${{ parameters.buildArchitecture }} -SkipReleaseChecks'
+      $(Build.SourcesDirectory)/tools/releaseBuild/macOS/PowerShellPackageVsts.ps1 -ReleaseTag $(ReleaseTagVar) -Destination $(System.ArtifactsDirectory) -location $(PowerShellRoot) -ArtifactName macosPkgResults -BuildZip $(BuildPackagePath) -ExtraPackage "tar" -Runtime 'osx-${{ parameters.buildArchitecture }}' -SkipReleaseChecks
     displayName: 'Package'
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0

--- a/tools/releaseBuild/azureDevOps/templates/mac-package-build.yml
+++ b/tools/releaseBuild/azureDevOps/templates/mac-package-build.yml
@@ -23,11 +23,11 @@ jobs:
 
   - pwsh: |
       # create folder
-      sudo mkdir "${env:HOME}/PowerShell"
+      sudo mkdir "$(Agent.TempDirectory)/PowerShell"
 
       # make the current user the owner
-      sudo chown $env:USER "${env:HOME}/PowerShell"
-    displayName: 'Create ${env:HOME}/PowerShell'
+      sudo chown $env:USER "$(Agent.TempDirectory)/PowerShell"
+    displayName: 'Create $(Agent.TempDirectory)/PowerShell'
 
   - template: SetVersionVariables.yml
     parameters:
@@ -36,6 +36,8 @@ jobs:
   - template: shouldSign.yml
 
   - template: cloneToOfficialPath.yml
+    parameters:
+      nativePathRoot: '$(Agent.TempDirectory)'
 
   - task: DownloadBuildArtifacts@0
     displayName: Download macosBinResults

--- a/tools/releaseBuild/azureDevOps/templates/mac-package-build.yml
+++ b/tools/releaseBuild/azureDevOps/templates/mac-package-build.yml
@@ -8,7 +8,7 @@ jobs:
   dependsOn: MacFileSigningJob_${{ parameters.buildArchitecture }}
   condition: succeeded()
   pool:
-    vmImage: internal-macos-11
+    vmImage: macos-latest
   variables:
     # Turn off Homebrew analytics
     - name: HOMEBREW_NO_ANALYTICS
@@ -23,11 +23,11 @@ jobs:
 
   - pwsh: |
       # create folder
-      sudo mkdir /PowerShell
+      sudo mkdir "${env:HOME}/PowerShell"
 
       # make the current user the owner
-      sudo chown $env:USER /PowerShell
-    displayName: 'Create /PowerShell'
+      sudo chown $env:USER "${env:HOME}/PowerShell"
+    displayName: 'Create ${env:HOME}/PowerShell'
 
   - template: SetVersionVariables.yml
     parameters:
@@ -108,7 +108,9 @@ jobs:
     displayName: 'Bootstrap VM'
 
   - pwsh: |
-      $(Build.SourcesDirectory)/tools/releaseBuild/macOS/PowerShellPackageVsts.ps1 -ReleaseTag $(ReleaseTagVar) -Destination $(System.ArtifactsDirectory) -location $(PowerShellRoot) -ArtifactName macosPkgResults -BuildZip $(BuildPackagePath) -ExtraPackage "tar" -Runtime 'osx-${{ parameters.buildArchitecture }}'
+      # Add -SkipReleaseChecks as a mitigation to unblock release.
+      # macos-10.15 does not allow creating a folder under root. Hence, moving the folder.
+      $(Build.SourcesDirectory)/tools/releaseBuild/macOS/PowerShellPackageVsts.ps1 -ReleaseTag $(ReleaseTagVar) -Destination $(System.ArtifactsDirectory) -location $(PowerShellRoot) -ArtifactName macosPkgResults -BuildZip $(BuildPackagePath) -ExtraPackage "tar" -Runtime 'osx-${{ parameters.buildArchitecture }} -SkipReleaseChecks'
     displayName: 'Package'
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0

--- a/tools/releaseBuild/azureDevOps/templates/mac.yml
+++ b/tools/releaseBuild/azureDevOps/templates/mac.yml
@@ -28,13 +28,15 @@ jobs:
 
   - pwsh: |
       # create folder
-      sudo mkdir "${env:HOME}/PowerShell"
+      sudo mkdir "$(Agent.TempDirectory)/PowerShell"
 
       # make the current user the owner
-      sudo chown $env:USER "${env:HOME}/PowerShell"
-    displayName: 'Create ${env:HOME}/PowerShell'
+      sudo chown $env:USER "$(Agent.TempDirectory)/PowerShell"
+    displayName: 'Create $(Agent.TempDirectory)/PowerShell'
 
   - template: cloneToOfficialPath.yml
+    parameters:
+      nativePathRoot: '$(Agent.TempDirectory)'
 
   - pwsh: |
       tools/releaseBuild/macOS/PowerShellPackageVsts.ps1 -location $(PowerShellRoot) -BootStrap

--- a/tools/releaseBuild/azureDevOps/templates/mac.yml
+++ b/tools/releaseBuild/azureDevOps/templates/mac.yml
@@ -6,7 +6,7 @@ jobs:
   displayName: Build macOS ${{ parameters.buildArchitecture }}
   condition: succeeded()
   pool:
-    vmImage: internal-macos-11
+    vmImage: macos-latest
   variables:
     # Turn off Homebrew analytics
     - name: HOMEBREW_NO_ANALYTICS


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Update to use macos-latest and the vmImage for the macOS release build.
Use the Agent.TempDirectory as the Powershell root, as the AzDO recommendation.
Optionally, use the Agent.TempDirectory as PS root for macOS builds.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
