### PR TITLE
Add lock and null check to remoting internals (#16542)

### DIFF
--- a/src/System.Management.Automation/engine/remoting/fanin/PriorityCollection.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/PriorityCollection.cs
@@ -225,11 +225,9 @@ namespace System.Management.Automation.Remoting
                 if (_dataSyncObjects != null && _dataToBeSent != null)
                 {
                     const int promptResponseIndex = (int)DataPriorityType.PromptResponse;
-
                     lock (_dataSyncObjects[promptResponseIndex])
                     {
-                        //NOTE: fix unhandled NullReference exception;
-                        //_dataToBeSent[promptResponseIndex] is disposed by Clear method from different thread 
+                        // _dataToBeSent array items can be asynchronously disposed and set to null value.
                         if (_dataToBeSent[promptResponseIndex] != null) 
                         {
                             // send data from which ever stream that has data directly.
@@ -243,6 +241,7 @@ namespace System.Management.Automation.Remoting
                         const int defaultIndex = (int)DataPriorityType.Default;
                         lock (_dataSyncObjects[defaultIndex]) 
                         {
+                            // _dataToBeSent array items can be asynchronously disposed and set to null value.
                             if (_dataToBeSent[defaultIndex] != null) 
                             {
                                 result = _dataToBeSent[defaultIndex].ReadOrRegisterCallback(_onSendCollectionDataAvailable);
@@ -250,6 +249,7 @@ namespace System.Management.Automation.Remoting
                             }
                         }
                     }
+
                     // no data to return..so register the callback.
                     if (result == null)
                     {


### PR DESCRIPTION
# PR Summary

Lock and null check of the PrioritySendDataCollection.cs members to avoid race condition.

## PR Context

Copy-Item cmdlet can throw unhandled exception that terminates the process.
The issue occures in WSManTransportManager internals.
The PrioritySendDataCollection class is used by 2 threads: first thread calls ReadOrRegisterCallback method, that gets _dataToBeSent field, when second thread calls Clear method, where _dataToBeSent member is disposed.  

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
