### PR TITLE
Ignore failure attempting to set console window title

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
@@ -2494,7 +2494,7 @@ namespace Microsoft.PowerShell
             return consoleTitle.ToString();
         }
 
-        internal static bool canSetConsoleWindowTitle = true;
+        private static bool canSetConsoleWindowTitle = true;
 
         /// <summary>
         /// Wraps Win32 SetConsoleTitle.

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
@@ -2494,7 +2494,7 @@ namespace Microsoft.PowerShell
             return consoleTitle.ToString();
         }
 
-        private static bool DontSetConsoleWindowTitle;
+        private static bool dontSetConsoleWindowTitle;
 
         /// <summary>
         /// Wraps Win32 SetConsoleTitle.
@@ -2507,7 +2507,7 @@ namespace Microsoft.PowerShell
         /// </exception>
         internal static void SetConsoleWindowTitle(string consoleTitle)
         {
-            if (DontSetConsoleWindowTitle)
+            if (dontSetConsoleWindowTitle)
             {
                 return;
             }
@@ -2522,7 +2522,7 @@ namespace Microsoft.PowerShell
                 if (err == 0x1f)
                 {
                     tracer.WriteLine("Call to SetConsoleTitle failed: {0}", err);
-                    DontSetConsoleWindowTitle = true;
+                    dontSetConsoleWindowTitle = true;
 
                     // We ignore this specific error as the console can still continue to operate
                     return;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
@@ -2518,7 +2518,8 @@ namespace Microsoft.PowerShell
             {
                 int err = Marshal.GetLastWin32Error();
 
-                if (err == 0x1f) // ERROR_GEN_FAILURE is returned if this api can't be used with the terminal
+                // ERROR_GEN_FAILURE is returned if this api can't be used with the terminal
+                if (err == 0x1f)
                 {
                     tracer.WriteLine("Call to SetConsoleTitle failed: {0}", err);
                     canSetConsoleWindowTitle = false;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
@@ -2527,12 +2527,10 @@ namespace Microsoft.PowerShell
                     // We ignore this specific error as the console can still continue to operate
                     return;
                 }
-                else
-                {
-                    HostException e = CreateHostException(err, "SetConsoleWindowTitle",
-                        ErrorCategory.ResourceUnavailable, ConsoleControlStrings.SetConsoleWindowTitleExceptionTemplate);
-                    throw e;
-                }
+
+                HostException e = CreateHostException(err, "SetConsoleWindowTitle",
+                    ErrorCategory.ResourceUnavailable, ConsoleControlStrings.SetConsoleWindowTitleExceptionTemplate);
+                throw e;
             }
         }
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
@@ -2494,7 +2494,7 @@ namespace Microsoft.PowerShell
             return consoleTitle.ToString();
         }
 
-        private static bool dontSetConsoleWindowTitle;
+        private static bool DontSetConsoleWindowTitle;
 
         /// <summary>
         /// Wraps Win32 SetConsoleTitle.
@@ -2507,7 +2507,7 @@ namespace Microsoft.PowerShell
         /// </exception>
         internal static void SetConsoleWindowTitle(string consoleTitle)
         {
-            if (dontSetConsoleWindowTitle)
+            if (DontSetConsoleWindowTitle)
             {
                 return;
             }
@@ -2522,7 +2522,7 @@ namespace Microsoft.PowerShell
                 if (err == 0x1f)
                 {
                     tracer.WriteLine("Call to SetConsoleTitle failed: {0}", err);
-                    dontSetConsoleWindowTitle = true;
+                    DontSetConsoleWindowTitle = true;
 
                     // We ignore this specific error as the console can still continue to operate
                     return;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
@@ -2494,6 +2494,8 @@ namespace Microsoft.PowerShell
             return consoleTitle.ToString();
         }
 
+        internal static bool canSetConsoleWindowTitle = true;
+
         /// <summary>
         /// Wraps Win32 SetConsoleTitle.
         /// </summary>
@@ -2505,15 +2507,17 @@ namespace Microsoft.PowerShell
         /// </exception>
         internal static void SetConsoleWindowTitle(string consoleTitle)
         {
+            if (!canSetConsoleWindowTitle)
+            {
+                // some scenarios don't allow setting the window title, so we can just ignore if this fails
+                return;
+            }
+
             bool result = NativeMethods.SetConsoleTitle(consoleTitle);
 
             if (!result)
             {
-                int err = Marshal.GetLastWin32Error();
-
-                HostException e = CreateHostException(err, "SetConsoleWindowTitle",
-                    ErrorCategory.ResourceUnavailable, ConsoleControlStrings.SetConsoleWindowTitleExceptionTemplate);
-                throw e;
+                canSetConsoleWindowTitle = false;
             }
         }
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
@@ -2494,7 +2494,7 @@ namespace Microsoft.PowerShell
             return consoleTitle.ToString();
         }
 
-        private static bool canSetConsoleWindowTitle = true;
+        private static bool dontSetConsoleWindowTitle;
 
         /// <summary>
         /// Wraps Win32 SetConsoleTitle.
@@ -2507,7 +2507,7 @@ namespace Microsoft.PowerShell
         /// </exception>
         internal static void SetConsoleWindowTitle(string consoleTitle)
         {
-            if (!canSetConsoleWindowTitle)
+            if (dontSetConsoleWindowTitle)
             {
                 return;
             }
@@ -2522,7 +2522,7 @@ namespace Microsoft.PowerShell
                 if (err == 0x1f)
                 {
                     tracer.WriteLine("Call to SetConsoleTitle failed: {0}", err);
-                    canSetConsoleWindowTitle = false;
+                    dontSetConsoleWindowTitle = true;
 
                     // We ignore this specific error as the console can still continue to operate
                     return;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
@@ -2494,7 +2494,7 @@ namespace Microsoft.PowerShell
             return consoleTitle.ToString();
         }
 
-        internal static bool SetConsoleWindowTitle = true;
+        internal static bool canSetConsoleWindowTitle = true;
 
         /// <summary>
         /// Wraps Win32 SetConsoleTitle.

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
@@ -2494,7 +2494,7 @@ namespace Microsoft.PowerShell
             return consoleTitle.ToString();
         }
 
-        private static bool dontSetConsoleWindowTitle;
+        private static bool s_dontsetConsoleWindowTitle;
 
         /// <summary>
         /// Wraps Win32 SetConsoleTitle.
@@ -2507,7 +2507,7 @@ namespace Microsoft.PowerShell
         /// </exception>
         internal static void SetConsoleWindowTitle(string consoleTitle)
         {
-            if (dontSetConsoleWindowTitle)
+            if (s_dontsetConsoleWindowTitle)
             {
                 return;
             }
@@ -2522,7 +2522,7 @@ namespace Microsoft.PowerShell
                 if (err == 0x1f)
                 {
                     tracer.WriteLine("Call to SetConsoleTitle failed: {0}", err);
-                    dontSetConsoleWindowTitle = true;
+                    s_dontsetConsoleWindowTitle = true;
 
                     // We ignore this specific error as the console can still continue to operate
                     return;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Reported by a partner that they are using PowerShell console host in automation where there is no terminal window and SetConsoleWindowTitle call fails and the console host exits.  Since this is a useful, but decorative feature, we should handle this gracefully by ignoring the Win32 API error and not attempt to set the window title subsequent times.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
