### PR TITLE
Fix the clean block for generated proxy function

### DIFF
--- a/src/System.Management.Automation/engine/CommandMetadata.cs
+++ b/src/System.Management.Automation/engine/CommandMetadata.cs
@@ -1128,7 +1128,9 @@ clean
             //  1. the 'Clean' block doesn't propagate up any exception (terminating error);
             //  2. only one expression in the script, so nothing else needs to be stopped when invoking the method fails.
             return @"
-    $steppablePipeline.Clean()
+    if ($null -ne $steppablePipeline) {
+        $steppablePipeline.Clean()
+    }
 ";
         }
 

--- a/test/powershell/Language/Scripting/PipelineBehaviour.Tests.ps1
+++ b/test/powershell/Language/Scripting/PipelineBehaviour.Tests.ps1
@@ -483,7 +483,13 @@ Describe 'Function Pipeline Behaviour' -Tag 'CI' {
             $function:TestProxyGci = [scriptblock]::Create(
                 [Management.Automation.ProxyCommand]::Create(
                 (Get-Command Get-ChildItem)))
-            { ProxyGci -Attributes } | Should -Throw -ErrorId 'MissingArgument,ProxyGci'
+
+            ## The proxy function 'TestProxyGci' contains the 'dynamicparam' block, which will
+            ## run during parameter binding. However, the parameter binding failed, and thus
+            ## the 'begin', 'process', and 'end' blocks will not run, so '$steppablePipeline'
+            ## in the proxy function is null (never created). The 'clean' block will run anyway,
+            ## but it should skip calling '$steppablePipeline.Clean()' in this case. 
+            { TestProxyGci -Attributes } | Should -Throw -ErrorId 'MissingArgument,TestProxyGci'
         }
     }
 

--- a/test/powershell/Language/Scripting/PipelineBehaviour.Tests.ps1
+++ b/test/powershell/Language/Scripting/PipelineBehaviour.Tests.ps1
@@ -478,6 +478,13 @@ Describe 'Function Pipeline Behaviour' -Tag 'CI' {
             ## Dispose the steppable pipeline.
             $step.Dispose()
         }
+
+        It "Clean block runs fine in a proxy function when a dynamic parameter fails to bind" {
+            $function:TestProxyGci = [scriptblock]::Create(
+                [Management.Automation.ProxyCommand]::Create(
+                (Get-Command Get-ChildItem)))
+            { ProxyGci -Attributes } | Should -Throw -ErrorId 'MissingArgument,ProxyGci'
+        }
     }
 
     Context "'exit' statement in command" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #16826
Fix the clean block for generated proxy function

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
