### PR TITLE
Make sure verbose message is not null

### DIFF
--- a/tools/UpdateDotnetRuntime.ps1
+++ b/tools/UpdateDotnetRuntime.ps1
@@ -227,9 +227,7 @@ function Get-DotnetUpdate {
         } else {
             $shouldUpdate = $false
             $newVersion = $latestSDKVersionString
-            if ($null -eq $currentVersion.PreReleaseLabel) {
-                $Message = "$latestSDKversion is not preview, update manually."
-            }
+            $Message = $null -eq $currentVersion.PreReleaseLabel ? "$latestSDKversion is not preview, update manually." : "No update needed."
         }
     } catch {
         Write-Verbose -Verbose "Error occured: $_.message"
@@ -241,7 +239,7 @@ function Get-DotnetUpdate {
     return @{
         ShouldUpdate = $shouldUpdate
         NewVersion   = $newVersion
-        Message      = $Message ?? "No update needed."
+        Message      = $Message
         FeedUrl      = $feedUrl
         Quality      = $selectedQuality
     }

--- a/tools/UpdateDotnetRuntime.ps1
+++ b/tools/UpdateDotnetRuntime.ps1
@@ -241,7 +241,7 @@ function Get-DotnetUpdate {
     return @{
         ShouldUpdate = $shouldUpdate
         NewVersion   = $newVersion
-        Message      = $Message
+        Message      = $Message ?? "No update needed."
         FeedUrl      = $feedUrl
         Quality      = $selectedQuality
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The failure from https://github.com/PowerShell/PowerShell/runs/6471314787?check_suite_focus=true:

```
VERBOSE: Setting CI variable OLD_VERSION to 7.0.100-preview.4.22252.9
UpdateDotnetRuntime.ps1: D:\a\_temp\00f3a01b-2[18](https://github.com/PowerShell/PowerShell/runs/6471314787?check_suite_focus=true#step:4:19)6-439d-ac62-afcbb0d616d8.ps1:6
Line |
   6 |  ./tools/UpdateDotnetRuntime.ps1 -UpdateMSIPackaging
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Cannot bind argument to parameter 'Message' because it is null.
```

