### PR TITLE
Fix native library loading for osx-arm64

### DIFF
--- a/src/System.Management.Automation/CoreCLR/CorePsAssemblyLoadContext.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsAssemblyLoadContext.cs
@@ -232,6 +232,9 @@ namespace System.Management.Automation
         ///                     |
         ///                     |--- 'osx-x64' subfolder
         ///                     |       |--- native.dylib
+        ///                     |
+        ///                     |--- 'osx-arm64' subfolder
+        ///                     |       |--- native.dylib
         /// </summary>
         internal static IntPtr NativeDllHandler(Assembly assembly, string libraryName)
         {
@@ -552,7 +555,7 @@ namespace System.Management.Automation
             }
             else if (Platform.IsMacOS)
             {
-                folderName = "osx-x64";
+                folderName = "osx-" + processArch;
                 ext = ".dylib";
             }
 


### PR DESCRIPTION
# PR Summary

The current native library loader on macOS is hardcoded to use "osx-x64", which breaks loading native libraries under the "osx-arm64" directory.

## PR Context

We've been fighting for days trying to figure out why PowerShell wouldn't load our arm64 native libraries for our PowerShell module on macOS. The reason why was quite obvious when looking at the source code.

Rather than hardcode "osx-x64" we should just use "osx-" + the process architecture like for other platforms. This is a really simple fix.

