### PR TITLE
Fix the word wrapping in formatting to handle escape sequences properly

### DIFF
--- a/Settings.StyleCop
+++ b/Settings.StyleCop
@@ -162,6 +162,7 @@
           <Value>op</Value>
           <Value>my</Value>
           <Value>sb</Value>
+          <Value>vt</Value>
         </CollectionProperty>
       </AnalyzerSettings>
     </Analyzer>

--- a/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
@@ -362,11 +362,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             if (valueStrDec.IsDecorated)
             {
                 vtSeqs = new StringBuilder();
-                vtRanges = new Dictionary<int, int>();
-                foreach (Match match in ValueStringDecorated.AnsiRegex.Matches(s))
-                {
-                    vtRanges.Add(match.Index, match.Length);
-                }
+                vtRanges = valueStrDec.EscapeSequenceRanges;
             }
 
             bool wordHasVtSeqs = false;
@@ -424,6 +420,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 if (sb.Length == vtSeqs.Length)
                 {
                     // This indicates 'sb' only contains all VT sequences, which may happen when the string ends with a word delimiter.
+                    // For a word that contains VT sequence only, it's the same as an empty string to the formatting system,
+                    // because nothing will actually be rendered.
+                    // So, we use an empty string in this case to avoid unneeded string allocations.
                     sb.Clear();
                 }
                 else if (!sb.EndsWith(PSStyle.Instance.Reset))
@@ -646,14 +645,12 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     {
                         Dictionary<int, int> vtRanges = null;
                         StringBuilder vtSeqs = null;
-                        if (wordToAdd.Contains(ValueStringDecorated.ESC))
+
+                        var valueStrDec = new ValueStringDecorated(wordToAdd);
+                        if (valueStrDec.IsDecorated)
                         {
                             vtSeqs = new StringBuilder();
-                            vtRanges = new Dictionary<int, int>();
-                            foreach (Match match in ValueStringDecorated.AnsiRegex.Matches(wordToAdd))
-                            {
-                                vtRanges.Add(match.Index, match.Length);
-                            }
+                            vtRanges = valueStrDec.EscapeSequenceRanges;
                         }
 
                         bool hasEscSeqs = false;
@@ -758,11 +755,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             if (valueStrDec.IsDecorated)
             {
                 vtSeqs = new StringBuilder();
-                vtRanges = new Dictionary<int, int>();
-                foreach (Match match in ValueStringDecorated.AnsiRegex.Matches(s))
-                {
-                    vtRanges.Add(match.Index, match.Length);
-                }
+                vtRanges = valueStrDec.EscapeSequenceRanges;
             }
 
             bool hasVtSeqs = false;
@@ -801,6 +794,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 if (sb.Length == vtSeqs.Length)
                 {
                     // This indicates 'sb' only contains all VT sequences, which may happen when the string ends with '\n'.
+                    // For a sub-string that contains VT sequence only, it's the same as an empty string to the formatting
+                    // system, because nothing will actually be rendered.
+                    // So, we use an empty string in this case to avoid unneeded string allocations.
                     sb.Clear();
                 }
                 else if (!sb.EndsWith(PSStyle.Instance.Reset))

--- a/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
@@ -597,24 +597,29 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 foreach (GetWordsResult word in GetWords(lines[k]))
                 {
                     string wordToAdd = word.Word;
+                    string suffix = null;
 
                     // Handle soft hyphen
-                    if (word.Delim == s_softHyphen.ToString())
+                    if (word.Delim.Length == 1 && word.Delim[0] == s_softHyphen)
                     {
                         int wordWidthWithHyphen = displayCells.Length(wordToAdd) + displayCells.Length(s_softHyphen);
 
                         // Add hyphen only if necessary
                         if (wordWidthWithHyphen == spacesLeft)
                         {
-                            wordToAdd = wordToAdd.EndsWith(resetStr)
-                                ? wordToAdd.Insert(wordToAdd.Length - resetStr.Length, "-")
-                                : wordToAdd + "-";
+                            suffix = "-";
                         }
                     }
                     else if (!string.IsNullOrEmpty(word.Delim))
                     {
-                        // Other non-empty delimiters are white-space characters, which we can directly add to the end. 
-                        wordToAdd += word.Delim;
+                        suffix = word.Delim;
+                    }
+
+                    if (suffix is not null)
+                    {
+                        wordToAdd = wordToAdd.EndsWith(resetStr)
+                            ? wordToAdd.Insert(wordToAdd.Length - resetStr.Length, suffix)
+                            : wordToAdd + suffix;
                     }
 
                     int wordWidth = displayCells.Length(wordToAdd);

--- a/src/System.Management.Automation/FormatAndOutput/common/ILineOutput.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ILineOutput.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Globalization;
+using System.Collections.Generic;
 using System.IO;
 using System.Management.Automation;
 using System.Management.Automation.Host;
@@ -379,10 +380,10 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             }
 
             // check for line breaks
-            string[] lines = StringManipulationHelper.SplitLines(val);
+            List<string> lines = StringManipulationHelper.SplitLines(val);
 
             // process the substrings as separate lines
-            for (int k = 0; k < lines.Length; k++)
+            for (int k = 0; k < lines.Count; k++)
             {
                 // compute the display length of the string
                 int displayLength = _displayCells.Length(lines[k]);

--- a/src/System.Management.Automation/FormatAndOutput/common/ILineOutput.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ILineOutput.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Globalization;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Management.Automation;
 using System.Management.Automation.Host;

--- a/src/System.Management.Automation/FormatAndOutput/common/ListWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ListWriter.cs
@@ -237,6 +237,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 {
                     if (string.IsNullOrWhiteSpace(prependString))
                     {
+                        // Sometimes 'prependString' is just padding white spaces.
+                        // We don't need to add formatting escape sequences in such a case.
                         _cachedBuilder.Append(prependString).Append(str);
                     }
                     else

--- a/src/System.Management.Automation/utils/StringUtil.cs
+++ b/src/System.Management.Automation/utils/StringUtil.cs
@@ -157,22 +157,16 @@ namespace System.Management.Automation.Internal
             if (valueStrDec.IsDecorated)
             {
                 // Handle strings with VT sequences.
-                var sb = new StringBuilder(capacity: str.Length);
                 bool copyStarted = startOffset == 0;
                 bool hasEscSeqs = false;
                 bool firstNonEscChar = true;
-
-                // Find all escape sequences in the string, and keep track of their starting indexes and length.
-                var ansiRanges = new Dictionary<int, int>();
-                foreach (Match match in ValueStringDecorated.AnsiRegex.Matches(str))
-                {
-                    ansiRanges.Add(match.Index, match.Length);
-                }
+                StringBuilder sb = new(capacity: str.Length);
+                Dictionary<int, int> vtRanges = valueStrDec.EscapeSequenceRanges;
 
                 for (int i = 0, offset = 0; i < str.Length; i++)
                 {
                     // Keep all leading ANSI escape sequences.
-                    if (ansiRanges.TryGetValue(i, out int len))
+                    if (vtRanges.TryGetValue(i, out int len))
                     {
                         hasEscSeqs = true;
                         sb.Append(str.AsSpan(i, len));

--- a/stylecop.json
+++ b/stylecop.json
@@ -25,7 +25,7 @@
         },
         "namingRules" : {
             "allowCommonHungarianPrefixes" : true,
-            "allowedHungarianPrefixes" : [ "n", "r", "l", "i", "io", "is", "fs", "lp", "dw", "h", "rs", "ps", "op", "sb", "my" ]
+            "allowedHungarianPrefixes" : [ "n", "r", "l", "i", "io", "is", "fs", "lp", "dw", "h", "rs", "ps", "op", "sb", "my", "vt" ]
         },
         "maintainabilityRules" : {
             "topLevelTypes" : [

--- a/test/powershell/engine/Formatting/PSStyle.Tests.ps1
+++ b/test/powershell/engine/Formatting/PSStyle.Tests.ps1
@@ -342,4 +342,42 @@ Billy Bob… Senior DevOps …  13
         $text = Get-Content $outFile -Raw
         $text.Trim().Replace("`r", "") | Should -BeExactly $expected.Replace("`r", "")
     }
+
+    It "Word wrapping for string with escape sequences" {
+       $expected = @"
+`e[32;1mLongDescription : `e[0m`e[33mPowerShell`e[0m 
+                  `e[33mscripting`e[0m 
+                  `e[33mlanguage`e[0m
+"@
+        $obj = [pscustomobject] @{ LongDescription = "`e[33mPowerShell scripting language" }
+        $obj | Format-List | Out-String -Width 35 | Out-File $outFile
+
+        $text = Get-Content $outFile -Raw
+        $text.Trim().Replace("`r", "") | Should -BeExactly $expected.Replace("`r", "")
+    }
+
+    It "Splitting multi-line string with escape sequences" {
+        $expected = @"
+`e[32;1mb : `e[0m`e[33mPowerShell is a task automation and configuration management program from Microsoft,`e[0m
+    `e[33mconsisting of a command-line shell and the associated scripting language`e[0m
+"@
+        $obj = [pscustomobject] @{ b = "`e[33mPowerShell is a task automation and configuration management program from Microsoft,`nconsisting of a command-line shell and the associated scripting language" }
+        $obj | Format-List | Out-File $outFile
+
+        $text = Get-Content $outFile -Raw
+        $text.Trim().Replace("`r", "") | Should -BeExactly $expected.Replace("`r", "")
+    }
+
+    It "Wrapping long word with escape sequences" {
+        $expected = @"
+`e[32;1mb : `e[0m`e[33mC:\repos\PowerShell\src\powershell-w`e[0m
+    `e[33min-core\bin\Debug\net7.0\win7-x64\pu`e[0m
+    `e[33mblish\pwsh.exe`e[0m
+"@
+        $obj = [pscustomobject] @{ b = "`e[33mC:\repos\PowerShell\src\powershell-win-core\bin\Debug\net7.0\win7-x64\publish\pwsh.exe" }
+        $obj | Format-List | Out-String -Width 40 | Out-File $outFile
+
+        $text = Get-Content $outFile -Raw
+        $text.Trim().Replace("`r", "") | Should -BeExactly $expected.Replace("`r", "")
+    }
 }

--- a/test/powershell/engine/Formatting/PSStyle.Tests.ps1
+++ b/test/powershell/engine/Formatting/PSStyle.Tests.ps1
@@ -345,8 +345,8 @@ Billy Bob… Senior DevOps …  13
 
     It "Word wrapping for string with escape sequences" {
        $expected = @"
-`e[32;1mLongDescription : `e[0m`e[33mPowerShell`e[0m 
-                  `e[33mscripting`e[0m 
+`e[32;1mLongDescription : `e[0m`e[33mPowerShell `e[0m
+                  `e[33mscripting `e[0m
                   `e[33mlanguage`e[0m
 "@
         $obj = [pscustomobject] @{ LongDescription = "`e[33mPowerShell scripting language" }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #17261
Fix the word wrapping in formatting to handle escape sequences properly.
The changes are mainly in 3 utility methods to take into account possible escape sequences when manipulate strings:
- `SplitLines`: split a multi-line string. Make sure the escape sequences are kept for all lines after the splitting.
- `GetWords`: split a single-line string into words. Make sure all escape sequences are kept for each word, so the decoration to the individual words is the same as they are in the string.
- `GenerateLinesWithWordWrap`. When splitting a word across multiple lines, make sure all escape sequences are kept in the same order for all individual sub-strings, so the decoration to the sub-strings is the same as they are in the original string.

Here are some examples to demonstrate the fix:

**Multi-line string in list view**

```pwsh
$m = [pscustomobject] @{ b = "`e[33mPowerShell is a task automation and configuration management program from Microsoft.`nIt consists of a command-line shell and the associated scripting language" }
$m | Format-List
```
![image](https://user-images.githubusercontent.com/127450/167923668-8799bfbf-1a3e-4bd2-87cd-37bab7d0e5e4.png)


**Multi-line string in list view with word wrapping**
```pwsh
$PSStyle.OutputRendering = 'Ansi'
$m = [pscustomobject] @{ b = "`e[33mPowerShell is a task `e[31mautomation and configuration`e[33m management program from Microsoft.`nIt consists of a command-line shell and the associated scripting language" }
$m | Format-List | Out-String -Width 45
```
![image](https://user-images.githubusercontent.com/127450/167923543-d6b930df-136d-47bc-9c62-750e93a29817.png)

**Long word across multiple lines**
```pwsh
$PSStyle.OutputRendering = 'Ansi'
$m = [pscustomobject] @{ b = "`e[33mC:\repos\PowerShell\src\`e[31mpowershell-win-core`e[33m\bin\Debug\net7.0\win7-x64\publish\pwsh.exe"; vv = "Hello world" }
$m | Format-List | Out-String -Width 40
```
![image](https://user-images.githubusercontent.com/127450/167924218-b6c6f6a8-0a06-43c2-a4e3-c746ff660102.png)


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
