### PR TITLE
Update to use `windows-latest` as the build agent image

### DIFF
--- a/.vsts-ci/templates/ci-build.yml
+++ b/.vsts-ci/templates/ci-build.yml
@@ -1,5 +1,5 @@
 parameters:
-  pool: 'vs2017-win2016'
+  pool: 'windows-latest'
   jobName: 'win_build'
   displayName: Windows Build
 

--- a/.vsts-ci/templates/credscan.yml
+++ b/.vsts-ci/templates/credscan.yml
@@ -1,12 +1,12 @@
 parameters:
-  pool: 'Hosted VS2017'
+  pool: 'windows-latest'
   jobName: 'credscan'
   displayName: Secret Scan
 
 jobs:
 - job: ${{ parameters.jobName }}
   pool:
-    name: ${{ parameters.pool }}
+    vmImage: ${{ parameters.pool }}
 
   displayName: ${{ parameters.displayName }}
 

--- a/.vsts-ci/templates/nanoserver.yml
+++ b/.vsts-ci/templates/nanoserver.yml
@@ -1,5 +1,5 @@
 parameters:
-  vmImage: 'windows-2019'
+  vmImage: 'windows-latest'
   jobName: 'Nanoserver_Tests'
   continueOnError: false
 

--- a/.vsts-ci/templates/verify-xunit.yml
+++ b/.vsts-ci/templates/verify-xunit.yml
@@ -1,6 +1,6 @@
 parameters:
   parentJobs: []
-  pool: 'vs2017-win2016'
+  pool: 'windows-latest'
   jobName: 'xunit_verify'
 
 jobs:

--- a/.vsts-ci/templates/windows-test.yml
+++ b/.vsts-ci/templates/windows-test.yml
@@ -1,5 +1,5 @@
 parameters:
-  pool: 'Hosted VS2017'
+  pool: 'windows-latest'
   parentJobs: []
   purpose: ''
   tagSet: 'CI'
@@ -9,7 +9,7 @@ jobs:
   dependsOn:
     ${{ parameters.parentJobs }}
   pool:
-    name: ${{ parameters.pool }}
+    vmImage: ${{ parameters.pool }}
 
   displayName: Windows Test - ${{ parameters.purpose }} - ${{ parameters.tagSet }}
 

--- a/.vsts-ci/windows-daily.yml
+++ b/.vsts-ci/windows-daily.yml
@@ -53,7 +53,7 @@ stages:
   jobs:
   - job: win_test
     pool:
-      vmImage: vs2017-win2016
+      vmImage: windows-latest
     displayName: Windows Test
     timeoutInMinutes: 90
 

--- a/.vsts-ci/windows/templates/windows-packaging.yml
+++ b/.vsts-ci/windows/templates/windows-packaging.yml
@@ -1,6 +1,6 @@
 parameters:
   - name: pool
-    default: 'Hosted VS2017'
+    default: 'windows-latest'
   - name: jobName
     default: 'win_packaging'
   - name: runtimePrefix
@@ -24,7 +24,7 @@ jobs:
       value: $(Agent.BuildDirectory)\$(complianceRepoFolder)
 
   pool:
-    name: ${{ parameters.pool }}
+    vmImage: ${{ parameters.pool }}
 
   displayName: Windows Packaging - ${{ parameters.architecture }} - ${{ parameters.channel }}
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -603,6 +603,13 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "Feature" {
             Import-Module Microsoft.PowerShell.Management -UseWindowsPowerShell
 
             $modules = Get-Module -Name Microsoft.PowerShell.Management
+
+            foreach ($m in $modules) {
+                Write-Verbose -Verbose $m.Name
+                Write-Verbose -Verbose ("    Module Base: " + $m.ModuleBase)
+                Write-Verbose -Verbose ("    Module Path: " + $m.Path)
+            }
+
             $modules.Count | Should -Be 2
             $proxyModule = $modules | Where-Object {$_.ModuleType -eq 'Script'}
             $coreModule = $modules | Where-Object {$_.ModuleType -eq 'Manifest'}
@@ -731,7 +738,14 @@ Remove-Module $desktopModuleToUse
             $originalModulePath = $env:PSModulePath
             try {
                 $env:PSModulePath += ";$mypath"
-                Import-Module $ModuleName2 -UseWindowsPowerShell -Force -WarningAction Ignore
+
+                Write-Verbose -Verbose ("pwsh PSModulePath: " + $env:PSModulePath)
+
+                Import-Module $ModuleName2 -UseWindowsPowerShell -Force
+
+                $m = Get-Module $ModuleName2
+                Write-Verbose -Verbose ($m.ModuleBase)
+
                 $s = Get-PSSession -Name WinPSCompatSession
                 $winpsPaths = Invoke-Command -Session $s -ScriptBlock {$env:psmodulepath}
                 $winpsPaths | Should -BeLike "*$mypath*"

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -600,6 +600,16 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "Feature" {
 
         It "NoClobber WinCompat import works for an engine module through -UseWindowsPowerShell parameter" {
 
+            "==============" | Write-Verbose -Verbose
+            "Check for if module is already pre-loaded " | Write-Verbose -Verbose
+            $modules = Get-Module -Name Microsoft.PowerShell.Management
+            foreach ($m in $modules) {
+                Write-Verbose -Verbose $m.Name
+                Write-Verbose -Verbose ("    Module Base: " + $m.ModuleBase)
+                Write-Verbose -Verbose ("    Module Path: " + $m.Path)
+            }
+            "==============" | Write-Verbose -Verbose
+
             Import-Module Microsoft.PowerShell.Management -UseWindowsPowerShell
 
             $modules = Get-Module -Name Microsoft.PowerShell.Management
@@ -609,6 +619,11 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "Feature" {
                 Write-Verbose -Verbose ("    Module Base: " + $m.ModuleBase)
                 Write-Verbose -Verbose ("    Module Path: " + $m.Path)
             }
+
+            "==============" | Write-Verbose -Verbose
+            "Check for bad WinPS module manifest " | Write-Verbose -Verbose
+            Get-Content "C:\Windows\system32\WindowsPowerShell\v1.0\Modules\Microsoft.PowerShell.Management\Microsoft.PowerShell.Management.psd1" | Out-String | Write-Verbose -Verbose
+            "==============" | Write-Verbose -Verbose
 
             $modules.Count | Should -Be 2
             $proxyModule = $modules | Where-Object {$_.ModuleType -eq 'Script'}
@@ -740,6 +755,15 @@ Remove-Module $desktopModuleToUse
                 $env:PSModulePath += ";$mypath"
 
                 Write-Verbose -Verbose ("pwsh PSModulePath: " + $env:PSModulePath)
+
+                "==============" | Write-Verbose -Verbose
+                "Check for pre-existing WinPSCompatSession" | Write-Verbose -Verbose
+                Get-PSSession -Name WinPSCompatSession | Out-String | Write-Verbose -Verbose
+                $s = Get-PSSession -Name WinPSCompatSession
+                if ($s) {
+                    Invoke-Command -Session $s -ScriptBlock {$env:psmodulepath} | Out-String | Write-Verbose -Verbose
+                }
+                "==============" | Write-Verbose -Verbose
 
                 Import-Module $ModuleName2 -UseWindowsPowerShell -Force
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -604,7 +604,7 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "Feature" {
             Get-Module -Name Microsoft.PowerShell.Management | Remove-Module
             Import-Module -Name Microsoft.PowerShell.Management # import the one that comes with PSCore
 
-            Import-Module Microsoft.PowerShell.Management -UseWindowsPowerShell # import through proxy the one that comes with WindowsPS
+            Import-Module Microsoft.PowerShell.Management -UseWindowsPowerShell
 
             $modules = Get-Module -Name Microsoft.PowerShell.Management
 
@@ -740,7 +740,7 @@ Remove-Module $desktopModuleToUse
             $originalModulePath = $env:PSModulePath
             try {
                 $env:PSModulePath += ";$mypath"
-                Import-Module $ModuleName2 -UseWindowsPowerShell -Force
+                Import-Module $ModuleName2 -UseWindowsPowerShell -Force -WarningAction Ignore
                 $s = Get-PSSession -Name WinPSCompatSession
                 $winpsPaths = Invoke-Command -Session $s -ScriptBlock {$env:psmodulepath}
                 $winpsPaths | Should -BeLike "*$mypath*"

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -604,30 +604,9 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "Feature" {
             Get-Module -Name Microsoft.PowerShell.Management | Remove-Module
             Import-Module -Name Microsoft.PowerShell.Management # import the one that comes with PSCore
 
-            "==============" | Write-Verbose -Verbose
-            "Check for if module is already pre-loaded " | Write-Verbose -Verbose
-            $modules = Get-Module -Name Microsoft.PowerShell.Management
-            foreach ($m in $modules) {
-                Write-Verbose -Verbose $m.Name
-                Write-Verbose -Verbose ("    Module Base: " + $m.ModuleBase)
-                Write-Verbose -Verbose ("    Module Path: " + $m.Path)
-            }
-            "==============" | Write-Verbose -Verbose
-
-            Import-Module Microsoft.PowerShell.Management -UseWindowsPowerShell
+            Import-Module Microsoft.PowerShell.Management -UseWindowsPowerShell # import through proxy the one that comes with WindowsPS
 
             $modules = Get-Module -Name Microsoft.PowerShell.Management
-
-            foreach ($m in $modules) {
-                Write-Verbose -Verbose $m.Name
-                Write-Verbose -Verbose ("    Module Base: " + $m.ModuleBase)
-                Write-Verbose -Verbose ("    Module Path: " + $m.Path)
-            }
-
-            "==============" | Write-Verbose -Verbose
-            "Check for bad WinPS module manifest " | Write-Verbose -Verbose
-            Get-Content "C:\Windows\system32\WindowsPowerShell\v1.0\Modules\Microsoft.PowerShell.Management\Microsoft.PowerShell.Management.psd1" | Out-String | Write-Verbose -Verbose
-            "==============" | Write-Verbose -Verbose
 
             $modules.Count | Should -Be 2
             $proxyModule = $modules | Where-Object {$_.ModuleType -eq 'Script'}
@@ -729,9 +708,12 @@ Remove-Module $desktopModuleToUse
             Restore-ModulePath
         }
 
+        BeforeEach {
+            Get-PSSession -Name WinPSCompatSession -ErrorAction SilentlyContinue | Remove-PSSession
+        }
+
         AfterEach {
             Get-Module $allModules | Remove-Module -Force
-            Get-PSSession -Name WinPSCompatSession -ErrorAction SilentlyContinue | Remove-PSSession
         }
 
         It 'WinCompat process does not inherit PowerShell-Core-specific paths' {
@@ -758,23 +740,7 @@ Remove-Module $desktopModuleToUse
             $originalModulePath = $env:PSModulePath
             try {
                 $env:PSModulePath += ";$mypath"
-
-                Write-Verbose -Verbose ("pwsh PSModulePath: " + $env:PSModulePath)
-
-                "==============" | Write-Verbose -Verbose
-                "Check for pre-existing WinPSCompatSession" | Write-Verbose -Verbose
-                Get-PSSession -Name WinPSCompatSession | Out-String | Write-Verbose -Verbose
-                $s = Get-PSSession -Name WinPSCompatSession
-                if ($s) {
-                    Invoke-Command -Session $s -ScriptBlock {$env:psmodulepath} | Out-String | Write-Verbose -Verbose
-                }
-                "==============" | Write-Verbose -Verbose
-
                 Import-Module $ModuleName2 -UseWindowsPowerShell -Force
-
-                $m = Get-Module $ModuleName2
-                Write-Verbose -Verbose ($m.ModuleBase)
-
                 $s = Get-PSSession -Name WinPSCompatSession
                 $winpsPaths = Invoke-Command -Session $s -ScriptBlock {$env:psmodulepath}
                 $winpsPaths | Should -BeLike "*$mypath*"

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -600,6 +600,10 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "Feature" {
 
         It "NoClobber WinCompat import works for an engine module through -UseWindowsPowerShell parameter" {
 
+            # pre-test cleanup
+            Get-Module -Name Microsoft.PowerShell.Management | Remove-Module
+            Import-Module -Name Microsoft.PowerShell.Management # import the one that comes with PSCore
+
             "==============" | Write-Verbose -Verbose
             "Check for if module is already pre-loaded " | Write-Verbose -Verbose
             $modules = Get-Module -Name Microsoft.PowerShell.Management
@@ -727,6 +731,7 @@ Remove-Module $desktopModuleToUse
 
         AfterEach {
             Get-Module $allModules | Remove-Module -Force
+            Get-PSSession -Name WinPSCompatSession -ErrorAction SilentlyContinue | Remove-PSSession
         }
 
         It 'WinCompat process does not inherit PowerShell-Core-specific paths' {

--- a/test/powershell/Modules/Microsoft.WSMan.Management/CredSSP.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.WSMan.Management/CredSSP.Tests.ps1
@@ -64,8 +64,10 @@ Describe "CredSSP cmdlet tests" -Tags 'Feature','RequireAdminOnWindows' {
         }
         else
         {
-            $c = Get-WSManCredSSP
-            $c[1] | Should -Match $expected
+            Wait-UntilTrue -IntervalInMilliseconds 500 -sb {
+                $c = Get-WSManCredSSP
+                $c[1] -match $expected
+            } | Should -BeTrue -Because "WSManCredSSP should have been enabled to allow receiving credentials from a remote client computer, but it was not."
         }
     }
 

--- a/test/powershell/Modules/Microsoft.WSMan.Management/CredSSP.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.WSMan.Management/CredSSP.Tests.ps1
@@ -48,10 +48,29 @@ Describe "CredSSP cmdlet tests" -Tags 'Feature','RequireAdminOnWindows' {
         @{params=@{Role="Server"};description="server"}
     ) {
         param ($params)
+
+        Write-Verbose -Verbose "=========== Enable-WSManCredSSP ==========="
+
         $c = Enable-WSManCredSSP @params -Force
+
+        Write-Verbose -Verbose ($c.GetType().FullName)
+        Write-Verbose -Verbose ($c | Format-List | Out-String)
+        Write-Verbose -Verbose ($Error[0])
+
+        Write-Verbose -Verbose "============ END ============"
+
         $c.CredSSP | Should -BeTrue
 
+        Write-Verbose -Verbose "=========== Get-WSManCredSSP ==========="
+
         $c = Get-WSManCredSSP
+
+        Write-Verbose -Verbose ($c.GetType().FullName)
+        Write-Verbose -Verbose ($c | Format-List | Out-String)
+        Write-Verbose -Verbose ($Error[0])
+
+        Write-Verbose -Verbose "============ END ============"
+
         if ($params.Role -eq "Client")
         {
             $c[0] | Should -Match "The machine is configured to allow delegating fresh credentials to the following target\(s\):wsman/\*"

--- a/test/powershell/Modules/Microsoft.WSMan.Management/CredSSP.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.WSMan.Management/CredSSP.Tests.ps1
@@ -49,27 +49,37 @@ Describe "CredSSP cmdlet tests" -Tags 'Feature','RequireAdminOnWindows' {
     ) {
         param ($params)
 
-        Write-Verbose -Verbose "=========== Enable-WSManCredSSP ==========="
+        Write-Verbose -Verbose "=========== $($params.Role) Enable-WSManCredSSP ==========="
 
         $c = Enable-WSManCredSSP @params -Force
 
         Write-Verbose -Verbose ($c.GetType().FullName)
         Write-Verbose -Verbose ($c | Format-List | Out-String)
-        Write-Verbose -Verbose ($Error[0])
 
         Write-Verbose -Verbose "============ END ============"
 
         $c.CredSSP | Should -BeTrue
 
-        Write-Verbose -Verbose "=========== Get-WSManCredSSP ==========="
+        Write-Verbose -Verbose "=========== $($params.Role) Get-WSManCredSSP ==========="
 
         $c = Get-WSManCredSSP
 
-        Write-Verbose -Verbose ($c.GetType().FullName)
-        Write-Verbose -Verbose ($c | Format-List | Out-String)
-        Write-Verbose -Verbose ($Error[0])
+        foreach ($i in $c) {
+            Write-Verbose -Verbose $i
+        }
 
         Write-Verbose -Verbose "============ END ============"
+
+        if ($params.Role -eq "Client") {
+            Start-Sleep -Seconds 2
+            $c = Get-WSManCredSSP
+
+            Write-Verbose -Verbose "============ Get again in 2 seconds ==========="
+            foreach ($i in $c) {
+                Write-Verbose -Verbose $i
+            }
+            Write-Verbose -Verbose "================== END ========================"
+        }
 
         if ($params.Role -eq "Client")
         {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Update to use `windows-latest` as the build agent image for CI, because the windows-2016 is being deprecated.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
