### PR TITLE
Add sles15 support to `install-powershell.sh`

### DIFF
--- a/tools/install-powershell.sh
+++ b/tools/install-powershell.sh
@@ -95,10 +95,6 @@ install(){
                 else
                     DistroBasedOn='redhat'
                 fi
-            elif [ -f /etc/SuSE-release ] ; then
-                DistroBasedOn='suse'
-                PSUEDONAME=$( (tr "\n" ' '| sed s/VERSION.*//) < /etc/SuSE-release )
-                REV=$( (grep 'VERSION' | sed s/.*=\ //) < /etc/SuSE-release )
             elif [ -f /etc/mandrake-release ] ; then
                 DistroBasedOn='mandrake'
                 PSUEDONAME=$( (sed s/.*\(// | sed s/\)//) < /etc/mandrake-release )
@@ -117,6 +113,11 @@ install(){
             if [ -f /etc/UnitedLinux-release ] ; then
                 DIST="${DIST}[$( (tr "\n" ' ' | sed s/VERSION.*//) < /etc/UnitedLinux-release )]"
             fi
+			osname=$(source /etc/os-release; echo $PRETTY_NAME)
+			if [[ $osname = *SUSE* ]]; then
+				DistroBasedOn='suse'
+				REV=$(source /etc/os-release; echo $VERSION_ID)
+			fi			
             OS=$(lowercase $OS)
             DistroBasedOn=$(lowercase $DistroBasedOn)
         fi

--- a/tools/installpsh-suse.sh
+++ b/tools/installpsh-suse.sh
@@ -71,8 +71,6 @@ else
             else
                 DistroBasedOn='redhat'
             fi
-        elif [ -f /etc/SuSE-release ] ; then
-            DistroBasedOn='suse'
         elif [ -f /etc/mandrake-release ] ; then
             DistroBasedOn='mandrake'
         elif [ -f /etc/debian_version ] ; then
@@ -82,6 +80,10 @@ else
             DIST="${DIST}[$( (tr "\n" ' ' | sed s/VERSION.*//) < /etc/UnitedLinux-release )]"
             DistroBasedOn=unitedlinux
         fi
+		osname=$(source /etc/os-release; echo $PRETTY_NAME)
+        if [[ $osname = *SUSE* ]]; then
+            DistroBasedOn='suse'
+        fi		
         OS=$(lowercase "$OS")
         DistroBasedOn=$(lowercase "$DistroBasedOn")
     fi


### PR DESCRIPTION
Script today fails for SLES15 because of some outdated code written for Sles12. This is fixed by using the correct command from /etc/os-release for all SUSE distros.