### PR TITLE
Make a variable assignment in a `ParenExpression` to return the variable value

### DIFF
--- a/src/System.Management.Automation/engine/ShellVariable.cs
+++ b/src/System.Management.Automation/engine/ShellVariable.cs
@@ -245,6 +245,14 @@ namespace System.Management.Automation
         }
 
         /// <summary>
+        /// Gets the value without triggering debugger check.
+        /// </summary>
+        internal virtual object GetValueRaw()
+        {
+            return _value;
+        }
+
+        /// <summary>
         /// Gets or sets the value of the variable.
         /// </summary>
         /// <exception cref="SessionStateUnauthorizedAccessException">
@@ -794,6 +802,11 @@ namespace System.Management.Automation
                 _tuple.SetValue(_tupleSlot, value);
                 DebuggerCheckVariableWrite();
             }
+        }
+
+        internal override object GetValueRaw()
+        {
+            return _tuple.GetValue(_tupleSlot);
         }
 
         internal override void SetValueRaw(object newValue, bool preserveValueTypeSemantics)

--- a/src/System.Management.Automation/engine/runtime/Operations/VariableOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/VariableOps.cs
@@ -48,8 +48,9 @@ namespace System.Management.Automation
 
                 if (attributes.Count > 0)
                 {
-                    // When there is any attributes, it's possible the value was converted/transformed.
-                    value = var.Value;
+                    // When there are any attributes, it's possible the value was converted/transformed.
+                    // Use 'GetValueRaw' here so the debugger check won't be triggered.
+                    value = var.GetValueRaw();
                 }
 
                 // Marking untrusted values for assignments in 'ConstrainedLanguage' mode is done in

--- a/src/System.Management.Automation/engine/runtime/Operations/VariableOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/VariableOps.cs
@@ -46,6 +46,12 @@ namespace System.Management.Automation
                                      : GetAttributeCollection(attributeAsts);
                 var = new PSVariable(variablePath.UnqualifiedPath, value, ScopedItemOptions.None, attributes);
 
+                if (attributes.Count > 0)
+                {
+                    // When there is any attributes, it's possible the value was converted/transformed.
+                    value = var.Value;
+                }
+
                 // Marking untrusted values for assignments in 'ConstrainedLanguage' mode is done in
                 // SessionStateScope.SetVariable.
                 sessionState.SetVariable(variablePath, var, false, origin);
@@ -81,7 +87,7 @@ namespace System.Management.Automation
                             null,
                             Metadata.InvalidValueFailure,
                             var.Name,
-                            ((value != null) ? value.ToString() : "$null"));
+                            (value != null) ? value.ToString() : "$null");
 
                         throw e;
                     }

--- a/test/powershell/Language/Scripting/Scripting.Followup.Tests.ps1
+++ b/test/powershell/Language/Scripting/Scripting.Followup.Tests.ps1
@@ -29,4 +29,10 @@ Describe "Scripting.Followup.Tests" -Tags "CI" {
         ## $arraylist.Clear() should be executed
         $arraylist.Count | Should -Be 0
     }
+
+    ## fix https://github.com/PowerShell/PowerShell/issues/17165
+    It "([bool] `$var = 42) should return the varaible value" {
+        ([bool]$var = 42).GetType().FullName | Should -Be "System.Boolean"
+        . { ([bool]$var = 42).GetType().FullName } | Should -Be "System.Boolean"
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #17165
Make a variable assignment in a `ParenExpression` to return the variable value.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
