### PR TITLE
Support forward slashes in network share (UNC path) completion (#17111)

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4301,7 +4301,8 @@ namespace System.Management.Automation
             var results = new List<CompletionResult>();
 
             // First, try to match \\server\share
-            var shareMatch = Regex.Match(wordToComplete, "^\\\\\\\\([^\\\\]+)\\\\([^\\\\]*)$");
+            // support both / and \ when entering UNC paths for typing convenience (#17111)
+            var shareMatch = Regex.Match(wordToComplete, @"^(?:\\\\|//)([^\\/]+)(?:\\|/)([^\\/]*)$");
             if (shareMatch.Success)
             {
                 // Only match share names, no filenames.

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -987,9 +987,9 @@ switch ($x)
 
         It "Tab completion UNC path with forward slashes" -Skip:(!$IsWindows) {
             $homeDrive = $env:HOMEDRIVE.Replace(":", "$")
-            $beforeTab = "//localhost/$homeDrive/wind"
+            $beforeTab = "//localhost/admin"
             # it is expected that tab completion turns forward slashes into backslashes
-            $afterTab = "& '\\localhost\$homeDrive\Windows'"
+            $afterTab = "\\localhost\ADMIN$"
             $res = TabExpansion2 -inputScript $beforeTab -cursorColumn $beforeTab.Length
             $res.CompletionMatches.Count | Should -BeGreaterThan 0
             $res.CompletionMatches[0].CompletionText | Should -BeExactly $afterTab

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -140,7 +140,7 @@ switch ($x)
             $res = TabExpansion2 -cursorColumn $CursorIndex -inputScript $TestString.Remove($CursorIndex, 1)
             $res.CompletionMatches[0].CompletionText | Should -BeExactly $Expected
         }
-    
+
     It 'Should Complete and replace existing member with space in front of cursor and cursor in front of word' {
         $TestString = '[System.Management.Automation.ActionPreference]:: ^Break'
         $CursorIndex = $TestString.IndexOf('^')
@@ -985,6 +985,17 @@ switch ($x)
             $res.CompletionMatches[0].CompletionText | Should -BeExactly $afterTab
         }
 
+        It "Tab completion UNC path with forward slashes" -Skip:(!$IsWindows) {
+            $homeDrive = $env:HOMEDRIVE.Replace(":", "$")
+            $beforeTab = "//localhost/$homeDrive/wind"
+            # it is expected that tab completion turns forward slashes into backslashes
+            $afterTab = "& '\\localhost\$homeDrive\Windows'"
+            $res = TabExpansion2 -inputScript $beforeTab -cursorColumn $beforeTab.Length
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly $afterTab
+        }
+
+
         It "Tab completion for registry" -Skip:(!$IsWindows) {
             $beforeTab = 'registry::HKEY_l'
             $afterTab = 'registry::HKEY_LOCAL_MACHINE'
@@ -1349,12 +1360,12 @@ dir -Recurse `
             $res.CompletionMatches | Should -HaveCount 2
             [string]::Join(',', ($res.CompletionMatches.completiontext | Sort-Object)) | Should -BeExactly "1.0,1.1"
         }
-        
+
         It 'Should complete Select-Object properties without duplicates' {
             $res = TabExpansion2 -inputScript '$PSVersionTable | Select-Object -Property Count,'
             $res.CompletionMatches.CompletionText | Should -Not -Contain "Count"
         }
-        
+
         It '<Intent>' -TestCases @(
             @{
                 Intent = 'Complete loop labels with no input'

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -986,7 +986,6 @@ switch ($x)
         }
 
         It "Tab completion UNC path with forward slashes" -Skip:(!$IsWindows) {
-            $homeDrive = $env:HOMEDRIVE.Replace(":", "$")
             $beforeTab = "//localhost/admin"
             # it is expected that tab completion turns forward slashes into backslashes
             $afterTab = "\\localhost\ADMIN$"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

This PR implements support for forward slashes in partial network share (UNC paths) names when performing tab completion (Close #17111)

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

This makes tab completion easier to use e.g. when using French layout keyboards, where entering a forward slash (`Shift+:`) is way easier than entering a backslash (`AltGr+8`).

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Tab expansion will handle partial inputs in the form `//hostname/...` in addition to the canonical `\\hostname\...` form 
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [X] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [X] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [X] Issue filed: <!-- Number/link of that issue here -->https://github.com/PowerShell/PowerShell/issues/17111
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
