### PR TITLE
WIP: Add PSConfig.json field to override threshold for slow profile loading msg

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -1845,9 +1845,28 @@ namespace Microsoft.PowerShell
                     sw.Stop();
 
                     var profileLoadTimeInMs = sw.ElapsedMilliseconds;
-                    if (profileLoadTimeInMs > 500 && s_cpp.ShowBanner)
+
+                    // Only check profile load time against threshold if we're actually going to show the message
+                    if (s_cpp.ShowBanner)
                     {
-                        Console.Error.WriteLine(ConsoleHostStrings.SlowProfileLoadingMessage, profileLoadTimeInMs);
+                        int showMessageThresholdMs = 500;
+
+                        int thresholdMs = PowerShellConfig.Instance.GetSlowProfileLoadingMessageThreshold(ConfigScope.AllUsers);
+                        if (thresholdMs > 0)
+                        {
+                            showMessageThresholdMs = thresholdMs;
+                        }
+
+                        thresholdMs = PowerShellConfig.Instance.GetSlowProfileLoadingMessageThreshold(ConfigScope.CurrentUser);
+                        if (thresholdMs > 0)
+                        {
+                            showMessageThresholdMs = thresholdMs;
+                        }
+
+                        if (profileLoadTimeInMs > showMessageThresholdMs)
+                        {
+                            Console.Error.WriteLine(ConsoleHostStrings.SlowProfileLoadingMessage, profileLoadTimeInMs);
+                        }
                     }
 
                     _profileLoadTimeInMS = profileLoadTimeInMs;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -1851,17 +1851,11 @@ namespace Microsoft.PowerShell
                     {
                         int showMessageThresholdMs = 500;
 
-                        int thresholdMs = PowerShellConfig.Instance.GetSlowProfileLoadingMessageThreshold(ConfigScope.AllUsers);
-                        if (thresholdMs > 0)
-                        {
-                            showMessageThresholdMs = thresholdMs;
-                        }
+                        int? userSpecifiedThresholdMs = PowerShellConfig.Instance.GetSlowProfileLoadingMessageThreshold(ConfigScope.AllUsers);
+                        showMessageThresholdMs = userSpecifiedThresholdMs ?? showMessageThresholdMs;
 
-                        thresholdMs = PowerShellConfig.Instance.GetSlowProfileLoadingMessageThreshold(ConfigScope.CurrentUser);
-                        if (thresholdMs > 0)
-                        {
-                            showMessageThresholdMs = thresholdMs;
-                        }
+                        userSpecifiedThresholdMs = PowerShellConfig.Instance.GetSlowProfileLoadingMessageThreshold(ConfigScope.CurrentUser);
+                        showMessageThresholdMs = userSpecifiedThresholdMs ?? showMessageThresholdMs;
 
                         if (profileLoadTimeInMs > showMessageThresholdMs)
                         {

--- a/src/System.Management.Automation/engine/PSConfiguration.cs
+++ b/src/System.Management.Automation/engine/PSConfiguration.cs
@@ -221,10 +221,9 @@ namespace System.Management.Automation.Configuration
         /// <summary>
         /// Gets the number of milliseconds profile loading must exceed in order to show the slow profile loading message.
         /// </summary>
-        internal int GetSlowProfileLoadingMessageThreshold(ConfigScope scope)
+        internal int? GetSlowProfileLoadingMessageThreshold(ConfigScope scope)
         {
-            int threshold = ReadValueFromFile<int>(scope, "SlowProfileLoadingMessageThreshold");
-            return threshold;            
+            return ReadValueFromFile<int?>(scope, "SlowProfileLoadingMessageThreshold");
         }
 
         internal bool IsImplicitWinCompatEnabled()

--- a/src/System.Management.Automation/engine/PSConfiguration.cs
+++ b/src/System.Management.Automation/engine/PSConfiguration.cs
@@ -181,6 +181,7 @@ namespace System.Management.Automation.Configuration
                 : string.Concat(shellId, ":", "ExecutionPolicy");
         }
 
+        /// <summary>
         /// Get the names of experimental features enabled in the config file.
         /// </summary>
         internal string[] GetExperimentalFeatures()
@@ -215,6 +216,15 @@ namespace System.Management.Automation.Configuration
                 features.Remove(featureName);
                 WriteValueToFile<string[]>(scope, "ExperimentalFeatures", features.ToArray());
             }
+        }
+
+        /// <summary>
+        /// Gets the number of milliseconds profile loading must exceed in order to show the slow profile loading message.
+        /// </summary>
+        internal int GetSlowProfileLoadingMessageThreshold(ConfigScope scope)
+        {
+            int threshold = ReadValueFromFile<int>(scope, "SlowProfileLoadingMessageThreshold");
+            return threshold;            
         }
 
         internal bool IsImplicitWinCompatEnabled()


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR adds a field to the powershell.config.json file to allow the end user to set the time threshold for showing the "slow profile loading" message.  Fixes #16929.

This is WIP because I haven't looked into the test impact yet (and have not written any new tests).  Before I do that I'd like to get a nod that the PR would be accepted.

I also expect some debate on what the JSON field should be named. The proposed name is descriptive but perhaps a bit too long - `SlowProfileLoadingMessageThreshold`.

## PR Context

To address and fix issue #16929.  See the issue for the complete rationale for this PR.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
