### PR TITLE
SemanticChecks: Avoid repeated type resolution of [ordered]

### DIFF
--- a/test/powershell/Language/Scripting/Scripting.Followup.Tests.ps1
+++ b/test/powershell/Language/Scripting/Scripting.Followup.Tests.ps1
@@ -41,4 +41,31 @@ Describe "Scripting.Followup.Tests" -Tags "CI" {
         $obj.ForEach('p', 32) | Should -BeNullOrEmpty
         $obj.p | Should -Be 32
     }
+
+    It "Test the special type name 'ordered'" {
+        class ordered {
+            [hashtable] $Member
+            ordered([hashtable] $hash) {
+                $this.Member = $hash
+            }
+        }
+
+        ## `<expr> -as\-is [ordered]` resolves 'ordered' as a normal type name.
+        $hash = @{ key = 2 }
+        $result = $hash -as [ordered]
+        $result.GetType().FullName | Should -BeExactly ([ordered].FullName)
+        $result -is [ordered] | Should -BeTrue
+        $result.Member['key'] | Should -Be 2
+        $result.Member.Count | Should -Be 1
+
+        ## `[ordered]$hash` causes parsing error.
+        $err = $null
+        $null = [System.Management.Automation.Language.Parser]::ParseInput('[ordered]$hash', [ref]$null, [ref]$err)
+        $err.Count | Should -Be 1
+        $err[0].ErrorId | Should -BeExactly 'OrderedAttributeOnlyOnHashLiteralNode'
+
+        ## `[ordered]@{ key = 1 }` creates 'OrderedDictionary'
+        $result = [ordered]@{ key = 1 }
+        $result | Should -BeOfType 'System.Collections.Specialized.OrderedDictionary'
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Avoid unnecessary attempts to resolve `[ordered]`'s underlying type (which isn't there) in post-parse checks

<!-- Summarize your PR between here and the checklist. -->

## PR Context

As highlighted in https://github.com/PowerShell/PowerShell/issues/17308, parsing the cast expression `[ordered]@{}` is exactly as slow as parsing `[NonExistingType]@{}`!

Most of this overhead is incurred during post-parse analysis conducted by the `SemanticChecks` visitor, when repeated attempts are made to resolve the underlying runtime type represented by `[ordered]`. Since `[ordered]` is a special attribute and not _really_ a type literal, the type resolution _fails_, which in itself is a relatively costly (and non-cacheable) operation.

This PR makes no functional changes to the flow of analysis, but reduces calls to `TypeName.GetReflectionType()` in situations where we've already assess the target type name is `[ordered]`.

This alone cuts the wallclock time for parsing `[ordered]@{}` compared to `[nonexisting]@{}` **by 45-50%**:

![image](https://user-images.githubusercontent.com/7413755/168182719-c44694b0-c7da-44ae-adbb-fc03edf0a2b6.png)

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
