### PR TITLE
Write out OSC indicator only if the stdout is not redirected

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceProgress.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceProgress.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Management.Automation;
+using System.Management.Automation.Host;
 using System.Threading;
 
 using Dbg = System.Management.Automation.Diagnostics;
@@ -10,7 +11,7 @@ using Dbg = System.Management.Automation.Diagnostics;
 namespace Microsoft.PowerShell
 {
     internal partial
-    class ConsoleHostUserInterface : System.Management.Automation.Host.PSHostUserInterface
+    class ConsoleHostUserInterface : PSHostUserInterface
     {
         /// <summary>
         /// Called at the end of a prompt loop to take down any progress display that might have appeared and purge any
@@ -48,7 +49,7 @@ namespace Microsoft.PowerShell
 
                 _pendingProgress = null;
 
-                if (SupportsVirtualTerminal && PSStyle.Instance.Progress.UseOSCIndicator)
+                if (SupportsVirtualTerminal && !PSHost.IsStdOutputRedirected && PSStyle.Instance.Progress.UseOSCIndicator)
                 {
                     // OSC sequence to turn off progress indicator
                     // https://github.com/microsoft/terminal/issues/6700
@@ -99,7 +100,7 @@ namespace Microsoft.PowerShell
             {
                 // Update the progress pane only when the timer set up the update flag or WriteProgress is completed.
                 // As a result, we do not block WriteProgress and whole script and eliminate unnecessary console locks and updates.
-                if (SupportsVirtualTerminal && PSStyle.Instance.Progress.UseOSCIndicator)
+                if (SupportsVirtualTerminal && !PSHost.IsStdOutputRedirected && PSStyle.Instance.Progress.UseOSCIndicator)
                 {
                     int percentComplete = record.PercentComplete;
                     if (percentComplete < 0)

--- a/test/powershell/engine/Formatting/PSStyle.Tests.ps1
+++ b/test/powershell/engine/Formatting/PSStyle.Tests.ps1
@@ -243,7 +243,7 @@ Describe 'Tests for $PSStyle automatic variable' {
 
         ## In the case that the stdout is redirected, pwsh should not write the OSC indicator Ansi sequence.
         $result = & $pwsh -noprofile -Command { $PSStyle.Progress.UseOSCIndicator = $true; 'hello'} | Format-List
-        $result | Out-String | Should -BeExactly 'hello'
+        $result | Out-String -Stream | Should -BeExactly 'hello'
     }
 }
 

--- a/test/powershell/engine/Formatting/PSStyle.Tests.ps1
+++ b/test/powershell/engine/Formatting/PSStyle.Tests.ps1
@@ -237,6 +237,14 @@ Describe 'Tests for $PSStyle automatic variable' {
             $PSStyle.Progress.MaxWidth = $maxWidth
         }
     }
+
+    It 'Do not use OSC indicator when the stdout is redirected' {
+        $pwsh = Join-Path $PSHOME 'pwsh'
+
+        ## In the case that the stdout is redirected, pwsh should not write the OSC indicator Ansi sequence.
+        $result = & $pwsh -noprofile -Command { $PSStyle.Progress.UseOSCIndicator = $true; 'hello'} | Format-List
+        $result | Should -BeExactly 'hello'
+    }
 }
 
 Describe 'Handle strings with escape sequences in formatting' {

--- a/test/powershell/engine/Formatting/PSStyle.Tests.ps1
+++ b/test/powershell/engine/Formatting/PSStyle.Tests.ps1
@@ -243,7 +243,7 @@ Describe 'Tests for $PSStyle automatic variable' {
 
         ## In the case that the stdout is redirected, pwsh should not write the OSC indicator Ansi sequence.
         $result = & $pwsh -noprofile -Command { $PSStyle.Progress.UseOSCIndicator = $true; 'hello'} | Format-List
-        $result | Should -BeExactly 'hello'
+        $result | Out-String | Should -BeExactly 'hello'
     }
 }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #17395
Write out OSC indicator only if the stdout is not redirected.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
