### PR TITLE
Improve handling of long named pipe server names on non-Windows hosts

### DIFF
--- a/src/System.Management.Automation/engine/remoting/common/RemoteSessionNamedPipe.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RemoteSessionNamedPipe.cs
@@ -141,13 +141,10 @@ namespace System.Management.Automation.Remoting
                 pipeName = pipeName.Substring(0, Math.Max(pipeName.Length - charsToTrim, 0));
                 if (pipeName.Length < uniqueLength)
                 {
-                    Console.WriteLine("Not long enough");
                     throw new PSArgumentNullException(nameof(proc));
                 }
             }
 #endif
-
-            Console.WriteLine(string.Format("'{0}'", pipeName));
 
             return pipeName;
         }

--- a/src/System.Management.Automation/engine/remoting/common/RemoteSessionNamedPipe.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RemoteSessionNamedPipe.cs
@@ -32,12 +32,14 @@ namespace System.Management.Automation.Remoting
         internal const string DefaultAppDomainName = "None";
         // This `CoreFxPipe` prefix is defined by CoreFx
         internal const string NamedPipeNamePrefixSearch = "CoreFxPipe_PSHost*";
+
+        // On non-Windows, .NET named pipes are limited to up to 108 characters (107 + NULL)
+        internal const int MaxNamedPipeNameSize = 107;
 #else
         internal const string DefaultAppDomainName = "DefaultAppDomain";
         internal const string NamedPipeNamePrefixSearch = "PSHost*";
+        internal const int MaxNamedPipeNameSize = 0;
 #endif
-        // On non-Windows, .NET named pipes are limited to up to 104 characters
-        internal const int MaxNamedPipeNameSize = 104;
 
         #endregion
 
@@ -108,30 +110,46 @@ namespace System.Management.Automation.Remoting
                 // The starttime is there to prevent another process easily guessing the pipe name
                 // and squatting on it.
                 // There is a limit of 104 characters in total including the temp path to the named pipe file
-                // on non-Windows systems, so we'll convert the starttime to hex and just take the first 8 characters.
+                // on non-Windows systems, so we'll convert the starttime to hex and just take 8 characters.
 #if UNIX
                 .Append(proc.StartTime.ToFileTime().ToString("X8").AsSpan(1, 8))
 #else
                 .Append(proc.StartTime.ToFileTime().ToString(CultureInfo.InvariantCulture))
 #endif
                 .Append('.')
-                .Append(proc.Id.ToString(CultureInfo.InvariantCulture))
-                .Append('.')
+                .Append(proc.Id.ToString(CultureInfo.InvariantCulture));
+
+            int uniqueLength = pipeNameBuilder.Length;
+            pipeNameBuilder.Append('.')
                 .Append(CleanAppDomainNameForPipeName(appDomainName))
                 .Append('.')
                 .Append(proc.ProcessName);
+
+            string pipeName = pipeNameBuilder.ToString();
 #if UNIX
-            int charsToTrim = pipeNameBuilder.Length - MaxNamedPipeNameSize;
+            // .NET Creates named pipes in the tmp path with a special prefix which needs to be included in the max
+            // length calculation.
+            string pipePrefix = Path.Combine(Path.GetTempPath(), "CoreFxPipe_");
+            int remainingPipeLength = Math.Max(MaxNamedPipeNameSize - pipePrefix.Length, 0);
+
+            int charsToTrim = pipeName.Length - remainingPipeLength;
             if (charsToTrim > 0)
             {
                 // TODO: In the case the pipe name is truncated, the user cannot connect to it using the cmdlet
                 // unless we add a `-Force` type switch as it attempts to validate the current process name
                 // matches the process name in the pipe name
-                pipeNameBuilder.Remove(MaxNamedPipeNameSize + 1, charsToTrim);
+                pipeName = pipeName.Substring(0, Math.Max(pipeName.Length - charsToTrim, 0));
+                if (pipeName.Length < uniqueLength)
+                {
+                    Console.WriteLine("Not long enough");
+                    throw new PSArgumentNullException(nameof(proc));
+                }
             }
 #endif
 
-            return pipeNameBuilder.ToString();
+            Console.WriteLine(string.Format("'{0}'", pipeName));
+
+            return pipeName;
         }
 
         private static string CleanAppDomainNameForPipeName(string appDomainName)


### PR DESCRIPTION
# PR Summary

Fixes handling on tmp dirs or process names that exceed the 108 character limit of a unix domain socket on non-Windows hosts. This PR ensures that the trimming of socket names take into account:

* The dir path length it is created in
* The null char at the end of the path
* It always has enough space for unique attributes of the proc and skips creating if it doesn't

## PR Context

Fixes https://github.com/PowerShell/PowerShell/issues/16994

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
