### PR TITLE
Make `AnsiRegex` able to capture Hyperlink ansi sequences

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/StringDecorated.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/StringDecorated.cs
@@ -109,8 +109,11 @@ namespace System.Management.Automation.Internal
         // CSI escape sequences
         private const string CsiRegex = @"(\x1b\[\?\d+[hl])";
 
+        // Hyperlink escape sequences
+        private const string HyperlinkRegex = @"(\x1b\]8;;.*?\x1b\\)";
+
         // replace regex with .NET 6 API once available
-        internal static readonly Regex AnsiRegex = new Regex($"{GraphicsRegex}|{CsiRegex}", RegexOptions.Compiled);
+        internal static readonly Regex AnsiRegex = new Regex($"{GraphicsRegex}|{CsiRegex}|{HyperlinkRegex}", RegexOptions.Compiled);
 
         /// <summary>
         /// Get the ranges of all escape sequences in the text.

--- a/src/System.Management.Automation/FormatAndOutput/common/StringDecorated.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/StringDecorated.cs
@@ -109,7 +109,7 @@ namespace System.Management.Automation.Internal
         // CSI escape sequences
         private const string CsiRegex = @"(\x1b\[\?\d+[hl])";
 
-        // Hyperlink escape sequences
+        // Hyperlink escape sequences. Note: '.*?' makes '.*' do non-greedy match.
         private const string HyperlinkRegex = @"(\x1b\]8;;.*?\x1b\\)";
 
         // replace regex with .NET 6 API once available

--- a/test/powershell/engine/Formatting/PSStyle.Tests.ps1
+++ b/test/powershell/engine/Formatting/PSStyle.Tests.ps1
@@ -245,6 +245,15 @@ Describe 'Tests for $PSStyle automatic variable' {
         $result = & $pwsh -noprofile -Command { $PSStyle.Progress.UseOSCIndicator = $true; 'hello'} | Format-List
         $result | Out-String -Stream | Should -BeExactly 'hello'
     }
+
+    It 'Able to handle Hyperlink ansi sequences' {
+        $word = "This is a link"
+        $hyperlink = $PSStyle.FormatHyperlink($word, "some random text as a link")
+        $strDec = [System.Management.Automation.Internal.StringDecorated]::new($hyperlink)
+        $strDec.IsDecorated | Should -BeTrue
+        $strDec.ContentLength | Should -Be $word.Length
+        $strDec.ToString("PlainText") | Should -Be $word
+    }
 }
 
 Describe 'Handle strings with escape sequences in formatting' {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #16420
Make `AnsiRegex` able to capture Hyperlink ansi sequences.

With this fix, the repro `dir | ft @{n="link";e={$PSStyle.FormatHyperlink($_.name, ("some random text as a link" + "x" * (random -Max 5) ) )}}, lastwritetime` get the following output

![image](https://user-images.githubusercontent.com/127450/170375041-862567d1-eaf6-4bd1-8859-ad78e38daf00.png)

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
