### PR TITLE
Allow a collection with `Automation.Null` elements to be piped to pipeline

### DIFF
--- a/src/System.Management.Automation/engine/Pipe.cs
+++ b/src/System.Management.Automation/engine/Pipe.cs
@@ -559,15 +559,28 @@ namespace System.Management.Automation.Internal
             else if (_enumeratorToProcess != null)
             {
                 if (_enumeratorToProcessIsEmpty)
-                    return AutomationNull.Value;
-
-                if (!ParserOps.MoveNext(_context, null, _enumeratorToProcess))
                 {
-                    _enumeratorToProcessIsEmpty = true;
                     return AutomationNull.Value;
                 }
 
-                return ParserOps.Current(null, _enumeratorToProcess);
+                while (true)
+                {
+                    if (!ParserOps.MoveNext(_context, errorPosition: null, _enumeratorToProcess))
+                    {
+                        _enumeratorToProcessIsEmpty = true;
+                        return AutomationNull.Value;
+                    }
+
+                    object retValue = ParserOps.Current(errorPosition: null, _enumeratorToProcess);
+                    if (retValue == AutomationNull.Value)
+                    {
+                        // 'AutomationNull.Value' from the enumerator won't be sent to the pipeline.
+                        // We try to get the next value in this case.
+                        continue;
+                    }
+
+                    return retValue;
+                }
             }
             else if (ExternalReader != null)
             {

--- a/test/powershell/Language/Scripting/PipelineBehaviour.Tests.ps1
+++ b/test/powershell/Language/Scripting/PipelineBehaviour.Tests.ps1
@@ -602,3 +602,24 @@ Describe 'Function Pipeline Behaviour' -Tag 'CI' {
         #>
     }
 }
+
+Describe 'Other Pipeline Behaviour' -Tag 'CI' {
+    It "Array with 'Automation.Null' elements can be piped to pipeline" {
+        $automationNull = & {}
+
+        ## 'Automation.Null' elements will not be sent to the pipeline (skipped).
+        1, $automationNull, 2, $automationNull, 3, 4, 5 | ForEach-Object { $_ } | Should -Be (1..5)
+        $array = 1, $automationNull, 2, $automationNull, 3, 4, 5
+        $array.Count | Should -Be 7
+        $array | ForEach-Object { $_ } | Should -Be (1..5)
+    }
+
+    It "Automation.Null is not written to pipeline in a function" {
+        $automationNull = & {}
+
+        function MyTest { 1, $automationNull, 2, $automationNull, 3, 4, 5 }
+        $result = MyTest
+        $result.Count | Should -Be 5
+        MyTest | Should -Be (1..5)
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #14920

Allow a collection with `Automation.Null` elements to be piped to pipeline.
`AutomationNull.Value` is used as the indicator that there is no data in the input pipe. The right behavior is to skip `AutomationNull.Value` elements from the enumerator and move to the next item in that case.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
