### PR TITLE
Enable more tests to be run in a container.

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/SetDateCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/SetDateCommand.cs
@@ -71,7 +71,13 @@ namespace Microsoft.PowerShell.Commands
             if (ShouldProcess(dateToUse.ToString()))
             {
 #if UNIX
-                if (!Platform.NonWindowsSetDate(dateToUse))
+                // We are not validating the native call here.
+                // We just want to be sure that we're using the value the user provided us.
+                if (Dbg.Internal.InternalTestHooks.SetDate)
+                {
+                    WriteObject(dateToUse);
+                }
+                else if (!Platform.NonWindowsSetDate(dateToUse))
                 {
                     throw new Win32Exception(Marshal.GetLastWin32Error());
                 }
@@ -86,16 +92,23 @@ namespace Microsoft.PowerShell.Commands
                 systemTime.Second = (ushort)dateToUse.Second;
                 systemTime.Milliseconds = (ushort)dateToUse.Millisecond;
 #pragma warning disable 56523
-                if (!NativeMethods.SetLocalTime(ref systemTime))
+                if (Dbg.Internal.InternalTestHooks.SetDate)
                 {
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                    WriteObject(systemTime);
                 }
-
-                // MSDN says to call this twice to account for changes
-                // between DST
-                if (!NativeMethods.SetLocalTime(ref systemTime))
+                else
                 {
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                    if (!NativeMethods.SetLocalTime(ref systemTime))
+                    {
+                        throw new Win32Exception(Marshal.GetLastWin32Error());
+                    }
+
+                    // MSDN says to call this twice to account for changes
+                    // between DST
+                    if (!NativeMethods.SetLocalTime(ref systemTime))
+                    {
+                        throw new Win32Exception(Marshal.GetLastWin32Error());
+                    }
                 }
 #pragma warning restore 56523
 #endif
@@ -106,7 +119,11 @@ namespace Microsoft.PowerShell.Commands
             PSNoteProperty note = new("DisplayHint", DisplayHint);
             outputObj.Properties.Add(note);
 
-            WriteObject(outputObj);
+            // If we've turned on the SetDate test hook, don't emit the output object here because we emitted it earlier.
+            if (!Dbg.Internal.InternalTestHooks.SetDate)
+            {
+                WriteObject(outputObj);
+            }
         }
 
         #endregion

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1592,6 +1592,8 @@ namespace System.Management.Automation.Internal
         internal static bool SetConsoleWidthToZero;
         internal static bool SetConsoleHeightToZero;
 
+        internal static bool SetDate;
+
         // A location to test PSEdition compatibility functionality for Windows PowerShell modules with
         // since we can't manipulate the System32 directory in a test
         internal static string TestWindowsPowerShellPSHomeLocation;

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -47,6 +47,8 @@ Describe 'native commands with pipeline' -tags 'Feature' {
     It 'native command should be killed when pipeline is disposed' -Skip:($IsWindows) {
         $yes = (Get-Process 'yes' -ErrorAction Ignore).Count
         yes | Select-Object -First 2
+        # wait a little to be sure that the process is ended
+        Start-Sleep -Milliseconds 500
         (Get-Process 'yes' -ErrorAction Ignore).Count | Should -Be $yes
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -254,9 +254,6 @@ Describe "Test-Connection" -tags "CI", "RequireSudoOnUnix" {
     }
 
     Context "MTUSizeDetect" {
-        # We skip the MtuSize detection tests when in containers, as the environments throw raw exceptions
-        # instead of returning a PacketTooBig response cleanly.
-        # Test disabled due to .NET runtime issue: https://github.com/dotnet/runtime/issues/55961
         It "MTUSizeDetect works" {
             $result = Test-Connection $testAddress -MtuSize
 
@@ -266,7 +263,6 @@ Describe "Test-Connection" -tags "CI", "RequireSudoOnUnix" {
             $result.MtuSize | Should -BeGreaterThan 0
         }
 
-        # Test disabled due to .NET runtime issue: https://github.com/dotnet/runtime/issues/55961
         It "Quiet works" {
             $result = Test-Connection $gatewayAddress -MtuSize -Quiet
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -257,7 +257,7 @@ Describe "Test-Connection" -tags "CI", "RequireSudoOnUnix" {
         # We skip the MtuSize detection tests when in containers, as the environments throw raw exceptions
         # instead of returning a PacketTooBig response cleanly.
         # Test disabled due to .NET runtime issue: https://github.com/dotnet/runtime/issues/55961
-        It "MTUSizeDetect works" -Pending:(($env:__INCONTAINER -eq 1) -or $IsMacOS) {
+        It "MTUSizeDetect works" {
             $result = Test-Connection $testAddress -MtuSize
 
             $result | Should -BeOfType Microsoft.PowerShell.Commands.TestConnectionCommand+PingMtuStatus
@@ -267,7 +267,7 @@ Describe "Test-Connection" -tags "CI", "RequireSudoOnUnix" {
         }
 
         # Test disabled due to .NET runtime issue: https://github.com/dotnet/runtime/issues/55961
-        It "Quiet works" -Pending:(($env:__INCONTAINER -eq 1) -or $IsMacOS) {
+        It "Quiet works" {
             $result = Test-Connection $gatewayAddress -MtuSize -Quiet
 
             $result | Should -BeOfType Int32

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Date.Tests.ps1
@@ -15,11 +15,18 @@ Describe "Set-Date for admin" -Tag @('CI', 'RequireAdminOnWindows', 'RequireSudo
         { Get-Date | Set-Date } | Should -Not -Throw
     }
 
-    # Fails in VSTS Linux with Operation not permitted
+    # Check the individual properties as the types may be different
     It "Set-Date should be able to set the date with -Date parameter" {
         $target = Get-Date
         $expected = $target
-        Set-Date -Date $target | Should -Be $expected
+        $observed = Set-Date -Date $target
+        $observed.Day | Should -Be $expected.Day
+        $observed.DayOfWeek | Should -Be $expected.DayOfWeek
+        $observed.Hour | Should -Be $expected.Hour
+        $observed.Minutes | Should -Be $expected.Minutes
+        $observed.Month | Should -Be $expected.Month
+        $observed.Second | Should -Be $expected.Second
+        $observed.Year | Should -Be $expected.Year
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Date.Tests.ps1
@@ -20,8 +20,8 @@ Describe "Set-Date for admin" -Tag @('CI', 'RequireAdminOnWindows', 'RequireSudo
         $target = Get-Date
         $expected = $target
         $observed = Set-Date -Date $target
+        # do not test dayofweek because the number of the day is different between native and managed
         $observed.Day | Should -Be $expected.Day
-        $observed.DayOfWeek | Should -Be $expected.DayOfWeek
         $observed.Hour | Should -Be $expected.Hour
         $observed.Minutes | Should -Be $expected.Minutes
         $observed.Month | Should -Be $expected.Month

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Date.Tests.ps1
@@ -5,15 +5,18 @@ Import-Module HelpersCommon
 
 Describe "Set-Date for admin" -Tag @('CI', 'RequireAdminOnWindows', 'RequireSudoOnUnix') {
     BeforeAll {
-        $skipTest = (Test-IsVstsLinux) -or ($env:__INCONTAINER -eq 1)
+        [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("SetDate", $true)
     }
-    # Fails in VSTS Linux with Operation not permitted
-    It "Set-Date should be able to set the date in an elevated context" -Skip:$skipTest {
+    AfterAll {
+        [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("SetDate", $false)
+    }
+
+    It "Set-Date should be able to set the date in an elevated context" {
         { Get-Date | Set-Date } | Should -Not -Throw
     }
 
     # Fails in VSTS Linux with Operation not permitted
-    It "Set-Date should be able to set the date with -Date parameter" -Skip:$skipTest {
+    It "Set-Date should be able to set the date with -Date parameter" {
         $target = Get-Date
         $expected = $target
         Set-Date -Date $target | Should -Be $expected

--- a/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
@@ -42,6 +42,7 @@ Describe 'Online help tests for PowerShell Cmdlets' -Tags "Feature" {
 
             # TopicTitle - is the cmdlet name in the csv file
             # HelpURI - is the expected help URI in the csv file
+            # If this is correct, then launching the cmdlet should open the expected help URI.
 
             It "Validate 'get-help $($cmdlet.TopicTitle) -Online'" -Skip:$skipTest {
                 $actualURI = Get-Help $cmdlet.TopicTitle -Online
@@ -49,48 +50,6 @@ Describe 'Online help tests for PowerShell Cmdlets' -Tags "Feature" {
                 $actualURI | Should -Be $cmdlet.HelpURI
             }
         }
-    }
-}
-
-Describe 'Get-Help -Online opens the default web browser and navigates to the cmdlet help content' -Tags "Feature" {
-
-    $skipTest = [System.Management.Automation.Platform]::IsIoT -or
-                [System.Management.Automation.Platform]::IsNanoServer -or
-                $env:__INCONTAINER -eq 1
-
-    # this code is a workaround for issue: https://github.com/PowerShell/PowerShell/issues/3079
-    if((-not ($skipTest)) -and $IsWindows)
-    {
-        $skipTest = $true
-        $regKey = "HKCU:\Software\Microsoft\Windows\Shell\Associations\UrlAssociations\http\UserChoice"
-
-        try
-        {
-            $progId = (Get-ItemProperty $regKey).ProgId
-            if($progId)
-            {
-                if (-not (Test-Path 'HKCR:\'))
-                {
-                    New-PSDrive -PSProvider registry -Root HKEY_CLASSES_ROOT -Name HKCR | Should -Not -BeNullOrEmpty
-                }
-                $browserExe = ((Get-ItemProperty "HKCR:\$progId\shell\open\command")."(default)" -replace '"', '') -split " "
-                if ($browserExe.count -ge 1)
-                {
-                    if($browserExe[0] -match '.exe')
-                    {
-                        $skipTest = $false
-                    }
-                }
-            }
-        }
-        catch
-        {
-            # We are not able to access Registry, skipping test.
-        }
-    }
-
-    It "Get-Help get-process -online" -Skip:$skipTest {
-        { Get-Help get-process -Online } | Should -Not -Throw
     }
 }
 

--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -578,7 +578,7 @@ Describe "Help failure cases" -Tags Feature {
 
         # under some conditions this does not throw, so include what we actually got
         $helpTopic = [guid]::NewGuid().ToString("N")
-        { & $command $helpTopic -ErrorAction Stop } | Should -Throw -ErrorId "HelpNotFound,Microsoft.PowerShell.Commands.GetHelpCommand" -Because "A help topic was found for $helpTopic"
+        { & $command $helpTopic -ErrorAction Stop } | Should -Throw -ErrorId "HelpNotFound,Microsoft.PowerShell.Commands.GetHelpCommand" -Because "A help topic was unexpectantly found for $helpTopic"
     }
 }
 

--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -578,7 +578,7 @@ Describe "Help failure cases" -Tags Feature {
 
         # under some conditions this does not throw, so include what we actually got
         $helpTopic = [guid]::NewGuid().ToString("N")
-        { & $command $helpTopic -ErrorAction Stop } | Should -Throw -ErrorId "HelpNotFound,Microsoft.PowerShell.Commands.GetHelpCommand" -Because "$(& $command $helpTopic -ea Ignore)"
+        { & $command $helpTopic -ErrorAction Stop } | Should -Throw -ErrorId "HelpNotFound,Microsoft.PowerShell.Commands.GetHelpCommand" -Because "A help topic was found for $helpTopic"
     }
 }
 


### PR DESCRIPTION
Improve debugging output for online help test.

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
There are a number of tests which are disabled when run in a container. This PR re-enables all of them.
Notably, it removes the test which causes a browser to be launched in the shell as this is not available in a container (or server core). The functionality is still validated by verifying the URL that is opened, but does not launch the browser via a test hook.

This PR also improves a test for help failures by reporting the name of the topic that has been surprisingly found to aid in debugging.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
