### PR TITLE
Fix `$PSNativeCommandArgPassing` = `Windows` to handle empty args correctly

### DIFF
--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -314,7 +314,7 @@ namespace System.Management.Automation
                         }
                         else
                         {
-                            if (argArrayAst != null && ArgumentPassingStyle == NativeArgumentPassingStyle.Standard)
+                            if (argArrayAst != null && ArgumentPassingStyle != NativeArgumentPassingStyle.Legacy)
                             {
                                 // We have a literal array, so take the extent, break it on spaces and add them to the argument list.
                                 foreach (string element in argArrayAst.Extent.Text.Split(' ', StringSplitOptions.RemoveEmptyEntries))
@@ -331,7 +331,7 @@ namespace System.Management.Automation
                         }
                     }
                 }
-                else if (ArgumentPassingStyle == NativeArgumentPassingStyle.Standard && currentObj != null)
+                else if (ArgumentPassingStyle != NativeArgumentPassingStyle.Legacy && currentObj != null)
                 {
                     // add empty strings to arglist, but not nulls
                     AddToArgumentList(parameter, arg);

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
@@ -171,7 +171,7 @@ Describe "Will error correctly if an attempt to set variable to improper value" 
     }
 }
 
-foreach ( $argumentListValue in "Standard","Legacy" ) {
+foreach ( $argumentListValue in "Standard","Legacy","Windows" ) {
     $PSNativeCommandArgumentPassing = $argumentListValue
     Describe "Native Command Arguments (${PSNativeCommandArgumentPassing})" -tags "CI" {
         # When passing arguments to native commands, quoted segments that contain
@@ -262,6 +262,28 @@ foreach ( $argumentListValue in "Standard","Legacy" ) {
             for ($i = 0; $i -lt $expected.Count; $i++) {
                 $lines[$i] | Should -BeExactly "Arg $i is <$($expected[$i])>"
             }
+        }
+
+        It "Should handle empty args correctly (ArgumentList=${PSNativeCommandArgumentPassing})" {
+            if ($PSNativeCommandArgumentPassing -eq 'Legacy') {
+                $expectedLines = 2
+            }
+            else {
+                $expectedLines = 3
+            }
+
+            $lines = testexe -echoargs 1 '' 2
+            $lines.Count | Should -Be $expectedLines
+            $lines[0] | Should -BeExactly 'Arg 0 is <1>'
+
+            if ($expectedLines -eq 2) {
+                $lines[1] | Should -BeExactly 'Arg 1 is <2>'
+            }
+            else {
+                $lines[1] | Should -BeExactly 'Arg 1 is <>'
+                $lines[2] | Should -BeExactly 'Arg 2 is <2>'
+            }
+
         }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

When the new `Windows` mode was added to `$PSNativeCommandArgPassing`, the PR didn't change some of the logic as it only expected `Standard` and `Legacy`.  The intent was that `Windows` would be `Standard`, but have exception to fallback to `Legacy` for a specific set of extensions and executables to maintain compatibility.  This resulted in `Windows` having the `Legacy` behavior when it came to empty args which get dropped.  The fix is to change the handling so instead of checking for `Standard` it checks if it's not `Legacy`.

## PR Context

Brought to my attention by .NET team member

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [x] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [x] Experimental feature name(s): `PSNativeCommandArgumentPassing`
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
