### PR TITLE
On Windows, reset cursor visibility back to previous state when rendering progress

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressPane.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressPane.cs
@@ -301,11 +301,11 @@ namespace Microsoft.PowerShell
         {
             if (_content is not null)
             {
+                // On Windows, we can check if the cursor is currently visible and not change it to visible
+                // if it is intentionally hidden.  On Unix, it is not currently supported to read the cursor visibility.
 #if UNIX
                 Console.CursorVisible = false;
 #else
-                // On Windows, we can check if the cursor is currently visible and not change it to visible
-                // if it is intentionally hidden.  On Unix, it is not currently supported to read the cursor visibility.
                 bool currentCursorVisible = Console.CursorVisible;
                 if (currentCursorVisible)
                 {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressPane.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressPane.cs
@@ -301,7 +301,17 @@ namespace Microsoft.PowerShell
         {
             if (_content is not null)
             {
+#if UNIX
                 Console.CursorVisible = false;
+#else
+                // On Windows, we can check if the cursor is currently visible and not change it to visible
+                // if it is intentionally hidden.  On Unix, it is not currently supported to read the cursor visibility.
+                bool currentCursorVisible = Console.CursorVisible;
+                if (currentCursorVisible)
+                {
+                    Console.CursorVisible = false;
+                }
+#endif
 
                 var currentPosition = _rawui.CursorPosition;
                 _rawui.CursorPosition = _location;
@@ -319,7 +329,11 @@ namespace Microsoft.PowerShell
                 }
 
                 _rawui.CursorPosition = currentPosition;
+#if UNIX
                 Console.CursorVisible = true;
+#else
+                Console.CursorVisible = currentCursorVisible;
+#endif
             }
         }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The progress rendering code hides the cursor during rendering and makes the cursor visible again after rendering as it assumes the cursor was previously in a visible state.  However, if a script intentionally hides the cursor, then using progress will result in the cursor being visible.  However, it seems that only Windows supports reading the current cursor visibility state and a platform not supported exception is thrown on Linux and macOS.  So the fix is to just cache the current cursor on Windows and set it back when done rendering.  No change for Linux/macOS as we still want to explicitly hide the cursor when rendering progress so that you don't see the cursor moving quickly in the console to render progress.

## PR Context

Fix #16412

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
