### PR TITLE
Telemetry changes

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -704,27 +704,27 @@ namespace Microsoft.PowerShell
                 return ParameterBitmap.EPUndefined;
             }
 
-            if (String.Equals(_executionPolicy, "remotesigned", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(_executionPolicy, "remotesigned", StringComparison.OrdinalIgnoreCase))
             {
                 return ParameterBitmap.EPRemoteSigned;
             }
-            else if (String.Equals(_executionPolicy, "bypass", StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(_executionPolicy, "bypass", StringComparison.OrdinalIgnoreCase))
             {
                 return ParameterBitmap.EPBypass;
             }
-            else if (String.Equals(_executionPolicy, "unrestricted", StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(_executionPolicy, "unrestricted", StringComparison.OrdinalIgnoreCase))
             {
                 return ParameterBitmap.EPUnrestricted;
             }
-            else if (String.Equals(_executionPolicy, "allsigned", StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(_executionPolicy, "allsigned", StringComparison.OrdinalIgnoreCase))
             {
                 return ParameterBitmap.EPAllSigned;
             }
-            else if (String.Equals(_executionPolicy, "restricted", StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(_executionPolicy, "restricted", StringComparison.OrdinalIgnoreCase))
             {
                 return ParameterBitmap.EPRestricted;
             }
-            else if (String.Equals(_executionPolicy, "undefined", StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(_executionPolicy, "undefined", StringComparison.OrdinalIgnoreCase))
             {
                 return ParameterBitmap.EPUndefined;
             }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -704,32 +704,36 @@ namespace Microsoft.PowerShell
                 return ParameterBitmap.EPUndefined;
             }
 
-            if (string.Equals(_executionPolicy, "remotesigned", StringComparison.OrdinalIgnoreCase))
+            ParameterBitmap ExecutionPolicySetting = ParameterBitmap.EPUndefined;
+            switch (_executionPolicy)
             {
-                return ParameterBitmap.EPRemoteSigned;
-            }
-            else if (string.Equals(_executionPolicy, "bypass", StringComparison.OrdinalIgnoreCase))
-            {
-                return ParameterBitmap.EPBypass;
-            }
-            else if (string.Equals(_executionPolicy, "unrestricted", StringComparison.OrdinalIgnoreCase))
-            {
-                return ParameterBitmap.EPUnrestricted;
-            }
-            else if (string.Equals(_executionPolicy, "allsigned", StringComparison.OrdinalIgnoreCase))
-            {
-                return ParameterBitmap.EPAllSigned;
-            }
-            else if (string.Equals(_executionPolicy, "restricted", StringComparison.OrdinalIgnoreCase))
-            {
-                return ParameterBitmap.EPRestricted;
-            }
-            else if (string.Equals(_executionPolicy, "undefined", StringComparison.OrdinalIgnoreCase))
-            {
-                return ParameterBitmap.EPUndefined;
+                case var b when string.Equals(_executionPolicy, "default", StringComparison.OrdinalIgnoreCase):
+                    ExecutionPolicySetting = ParameterBitmap.EPDefault;
+                    break;
+                case var b when string.Equals(_executionPolicy, "remotesigned", StringComparison.OrdinalIgnoreCase):
+                    ExecutionPolicySetting = ParameterBitmap.EPRemoteSigned;
+                    break;
+                case var b when string.Equals(_executionPolicy, "bypass", StringComparison.OrdinalIgnoreCase):
+                    ExecutionPolicySetting = ParameterBitmap.EPBypass;
+                    break;
+                case var b when string.Equals(_executionPolicy, "unrestricted", StringComparison.OrdinalIgnoreCase):
+                    ExecutionPolicySetting = ParameterBitmap.EPUnrestricted;
+                    break;
+                case var b when string.Equals(_executionPolicy, "allsigned", StringComparison.OrdinalIgnoreCase):
+                    ExecutionPolicySetting = ParameterBitmap.EPAllSigned;
+                    break;
+                case var b when string.Equals(_executionPolicy, "restricted", StringComparison.OrdinalIgnoreCase):
+                    ExecutionPolicySetting = ParameterBitmap.EPRestricted;
+                    break;
+                case var b when string.Equals(_executionPolicy, "undefined", StringComparison.OrdinalIgnoreCase):
+                    ExecutionPolicySetting = ParameterBitmap.EPUndefined;
+                    break;
+                default:
+                    ExecutionPolicySetting = ParameterBitmap.EPIncorrect;
+                    break;
             }
 
-            return ParameterBitmap.EPIncorrect;
+            return ExecutionPolicySetting;
         }
 
         private static bool MatchSwitch(string switchKey, string match, string smallestUnambiguousMatch)

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -705,32 +705,38 @@ namespace Microsoft.PowerShell
             }
 
             ParameterBitmap executionPolicySetting = ParameterBitmap.EPUndefined;
-            switch (_executionPolicy)
+
+            if (string.Equals(_executionPolicy, "default", StringComparison.OrdinalIgnoreCase))
             {
-                case var b when string.Equals(_executionPolicy, "default", StringComparison.OrdinalIgnoreCase):
-                    executionPolicySetting = ParameterBitmap.EPDefault;
-                    break;
-                case var b when string.Equals(_executionPolicy, "remotesigned", StringComparison.OrdinalIgnoreCase):
-                    executionPolicySetting = ParameterBitmap.EPRemoteSigned;
-                    break;
-                case var b when string.Equals(_executionPolicy, "bypass", StringComparison.OrdinalIgnoreCase):
-                    executionPolicySetting = ParameterBitmap.EPBypass;
-                    break;
-                case var b when string.Equals(_executionPolicy, "unrestricted", StringComparison.OrdinalIgnoreCase):
-                    executionPolicySetting = ParameterBitmap.EPUnrestricted;
-                    break;
-                case var b when string.Equals(_executionPolicy, "allsigned", StringComparison.OrdinalIgnoreCase):
-                    executionPolicySetting = ParameterBitmap.EPAllSigned;
-                    break;
-                case var b when string.Equals(_executionPolicy, "restricted", StringComparison.OrdinalIgnoreCase):
-                    executionPolicySetting = ParameterBitmap.EPRestricted;
-                    break;
-                case var b when string.Equals(_executionPolicy, "undefined", StringComparison.OrdinalIgnoreCase):
-                    executionPolicySetting = ParameterBitmap.EPUndefined;
-                    break;
-                default:
-                    executionPolicySetting = ParameterBitmap.EPIncorrect;
-                    break;
+                executionPolicySetting = ParameterBitmap.EPDefault;
+            }
+            else if (string.Equals(_executionPolicy, "remotesigned", StringComparison.OrdinalIgnoreCase))
+            {
+                executionPolicySetting = ParameterBitmap.EPRemoteSigned;
+            }
+            else if (string.Equals(_executionPolicy, "bypass", StringComparison.OrdinalIgnoreCase))
+            {
+                executionPolicySetting = ParameterBitmap.EPBypass;
+            }
+            else if (string.Equals(_executionPolicy, "allsigned", StringComparison.OrdinalIgnoreCase))
+            {
+                executionPolicySetting = ParameterBitmap.EPAllSigned;
+            }
+            else if (string.Equals(_executionPolicy, "restricted", StringComparison.OrdinalIgnoreCase))
+            {
+                executionPolicySetting = ParameterBitmap.EPRestricted;
+            }
+            else if (string.Equals(_executionPolicy, "unrestricted", StringComparison.OrdinalIgnoreCase))
+            {
+                executionPolicySetting = ParameterBitmap.EPUnrestricted;
+            }
+            else if (string.Equals(_executionPolicy, "undefined", StringComparison.OrdinalIgnoreCase))
+            {
+                executionPolicySetting = ParameterBitmap.EPUndefined;
+            }
+            else
+            {
+                executionPolicySetting = ParameterBitmap.EPIncorrect;
             }
 
             return executionPolicySetting;
@@ -1054,7 +1060,6 @@ namespace Microsoft.PowerShell
                 }
                 else if (MatchSwitch(switchKey, "sta", "sta"))
                 {
-                    ParametersUsed |= ParameterBitmap.STA;
                     if (!Platform.IsWindowsDesktop || !Platform.IsStaSupported)
                     {
                         SetCommandLineError(
@@ -1071,10 +1076,10 @@ namespace Microsoft.PowerShell
                     }
 
                     _staMode = true;
+                    ParametersUsed |= ParameterBitmap.STA;
                 }
                 else if (MatchSwitch(switchKey, "mta", "mta"))
                 {
-                    ParametersUsed |= ParameterBitmap.MTA;
                     if (!Platform.IsWindowsDesktop)
                     {
                         SetCommandLineError(
@@ -1091,6 +1096,7 @@ namespace Microsoft.PowerShell
                     }
 
                     _staMode = false;
+                    ParametersUsed |= ParameterBitmap.MTA;
                 }
                 else if (MatchSwitch(switchKey, "workingdirectory", "wo") || MatchSwitch(switchKey, "wd", "wd"))
                 {
@@ -1102,8 +1108,8 @@ namespace Microsoft.PowerShell
                         break;
                     }
 
-                    ParametersUsed |= ParameterBitmap.WorkingDirectory;
                     _workingDirectory = args[i];
+                    ParametersUsed |= ParameterBitmap.WorkingDirectory;
                 }
 #if !UNIX
                 else if (MatchSwitch(switchKey, "removeworkingdirectorytrailingcharacter", "removeworkingdirectorytrailingcharacter"))

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -201,37 +201,41 @@ namespace Microsoft.PowerShell
         [Flags]
         internal enum ParameterBitmap : long
         {
-            Command           = 0x00000001, // -Command | -c
-            ConfigurationName = 0x00000002, // -ConfigurationName | -config
-            CustomPipeName    = 0x00000004, // -CustomPipeName
-            EncodedCommand    = 0x00000008, // -EncodedCommand | -e | -ec
-            ExecutionPolicy   = 0x00000010, // -ExecutionPolicy | -ex | -ep
-            File              = 0x00000020, // -File | -f
-            Help              = 0x00000040, // -Help, -?, /?
-            InputFormat       = 0x00000100, // -InputFormat | -inp | -if
-            Interactive       = 0x00000200, // -Interactive | -i
-            Login             = 0x00000400, // -Login | -l
-            MTA               = 0x00000800, // -MTA
-            NoExit            = 0x00001000, // -NoExit | -noe
-            NoLogo            = 0x00002000, // -NoLogo | -nol
-            NonInteractive    = 0x00004000, // -NonInteractive | -noni
-            NoProfile         = 0x00008000, // -NoProfile | -nop
-            OutputFormat      = 0x00010000, // -OutputFormat | -o | -of
-            SettingsFile      = 0x00020000, // -SettingsFile | -settings
-            SSHServerMode     = 0x00040000, // -SSHServerMode | -sshs
-            STA               = 0x00080000, // -STA
-            Version           = 0x00100000, // -Version | -v
-            WindowStyle       = 0x00200000, // -WindowStyle | -w
-            WorkingDirectory  = 0x00400000, // -WorkingDirectory | -wd
-            // Parameter values for ExecutionPolicy
-            EPUnrestricted    = 0x0000000100000000, // ExecutionPolicy unrestricted
-            EPRemoteSigned    = 0x0000000200000000, // ExecutionPolicy remote signed
-            EPAllSigned       = 0x0000000400000000, // ExecutionPolicy all signed
-            EPRestricted      = 0x0000000800000000, // ExecutionPolicy restricted
-            EPDefault         = 0x0000001000000000, // ExecutionPolicy default
-            EPBypass          = 0x0000002000000000, // ExecutionPolicy bypass
-            EPUndefined       = 0x0000004000000000, // ExecutionPolicy undefined
-            EPIncorrect       = 0x0000008000000000, // ExecutionPolicy incorrect
+            Command             = 0x00000001, // -Command | -c
+            ConfigurationName   = 0x00000002, // -ConfigurationName | -config
+            CustomPipeName      = 0x00000004, // -CustomPipeName
+            EncodedCommand      = 0x00000008, // -EncodedCommand | -e | -ec
+            EncodedArgument     = 0x00000010, // -EncodedArgument
+            ExecutionPolicy     = 0x00000020, // -ExecutionPolicy | -ex | -ep
+            File                = 0x00000040, // -File | -f
+            Help                = 0x00000080, // -Help, -?, /?
+            InputFormat         = 0x00000100, // -InputFormat | -inp | -if
+            Interactive         = 0x00000200, // -Interactive | -i
+            Login               = 0x00000400, // -Login | -l
+            MTA                 = 0x00000800, // -MTA
+            NoExit              = 0x00001000, // -NoExit | -noe
+            NoLogo              = 0x00002000, // -NoLogo | -nol
+            NonInteractive      = 0x00004000, // -NonInteractive | -noni
+            NoProfile           = 0x00008000, // -NoProfile | -nop
+            OutputFormat        = 0x00010000, // -OutputFormat | -o | -of
+            SettingsFile        = 0x00020000, // -SettingsFile | -settings
+            SSHServerMode       = 0x00040000, // -SSHServerMode | -sshs
+            SocketServerMode    = 0x00080000, // -SocketServerMode | -sockets
+            ServerMode          = 0x00100000, // -ServerMode | -server
+            NamedPipeServerMode = 0x00200000, // -NamedPipeServerMode | -namedpipes
+            STA                 = 0x00400000, // -STA
+            Version             = 0x00800000, // -Version | -v
+            WindowStyle         = 0x01000000, // -WindowStyle | -w
+            WorkingDirectory    = 0x02000000, // -WorkingDirectory | -wd
+            // Enum values for specified ExecutionPolicy
+            EPUnrestricted      = 0x0000000100000000, // ExecutionPolicy unrestricted
+            EPRemoteSigned      = 0x0000000200000000, // ExecutionPolicy remote signed
+            EPAllSigned         = 0x0000000400000000, // ExecutionPolicy all signed
+            EPRestricted        = 0x0000000800000000, // ExecutionPolicy restricted
+            EPDefault           = 0x0000001000000000, // ExecutionPolicy default
+            EPBypass            = 0x0000002000000000, // ExecutionPolicy bypass
+            EPUndefined         = 0x0000004000000000, // ExecutionPolicy undefined
+            EPIncorrect         = 0x0000008000000000, // ExecutionPolicy incorrect
         }
 
         internal ParameterBitmap ParametersUsed = 0;
@@ -700,27 +704,27 @@ namespace Microsoft.PowerShell
                 return ParameterBitmap.EPUndefined;
             }
 
-            if (MatchSwitch(_executionPolicy, "remotesigned", "remotesigned"))
+            if (String.Equals(_executionPolicy, "remotesigned", StringComparison.OrdinalIgnoreCase))
             {
                 return ParameterBitmap.EPRemoteSigned;
             }
-            else if (MatchSwitch(_executionPolicy, "bypass", "bypass"))
+            else if (String.Equals(_executionPolicy, "bypass", StringComparison.OrdinalIgnoreCase))
             {
                 return ParameterBitmap.EPBypass;
             }
-            else if (MatchSwitch(_executionPolicy, "unrestricted", "unrestricted"))
+            else if (String.Equals(_executionPolicy, "unrestricted", StringComparison.OrdinalIgnoreCase))
             {
                 return ParameterBitmap.EPUnrestricted;
             }
-            else if (MatchSwitch(_executionPolicy, "allsigned", "allsigned"))
+            else if (String.Equals(_executionPolicy, "allsigned", StringComparison.OrdinalIgnoreCase))
             {
                 return ParameterBitmap.EPAllSigned;
             }
-            else if (MatchSwitch(_executionPolicy, "restricted", "restricted"))
+            else if (String.Equals(_executionPolicy, "restricted", StringComparison.OrdinalIgnoreCase))
             {
                 return ParameterBitmap.EPRestricted;
             }
-            else if (MatchSwitch(_executionPolicy, "undefined", "undefined"))
+            else if (String.Equals(_executionPolicy, "undefined", StringComparison.OrdinalIgnoreCase))
             {
                 return ParameterBitmap.EPUndefined;
             }
@@ -862,45 +866,48 @@ namespace Microsoft.PowerShell
                 else if (MatchSwitch(switchKey, "noexit", "noe"))
                 {
                     _noExit = true;
-                    ParametersUsed |= ParameterBitmap.NoExit;
                     noexitSeen = true;
+                    ParametersUsed |= ParameterBitmap.NoExit;
                 }
                 else if (MatchSwitch(switchKey, "noprofile", "nop"))
                 {
-                    ParametersUsed |= ParameterBitmap.NoProfile;
                     _skipUserInit = true;
+                    ParametersUsed |= ParameterBitmap.NoProfile;
                 }
                 else if (MatchSwitch(switchKey, "nologo", "nol"))
                 {
-                    ParametersUsed |= ParameterBitmap.NoLogo;
                     _showBanner = false;
+                    ParametersUsed |= ParameterBitmap.NoLogo;
                 }
                 else if (MatchSwitch(switchKey, "noninteractive", "noni"))
                 {
-                    ParametersUsed |= ParameterBitmap.NonInteractive;
                     _noInteractive = true;
+                    ParametersUsed |= ParameterBitmap.NonInteractive;
                 }
                 else if (MatchSwitch(switchKey, "socketservermode", "so"))
                 {
                     _socketServerMode = true;
+                    ParametersUsed |= ParameterBitmap.SocketServerMode;
                 }
                 else if (MatchSwitch(switchKey, "servermode", "s"))
                 {
                     _serverMode = true;
+                    ParametersUsed |= ParameterBitmap.ServerMode;
                 }
                 else if (MatchSwitch(switchKey, "namedpipeservermode", "nam"))
                 {
                     _namedPipeServerMode = true;
+                    ParametersUsed |= ParameterBitmap.NamedPipeServerMode;
                 }
                 else if (MatchSwitch(switchKey, "sshservermode", "sshs"))
                 {
-                    ParametersUsed |= ParameterBitmap.SSHServerMode;
                     _sshServerMode = true;
+                    ParametersUsed |= ParameterBitmap.SSHServerMode;
                 }
                 else if (MatchSwitch(switchKey, "interactive", "i"))
                 {
-                    ParametersUsed |= ParameterBitmap.Interactive;
                     _noInteractive = false;
+                    ParametersUsed |= ParameterBitmap.Interactive;
                 }
                 else if (MatchSwitch(switchKey, "configurationname", "config"))
                 {
@@ -925,8 +932,6 @@ namespace Microsoft.PowerShell
                         break;
                     }
 
-                    ParametersUsed |= ParameterBitmap.CustomPipeName;
-
 #if UNIX
                     int maxNameLength = MaxNameLength();
                     if (args[i].Length > maxNameLength)
@@ -940,7 +945,9 @@ namespace Microsoft.PowerShell
                         break;
                     }
 #endif
+
                     _customPipeName = args[i];
+                    ParametersUsed |= ParameterBitmap.CustomPipeName;
                 }
                 else if (MatchSwitch(switchKey, "command", "c"))
                 {
@@ -953,7 +960,6 @@ namespace Microsoft.PowerShell
                 }
                 else if (MatchSwitch(switchKey, "windowstyle", "w"))
                 {
-                    ParametersUsed |= ParameterBitmap.WindowStyle;
 #if UNIX
                     SetCommandLineError(
                         CommandLineParameterParserStrings.WindowStyleArgumentNotImplemented);
@@ -977,15 +983,18 @@ namespace Microsoft.PowerShell
                             string.Format(CultureInfo.CurrentCulture, CommandLineParameterParserStrings.InvalidWindowStyleArgument, args[i], e.Message));
                         break;
                     }
+
+                    ParametersUsed |= ParameterBitmap.WindowStyle;
 #endif
                 }
                 else if (MatchSwitch(switchKey, "file", "f"))
                 {
-                    ParametersUsed |= ParameterBitmap.File;
                     if (!ParseFile(args, ref i, noexitSeen))
                     {
                         break;
                     }
+
+                    ParametersUsed |= ParameterBitmap.File;
                 }
 #if DEBUG
                 else if (MatchSwitch(switchKey, "isswait", "isswait"))
@@ -1013,11 +1022,12 @@ namespace Microsoft.PowerShell
                 else if (MatchSwitch(switchKey, "encodedcommand", "e") || MatchSwitch(switchKey, "ec", "e"))
                 {
                     _wasCommandEncoded = true;
-                    ParametersUsed |= ParameterBitmap.EncodedCommand;
                     if (!ParseCommand(args, ref i, noexitSeen, true))
                     {
                         break;
                     }
+
+                    ParametersUsed |= ParameterBitmap.EncodedCommand;
                 }
                 else if (MatchSwitch(switchKey, "encodedarguments", "encodeda") || MatchSwitch(switchKey, "ea", "ea"))
                 {
@@ -1025,6 +1035,8 @@ namespace Microsoft.PowerShell
                     {
                         break;
                     }
+
+                    ParametersUsed |= ParameterBitmap.EncodedArgument;
                 }
                 else if (MatchSwitch(switchKey, "settingsfile", "settings"))
                 {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -704,36 +704,36 @@ namespace Microsoft.PowerShell
                 return ParameterBitmap.EPUndefined;
             }
 
-            ParameterBitmap ExecutionPolicySetting = ParameterBitmap.EPUndefined;
+            ParameterBitmap executionPolicySetting = ParameterBitmap.EPUndefined;
             switch (_executionPolicy)
             {
                 case var b when string.Equals(_executionPolicy, "default", StringComparison.OrdinalIgnoreCase):
-                    ExecutionPolicySetting = ParameterBitmap.EPDefault;
+                    executionPolicySetting = ParameterBitmap.EPDefault;
                     break;
                 case var b when string.Equals(_executionPolicy, "remotesigned", StringComparison.OrdinalIgnoreCase):
-                    ExecutionPolicySetting = ParameterBitmap.EPRemoteSigned;
+                    executionPolicySetting = ParameterBitmap.EPRemoteSigned;
                     break;
                 case var b when string.Equals(_executionPolicy, "bypass", StringComparison.OrdinalIgnoreCase):
-                    ExecutionPolicySetting = ParameterBitmap.EPBypass;
+                    executionPolicySetting = ParameterBitmap.EPBypass;
                     break;
                 case var b when string.Equals(_executionPolicy, "unrestricted", StringComparison.OrdinalIgnoreCase):
-                    ExecutionPolicySetting = ParameterBitmap.EPUnrestricted;
+                    executionPolicySetting = ParameterBitmap.EPUnrestricted;
                     break;
                 case var b when string.Equals(_executionPolicy, "allsigned", StringComparison.OrdinalIgnoreCase):
-                    ExecutionPolicySetting = ParameterBitmap.EPAllSigned;
+                    executionPolicySetting = ParameterBitmap.EPAllSigned;
                     break;
                 case var b when string.Equals(_executionPolicy, "restricted", StringComparison.OrdinalIgnoreCase):
-                    ExecutionPolicySetting = ParameterBitmap.EPRestricted;
+                    executionPolicySetting = ParameterBitmap.EPRestricted;
                     break;
                 case var b when string.Equals(_executionPolicy, "undefined", StringComparison.OrdinalIgnoreCase):
-                    ExecutionPolicySetting = ParameterBitmap.EPUndefined;
+                    executionPolicySetting = ParameterBitmap.EPUndefined;
                     break;
                 default:
-                    ExecutionPolicySetting = ParameterBitmap.EPIncorrect;
+                    executionPolicySetting = ParameterBitmap.EPIncorrect;
                     break;
             }
 
-            return ExecutionPolicySetting;
+            return executionPolicySetting;
         }
 
         private static bool MatchSwitch(string switchKey, string match, string smallestUnambiguousMatch)

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -1,7 +1,5 @@
-using System.Reflection.Metadata;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-
 #nullable enable
 
 using System;
@@ -691,15 +689,17 @@ namespace Microsoft.PowerShell
 
         /// <summary>
         /// Determine the execution policy based on the supplied string.
-        /// If the string doesn't match to any known execution policy, set it to incorrect
+        /// If the string doesn't match to any known execution policy, set it to incorrect.
         /// </summary>
         /// <param name="_executionPolicy">The value provided on the command line.</param>
+        /// <returns>The execution policy.</returns>
         private static ParameterBitmap GetExecutionPolicy(string? _executionPolicy)
         {
             if (_executionPolicy is null)
             {
                 return ParameterBitmap.EPUndefined;
             }
+
             if (MatchSwitch(_executionPolicy, "remotesigned", "remotesigned"))
             {
                 return ParameterBitmap.EPRemoteSigned;
@@ -724,6 +724,7 @@ namespace Microsoft.PowerShell
             {
                 return ParameterBitmap.EPUndefined;
             }
+
             return ParameterBitmap.EPIncorrect;
         }
 
@@ -923,6 +924,7 @@ namespace Microsoft.PowerShell
                             CommandLineParameterParserStrings.MissingCustomPipeNameArgument);
                         break;
                     }
+
                     ParametersUsed |= ParameterBitmap.CustomPipeName;
 
 #if UNIX
@@ -946,6 +948,7 @@ namespace Microsoft.PowerShell
                     {
                         break;
                     }
+
                     ParametersUsed |= ParameterBitmap.Command;
                 }
                 else if (MatchSwitch(switchKey, "windowstyle", "w"))
@@ -1030,6 +1033,7 @@ namespace Microsoft.PowerShell
                     {
                         break;
                     }
+
                     ParametersUsed |= ParameterBitmap.SettingsFile;
                 }
                 else if (MatchSwitch(switchKey, "sta", "sta"))
@@ -1099,6 +1103,7 @@ namespace Microsoft.PowerShell
                     {
                         break;
                     }
+
                     // default to filename being the next argument.
                     ParametersUsed |= ParameterBitmap.File;
                 }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -704,7 +704,7 @@ namespace Microsoft.PowerShell
                 return ParameterBitmap.EPUndefined;
             }
 
-            ParameterBitmap executionPolicySetting = ParameterBitmap.EPUndefined;
+            ParameterBitmap executionPolicySetting = ParameterBitmap.EPIncorrect;
 
             if (string.Equals(_executionPolicy, "default", StringComparison.OrdinalIgnoreCase))
             {
@@ -733,10 +733,6 @@ namespace Microsoft.PowerShell
             else if (string.Equals(_executionPolicy, "undefined", StringComparison.OrdinalIgnoreCase))
             {
                 executionPolicySetting = ParameterBitmap.EPUndefined;
-            }
-            else
-            {
-                executionPolicySetting = ParameterBitmap.EPIncorrect;
             }
 
             return executionPolicySetting;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -196,14 +196,18 @@ namespace Microsoft.PowerShell
             "workingdirectory"
         };
 
+        /// <summary>
+        /// These represent the parameters that are used when starting pwsh.
+        /// We can query in our telemetry to determine how pwsh was invoked.
+        /// </summary>
         [Flags]
-        internal enum ParameterMask : long
+        internal enum ParameterBitmap : long
         {
-            Command           = 0x0000001, // -Command | -c
-            ConfigurationName = 0x0000002, // -ConfigurationName | -config
-            CustomPipeName    = 0x0000004, // -CustomPipeName
-            EncodedCommand    = 0x0000008, // -EncodedCommand | -e | -ec
-            ExecutionPolicy   = 0x0000010, // -ExecutionPolicy | -ex | -ep
+            Command           = 0x00000001, // -Command | -c
+            ConfigurationName = 0x00000002, // -ConfigurationName | -config
+            CustomPipeName    = 0x00000004, // -CustomPipeName
+            EncodedCommand    = 0x00000008, // -EncodedCommand | -e | -ec
+            ExecutionPolicy   = 0x00000010, // -ExecutionPolicy | -ex | -ep
             File              = 0x00000020, // -File | -f
             Help              = 0x00000040, // -Help, -?, /?
             InputFormat       = 0x00000100, // -InputFormat | -inp | -if
@@ -232,7 +236,7 @@ namespace Microsoft.PowerShell
             EPIncorrect       = 0x0000008000000000, // ExecutionPolicy incorrect
         }
 
-        internal ParameterMask ParametersUsed = 0;
+        internal ParameterBitmap ParametersUsed = 0;
 
         internal double ParametersUsedAsDouble
         {
@@ -690,37 +694,37 @@ namespace Microsoft.PowerShell
         /// If the string doesn't match to any known execution policy, set it to incorrect
         /// </summary>
         /// <param name="_executionPolicy">The value provided on the command line.</param>
-        private static ParameterMask GetExecutionPolicy(string? _executionPolicy)
+        private static ParameterBitmap GetExecutionPolicy(string? _executionPolicy)
         {
             if (_executionPolicy is null)
             {
-                return ParameterMask.EPUndefined;
+                return ParameterBitmap.EPUndefined;
             }
             if (MatchSwitch(_executionPolicy, "remotesigned", "remotesigned"))
             {
-                return ParameterMask.EPRemoteSigned;
+                return ParameterBitmap.EPRemoteSigned;
             }
             else if (MatchSwitch(_executionPolicy, "bypass", "bypass"))
             {
-                return ParameterMask.EPBypass;
+                return ParameterBitmap.EPBypass;
             }
             else if (MatchSwitch(_executionPolicy, "unrestricted", "unrestricted"))
             {
-                return ParameterMask.EPUnrestricted;
+                return ParameterBitmap.EPUnrestricted;
             }
             else if (MatchSwitch(_executionPolicy, "allsigned", "allsigned"))
             {
-                return ParameterMask.EPAllSigned;
+                return ParameterBitmap.EPAllSigned;
             }
             else if (MatchSwitch(_executionPolicy, "restricted", "restricted"))
             {
-                return ParameterMask.EPRestricted;
+                return ParameterBitmap.EPRestricted;
             }
             else if (MatchSwitch(_executionPolicy, "undefined", "undefined"))
             {
-                return ParameterMask.EPUndefined;
+                return ParameterBitmap.EPUndefined;
             }
-            return ParameterMask.EPIncorrect;
+            return ParameterBitmap.EPIncorrect;
         }
 
         private static bool MatchSwitch(string switchKey, string match, string smallestUnambiguousMatch)
@@ -837,7 +841,7 @@ namespace Microsoft.PowerShell
                     _noInteractive = true;
                     _skipUserInit = true;
                     _noExit = false;
-                    ParametersUsed |= ParameterMask.Version;
+                    ParametersUsed |= ParameterBitmap.Version;
                     break;
                 }
 
@@ -846,33 +850,33 @@ namespace Microsoft.PowerShell
                     _showHelp = true;
                     _showExtendedHelp = true;
                     _abortStartup = true;
-                    ParametersUsed |= ParameterMask.Help;
+                    ParametersUsed |= ParameterBitmap.Help;
                 }
                 else if (MatchSwitch(switchKey, "login", "l"))
                 {
                     // On Windows, '-Login' does nothing.
                     // On *nix, '-Login' is already handled much earlier to improve startup performance, so we do nothing here.
-                    ParametersUsed |= ParameterMask.Login;
+                    ParametersUsed |= ParameterBitmap.Login;
                 }
                 else if (MatchSwitch(switchKey, "noexit", "noe"))
                 {
                     _noExit = true;
-                    ParametersUsed |= ParameterMask.NoExit;
+                    ParametersUsed |= ParameterBitmap.NoExit;
                     noexitSeen = true;
                 }
                 else if (MatchSwitch(switchKey, "noprofile", "nop"))
                 {
-                    ParametersUsed |= ParameterMask.NoProfile;
+                    ParametersUsed |= ParameterBitmap.NoProfile;
                     _skipUserInit = true;
                 }
                 else if (MatchSwitch(switchKey, "nologo", "nol"))
                 {
-                    ParametersUsed |= ParameterMask.NoLogo;
+                    ParametersUsed |= ParameterBitmap.NoLogo;
                     _showBanner = false;
                 }
                 else if (MatchSwitch(switchKey, "noninteractive", "noni"))
                 {
-                    ParametersUsed |= ParameterMask.NonInteractive;
+                    ParametersUsed |= ParameterBitmap.NonInteractive;
                     _noInteractive = true;
                 }
                 else if (MatchSwitch(switchKey, "socketservermode", "so"))
@@ -889,12 +893,12 @@ namespace Microsoft.PowerShell
                 }
                 else if (MatchSwitch(switchKey, "sshservermode", "sshs"))
                 {
-                    ParametersUsed |= ParameterMask.SSHServerMode;
+                    ParametersUsed |= ParameterBitmap.SSHServerMode;
                     _sshServerMode = true;
                 }
                 else if (MatchSwitch(switchKey, "interactive", "i"))
                 {
-                    ParametersUsed |= ParameterMask.Interactive;
+                    ParametersUsed |= ParameterBitmap.Interactive;
                     _noInteractive = false;
                 }
                 else if (MatchSwitch(switchKey, "configurationname", "config"))
@@ -908,7 +912,7 @@ namespace Microsoft.PowerShell
                     }
 
                     _configurationName = args[i];
-                    ParametersUsed |= ParameterMask.ConfigurationName;
+                    ParametersUsed |= ParameterBitmap.ConfigurationName;
                 }
                 else if (MatchSwitch(switchKey, "custompipename", "cus"))
                 {
@@ -919,7 +923,7 @@ namespace Microsoft.PowerShell
                             CommandLineParameterParserStrings.MissingCustomPipeNameArgument);
                         break;
                     }
-                    ParametersUsed |= ParameterMask.CustomPipeName;
+                    ParametersUsed |= ParameterBitmap.CustomPipeName;
 
 #if UNIX
                     int maxNameLength = MaxNameLength();
@@ -942,11 +946,11 @@ namespace Microsoft.PowerShell
                     {
                         break;
                     }
-                    ParametersUsed |= ParameterMask.Command;
+                    ParametersUsed |= ParameterBitmap.Command;
                 }
                 else if (MatchSwitch(switchKey, "windowstyle", "w"))
                 {
-                    ParametersUsed |= ParameterMask.WindowStyle;
+                    ParametersUsed |= ParameterBitmap.WindowStyle;
 #if UNIX
                     SetCommandLineError(
                         CommandLineParameterParserStrings.WindowStyleArgumentNotImplemented);
@@ -974,7 +978,7 @@ namespace Microsoft.PowerShell
                 }
                 else if (MatchSwitch(switchKey, "file", "f"))
                 {
-                    ParametersUsed |= ParameterMask.File;
+                    ParametersUsed |= ParameterBitmap.File;
                     if (!ParseFile(args, ref i, noexitSeen))
                     {
                         break;
@@ -990,23 +994,23 @@ namespace Microsoft.PowerShell
                 {
                     ParseFormat(args, ref i, ref _outFormat, CommandLineParameterParserStrings.MissingOutputFormatParameter);
                     _outputFormatSpecified = true;
-                    ParametersUsed |= ParameterMask.OutputFormat;
+                    ParametersUsed |= ParameterBitmap.OutputFormat;
                 }
                 else if (MatchSwitch(switchKey, "inputformat", "inp") || MatchSwitch(switchKey, "if", "if"))
                 {
                     ParseFormat(args, ref i, ref _inFormat, CommandLineParameterParserStrings.MissingInputFormatParameter);
-                    ParametersUsed |= ParameterMask.InputFormat;
+                    ParametersUsed |= ParameterBitmap.InputFormat;
                 }
                 else if (MatchSwitch(switchKey, "executionpolicy", "ex") || MatchSwitch(switchKey, "ep", "ep"))
                 {
                     ParseExecutionPolicy(args, ref i, ref _executionPolicy, CommandLineParameterParserStrings.MissingExecutionPolicyParameter);
-                    ParametersUsed |= ParameterMask.ExecutionPolicy;
+                    ParametersUsed |= ParameterBitmap.ExecutionPolicy;
                     ParametersUsed |= GetExecutionPolicy(_executionPolicy);
                 }
                 else if (MatchSwitch(switchKey, "encodedcommand", "e") || MatchSwitch(switchKey, "ec", "e"))
                 {
                     _wasCommandEncoded = true;
-                    ParametersUsed |= ParameterMask.EncodedCommand;
+                    ParametersUsed |= ParameterBitmap.EncodedCommand;
                     if (!ParseCommand(args, ref i, noexitSeen, true))
                     {
                         break;
@@ -1026,11 +1030,11 @@ namespace Microsoft.PowerShell
                     {
                         break;
                     }
-                    ParametersUsed |= ParameterMask.SettingsFile;
+                    ParametersUsed |= ParameterBitmap.SettingsFile;
                 }
                 else if (MatchSwitch(switchKey, "sta", "sta"))
                 {
-                    ParametersUsed |= ParameterMask.STA;
+                    ParametersUsed |= ParameterBitmap.STA;
                     if (!Platform.IsWindowsDesktop || !Platform.IsStaSupported)
                     {
                         SetCommandLineError(
@@ -1050,7 +1054,7 @@ namespace Microsoft.PowerShell
                 }
                 else if (MatchSwitch(switchKey, "mta", "mta"))
                 {
-                    ParametersUsed |= ParameterMask.MTA;
+                    ParametersUsed |= ParameterBitmap.MTA;
                     if (!Platform.IsWindowsDesktop)
                     {
                         SetCommandLineError(
@@ -1078,7 +1082,7 @@ namespace Microsoft.PowerShell
                         break;
                     }
 
-                    ParametersUsed |= ParameterMask.WorkingDirectory;
+                    ParametersUsed |= ParameterBitmap.WorkingDirectory;
                     _workingDirectory = args[i];
                 }
 #if !UNIX
@@ -1096,7 +1100,7 @@ namespace Microsoft.PowerShell
                         break;
                     }
                     // default to filename being the next argument.
-                    ParametersUsed |= ParameterMask.File;
+                    ParametersUsed |= ParameterBitmap.File;
                 }
             }
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -192,7 +192,7 @@ namespace Microsoft.PowerShell
                 // First check for and handle PowerShell running in a server mode.
                 if (s_cpp.ServerMode)
                 {
-                    ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("ServerMode");
+                    ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("ServerMode", s_cpp.ParametersUsedAsDouble);
                     ProfileOptimization.StartProfile("StartupProfileData-ServerMode");
                     StdIOProcessMediator.Run(
                         initialCommand: s_cpp.InitialCommand,
@@ -202,7 +202,7 @@ namespace Microsoft.PowerShell
                 }
                 else if (s_cpp.SSHServerMode)
                 {
-                    ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("SSHServer");
+                    ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("SSHServer", s_cpp.ParametersUsedAsDouble);
                     ProfileOptimization.StartProfile("StartupProfileData-SSHServerMode");
                     StdIOProcessMediator.Run(
                         initialCommand: s_cpp.InitialCommand,
@@ -212,7 +212,7 @@ namespace Microsoft.PowerShell
                 }
                 else if (s_cpp.NamedPipeServerMode)
                 {
-                    ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("NamedPipe");
+                    ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("NamedPipe", s_cpp.ParametersUsedAsDouble);
                     ProfileOptimization.StartProfile("StartupProfileData-NamedPipeServerMode");
                     RemoteSessionNamedPipeServer.RunServerMode(
                         configurationName: s_cpp.ConfigurationName);
@@ -220,7 +220,7 @@ namespace Microsoft.PowerShell
                 }
                 else if (s_cpp.SocketServerMode)
                 {
-                    ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("SocketServerMode");
+                    ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("SocketServerMode", s_cpp.ParametersUsedAsDouble);
                     ProfileOptimization.StartProfile("StartupProfileData-SocketServerMode");
                     HyperVSocketMediator.Run(
                         initialCommand: s_cpp.InitialCommand,
@@ -255,7 +255,7 @@ namespace Microsoft.PowerShell
                     PSHost.IsStdOutputRedirected = Console.IsOutputRedirected;
 
                     // Send startup telemetry for ConsoleHost startup
-                    ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("Normal");
+                    ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("Normal", s_cpp.ParametersUsedAsDouble);
 
                     exitCode = s_theConsoleHost.Run(s_cpp, false);
                 }

--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -619,7 +619,7 @@ namespace Microsoft.PowerShell.Commands
                 // avoid double reporting for WinCompat modules that go through CommandDiscovery\AutoloadSpecifiedModule
                 if (!foundModule.IsWindowsPowerShellCompatModule)
                 {
-                    ApplicationInsightsTelemetry.SendTelemetryMetric(TelemetryType.ModuleLoad, foundModule.Name);
+                    ApplicationInsightsTelemetry.SendModuleTelemetryMetric(TelemetryType.ModuleLoad, foundModule.Name, foundModule.Version.ToString());
 #if LEGACYTELEMETRY
                     TelemetryAPI.ReportModuleLoad(foundModule);
 #endif
@@ -896,7 +896,7 @@ namespace Microsoft.PowerShell.Commands
 
             if (foundModule != null)
             {
-                ApplicationInsightsTelemetry.SendTelemetryMetric(TelemetryType.ModuleLoad, foundModule.Name);
+                ApplicationInsightsTelemetry.SendModuleTelemetryMetric(TelemetryType.ModuleLoad, foundModule.Name, foundModule.Version?.ToString());
                 SetModuleBaseForEngineModules(foundModule.Name, this.Context);
             }
 
@@ -938,7 +938,7 @@ namespace Microsoft.PowerShell.Commands
             // Send telemetry on the imported modules
             foreach (PSModuleInfo moduleInfo in remotelyImportedModules)
             {
-                ApplicationInsightsTelemetry.SendTelemetryMetric(usingWinCompat ? TelemetryType.WinCompatModuleLoad : TelemetryType.ModuleLoad, moduleInfo.Name);
+                ApplicationInsightsTelemetry.SendModuleTelemetryMetric(usingWinCompat ? TelemetryType.WinCompatModuleLoad : TelemetryType.ModuleLoad, moduleInfo.Name, moduleInfo.Version?.ToString());
             }
 
             return remotelyImportedModules;
@@ -1369,7 +1369,8 @@ namespace Microsoft.PowerShell.Commands
             foreach (RemoteDiscoveryHelper.CimModule remoteCimModule in remotePsCimModules)
             {
                 ImportModule_RemotelyViaCimModuleData(importModuleOptions, remoteCimModule, cimSession);
-                ApplicationInsightsTelemetry.SendTelemetryMetric(TelemetryType.ModuleLoad, remoteCimModule.ModuleName);
+                // we don't know the version of the module
+                ApplicationInsightsTelemetry.SendModuleTelemetryMetric(TelemetryType.ModuleLoad, remoteCimModule.ModuleName);
             }
         }
 
@@ -1874,7 +1875,7 @@ namespace Microsoft.PowerShell.Commands
                 // of doing Get-Module -list
                 foreach (PSModuleInfo module in ModuleInfo)
                 {
-                    ApplicationInsightsTelemetry.SendTelemetryMetric(TelemetryType.ModuleLoad, module.Name);
+                    ApplicationInsightsTelemetry.SendModuleTelemetryMetric(TelemetryType.ModuleLoad, module.Name, module.Version?.ToString());
                     RemoteDiscoveryHelper.DispatchModuleInfoProcessing(
                         module,
                         localAction: () =>
@@ -1902,7 +1903,8 @@ namespace Microsoft.PowerShell.Commands
                 // Now load all of the supplied assemblies...
                 foreach (Assembly suppliedAssembly in Assembly)
                 {
-                    ApplicationInsightsTelemetry.SendTelemetryMetric(TelemetryType.ModuleLoad, suppliedAssembly.GetName().Name);
+                    // we don't know what the version of the module is.
+                    ApplicationInsightsTelemetry.SendModuleTelemetryMetric(TelemetryType.ModuleLoad, suppliedAssembly.GetName().Name);
                     ImportModule_ViaAssembly(importModuleOptions, suppliedAssembly);
                 }
             }
@@ -1933,7 +1935,7 @@ namespace Microsoft.PowerShell.Commands
                 ImportModule_RemotelyViaPsrpSession(importModuleOptions, null, FullyQualifiedName, this.PSSession);
                 foreach (ModuleSpecification modulespec in FullyQualifiedName)
                 {
-                    ApplicationInsightsTelemetry.SendTelemetryMetric(TelemetryType.ModuleLoad, modulespec.Name);
+                    ApplicationInsightsTelemetry.SendModuleTelemetryMetric(TelemetryType.ModuleLoad, modulespec.Name, modulespec.Version?.ToString());
                 }
             }
             else if (this.ParameterSetName.Equals(ParameterSet_ViaWinCompat, StringComparison.OrdinalIgnoreCase)

--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -619,7 +619,7 @@ namespace Microsoft.PowerShell.Commands
                 // avoid double reporting for WinCompat modules that go through CommandDiscovery\AutoloadSpecifiedModule
                 if (!foundModule.IsWindowsPowerShellCompatModule)
                 {
-                    ApplicationInsightsTelemetry.SendModuleTelemetryMetric(TelemetryType.ModuleLoad, foundModule.Name, foundModule.Version.ToString());
+                    ApplicationInsightsTelemetry.SendModuleTelemetryMetric(TelemetryType.ModuleLoad, foundModule.Name, foundModule.Version?.ToString());
 #if LEGACYTELEMETRY
                     TelemetryAPI.ReportModuleLoad(foundModule);
 #endif

--- a/src/System.Management.Automation/engine/pipeline.cs
+++ b/src/System.Management.Automation/engine/pipeline.cs
@@ -1077,8 +1077,6 @@ namespace System.Management.Automation.Internal
                     CommandState.Started,
                     commandProcessor.Command.MyInvocation);
 
-                // Send telemetry that includes the type of command.
-                ApplicationInsightsTelemetry.SendTelemetryMetric(TelemetryType.ApplicationType, commandProcessor.Command.CommandInfo.CommandType.ToString());
 #if LEGACYTELEMETRY
                 Microsoft.PowerShell.Telemetry.Internal.TelemetryAPI.TraceExecutedCommand(commandProcessor.Command.CommandInfo, commandProcessor.Command.CommandOrigin);
 #endif

--- a/src/System.Management.Automation/utils/Telemetry.cs
+++ b/src/System.Management.Automation/utils/Telemetry.cs
@@ -248,6 +248,7 @@ namespace Microsoft.PowerShell.Telemetry
                         "Az.StorageTable",
                         "Az.StreamAnalytics",
                         "Az.Subscription",
+                        "Az.Tools.Predictor",
                         "Az.TrafficManager",
                         "Az.Websites",
                         "Azs.Azurebridge.Admin",

--- a/src/System.Management.Automation/utils/Telemetry.cs
+++ b/src/System.Management.Automation/utils/Telemetry.cs
@@ -680,8 +680,6 @@ namespace Microsoft.PowerShell.Telemetry
                 return;
             }
 
-            // SendPSCoreStartupTelemetry("hosted", 0);
-
             // These should be handled by SendModuleTelemetryMetric.
             Debug.Assert(metricId != TelemetryType.ModuleLoad);
             Debug.Assert(metricId != TelemetryType.WinCompatModuleLoad);

--- a/src/System.Management.Automation/utils/Telemetry.cs
+++ b/src/System.Management.Automation/utils/Telemetry.cs
@@ -146,7 +146,7 @@ namespace Microsoft.PowerShell.Telemetry
                 configuration.InstrumentationKey = _psCoreTelemetryKey;
 
                 // Set this to true to reduce latency during development
-                configuration.TelemetryChannel.DeveloperMode = true;
+                configuration.TelemetryChannel.DeveloperMode = false;
 
                 // Be sure to obscure any information about the client node name.
                 configuration.TelemetryInitializers.Add(new NameObscurerTelemetryInitializer());

--- a/src/System.Management.Automation/utils/Telemetry.cs
+++ b/src/System.Management.Automation/utils/Telemetry.cs
@@ -691,6 +691,7 @@ namespace Microsoft.PowerShell.Telemetry
             {
                 switch (metricId)
                 {
+                    case TelemetryType.ApplicationType:
                     case TelemetryType.PowerShellCreate:
                     case TelemetryType.RemoteSessionOpen:
                     case TelemetryType.ExperimentalEngineFeatureActivation:

--- a/src/System.Management.Automation/utils/Telemetry.cs
+++ b/src/System.Management.Automation/utils/Telemetry.cs
@@ -100,10 +100,10 @@ namespace Microsoft.PowerShell.Telemetry
         private static readonly Guid _defaultNodeIdentifier = new Guid("2f998828-3f4a-4741-bf50-d11c6be42f50");
 
         // Use "anonymous" as the string to return when you can't report a name
-        private const string _anonymous = "anonymous";
+        private const string Anonymous = "anonymous";
 
         // Use '0.0' as the string for an anonymous module version
-        private const string _anonymousVersion = "0.0";
+        private const string AnonymousVersion = "0.0";
 
         // the telemetry failure string
         private const string _telemetryFailure = "TELEMETRY_FAILURE";
@@ -659,12 +659,12 @@ namespace Microsoft.PowerShell.Telemetry
         /// <param name="telemetryType">The type of telemetry that we'll be sending.</param>
         /// <param name="moduleName">The module name to report. If it is not allowed, then it is set to 'anonymous'.</param>
         /// <param name="moduleVersion">The module version to report. The default value is the anonymous version '0.0.0.0'.</param>
-        internal static void SendModuleTelemetryMetric(TelemetryType telemetryType, string moduleName, string moduleVersion = _anonymousVersion)
+        internal static void SendModuleTelemetryMetric(TelemetryType telemetryType, string moduleName, string moduleVersion = AnonymousVersion)
         {
             try
             {
                 string allowedModuleName = GetModuleName(moduleName);
-                string allowedModuleVersion = allowedModuleName == _anonymous ? _anonymousVersion : moduleVersion;
+                string allowedModuleVersion = allowedModuleName == Anonymous ? AnonymousVersion : moduleVersion;
                 s_telemetryClient.GetMetric(telemetryType.ToString(), "uuid", "SessionId", "ModuleName", "Version").TrackValue(metricValue: 1.0, s_uniqueUserIdentifier, s_sessionId, allowedModuleName, allowedModuleVersion);
             }
             catch
@@ -725,7 +725,7 @@ namespace Microsoft.PowerShell.Telemetry
                 return featureNameToValidate;
             }
 
-            return _anonymous;
+            return Anonymous;
         }
 
         // Get the module name. If we can report it, we'll return the name, otherwise, we'll return "anonymous"
@@ -736,7 +736,7 @@ namespace Microsoft.PowerShell.Telemetry
                 return moduleNameToValidate;
             }
 
-            return _anonymous;
+            return Anonymous;
         }
 
         /// <summary>

--- a/src/System.Management.Automation/utils/Telemetry.cs
+++ b/src/System.Management.Automation/utils/Telemetry.cs
@@ -1,9 +1,9 @@
-using System.Diagnostics;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Management.Automation;
 using System.Runtime.InteropServices;
@@ -652,7 +652,7 @@ namespace Microsoft.PowerShell.Telemetry
         /// Some modules (CIM) will continue use the string alternative method.
         /// </summary>
         /// <param name="telemetryType">The type of telemetry that we'll be sending.</param>
-        /// <param name="moduleName">The module name to report. If it is not allowed, then it is set to 'anonymous'</param>
+        /// <param name="moduleName">The module name to report. If it is not allowed, then it is set to 'anonymous'.</param>
         /// <param name="moduleVersion">The module version to report. The default value is the anonymous version '0.0.0.0'.</param>
         internal static void SendModuleTelemetryMetric(TelemetryType telemetryType, string moduleName, string moduleVersion = _anonymousVersion)
         {
@@ -681,8 +681,8 @@ namespace Microsoft.PowerShell.Telemetry
             }
 
             // These should be handled by SendModuleTelemetryMetric.
-            Debug.Assert(metricId != TelemetryType.ModuleLoad);
-            Debug.Assert(metricId != TelemetryType.WinCompatModuleLoad);
+            Debug.Assert(metricId != TelemetryType.ModuleLoad, "ModuleLoad should be handled by SendModuleTelemetryMetric.");
+            Debug.Assert(metricId != TelemetryType.WinCompatModuleLoad, "WinCompatModuleLoad should be handled by SendModuleTelemetryMetric.");
 
             string metricName = metricId.ToString();
             try
@@ -755,12 +755,13 @@ namespace Microsoft.PowerShell.Telemetry
 
             // This is the payload which reports the startup information of OS and shell details.
             var properties = new Dictionary<string, string>();
+
             // This is the payload for the parameter data which is sent as a metric.
             var parameters = new Dictionary<string, double>();
 
             // The variable POWERSHELL_DISTRIBUTION_CHANNEL is set in our docker images.
             // This allows us to track the actual docker OS as OSDescription provides only "linuxkit"
-            // which has limited usefulness
+            // which has limited usefulness.
             var channel = Environment.GetEnvironmentVariable("POWERSHELL_DISTRIBUTION_CHANNEL");
 
             // Construct the payload for the OS and shell details.
@@ -770,6 +771,7 @@ namespace Microsoft.PowerShell.Telemetry
             properties.Add("OSDescription", RuntimeInformation.OSDescription);
             properties.Add("OSChannel", string.IsNullOrEmpty(channel) ? "unknown" : channel);
             properties.Add("StartMode", string.IsNullOrEmpty(mode) ? "unknown" : mode);
+
             // Construct the payload for the parameters used.
             parameters.Add("Param", parametersUsed);
             try

--- a/src/System.Management.Automation/utils/Telemetry.cs
+++ b/src/System.Management.Automation/utils/Telemetry.cs
@@ -142,7 +142,7 @@ namespace Microsoft.PowerShell.Telemetry
                 configuration.InstrumentationKey = _psCoreTelemetryKey;
 
                 // Set this to true to reduce latency during development
-                configuration.TelemetryChannel.DeveloperMode = true;
+                configuration.TelemetryChannel.DeveloperMode = false;
 
                 // Be sure to obscure any information about the client node name.
                 configuration.TelemetryInitializers.Add(new NameObscurerTelemetryInitializer());
@@ -741,7 +741,7 @@ namespace Microsoft.PowerShell.Telemetry
         /// This is done only once during for the console host.
         /// </summary>
         /// <param name="mode">The "mode" of the startup.</param>
-        /// <param name="parametersUsed">The parameters (as a bitmap) used when starting.</param>
+        /// <param name="parametersUsed">The parameter bitmap used when starting.</param>
         internal static void SendPSCoreStartupTelemetry(string mode, double parametersUsed)
         {
             // Check if we already sent startup telemetry
@@ -755,7 +755,9 @@ namespace Microsoft.PowerShell.Telemetry
                 return;
             }
 
+            // This is the payload which reports the startup information of OS and shell details.
             var properties = new Dictionary<string, string>();
+            // This is the payload for the parameter data which is sent as a metric.
             var parameters = new Dictionary<string, double>();
 
             // The variable POWERSHELL_DISTRIBUTION_CHANNEL is set in our docker images.
@@ -763,12 +765,14 @@ namespace Microsoft.PowerShell.Telemetry
             // which has limited usefulness
             var channel = Environment.GetEnvironmentVariable("POWERSHELL_DISTRIBUTION_CHANNEL");
 
+            // Construct the payload for the OS and shell details.
             properties.Add("SessionId", s_sessionId);
             properties.Add("UUID", s_uniqueUserIdentifier);
             properties.Add("GitCommitID", PSVersionInfo.GitCommitId);
             properties.Add("OSDescription", RuntimeInformation.OSDescription);
             properties.Add("OSChannel", string.IsNullOrEmpty(channel) ? "unknown" : channel);
             properties.Add("StartMode", string.IsNullOrEmpty(mode) ? "unknown" : mode);
+            // Construct the payload for the parameters used.
             parameters.Add("Param", parametersUsed);
             try
             {

--- a/src/System.Management.Automation/utils/Telemetry.cs
+++ b/src/System.Management.Automation/utils/Telemetry.cs
@@ -96,6 +96,7 @@ namespace Microsoft.PowerShell.Telemetry
         private const string _psCoreTelemetryKey = "d26a5ef4-d608-452c-a6b8-a4a55935f70d"; // V7 Preview 3
 
         // In the event there is a problem in creating the node identifier file, use the default identifier.
+        // This can happen if we are running in a system which has a read-only filesystem.
         private static readonly Guid _defaultNodeIdentifier = new Guid("2f998828-3f4a-4741-bf50-d11c6be42f50");
 
         // Use "anonymous" as the string to return when you can't report a name


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- Stop sending telemetry for application type
- Send telemetry for parameters used when running pwsh
- Include version number when reporting module import

<!-- Summarize your PR between here and the checklist. -->

## PR Context

Our telemetry ingestion is currently very high with between 75-80% being taken up by ApplicationType metrics. The data doesn't seem to be showing a lot of variation over time, and isn't providing the value it did initially for its cost. We also have questions which are difficult to answer with the current telemetry (primarily disambiguating automation from interactive sessions). This PR includes metrics of how parameters of pwsh.exe are used. To reduce the payload size, the parameters are created as a bitmap which can then be investigated via kusto queries. In addition to collecting the used parameters, we are now capturing the value of ExecutionPolicy to help us understand the distribution of how this is being used. Lastly, this PR will also collect the version number of the loaded module where we can report it. With this we can make determinations as to how new modules are picked up, and how long older modules remain in use.


<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
