### PR TITLE
Update script to automatically take new preview pre-release builds

### DIFF
--- a/DotnetRuntimeMetadata.json
+++ b/DotnetRuntimeMetadata.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
     "channel": "7.0.1xx-preview4",
-    "quality": "signed",
-    "qualityFallback": "daily",
+    "quality": "daily",
+    "qualityFallback": "preview",
     "packageVersionPattern": "7.0.0-preview.4",
     "sdkImageVersion": "7.0.100",
-    "nextChannel": "7.0.1xx-preview4",
+    "nextChannel": "7.0.1xx",
     "azureFeed": "",
     "sdkImageOverride": ""
   },

--- a/tools/UpdateDotnetRuntime.ps1
+++ b/tools/UpdateDotnetRuntime.ps1
@@ -254,6 +254,25 @@ function Update-DevContainer {
     $devContainerDocker | Out-File -FilePath $dockerFilePath -Force
 }
 
+<#
+ .DESCRIPTION Update the DotnetMetadata.json file with the latest version of the SDK
+ #>
+function Update-DotnetRuntimeMetadataChannel {
+    param (
+        [string] $newSdk
+    )
+
+    # -replace uses regex so we are splitting on "."
+    $sdkParts = $newSdk -split '\.'
+    $newChannel = $sdkParts[0] + "." + $sdkParts[1] + "." + ($sdkParts[2] -replace '0','x') + $sdkParts[3]
+
+    Write-Verbose -Verbose -Message "Updating DotnetRuntimeMetadata.json with channel $newChannel"
+
+    $metadata = Get-Content -Raw "$PSScriptRoot/../DotnetRuntimeMetadata.json" | ConvertFrom-Json
+    $metadata.sdk.channel = $newChannel
+    $metadata | ConvertTo-Json | Out-File -FilePath "$PSScriptRoot/../DotnetRuntimeMetadata.json" -Force
+}
+
 $dotnetMetadataPath = "$PSScriptRoot/../DotnetRuntimeMetadata.json"
 $dotnetMetadataJson = Get-Content $dotnetMetadataPath -Raw | ConvertFrom-Json
 $channel = $dotnetMetadataJson.sdk.channel
@@ -364,6 +383,8 @@ if ($dotnetUpdate.ShouldUpdate) {
     }
 
     Update-DevContainer
+
+    Update-DotnetRuntimeMetadataChannel -newSdk $latestSdkVersion
 }
 else {
     Write-Verbose -Verbose -Message $dotnetUpdate.Message

--- a/tools/UpdateDotnetRuntime.ps1
+++ b/tools/UpdateDotnetRuntime.ps1
@@ -262,7 +262,7 @@ function Update-DotnetRuntimeMetadataChannel {
         [string] $newSdk
     )
 
-    # -replace uses regex so we are splitting on "." and not on "\.". "\" is escaped in the regex.
+    # -replace uses regex so in order to split on `.`, we need to use `\.` to escape the dot character.
     $sdkParts = $newSdk -split '\.'
 
     # Transform SDK Version '7.0.100-preview.5.22263.22' -> '7.0.1xx-preview5'

--- a/tools/UpdateDotnetRuntime.ps1
+++ b/tools/UpdateDotnetRuntime.ps1
@@ -262,8 +262,10 @@ function Update-DotnetRuntimeMetadataChannel {
         [string] $newSdk
     )
 
-    # -replace uses regex so we are splitting on "."
+    # -replace uses regex so we are splitting on "." and not on "\.". "\" is escaped in the regex.
     $sdkParts = $newSdk -split '\.'
+
+    # Transform SDK Version '7.0.100-preview.5.22263.22' -> '7.0.1xx-preview5'
     $newChannel = $sdkParts[0] + "." + $sdkParts[1] + "." + ($sdkParts[2] -replace '0','x') + $sdkParts[3]
 
     Write-Verbose -Verbose -Message "Updating DotnetRuntimeMetadata.json with channel $newChannel"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Use new feature in dotnet-install.ps1 to automatically update to latest available preview build.
Some things to note:

1. The script now has `7.0.1xx` as the nextChannel. This means it will look for the latest preview even if PS skips a preview.
2. The default quality to look for is now daily. If not available, then we fallback to preview. Preview means last release .NET 7 preview version.
3. One additional change is that the script also updates DotnetRuntimeMetadata.json as well to update the value for channel. This is used by Start-PSBootstrap to know which build to install. The format for that is like: `7.0.1xx-preview4`. So, we construct that from the latest SDK found and update it.

## PR Context

Marking this a WIP till we snap for next preview.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
