### PR TITLE
Let macOS installer run without Rosetta on Apple Silicon

### DIFF
--- a/tools/packaging/packaging.strings.psd1
+++ b/tools/packaging/packaging.strings.psd1
@@ -125,7 +125,7 @@ open {0}
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <installer-gui-script minSpecVersion="1">
     <title>{0}</title>
-    <options hostArchitectures="x86_64"/>
+    <options hostArchitectures="{5}"/>
     <options customize="never" rootVolumeOnly="true"/>
     <background file="macDialog.png" scaling="tofit" alignment="bottomleft"/>
     <allowed-os-versions>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

Let the macOS installer can run without Rosetta on Apple Silicon.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

This patch makes the macOS installer (_powershell-\*-osx-arm64.pkg_) able to run without [Rosetta] on Apple Silicon (e.g., M1, M1 Pro, M1 Max).  Although the executable binary (*pwsh*) in itself already natively runs on Apple Silicon, the installer for it still requires Rosetta (as of 7.3.0-preview.1):

<img width="732" alt="To install “PowerShell - 7.3.0-preview.1”, you need to install Rosetta.  Do you want to install it now?  Rosetta enables Intel-based features to run on Apple silicon Macs. Reopening applications after installation is required to start using Rosetta." src="https://user-images.githubusercontent.com/12431/149346872-c7662670-b323-496c-bfc2-14ddf96d0571.png">

I fixed it by specifying the proper `hostArchitectures` to the `installer-gui-script` configuration.  (In PowerShell's packaging script, the template for it is placed in *tools/packaging/packaging.strings.psd1*.)  The solution was inspired by fish's fix commit: <https://github.com/fish-shell/fish-shell/commit/c1a1b7020356a4a8271542bd6f969670af260b42>.

Fixes <https://github.com/PowerShell/PowerShell/issues/16571>.

[Rosetta]: https://en.wikipedia.org/wiki/Rosetta_(software)#Rosetta_2

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
