### PR TITLE
Add a finalize template which causes jobs with issues to fail

### DIFF
--- a/tools/releaseBuild/azureDevOps/releaseBuild.yml
+++ b/tools/releaseBuild/azureDevOps/releaseBuild.yml
@@ -227,3 +227,5 @@ stages:
             Get-Content "$(Build.StagingDirectory)\release.json"
             Write-Host "##vso[artifact.upload containerfolder=metadata;artifactname=metadata]$(Build.StagingDirectory)\release.json"
           displayName: Create and upload release.json file to build artifact
+
+        - template: /tools/releaseBuild/azureDevOps/templates/step/finalize.yml

--- a/tools/releaseBuild/azureDevOps/templates/checkAzureContainer.yml
+++ b/tools/releaseBuild/azureDevOps/templates/checkAzureContainer.yml
@@ -47,4 +47,4 @@ jobs:
             }
         }
 
-
+  - template: /tools/releaseBuild/azureDevOps/templates/step/finalize.yml

--- a/tools/releaseBuild/azureDevOps/templates/checkAzureContainer.yml
+++ b/tools/releaseBuild/azureDevOps/templates/checkAzureContainer.yml
@@ -22,6 +22,7 @@ jobs:
       UseJson: no
 
   - task: AzurePowerShell@4
+    displayName: Check if blob exists and delete if specified
     inputs:
       azureSubscription: '$(AzureFileCopySubscription)'
       scriptType: inlineScript

--- a/tools/releaseBuild/azureDevOps/templates/compliance/compliance.yml
+++ b/tools/releaseBuild/azureDevOps/templates/compliance/compliance.yml
@@ -88,3 +88,5 @@ jobs:
     inputs:
       sourceScanPath: '$(Build.SourcesDirectory)\tools'
       snapshotForceEnabled: true
+
+  - template: /tools/releaseBuild/azureDevOps/templates/step/finalize.yml

--- a/tools/releaseBuild/azureDevOps/templates/json.yml
+++ b/tools/releaseBuild/azureDevOps/templates/json.yml
@@ -53,3 +53,5 @@ jobs:
     inputs:
       sourceScanPath: '$(Build.SourcesDirectory)\tools'
       snapshotForceEnabled: true
+
+  - template: /tools/releaseBuild/azureDevOps/templates/step/finalize.yml

--- a/tools/releaseBuild/azureDevOps/templates/linux.yml
+++ b/tools/releaseBuild/azureDevOps/templates/linux.yml
@@ -153,6 +153,8 @@ jobs:
     condition: and(succeeded(), ne(variables['SkipBuild'], 'true'))
     workingDirectory: $(PowerShellRoot)
 
+  - template: /tools/releaseBuild/azureDevOps/templates/step/finalize.yml
+
 - job: upload_${{ parameters.buildName }}
   displayName: ${{ parameters.uploadDisplayName }} ${{ parameters.buildName }}
   dependsOn: build_${{ parameters.buildName }}
@@ -335,3 +337,5 @@ jobs:
     parameters:
       artifactPath: '$(Build.StagingDirectory)\signedPackages\release'
       condition: and(and(succeeded(), eq(variables['SHOULD_SIGN'], 'true')),eq(variables['buildName'], 'RPM'))
+
+  - template: /tools/releaseBuild/azureDevOps/templates/step/finalize.yml

--- a/tools/releaseBuild/azureDevOps/templates/mac-file-signing.yml
+++ b/tools/releaseBuild/azureDevOps/templates/mac-file-signing.yml
@@ -118,3 +118,5 @@ jobs:
       inputs:
         sourceScanPath: '$(repoRoot)\tools'
         snapshotForceEnabled: true
+
+    - template: /tools/releaseBuild/azureDevOps/templates/step/finalize.yml

--- a/tools/releaseBuild/azureDevOps/templates/mac-package-build.yml
+++ b/tools/releaseBuild/azureDevOps/templates/mac-package-build.yml
@@ -133,3 +133,5 @@ jobs:
     inputs:
       sourceScanPath: '$(PowerShellRoot)/tools'
       snapshotForceEnabled: true
+
+  - template: /tools/releaseBuild/azureDevOps/templates/step/finalize.yml

--- a/tools/releaseBuild/azureDevOps/templates/mac-package-signing.yml
+++ b/tools/releaseBuild/azureDevOps/templates/mac-package-signing.yml
@@ -130,3 +130,5 @@ jobs:
     inputs:
       sourceScanPath: '$(repoRoot)/tools'
       snapshotForceEnabled: true
+
+  - template: /tools/releaseBuild/azureDevOps/templates/step/finalize.yml

--- a/tools/releaseBuild/azureDevOps/templates/mac.yml
+++ b/tools/releaseBuild/azureDevOps/templates/mac.yml
@@ -59,3 +59,5 @@ jobs:
     inputs:
       sourceScanPath: '$(Build.SourcesDirectory)/tools'
       snapshotForceEnabled: true
+
+  - template: /tools/releaseBuild/azureDevOps/templates/step/finalize.yml

--- a/tools/releaseBuild/azureDevOps/templates/step/finalize.yml
+++ b/tools/releaseBuild/azureDevOps/templates/step/finalize.yml
@@ -2,4 +2,4 @@ steps:
   - pwsh: |
       throw "Jobs with an Issue will not work for release. Please fix the issue and try again."
     displayName: Check for SucceededWithIssues
-    condition: eq('$(Agent.JobStatus)','SucceededWithIssues')
+    condition: eq(variables['Agent.JobStatus'],'SucceededWithIssues')

--- a/tools/releaseBuild/azureDevOps/templates/step/finalize.yml
+++ b/tools/releaseBuild/azureDevOps/templates/step/finalize.yml
@@ -1,5 +1,5 @@
 steps:
   - pwsh: |
       throw "Jobs with an Issue will not work for release. Please fix the issue and try again."
-    displayName: Fail jobs with SucceededWithIssues status
+    displayName: Check for SucceededWithIssues
     condition: eq('$(Agent.JobStatus)','SucceededWithIssues')

--- a/tools/releaseBuild/azureDevOps/templates/step/finalize.yml
+++ b/tools/releaseBuild/azureDevOps/templates/step/finalize.yml
@@ -1,10 +1,5 @@
 steps:
   - pwsh: |
-      throw "Fake issue"
-    displayName: Force SucceededWithIssues
-    continueOnError: true
-
-  - pwsh: |
       throw "Jobs with an Issue will not work for release. Please fix the issue and try again."
     displayName: Check for SucceededWithIssues
     condition: eq(variables['Agent.JobStatus'],'SucceededWithIssues')

--- a/tools/releaseBuild/azureDevOps/templates/step/finalize.yml
+++ b/tools/releaseBuild/azureDevOps/templates/step/finalize.yml
@@ -1,0 +1,5 @@
+steps:
+  - pwsh: |
+      throw "Jobs with an Issue will not work for release. Please fix the issue and try again."
+    displayName: Fail jobs with SucceededWithIssues status
+    condition: eq('$(Agent.JobStatus)','SucceededWithIssues')

--- a/tools/releaseBuild/azureDevOps/templates/step/finalize.yml
+++ b/tools/releaseBuild/azureDevOps/templates/step/finalize.yml
@@ -1,5 +1,10 @@
 steps:
   - pwsh: |
+      throw "Fake issue"
+    displayName: Force SucceededWithIssues
+    continueOnError: true
+
+  - pwsh: |
       throw "Jobs with an Issue will not work for release. Please fix the issue and try again."
     displayName: Check for SucceededWithIssues
     condition: eq(variables['Agent.JobStatus'],'SucceededWithIssues')

--- a/tools/releaseBuild/azureDevOps/templates/testartifacts.yml
+++ b/tools/releaseBuild/azureDevOps/templates/testartifacts.yml
@@ -57,3 +57,5 @@ jobs:
       BuildTestPackage -runtime linux-musl-x64
 
     displayName: Build test package and upload
+
+  - template: /tools/releaseBuild/azureDevOps/templates/step/finalize.yml

--- a/tools/releaseBuild/azureDevOps/templates/windows-hosted-build.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-hosted-build.yml
@@ -78,3 +78,5 @@ jobs:
     inputs:
       sourceScanPath: '$(PowerShellRoot)\tools'
       snapshotForceEnabled: true
+
+  - template: /tools/releaseBuild/azureDevOps/templates/step/finalize.yml

--- a/tools/releaseBuild/azureDevOps/templates/windows-package-signing.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-package-signing.yml
@@ -134,3 +134,5 @@ jobs:
     inputs:
       sourceScanPath: '$(repoRoot)\tools'
       snapshotForceEnabled: true
+
+  - template: /tools/releaseBuild/azureDevOps/templates/step/finalize.yml

--- a/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
@@ -353,3 +353,5 @@ jobs:
       }
     displayName: Clean up local Clone
     condition: always()
+
+  - template: /tools/releaseBuild/azureDevOps/templates/step/finalize.yml


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add a finalize template which causes jobs with issues to fail

Verified it works with 5b10f299ce8f2c0f5cc11a8484b7b3b396d4a473:  
<img width="1564" alt="CleanShot 2022-05-11 at 11 05 56@2x" src="https://user-images.githubusercontent.com/10873629/167917114-efc99119-c9a7-4164-9756-2093db86d477.png">

This is what it looks like on the success path:
<img width="708" alt="CleanShot 2022-05-11 at 11 08 31@2x" src="https://user-images.githubusercontent.com/10873629/167917352-24917165-b31a-4ff9-bc51-5982adda81fe.png">

## PR Context

the release won't work on a pipeline with issue.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
