### PR TITLE
Fix the parsing code for method generic arguments

### DIFF
--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -7828,14 +7828,14 @@ namespace System.Management.Automation.Language
                 // The latter syntax has been supported for type expression since the beginning, but it's ambiguous in
                 // this scenario because we could be looking at an indexing operation on a property like:
                 //    `$var.Property[<expression>]`
-                // and the '<expression>' could start with a type expression like `[TypeName]::Method()`, or even just
+                // and the `<expression>` could start with a type expression like `[TypeName]::Method()`, or even just
                 // a single type expression acting as a key to a hashtable property. Such cases will cause ambiguities.
                 //
                 // It could be possible to write code that sorts out the ambiguity and continue to support the latter
                 // syntax for method generic arguments, and thus to allow assembly-qualified type names. But we choose
-                // to not do so becuase:
+                // not to do so because:
                 //   1. that will definitely increase the complexity of the parsing code and also make it fragile;
-                //   2. the latter syntax hurts readability due to the number of opening/closing brackets.
+                //   2. the latter syntax hurts readability a lot due to the number of opening/closing brackets.
                 // The downside is that the assembly-qualified type names won't be supported for method generic args,
                 // but that's likely not a problem in practice, and we can revisit if it turns out otherwise.
                 if (firstToken.Kind == TokenKind.Identifier)

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -7745,7 +7745,6 @@ namespace System.Management.Automation.Language
             // On entry, we've verified that operatorToken is not preceded by whitespace.
 
             CommandElementAst member = MemberNameRule();
-            List<ITypeName> genericTypeArguments = null;
 
             if (member == null)
             {
@@ -7763,7 +7762,7 @@ namespace System.Management.Automation.Language
                 // Member name may be an incomplete token like `$a.$(Command-Name`, in which case, '_ungotToken != null'.
                 // We do not look for generic args or invocation token if the member name token is recognisably incomplete.
                 int resyncIndex = _tokenizer.GetRestorePoint();
-                genericTypeArguments = GenericMethodArgumentsRule(resyncIndex, out Token rBracket);
+                List<ITypeName> genericTypeArguments = GenericMethodArgumentsRule(resyncIndex, out Token rBracket);
                 Token lParen = NextInvokeMemberToken();
 
                 if (lParen != null)

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -8012,16 +8012,10 @@ namespace System.Management.Automation.Language
         /// <param name="static">True if the '::' operator was used, false if '.' is used.
         /// True if the member access is for a static member, using '::', false if accessing a member on an instance using '.'.
         /// </param>
-        /// <param name="genericTypes">The generic type arguments passed to the member.</param>
         /// <exception cref="PSArgumentNullException">
         /// If <paramref name="extent"/>, <paramref name="expression"/>, or <paramref name="member"/> is null.
         /// </exception>
-        public MemberExpressionAst(
-            IScriptExtent extent,
-            ExpressionAst expression,
-            CommandElementAst member,
-            bool @static,
-            IList<ITypeName> genericTypes)
+        public MemberExpressionAst(IScriptExtent extent, ExpressionAst expression, CommandElementAst member, bool @static)
             : base(extent)
         {
             if (expression == null || member == null)
@@ -8034,35 +8028,6 @@ namespace System.Management.Automation.Language
             this.Member = member;
             SetParent(member);
             this.Static = @static;
-
-            if (genericTypes is not null && genericTypes.Count > 0)
-            {
-                this.GenericTypeArguments = new ReadOnlyCollection<ITypeName>(genericTypes);
-            }
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MemberExpressionAst"/> class.
-        /// </summary>
-        /// <param name="extent">
-        /// The extent of the expression, starting with the expression before the operator '.' or '::' and ending after
-        /// membername or expression naming the member.
-        /// </param>
-        /// <param name="expression">The expression before the member access operator '.' or '::'.</param>
-        /// <param name="member">The name or expression naming the member to access.</param>
-        /// <param name="static">True if the '::' operator was used, false if '.' is used.
-        /// True if the member access is for a static member, using '::', false if accessing a member on an instance using '.'.
-        /// </param>
-        /// <exception cref="PSArgumentNullException">
-        /// If <paramref name="extent"/>, <paramref name="expression"/>, or <paramref name="member"/> is null.
-        /// </exception>
-        public MemberExpressionAst(
-            IScriptExtent extent,
-            ExpressionAst expression,
-            CommandElementAst member,
-            bool @static)
-            : this(extent, expression, member, @static, genericTypes: null)
-        {
         }
 
         /// <summary>
@@ -8076,44 +8041,13 @@ namespace System.Management.Automation.Language
         /// <param name="member">The name or expression naming the member to access.</param>
         /// <param name="static">True if the '::' operator was used, false if '.' or '?.' is used.</param>
         /// <param name="nullConditional">True if '?.' used.</param>
-        /// <param name="genericTypes">The generic type arguments passed to the member.</param>
         /// <exception cref="PSArgumentNullException">
         /// If <paramref name="extent"/>, <paramref name="expression"/>, or <paramref name="member"/> is null.
         /// </exception>
-        public MemberExpressionAst(
-            IScriptExtent extent,
-            ExpressionAst expression,
-            CommandElementAst member,
-            bool @static,
-            bool nullConditional,
-            IList<ITypeName> genericTypes)
-            : this(extent, expression, member, @static, genericTypes)
+        public MemberExpressionAst(IScriptExtent extent, ExpressionAst expression, CommandElementAst member, bool @static, bool nullConditional)
+            : this(extent, expression, member, @static)
         {
             this.NullConditional = nullConditional;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MemberExpressionAst"/> class.
-        /// </summary>
-        /// <param name="extent">
-        /// The extent of the expression, starting with the expression before the operator '.', '::' or '?.' and ending after
-        /// membername or expression naming the member.
-        /// </param>
-        /// <param name="expression">The expression before the member access operator '.', '::' or '?.'.</param>
-        /// <param name="member">The name or expression naming the member to access.</param>
-        /// <param name="static">True if the '::' operator was used, false if '.' or '?.' is used.</param>
-        /// <param name="nullConditional">True if '?.' used.</param>
-        /// <exception cref="PSArgumentNullException">
-        /// If <paramref name="extent"/>, <paramref name="expression"/>, or <paramref name="member"/> is null.
-        /// </exception>
-        public MemberExpressionAst(
-            IScriptExtent extent,
-            ExpressionAst expression,
-            CommandElementAst member,
-            bool @static,
-            bool nullConditional)
-            : this(extent, expression, member, @static, nullConditional, genericTypes: null)
-        {
         }
 
         /// <summary>
@@ -8137,11 +8071,6 @@ namespace System.Management.Automation.Language
         public bool NullConditional { get; protected set; }
 
         /// <summary>
-        /// Gets a list of generic type arguments passed to this member.
-        /// </summary>
-        public ReadOnlyCollection<ITypeName> GenericTypeArguments { get; }
-
-        /// <summary>
         /// Copy the MemberExpressionAst instance.
         /// </summary>
         public override Ast Copy()
@@ -8154,8 +8083,7 @@ namespace System.Management.Automation.Language
                 newExpression,
                 newMember,
                 this.Static,
-                this.NullConditional,
-                this.GenericTypeArguments);
+                this.NullConditional);
         }
 
         #region Visitors
@@ -8214,12 +8142,17 @@ namespace System.Management.Automation.Language
             IEnumerable<ExpressionAst> arguments,
             bool @static,
             IList<ITypeName> genericTypes)
-            : base(extent, expression, method, @static, genericTypes)
+            : base(extent, expression, method, @static)
         {
             if (arguments != null && arguments.Any())
             {
                 this.Arguments = new ReadOnlyCollection<ExpressionAst>(arguments.ToArray());
                 SetParents(Arguments);
+            }
+
+            if (genericTypes != null && genericTypes.Count > 0)
+            {
+                this.GenericTypeArguments = new ReadOnlyCollection<ITypeName>(genericTypes);
             }
         }
 
@@ -8307,6 +8240,11 @@ namespace System.Management.Automation.Language
             : this(extent, expression, method, arguments, @static, nullConditional, genericTypes: null)
         {
         }
+
+        /// <summary>
+        /// Gets a list of generic type arguments passed to this method invocation.
+        /// </summary>
+        public ReadOnlyCollection<ITypeName> GenericTypeArguments { get; }
 
         /// <summary>
         /// The non-empty collection of arguments to pass when invoking the method, or null if no arguments were specified.

--- a/test/powershell/Language/Parser/MethodInvocation.Tests.ps1
+++ b/test/powershell/Language/Parser/MethodInvocation.Tests.ps1
@@ -13,9 +13,18 @@ Describe 'Generic Method invocation' -Tags 'CI' {
                 Script       = '[Array]::Empty[System.Collections.Generic.Dictionary[System.Numerics.BigInteger, System.Collections.Generic.List[string[,]]]]()'
                 ExpectedType = [System.Collections.Generic.Dictionary[System.Numerics.BigInteger, System.Collections.Generic.List[string[, ]]][]]
             }
+        )
+
+        $IndexingAProperty = @(
             @{
-                Script       = '[Array]::$("Empty")[[System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib],[System.Numerics.BigInteger, System.Runtime.Numerics]], System.Private.CoreLib]]()'
-                ExpectedType = [System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib], [System.Numerics.BigInteger, System.Runtime.Numerics]][], System.Private.CoreLib]
+                Script       = '[object]::Property[[type]]'
+                IndexType    = 'System.Management.Automation.Language.TypeExpressionAst'
+                IndexString  = '[type]'
+            }
+            @{
+                Script       = '$object.IPSubnet[[Array]::IndexOf($_.IPAddress, $_.IPAddress[0])]'
+                IndexType    = 'System.Management.Automation.Language.InvokeMemberExpressionAst'
+                IndexString  = '[Array]::IndexOf($_.IPAddress, $_.IPAddress[0])'
             }
         )
 
@@ -37,8 +46,8 @@ Describe 'Generic Method invocation' -Tags 'CI' {
             }
             @{
                 Script         = '[array]::empty[type]]()'
-                ExpectedErrors = @('UnexpectedToken', 'ExpectedExpression')
-                ErrorCount     = 2
+                ExpectedErrors = @('MissingArrayIndexExpression', 'UnexpectedToken', 'ExpectedExpression')
+                ErrorCount     = 3
             }
             @{
                 Script         = '$object.Method[type,]()'
@@ -70,6 +79,21 @@ Describe 'Generic Method invocation' -Tags 'CI' {
                 ExpectedErrors = @('EndSquareBracketExpectedAtEndOfType', 'UnexpectedToken')
                 ErrorCount     = 2
             }
+            @{
+                Script         = '$object.Method[[type]]()'
+                ExpectedErrors = @('UnexpectedToken', 'ExpectedExpression')
+                ErrorCount     = 2
+            }
+            @{
+                Script         = '[Array]::Empty[[type]]()'
+                ExpectedErrors = @('UnexpectedToken', 'ExpectedExpression')
+                ErrorCount     = 2
+            }
+            @{
+                Script         = '$object.Property[type]'
+                ExpectedErrors = @('MissingArrayIndexExpression', 'UnexpectedToken')
+                ErrorCount     = 2
+            }
         )
     }
 
@@ -77,6 +101,21 @@ Describe 'Generic Method invocation' -Tags 'CI' {
         param($Script)
 
         { [scriptblock]::Create($script) } | Should -Not -Throw
+    }
+
+    It "parses fine for indexing a property" -TestCases $IndexingAProperty {
+        param($Script, $IndexType, $IndexString)
+
+        $parseErrors = $null
+
+        $ast = [System.Management.Automation.Language.Parser]::ParseInput($Script, [ref]$null, [ref]$parseErrors)
+        $parseErrors | Should -BeNullOrEmpty
+
+        $cmdExpr = $ast.EndBlock.Statements[0].PipelineElements[0]
+        $cmdExpr | Should -BeOfType 'System.Management.Automation.Language.CommandExpressionAst'
+        $cmdExpr.Expression | Should -BeOfType 'System.Management.Automation.Language.IndexExpressionAst'
+        $cmdExpr.Expression.Index | Should -BeOfType $IndexType
+        $cmdExpr.Expression.Index.ToString() | Should -BeExactly $IndexString
     }
 
     It 'reports a parse error for "<Script>"' -TestCases $ExpectedParseErrors {
@@ -162,16 +201,6 @@ Describe 'Generic Method invocation' -Tags 'CI' {
             $_.Exception.Message | Should -BeLike "*[thisdoesnotexist]*"
             $_.FullyQualifiedErrorId | Should -BeExactly 'TypeNotFound'
         }
-    }
-
-    It 'lists the same method group information with and without type parameters' {
-        $dict = [System.Collections.Concurrent.ConcurrentDictionary[string, int]]::new()
-        $noTypeParams = $dict.AddOrUpdate
-        $typeParams = $dict.AddOrUpdate[string]
-        $extraTypeParams = $dict.AddOrUpdate[string, int]
-
-        $typeParams.OverloadDefinitions | Should -BeExactly $noTypeParams.OverloadDefinitions
-        $extraTypeParams.OverloadDefinitions | Should -BeExactly $typeParams.OverloadDefinitions
     }
 
     It 'successfully invokes common Linq generic methods' {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #16870

Update the parsing code to only support the syntax `$var.Method[TypeName1 <, TypeName2 ...>]` for method generic arguments, not the syntax `$var.Method[[TypeName1] <, [TypeName2] ...>]`.

The latter syntax has been supported for type expression since the beginning, but it's ambiguous in this scenario because we could be looking at an indexing operation on a property like: `$var.Property[<expression>]` and the `<expression>` could start with a type expression like `[TypeName]::Method()`, or even just a single type expression acting as a key to a hashtable property. Such cases will cause ambiguities.

Even though it might be possible to write code that sorts out the ambiguity and continue to support the latter syntax for method generic arguments, I choose not to do so, because:
  1. that will definitely increase the complexity of the parsing code and also make it fragile.
  2. the latter syntax hurts readability a lot due to the number of opening/closing brackets.

The downside is that the assembly-qualified type names won't be supported for method generic arguments, but that's likely not a problem in practice, and we can revisit if it turns out otherwise.

-----

Besides, there is no point to allow declaring generic arguments for a property. Even for method group, it makes no sense to allow generic arguments to be declared for it because we don't do anything with the generic arguments for a method group, so no validation will be done -- you will see the following script works in 7.3-preview.1 unexpectedly:
```
PS:1> [string]::Join[nonexisting]

OverloadDefinitions
-------------------
static string Join(char separator, Params string[] value)
static string Join(string separator, Params string[] value)
static string Join(char separator, string[] value, int startIndex, int count)
static string Join(string separator, string[] value, int startIndex, int count)
static string Join(string separator, System.Collections.Generic.IEnumerable[string] values)
static string Join(char separator, Params System.Object[] values)
static string Join(string separator, Params System.Object[] values)
static string Join[T](char separator, System.Collections.Generic.IEnumerable[T] values)
static string Join[T](string separator, System.Collections.Generic.IEnumerable[T] values)
```

So, the related code in AST and parser are removed, and declaring a generic argument on a property will generate the same parsing errors as before:
```
PS:1> [string]::Join[nonexisting]
ParserError:
Line |
   1 |  [string]::Join[nonexisting]
     |                 ~
     | Array index expression is missing or not valid.
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.

