### PR TITLE
Remove BinaryFormatter use in PSRP serialization

### DIFF
--- a/src/System.Management.Automation/engine/remoting/common/WireDataFormat/EncodeAndDecode.cs
+++ b/src/System.Management.Automation/engine/remoting/common/WireDataFormat/EncodeAndDecode.cs
@@ -1602,7 +1602,7 @@ namespace System.Management.Automation
         {
             PSObject temp = GenerateSessionCapability(capability);
             temp.Properties.Add(
-                new PSNoteProperty(RemoteDataNameStrings.TimeZone, RemoteSessionCapability.GetCurrentTimeZoneInByteFormat()));
+                new PSNoteProperty(RemoteDataNameStrings.TimeZone, Array.Empty<byte>()));
             return RemoteDataObject.CreateFrom(capability.RemotingDestination,
                 RemotingDataType.SessionCapability, runspacePoolId, Guid.Empty, temp);
         }
@@ -2372,24 +2372,6 @@ namespace System.Management.Automation
             RemoteSessionCapability result = new RemoteSessionCapability(
                 RemotingDestination.InvalidDestination,
                 protocolVersion, psVersion, serializationVersion);
-
-            if (dataAsPSObject.Properties[RemoteDataNameStrings.TimeZone] != null)
-            {
-                // Binary deserialization of timezone info via BinaryFormatter is unsafe,
-                // so don't deserialize any untrusted client data using this API.
-                //
-                // In addition, the binary data being sent by the client doesn't represent
-                // the client's current TimeZone unless they somehow accessed the
-                // StandardName and DaylightName. These properties are initialized lazily
-                // by the .NET Framework, and would be populated by the server with local
-                // values anyways.
-                //
-                // So just return the CurrentTimeZone.
-
-#if !CORECLR // TimeZone Not In CoreCLR
-                result.TimeZone = TimeZone.CurrentTimeZone;
-#endif
-            }
 
             return result;
         }

--- a/src/System.Management.Automation/engine/remoting/common/WireDataFormat/EncodeAndDecode.cs
+++ b/src/System.Management.Automation/engine/remoting/common/WireDataFormat/EncodeAndDecode.cs
@@ -1601,8 +1601,6 @@ namespace System.Management.Automation
                 Guid runspacePoolId)
         {
             PSObject temp = GenerateSessionCapability(capability);
-            temp.Properties.Add(
-                new PSNoteProperty(RemoteDataNameStrings.TimeZone, Array.Empty<byte>()));
             return RemoteDataObject.CreateFrom(capability.RemotingDestination,
                 RemotingDataType.SessionCapability, runspacePoolId, Guid.Empty, temp);
         }

--- a/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemoteSessionCapability.cs
+++ b/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemoteSessionCapability.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Management.Automation.Host;
 using System.Management.Automation.Internal.Host;
-using System.Runtime.Serialization.Formatters.Binary;
 
 using Dbg = System.Management.Automation.Diagnostics;
 
@@ -25,8 +24,6 @@ namespace System.Management.Automation.Remoting
         private readonly Version _serversion;
         private Version _protocolVersion;
         private readonly RemotingDestination _remotingDestination;
-        private static byte[] _timeZoneInByteFormat;
-        private TimeZoneInfo _timeZone;
 
         #endregion
 
@@ -90,64 +87,6 @@ namespace System.Management.Automation.Remoting
         internal static RemoteSessionCapability CreateServerCapability()
         {
             return new RemoteSessionCapability(RemotingDestination.Client);
-        }
-
-        /// <summary>
-        /// This is static property which gets Current TimeZone in byte format
-        /// by using ByteFormatter.
-        /// This is static to make client generate this only once.
-        /// </summary>
-        internal static byte[] GetCurrentTimeZoneInByteFormat()
-        {
-            if (_timeZoneInByteFormat == null)
-            {
-                Exception e = null;
-                try
-                {
-                    BinaryFormatter formatter = new BinaryFormatter();
-                    using (MemoryStream stream = new MemoryStream())
-                    {
-#pragma warning disable SYSLIB0011
-                        formatter.Serialize(stream, TimeZoneInfo.Local);
-#pragma warning restore SYSLIB0011
-                        stream.Seek(0, SeekOrigin.Begin);
-                        byte[] result = new byte[stream.Length];
-                        stream.Read(result, 0, (int)stream.Length);
-                        _timeZoneInByteFormat = result;
-                    }
-                }
-                catch (ArgumentNullException ane)
-                {
-                    e = ane;
-                }
-                catch (System.Runtime.Serialization.SerializationException sre)
-                {
-                    e = sre;
-                }
-                catch (System.Security.SecurityException se)
-                {
-                    e = se;
-                }
-
-                // if there is any exception serializing the timezone information
-                // ignore it and dont try to serialize again.
-                if (e != null)
-                {
-                    _timeZoneInByteFormat = Array.Empty<byte>();
-                }
-            }
-
-            return _timeZoneInByteFormat;
-        }
-
-        /// <summary>
-        /// Gets the TimeZone of the destination machine. This may be null.
-        /// </summary>
-        internal TimeZoneInfo TimeZone
-        {
-            get { return _timeZone; }
-
-            set { _timeZone = value; }
         }
     }
 

--- a/src/System.Management.Automation/engine/remoting/fanin/PSPrincipal.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/PSPrincipal.cs
@@ -125,9 +125,8 @@ namespace System.Management.Automation.Remoting
 
         /// <summary>
         /// Contains the TimeZone information from the client machine.
-        /// This value is obsolete and is always set to TimeZoneInfo.Local.
         /// </summary>
-        public TimeZoneInfo ClientTimeZone => TimeZoneInfo.Local;
+        public TimeZoneInfo ClientTimeZone => null;
 
         /// <summary>
         /// Connection string used by the client to connect to the server. This is

--- a/src/System.Management.Automation/engine/remoting/fanin/PSPrincipal.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/PSPrincipal.cs
@@ -18,9 +18,8 @@ namespace System.Management.Automation.Remoting
     /// <summary>
     /// This class is used in the server side remoting scenarios. This class
     /// holds information about the incoming connection like:
-    /// (a) Client's TimeZone
-    /// (b) Connecting User information
-    /// (c) Connection String used by the user to connect to the server.
+    /// (a) Connecting User information
+    /// (b) Connection String used by the user to connect to the server.
     /// </summary>
     [Serializable]
     public sealed class PSSenderInfo : ISerializable
@@ -81,8 +80,6 @@ namespace System.Management.Automation.Remoting
                 UserInfo = senderInfo.UserInfo;
                 ConnectionString = senderInfo.ConnectionString;
                 _applicationArguments = senderInfo._applicationArguments;
-
-                ClientTimeZone = senderInfo.ClientTimeZone;
             }
             catch (Exception)
             {
@@ -128,12 +125,9 @@ namespace System.Management.Automation.Remoting
 
         /// <summary>
         /// Contains the TimeZone information from the client machine.
+        /// This value is obsolete and is always set to TimeZoneInfo.Local.
         /// </summary>
-        public TimeZoneInfo ClientTimeZone
-        {
-            get;
-            internal set;
-        }
+        public TimeZoneInfo ClientTimeZone => TimeZoneInfo.Local;
 
         /// <summary>
         /// Connection string used by the client to connect to the server. This is

--- a/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
+++ b/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
@@ -749,13 +749,6 @@ namespace System.Management.Automation.Remoting
             RemoteDataObject<PSObject> rcvdData = createRunspaceEventArg.ReceivedData;
             Dbg.Assert(rcvdData != null, "rcvdData must be non-null");
 
-            // set the PSSenderInfo sent in the first packets
-            // This is used by the initial session state configuration providers like Exchange.
-            if (Context != null)
-            {
-                _senderInfo.ClientTimeZone = Context.ClientCapability.TimeZone;
-            }
-
             _senderInfo.ApplicationArguments = RemotingDecoder.GetApplicationArguments(rcvdData.Data);
 
             // Get Initial Session State from custom session config suppliers

--- a/src/System.Management.Automation/engine/serialization.cs
+++ b/src/System.Management.Automation/engine/serialization.cs
@@ -7212,7 +7212,6 @@ namespace Microsoft.PowerShell
 
             PSSenderInfo senderInfo = new PSSenderInfo(psPrincipal, GetPropertyValue<string>(pso, "ConnectionString"));
 
-            senderInfo.ClientTimeZone = TimeZoneInfo.Local;
             senderInfo.ApplicationArguments = GetPropertyValue<PSPrimitiveDictionary>(pso, "ApplicationArguments");
 
             return senderInfo;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Removes the usage of `BinaryFormatter` in PSRP connections.

## PR Context

The `BinaryFormatter` class is marked as obsolete and is planned to be removed in a future .NET version https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md. One location where it is used in pwsh is when serializing the client's time zone. On the server end PowerShell has ignored this property since v3 and even on v2 it has an exception handler to ignore invalid values. This means the client can either omit the property altogether or send an empty value and the server will still be fine.

One minor difference between a missing property and an empty property value is that `$PSSenderInfo.ClientTimeZone` is `$null` when it's missing and set to `[TimeZone]::Current` when it's an empty value. So to preserve as much existing behaviour an empty value was used instead.

The only concern I have with this approach that I haven't tested it with an Exchange endpoint to see if it has any special behaviour with this property.

Partially addressed https://github.com/PowerShell/PowerShell/issues/14054

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
