### PR TITLE
Report error when PowerShell built-in modules are missing

### DIFF
--- a/src/System.Management.Automation/engine/CommandDiscovery.cs
+++ b/src/System.Management.Automation/engine/CommandDiscovery.cs
@@ -376,9 +376,8 @@ namespace System.Management.Automation
 
             foreach (var requiresPSSnapIn in requiresPSSnapIns)
             {
-                IEnumerable<PSSnapInInfo> loadedPSSnapIns = null;
-                loadedPSSnapIns = context.InitialSessionState.GetPSSnapIn(requiresPSSnapIn.Name);
-                if (loadedPSSnapIns == null || !loadedPSSnapIns.Any())
+                var loadedPSSnapIn = context.InitialSessionState.GetPSSnapIn(requiresPSSnapIn.Name);
+                if (loadedPSSnapIn is null)
                 {
                     if (requiresMissingPSSnapIns == null)
                     {
@@ -390,8 +389,7 @@ namespace System.Management.Automation
                 else
                 {
                     // the requires PSSnapin is loaded. now check the PSSnapin version
-                    PSSnapInInfo loadedPSSnapIn = loadedPSSnapIns.First();
-                    Diagnostics.Assert(loadedPSSnapIn.Version != null,
+                    Dbg.Assert(loadedPSSnapIn.Version != null,
                         string.Format(
                             CultureInfo.InvariantCulture,
                             "Version is null for loaded PSSnapin {0}.", loadedPSSnapIn));

--- a/src/System.Management.Automation/engine/CommandDiscovery.cs
+++ b/src/System.Management.Automation/engine/CommandDiscovery.cs
@@ -1110,7 +1110,7 @@ namespace System.Management.Automation
                                     throw new CommandNotFoundException(
                                         originalCommandName,
                                         lastError,
-                                        nameof(DiscoveryExceptions.CouldNotAutoImportMatchingModule),
+                                        "CouldNotAutoloadMatchingModule",
                                         errorMessage);
                                 }
 

--- a/src/System.Management.Automation/engine/CommandDiscovery.cs
+++ b/src/System.Management.Automation/engine/CommandDiscovery.cs
@@ -379,11 +379,7 @@ namespace System.Management.Automation
                 var loadedPSSnapIn = context.InitialSessionState.GetPSSnapIn(requiresPSSnapIn.Name);
                 if (loadedPSSnapIn is null)
                 {
-                    if (requiresMissingPSSnapIns == null)
-                    {
-                        requiresMissingPSSnapIns = new Collection<string>();
-                    }
-
+                    requiresMissingPSSnapIns ??= new Collection<string>();
                     requiresMissingPSSnapIns.Add(BuildPSSnapInDisplayName(requiresPSSnapIn));
                 }
                 else
@@ -398,11 +394,7 @@ namespace System.Management.Automation
                         if (!AreInstalledRequiresVersionsCompatible(
                             requiresPSSnapIn.Version, loadedPSSnapIn.Version))
                         {
-                            if (requiresMissingPSSnapIns == null)
-                            {
-                                requiresMissingPSSnapIns = new Collection<string>();
-                            }
-
+                            requiresMissingPSSnapIns ??= new Collection<string>();
                             requiresMissingPSSnapIns.Add(BuildPSSnapInDisplayName(requiresPSSnapIn));
                         }
                     }
@@ -1097,7 +1089,7 @@ namespace System.Management.Automation
                                     cmdletInfo != null ? cmdletInfo.Visibility : SessionStateEntryVisibility.Private,
                                     out lastError);
 
-                                if (matchingModule == null || matchingModule.Count == 0)
+                                if (matchingModule is null || matchingModule.Count == 0)
                                 {
                                     string errorMessage = lastError is null
                                         ? StringUtil.Format(DiscoveryExceptions.CouldNotAutoImportMatchingModule, commandName, moduleShortName)

--- a/src/System.Management.Automation/engine/CommandDiscovery.cs
+++ b/src/System.Management.Automation/engine/CommandDiscovery.cs
@@ -1063,14 +1063,12 @@ namespace System.Management.Automation
                     return null;
 
                 CmdletInfo cmdletInfo = context.SessionState.InvokeCommand.GetCmdlet("Microsoft.PowerShell.Core\\Get-Module");
-                if ((commandOrigin == CommandOrigin.Internal) ||
-                    ((cmdletInfo != null) && (cmdletInfo.Visibility == SessionStateEntryVisibility.Public)))
+                if (commandOrigin == CommandOrigin.Internal || cmdletInfo?.Visibility == SessionStateEntryVisibility.Public)
                 {
                     // Search for a module with a matching command, as long as the user would have the ability to
                     // import the module.
                     cmdletInfo = context.SessionState.InvokeCommand.GetCmdlet("Microsoft.PowerShell.Core\\Import-Module");
-                    if (((commandOrigin == CommandOrigin.Internal) ||
-                         ((cmdletInfo != null) && (cmdletInfo.Visibility == SessionStateEntryVisibility.Public))))
+                    if (commandOrigin == CommandOrigin.Internal || cmdletInfo?.Visibility == SessionStateEntryVisibility.Public)
                     {
                         discoveryTracer.WriteLine("Executing non module-qualified search: {0}", commandName);
                         context.CommandDiscovery.RegisterLookupCommandInfoAction("ActiveModuleSearch", commandName);
@@ -1085,8 +1083,8 @@ namespace System.Management.Automation
                         {
                             // WinBlue:69141 - We need to get the full path here because the module path might be C:\Users\User1\DOCUME~1
                             // While the exportedCommands are cached, they are cached with the full path
-                            string expandedModulePath = IO.Path.GetFullPath(modulePath);
-                            string moduleShortName = System.IO.Path.GetFileNameWithoutExtension(expandedModulePath);
+                            string expandedModulePath = Path.GetFullPath(modulePath);
+                            string moduleShortName = Path.GetFileNameWithoutExtension(expandedModulePath);
                             var exportedCommands = AnalysisCache.GetExportedCommands(expandedModulePath, false, context);
 
                             if (exportedCommands == null) { continue; }

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -3970,20 +3970,14 @@ namespace System.Management.Automation.Runspaces
             return psSnapInInfo;
         }
 
-        internal List<PSSnapInInfo> GetPSSnapIn(string psSnapinName)
+        internal PSSnapInInfo GetPSSnapIn(string psSnapinName)
         {
-            List<PSSnapInInfo> loadedSnapins = null;
             if (ImportedSnapins.TryGetValue(psSnapinName, out PSSnapInInfo importedSnapin))
             {
-                if (loadedSnapins is null)
-                {
-                    loadedSnapins = new List<PSSnapInInfo>();
-                }
-
-                loadedSnapins.Add(importedSnapin);
+                return importedSnapin;
             }
 
-            return loadedSnapins;
+            return null;
         }
 
         [SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.Reflection.Assembly.LoadFrom")]

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -1663,11 +1663,6 @@ namespace System.Management.Automation.Runspaces
 
             ss.DisableFormatUpdates = this.DisableFormatUpdates;
 
-            foreach (var s in this.defaultSnapins)
-            {
-                ss.defaultSnapins.Add(s);
-            }
-
             foreach (var s in ImportedSnapins)
             {
                 ss.ImportedSnapins.Add(s.Key, s.Value);
@@ -3801,34 +3796,26 @@ namespace System.Management.Automation.Runspaces
 
             // Now actually load the snapin...
             PSSnapInInfo snapin = ImportPSSnapIn(newPSSnapIn, out warning);
-            if (snapin != null)
-            {
-                ImportedSnapins.Add(snapin.Name, snapin);
-            }
 
             return snapin;
         }
 
         internal PSSnapInInfo ImportCorePSSnapIn()
         {
-            // Load Microsoft.PowerShell.Core as a snapin
+            // Load Microsoft.PowerShell.Core as a snapin.
             PSSnapInInfo coreSnapin = PSSnapInReader.ReadCoreEngineSnapIn();
-            this.defaultSnapins.Add(coreSnapin);
-            try
-            {
-                PSSnapInException warning;
-                this.ImportPSSnapIn(coreSnapin, out warning);
-            }
-            catch (PSSnapInException)
-            {
-                throw;
-            }
-
+            ImportPSSnapIn(coreSnapin, out _);
             return coreSnapin;
         }
 
         internal PSSnapInInfo ImportPSSnapIn(PSSnapInInfo psSnapInInfo, out PSSnapInException warning)
         {
+            if (psSnapInInfo == null)
+            {
+                ArgumentNullException e = new ArgumentNullException(nameof(psSnapInInfo));
+                throw e;
+            }
+
             // See if the snapin is already loaded. If has been then there will be an entry in the
             // Assemblies list for it already...
             bool reload = true;
@@ -3860,12 +3847,6 @@ namespace System.Management.Automation.Runspaces
             Dictionary<string, SessionStateCmdletEntry> cmdlets = null;
             Dictionary<string, List<SessionStateAliasEntry>> aliases = null;
             Dictionary<string, SessionStateProviderEntry> providers = null;
-
-            if (psSnapInInfo == null)
-            {
-                ArgumentNullException e = new ArgumentNullException(nameof(psSnapInInfo));
-                throw e;
-            }
 
             Assembly assembly = null;
             string helpFile = null;
@@ -3985,29 +3966,16 @@ namespace System.Management.Automation.Runspaces
                 }
             }
 
+            ImportedSnapins.Add(psSnapInInfo.Name, psSnapInInfo);
             return psSnapInInfo;
         }
 
         internal List<PSSnapInInfo> GetPSSnapIn(string psSnapinName)
         {
             List<PSSnapInInfo> loadedSnapins = null;
-            foreach (var defaultSnapin in defaultSnapins)
+            if (ImportedSnapins.TryGetValue(psSnapinName, out PSSnapInInfo importedSnapin))
             {
-                if (defaultSnapin.Name.Equals(psSnapinName, StringComparison.OrdinalIgnoreCase))
-                {
-                    if (loadedSnapins == null)
-                    {
-                        loadedSnapins = new List<PSSnapInInfo>();
-                    }
-
-                    loadedSnapins.Add(defaultSnapin);
-                }
-            }
-
-            PSSnapInInfo importedSnapin = null;
-            if (ImportedSnapins.TryGetValue(psSnapinName, out importedSnapin))
-            {
-                if (loadedSnapins == null)
+                if (loadedSnapins is null)
                 {
                     loadedSnapins = new List<PSSnapInInfo>();
                 }
@@ -4886,7 +4854,6 @@ end {
 
         internal static readonly string CoreSnapin = "Microsoft.PowerShell.Core";
         internal static readonly string CoreModule = "Microsoft.PowerShell.Core";
-        internal Collection<PSSnapInInfo> defaultSnapins = new Collection<PSSnapInInfo>();
 
         // The list of engine modules to create warnings when you try to remove them
         internal static readonly HashSet<string> EngineModules = new HashSet<string>(StringComparer.OrdinalIgnoreCase)

--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -636,6 +636,8 @@ namespace Microsoft.PowerShell.Commands
 
         private PSModuleInfo ImportModule_LocallyViaName(ImportModuleOptions importModuleOptions, string name)
         {
+            bool shallWriteError = !importModuleOptions.SkipSystem32ModulesAndSuppressError;
+
             try
             {
                 bool found = false;
@@ -671,14 +673,14 @@ namespace Microsoft.PowerShell.Commands
                 }
 
                 bool alreadyLoaded = false;
+                var manifestProcessingFlags = ManifestProcessingFlags.LoadElements | ManifestProcessingFlags.NullOnFirstError;
+                if (shallWriteError)
+                {
+                    manifestProcessingFlags |= ManifestProcessingFlags.WriteErrors;
+                }
+
                 if (!string.IsNullOrEmpty(rootedPath))
                 {
-                    // TODO/FIXME: use IsModuleAlreadyLoaded to get consistent behavior
-                    // TODO/FIXME: (for example checking ModuleType != Manifest below seems incorrect - cdxml modules also declare their own version)
-                    // PSModuleInfo alreadyLoadedModule = null;
-                    // TryGetFromModuleTable(rootedPath, out alreadyLoadedModule);
-                    // if (!BaseForce && IsModuleAlreadyLoaded(alreadyLoadedModule))
-
                     // If the module has already been loaded, just emit it and continue...
                     if (!BaseForce && TryGetFromModuleTable(rootedPath, out PSModuleInfo module))
                     {
@@ -725,9 +727,14 @@ namespace Microsoft.PowerShell.Commands
                                 RemoveModule(moduleToRemove);
                             }
 
-                            foundModule = LoadModule(rootedPath, null, this.BasePrefix, null, ref importModuleOptions,
-                                                     ManifestProcessingFlags.LoadElements | ManifestProcessingFlags.WriteErrors | ManifestProcessingFlags.NullOnFirstError,
-                                                     out found);
+                            foundModule = LoadModule(
+                                fileName: rootedPath,
+                                moduleBase: null,
+                                prefix: BasePrefix,
+                                ss: null, /*SessionState*/
+                                ref importModuleOptions,
+                                manifestProcessingFlags,
+                                out found);
                         }
                         else if (Directory.Exists(rootedPath))
                         {
@@ -738,21 +745,24 @@ namespace Microsoft.PowerShell.Commands
                             }
 
                             // Load the latest valid version if it is a multi-version module directory
-                            foundModule = LoadUsingMultiVersionModuleBase(rootedPath,
-                                                                            ManifestProcessingFlags.LoadElements |
-                                                                            ManifestProcessingFlags.WriteErrors |
-                                                                            ManifestProcessingFlags.NullOnFirstError,
-                                                                            importModuleOptions, out found);
+                            foundModule = LoadUsingMultiVersionModuleBase(rootedPath, manifestProcessingFlags, importModuleOptions, out found);
 
                             if (!found)
                             {
                                 // If the path is a directory, double up the end of the string
                                 // then try to load that using extensions...
                                 rootedPath = Path.Combine(rootedPath, Path.GetFileName(rootedPath));
-                                foundModule = LoadUsingExtensions(null, rootedPath, rootedPath, null, null, this.BasePrefix, /*SessionState*/ null,
-                                                                  importModuleOptions,
-                                                                  ManifestProcessingFlags.LoadElements | ManifestProcessingFlags.WriteErrors | ManifestProcessingFlags.NullOnFirstError,
-                                                                  out found);
+                                foundModule = LoadUsingExtensions(
+                                    parentModule: null,
+                                    moduleName: rootedPath,
+                                    fileBaseName: rootedPath,
+                                    extension: null,
+                                    moduleBase: null,
+                                    prefix: BasePrefix,
+                                    ss: null, /*SessionState*/
+                                    importModuleOptions,
+                                    manifestProcessingFlags,
+                                    out found);
                             }
                         }
                     }
@@ -786,16 +796,28 @@ namespace Microsoft.PowerShell.Commands
                         // If there is no extension, we'll have to search using the extensions
                         if (!string.IsNullOrEmpty(Path.GetExtension(name)))
                         {
-                            foundModule = LoadModule(name, null, this.BasePrefix, null, ref importModuleOptions,
-                                                     ManifestProcessingFlags.LoadElements | ManifestProcessingFlags.WriteErrors | ManifestProcessingFlags.NullOnFirstError,
-                                                     out found);
+                            foundModule = LoadModule(
+                                fileName: name,
+                                moduleBase: null,
+                                prefix: BasePrefix,
+                                ss: null, /*SessionState*/
+                                ref importModuleOptions,
+                                manifestProcessingFlags,
+                                out found);
                         }
                         else
                         {
-                            foundModule = LoadUsingExtensions(null, name, name, null, null, this.BasePrefix, /*SessionState*/ null,
-                                                              importModuleOptions,
-                                                              ManifestProcessingFlags.LoadElements | ManifestProcessingFlags.WriteErrors | ManifestProcessingFlags.NullOnFirstError,
-                                                              out found);
+                            foundModule = LoadUsingExtensions(
+                                parentModule: null,
+                                moduleName: name,
+                                fileBaseName: name,
+                                extension: null,
+                                moduleBase: null,
+                                prefix: BasePrefix,
+                                ss: null, /*SessionState*/
+                                importModuleOptions,
+                                manifestProcessingFlags,
+                                out found);
                         }
                     }
                     else
@@ -807,14 +829,17 @@ namespace Microsoft.PowerShell.Commands
                             this.AddToAppDomainLevelCache = true;
                         }
 
-                        found = LoadUsingModulePath(found, modulePath, name, /* SessionState*/ null,
-                                                    importModuleOptions,
-                                                    ManifestProcessingFlags.LoadElements | ManifestProcessingFlags.WriteErrors | ManifestProcessingFlags.NullOnFirstError,
-                                                    out foundModule);
+                        found = LoadUsingModulePath(
+                            modulePath,
+                            name,
+                            ss: null, /* SessionState*/
+                            importModuleOptions,
+                            manifestProcessingFlags,
+                            out foundModule);
                     }
                 }
 
-                if (!found)
+                if (!found && shallWriteError)
                 {
                     ErrorRecord er = null;
                     string message = null;
@@ -856,8 +881,10 @@ namespace Microsoft.PowerShell.Commands
             }
             catch (PSInvalidOperationException e)
             {
-                ErrorRecord er = new ErrorRecord(e.ErrorRecord, e);
-                WriteError(er);
+                if (shallWriteError)
+                {
+                    WriteError(new ErrorRecord(e.ErrorRecord, e));
+                }
             }
 
             return null;
@@ -1987,16 +2014,15 @@ namespace Microsoft.PowerShell.Commands
             string[] noClobberModuleList = PowerShellConfig.Instance.GetWindowsPowerShellCompatibilityNoClobberModuleList();
             if (isBuiltInModule || noClobberModuleList?.Contains(moduleToLoad, StringComparer.OrdinalIgnoreCase) == true)
             {
-                // if it is one of engine modules - first try to load it from $PSHOME\Modules
-                // otherwise rely on $env:PSModulePath (in which WinPS module location has to go after CorePS module location)
-                bool tryLoadingModuleLocally = true;
+                bool shouldLoadModuleLocally = true;
                 if (isBuiltInModule)
                 {
                     PSSnapInInfo loadedSnapin = Context.CurrentRunspace.InitialSessionState.GetPSSnapIn(moduleToLoad);
-                    tryLoadingModuleLocally = loadedSnapin is null;
+                    shouldLoadModuleLocally = loadedSnapin is null;
 
-                    if (tryLoadingModuleLocally)
+                    if (shouldLoadModuleLocally)
                     {
+                        // If it is one of built-in modules, first try loading it from $PSHOME\Modules, otherwise rely on $env:PSModulePath.
                         string expectedCoreModulePath = Path.Combine(ModuleIntrinsics.GetPSHomeModulePath(), moduleToLoad);
                         if (Directory.Exists(expectedCoreModulePath))
                         {
@@ -2005,10 +2031,15 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
 
-                if (tryLoadingModuleLocally)
+                if (shouldLoadModuleLocally)
                 {
-                    bool savedValue = importModuleOptions.CoreEditionCompatibleOnly;
-                    importModuleOptions.CoreEditionCompatibleOnly = true;
+                    // Here we want to load a core-edition compatible version of the module, so the loading procedure will skip
+                    // the 'System32' module path when searching. Also, we want to suppress writing out errors in case that a
+                    // core-compatible version of the module cannot be found, because:
+                    //  1. that's OK as long as it's not a PowerShell built-in module such as the 'Utility' moudle;
+                    //  2. the error message will be confusing to the user.
+                    bool savedValue = importModuleOptions.SkipSystem32ModulesAndSuppressError;
+                    importModuleOptions.SkipSystem32ModulesAndSuppressError = true;
 
                     PSModuleInfo moduleInfo = moduleSpec is null
                         ? ImportModule_LocallyViaName_WithTelemetry(importModuleOptions, moduleToLoad)
@@ -2023,15 +2054,22 @@ namespace Microsoft.PowerShell.Commands
                                 Name = moduleToLoad
                             });
 
+                    // If we failed to load a core-compatible version of a built-in module, we should stop trying to load the
+                    // module in 'WinCompat' mode and report an error. This could happen when a user didn't correctly deploy
+                    // the built-in modules, which would result in very confusing errors when the module auto-loading silently
+                    // attempts to load those built-in modules in 'WinCompat' mode from the 'System32' module path.
+                    //
+                    // If the loading failed but it's NOT a built-in module, then it's fine to ignore this failure and continue
+                    // to load the module in 'WinCompat' mode.
                     if (moduleInfo is null && isBuiltInModule)
                     {
                         throw new InvalidOperationException(
                             StringUtil.Format(
-                                Modules.CannotFindBuiltInModules,
-                                moduleName));
+                                Modules.CannotFindCoreCompatibleBuiltInModule,
+                                moduleToLoad));
                     }
 
-                    importModuleOptions.CoreEditionCompatibleOnly = savedValue;
+                    importModuleOptions.SkipSystem32ModulesAndSuppressError = savedValue;
                 }
 
                 importModuleOptions.NoClobberExportPSSession = true;
@@ -2047,22 +2085,9 @@ namespace Microsoft.PowerShell.Commands
             IEnumerable<ModuleSpecification> filteredModuleFullyQualifiedNames = FilterModuleCollection(moduleFullyQualifiedNames);
 
             // do not setup WinCompat resources if we have no modules to import
-            if ((filteredModuleNames?.Any() != true) && (filteredModuleFullyQualifiedNames?.Any() != true))
+            if (filteredModuleNames?.Any() != true && filteredModuleFullyQualifiedNames?.Any() != true)
             {
                 return moduleProxyList;
-            }
-
-            var winPSVersionString = Utils.GetWindowsPowerShellVersionFromRegistry();
-            if (!winPSVersionString.StartsWith("5.1", StringComparison.OrdinalIgnoreCase))
-            {
-                string errorMessage = string.Format(CultureInfo.InvariantCulture, Modules.WinCompatRequredVersionError, winPSVersionString);
-                throw new InvalidOperationException(errorMessage);
-            }
-
-            PSSession WindowsPowerShellCompatRemotingSession = CreateWindowsPowerShellCompatResources();
-            if (WindowsPowerShellCompatRemotingSession == null)
-            {
-                return new List<PSModuleInfo>();
             }
 
             // perform necessary preparations if module has to be imported with NoClobber mode
@@ -2082,13 +2107,26 @@ namespace Microsoft.PowerShell.Commands
                 }
             }
 
+            var winPSVersionString = Utils.GetWindowsPowerShellVersionFromRegistry();
+            if (!winPSVersionString.StartsWith("5.1", StringComparison.OrdinalIgnoreCase))
+            {
+                string errorMessage = string.Format(CultureInfo.InvariantCulture, Modules.WinCompatRequredVersionError, winPSVersionString);
+                throw new InvalidOperationException(errorMessage);
+            }
+
+            PSSession WindowsPowerShellCompatRemotingSession = CreateWindowsPowerShellCompatResources();
+            if (WindowsPowerShellCompatRemotingSession == null)
+            {
+                return new List<PSModuleInfo>();
+            }
+
             // perform the module import / proxy generation
             moduleProxyList = ImportModule_RemotelyViaPsrpSession(importModuleOptions, filteredModuleNames, filteredModuleFullyQualifiedNames, WindowsPowerShellCompatRemotingSession, usingWinCompat: true);
 
             foreach (PSModuleInfo moduleProxy in moduleProxyList)
             {
                 moduleProxy.IsWindowsPowerShellCompatModule = true;
-                System.Threading.Interlocked.Increment(ref s_WindowsPowerShellCompatUsageCounter);
+                Interlocked.Increment(ref s_WindowsPowerShellCompatUsageCounter);
 
                 string message = StringUtil.Format(Modules.WinCompatModuleWarning, moduleProxy.Name, WindowsPowerShellCompatRemotingSession.Name);
                 WriteWarning(message);

--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -762,7 +762,7 @@ namespace Microsoft.PowerShell.Commands
                     // Check if module could be a snapin. This was the case for PowerShell version 2 engine modules.
                     if (InitialSessionState.IsEngineModule(name))
                     {
-                        PSSnapInInfo snapin = ModuleCmdletBase.GetEngineSnapIn(Context, name);
+                        PSSnapInInfo snapin = GetEngineSnapIn(Context, name);
 
                         // Return the command if we found a module
                         if (snapin != null)

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -5397,13 +5397,6 @@ namespace Microsoft.PowerShell.Commands
                 if (!string.IsNullOrEmpty(Context.ModuleBeingProcessed) &&
                     Context.ModuleBeingProcessed.Equals(fileName, StringComparison.OrdinalIgnoreCase))
                 {
-                    // If the module being processed points to the same module manifest file, then we should stop trying other
-                    // module extensions, because we are actually attempting to load the same module that is being processed.
-                    if (StringLiterals.PowerShellDataFileExtension.Equals(ext, StringComparison.OrdinalIgnoreCase))
-                    {
-                        break;
-                    }
-
                     continue;
                 }
 

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -977,6 +977,13 @@ namespace System.Management.Automation
             {
                 string psHome = Utils.DefaultPowerShellAppBase;
 #if !UNIX
+                // Win8: 584267 Powershell Modules are listed twice in x86, and cannot be removed.
+                // This happens because 'ModuleTable' uses Path as the key and x86 WinPS has "SysWOW64" in its $PSHOME.
+                // Because of this, the module that is getting loaded during startup (through LocalRunspace) is using
+                // "SysWow64" in the key. Later, when 'Import-Module' is called, it loads the module using ""System32"
+                // in the key.
+                // For the cross-platform PowerShell, a user can choose to install it under "C:\Windows\SysWOW64", and
+                // thus it may have the same problem as described above.
                 psHome = psHome.ToLowerInvariant().Replace(@"\syswow64\", @"\system32\");
 #endif
                 Interlocked.CompareExchange(ref s_psHomeModulePath, Path.Combine(psHome, "Modules"), null);

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -976,20 +976,10 @@ namespace System.Management.Automation
             try
             {
                 string psHome = Utils.DefaultPowerShellAppBase;
-                if (!string.IsNullOrEmpty(psHome))
-                {
-                    // Win8: 584267 Powershell Modules are listed twice in x86, and cannot be removed
-                    // This happens because ModuleTable uses Path as the key and CBS installer
-                    // expands the path to include "SysWOW64" (for
-                    // HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\PowerShell\3\PowerShellEngine ApplicationBase).
-                    // Because of this, the module that is getting loaded during startup (through LocalRunspace)
-                    // is using "SysWow64" in the key. Later, when Import-Module is called, it loads the
-                    // module using ""System32" in the key.
 #if !UNIX
-                    psHome = psHome.ToLowerInvariant().Replace("\\syswow64\\", "\\system32\\");
+                psHome = psHome.ToLowerInvariant().Replace(@"\syswow64\", @"\system32\");
 #endif
-                    Interlocked.CompareExchange(ref s_psHomeModulePath, Path.Combine(psHome, "Modules"), null);
-                }
+                Interlocked.CompareExchange(ref s_psHomeModulePath, Path.Combine(psHome, "Modules"), null);
             }
             catch (System.Security.SecurityException)
             {

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -983,7 +983,7 @@ namespace System.Management.Automation
                 // "SysWow64" in the key. Later, when 'Import-Module' is called, it loads the module using ""System32"
                 // in the key.
                 // For the cross-platform PowerShell, a user can choose to install it under "C:\Windows\SysWOW64", and
-                // thus it may have the same problem as described above.
+                // thus it may have the same problem as described above. So we keep this line of code.
                 psHome = psHome.ToLowerInvariant().Replace(@"\syswow64\", @"\system32\");
 #endif
                 Interlocked.CompareExchange(ref s_psHomeModulePath, Path.Combine(psHome, "Modules"), null);

--- a/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
@@ -121,7 +121,7 @@ namespace System.Management.Automation.Internal
 #if UNIX
             return true;
 #else
-            if (!ModuleUtils.IsOnSystem32ModulePath(moduleManifestPath))
+            if (!IsOnSystem32ModulePath(moduleManifestPath))
             {
                 return true;
             }

--- a/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
+++ b/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
@@ -221,11 +221,7 @@ namespace System.Management.Automation
         {
             get
             {
-#pragma warning disable 56503
-
                 throw PSTraceSource.NewNotImplementedException();
-
-#pragma warning restore 56503
             }
         }
 
@@ -236,11 +232,7 @@ namespace System.Management.Automation
         {
             get
             {
-#pragma warning disable 56503
-
                 throw PSTraceSource.NewNotImplementedException();
-
-#pragma warning restore 56503
             }
         }
 

--- a/src/System.Management.Automation/resources/DiscoveryExceptions.resx
+++ b/src/System.Management.Automation/resources/DiscoveryExceptions.resx
@@ -206,6 +206,10 @@ The #requires statement must be in one of the following formats:
   <data name="CouldNotAutoImportMatchingModule" xml:space="preserve">
     <value>The '{0}' command was found in the module '{1}', but the module could not be loaded. For more information, run 'Import-Module {1}'.</value>
   </data>
+  <data name="CouldNotAutoImportMatchingModuleWithErrorMessage" xml:space="preserve">
+    <value>The '{0}' command was found in the module '{1}', but the module could not be loaded due to the following error: [{2}]
+For more information, run 'Import-Module {1}'.</value>
+  </data>
   <data name="CouldNotAutoImportModule" xml:space="preserve">
     <value>The module '{0}' could not be loaded. For more information, run 'Import-Module {0}'.</value>
   </data>

--- a/src/System.Management.Automation/resources/Modules.resx
+++ b/src/System.Management.Automation/resources/Modules.resx
@@ -624,7 +624,7 @@
   <data name="CannotCreateModuleWithScriptBlock" xml:space="preserve">
     <value>Cannot create new module while the session is in ConstrainedLanguage mode.</value>
   </data>
-  <data name="CannotFindBuiltInModules" xml:space="preserve">
-    <value>The built-in module '{0}' cannot be found under the $PSHOME module path '{1}'. Please make sure the PowerShell built-in modules are available because they are required for PowerShell to function properly.</value>
+  <data name="CannotFindCoreCompatibleBuiltInModule" xml:space="preserve">
+    <value>Cannot find the built-in module '{0}' that is compatible with the 'Core' edition. Please make sure the PowerShell built-in modules are available. They usually come along with the PowerShell package under the $PSHOME module path, and are required for PowerShell to function properly.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/Modules.resx
+++ b/src/System.Management.Automation/resources/Modules.resx
@@ -625,6 +625,6 @@
     <value>Cannot create new module while the session is in ConstrainedLanguage mode.</value>
   </data>
   <data name="CannotFindCoreCompatibleBuiltInModule" xml:space="preserve">
-    <value>Cannot find the built-in module '{0}' that is compatible with the 'Core' edition. Please make sure the PowerShell built-in modules are available. They usually come along with the PowerShell package under the $PSHOME module path, and are required for PowerShell to function properly.</value>
+    <value>Cannot find the built-in module '{0}' that is compatible with the 'Core' edition. Please make sure the PowerShell built-in modules are available. They usually come with the PowerShell package under the $PSHOME module path, and are required for PowerShell to function properly.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/Modules.resx
+++ b/src/System.Management.Automation/resources/Modules.resx
@@ -624,4 +624,7 @@
   <data name="CannotCreateModuleWithScriptBlock" xml:space="preserve">
     <value>Cannot create new module while the session is in ConstrainedLanguage mode.</value>
   </data>
+  <data name="CannotFindBuiltInModules" xml:space="preserve">
+    <value>The built-in module '{0}' cannot be found under the $PSHOME module path '{1}'. Please make sure the PowerShell built-in modules are available because they are required for PowerShell to function properly.</value>
+  </data>
 </root>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

When a PowerShell built-in module is getting imported in the `WinCompat` mode, we check whether a core-edition compatible version of this module is available in module paths. If not, report error instead of blindly loading the module under `System32` module path, because that could result in very confusing errors later on.

Fix #13157. Related to #16525.
We also had a stack overflow issue reported from internal team when they were testing with PowerShell 7.2. The investigation showed the root cause was that they didn't recursively copy the `$PSHOME\Modules` when deploying their test infrastructure, and the stack overflow exception was caused by auto-loading attempts to load `Microsoft.PowerShell.Utility` from the `System32` module path.

With this change, we should be able to avoid the confusing errors when somehow a user has the built-in modules missing. The error will explicitly call out that a core-edition compatible version of the built-in module cannot be found.

Here is an example to show the UX:

![image](https://user-images.githubusercontent.com/127450/147056172-f0d46fc5-ffd5-4423-8231-1af1b34dc644.png)

Basically, for built-in modules, PowerShell blocks the loading of the same module in `System32\WindowsPowerShell\v1.0\Modules` via `WinCompat` when a core-edition compatible version of such module cannot be found. When the core-edition compatible built-in modules are available, loading of the same module in `System32` module path will proceed normally.

**Where is the check done?**

The check is done in `PrepareNoClobberWinCompatModuleImport`.
When importing a module remotely via `WinCompat`, if the module is a built-in module, or it's listed in `WindowsPowerShellCompatibilityNoClobberModuleList` in `powershell.config.json`, we first attempt to load a core-edition compatible version of such module, and then proceed with loading the module remotely. This is how `WInCompat` works today.

This PR made an improvement to the existing code:
- skip the `System32` module path when attempting to load a core-compatible version of the module, so that
   1. a Desktop module listed in the no-clobber list won't be loaded as remote module twice.
   2. a core-compatible module can be discovered even if it's in a module path that appears behind the `System32` module path in `$env:PSModulePath`.
- when a core-compatible version of the module cannot be found,
  1. if the module to be loaded remotely is a built-in module, we throw exception because that means core-compatible built-in modules are not available.
  2. if the module to be loaded remotely is NOT a built-in module, then it's OK to proceed with loading it remotely.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
