### PR TITLE
re-factor ArgumentToPSVersionTransformationAttribute

### DIFF
--- a/src/System.Management.Automation/engine/ArgumentToVersionTransformationAttribute.cs
+++ b/src/System.Management.Automation/engine/ArgumentToVersionTransformationAttribute.cs
@@ -12,8 +12,8 @@ namespace System.Management.Automation
     /// To make it easier to specify a version, we add some conversions that wouldn't happen otherwise:
     ///   * A simple integer, i.e. 2;
     ///   * A string without a dot, i.e. "2".
-    ///   * the string "off" sets the version to 0.0 (unset)
-    ///   * the string "latest" sets to the current version
+    ///   * the string "off" sets the version to 0.0 (unset).
+    ///   * the string "latest" sets to the current version.
     /// </summary>
     internal sealed class ArgumentToPSVersionTransformationAttribute : ArgumentToVersionTransformationAttribute
     {

--- a/src/System.Management.Automation/engine/ArgumentToVersionTransformationAttribute.cs
+++ b/src/System.Management.Automation/engine/ArgumentToVersionTransformationAttribute.cs
@@ -12,6 +12,33 @@ namespace System.Management.Automation
     /// To make it easier to specify a version, we add some conversions that wouldn't happen otherwise:
     ///   * A simple integer, i.e. 2;
     ///   * A string without a dot, i.e. "2".
+    ///   * the string "off" sets the version to 0.0 (unset)
+    ///   * the string "latest" sets to the current version
+    /// </summary>
+    internal sealed class ArgumentToPSVersionTransformationAttribute : ArgumentToVersionTransformationAttribute
+    {
+        protected override bool TryConvertFromString(string versionString, [NotNullWhen(true)] out Version? version)
+        {
+            if (string.Equals("off", versionString, StringComparison.OrdinalIgnoreCase))
+            {
+                version = new Version(0, 0);
+                return true;
+            }
+
+            if (string.Equals("latest", versionString, StringComparison.OrdinalIgnoreCase))
+            {
+                version = PSVersionInfo.PSVersion;
+                return true;
+            }
+
+            return base.TryConvertFromString(versionString, out version);
+        }
+    }
+
+    /// <summary>
+    /// To make it easier to specify a version, we add some conversions that wouldn't happen otherwise:
+    ///   * A simple integer, i.e. 2;
+    ///   * A string without a dot, i.e. "2".
     /// </summary>
     internal class ArgumentToVersionTransformationAttribute : ArgumentTransformationAttribute
     {

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -2635,23 +2635,6 @@ namespace Microsoft.PowerShell.Commands
 
         private SwitchParameter _off;
 
-        /// <summary>
-        /// Handle 'latest', which we interpret to be the current version of PowerShell.
-        /// </summary>
-        private sealed class ArgumentToPSVersionTransformationAttribute : ArgumentToVersionTransformationAttribute
-        {
-            protected override bool TryConvertFromString(string versionString, [NotNullWhen(true)] out Version version)
-            {
-                if (string.Equals("latest", versionString, StringComparison.OrdinalIgnoreCase))
-                {
-                    version = PSVersionInfo.PSVersion;
-                    return true;
-                }
-
-                return base.TryConvertFromString(versionString, out version);
-            }
-        }
-
         private sealed class ValidateVersionAttribute : ValidateArgumentsAttribute
         {
             protected override void Validate(object arguments, EngineIntrinsics engineIntrinsics)

--- a/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
@@ -263,26 +263,6 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        private sealed class ArgumentToPSVersionTransformationAttribute : ArgumentToVersionTransformationAttribute
-        {
-            protected override bool TryConvertFromString(string versionString, [NotNullWhen(true)] out Version version)
-            {
-                if (string.Equals("off", versionString, StringComparison.OrdinalIgnoreCase))
-                {
-                    version = new Version(0, 0);
-                    return true;
-                }
-
-                if (string.Equals("latest", versionString, StringComparison.OrdinalIgnoreCase))
-                {
-                    version = PSVersionInfo.PSVersion;
-                    return true;
-                }
-
-                return base.TryConvertFromString(versionString, out version);
-            }
-        }
-
         private static readonly Version s_OffVersion = new Version(0, 0);
 
         private sealed class ValidateVersionAttribute : ValidateArgumentsAttribute

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -2294,6 +2294,8 @@ function CleanupGeneratedSourceCode
         '[Microsoft.PowerShell.Commands.SetStrictModeCommand.ArgumentToPSVersionTransformationAttribute]'
         '[Microsoft.PowerShell.Commands.HttpVersionCompletionsAttribute]'
         '[System.Management.Automation.ArgumentToVersionTransformationAttribute]'
+        '[Microsoft.PowerShell.Commands.InvokeCommandCommand.ValidateVersionAttribute]'
+        '[System.Management.Automation.ArgumentToPSVersionTransformationAttribute]'
         )
 
     $patternsToReplace = @(


### PR DESCRIPTION


<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This attribute is multiply defined in multiple places, this PR re-factor is the code to have only one definition.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

This should fix the build break when creating nuget packages.
One side effect of this PR is that the cmdlet `set-strictmode` will support `set-strictmode -version off`.

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
