### PR TITLE
Update `AzureFileCopy` task and fix the syntax for specifying `pool`

### DIFF
--- a/tools/releaseBuild/azureDevOps/templates/release-BuildJson.yml
+++ b/tools/releaseBuild/azureDevOps/templates/release-BuildJson.yml
@@ -68,7 +68,7 @@ steps:
     }
   displayName: Download and Capture NuPkgs
 
-- task: AzureFileCopy@2
+- task: AzureFileCopy@4
   displayName: 'AzureBlob build info JSON file Copy'
   inputs:
     SourcePath: '$(BuildInfoJsonFile)'
@@ -78,7 +78,7 @@ steps:
     ContainerName: BuildInfo
   condition: and(succeeded(), eq(variables['CopyMainBuildInfo'], 'YES'))
 
-- task: AzureFileCopy@2
+- task: AzureFileCopy@4
   displayName: 'AzureBlob build info ''lts.json'' Copy when needed'
   inputs:
     SourcePath: '$(LtsBuildInfoJsonFile)'
@@ -88,7 +88,7 @@ steps:
     ContainerName: BuildInfo
   condition: and(succeeded(), eq(variables['CopyLTSBuildInfo'], 'YES'))
 
-- task: AzureFileCopy@2
+- task: AzureFileCopy@4
   displayName: 'AzureBlob build info ''Major-Minor.json'' Copy when needed'
   inputs:
     SourcePath: '$(VersionBuildInfoJsonFile)'

--- a/tools/releaseBuild/azureDevOps/templates/release-UpdateDepsJson.yml
+++ b/tools/releaseBuild/azureDevOps/templates/release-UpdateDepsJson.yml
@@ -59,7 +59,7 @@ jobs:
       Write-Host "##$vstsCommand"
     displayName: Determine file to upload
 
-  - task: AzureFileCopy@2
+  - task: AzureFileCopy@4
     displayName: 'AzureBlob pwsh.deps.json file Copy'
     inputs:
       SourcePath: '$(FileToUpload)'

--- a/tools/releaseBuild/azureDevOps/vpackRelease.yml
+++ b/tools/releaseBuild/azureDevOps/vpackRelease.yml
@@ -25,7 +25,8 @@ stages:
     displayName: Name the build
     condition: succeeded()
 
-    pool: PowerShell1ES
+    pool:
+      name: PowerShell1ES
       demands:
       - ImageOverride -equals PSMMS2019-Secure
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Update `AzureFileCopy` task and fix the syntax for specifying `pool`.
The former causes 2 jobs in release pipeline to fail, and the latter causes the vpack build to fail.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
