### PR TITLE
Fix the error message in Hashtable-to-object conversion

### DIFF
--- a/src/System.Management.Automation/resources/ExtendedTypeSystem.resx
+++ b/src/System.Management.Automation/resources/ExtendedTypeSystem.resx
@@ -352,7 +352,10 @@
     <value>"{0}" returned a null value.</value>
   </data>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>The {0} property was not found for the {1} object. The available property is: {2}</value>
+    <value>The property '{0}' was not found for the '{1}' object. The settable properties are: {2}.</value>
+  </data>
+  <data name="NoSettableProperty" xml:space="preserve">
+    <value>The property '{0}' was not found for the '{1}' object. There is no settable property available.</value>
   </data>
   <data name="ObjectCreationError" xml:space="preserve">
     <value>Cannot create object of type "{0}". {1}</value>

--- a/test/powershell/Language/Scripting/HashtableToPSCustomObjectConversion.Tests.ps1
+++ b/test/powershell/Language/Scripting/HashtableToPSCustomObjectConversion.Tests.ps1
@@ -163,8 +163,23 @@ namespace HashtableConversionTest {
         }
 
         $e.FullyQualifiedErrorId | Should -BeExactly "ObjectCreationError"
+        $e.Exception.Message.Contains("key") | Should -BeTrue
         $e.Exception.Message.Contains("Name") | Should -BeTrue
         $e.Exception.Message.Contains("Path") | Should -BeTrue
         $e.Exception.Message.Contains("Id") | Should -BeFalse
+    }
+
+    It "Shows no property when there is no settable property" {
+        try {
+            [System.Collections.Specialized.OrderedDictionary]@{ key = 1 }
+        } catch {
+            $e = $_
+        }
+
+        $type = [psobject].Assembly.GetType("ExtendedTypeSystem")
+        $property = $type.GetProperty("NoSettableProperty", @("NonPublic", "Static"))
+        $resString = $property.GetValue($null) -f 'key', 'System.Collections.Specialized.OrderedDictionary'
+
+        $e.Exception.Message | Should -BeLike "*$resString"
     }
 }

--- a/test/powershell/Language/Scripting/HashtableToPSCustomObjectConversion.Tests.ps1
+++ b/test/powershell/Language/Scripting/HashtableToPSCustomObjectConversion.Tests.ps1
@@ -142,3 +142,29 @@ Describe "Tests for hashtable to PSCustomObject conversion" -Tags "CI" {
     }
 }
 
+Describe "Error message with settable Property information" {
+    BeforeAll {
+        Add-Type @"
+namespace HashtableConversionTest {
+    public class AType {
+        public string Name;
+        public string Path { get; set; }
+        public string Id { get; }
+    }
+}
+"@
+    }
+
+    It "Only settable properties are called out in the error message" {
+        try {
+            [HashtableConversionTest.AType]@{ key = 1 }
+        } catch {
+            $e = $_
+        }
+
+        $e.FullyQualifiedErrorId | Should -BeExactly "ObjectCreationError"
+        $e.Exception.Message.Contains("Name") | Should -BeTrue
+        $e.Exception.Message.Contains("Path") | Should -BeTrue
+        $e.Exception.Message.Contains("Id") | Should -BeFalse
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix the error message in Hashtable-to-object conversion.

In Hashtable-to-object conversion, when a key in the Hashtable cannot be found as a settable property in the convert-to type, the error message calls out all property information including the read-only ones. Since Hashtable-to-object conversion can only work for settable properties, the error message should only call out the settable properties.

Run `[System.Collections.Specialized.OrderedDictionary]@{a = 1}` as an example to demonstrate:

Before the change, the error message calls out all properties, even though all are read-only:

![image](https://user-images.githubusercontent.com/127450/168184931-ba8c3d48-0196-4ce0-bee4-f32659200aed.png)

After the change, the error message says "no settable property available" when there is no settable property:

![image](https://user-images.githubusercontent.com/127450/168185023-7e74e0e1-7ea9-4295-b667-d2e81625b0ba.png)

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
