### PR TITLE
Reduce unneeded verbose message from `build.psm1`

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -1949,7 +1949,7 @@ function Install-Dotnet {
 
             $psArgs += @('-SkipNonVersionedFiles')
 
-            $psArgs | Out-String | Write-Verbose -Verbose
+            $psArgs -join ' ' | Write-Verbose -Verbose
 
             Start-NativeExecution {
                 & $fullPSPath @psArgs

--- a/build.psm1
+++ b/build.psm1
@@ -2195,21 +2195,21 @@ function Start-PSBootstrap {
 }
 
 function Get-LatestInstalledSDK {
-    Start-NativeExecution -sb {
-        dotnet --list-sdks | ForEach-Object {
-            # this splits strings like
-            # '6.0.202 [C:\Program Files\dotnet\sdk]'
-            # '7.0.100-preview.2.22153.17 [C:\Users\johndoe\AppData\Local\Microsoft\dotnet\sdk]'
-            # into version and path parts.
-            $version, $null = $_ -split '\s',2
-            try {
-                [System.Management.Automation.SemanticVersion]::new($version)
-            }
-            catch {
-                Write-Warning -Message "Unable to parse dotnet version semantically: $version"
-            }
-        } | Sort-Object -Descending | Select-Object -First 1
-    } -IgnoreExitcode 2> $null
+    $output = Start-NativeExecution -sb { dotnet --list-sdks } -IgnoreExitcode 2> $null
+
+    $output | ForEach-Object {
+        # this splits strings like
+        # '6.0.202 [C:\Program Files\dotnet\sdk]'
+        # '7.0.100-preview.2.22153.17 [C:\Users\johndoe\AppData\Local\Microsoft\dotnet\sdk]'
+        # into version and path parts.
+        $version, $null = $_ -split '\s',2
+        try {
+            [System.Management.Automation.SemanticVersion]::new($version)
+        }
+        catch {
+            Write-Warning -Message "Unable to parse dotnet version semantically: $version"
+        }
+    } | Sort-Object -Descending | Select-Object -First 1
 }
 
 function Start-DevPowerShell {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Change in `build.psm1` is to reducing unnecessary verbose messages because `Start-NativeExecution` write the whole script block text as verbose message.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
