### PR TITLE
Do not generate clean block in proxy command when the feature is disabled

### DIFF
--- a/src/System.Management.Automation/engine/CommandMetadata.cs
+++ b/src/System.Management.Automation/engine/CommandMetadata.cs
@@ -864,6 +864,15 @@ dynamicparam
 ", GetDynamicParamBlock());
             }
 
+            string cleanBlock = string.Empty;
+            if (ExperimentalFeature.IsEnabled(ExperimentalFeature.PSCleanBlockFeatureName))
+            {
+                cleanBlock = string.Format(CultureInfo.InvariantCulture, @"
+clean
+{{{0}}}
+", GetCleanBlock());
+            }
+
             string result = string.Format(CultureInfo.InvariantCulture, @"{0}
 param({1})
 
@@ -875,9 +884,7 @@ process
 
 end
 {{{5}}}
-
-clean
-{{{6}}}
+{6}
 <#
 {7}
 #>
@@ -888,7 +895,7 @@ clean
                 GetBeginBlock(),
                 GetProcessBlock(),
                 GetEndBlock(),
-                GetCleanBlock(),
+                cleanBlock,
                 CodeGeneration.EscapeBlockCommentContent(helpComment));
 
             return result;


### PR DESCRIPTION

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #17110
When the `PSCleanBlock` experimental feature is not enabled, `ProxyCommand.Create` should not generate the clean block for the proxy function.

After the fix,
1. **when the feature is disabled**, generated proxy function for `Get-Command` doesn't have the `clean` block in it:
    ```powershell
    PS:4> [System.Management.Automation.ProxyCommand]::Create($cm)
    [CmdletBinding(DefaultParameterSetName='CmdletSet', HelpUri='https://go.microsoft.com/fwlink/?LinkID=2096579')]
    param(
       .... ## skip the long param block
       )
    
    begin
    {
        ... ## skip the long begin block
    }
    
    process
    {
        try {
            $steppablePipeline.Process($_)
        } catch {
            throw
        }
    }
    
    end
    {
        try {
            $steppablePipeline.End()
        } catch {
            throw
        }
    }
    
    <#
    
    .ForwardHelpTargetName Microsoft.PowerShell.Core\Get-Command
    .ForwardHelpCategory Cmdlet
    
    #>
    ```

2. **When the feature is enabled**, the generated proxy function for `Get-Command` has the `clean` block in it:
    ```powershell
    PS:3> [System.Management.Automation.ProxyCommand]::Create($cm)
    [CmdletBinding(DefaultParameterSetName='CmdletSet', HelpUri='https://go.microsoft.com/fwlink/?LinkID=2096579')]
    param(
       ... ## skip the long param block
        )
    
    begin
    {
        ... ## skip the long begin block
    }
    
    process
    {
        try {
            $steppablePipeline.Process($_)
        } catch {
            throw
        }
    }
    
    end
    {
        try {
            $steppablePipeline.End()
        } catch {
            throw
        }
    }
    
    clean
    {
        if ($null -ne $steppablePipeline) {
            $steppablePipeline.Clean()
        }
    }
    
    <#
    
    .ForwardHelpTargetName Microsoft.PowerShell.Core\Get-Command
    .ForwardHelpCategory Cmdlet
    
    #>
    ```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
