### PR TITLE
Fix formatting truncation to handle strings with VT sequences

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
@@ -451,7 +451,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     {
                         // we are not at the end of the string, select a sub string
                         // that would fit in the remaining display length
-                        int charactersToAdd = displayCells.GetHeadSplitLength(currentLine, offset, currentDisplayLen);
+                        int charactersToAdd = displayCells.TruncateTail(currentLine, offset, currentDisplayLen);
 
                         if (charactersToAdd <= 0)
                         {
@@ -465,7 +465,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                         else
                         {
                             // of the given length, add it to the accumulator
-                            accumulator.AddLine(currentLine.Substring(offset, charactersToAdd));
+                            accumulator.AddLine(currentLine.VtSubstring(offset, charactersToAdd));
                         }
 
                         // increase the offset by the # of characters added
@@ -474,7 +474,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     else
                     {
                         // we reached the last (partial) line, we add it all
-                        accumulator.AddLine(currentLine.Substring(offset));
+                        accumulator.AddLine(currentLine.VtSubstring(offset));
                         break;
                     }
                 }
@@ -553,7 +553,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     // Handle soft hyphen
                     if (word.Delim == s_softHyphen.ToString())
                     {
-                        int wordWidthWithHyphen = displayCells.Length(wordToAdd) + displayCells.Length(s_softHyphen.ToString());
+                        int wordWidthWithHyphen = displayCells.Length(wordToAdd) + displayCells.Length(s_softHyphen);
 
                         // Add hyphen only if necessary
                         if (wordWidthWithHyphen == spacesLeft)

--- a/src/System.Management.Automation/FormatAndOutput/common/ILineOutput.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ILineOutput.cs
@@ -14,7 +14,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 {
     /// <summary>
     /// Base class providing support for string manipulation.
-    /// This class is a tear off class provided by the LineOutput class
+    /// This class is a tear off class provided by the LineOutput class.
     /// </summary>
     internal class DisplayCells
     {
@@ -61,6 +61,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// Calculate the buffer cell length of the given character.
         /// </summary>
+        /// <param name="character"></param>
+        /// <returns>Number of buffer cells the character needs to take.</returns>
         internal virtual int Length(char character)
         {
             return CharLengthInBufferCells(character);
@@ -71,7 +73,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// </summary>
         /// <param name="str">String that may contain VT escape sequences.</param>
         /// <param name="displayCells">Number of buffer cells to fit in.</param>
-        /// <returns></returns>
+        /// <returns>Number of non-escape-sequence characters from head of the string that can fit in the space.</returns>
         internal int TruncateTail(string str, int displayCells)
         {
             return TruncateTail(str, offset: 0, displayCells);

--- a/src/System.Management.Automation/FormatAndOutput/common/ILineOutput.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ILineOutput.cs
@@ -161,7 +161,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             int kFinal = startFromHead ? str.Length - 1 : offset;
             while (true)
             {
-                if ((startFromHead && (k > kFinal)) || ((!startFromHead) && (k < kFinal)))
+                if ((startFromHead && k > kFinal) || (!startFromHead && k < kFinal))
                 {
                     break;
                 }

--- a/src/System.Management.Automation/FormatAndOutput/common/ILineOutput.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ILineOutput.cs
@@ -15,59 +15,109 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     /// <summary>
     /// Base class providing support for string manipulation.
     /// This class is a tear off class provided by the LineOutput class
-    ///
-    /// Assumptions (in addition to the assumptions made for LineOutput):
-    /// - characters map to one or more character cells
-    ///
-    /// NOTE: we provide a base class that is valid for devices that have a
-    /// 1:1 mapping between a UNICODE character and a display cell.
     /// </summary>
     internal class DisplayCells
     {
-        internal virtual int Length(string str)
+        /// <summary>
+        /// Calculate the buffer cell length of the given string.
+        /// </summary>
+        /// <param name="str">String that may contain VT escape sequences.</param>
+        /// <returns>Number of buffer cells the string needs to take.</returns>
+        internal int Length(string str)
         {
             return Length(str, 0);
         }
 
+        /// <summary>
+        /// Calculate the buffer cell length of the given string.
+        /// </summary>
+        /// <param name="str">String that may contain VT escape sequences.</param>
+        /// <param name="offset">
+        /// When the string doesn't contain VT sequences, it's the starting index.
+        /// When the string contains VT sequences, it means starting from the 'n-th' char that doesn't belong to a escape sequence.</param>
+        /// <returns>Number of buffer cells the string needs to take.</returns>
         internal virtual int Length(string str, int offset)
         {
-            int length = 0;
-
-            foreach (char c in str)
+            if (string.IsNullOrEmpty(str))
             {
-                length += LengthInBufferCells(c);
+                return 0;
             }
 
-            return length - offset;
+            var valueStrDec = new ValueStringDecorated(str);
+            if (valueStrDec.IsDecorated)
+            {
+                str = valueStrDec.ToString(OutputRendering.PlainText);
+            }
+
+            int length = 0;
+            for (; offset < str.Length; offset++)
+            {
+                length += CharLengthInBufferCells(str[offset]);
+            }
+
+            return length;
         }
 
-        internal virtual int Length(char character) { return 1; }
-
-        internal virtual int GetHeadSplitLength(string str, int displayCells)
+        /// <summary>
+        /// Calculate the buffer cell length of the given character.
+        /// </summary>
+        internal virtual int Length(char character)
         {
-            return GetHeadSplitLength(str, 0, displayCells);
+            return CharLengthInBufferCells(character);
         }
 
-        internal virtual int GetHeadSplitLength(string str, int offset, int displayCells)
+        /// <summary>
+        /// Truncate from the tail of the string.
+        /// </summary>
+        /// <param name="str">String that may contain VT escape sequences.</param>
+        /// <param name="displayCells">Number of buffer cells to fit in.</param>
+        /// <returns></returns>
+        internal int TruncateTail(string str, int displayCells)
         {
-            int len = str.Length - offset;
-            return (len < displayCells) ? len : displayCells;
+            return TruncateTail(str, offset: 0, displayCells);
         }
 
-        internal virtual int GetTailSplitLength(string str, int displayCells)
+        /// <summary>
+        /// Truncate from the tail of the string.
+        /// </summary>
+        /// <param name="str">String that may contain VT escape sequences.</param>
+        /// <param name="offset">
+        /// When the string doesn't contain VT sequences, it's the starting index.
+        /// When the string contains VT sequences, it means starting from the 'n-th' char that doesn't belong to a escape sequence.</param>
+        /// <param name="displayCells">Number of buffer cells to fit in.</param>
+        /// <returns>Number of non-escape-sequence characters from head of the string that can fit in the space.</returns>
+        internal int TruncateTail(string str, int offset, int displayCells)
         {
-            return GetTailSplitLength(str, 0, displayCells);
+            var valueStrDec = new ValueStringDecorated(str);
+            if (valueStrDec.IsDecorated)
+            {
+                str = valueStrDec.ToString(OutputRendering.PlainText);
+            }
+
+            return GetFitLength(str, offset, displayCells, startFromHead: true);
         }
 
-        internal virtual int GetTailSplitLength(string str, int offset, int displayCells)
+        /// <summary>
+        /// Truncate from the head of the string.
+        /// </summary>
+        /// <param name="str">String that may contain VT escape sequences.</param>
+        /// <param name="displayCells">Number of buffer cells to fit in.</param>
+        /// <returns>Number of non-escape-sequence characters from head of the string that should be skipped.</returns>
+        internal int TruncateHead(string str, int displayCells)
         {
-            int len = str.Length - offset;
-            return (len < displayCells) ? len : displayCells;
+            var valueStrDec = new ValueStringDecorated(str);
+            if (valueStrDec.IsDecorated)
+            {
+                str = valueStrDec.ToString(OutputRendering.PlainText);
+            }
+
+            int tailCount = GetFitLength(str, offset: 0, displayCells, startFromHead: false);
+            return str.Length - tailCount;
         }
 
         #region Helpers
 
-        protected static int LengthInBufferCells(char c)
+        protected static int CharLengthInBufferCells(char c)
         {
             // The following is based on http://www.cl.cam.ac.uk/~mgk25/c/wcwidth.c
             // which is derived from https://www.unicode.org/Public/UCD/latest/ucd/EastAsianWidth.txt
@@ -94,25 +144,26 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// Given a string and a number of display cells, it computes how many
         /// characters would fit starting from the beginning or end of the string.
         /// </summary>
-        /// <param name="str">String to be displayed.</param>
+        /// <param name="str">String to be displayed, which doesn't contain any VT sequences.</param>
         /// <param name="offset">Offset inside the string.</param>
         /// <param name="displayCells">Number of display cells.</param>
-        /// <param name="head">If true compute from the head (i.e. k++) else from the tail (i.e. k--).</param>
+        /// <param name="startFromHead">If true compute from the head (i.e. k++) else from the tail (i.e. k--).</param>
         /// <returns>Number of characters that would fit.</returns>
-        protected int GetSplitLengthInternalHelper(string str, int offset, int displayCells, bool head)
+        protected int GetFitLength(string str, int offset, int displayCells, bool startFromHead)
         {
             int filledDisplayCellsCount = 0; // number of cells that are filled in
             int charactersAdded = 0; // number of characters that fit
             int currCharDisplayLen; // scratch variable
 
-            int k = (head) ? offset : str.Length - 1;
-            int kFinal = (head) ? str.Length - 1 : offset;
+            int k = startFromHead ? offset : str.Length - 1;
+            int kFinal = startFromHead ? str.Length - 1 : offset;
             while (true)
             {
-                if ((head && (k > kFinal)) || ((!head) && (k < kFinal)))
+                if ((startFromHead && (k > kFinal)) || ((!startFromHead) && (k < kFinal)))
                 {
                     break;
                 }
+
                 // compute the cell number for the current character
                 currCharDisplayLen = this.Length(str[k]);
 
@@ -121,6 +172,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     // if we added this character it would not fit, we cannot continue
                     break;
                 }
+
                 // keep adding, we fit
                 filledDisplayCellsCount += currCharDisplayLen;
                 charactersAdded++;
@@ -132,13 +184,13 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     break;
                 }
 
-                k = (head) ? (k + 1) : (k - 1);
+                k = startFromHead ? (k + 1) : (k - 1);
             }
 
             return charactersAdded;
         }
-        #endregion
 
+        #endregion
     }
 
     /// <summary>
@@ -354,11 +406,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 {
                     // the string is still too long to fit, write the first cols characters
                     // and go back for more wraparound
-                    int splitLen = _displayCells.GetHeadSplitLength(s, cols);
-                    WriteLineInternal(s.Substring(0, splitLen), cols);
+                    int headCount = _displayCells.TruncateTail(s, cols);
+                    WriteLineInternal(s.VtSubstring(0, headCount), cols);
 
                     // chop off the first fieldWidth characters, already printed
-                    s = s.Substring(splitLen);
+                    s = s.VtSubstring(headCount);
                     if (_displayCells.Length(s) <= cols)
                     {
                         // if we fit, print the tail of the string and we are done

--- a/src/System.Management.Automation/FormatAndOutput/common/ListWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ListWriter.cs
@@ -88,19 +88,20 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
             for (int k = 0; k < propertyNames.Length; k++)
             {
+                string propertyName = propertyNames[k];
                 if (propertyNameCellCounts[k] < _propertyLabelsDisplayLength)
                 {
                     // shorter than the max, add padding
-                    _propertyLabels[k] = propertyNames[k] + StringUtil.Padding(_propertyLabelsDisplayLength - propertyNameCellCounts[k]);
+                    _propertyLabels[k] = propertyName + StringUtil.Padding(_propertyLabelsDisplayLength - propertyNameCellCounts[k]);
                 }
                 else if (propertyNameCellCounts[k] > _propertyLabelsDisplayLength)
                 {
                     // longer than the max, clip
-                    _propertyLabels[k] = propertyNames[k].Substring(0, dc.GetHeadSplitLength(propertyNames[k], _propertyLabelsDisplayLength));
+                    _propertyLabels[k] = propertyName.VtSubstring(0, dc.TruncateTail(propertyName, _propertyLabelsDisplayLength));
                 }
                 else
                 {
-                    _propertyLabels[k] = propertyNames[k];
+                    _propertyLabels[k] = propertyName;
                 }
 
                 _propertyLabels[k] += Separator;

--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
@@ -26,6 +26,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         #endregion tracer
 
         internal const char Ellipsis = '\u2026';
+        internal const string EllipsisStr = "\u2026";
 
         internal static string PSObjectIsOfExactType(Collection<string> typeNames)
         {

--- a/src/System.Management.Automation/FormatAndOutput/out-console/ConsoleLineOutput.cs
+++ b/src/System.Management.Automation/FormatAndOutput/out-console/ConsoleLineOutput.cs
@@ -187,9 +187,14 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         internal ConsoleLineOutput(PSHost host, bool paging, TerminatingErrorContext errorContext)
         {
             if (host == null)
+            {
                 throw PSTraceSource.NewArgumentNullException(nameof(host));
+            }
+
             if (errorContext == null)
+            {
                 throw PSTraceSource.NewArgumentNullException(nameof(errorContext));
+            }
 
             _console = host.UI;
             _errorContext = errorContext;
@@ -197,8 +202,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             if (paging)
             {
                 tracer.WriteLine("paging is needed");
-                // if we need to do paging, instantiate a prompt handler
-                // that will take care of the screen interaction
+
+                // If we need to do paging, instantiate a prompt handler that will take care of the screen interaction
                 string promptString = StringUtil.Format(FormatAndOut_out_xxx.ConsoleLineOutput_PagingPrompt);
                 _prompt = new PromptHandler(promptString, this);
             }

--- a/src/System.Management.Automation/FormatAndOutput/out-console/ConsoleLineOutput.cs
+++ b/src/System.Management.Automation/FormatAndOutput/out-console/ConsoleLineOutput.cs
@@ -87,6 +87,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         internal static readonly PSTraceSource tracer = PSTraceSource.GetTracer("ConsoleLineOutput", "ConsoleLineOutput");
         #endregion tracer
 
+        /// <summary>
+        /// The default buffer cell calculation already works for the PowerShell console host and Visual studio code host.
+        /// </summary>
         private static readonly HashSet<string> s_psHost = new(StringComparer.Ordinal) { "ConsoleHost", "Visual Studio Code Host" };
 
         #region LineOutput implementation

--- a/src/System.Management.Automation/FormatAndOutput/out-console/ConsoleLineOutput.cs
+++ b/src/System.Management.Automation/FormatAndOutput/out-console/ConsoleLineOutput.cs
@@ -1,11 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// NOTE: define this if you want to test the output on US machine and ASCII
-// characters
-//#define TEST_MULTICELL_ON_SINGLE_CELL_LOCALE
-
 using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Management.Automation;
 using System.Management.Automation.Internal;
@@ -17,70 +14,12 @@ using Dbg = System.Management.Automation.Diagnostics;
 
 namespace Microsoft.PowerShell.Commands.Internal.Format
 {
-#if TEST_MULTICELL_ON_SINGLE_CELL_LOCALE
-
-    /// <summary>
-    /// Test class to provide easily overridable behavior for testing on US machines
-    /// using US data.
-    /// NOTE: the class just forces any uppercase letter [A-Z] to be prepended
-    /// with an underscore (e.g. "A" becomes "_A", but "a" stays the same)
-    /// </summary>
-    internal class DisplayCellsTest : DisplayCells
-    {
-        internal override int Length(string str, int offset)
-        {
-            int len = 0;
-            for (int k = offset; k < str.Length; k++)
-            {
-                len += this.Length(str[k]);
-            }
-
-            return len;
-        }
-
-        internal override int Length(char character)
-        {
-            if (character >= 'A' && character <= 'Z')
-                return 2;
-            return 1;
-        }
-
-        internal override int GetHeadSplitLength(string str, int offset, int displayCells)
-        {
-            return GetSplitLengthInternalHelper(str, offset, displayCells, true);
-        }
-
-        internal override int GetTailSplitLength(string str, int offset, int displayCells)
-        {
-            return GetSplitLengthInternalHelper(str, offset, displayCells, false);
-        }
-
-        internal string GenerateTestString(string str)
-        {
-            StringBuilder sb = new StringBuilder();
-            for (int k = 0; k < str.Length; k++)
-            {
-                char ch = str[k];
-                if (this.Length(ch) == 2)
-                {
-                    sb.Append('_');
-                }
-
-                sb.Append(ch);
-            }
-
-            return sb.ToString();
-        }
-
-    }
-#endif
-
     /// <summary>
     /// Tear off class.
     /// </summary>
-    internal class DisplayCellsPSHost : DisplayCells
+    internal class DisplayCellsHost : DisplayCells
     {
-        internal DisplayCellsPSHost(PSHostRawUserInterface rawUserInterface)
+        internal DisplayCellsHost(PSHostRawUserInterface rawUserInterface)
         {
             _rawUserInterface = rawUserInterface;
         }
@@ -99,30 +38,26 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
             try
             {
-                return _rawUserInterface.LengthInBufferCells(str, offset);
+                var valueStrDec = new ValueStringDecorated(str);
+                if (valueStrDec.IsDecorated)
+                {
+                    str = valueStrDec.ToString(OutputRendering.PlainText);
+                }
+
+                int length = 0;
+                for (; offset < str.Length; offset++)
+                {
+                    length += _rawUserInterface.LengthInBufferCells(str[offset]);
+                }
+
+                return length;
             }
             catch
             {
                 // thrown when external host rawui is not implemented, in which case
                 // we will fallback to the default value.
+                return base.Length(str, offset);
             }
-
-            return str.Length - offset;
-        }
-
-        internal override int Length(string str)
-        {
-            try
-            {
-                return _rawUserInterface.LengthInBufferCells(str);
-            }
-            catch
-            {
-                // thrown when external host rawui is not implemented, in which case
-                // we will fallback to the default value.
-            }
-
-            return string.IsNullOrEmpty(str) ? 0 : str.Length;
         }
 
         internal override int Length(char character)
@@ -135,19 +70,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             {
                 // thrown when external host rawui is not implemented, in which case
                 // we will fallback to the default value.
+                return base.Length(character);
             }
-
-            return 1;
-        }
-
-        internal override int GetHeadSplitLength(string str, int offset, int displayCells)
-        {
-            return GetSplitLengthInternalHelper(str, offset, displayCells, true);
-        }
-
-        internal override int GetTailSplitLength(string str, int offset, int displayCells)
-        {
-            return GetSplitLengthInternalHelper(str, offset, displayCells, false);
         }
 
         private readonly PSHostRawUserInterface _rawUserInterface;
@@ -162,6 +86,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         [TraceSource("ConsoleLineOutput", "ConsoleLineOutput")]
         internal static readonly PSTraceSource tracer = PSTraceSource.GetTracer("ConsoleLineOutput", "ConsoleLineOutput");
         #endregion tracer
+
+        private static readonly HashSet<string> s_psHost = new(StringComparer.Ordinal) { "ConsoleHost", "Visual Studio Code Host" };
 
         #region LineOutput implementation
         /// <summary>
@@ -241,12 +167,13 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             get
             {
                 CheckStopProcessing();
-                if (_displayCellsPSHost != null)
+                if (_displayCellsHost != null)
                 {
-                    return _displayCellsPSHost;
+                    return _displayCellsHost;
                 }
+
                 // fall back if we do not have a Msh host specific instance
-                return _displayCellsPSHost;
+                return _displayCellsDefault;
             }
         }
         #endregion
@@ -254,17 +181,17 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// Constructor for the ConsoleLineOutput.
         /// </summary>
-        /// <param name="hostConsole">PSHostUserInterface to wrap.</param>
+        /// <param name="host">PSHostUserInterface to wrap.</param>
         /// <param name="paging">True if we require prompting for page breaks.</param>
         /// <param name="errorContext">Error context to throw exceptions.</param>
-        internal ConsoleLineOutput(PSHostUserInterface hostConsole, bool paging, TerminatingErrorContext errorContext)
+        internal ConsoleLineOutput(PSHost host, bool paging, TerminatingErrorContext errorContext)
         {
-            if (hostConsole == null)
-                throw PSTraceSource.NewArgumentNullException(nameof(hostConsole));
+            if (host == null)
+                throw PSTraceSource.NewArgumentNullException(nameof(host));
             if (errorContext == null)
                 throw PSTraceSource.NewArgumentNullException(nameof(errorContext));
 
-            _console = hostConsole;
+            _console = host.UI;
             _errorContext = errorContext;
 
             if (paging)
@@ -276,17 +203,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 _prompt = new PromptHandler(promptString, this);
             }
 
-            PSHostRawUserInterface raw = _console.RawUI;
-            if (raw != null)
+            if (!s_psHost.Contains(host.Name) && _console.RawUI is not null)
             {
-                tracer.WriteLine("there is a valid raw interface");
-#if TEST_MULTICELL_ON_SINGLE_CELL_LOCALE
-                // create a test instance with fake behavior
-                this._displayCellsPSHost = new DisplayCellsTest();
-#else
                 // set only if we have a valid raw interface
-                _displayCellsPSHost = new DisplayCellsPSHost(raw);
-#endif
+                tracer.WriteLine("there is a valid raw interface");
+                _displayCellsHost = new DisplayCellsHost(_console.RawUI);
             }
 
             // instantiate the helper to do the line processing when ILineOutput.WriteXXX() is called
@@ -309,9 +230,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <param name="s">String to write.</param>
         private void OnWriteLine(string s)
         {
-#if TEST_MULTICELL_ON_SINGLE_CELL_LOCALE
-            s = ((DisplayCellsTest)this._displayCellsPSHost).GenerateTestString(s);
-#endif
             // Do any default transcription.
             _console.TranscribeResult(s);
 
@@ -356,10 +274,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <param name="s">String to write.</param>
         private void OnWrite(string s)
         {
-#if TEST_MULTICELL_ON_SINGLE_CELL_LOCALE
-            s = ((DisplayCellsTest)this._displayCellsPSHost).GenerateTestString(s);
-#endif
-
             switch (this.WriteStream)
             {
                 case WriteStreamType.Error:
@@ -615,7 +529,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// Msh host specific string manipulation helper.
         /// </summary>
-        private readonly DisplayCells _displayCellsPSHost;
+        private readonly DisplayCells _displayCellsHost;
 
         /// <summary>
         /// Reference to error context to throw Msh exceptions.

--- a/src/System.Management.Automation/FormatAndOutput/out-console/OutConsole.cs
+++ b/src/System.Management.Automation/FormatAndOutput/out-console/OutConsole.cs
@@ -65,8 +65,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void BeginProcessing()
         {
-            PSHostUserInterface console = this.Host.UI;
-            ConsoleLineOutput lineOutput = new ConsoleLineOutput(console, false, new TerminatingErrorContext(this));
+            var lineOutput = new ConsoleLineOutput(Host, false, new TerminatingErrorContext(this));
 
             ((OutputManagerInner)this.implementation).LineOutput = lineOutput;
 
@@ -206,8 +205,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void BeginProcessing()
         {
-            PSHostUserInterface console = this.Host.UI;
-            ConsoleLineOutput lineOutput = new ConsoleLineOutput(console, _paging, new TerminatingErrorContext(this));
+            var lineOutput = new ConsoleLineOutput(Host, _paging, new TerminatingErrorContext(this));
 
             ((OutputManagerInner)this.implementation).LineOutput = lineOutput;
             base.BeginProcessing();

--- a/src/System.Management.Automation/utils/StringUtil.cs
+++ b/src/System.Management.Automation/utils/StringUtil.cs
@@ -1,9 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Globalization;
 using System.Management.Automation.Host;
 using System.Threading;
+using System.Text;
+using System.Text.RegularExpressions;
 
 using Dbg = System.Management.Automation.Diagnostics;
 
@@ -92,6 +95,179 @@ namespace System.Management.Automation.Internal
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Substring implementation that takes into account the VT escape sequences.
+        /// </summary>
+        /// <param name="str">String that may contain VT escape sequences.</param>
+        /// <param name="startOffset">
+        /// When the string doesn't contain VT sequences, it's the starting index.
+        /// When the string contains VT sequences, it means starting from the 'n-th' char that doesn't belong to a escape sequence.
+        /// </param>
+        internal static string VtSubstring(this string str, int startOffset)
+        {
+            return VtSubstring(str, 0, int.MaxValue, prependStr: null, appendStr: null);
+        }
+
+        /// <summary>
+        /// Substring implementation that takes into account the VT escape sequences.
+        /// </summary>
+        /// <param name="str">String that may contain VT escape sequences.</param>
+        /// <param name="startOffset">
+        /// When the string doesn't contain VT sequences, it's the starting index.
+        /// When the string contains VT sequences, it means starting from the 'n-th' char that doesn't belong to a escape sequence.</param>
+        /// <param name="length">Number of non-escape-sequence characters to be included in the substring.</param>
+        internal static string VtSubstring(this string str, int startOffset, int length)
+        {
+            return VtSubstring(str, startOffset, length, prependStr: null, appendStr: null);
+        }
+
+        /// <summary>
+        /// Substring implementation that takes into account the VT escape sequences.
+        /// </summary>
+        /// <param name="str">String that may contain VT escape sequences.</param>
+        /// <param name="startOffset">
+        /// When the string doesn't contain VT sequences, it's the starting index.
+        /// When the string contains VT sequences, it means starting from the 'n-th' char that doesn't belong to a escape sequence.</param>
+        /// <param name="prependStr">The string to be prepended to the substring.</param>
+        /// <param name="appendStr">The string to be appended to the substring.</param>
+        internal static string VtSubstring(this string str, int startOffset, string prependStr, string appendStr)
+        {
+            return VtSubstring(str, 0, int.MaxValue, prependStr, appendStr);
+        }
+
+        /// <summary>
+        /// Substring implementation that takes into account the VT escape sequences.
+        /// </summary>
+        /// <param name="str">String that may contain VT escape sequences.</param>
+        /// <param name="startOffset">
+        /// When the string doesn't contain VT sequences, it's the starting index.
+        /// When the string contains VT sequences, it means starting from the 'n-th' char that doesn't belong to a escape sequence.</param>
+        /// <param name="length">Number of non-escape-sequence characters to be included in the substring.</param>
+        /// <param name="prependStr">The string to be prepended to the substring.</param>
+        /// <param name="appendStr">The string to be appended to the substring.</param>
+        internal static string VtSubstring(this string str, int startOffset, int length, string prependStr, string appendStr)
+        {
+            var valueStrDec = new ValueStringDecorated(str);
+            if (valueStrDec.IsDecorated)
+            {
+                // Handle strings with VT sequences.
+                var sb = new StringBuilder(capacity: str.Length);
+                bool copyStarted = startOffset == 0;
+                bool hasEscSeqs = false;
+                bool firstNonEscChar = true;
+
+                // Find all escape sequences in the string, and keep track of their starting indexes and length.
+                var ansiRanges = new Dictionary<int, int>();
+                foreach (Match match in ValueStringDecorated.AnsiRegex.Matches(str))
+                {
+                    ansiRanges.Add(match.Index, match.Length);
+                }
+
+                for (int i = 0, offset = 0; i < str.Length; i++)
+                {
+                    // Keep all leading ANSI escape sequences.
+                    if (ansiRanges.TryGetValue(i, out int len))
+                    {
+                        hasEscSeqs = true;
+                        sb.Append(str.AsSpan(i, len));
+
+                        i += len - 1;
+                        continue;
+                    }
+
+                    // OK, now we get a non-escape-sequence character.
+                    if (copyStarted)
+                    {
+                        if (firstNonEscChar)
+                        {
+                            // Prepend the string before we copy the first non-escape-sequence character.
+                            sb.Append(prependStr);
+                            firstNonEscChar = false;
+                        }
+
+                        // Copy this character if we've started the copy.
+                        sb.Append(str[i]);
+                        // Increment 'offset' to keep track of number of non-escape-sequence characters we've copied.
+                        offset++;
+                    }
+                    else if (++offset == startOffset)
+                    {
+                        // We've skipped enough non-escape-sequence characters, and will be copying the next one.
+                        copyStarted = true;
+                        // Reset 'offset' and from now on use it to track the number of copied non-escape-sequence characters.
+                        offset = 0;
+                        continue;
+                    }
+
+                    // If the number of copied non-escape-sequence characters has reached the specified length, done copying.
+                    if (offset == length)
+                    {
+                        break;
+                    }
+                }
+
+                if (hasEscSeqs)
+                {
+                    string resetStr = PSStyle.Instance.Reset;
+                    bool endsWithReset = sb.EndsWith(resetStr);
+                    if (endsWithReset)
+                    {
+                        // Append the given string before the reset VT sequence.
+                        sb.Insert(sb.Length - resetStr.Length, appendStr);
+                    }
+                    else
+                    {
+                        // Append the given string and add the reset VT sequence.
+                        sb.Append(appendStr).Append(resetStr);
+                    }
+                }
+                else
+                {
+                    sb.Append(appendStr);
+                }
+
+                return sb.ToString();
+            }
+
+            // Handle strings without VT sequences.
+            if (length == int.MaxValue)
+            {
+                length = str.Length - startOffset;
+            }
+
+            if (prependStr is null && appendStr is null)
+            {
+                return str.Substring(startOffset, length);
+            }
+            else
+            {
+                int capacity = length + prependStr?.Length ?? 0 + appendStr?.Length ?? 0;
+                return new StringBuilder(prependStr, capacity)
+                    .Append(str, startOffset, length)
+                    .Append(appendStr)
+                    .ToString();
+            }
+        }
+
+        internal static bool EndsWith(this StringBuilder sb, string value)
+        {
+            if (sb.Length < value.Length)
+            {
+                return false;
+            }
+
+            int offset = sb.Length - value.Length;
+            for (int i = 0; i < value.Length; i++)
+            {
+                if (sb[offset + i] != value[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/src/System.Management.Automation/utils/StringUtil.cs
+++ b/src/System.Management.Automation/utils/StringUtil.cs
@@ -4,9 +4,9 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Management.Automation.Host;
-using System.Threading;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 
 using Dbg = System.Management.Automation.Diagnostics;
 
@@ -105,6 +105,7 @@ namespace System.Management.Automation.Internal
         /// When the string doesn't contain VT sequences, it's the starting index.
         /// When the string contains VT sequences, it means starting from the 'n-th' char that doesn't belong to a escape sequence.
         /// </param>
+        /// <returns>The requested substring.</returns>
         internal static string VtSubstring(this string str, int startOffset)
         {
             return VtSubstring(str, startOffset, int.MaxValue, prependStr: null, appendStr: null);
@@ -118,6 +119,7 @@ namespace System.Management.Automation.Internal
         /// When the string doesn't contain VT sequences, it's the starting index.
         /// When the string contains VT sequences, it means starting from the 'n-th' char that doesn't belong to a escape sequence.</param>
         /// <param name="length">Number of non-escape-sequence characters to be included in the substring.</param>
+        /// <returns>The requested substring.</returns>
         internal static string VtSubstring(this string str, int startOffset, int length)
         {
             return VtSubstring(str, startOffset, length, prependStr: null, appendStr: null);
@@ -132,6 +134,7 @@ namespace System.Management.Automation.Internal
         /// When the string contains VT sequences, it means starting from the 'n-th' char that doesn't belong to a escape sequence.</param>
         /// <param name="prependStr">The string to be prepended to the substring.</param>
         /// <param name="appendStr">The string to be appended to the substring.</param>
+        /// <returns>The requested substring.</returns>
         internal static string VtSubstring(this string str, int startOffset, string prependStr, string appendStr)
         {
             return VtSubstring(str, startOffset, int.MaxValue, prependStr, appendStr);
@@ -147,6 +150,7 @@ namespace System.Management.Automation.Internal
         /// <param name="length">Number of non-escape-sequence characters to be included in the substring.</param>
         /// <param name="prependStr">The string to be prepended to the substring.</param>
         /// <param name="appendStr">The string to be appended to the substring.</param>
+        /// <returns>The requested substring.</returns>
         internal static string VtSubstring(this string str, int startOffset, int length, string prependStr, string appendStr)
         {
             var valueStrDec = new ValueStringDecorated(str);
@@ -189,6 +193,7 @@ namespace System.Management.Automation.Internal
 
                         // Copy this character if we've started the copy.
                         sb.Append(str[i]);
+
                         // Increment 'offset' to keep track of number of non-escape-sequence characters we've copied.
                         offset++;
                     }
@@ -196,6 +201,7 @@ namespace System.Management.Automation.Internal
                     {
                         // We've skipped enough non-escape-sequence characters, and will be copying the next one.
                         copyStarted = true;
+
                         // Reset 'offset' and from now on use it to track the number of copied non-escape-sequence characters.
                         offset = 0;
                         continue;

--- a/src/System.Management.Automation/utils/StringUtil.cs
+++ b/src/System.Management.Automation/utils/StringUtil.cs
@@ -107,7 +107,7 @@ namespace System.Management.Automation.Internal
         /// </param>
         internal static string VtSubstring(this string str, int startOffset)
         {
-            return VtSubstring(str, 0, int.MaxValue, prependStr: null, appendStr: null);
+            return VtSubstring(str, startOffset, int.MaxValue, prependStr: null, appendStr: null);
         }
 
         /// <summary>
@@ -134,7 +134,7 @@ namespace System.Management.Automation.Internal
         /// <param name="appendStr">The string to be appended to the substring.</param>
         internal static string VtSubstring(this string str, int startOffset, string prependStr, string appendStr)
         {
-            return VtSubstring(str, 0, int.MaxValue, prependStr, appendStr);
+            return VtSubstring(str, startOffset, int.MaxValue, prependStr, appendStr);
         }
 
         /// <summary>

--- a/test/powershell/engine/Formatting/PSStyle.Tests.ps1
+++ b/test/powershell/engine/Formatting/PSStyle.Tests.ps1
@@ -248,8 +248,14 @@ Describe 'Handle strings with escape sequences in formatting' {
             [PSCustomObject]@{PSTypeName = "User"; Name = "Billy Bob Thorton"; Tenure = 13; Role = "Senior DevOps Engineer" }
         }
 
+        $oldOutputRendering = $PSStyle.OutputRendering
+        $PSStyle.OutputRendering = [System.Management.Automation.OutputRendering]::Ansi
         $colors = @("`e[32m", "`e[34m", "`e[33m", "`e[31m", "`e[33m", "`e[34m", "`e[32m")
         $outFile = "$TestDrive\outFile.txt"
+    }
+
+    AfterAll {
+        $PSStyle.OutputRendering = $oldOutputRendering
     }
 
     It 'Truncation for strings with no escape sequences' {
@@ -267,7 +273,6 @@ Billy Bob… Senior DevOps …  13
             Out-File $outFile
 
         $text = Get-Content $outFile -Raw
-        Write-Verbose -Verbose $text
         $text.Trim().Replace("`r", "") | Should -BeExactly $expected.Replace("`r", "")
     }
 

--- a/test/powershell/engine/Formatting/PSStyle.Tests.ps1
+++ b/test/powershell/engine/Formatting/PSStyle.Tests.ps1
@@ -267,6 +267,7 @@ Billy Bob… Senior DevOps …  13
             Out-File $outFile
 
         $text = Get-Content $outFile -Raw
+        Write-Verbose -Verbose $text
         $text.Trim().Replace("`r", "") | Should -BeExactly $expected.Replace("`r", "")
     }
 

--- a/tools/cgmanifest.json
+++ b/tools/cgmanifest.json
@@ -695,7 +695,7 @@
         "Type": "nuget",
         "Nuget": {
           "Name": "StyleCop.Analyzers.Unstable",
-          "Version": "1.2.0.406"
+          "Version": "1.2.0.435"
         }
       },
       "DevelopmentDependency": true


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #16700

Fix formatting truncation to handle strings with VT sequences.
The main changes are in buffer cell length calculation, as well as adding `VtSubstring` implementations, which are used to get part of a string that may contain escape sequences.

With the changes in this PR, the formatting works fine with the demo scripts from https://github.com/PowerShell/PowerShell/issues/16700#issuecomment-1103474523 and https://github.com/PowerShell/PowerShell/issues/16700#issuecomment-1103486148:

```pwsh
function Get-DemoObjects {
    [PSCustomObject]@{PSTypeName = "User"; Name = "Bob Saggat"; Tenure = 2; Role = "Developer" }
    [PSCustomObject]@{PSTypeName = "User"; Name = "John Seymour"; Tenure = 6; Role = "Sw Engineer" }
    [PSCustomObject]@{PSTypeName = "User"; Name = "Billy Bob Thorton"; Tenure = 13; Role = "Senior DevOps Engineer" }
}

Get-DemoObjects |
    Format-Table @{Width = 10; Name = "Name"; E = { (@("`e[32m", "`e[34m", "`e[33m", "`e[31m", "`e[33m", "`e[34m", "`e[32m")[[array]::BinarySearch(@(3, 5, 8), $_.Tenure)]) + $_.Name + "`e[39m"}},
                 @{Width = 15; Name = "Role";  E = { $_.Role }}, 
                 @{Width = 3; Name = "YIR";  E = { $_.Tenure }}
```

![image](https://user-images.githubusercontent.com/127450/166813836-18762c3c-1d44-4988-9282-67933c2d84d8.png)

```pwsh
Get-DemoObjects |
    Format-Table @{Width = 10; Name = "Name"; E = { (@("`e[32m", "`e[34m", "`e[33m", "`e[31m", "`e[33m", "`e[34m", "`e[32m")[[array]::BinarySearch(@(3, 5, 8), $_.Tenure)]) + $_.Name + "`e[39m"}},
                 @{Width = 15; Name = "Role";  E = {
                                -join $(switch -regex ($_.Role){
                                        "Senior" { "`e[42m" }
                                        "Engineer" { "`e[1;33m" }
                                    }) + $_.Role  + "`e[0m"}}, 
                 @{Width = 3; Name = "YIR";  E = { $_.Tenure }}
```
![image](https://user-images.githubusercontent.com/127450/166813920-7bb444a5-bfbd-482b-9f72-2c01493e02c9.png)

```pwsh
$PSStyle.OutputRendering = "Ansi"
(Get-DemoObjects) + (Get-DemoObjects) + 
(Get-DemoObjects) + (Get-DemoObjects) + 
(Get-DemoObjects) + (Get-DemoObjects) | 
    Format-Wide @{E = { (@("`e[32m", "`e[34m", "`e[33m", "`e[31m", "`e[33m", "`e[34m", "`e[32m")[[array]::BinarySearch(@(3, 5, 8), $_.Tenure)]) + $_.Name + "`e[39m"}} -co 2 | Out-String -Width 47
```
![image](https://user-images.githubusercontent.com/127450/166814126-e2252eb8-133b-4570-87bf-104e4ab8f1c9.png)

```pwsh
Get-DemoObjects | Format-Table @{Width = 10; Name = "Name"; E = { "`e[33m" + $_.Name } }, 
                               @{Width = 15; Name = "Role"; E = { $_.Role }},
                               @{Width = 3;  Name = "YIR";  E = { $_.Tenure }}

Get-DemoObjects | Format-Table @{Width = 10; Name = "Name"; E = { "`e[1;33m" + $_.Name } }, 
                               @{Width = 15; Name = "Role"; E = { $_.Role }},
                               @{Width = 3;  Name = "YIR";  E = { $_.Tenure }}
```
![image](https://user-images.githubusercontent.com/127450/166814208-f780f670-e9e8-4190-ba40-4c588975de62.png)

Using the repro provided in https://github.com/PowerShell/PowerShell/issues/16700#issue-1093826191, now the formatting truncation and alignment work as expected:

![image](https://user-images.githubusercontent.com/127450/166814640-75b3735f-7869-4b58-924a-5ce543f13276.png)

`Out-String` works as well:

![image](https://user-images.githubusercontent.com/127450/166980934-8f1b235b-86ab-4420-9c9d-0a17c5be5b55.png)



## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
