### PR TITLE
Fix Stable Unique sort not being stable

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Sort-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Sort-Object.cs
@@ -162,9 +162,11 @@ namespace Microsoft.PowerShell.Commands
                     discardedDuplicates++;
                     dataIndex--;
                     continue;
-                }               
+                }
+
                 // Shift next non-duplicate entry into place
-                if (discardedDuplicates > 0){
+                if (discardedDuplicates > 0)
+                {
                     dataToSort[dataIndex] = dataToSort[dataIndex + discardedDuplicates];
                 }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Sort-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Sort-Object.cs
@@ -147,7 +147,7 @@ namespace Microsoft.PowerShell.Commands
 
             // Tracking the index is necessary so that unsortable items can be output at the end, in the order
             // in which they were received.
-            for (int dataIndex = 0, discardedDuplicates = 0; dataIndex < dataToSort.Count - discardedDuplicates; dataIndex++)
+            for (int dataIndex = 0; dataIndex < dataToSort.Count; dataIndex++)
             {
                 // Min-heap: if the heap is full and the root item is larger than the entry, discard the entry
                 // Max-heap: if the heap is full and the root item is smaller than the entry, discard the entry
@@ -159,15 +159,8 @@ namespace Microsoft.PowerShell.Commands
                 // If we're doing a unique sort and the entry is not unique, discard the duplicate entry
                 if (Unique && !uniqueSet.Add(dataToSort[dataIndex]))
                 {
-                    discardedDuplicates++;
-                    if (dataIndex != dataToSort.Count - discardedDuplicates)
-                    {
-                        // When discarding duplicates, replace them with an item at the end of the list and
-                        // adjust our counter so that we check the item we just swapped in next
-                        dataToSort[dataIndex] = dataToSort[dataToSort.Count - discardedDuplicates];
-                        dataIndex--;
-                    }
-
+                    dataToSort.RemoveAt(dataIndex);
+                    dataIndex--;
                     continue;
                 }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Sort-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Sort-Object.cs
@@ -147,7 +147,7 @@ namespace Microsoft.PowerShell.Commands
 
             // Tracking the index is necessary so that unsortable items can be output at the end, in the order
             // in which they were received.
-            for (int dataIndex = 0; dataIndex < dataToSort.Count; dataIndex++)
+            for (int dataIndex = 0, discardedDuplicates = 0; dataIndex + discardedDuplicates < dataToSort.Count; dataIndex++)
             {
                 // Min-heap: if the heap is full and the root item is larger than the entry, discard the entry
                 // Max-heap: if the heap is full and the root item is smaller than the entry, discard the entry
@@ -157,11 +157,15 @@ namespace Microsoft.PowerShell.Commands
                 }
 
                 // If we're doing a unique sort and the entry is not unique, discard the duplicate entry
-                if (Unique && !uniqueSet.Add(dataToSort[dataIndex]))
+                if (Unique && !uniqueSet.Add(dataToSort[dataIndex + discardedDuplicates]))
                 {
-                    dataToSort.RemoveAt(dataIndex);
+                    discardedDuplicates++;
                     dataIndex--;
                     continue;
+                }               
+                // Shift next non-duplicate entry into place
+                if (discardedDuplicates > 0){
+                    dataToSort[dataIndex] = dataToSort[dataIndex + discardedDuplicates];
                 }
 
                 // Add the current item to the heap and bubble it up into the correct position

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Sort-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Sort-Object.Tests.ps1
@@ -297,7 +297,7 @@ Describe 'Sort-Object Stable Unit Tests' -Tags 'CI' {
 			$results[2]  | Should -Be 3
 		}
 		
-		It "Sort-Object with Uniqe Stable should return proper records"{
+		It "Sort-Object with Unique Stable should return proper records"{
 			$Record1=[PSCustomObject]@{Key="A";Record="A1"}
 			$Record2=[PSCustomObject]@{Key="A";Record="A2"}
 			$Record3=[PSCustomObject]@{Key="B";Record="B1"}

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Sort-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Sort-Object.Tests.ps1
@@ -296,6 +296,18 @@ Describe 'Sort-Object Stable Unit Tests' -Tags 'CI' {
 			$results[1]  | Should -Be 1
 			$results[2]  | Should -Be 3
 		}
+		
+		It "Sort-Object with Uniqe Stable should return proper records"{
+			$Record1=[PSCustomObject]@{Key="A";Record="A1"}
+			$Record2=[PSCustomObject]@{Key="A";Record="A2"}
+			$Record3=[PSCustomObject]@{Key="B";Record="B1"}
+			$Record4=[PSCustomObject]@{Key="B";Record="B2"}
+			$Records = @($Record1,$Record2,$Record3,$Record4)
+			$results = $Records | Sort-Object -Stable -Unique -Property Key
+	
+			$results[0] | Should -Be $Records[0]
+			$results[1] | Should -Be $Records[2]
+		}
 	}
 }
 


### PR DESCRIPTION
This corrects an issue where the movement of objects in the array to be sorted where removing duplicate elements may result in a side effect of objects being out of order for a unique stable sort as seen in issue #16907.  

This can be reproduced with the below code
```powershell
$Record1=[PSCustomObject]@{Key="A";Record="A1"}
$Record2=[PSCustomObject]@{Key="A";Record="A2"}
$Record3=[PSCustomObject]@{Key="B";Record="B1"}
$Record4=[PSCustomObject]@{Key="B";Record="B2"}
$Records = @($Record1,$Record2,$Record3,$Record4)
$results = $Records | Sort-Object -Stable -Unique -Property Key
$results  | Format-Table
```

This results in 
```
Key Record
--- ------
A   A1
B   B2
```

Where the expected results is.
```
Key Record
--- ------
A   A1
B   B1
```

This problem occurs when a duplicate element in the array is found and then replaced with an element from the end.  In the example above causing record B2 to be put in place of A2.  After that, record B2 is treated as the first object for the unique selection despite the stable flag being set to retain the order.