### PR TITLE
Add `CustomTableHeaderLabel` formatting to differentiate table header labels that are not property names

### DIFF
--- a/experimental-feature-linux.json
+++ b/experimental-feature-linux.json
@@ -3,5 +3,5 @@
   "PSCustomTableHeaderDecoration",
   "PSLoadAssemblyFromNativeCode",
   "PSNativeCommandErrorActionPreference",
-  "PSPSCustomTableHeaderDecoration"
+  "PSSubsystemPluginModel"
 ]

--- a/experimental-feature-linux.json
+++ b/experimental-feature-linux.json
@@ -1,6 +1,6 @@
 [
   "PSCommandNotFoundSuggestion",
-  "PSCustomTableHeaderDecoration",
+  "PSCustomTableHeaderLabelDecoration",
   "PSLoadAssemblyFromNativeCode",
   "PSNativeCommandErrorActionPreference",
   "PSSubsystemPluginModel"

--- a/experimental-feature-linux.json
+++ b/experimental-feature-linux.json
@@ -3,5 +3,5 @@
   "PSCustomTableHeaderDecoration",
   "PSLoadAssemblyFromNativeCode",
   "PSNativeCommandErrorActionPreference",
-  "PSSubsystemPluginModel"
+  "PSPSCustomTableHeaderDecoration"
 ]

--- a/experimental-feature-linux.json
+++ b/experimental-feature-linux.json
@@ -1,5 +1,6 @@
 [
   "PSCommandNotFoundSuggestion",
+  "PSCustomTableHeaderDecoration",
   "PSLoadAssemblyFromNativeCode",
   "PSNativeCommandErrorActionPreference",
   "PSSubsystemPluginModel"

--- a/experimental-feature-windows.json
+++ b/experimental-feature-windows.json
@@ -1,6 +1,6 @@
 [
   "PSCommandNotFoundSuggestion",
-  "PSCustomTableHeaderDecoration",
+  "PSCustomTableHeaderLabelDecoration",
   "PSLoadAssemblyFromNativeCode",
   "PSNativeCommandErrorActionPreference",
   "PSSubsystemPluginModel"

--- a/experimental-feature-windows.json
+++ b/experimental-feature-windows.json
@@ -1,5 +1,6 @@
 [
   "PSCommandNotFoundSuggestion",
+  "PSCustomTableHeaderDecoration",
   "PSLoadAssemblyFromNativeCode",
   "PSNativeCommandErrorActionPreference",
   "PSSubsystemPluginModel"

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -1003,7 +1003,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 {
                     columnWidths[k] = (columnWidthsHint != null) ? columnWidthsHint[k] : tci.width;
                     alignment[k] = tci.alignment;
-                    headerMatchesProperty[k] = tci.headerMatchesProperty;
+                    headerMatchesProperty[k] = tci.HeaderMatchesProperty;
                     k++;
                 }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -1236,7 +1236,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     alignment[k] = TextAlignment.Left;
                 }
 
-                this.Writer.Initialize(0, columnsOnTheScreen, columnWidths, alignment, null, false, GetConsoleWindowHeight(this.InnerCommand._lo.RowNumber));
+                this.Writer.Initialize(leftMarginIndent: 0, columnsOnTheScreen, columnWidths, alignment, headerMatchesProperty: null, suppressHeader: false, screenRows: GetConsoleWindowHeight(this.InnerCommand._lo.RowNumber));
             }
 
             /// <summary>

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -996,16 +996,18 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 // create arrays for widths and alignment
                 Span<int> columnWidths = columns <= StackAllocThreshold ? stackalloc int[columns] : new int[columns];
                 Span<int> alignment = columns <= StackAllocThreshold ? stackalloc int[columns] : new int[columns];
+                Span<bool> headerMatchesProperty = columns <= StackAllocThreshold ? stackalloc bool[columns] : new bool[columns];
 
                 int k = 0;
                 foreach (TableColumnInfo tci in this.CurrentTableHeaderInfo.tableColumnInfoList)
                 {
                     columnWidths[k] = (columnWidthsHint != null) ? columnWidthsHint[k] : tci.width;
                     alignment[k] = tci.alignment;
+                    headerMatchesProperty[k] = tci.headerMatchesProperty;
                     k++;
                 }
 
-                this.Writer.Initialize(0, _consoleWidth, columnWidths, alignment, this.CurrentTableHeaderInfo.hideHeader);
+                this.Writer.Initialize(0, _consoleWidth, columnWidths, alignment, headerMatchesProperty, this.CurrentTableHeaderInfo.hideHeader);
             }
 
             /// <summary>
@@ -1234,7 +1236,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     alignment[k] = TextAlignment.Left;
                 }
 
-                this.Writer.Initialize(0, columnsOnTheScreen, columnWidths, alignment, false, GetConsoleWindowHeight(this.InnerCommand._lo.RowNumber));
+                this.Writer.Initialize(0, columnsOnTheScreen, columnWidths, alignment, null, false, GetConsoleWindowHeight(this.InnerCommand._lo.RowNumber));
             }
 
             /// <summary>

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
@@ -176,11 +176,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                         string labelText = this.dataBaseInfo.db.displayResourceManagerCache.GetTextTokenString(colHeader.label);
                         if (so.Properties[labelText] != null)
                         {
-                            ci.label = labelText;
+                            ci.label = PSStyle.Instance.Formatting.TableHeader + labelText + PSStyle.Instance.Reset;
                         }
                         else
                         {
-                            ci.label = PSStyle.Instance.Formatting.ModifiedTableHeader + labelText;
+                            ci.label = PSStyle.Instance.Formatting.ModifiedTableHeader + labelText + PSStyle.Instance.Reset;
                         }
                     }
                 }
@@ -207,7 +207,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                             TextToken tt = token as TextToken;
                             if (tt != null)
                             {
-                                ci.label = this.dataBaseInfo.db.displayResourceManagerCache.GetTextTokenString(tt);
+                                ci.label = PSStyle.Instance.Formatting.TableHeader + this.dataBaseInfo.db.displayResourceManagerCache.GetTextTokenString(tt) + PSStyle.Instance.Reset;
                             }
                         }
                     }

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
@@ -180,7 +180,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                         }
                         else
                         {
-                            ci.label = PSStyle.Instance.Reset + PSStyle.Instance.Formatting.ModifiedTableHeader + labelText + PSStyle.Instance.Reset;
+                            ci.label = PSStyle.Instance.Reset + PSStyle.Instance.Formatting.CustomTableHeader + labelText + PSStyle.Instance.Reset;
                         }
                     }
                 }

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
@@ -174,13 +174,13 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     if (colHeader.label != null)
                     {
                         string labelText = this.dataBaseInfo.db.displayResourceManagerCache.GetTextTokenString(colHeader.label);
-                        if (so.Properties[labelText] != null)
+                        if (so.Properties[labelText] != null || !ExperimentalFeature.IsEnabled(ExperimentalFeature.PSModifiedTableHeaderDecoration))
                         {
-                            ci.label = PSStyle.Instance.Formatting.TableHeader + labelText + PSStyle.Instance.Reset;
+                            ci.label = PSStyle.Instance.Reset + PSStyle.Instance.Formatting.TableHeader + labelText + PSStyle.Instance.Reset;
                         }
                         else
                         {
-                            ci.label = PSStyle.Instance.Formatting.ModifiedTableHeader + labelText + PSStyle.Instance.Reset;
+                            ci.label = PSStyle.Instance.Reset + PSStyle.Instance.Formatting.ModifiedTableHeader + labelText + PSStyle.Instance.Reset;
                         }
                     }
                 }
@@ -200,14 +200,14 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                         FieldPropertyToken fpt = token as FieldPropertyToken;
                         if (fpt != null)
                         {
-                            ci.label = fpt.expression.expressionValue;
+                            ci.label = PSStyle.Instance.Reset + PSStyle.Instance.Formatting.TableHeader + fpt.expression.expressionValue + PSStyle.Instance.Reset;
                         }
                         else
                         {
                             TextToken tt = token as TextToken;
                             if (tt != null)
                             {
-                                ci.label = PSStyle.Instance.Formatting.TableHeader + this.dataBaseInfo.db.displayResourceManagerCache.GetTextTokenString(tt) + PSStyle.Instance.Reset;
+                                ci.label = PSStyle.Instance.Reset + PSStyle.Instance.Formatting.TableHeader + this.dataBaseInfo.db.displayResourceManagerCache.GetTextTokenString(tt) + PSStyle.Instance.Reset;
                             }
                         }
                     }

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
@@ -175,7 +175,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     {
                         if (so.Properties[colHeader.label.text] == null && ExperimentalFeature.IsEnabled(ExperimentalFeature.PSCustomTableHeaderDecoration))
                         {
-                            ci.headerMatchesProperty = false;
+                            ci.HeaderMatchesProperty = false;
                         }
 
                         ci.label = this.dataBaseInfo.db.displayResourceManagerCache.GetTextTokenString(colHeader.label);

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
@@ -173,10 +173,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     ci.alignment = colHeader.alignment;
                     if (colHeader.label != null)
                     {
-                        if (so.Properties[colHeader.label.text] == null && ExperimentalFeature.IsEnabled(ExperimentalFeature.PSCustomTableHeaderLabelDecoration))
-                        {
-                            ci.HeaderMatchesProperty = false;
-                        }
+                        ci.HeaderMatchesProperty = so.Properties[colHeader.label.text] is not null || !ExperimentalFeature.IsEnabled(ExperimentalFeature.PSCustomTableHeaderLabelDecoration);
 
                         ci.label = this.dataBaseInfo.db.displayResourceManagerCache.GetTextTokenString(colHeader.label);
                     }

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
@@ -172,7 +172,17 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     ci.width = colHeader.width;
                     ci.alignment = colHeader.alignment;
                     if (colHeader.label != null)
-                        ci.label = this.dataBaseInfo.db.displayResourceManagerCache.GetTextTokenString(colHeader.label);
+                    {
+                        string labelText = this.dataBaseInfo.db.displayResourceManagerCache.GetTextTokenString(colHeader.label);
+                        if (so.Properties[labelText] != null)
+                        {
+                            ci.label = labelText;
+                        }
+                        else
+                        {
+                            ci.label = PSStyle.Instance.Formatting.ModifiedTableHeader + labelText;
+                        }
+                    }
                 }
 
                 if (ci.alignment == TextAlignment.Undefined)

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
@@ -173,15 +173,12 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     ci.alignment = colHeader.alignment;
                     if (colHeader.label != null)
                     {
-                        string labelText = this.dataBaseInfo.db.displayResourceManagerCache.GetTextTokenString(colHeader.label);
-                        if (so.Properties[labelText] != null || !ExperimentalFeature.IsEnabled(ExperimentalFeature.PSCustomTableHeaderDecoration))
+                        if (so.Properties[colHeader.label.text] == null && ExperimentalFeature.IsEnabled(ExperimentalFeature.PSCustomTableHeaderDecoration))
                         {
-                            ci.label = PSStyle.Instance.Reset + PSStyle.Instance.Formatting.TableHeader + labelText + PSStyle.Instance.Reset;
+                            ci.headerMatchesProperty = false;
                         }
-                        else
-                        {
-                            ci.label = PSStyle.Instance.Reset + PSStyle.Instance.Formatting.CustomTableHeader + labelText + PSStyle.Instance.Reset;
-                        }
+
+                        ci.label = this.dataBaseInfo.db.displayResourceManagerCache.GetTextTokenString(colHeader.label);
                     }
                 }
 
@@ -200,14 +197,14 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                         FieldPropertyToken fpt = token as FieldPropertyToken;
                         if (fpt != null)
                         {
-                            ci.label = PSStyle.Instance.Reset + PSStyle.Instance.Formatting.TableHeader + fpt.expression.expressionValue + PSStyle.Instance.Reset;
+                            ci.label = fpt.expression.expressionValue;
                         }
                         else
                         {
                             TextToken tt = token as TextToken;
                             if (tt != null)
                             {
-                                ci.label = PSStyle.Instance.Reset + PSStyle.Instance.Formatting.TableHeader + this.dataBaseInfo.db.displayResourceManagerCache.GetTextTokenString(tt) + PSStyle.Instance.Reset;
+                                ci.label = this.dataBaseInfo.db.displayResourceManagerCache.GetTextTokenString(tt);
                             }
                         }
                     }

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
@@ -174,7 +174,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     if (colHeader.label != null)
                     {
                         string labelText = this.dataBaseInfo.db.displayResourceManagerCache.GetTextTokenString(colHeader.label);
-                        if (so.Properties[labelText] != null || !ExperimentalFeature.IsEnabled(ExperimentalFeature.PSModifiedTableHeaderDecoration))
+                        if (so.Properties[labelText] != null || !ExperimentalFeature.IsEnabled(ExperimentalFeature.PSCustomTableHeaderDecoration))
                         {
                             ci.label = PSStyle.Instance.Reset + PSStyle.Instance.Formatting.TableHeader + labelText + PSStyle.Instance.Reset;
                         }

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
@@ -173,7 +173,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     ci.alignment = colHeader.alignment;
                     if (colHeader.label != null)
                     {
-                        if (so.Properties[colHeader.label.text] == null && ExperimentalFeature.IsEnabled(ExperimentalFeature.PSCustomTableHeaderDecoration))
+                        if (so.Properties[colHeader.label.text] == null && ExperimentalFeature.IsEnabled(ExperimentalFeature.PSCustomTableHeaderLabelDecoration))
                         {
                             ci.HeaderMatchesProperty = false;
                         }

--- a/src/System.Management.Automation/FormatAndOutput/common/FormattingObjects.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormattingObjects.cs
@@ -207,7 +207,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         public int alignment = TextAlignment.Left;
         public string label = null;
         public string propertyName = null;
-        internal bool headerMatchesProperty = true;
+        internal bool HeaderMatchesProperty = true;
     }
 
     internal sealed class ListViewHeaderInfo : ShapeInfo

--- a/src/System.Management.Automation/FormatAndOutput/common/FormattingObjects.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormattingObjects.cs
@@ -207,6 +207,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         public int alignment = TextAlignment.Left;
         public string label = null;
         public string propertyName = null;
+        internal bool headerMatchesProperty = true;
     }
 
     internal sealed class ListViewHeaderInfo : ShapeInfo

--- a/src/System.Management.Automation/FormatAndOutput/common/FormattingObjects.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormattingObjects.cs
@@ -207,7 +207,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         public int alignment = TextAlignment.Left;
         public string label = null;
         public string propertyName = null;
-        internal bool HeaderMatchesProperty = true;
+        public bool HeaderMatchesProperty = true;
     }
 
     internal sealed class ListViewHeaderInfo : ShapeInfo

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -369,13 +369,13 @@ namespace System.Management.Automation
             /// <summary>
             /// Gets or sets the style for custom table headers.
             /// </summary>
-            public string CustomTableHeader
+            public string CustomTableHeaderLabel
             {
-                get => _customTableHeader;
-                set => _customTableHeader = ValidateNoContent(value);
+                get => _customTableHeaderLabel;
+                set => _customTableHeaderLabel = ValidateNoContent(value);
             }
 
-            private string _customTableHeader = "\x1b[32;1;3m";
+            private string _customTableHeaderLabel = "\x1b[32;1;3m";
 
             /// <summary>
             /// Gets or sets the accent style for errors.

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -369,7 +369,7 @@ namespace System.Management.Automation
             /// <summary>
             /// Gets or sets the style for modified table headers.
             /// </summary>
-            public string ModifiedTableHeader
+            public string CustomTableHeader
             {
                 get => _customTableHeader;
                 set => _customTableHeader = ValidateNoContent(value);

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -375,7 +375,7 @@ namespace System.Management.Automation
                 set => _modifiedTableHeader = ValidateNoContent(value);
             }
 
-            private string _modifiedTableHeader = "\x1b[32;3m";
+            private string _modifiedTableHeader = "\x1b[32;1;3m";
 
             /// <summary>
             /// Gets or sets the accent style for errors.

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -371,11 +371,11 @@ namespace System.Management.Automation
             /// </summary>
             public string ModifiedTableHeader
             {
-                get => _modifiedTableHeader;
-                set => _modifiedTableHeader = ValidateNoContent(value);
+                get => _customTableHeader;
+                set => _customTableHeader = ValidateNoContent(value);
             }
 
-            private string _modifiedTableHeader = "\x1b[32;1;3m";
+            private string _customTableHeader = "\x1b[32;1;3m";
 
             /// <summary>
             /// Gets or sets the accent style for errors.

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -367,6 +367,17 @@ namespace System.Management.Automation
             private string _tableHeader = "\x1b[32;1m";
 
             /// <summary>
+            /// Gets or sets the style for modified table headers.
+            /// </summary>
+            public string ModifiedTableHeader
+            {
+                get => _modifiedTableHeader;
+                set => _modifiedTableHeader = ValidateNoContent(value);
+            }
+
+            private string _modifiedTableHeader = "\x1b[32;3m";
+
+            /// <summary>
             /// Gets or sets the accent style for errors.
             /// </summary>
             public string ErrorAccent

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -367,7 +367,7 @@ namespace System.Management.Automation
             private string _tableHeader = "\x1b[32;1m";
 
             /// <summary>
-            /// Gets or sets the style for modified table headers.
+            /// Gets or sets the style for custom table headers.
             /// </summary>
             public string CustomTableHeader
             {

--- a/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
@@ -407,7 +407,19 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                         }
                         else
                         {
-                            sb.Append(PSStyle.Instance.Formatting.CustomTableHeaderLabel);
+                            // columns always start with a leading whitespace, so we insert the decoration right after that
+                            if (value.Length > 0)
+                            {
+                                if (col == 0)
+                                {
+                                    value = value.Insert(0, PSStyle.Instance.Formatting.CustomTableHeaderLabel);
+                                }
+                                else
+                                {
+                                    // after the first column, each additional column starts with a whitespace for separation
+                                    value = value.Insert(1, PSStyle.Instance.Formatting.CustomTableHeaderLabel);
+                                }
+                            }
                         }
                     }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
@@ -141,7 +141,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 _si.columnInfo[k].startCol = startCol;
                 _si.columnInfo[k].width = columnWidths[k];
                 _si.columnInfo[k].alignment = alignment[k];
-                if (headerMatchesProperty != null)
+                if (!headerMatchesProperty.IsEmpty)
                 {
                     _si.columnInfo[k].HeaderMatchesProperty = headerMatchesProperty[k];
                 }
@@ -244,36 +244,14 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 foreach (string line in GenerateTableRow(values, currentAlignment, lo.DisplayCells, isHeader))
                 {
                     generatedRows?.Add(line);
-<<<<<<< HEAD
-                    if (isHeader)
-                    {
-                        lo.WriteLine(style == string.Empty ? line : style + line + reset);
-                    }
-                    else
-                    {
-                        lo.WriteLine(line);
-                    }
-=======
                     lo.WriteLine(line);
->>>>>>> 21e3c01cf (fix applying decoration to header where the label may split across multiple lines and fix tests)
                 }
             }
             else
             {
                 string line = GenerateRow(values, currentAlignment, dc, isHeader);
                 generatedRows?.Add(line);
-<<<<<<< HEAD
-                if (isHeader)
-                {
-                    lo.WriteLine(style == string.Empty ? line : style + line + reset);
-                }
-                else
-                {
-                    lo.WriteLine(line);
-                }
-=======
                 lo.WriteLine(line);
->>>>>>> 21e3c01cf (fix applying decoration to header where the label may split across multiple lines and fix tests)
             }
         }
 
@@ -423,7 +401,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
                     if (isHeader)
                     {
-                        if (_si.columnInfo[col].HeaderMatchesProperty || !ExperimentalFeature.IsEnabled("PSCustomTableHeaderLabelDecoration"))
+                        if (_si.columnInfo[col].HeaderMatchesProperty || !ExperimentalFeature.IsEnabled(ExperimentalFeature.PSCustomTableHeaderLabelDecoration))
                         {
                             sb.Append(PSStyle.Instance.Formatting.TableHeader);
                         }

--- a/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
@@ -387,16 +387,12 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 // for a given row, walk the columns
                 for (int col = 0; col < scArray.Length; col++)
                 {
-                    string value;
+                    string value = scArray[col][row];
 
                     // if the column is the last column with content, we need to trim trailing whitespace, unless there is only one row
                     if (col == lastColWithContent[row] && screenRows > 1)
                     {
-                        value = scArray[col][row].TrimEnd();
-                    }
-                    else
-                    {
-                        value = scArray[col][row];
+                        value = value.TrimEnd();
                     }
 
                     if (isHeader)
@@ -405,21 +401,10 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                         {
                             sb.Append(PSStyle.Instance.Formatting.TableHeader);
                         }
-                        else
+                        else if (value.Length > 0)
                         {
-                            // columns always start with a leading whitespace, so we insert the decoration right after that
-                            if (value.Length > 0)
-                            {
-                                if (col == 0)
-                                {
-                                    value = value.Insert(0, PSStyle.Instance.Formatting.CustomTableHeaderLabel);
-                                }
-                                else
-                                {
-                                    // after the first column, each additional column starts with a whitespace for separation
-                                    value = value.Insert(1, PSStyle.Instance.Formatting.CustomTableHeaderLabel);
-                                }
-                            }
+                            // after the first column, each additional column starts with a whitespace for separation
+                            value = value.Insert(col == 0 ? 0 : 1, PSStyle.Instance.Formatting.CustomTableHeaderLabel);
                         }
                     }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
@@ -22,6 +22,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             internal int startCol = 0;
             internal int width = 0;
             internal int alignment = TextAlignment.Left;
+            internal bool headerMatchesProperty = true;
         }
         /// <summary>
         /// Class containing information about the tabular layout.
@@ -82,9 +83,10 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <param name="screenColumns">Number of character columns on the screen.</param>
         /// <param name="columnWidths">Array of specified column widths.</param>
         /// <param name="alignment">Array of alignment flags.</param>
+        /// <param name="headerMatchesProperty">Array of flags where the header label matches a property name.</param>
         /// <param name="suppressHeader">If true, suppress header printing.</param>
         /// <param name="screenRows">Number of rows on the screen.</param>
-        internal void Initialize(int leftMarginIndent, int screenColumns, Span<int> columnWidths, ReadOnlySpan<int> alignment, bool suppressHeader, int screenRows = int.MaxValue)
+        internal void Initialize(int leftMarginIndent, int screenColumns, Span<int> columnWidths, ReadOnlySpan<int> alignment, ReadOnlySpan<bool> headerMatchesProperty, bool suppressHeader, int screenRows = int.MaxValue)
         {
             if (leftMarginIndent < 0)
             {
@@ -139,6 +141,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 _si.columnInfo[k].startCol = startCol;
                 _si.columnInfo[k].width = columnWidths[k];
                 _si.columnInfo[k].alignment = alignment[k];
+                if (headerMatchesProperty != null)
+                {
+                    _si.columnInfo[k].headerMatchesProperty = headerMatchesProperty[k];
+                }
+
                 startCol += columnWidths[k] + ScreenInfo.separatorCharacterCount;
             }
         }
@@ -156,7 +163,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
                 foreach (string line in _header)
                 {
-                    lo.WriteLine(style == string.Empty ? line : style + line + reset);
+                    lo.WriteLine(line);
                 }
 
                 return _header.Count;
@@ -234,9 +241,10 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
             if (multiLine)
             {
-                foreach (string line in GenerateTableRow(values, currentAlignment, lo.DisplayCells))
+                foreach (string line in GenerateTableRow(values, currentAlignment, lo.DisplayCells, isHeader))
                 {
                     generatedRows?.Add(line);
+<<<<<<< HEAD
                     if (isHeader)
                     {
                         lo.WriteLine(style == string.Empty ? line : style + line + reset);
@@ -245,12 +253,16 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     {
                         lo.WriteLine(line);
                     }
+=======
+                    lo.WriteLine(line);
+>>>>>>> 21e3c01cf (fix applying decoration to header where the label may split across multiple lines and fix tests)
                 }
             }
             else
             {
-                string line = GenerateRow(values, currentAlignment, dc);
+                string line = GenerateRow(values, currentAlignment, dc, isHeader);
                 generatedRows?.Add(line);
+<<<<<<< HEAD
                 if (isHeader)
                 {
                     lo.WriteLine(style == string.Empty ? line : style + line + reset);
@@ -259,10 +271,13 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 {
                     lo.WriteLine(line);
                 }
+=======
+                lo.WriteLine(line);
+>>>>>>> 21e3c01cf (fix applying decoration to header where the label may split across multiple lines and fix tests)
             }
         }
 
-        private string[] GenerateTableRow(string[] values, ReadOnlySpan<int> alignment, DisplayCells ds)
+        private string[] GenerateTableRow(string[] values, ReadOnlySpan<int> alignment, DisplayCells ds, bool isHeader)
         {
             // select the active columns (skip hidden ones)
             Span<int> validColumnArray = _si.columnInfo.Length <= OutCommandInner.StackAllocThreshold ? stackalloc int[_si.columnInfo.Length] : new int[_si.columnInfo.Length];
@@ -393,14 +408,34 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 // for a given row, walk the columns
                 for (int col = 0; col < scArray.Length; col++)
                 {
+                    string value;
                     // if the column is the last column with content, we need to trim trailing whitespace, unless there is only one row
                     if (col == lastColWithContent[row] && screenRows > 1)
                     {
-                        sb.Append(scArray[col][row].TrimEnd());
+                        value = scArray[col][row].TrimEnd();
                     }
                     else
                     {
-                        sb.Append(scArray[col][row]);
+                        value = scArray[col][row];
+                    }
+
+                    if (isHeader)
+                    {
+                        if (_si.columnInfo[col].headerMatchesProperty)
+                        {
+                            sb.Append(PSStyle.Instance.Formatting.TableHeader);
+                        }
+                        else
+                        {
+                            sb.Append(PSStyle.Instance.Formatting.CustomTableHeader);
+                        }
+                    }
+
+                    sb.Append(value);
+
+                    if (isHeader)
+                    {
+                        sb.Append(PSStyle.Instance.Reset);
                     }
                 }
 
@@ -427,7 +462,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return sc;
         }
 
-        private string GenerateRow(string[] values, ReadOnlySpan<int> alignment, DisplayCells dc)
+        private string GenerateRow(string[] values, ReadOnlySpan<int> alignment, DisplayCells dc, bool isHeader)
         {
             StringBuilder sb = new StringBuilder();
 
@@ -462,9 +497,14 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 }
 
                 string rowField = GenerateRowField(values[k], _si.columnInfo[k].width, alignment[k], dc, addPadding);
+                if (isHeader)
+                {
+                    sb.Append(PSStyle.Instance.Formatting.TableHeader);
+                }
+
                 sb.Append(rowField);
 
-                if (rowField is not null && rowField.Contains(ValueStringDecorated.ESC) && !rowField.AsSpan().TrimEnd().EndsWith(PSStyle.Instance.Reset))
+                if (rowField is not null && rowField.Contains(ValueStringDecorated.ESC) && !rowField.AsSpan().TrimEnd().EndsWith(PSStyle.Instance.Reset) || isHeader)
                 {
                     // Reset the console output if the content of this column contains ESC
                     sb.Append(PSStyle.Instance.Reset);

--- a/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
@@ -429,7 +429,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                         }
                         else
                         {
-                            sb.Append(PSStyle.Instance.Formatting.CustomTableHeader);
+                            sb.Append(PSStyle.Instance.Formatting.CustomTableHeaderLabel);
                         }
                     }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
@@ -397,7 +397,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
                     if (isHeader)
                     {
-                        if (_si.columnInfo[col].HeaderMatchesProperty || !ExperimentalFeature.IsEnabled(ExperimentalFeature.PSCustomTableHeaderLabelDecoration))
+                        if (_si.columnInfo[col].HeaderMatchesProperty)
                         {
                             sb.Append(PSStyle.Instance.Formatting.TableHeader);
                         }

--- a/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             internal int startCol = 0;
             internal int width = 0;
             internal int alignment = TextAlignment.Left;
-            internal bool headerMatchesProperty = true;
+            internal bool HeaderMatchesProperty = true;
         }
         /// <summary>
         /// Class containing information about the tabular layout.
@@ -143,7 +143,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 _si.columnInfo[k].alignment = alignment[k];
                 if (headerMatchesProperty != null)
                 {
-                    _si.columnInfo[k].headerMatchesProperty = headerMatchesProperty[k];
+                    _si.columnInfo[k].HeaderMatchesProperty = headerMatchesProperty[k];
                 }
 
                 startCol += columnWidths[k] + ScreenInfo.separatorCharacterCount;
@@ -306,8 +306,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 }
 
                 // obtain a set of tokens for each field
-                scArray[k] = GenerateMultiLineRowField(values[validColumnArray[k]], validColumnArray[k],
-                    alignment[validColumnArray[k]], ds, addPadding);
+                scArray[k] = GenerateMultiLineRowField(values[validColumnArray[k]], validColumnArray[k], alignment[validColumnArray[k]], ds, addPadding);
 
                 // NOTE: the following padding operations assume that we
                 // pad with a blank (or any character that ALWAYS maps to a single screen cell
@@ -338,7 +337,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             for (int k = 0; k < scArray.Length; k++)
             {
                 if (scArray[k].Count > screenRows)
+                {
                     screenRows = scArray[k].Count;
+                }
             }
 
             // column headers can span multiple rows if the width of the column is shorter than the header text like:
@@ -350,7 +351,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             // 1    2       3
             //
             // To ensure we don't add whitespace to the end, we need to determine the last column in each row with content
-
             System.Span<int> lastColWithContent = screenRows <= OutCommandInner.StackAllocThreshold ? stackalloc int[screenRows] : new int[screenRows];
             for (int row = 0; row < screenRows; row++)
             {
@@ -405,10 +405,12 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             for (int row = 0; row < screenRows; row++)
             {
                 StringBuilder sb = new StringBuilder();
+
                 // for a given row, walk the columns
                 for (int col = 0; col < scArray.Length; col++)
                 {
                     string value;
+
                     // if the column is the last column with content, we need to trim trailing whitespace, unless there is only one row
                     if (col == lastColWithContent[row] && screenRows > 1)
                     {
@@ -421,7 +423,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
                     if (isHeader)
                     {
-                        if (_si.columnInfo[col].headerMatchesProperty)
+                        if (_si.columnInfo[col].HeaderMatchesProperty)
                         {
                             sb.Append(PSStyle.Instance.Formatting.TableHeader);
                         }
@@ -504,7 +506,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
                 sb.Append(rowField);
 
-                if (rowField is not null && rowField.Contains(ValueStringDecorated.ESC) && !rowField.AsSpan().TrimEnd().EndsWith(PSStyle.Instance.Reset) || isHeader)
+                if (isHeader || (rowField is not null && rowField.Contains(ValueStringDecorated.ESC) && !rowField.AsSpan().TrimEnd().EndsWith(PSStyle.Instance.Reset)))
                 {
                     // Reset the console output if the content of this column contains ESC
                     sb.Append(PSStyle.Instance.Reset);

--- a/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
@@ -423,7 +423,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
                     if (isHeader)
                     {
-                        if (_si.columnInfo[col].HeaderMatchesProperty)
+                        if (_si.columnInfo[col].HeaderMatchesProperty || !ExperimentalFeature.IsEnabled("PSCustomTableHeaderLabelDecoration"))
                         {
                             sb.Append(PSStyle.Instance.Formatting.TableHeader);
                         }

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -22,6 +22,7 @@ namespace System.Management.Automation
 
         internal const string EngineSource = "PSEngine";
         internal const string PSNativeCommandErrorActionPreferenceFeatureName = "PSNativeCommandErrorActionPreference";
+        internal const string PSModifiedTableHeaderDecoration = "PSModifiedTableHeaderDecoration";
 
         #endregion
 
@@ -116,6 +117,9 @@ namespace System.Management.Automation
                 new ExperimentalFeature(
                     name: PSNativeCommandErrorActionPreferenceFeatureName,
                     description: "Native commands with non-zero exit codes issue errors according to $ErrorActionPreference when $PSNativeCommandUseErrorActionPreference is $true"),
+                new ExperimentalFeature(
+                    name: PSModifiedTableHeaderDecoration,
+                    description: "Formatting differentiation for table headers that aren't property members"),
             };
 
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -22,7 +22,7 @@ namespace System.Management.Automation
 
         internal const string EngineSource = "PSEngine";
         internal const string PSNativeCommandErrorActionPreferenceFeatureName = "PSNativeCommandErrorActionPreference";
-        internal const string PSModifiedTableHeaderDecoration = "PSModifiedTableHeaderDecoration";
+        internal const string PSCustomTableHeaderDecoration = "PSCustomTableHeaderDecoration";
 
         #endregion
 
@@ -118,7 +118,7 @@ namespace System.Management.Automation
                     name: PSNativeCommandErrorActionPreferenceFeatureName,
                     description: "Native commands with non-zero exit codes issue errors according to $ErrorActionPreference when $PSNativeCommandUseErrorActionPreference is $true"),
                 new ExperimentalFeature(
-                    name: PSModifiedTableHeaderDecoration,
+                    name: PSCustomTableHeaderDecoration,
                     description: "Formatting differentiation for table headers that aren't property members"),
             };
 

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -22,7 +22,7 @@ namespace System.Management.Automation
 
         internal const string EngineSource = "PSEngine";
         internal const string PSNativeCommandErrorActionPreferenceFeatureName = "PSNativeCommandErrorActionPreference";
-        internal const string PSCustomTableHeaderDecoration = "PSCustomTableHeaderDecoration";
+        internal const string PSCustomTableHeaderLabelDecoration = "PSCustomTableHeaderLabelDecoration";
 
         #endregion
 
@@ -118,8 +118,8 @@ namespace System.Management.Automation
                     name: PSNativeCommandErrorActionPreferenceFeatureName,
                     description: "Native commands with non-zero exit codes issue errors according to $ErrorActionPreference when $PSNativeCommandUseErrorActionPreference is $true"),
                 new ExperimentalFeature(
-                    name: PSCustomTableHeaderDecoration,
-                    description: "Formatting differentiation for table headers that aren't property members"),
+                    name: PSCustomTableHeaderLabelDecoration,
+                    description: "Formatting differentiation for table header labels that aren't property members"),
             };
 
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
@@ -876,10 +876,10 @@ Describe 'Table color tests' {
         $PSStyle.OutputRendering = $originalRendering
     }
 
-    It 'Table header should use FormatAccent' {
+    It 'Table header should use TableHeader' {
         ([pscustomobject]@{foo = 1} | Format-Table | Out-String).Trim() | Should -BeExactly @"
-$($PSStyle.Formatting.FormatAccent)foo$($PSStyle.Reset)
-$($PSStyle.Formatting.FormatAccent)---$($PSStyle.Reset)
+$($PSStyle.Formatting.TableHeader)foo$($PSStyle.Reset)
+$($PSStyle.Formatting.TableHeader)---$($PSStyle.Reset)
   1
 "@
     }

--- a/test/powershell/engine/Formatting/PSStyle.Tests.ps1
+++ b/test/powershell/engine/Formatting/PSStyle.Tests.ps1
@@ -24,7 +24,7 @@ Describe 'Tests for $PSStyle automatic variable' {
         $formattingDefaults = @{
             FormatAccent = "`e[32;1m"
             TableHeader = "`e[32;1m"
-            CustomTableHeader = "`e[32;1;3m"
+            CustomTableHeaderLabel = "`e[32;1;3m"
             ErrorAccent = "`e[36;1m"
             Error = "`e[31;1m"
             Debug = "`e[33;1m"
@@ -200,22 +200,22 @@ Describe 'Tests for $PSStyle automatic variable' {
         }
     }
 
-    It '$PSStyle.Formatting.CustomTableHeader is applied to Format-Table' {
-        $old = $PSStyle.Formatting.CustomTableHeader
+    It '$PSStyle.Formatting.CustomTableHeaderLabel is applied to Format-Table' {
+        $old = $PSStyle.Formatting.CustomTableHeaderLabel
         $oldRender = $PSStyle.OutputRendering
 
         try {
             $PSStyle.OutputRendering = 'Ansi'
-            $PSStyle.Formatting.CustomTableHeader = $PSStyle.Foreground.Blue + $PSStyle.Background.White + $PSStyle.Bold
+            $PSStyle.Formatting.CustomTableHeaderLabel = $PSStyle.Foreground.Blue + $PSStyle.Background.White + $PSStyle.Bold
             $out = Get-Process pwsh | Select-Object -First 1 | Format-Table | Out-String
-            $format = $PSStyle.Formatting.CustomTableHeader.Replace('[',"``[")
+            $format = $PSStyle.Formatting.CustomTableHeaderLabel.Replace('[',"``[")
             $header = $PSStyle.Formatting.TableHeader.Replace('[',"``[")
             $reset = $PSStyle.Reset.Replace('[',"``[")
             $out | Should -BeLike "*${format}*NPM(K)${reset}*${format}*PM(M)${reset}*${format}*WS(M)${reset}*${format}*CPU(s)${reset}*${header}*Id${reset}*${header}*SI${reset}*${header}*ProcessName${reset}*"
         }
         finally {
             $PSStyle.OutputRendering = $oldRender
-            $PSStyle.Formatting.CustomTableHeader = $old
+            $PSStyle.Formatting.CustomTableHeaderLabel = $old
         }
     }
 
@@ -235,7 +235,7 @@ Describe 'Tests for $PSStyle automatic variable' {
         @{ Submember = 'Strikethrough' }
         @{ Member = 'Formatting'; Submember = 'FormatAccent' }
         @{ Member = 'Formatting'; Submember = 'TableHeader' }
-        @{ Member = 'Formatting'; Submember = 'CustomTableHeader' }
+        @{ Member = 'Formatting'; Submember = 'CustomTableHeaderLabel' }
         @{ Member = 'Formatting'; Submember = 'ErrorAccent' }
         @{ Member = 'Formatting'; Submember = 'Error' }
         @{ Member = 'Formatting'; Submember = 'Warning' }

--- a/test/powershell/engine/Formatting/PSStyle.Tests.ps1
+++ b/test/powershell/engine/Formatting/PSStyle.Tests.ps1
@@ -211,7 +211,7 @@ Describe 'Tests for $PSStyle automatic variable' {
             $format = $PSStyle.Formatting.CustomTableHeader.Replace('[',"``[")
             $header = $PSStyle.Formatting.TableHeader.Replace('[',"``[")
             $reset = $PSStyle.Reset.Replace('[',"``[")
-            $out | Should -BeLike "*${format}NPM(K)${reset}*${format}PM(M)${reset}*${format}WS(M)${reset}*${format}CPU(s)${reset}*${header}Id${reset}*${header}SI${reset}*${header}ProcessName${reset}*"
+            $out | Should -BeLike "*${format}*NPM(K)${reset}*${format}*PM(M)${reset}*${format}*WS(M)${reset}*${format}*CPU(s)${reset}*${header}*Id${reset}*${header}*SI${reset}*${header}*ProcessName${reset}*"
         }
         finally {
             $PSStyle.OutputRendering = $oldRender
@@ -401,8 +401,8 @@ Describe 'Handle strings with escape sequences in formatting' {
 
     It 'Truncation for strings with no escape sequences' {
         $expected = @"
-`e[32;1mName       Role            YIR`e[0m
-`e[32;1m----       ----            ---`e[0m
+`e[32;1mName      `e[0m`e[32;1m Role           `e[0m`e[32;1m YIR`e[0m
+`e[32;1m----      `e[0m `e[32;1m----           `e[0m `e[32;1m---`e[0m
 Bob Saggat Developer         2
 John Seym… Sw Engineer       6
 Billy Bob… Senior DevOps …  13
@@ -419,8 +419,8 @@ Billy Bob… Senior DevOps …  13
 
     It "Truncation for strings with escape sequences - TableView-1" {
         $expected = @"
-`e[32;1mName       Role            YIR`e[0m
-`e[32;1m----       ----            ---`e[0m
+`e[32;1mName      `e[0m`e[32;1m Role           `e[0m`e[32;1m YIR`e[0m
+`e[32;1m----      `e[0m `e[32;1m----           `e[0m `e[32;1m---`e[0m
 `e[32mBob Saggat`e[39m`e[0m Developer         2
 `e[33mJohn Seym…`e[0m Sw Engineer       6
 `e[31mBilly Bob…`e[0m Senior DevOps …  13
@@ -441,8 +441,8 @@ Billy Bob… Senior DevOps …  13
 
     It "Truncation for strings with escape sequences - TableView-2" {
         $expected = @"
-`e[32;1mName       Role            YIR`e[0m
-`e[32;1m----       ----            ---`e[0m
+`e[32;1mName      `e[0m`e[32;1m Role           `e[0m`e[32;1m YIR`e[0m
+`e[32;1m----      `e[0m `e[32;1m----           `e[0m `e[32;1m---`e[0m
 `e[32mBob Saggat`e[39m`e[0m Developer`e[0m         2
 `e[33mJohn Seym…`e[0m `e[1;33mSw Engineer`e[0m       6
 `e[31mBilly Bob…`e[0m `e[42m`e[1;33mSenior DevOps …`e[0m  13


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add `$PSStyle.Formatting.CustomTableHeaderLabel` to enable differentiation in `Format-Table` output where a table header label isn't an actual property name.  Usually these are either abbreviated, calculated, or has units added.  Users can get confused because they expect it to be a property name and can't use dot-notation to access it.  The default format is the same color as the table header but use italics.

Since decoration is absolute and not relative (additive), to make this work correctly for each table header which IS a property member we need to wrap it with the normal decoration.  This results in extra characters being emitted.

## PR Context

Brought up in https://twitter.com/JustinWGrote/status/1524882725781377024

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [x] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [x] Experimental feature name(s): `PSCustomTableHeaderLabelDecoration `
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: [8815](https://github.com/MicrosoftDocs/PowerShell-Docs/issues/8815)
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
