### PR TITLE
Fix line breakpoints for `return` statements without a value

### DIFF
--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -642,7 +642,7 @@ namespace System.Management.Automation.Language
 
         internal static readonly MethodInfo ArgumentTransformationAttribute_Transform =
             typeof(ArgumentTransformationAttribute).GetMethod(nameof(ArgumentTransformationAttribute.Transform), InstancePublicFlags);
-        
+
         internal static readonly MethodInfo MemberInvocationLoggingOps_LogMemberInvocation =
             typeof(MemberInvocationLoggingOps).GetMethod(nameof(MemberInvocationLoggingOps.LogMemberInvocation), StaticFlags);
     }
@@ -5617,7 +5617,9 @@ namespace System.Management.Automation.Language
                 return Expression.Block(returnValue, returnExpr);
             }
 
-            return returnExpr;
+            return Expression.Block(
+                UpdatePosition(returnStatementAst),
+                returnExpr);
         }
 
         public object VisitExitStatement(ExitStatementAst exitStatementAst)

--- a/test/powershell/Language/Scripting/Debugging/Debugging.Tests.ps1
+++ b/test/powershell/Language/Scripting/Debugging/Debugging.Tests.ps1
@@ -334,30 +334,30 @@ elseif (Test-Path $PSCommandPath)
 
     Context "Break point on return should hit" {
         BeforeAll {
-            $if_script_1 = @'
+            $return_script_1 = @'
 return
 '@
-            $if_script_2 = @'
+            $return_script_2 = @'
 return 10
 '@
 
-            $IfScript_1 = Setup -PassThru -File IfScript_1.ps1 -Content $if_script_1
-            $bp_1 = Set-PSBreakpoint -Script $IfScript_1 -Line 1 -Action { continue }
+            $ReturnScript_1 = Setup -PassThru -File ReturnScript_1.ps1 -Content $return_script_1
+            $bp_1 = Set-PSBreakpoint -Script $ReturnScript_1 -Line 1 -Action { continue }
 
-            $IfScript_2 = Setup -PassThru -File IfScript_2.ps1 -Content $if_script_2
-            $bp_2 = Set-PSBreakpoint -Script $IfScript_2 -Line 1 -Action { continue }
+            $ReturnScript_2 = Setup -PassThru -File ReturnScript_2.ps1 -Content $return_script_2
+            $bp_2 = Set-PSBreakpoint -Script $ReturnScript_2 -Line 1 -Action { continue }
 
             $testCases = @(
-                @{ Name = "return without pipeline should be hit once"; Path = $IfScript_1; Breakpoint = $bp_1; HitCount = 1 }
-                @{ Name = "return with pipeline should be hit once";    Path = $IfScript_2; Breakpoint = $bp_2; HitCount = 1 }
+                @{ Name = "return without pipeline should be hit once"; Path = $ReturnScript_1; Breakpoint = $bp_1; HitCount = 1 }
+                @{ Name = "return with pipeline should be hit once";    Path = $ReturnScript_2; Breakpoint = $bp_2; HitCount = 1 }
             )
         }
 
         AfterAll {
-            Get-PSBreakpoint -Script $IfScript_1, $IfScript_2, $IfScript_3, $IfScript_4 | Remove-PSBreakpoint
+            Get-PSBreakpoint -Script $ReturnScript_1, $ReturnScript_2 | Remove-PSBreakpoint
         }
 
-        It "If statement <Name>" -TestCases $testCases {
+        It "Return statement <Name>" -TestCases $testCases {
             param($Path, $Breakpoint, $HitCount)
             $null = & $Path
             $Breakpoint.HitCount | Should -Be $HitCount

--- a/test/powershell/Language/Scripting/Debugging/Debugging.Tests.ps1
+++ b/test/powershell/Language/Scripting/Debugging/Debugging.Tests.ps1
@@ -340,6 +340,13 @@ return
             $return_script_2 = @'
 return 10
 '@
+            $return_script_3 = @'
+trap {
+    return
+}
+
+throw
+'@
 
             $ReturnScript_1 = Setup -PassThru -File ReturnScript_1.ps1 -Content $return_script_1
             $bp_1 = Set-PSBreakpoint -Script $ReturnScript_1 -Line 1 -Action { continue }
@@ -347,14 +354,18 @@ return 10
             $ReturnScript_2 = Setup -PassThru -File ReturnScript_2.ps1 -Content $return_script_2
             $bp_2 = Set-PSBreakpoint -Script $ReturnScript_2 -Line 1 -Action { continue }
 
+            $ReturnScript_3 = Setup -PassThru -File ReturnScript_3.ps1 -Content $return_script_3
+            $bp_3 = Set-PSBreakpoint -Script $ReturnScript_3 -Line 2 -Action { continue }
+
             $testCases = @(
                 @{ Name = "return without pipeline should be hit once"; Path = $ReturnScript_1; Breakpoint = $bp_1; HitCount = 1 }
                 @{ Name = "return with pipeline should be hit once";    Path = $ReturnScript_2; Breakpoint = $bp_2; HitCount = 1 }
+                @{ Name = "return from trap should be hit once";        Path = $ReturnScript_3; Breakpoint = $bp_3; HitCount = 1 }
             )
         }
 
         AfterAll {
-            Get-PSBreakpoint -Script $ReturnScript_1, $ReturnScript_2 | Remove-PSBreakpoint
+            Get-PSBreakpoint -Script $ReturnScript_1, $ReturnScript_2, $ReturnScript_3 | Remove-PSBreakpoint
         }
 
         It "Return statement <Name>" -TestCases $testCases {

--- a/test/powershell/Language/Scripting/Debugging/Debugging.Tests.ps1
+++ b/test/powershell/Language/Scripting/Debugging/Debugging.Tests.ps1
@@ -331,6 +331,38 @@ elseif (Test-Path $PSCommandPath)
             $Breakpoint.HitCount | Should -Be $HitCount
         }
     }
+
+    Context "Break point on return should hit" {
+        BeforeAll {
+            $if_script_1 = @'
+return
+'@
+            $if_script_2 = @'
+return 10
+'@
+
+            $IfScript_1 = Setup -PassThru -File IfScript_1.ps1 -Content $if_script_1
+            $bp_1 = Set-PSBreakpoint -Script $IfScript_1 -Line 1 -Action { continue }
+
+            $IfScript_2 = Setup -PassThru -File IfScript_2.ps1 -Content $if_script_2
+            $bp_2 = Set-PSBreakpoint -Script $IfScript_2 -Line 1 -Action { continue }
+
+            $testCases = @(
+                @{ Name = "return without pipeline should be hit once"; Path = $IfScript_1; Breakpoint = $bp_1; HitCount = 1 }
+                @{ Name = "return with pipeline should be hit once";    Path = $IfScript_2; Breakpoint = $bp_2; HitCount = 1 }
+            )
+        }
+
+        AfterAll {
+            Get-PSBreakpoint -Script $IfScript_1, $IfScript_2, $IfScript_3, $IfScript_4 | Remove-PSBreakpoint
+        }
+
+        It "If statement <Name>" -TestCases $testCases {
+            param($Path, $Breakpoint, $HitCount)
+            $null = & $Path
+            $Breakpoint.HitCount | Should -Be $HitCount
+        }
+    }
 }
 
 Describe "It should be possible to reset runspace debugging" -Tag "Feature" {

--- a/test/powershell/Language/Scripting/Debugging/Debugging.Tests.ps1
+++ b/test/powershell/Language/Scripting/Debugging/Debugging.Tests.ps1
@@ -342,6 +342,7 @@ return 10
 '@
             $return_script_3 = @'
 trap {
+    'statement to ignore trap registration sequence point'
     return
 }
 
@@ -355,7 +356,7 @@ throw
             $bp_2 = Set-PSBreakpoint -Script $ReturnScript_2 -Line 1 -Action { continue }
 
             $ReturnScript_3 = Setup -PassThru -File ReturnScript_3.ps1 -Content $return_script_3
-            $bp_3 = Set-PSBreakpoint -Script $ReturnScript_3 -Line 2 -Action { continue }
+            $bp_3 = Set-PSBreakpoint -Script $ReturnScript_3 -Line 3 -Action { continue }
 
             $testCases = @(
                 @{ Name = "return without pipeline should be hit once"; Path = $ReturnScript_1; Breakpoint = $bp_1; HitCount = 1 }


### PR DESCRIPTION
Fixes #17081

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Adds an explicit call to `UpdatePosition` when a `return` statement does not include a pipeline.

Codegen before change:

```csharp
// Generated with:
// { return } | Get-ScriptBlockDisassembly -IgnoreStartupAndTeardown
// ScriptBlock.EndBlock
funcContext._currentSequencePointIndex = 0;
try
{
    return ;
}
catch (FlowControlException)
{
    throw;
}
catch (Exception exception)
{
    ExceptionHandlingOps.CheckActionPreference(funcContext, exception);
}
funcContext._currentSequencePointIndex = 1;

if (context._debuggingMode > 0)
{
    context._debugger.OnSequencePointHit(funcContext);
}
```

Codegen after change:

```csharp
// Generated with:
// { return } | Get-ScriptBlockDisassembly -IgnoreStartupAndTeardown
// ScriptBlock.EndBlock
funcContext._currentSequencePointIndex = 0;
try
{
    funcContext._currentSequencePointIndex = 1;

    if (context._debuggingMode > 0)
    {
        context._debugger.OnSequencePointHit(funcContext);
    }
    return ;
}
catch (FlowControlException)
{
    throw;
}
catch (Exception exception)
{
    ExceptionHandlingOps.CheckActionPreference(funcContext, exception);
}
funcContext._currentSequencePointIndex = 2;

if (context._debuggingMode > 0)
{
    context._debugger.OnSequencePointHit(funcContext);
}
```

<details>
<summary>

## Trap compilation (click to expand)</summary>

Turns out there wasn't an easy way to view disassembly of a trap with `ScriptBlockDisassembler`. So that took a minute to figure out how to do easily:

<details>
<summary>

### Code to generate (click to expand)</summary>

```powershell
#requires -Modules ImpliedReflection, ScriptBlockDisassembler

Enable-ImpliedReflection -YesIKnowIShouldNotDoThis

$sb = {
    trap { return }
    throw
}

$trap = $sb.Ast.EndBlock.Traps[0]
$main = [System.Management.Automation.Language.Compiler]::new()
$main.Compile($sb.ScriptBlockData, $true)
$secondary = [System.Management.Automation.Language.Compiler]::new(
    $main._sequencePoints,
    $main._sequencePointIndexMap)

$secondary._compilingTrap = $true
$funcName = $main._currentFunctionName + '<trap>'
if ($null -ne $trap.TrapType) {
    $funcName += '<' + $trap.TrapType.TypeName.Name + '>'
}

$tuple = [Management.Automation.Language.VariableAnalysis]::AnalyzeTrap($trap)
$secondary.LocalVariablesTupleType = $tuple.Item1
$secondary.LocalVariablesParameter = [Linq.Expressions.Expression]::Variable(
    $secondary.LocalVariablesTupleType,
    'locals')

$lambda = $secondary.CompileSingleLambda(
    $trap.Body.Statements,
    $trap.Body.Traps,
    $funcName,
    <# entryExtent: #> $null,
    <# exitExtent: #> $null,
    <# rootForDefiningTypesAndUsings: #> $null)

$lambda | Format-ExpressionTree | bat -l cs
```
</details>

### Codegen before:

```csharp
(FunctionContext funcContext) =>
{
    try
    {
        ExecutionContext context = funcContext._executionContext;
        MutableTuple<object, object[], object, object, PSScriptCmdlet, PSBoundParametersDictionary, InvocationInfo, string, string, LanguagePrimitives.Null, LanguagePrimitives.Null, LanguagePrimitives.Null, LanguagePrimitives.Null, LanguagePrimitives.Null, LanguagePrimitives.Null, LanguagePrimitives.Null> locals = (MutableTuple<object, object[], object, object, PSScriptCmdlet, PSBoundParametersDictionary, InvocationInfo, string, string, LanguagePrimitives.Null, LanguagePrimitives.Null, LanguagePrimitives.Null, LanguagePrimitives.Null, LanguagePrimitives.Null, LanguagePrimitives.Null, LanguagePrimitives.Null>)funcContext._localsTuple;
        funcContext._functionName = "<ScriptBlock><trap>";
        context._debugger.EnterScriptFunction(funcContext);
        try
        {
            throw new ReturnException(AutomationNull.Value);
        }
        catch (FlowControlException)
        {
            throw;
        }
        catch (Exception exception)
        {
            ExceptionHandlingOps.CheckActionPreference(funcContext, exception);
        }
    }
    finally
    {
        context._debugger.ExitScriptFunction();
    }
}
```

### Codegen after:

```csharp
(FunctionContext funcContext) =>
{
    try
    {
        ExecutionContext context = funcContext._executionContext;
        MutableTuple<object, object[], object, object, PSScriptCmdlet, PSBoundParametersDictionary, InvocationInfo, string, string, LanguagePrimitives.Null, LanguagePrimitives.Null, LanguagePrimitives.Null, LanguagePrimitives.Null, LanguagePrimitives.Null, LanguagePrimitives.Null, LanguagePrimitives.Null> locals = (MutableTuple<object, object[], object, object, PSScriptCmdlet, PSBoundParametersDictionary, InvocationInfo, string, string, LanguagePrimitives.Null, LanguagePrimitives.Null, LanguagePrimitives.Null, LanguagePrimitives.Null, LanguagePrimitives.Null, LanguagePrimitives.Null, LanguagePrimitives.Null>)funcContext._localsTuple;
        funcContext._functionName = "<ScriptBlock><trap>";
        context._debugger.EnterScriptFunction(funcContext);
        try
        {
            funcContext._currentSequencePointIndex = 1;

            if (context._debuggingMode > 0)
            {
                context._debugger.OnSequencePointHit(funcContext);
            }
            throw new ReturnException(AutomationNull.Value);
        }
        catch (FlowControlException)
        {
            throw;
        }
        catch (Exception exception)
        {
            ExceptionHandlingOps.CheckActionPreference(funcContext, exception);
        }
    }
    finally
    {
        context._debugger.ExitScriptFunction();
    }
}
```

</details>

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
