### PR TITLE
Update regex used to remove ANSI escape sequences to be more specific to decoration and hyperlinks

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -572,7 +572,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets or sets the rendering mode for output.
         /// </summary>
-        public OutputRendering OutputRendering { get; set; } = OutputRendering.Ansi;
+        public OutputRendering OutputRendering { get; set; } = OutputRendering.Host;
 
         /// <summary>
         /// Gets value to turn off all attributes.

--- a/src/System.Management.Automation/FormatAndOutput/common/StringDecorated.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/StringDecorated.cs
@@ -101,8 +101,14 @@ namespace System.Management.Automation.Internal
             }
         }
 
+        // graphics/color mode ESC[1;2;...m
+        private const string graphicsRegex = @"\x1b\[\d+(;\d+)*m";
+
+        // hyperlink ESC]8;;<url>ESC\<text>ESC]8;;ESC\ taken from https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
+        private const string hyperlinkRegex = @"\x1b\]8;;[^\x1b]+\x1b\\[^\x1b]+\x1b\]8;;\x1b\\";
+
         // replace regex with .NET 6 API once available
-        internal static readonly Regex AnsiRegex = new Regex(@"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])", RegexOptions.Compiled);
+        internal static readonly Regex AnsiRegex = new Regex($"({graphicsRegex})|(({hyperlinkRegex}))", RegexOptions.Compiled);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ValueStringDecorated"/> struct.

--- a/src/System.Management.Automation/FormatAndOutput/common/StringDecorated.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/StringDecorated.cs
@@ -102,13 +102,16 @@ namespace System.Management.Automation.Internal
         }
 
         // graphics/color mode ESC[1;2;...m
-        private const string graphicsRegex = @"\x1b\[\d+(;\d+)*m";
+        private const string GraphicsRegex = @"(\x1b\[\d+(;\d+)*m)";
 
         // hyperlink ESC]8;;<url>ESC\<text>ESC]8;;ESC\ taken from https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
-        private const string hyperlinkRegex = @"\x1b\]8;;[^\x1b]+\x1b\\[^\x1b]+\x1b\]8;;\x1b\\";
+        private const string HyperlinkRegex = @"(\x1b\]8;;[^\x1b]+\x1b\\[^\x1b]+\x1b\]8;;\x1b\\)";
+
+        // CSI escape sequences
+        private const string CsiRegex = @"(\x1b\[?\d+[hl])";
 
         // replace regex with .NET 6 API once available
-        internal static readonly Regex AnsiRegex = new Regex($"({graphicsRegex})|(({hyperlinkRegex}))", RegexOptions.Compiled);
+        internal static readonly Regex AnsiRegex = new Regex($"{GraphicsRegex}|{HyperlinkRegex}|{CsiRegex}", RegexOptions.Compiled);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ValueStringDecorated"/> struct.

--- a/src/System.Management.Automation/FormatAndOutput/common/StringDecorated.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/StringDecorated.cs
@@ -104,14 +104,11 @@ namespace System.Management.Automation.Internal
         // graphics/color mode ESC[1;2;...m
         private const string GraphicsRegex = @"(\x1b\[\d+(;\d+)*m)";
 
-        // hyperlink ESC]8;;<url>ESC\<text>ESC]8;;ESC\ taken from https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
-        private const string HyperlinkRegex = @"(\x1b\]8;;[^\x1b]+\x1b\\[^\x1b]+\x1b\]8;;\x1b\\)";
-
         // CSI escape sequences
         private const string CsiRegex = @"(\x1b\[\?\d+[hl])";
 
         // replace regex with .NET 6 API once available
-        internal static readonly Regex AnsiRegex = new Regex($"{GraphicsRegex}|{HyperlinkRegex}|{CsiRegex}", RegexOptions.Compiled);
+        internal static readonly Regex AnsiRegex = new Regex($"{GraphicsRegex}|{CsiRegex}", RegexOptions.Compiled);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ValueStringDecorated"/> struct.

--- a/src/System.Management.Automation/FormatAndOutput/common/StringDecorated.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/StringDecorated.cs
@@ -108,7 +108,7 @@ namespace System.Management.Automation.Internal
         private const string HyperlinkRegex = @"(\x1b\]8;;[^\x1b]+\x1b\\[^\x1b]+\x1b\]8;;\x1b\\)";
 
         // CSI escape sequences
-        private const string CsiRegex = @"(\x1b\[?\d+[hl])";
+        private const string CsiRegex = @"(\x1b\[\?\d+[hl])";
 
         // replace regex with .NET 6 API once available
         internal static readonly Regex AnsiRegex = new Regex($"{GraphicsRegex}|{HyperlinkRegex}|{CsiRegex}", RegexOptions.Compiled);

--- a/test/powershell/engine/Formatting/PSStyle.Tests.ps1
+++ b/test/powershell/engine/Formatting/PSStyle.Tests.ps1
@@ -83,7 +83,7 @@ Describe 'Tests for $PSStyle automatic variable' {
 
     It '$PSStyle has correct default for OutputRendering' {
         $PSStyle | Should -Not -BeNullOrEmpty
-        $PSStyle.OutputRendering | Should -BeExactly 'Ansi'
+        $PSStyle.OutputRendering | Should -BeExactly 'Host'
     }
 
     It '$PSStyle has correct defaults for style <key>' -TestCases (Get-TestCases $styleDefaults) {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The previous regex to remove ANSI escape sequences was too broad and would remove content that appeared to be ANSI but was not.  The change is to have specific regex targeting colors/decoration and CSI ANSI escape sequences (generated by PSReadLine) which are ones used by PS7 and PSReadLine currently.

Hyperlink isn't supported here as no default formatting emits it and the way the escape sequence works it can be too broad.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/16730

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
