### PR TITLE
Allow the `PSGetMemberBinder` to handle ByRef property

### DIFF
--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -252,6 +252,9 @@ namespace System.Management.Automation.Language
                 new Type[] { typeof(int), typeof(IEqualityComparer) },
                 null);
 
+        internal static readonly MethodInfo ByRefOps_GetByRefPropertyValue =
+            typeof(ByRefOps).GetMethod(nameof(ByRefOps.GetByRefPropertyValue), StaticFlags);
+
         internal static readonly MethodInfo HashtableOps_Add =
             typeof(HashtableOps).GetMethod(nameof(HashtableOps.Add), StaticFlags);
 

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -5277,7 +5277,17 @@ namespace System.Management.Automation.Language
                                     return GenerateGetPropertyException(restrictions).WriteToDebugLog(this);
                                 }
 
-                                expr = Expression.Property(targetExpr, propertyAccessor);
+                                if (propertyAccessor.PropertyType.IsByRef)
+                                {
+                                    expr = Expression.Call(
+                                        CachedReflectionInfo.ByRefOps_GetByRefPropertyValue,
+                                        targetExpr,
+                                        Expression.Constant(propertyAccessor));
+                                }
+                                else
+                                {
+                                    expr = Expression.Property(targetExpr, propertyAccessor);
+                                }
                             }
                             else
                             {

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -1314,6 +1314,17 @@ namespace System.Management.Automation
         }
     }
 
+    internal static class ByRefOps
+    {
+        /// <summary>
+        /// There is no way to directly work with ByRef type in the expression tree, so we turn to reflection in this case.
+        /// </summary>
+        internal static object GetByRefPropertyValue(object target, PropertyInfo property)
+        {
+            return property.GetValue(target);
+        }
+    }
+
     internal static class HashtableOps
     {
         internal static void AddKeyValuePair(IDictionary hashtable, object key, object value, IScriptExtent errorExtent)

--- a/test/powershell/Language/Scripting/Adapter.Tests.ps1
+++ b/test/powershell/Language/Scripting/Adapter.Tests.ps1
@@ -108,3 +108,21 @@ Describe "Interface static members" -Tags "CI" {
         $obj.GetId() | Should -Be 100
     }
 }
+
+Describe "ByRef property" -Tags "CI" {
+
+    It "Get value from ByRef property" {
+        $list = [System.Collections.Generic.LinkedList[int]]::new()
+        $node = $list.AddLast(1)
+
+        ## Get value through language binder.
+        $node.ValueRef | Should -Be 1
+
+        ## Get value through .NET adapter.
+        $property = $node.PSObject.Properties["ValueRef"]
+        $property.IsSettable | Should -BeFalse
+        $property.IsGettable | Should -BeTrue
+        $property.TypeNameOfValue | Should -BeExactly 'System.Int32&'
+        $property.Value | Should -Be 1
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #14632

Allow the `PSGetMemberBinder` to handle `ByRef` property.
There is no way to work with ByRef type directly in expression tree, so we turn to reflection in this case.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.