### PR TITLE
Improve how Linux container CI builds are identified

### DIFF
--- a/.vsts-ci/linux.yml
+++ b/.vsts-ci/linux.yml
@@ -153,6 +153,15 @@ stages:
         Import-Module ./PowerShell/tools/ci.psm1
         Set-BuildVariable -Name containerName -Value $containerName -IsOutput
         Set-BuildVariable -Name containerBuildName -Value $selectedImage.JobName -IsOutput
+
+        if($env:BUILD_REASON -eq 'PullRequest') {
+          Write-Host "##vso[build.updatebuildnumber]PR-$(System.PullRequest.PullRequestNumber)-$containerBuildName-$((get-date).ToString("yyyyMMddhhmmss"))"
+        } else {
+          Write-Host "##vso[build.updatebuildnumber]${env:BUILD_SOURCEBRANCHNAME}-${env:BUILD_SOURCEVERSION}-$containerBuildName-$((get-date).ToString("yyyyMMddhhmmss"))"
+
+          # Cannot do this for a PR
+          Write-Host "##vso[build.addbuildtag]$containerBuildName"
+        }
       name: getContainerTask
       displayName: Get Container
       continueOnError: true

--- a/.vsts-ci/linux.yml
+++ b/.vsts-ci/linux.yml
@@ -155,12 +155,12 @@ stages:
         Set-BuildVariable -Name containerBuildName -Value $selectedImage.JobName -IsOutput
 
         if($env:BUILD_REASON -eq 'PullRequest') {
-          Write-Host "##vso[build.updatebuildnumber]PR-$(System.PullRequest.PullRequestNumber)-$containerBuildName-$((get-date).ToString("yyyyMMddhhmmss"))"
+          Write-Host "##vso[build.updatebuildnumber]PR-$(System.PullRequest.PullRequestNumber)-$($selectedImage.JobName)-$((get-date).ToString("yyyyMMddhhmmss"))"
         } else {
-          Write-Host "##vso[build.updatebuildnumber]${env:BUILD_SOURCEBRANCHNAME}-${env:BUILD_SOURCEVERSION}-$containerBuildName-$((get-date).ToString("yyyyMMddhhmmss"))"
+          Write-Host "##vso[build.updatebuildnumber]${env:BUILD_SOURCEBRANCHNAME}-${env:BUILD_SOURCEVERSION}-$($selectedImage.JobName)-$((get-date).ToString("yyyyMMddhhmmss"))"
 
           # Cannot do this for a PR
-          Write-Host "##vso[build.addbuildtag]$containerBuildName"
+          Write-Host "##vso[build.addbuildtag]$($selectedImage.JobName)"
         }
       name: getContainerTask
       displayName: Get Container

--- a/.vsts-ci/templates/test/nix-container-test.yml
+++ b/.vsts-ci/templates/test/nix-container-test.yml
@@ -12,7 +12,7 @@ jobs:
 
   strategy:
     matrix:
-      ${{ dependencies.getContainerJob.outputs['getContainerTask.containerBuildName'] }}:
+      $[ dependencies.getContainerJob.outputs['getContainerTask.containerBuildName'] ]:
         getContainerJob: $[ dependencies.getContainerJob.outputs['getContainerTask.containerName'] ]
         containerBuildName: $[ dependencies.getContainerJob.outputs['getContainerTask.containerBuildName'] ]
 

--- a/.vsts-ci/templates/test/nix-container-test.yml
+++ b/.vsts-ci/templates/test/nix-container-test.yml
@@ -20,7 +20,7 @@ jobs:
   pool:
     vmImage: ${{ parameters.pool }}
 
-  displayName: $[ dependencies.getContainerJob.outputs['getContainerTask.containerBuildName'] ] Test - ${{ parameters.purpose }} - ${{ parameters.tagSet }}
+  displayName: ${{ parameters.name }} Test - ${{ parameters.purpose }} - ${{ parameters.tagSet }}
 
   steps:
     - pwsh: |

--- a/.vsts-ci/templates/test/nix-container-test.yml
+++ b/.vsts-ci/templates/test/nix-container-test.yml
@@ -20,7 +20,7 @@ jobs:
   pool:
     vmImage: ${{ parameters.pool }}
 
-  displayName: ${{ parameters.name }} Test - ${{ parameters.purpose }} - ${{ parameters.tagSet }}
+  displayName: $[ dependencies.getContainerJob.outputs['getContainerTask.containerBuildName'] ] Test - ${{ parameters.purpose }} - ${{ parameters.tagSet }}
 
   steps:
     - template: ./nix-test-steps.yml

--- a/.vsts-ci/templates/test/nix-container-test.yml
+++ b/.vsts-ci/templates/test/nix-container-test.yml
@@ -10,14 +10,10 @@ jobs:
   dependsOn:
     - getContainerJob
 
-  strategy:
-    matrix:
-      $[ dependencies.getContainerJob.outputs['getContainerTask.containerBuildName'] ]:
-        getContainerJob: $[ dependencies.getContainerJob.outputs['getContainerTask.containerName'] ]
-        containerBuildName: $[ dependencies.getContainerJob.outputs['getContainerTask.containerBuildName'] ]
-
   variables:
     __INCONTAINER: 1
+    getContainerJob: $[ dependencies.getContainerJob.outputs['getContainerTask.containerName'] ]
+    containerBuildName: $[ dependencies.getContainerJob.outputs['getContainerTask.containerBuildName'] ]
 
   container: $[ variables.getContainerJob ]
 

--- a/.vsts-ci/templates/test/nix-container-test.yml
+++ b/.vsts-ci/templates/test/nix-container-test.yml
@@ -23,17 +23,6 @@ jobs:
   displayName: ${{ parameters.name }} Test - ${{ parameters.purpose }} - ${{ parameters.tagSet }}
 
   steps:
-    - pwsh: |
-        if($env:BUILD_REASON -eq 'PullRequest') {
-          Write-Host "##vso[build.updatebuildnumber]PR-$(System.PullRequest.PullRequestNumber)-$(containerBuildName)-$((get-date).ToString("yyyyMMddhhmmss"))"
-        } else {
-          Write-Host "##vso[build.updatebuildnumber]${env:BUILD_SOURCEBRANCHNAME}-${env:BUILD_SOURCEVERSION}-$(containerBuildName)-$((get-date).ToString("yyyyMMddhhmmss"))"
-        }
-
-        # Add tag for container that is being tested
-        Write-Host "##vso[build.addbuildtag]$(containerBuildName)"
-      displayName: Update build name and Add tag
-
     - template: ./nix-test-steps.yml
       parameters:
         purpose: ${{ parameters.purpose }}

--- a/.vsts-ci/templates/test/nix-container-test.yml
+++ b/.vsts-ci/templates/test/nix-container-test.yml
@@ -27,4 +27,4 @@ jobs:
       parameters:
         purpose: ${{ parameters.purpose }}
         tagSet: ${{ parameters.tagSet }}
-        buildName: ${{ variables.containerBuildName}}
+        buildName: $(containerBuildName)

--- a/.vsts-ci/templates/test/nix-container-test.yml
+++ b/.vsts-ci/templates/test/nix-container-test.yml
@@ -23,6 +23,10 @@ jobs:
   displayName: $[ dependencies.getContainerJob.outputs['getContainerTask.containerBuildName'] ] Test - ${{ parameters.purpose }} - ${{ parameters.tagSet }}
 
   steps:
+    - pwsh: |
+        Write-Host "##vso[build.updatebuildnumber]PR-$(System.PullRequest.PullRequestNumber)-$(containerBuildName)-$((get-date).ToString("yyyyMMddhhmmss"))"
+        Write-Host "##vso[build.addbuildtag]$(containerBuildName)"
+      displayName: Update build name and add tag
     - template: ./nix-test-steps.yml
       parameters:
         purpose: ${{ parameters.purpose }}

--- a/.vsts-ci/templates/test/nix-container-test.yml
+++ b/.vsts-ci/templates/test/nix-container-test.yml
@@ -10,8 +10,13 @@ jobs:
   dependsOn:
     - getContainerJob
 
+  strategy:
+    matrix:
+      ${{ dependencies.getContainerJob.outputs['getContainerTask.containerBuildName'] }}:
+        getContainerJob: $[ dependencies.getContainerJob.outputs['getContainerTask.containerName'] ]
+        containerBuildName: $[ dependencies.getContainerJob.outputs['getContainerTask.containerBuildName'] ]
+
   variables:
-    getContainerJob: $[ dependencies.getContainerJob.outputs['getContainerTask.containerName'] ]
     __INCONTAINER: 1
 
   container: $[ variables.getContainerJob ]
@@ -26,3 +31,4 @@ jobs:
       parameters:
         purpose: ${{ parameters.purpose }}
         tagSet: ${{ parameters.tagSet }}
+        buildName: ${{ variables.containerBuildName}}

--- a/.vsts-ci/templates/test/nix-container-test.yml
+++ b/.vsts-ci/templates/test/nix-container-test.yml
@@ -24,9 +24,16 @@ jobs:
 
   steps:
     - pwsh: |
-        Write-Host "##vso[build.updatebuildnumber]PR-$(System.PullRequest.PullRequestNumber)-$(containerBuildName)-$((get-date).ToString("yyyyMMddhhmmss"))"
+        if($env:BUILD_REASON -eq 'PullRequest') {
+          Write-Host "##vso[build.updatebuildnumber]PR-$(System.PullRequest.PullRequestNumber)-$(containerBuildName)-$((get-date).ToString("yyyyMMddhhmmss"))"
+        } else {
+          Write-Host "##vso[build.updatebuildnumber]${env:BUILD_SOURCEBRANCHNAME}-${env:BUILD_SOURCEVERSION}-$(containerBuildName)-$((get-date).ToString("yyyyMMddhhmmss"))"
+        }
+
+        # Add tag for container that is being tested
         Write-Host "##vso[build.addbuildtag]$(containerBuildName)"
-      displayName: Update build name and add tag
+      displayName: Update build name and Add tag
+
     - template: ./nix-test-steps.yml
       parameters:
         purpose: ${{ parameters.purpose }}

--- a/.vsts-ci/templates/test/nix-test-steps.yml
+++ b/.vsts-ci/templates/test/nix-test-steps.yml
@@ -1,6 +1,7 @@
 parameters:
   purpose: ''
   tagSet: 'CI'
+  buildName: 'Ubuntu'
 
 steps:
   - pwsh: |
@@ -54,6 +55,6 @@ steps:
       chmod a+x $pwshPath
       $options.Output = $pwshPath
       Set-PSOptions $options
-      Invoke-CITest -Purpose '${{ parameters.purpose }}' -TagSet '${{ parameters.tagSet }}'
+      Invoke-CITest -Purpose '${{ parameters.purpose }}' -TagSet '${{ parameters.tagSet }}' -TitlePrefix '${{ parameters.buildName }}'
     displayName: Test
     condition: succeeded()

--- a/tools/ci.psm1
+++ b/tools/ci.psm1
@@ -219,7 +219,8 @@ function Invoke-CITest
         [ValidateSet('UnelevatedPesterTests', 'ElevatedPesterTests')]
         [string] $Purpose,
         [ValidateSet('CI', 'Others')]
-        [string] $TagSet
+        [string] $TagSet,
+        [string] $TitlePrefix
     )
 
     # Set locale correctly for Linux CIs
@@ -271,7 +272,12 @@ function Invoke-CITest
             ExcludeTag = $ExcludeTag + 'RequireAdminOnWindows'
         }
 
-        Start-PSPester @arguments -Title "Pester Unelevated - $TagSet"
+        $title = "Pester Unelevated - $TagSet"
+        if ($TitlePrefix) {
+            $title = "$TitlePrefix - $title"
+        }
+        Start-PSPester @arguments -Title $title
+
         # Fail the build, if tests failed
         Test-PSPesterResults -TestResultsFile $testResultsNonAdminFile
 
@@ -293,7 +299,11 @@ function Invoke-CITest
                 $arguments['Path'] = $testFiles
             }
 
-            Start-PSPester @arguments -Title "Pester Experimental Unelevated - $featureName"
+            $title = "Pester Experimental Unelevated - $featureName"
+            if ($TitlePrefix) {
+                $title = "$TitlePrefix - $title"
+            }
+            Start-PSPester @arguments -Title $title
 
             # Fail the build, if tests failed
             Test-PSPesterResults -TestResultsFile $expFeatureTestResultFile
@@ -309,7 +319,11 @@ function Invoke-CITest
             ExcludeTag = $ExcludeTag
         }
 
-        Start-PSPester @arguments -Title "Pester Elevated - $TagSet"
+        $title = "Pester Elevated - $TagSet"
+        if ($TitlePrefix) {
+            $title = "$TitlePrefix - $title"
+        }
+        Start-PSPester @arguments -Title $title
 
         # Fail the build, if tests failed
         Test-PSPesterResults -TestResultsFile $testResultsAdminFile
@@ -334,7 +348,12 @@ function Invoke-CITest
                 # If a non-empty string or array is specified for the feature name, we only run those test files.
                 $arguments['Path'] = $testFiles
             }
-            Start-PSPester @arguments -Title "Pester Experimental Elevated - $featureName"
+
+            $title = "Pester Experimental >levated - $featureName"
+            if ($TitlePrefix) {
+                $title = "$TitlePrefix - $title"
+            }
+            Start-PSPester @arguments -Title $title
 
             # Fail the build, if tests failed
             Test-PSPesterResults -TestResultsFile $expFeatureTestResultFile
@@ -612,7 +631,8 @@ function Invoke-LinuxTestsCore
         [ValidateSet('UnelevatedPesterTests', 'ElevatedPesterTests', 'All')]
         [string] $Purpose = 'All',
         [string[]] $ExcludeTag = @('Slow', 'Feature', 'Scenario'),
-        [string] $TagSet = 'CI'
+        [string] $TagSet = 'CI',
+        [string] $TitlePrefix
     )
 
     $output = Split-Path -Parent (Get-PSOutput -Options (Get-PSOptions))
@@ -639,7 +659,11 @@ function Invoke-LinuxTestsCore
     # Running tests which do not require sudo.
     if($Purpose -eq 'UnelevatedPesterTests' -or $Purpose -eq 'All')
     {
-        $pesterPassThruNoSudoObject = Start-PSPester @noSudoPesterParam -Title "Pester No Sudo - $TagSet"
+        $title = "Pester No Sudo - $TagSet"
+        if ($TitlePrefix) {
+            $title = "$TitlePrefix - $title"
+        }
+        $pesterPassThruNoSudoObject = Start-PSPester @noSudoPesterParam -Title $title
 
         # Running tests that do not require sudo, with specified experimental features enabled
         $noSudoResultsWithExpFeatures = @()
@@ -660,7 +684,12 @@ function Invoke-LinuxTestsCore
                 # If a non-empty string or array is specified for the feature name, we only run those test files.
                 $noSudoPesterParam['Path'] = $testFiles
             }
-            $passThruResult = Start-PSPester @noSudoPesterParam -Title "Pester Experimental No Sudo - $featureName - $TagSet"
+            $title = "Pester Experimental No Sudo - $featureName - $TagSet"
+            if ($TitlePrefix) {
+                $title = "$TitlePrefix - $title"
+            }
+            $passThruResult = Start-PSPester @noSudoPesterParam -Title $title
+
             $noSudoResultsWithExpFeatures += $passThruResult
         }
     }
@@ -674,7 +703,12 @@ function Invoke-LinuxTestsCore
         $sudoPesterParam['ExcludeTag'] = $ExcludeTag
         $sudoPesterParam['Sudo'] = $true
         $sudoPesterParam['OutputFile'] = $testResultsSudo
-        $pesterPassThruSudoObject = Start-PSPester @sudoPesterParam -Title "Pester Sudo - $TagSet"
+
+        $title = "Pester Sudo - $TagSet"
+        if ($TitlePrefix) {
+            $title = "$TitlePrefix - $title"
+        }
+        $pesterPassThruSudoObject = Start-PSPester @sudoPesterParam -Title $title
 
         # Running tests that require sudo, with specified experimental features enabled
         $sudoResultsWithExpFeatures = @()
@@ -696,7 +730,13 @@ function Invoke-LinuxTestsCore
                 # If a non-empty string or array is specified for the feature name, we only run those test files.
                 $sudoPesterParam['Path'] = $testFiles
             }
-            $passThruResult = Start-PSPester @sudoPesterParam -Title "Pester Experimental Sudo - $featureName - $TagSet"
+
+            $title = "Pester Experimental Sudo - $featureName - $TagSet"
+            if ($TitlePrefix) {
+                $title = "$TitlePrefix - $title"
+            }
+            $passThruResult = Start-PSPester @sudoPesterParam -Title $title
+
             $sudoResultsWithExpFeatures += $passThruResult
         }
     }

--- a/tools/ci.psm1
+++ b/tools/ci.psm1
@@ -245,7 +245,7 @@ function Invoke-CITest
 
     if($IsLinux -or $IsMacOS)
     {
-        return Invoke-LinuxTestsCore -Purpose $Purpose -ExcludeTag $ExcludeTag -TagSet $TagSet
+        return Invoke-LinuxTestsCore -Purpose $Purpose -ExcludeTag $ExcludeTag -TagSet $TagSet -TitlePrefix $TitlePrefix
     }
 
     # CoreCLR


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- Improve how Linux container CI builds are identified
  - Add tag to non-PR builds (not allowed on CI builds)
  - Add container identifier to build name
     <img width="505" alt="CleanShot 2022-05-09 at 16 09 41@2x" src="https://user-images.githubusercontent.com/10873629/167513010-5c6978a0-7542-4508-9128-dd1ae13cb902.png">

  - Add container identifier to test pass names
    <img width="599" alt="CleanShot 2022-05-09 at 16 10 57@2x" src="https://user-images.githubusercontent.com/10873629/167513109-96c03465-74b4-44e0-905d-bb0a1d9c7139.png">

  
## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
