### PR TITLE
Add local session configuration -ConfigurationFile cmd line parameter to pwsh

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -227,6 +227,7 @@ namespace Microsoft.PowerShell
             Version             = 0x00800000, // -Version | -v
             WindowStyle         = 0x01000000, // -WindowStyle | -w
             WorkingDirectory    = 0x02000000, // -WorkingDirectory | -wd
+            ConfigurationFile   = 0x04000000, // -ConfigurationFile | -ConfigurationFile
             // Enum values for specified ExecutionPolicy
             EPUnrestricted      = 0x0000000100000000, // ExecutionPolicy unrestricted
             EPRemoteSigned      = 0x0000000200000000, // ExecutionPolicy remote signed
@@ -367,6 +368,23 @@ namespace Microsoft.PowerShell
             {
                 AssertArgumentsParsed();
                 return _collectedArgs;
+            }
+        }
+
+        internal string? ConfigurationFile
+        {
+            get
+            {
+                AssertArgumentsParsed();
+                return _configurationFile;
+            }
+
+            set
+            {
+                if (!string.IsNullOrEmpty(value))
+                {
+                    _configurationFile = value;
+                }
             }
         }
 
@@ -914,6 +932,19 @@ namespace Microsoft.PowerShell
                 {
                     _noInteractive = false;
                     ParametersUsed |= ParameterBitmap.Interactive;
+                }
+                else if (MatchSwitch(switchKey, "configurationfile", "configurationfile"))
+                {
+                    ++i;
+                    if (i >= args.Length)
+                    {
+                        SetCommandLineError(
+                            CommandLineParameterParserStrings.MissingConfigurationFileArgument);
+                        break;
+                    }
+
+                    _configurationFile = args[i];
+                    ParametersUsed |= ParameterBitmap.ConfigurationFile;
                 }
                 else if (MatchSwitch(switchKey, "configurationname", "config"))
                 {
@@ -1474,6 +1505,7 @@ namespace Microsoft.PowerShell
         private bool _namedPipeServerMode;
         private bool _sshServerMode;
         private bool _showVersion;
+        private string? _configurationFile;
         private string? _configurationName;
         private string? _error;
         private bool _showHelp;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -227,7 +227,7 @@ namespace Microsoft.PowerShell
             Version             = 0x00800000, // -Version | -v
             WindowStyle         = 0x01000000, // -WindowStyle | -w
             WorkingDirectory    = 0x02000000, // -WorkingDirectory | -wd
-            ConfigurationFile   = 0x04000000, // -ConfigurationFile | -ConfigurationFile
+            ConfigurationFile   = 0x04000000, // -ConfigurationFile | -cf
             // Enum values for specified ExecutionPolicy
             EPUnrestricted      = 0x0000000100000000, // ExecutionPolicy unrestricted
             EPRemoteSigned      = 0x0000000200000000, // ExecutionPolicy remote signed
@@ -933,7 +933,7 @@ namespace Microsoft.PowerShell
                     _noInteractive = false;
                     ParametersUsed |= ParameterBitmap.Interactive;
                 }
-                else if (MatchSwitch(switchKey, "configurationfile", "configurationfile"))
+                else if (MatchSwitch(switchKey, "configurationfile", "cf"))
                 {
                     ++i;
                     if (i >= args.Length)

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -378,14 +378,6 @@ namespace Microsoft.PowerShell
                 AssertArgumentsParsed();
                 return _configurationFile;
             }
-
-            set
-            {
-                if (!string.IsNullOrEmpty(value))
-                {
-                    _configurationFile = value;
-                }
-            }
         }
 
         internal string? ConfigurationName
@@ -933,7 +925,7 @@ namespace Microsoft.PowerShell
                     _noInteractive = false;
                     ParametersUsed |= ParameterBitmap.Interactive;
                 }
-                else if (MatchSwitch(switchKey, "configurationfile", "configurationFile"))
+                else if (MatchSwitch(switchKey, "configurationfile", "configurationfile"))
                 {
                     ++i;
                     if (i >= args.Length)

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -227,7 +227,7 @@ namespace Microsoft.PowerShell
             Version             = 0x00800000, // -Version | -v
             WindowStyle         = 0x01000000, // -WindowStyle | -w
             WorkingDirectory    = 0x02000000, // -WorkingDirectory | -wd
-            ConfigurationFile   = 0x04000000, // -ConfigurationFile | -cf
+            ConfigurationFile   = 0x04000000, // -ConfigurationFile
             // Enum values for specified ExecutionPolicy
             EPUnrestricted      = 0x0000000100000000, // ExecutionPolicy unrestricted
             EPRemoteSigned      = 0x0000000200000000, // ExecutionPolicy remote signed
@@ -933,7 +933,7 @@ namespace Microsoft.PowerShell
                     _noInteractive = false;
                     ParametersUsed |= ParameterBitmap.Interactive;
                 }
-                else if (MatchSwitch(switchKey, "configurationfile", "cf"))
+                else if (MatchSwitch(switchKey, "configurationfile", "configurationFile"))
                 {
                     ++i;
                     if (i >= args.Length)

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -188,7 +188,6 @@ namespace Microsoft.PowerShell
 #if !UNIX
                 TaskbarJumpList.CreateRunAsAdministratorJumpList();
 #endif
-
                 // First check for and handle PowerShell running in a server mode.
                 if (s_cpp.ServerMode)
                 {
@@ -197,7 +196,9 @@ namespace Microsoft.PowerShell
                     StdIOProcessMediator.Run(
                         initialCommand: s_cpp.InitialCommand,
                         workingDirectory: s_cpp.WorkingDirectory,
-                        configurationName: null);
+                        configurationName: null,
+                        configurationFile: s_cpp.ConfigurationFile,
+                        combineErrOutStream: false);
                     exitCode = 0;
                 }
                 else if (s_cpp.SSHServerMode)
@@ -207,7 +208,9 @@ namespace Microsoft.PowerShell
                     StdIOProcessMediator.Run(
                         initialCommand: s_cpp.InitialCommand,
                         workingDirectory: null,
-                        configurationName: null);
+                        configurationName: null,
+                        configurationFile: s_cpp.ConfigurationFile,
+                        combineErrOutStream: true);
                     exitCode = 0;
                 }
                 else if (s_cpp.NamedPipeServerMode)
@@ -301,8 +304,8 @@ namespace Microsoft.PowerShell
                 PowerShellConfig.Instance.SetSystemConfigFilePath(s_cpp.SettingsFile);
             }
 
-            // Check registry setting for a Group Policy ConfigurationName entry and
-            // use it to override anything set by the user.
+            // Check registry setting for a Group Policy ConfigurationName entry,
+            // and use it to override anything set by the user on the command line.
             // It depends on setting file so 'SetSystemConfigFilePath()' should be called before.
             s_cpp.ConfigurationName = CommandLineParameterParser.GetConfigurationNameFromGroupPolicy();
         }
@@ -1489,7 +1492,7 @@ namespace Microsoft.PowerShell
 
                 // NTRAID#Windows Out Of Band Releases-915506-2005/09/09
                 // Removed HandleUnexpectedExceptions infrastructure
-                exitCode = DoRunspaceLoop(cpp.InitialCommand, cpp.SkipProfiles, cpp.Args, cpp.StaMode, cpp.ConfigurationName);
+                exitCode = DoRunspaceLoop(cpp.InitialCommand, cpp.SkipProfiles, cpp.Args, cpp.StaMode, cpp.ConfigurationName, cpp.ConfigurationFile);
             }
             while (false);
 
@@ -1502,13 +1505,19 @@ namespace Microsoft.PowerShell
         /// <returns>
         /// The process exit code to be returned by Main.
         /// </returns>
-        private uint DoRunspaceLoop(string initialCommand, bool skipProfiles, Collection<CommandParameter> initialCommandArgs, bool staMode, string configurationName)
+        private uint DoRunspaceLoop(
+            string initialCommand,
+            bool skipProfiles,
+            Collection<CommandParameter> initialCommandArgs,
+            bool staMode,
+            string configurationName,
+            string configurationFilePath)
         {
             ExitCode = ExitCodeSuccess;
 
             while (!ShouldEndSession)
             {
-                RunspaceCreationEventArgs args = new RunspaceCreationEventArgs(initialCommand, skipProfiles, staMode, configurationName, initialCommandArgs);
+                RunspaceCreationEventArgs args = new RunspaceCreationEventArgs(initialCommand, skipProfiles, staMode, configurationName, configurationFilePath, initialCommandArgs);
                 CreateRunspace(args);
 
                 if (ExitCode == ExitCodeInitFailure) { break; }
@@ -1584,14 +1593,12 @@ namespace Microsoft.PowerShell
             return e;
         }
 
-        private void CreateRunspace(object runspaceCreationArgs)
+        private void CreateRunspace(RunspaceCreationEventArgs runspaceCreationArgs)
         {
-            RunspaceCreationEventArgs args = null;
             try
             {
-                args = runspaceCreationArgs as RunspaceCreationEventArgs;
-                Dbg.Assert(args != null, "Event Arguments to CreateRunspace should not be null");
-                DoCreateRunspace(args.InitialCommand, args.SkipProfiles, args.StaMode, args.ConfigurationName, args.InitialCommandArgs);
+                Dbg.Assert(runspaceCreationArgs != null, "Arguments to CreateRunspace should not be null.");
+                DoCreateRunspace(runspaceCreationArgs);
             }
             catch (ConsoleHostStartupException startupException)
             {
@@ -1603,7 +1610,7 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// Check if a screen reviewer utility is running.
         /// When a screen reader is running, we don't auto-load the PSReadLine module at startup,
-        /// since PSReadLine is not accessibility-firendly enough as of today.
+        /// since PSReadLine is not accessibility-friendly enough as of today.
         /// </summary>
         private bool IsScreenReaderActive()
         {
@@ -1646,11 +1653,32 @@ namespace Microsoft.PowerShell
         /// Opens and Initializes the Host's sole Runspace.  Processes the startup scripts and runs any command passed on the
         /// command line.
         /// </summary>
-        private void DoCreateRunspace(string initialCommand, bool skipProfiles, bool staMode, string configurationName, Collection<CommandParameter> initialCommandArgs)
+        /// <param name="args">Runspace creation event arguments.</param>
+        private void DoCreateRunspace(RunspaceCreationEventArgs args)
         {
-            Dbg.Assert(_runspaceRef == null, "runspace should be null");
+            Dbg.Assert(_runspaceRef == null, "_runspaceRef field should be null");
             Dbg.Assert(DefaultInitialSessionState != null, "DefaultInitialSessionState should not be null");
             s_runspaceInitTracer.WriteLine("Calling RunspaceFactory.CreateRunspace");
+
+            // Use session configuration file if provided.
+            bool customConfigurationProvided = false;
+            if (!string.IsNullOrEmpty(args.ConfigurationFilePath))
+            {
+                try
+                {
+                    // Replace DefaultInitialSessionState with the initial state configuration defined by the file.
+                    DefaultInitialSessionState = InitialSessionState.CreateFromSessionConfigurationFile(
+                        path: args.ConfigurationFilePath,
+                        roleVerifier: null,
+                        validateFile: true);
+                }
+                catch (Exception ex)
+                {
+                    throw new ConsoleHostStartupException(ConsoleHostStrings.ShellCannotBeStarted, ex);
+                }
+
+                customConfigurationProvided = true;
+            }
 
             try
             {
@@ -1667,7 +1695,7 @@ namespace Microsoft.PowerShell
                 //    powershell -command "Update-Module PSReadline"
                 // This should work just fine as long as no other instances of PowerShell are running.
                 ReadOnlyCollection<ModuleSpecification> defaultImportModulesList = null;
-                if (LoadPSReadline())
+                if (!customConfigurationProvided && LoadPSReadline())
                 {
                     if (IsScreenReaderActive())
                     {
@@ -1682,7 +1710,7 @@ namespace Microsoft.PowerShell
                         consoleRunspace = RunspaceFactory.CreateRunspace(this, DefaultInitialSessionState);
                         try
                         {
-                            OpenConsoleRunspace(consoleRunspace, staMode);
+                            OpenConsoleRunspace(consoleRunspace, args.StaMode);
                         }
                         catch (Exception)
                         {
@@ -1702,7 +1730,7 @@ namespace Microsoft.PowerShell
                     }
 
                     consoleRunspace = RunspaceFactory.CreateRunspace(this, DefaultInitialSessionState);
-                    OpenConsoleRunspace(consoleRunspace, staMode);
+                    OpenConsoleRunspace(consoleRunspace, args.StaMode);
                 }
 
                 Runspace.PrimaryRunspace = consoleRunspace;
@@ -1734,7 +1762,7 @@ namespace Microsoft.PowerShell
             _readyForInputTimeInMS = (DateTime.Now - Process.GetCurrentProcess().StartTime).TotalMilliseconds;
 #endif
 
-            DoRunspaceInitialization(skipProfiles, initialCommand, configurationName, initialCommandArgs);
+            DoRunspaceInitialization(args);
         }
 
         private static void OpenConsoleRunspace(Runspace runspace, bool staMode)
@@ -1751,7 +1779,7 @@ namespace Microsoft.PowerShell
             runspace.Open();
         }
 
-        private void DoRunspaceInitialization(bool skipProfiles, string initialCommand, string configurationName, Collection<CommandParameter> initialCommandArgs)
+        private void DoRunspaceInitialization(RunspaceCreationEventArgs args)
         {
             if (_runspaceRef.Runspace.Debugger != null)
             {
@@ -1786,13 +1814,13 @@ namespace Microsoft.PowerShell
                 }
             }
 
-            if (!string.IsNullOrEmpty(configurationName))
+            if (!string.IsNullOrEmpty(args.ConfigurationName))
             {
                 // If an endpoint configuration is specified then create a loop-back remote runspace targeting
                 // the endpoint and push onto runspace ref stack.  Ignore profile and configuration scripts.
                 try
                 {
-                    RemoteRunspace remoteRunspace = HostUtilities.CreateConfiguredRunspace(configurationName, this);
+                    RemoteRunspace remoteRunspace = HostUtilities.CreateConfiguredRunspace(args.ConfigurationName, this);
                     remoteRunspace.ShouldCloseOnPop = true;
                     PushRunspace(remoteRunspace);
 
@@ -1827,7 +1855,7 @@ namespace Microsoft.PowerShell
                         currentUserProfile,
                         currentUserHostSpecificProfile));
 
-                if (!skipProfiles)
+                if (!args.SkipProfiles)
                 {
                     // Run the profiles.
                     // Profiles are run in the following order:
@@ -1887,11 +1915,11 @@ namespace Microsoft.PowerShell
 
                 tempPipeline.Commands.Add(c);
 
-                if (initialCommandArgs != null)
+                if (args.InitialCommandArgs != null)
                 {
                     // add the args passed to the command.
 
-                    foreach (CommandParameter p in initialCommandArgs)
+                    foreach (CommandParameter p in args.InitialCommandArgs)
                     {
                         c.Parameters.Add(p);
                     }
@@ -1948,19 +1976,19 @@ namespace Microsoft.PowerShell
                     ReportException(e1, exec);
                 }
             }
-            else if (!string.IsNullOrEmpty(initialCommand))
+            else if (!string.IsNullOrEmpty(args.InitialCommand))
             {
                 // Run the command passed on the command line
 
                 s_tracer.WriteLine("running initial command");
 
-                Pipeline tempPipeline = exec.CreatePipeline(initialCommand, true);
+                Pipeline tempPipeline = exec.CreatePipeline(args.InitialCommand, true);
 
-                if (initialCommandArgs != null)
+                if (args.InitialCommandArgs != null)
                 {
                     // add the args passed to the command.
 
-                    foreach (CommandParameter p in initialCommandArgs)
+                    foreach (CommandParameter p in args.InitialCommandArgs)
                     {
                         tempPipeline.Commands[0].Parameters.Add(p);
                     }
@@ -1976,7 +2004,7 @@ namespace Microsoft.PowerShell
                     ParseError[] errors;
 
                     // Detect if they're using input. If so, read from it.
-                    Ast parsedInput = Parser.ParseInput(initialCommand, out tokens, out errors);
+                    Ast parsedInput = Parser.ParseInput(args.InitialCommand, out tokens, out errors);
                     if (AstSearcher.IsUsingDollarInput(parsedInput))
                     {
                         executionOptions |= Executor.ExecutionOptions.ReadInputObjects;
@@ -3021,12 +3049,14 @@ namespace Microsoft.PowerShell
             bool skipProfiles,
             bool staMode,
             string configurationName,
+            string configurationFilePath,
             Collection<CommandParameter> initialCommandArgs)
         {
             InitialCommand = initialCommand;
             SkipProfiles = skipProfiles;
             StaMode = staMode;
             ConfigurationName = configurationName;
+            ConfigurationFilePath = configurationFilePath;
             InitialCommandArgs = initialCommandArgs;
         }
 
@@ -3037,6 +3067,8 @@ namespace Microsoft.PowerShell
         internal bool StaMode { get; set; }
 
         internal string ConfigurationName { get; set; }
+
+        internal string ConfigurationFilePath { get; set; }
 
         internal Collection<CommandParameter> InitialCommandArgs { get; set; }
     }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleShell.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleShell.cs
@@ -21,7 +21,12 @@ namespace Microsoft.PowerShell
         /// <returns>An integer value which should be used as exit code for the process.</returns>
         public static int Start(string? bannerText, string? helpText, string[] args)
         {
-            return Start(InitialSessionState.CreateDefault2(), bannerText, helpText, args);
+            return StartImpl(
+                initialSessionState: InitialSessionState.CreateDefault2(),
+                bannerText,
+                helpText,
+                args,
+                issProvided: false);
         }
 
         /// <summary>Entry point in to ConsoleShell. Used to create a custom Powershell console application.</summary>
@@ -31,6 +36,31 @@ namespace Microsoft.PowerShell
         /// <param name="args">Commandline parameters specified by user.</param>
         /// <returns>An integer value which should be used as exit code for the process.</returns>
         public static int Start(InitialSessionState initialSessionState, string? bannerText, string? helpText, string[] args)
+        {
+            return StartImpl(
+                initialSessionState,
+                bannerText,
+                helpText,
+                args,
+                issProvided: true);
+        }
+
+        /// <summary>
+        /// Implementation of entry point to ConsoleShell.
+        /// Used to create a custom Powershell console application.
+        /// </summary>
+        /// <param name="initialSessionState">InitialSessionState to be used by the ConsoleHost.</param>
+        /// <param name="bannerText">Banner text to be displayed by ConsoleHost.</param>
+        /// <param name="helpText">Help text for the shell.</param>
+        /// <param name="args">Commandline parameters specified by user.</param>
+        /// <param name="issProvided">True when the InitialSessionState object is provided by caller.</param>
+        /// <returns>An integer value which should be used as exit code for the process.</returns>
+        private static int StartImpl(
+            InitialSessionState initialSessionState,
+            string? bannerText,
+            string? helpText,
+            string[] args,
+            bool issProvided)
         {
             if (initialSessionState == null)
             {
@@ -45,7 +75,7 @@ namespace Microsoft.PowerShell
             ConsoleHost.ParseCommandLine(args);
             ConsoleHost.DefaultInitialSessionState = initialSessionState;
 
-            return ConsoleHost.Start(bannerText, helpText);
+            return ConsoleHost.Start(bannerText, helpText, issProvided);
         }
     }
 }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ManagedEntrance.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ManagedEntrance.cs
@@ -96,7 +96,10 @@ namespace Microsoft.PowerShell
 
                 ConsoleHost.DefaultInitialSessionState = InitialSessionState.CreateDefault2();
 
-                exitCode = ConsoleHost.Start(banner, ManagedEntranceStrings.UsageHelp);
+                exitCode = ConsoleHost.Start(
+                    bannerText: banner,
+                    helpText: ManagedEntranceStrings.UsageHelp,
+                    issProvidedExternally: false);
             }
             catch (HostException e)
             {

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/CommandLineParameterParserStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/CommandLineParameterParserStrings.resx
@@ -187,7 +187,10 @@ Valid formats are:
     <value>Cannot process the command because -STA and -MTA are both specified. Specify either -STA or -MTA.</value>
   </data>
   <data name="MissingConfigurationNameArgument" xml:space="preserve">
-    <value>Cannot process the command because -Configuration requires an argument that is a remote endpoint configuration name. Specify this argument and try again.</value>
+    <value>Cannot process the command because -ConfigurationName requires an argument that is a remote endpoint configuration name. Specify this argument and try again.</value>
+  </data>
+  <data name="MissingConfigurationFileArgument" xml:space="preserve">
+    <value>Cannot process the command because -ConfigurationFile requires an argument that is a session configuration (.pssc) file path name. Specify this argument and try again.</value>
   </data>
   <data name="MissingCustomPipeNameArgument" xml:space="preserve">
     <value>Cannot process the command because -CustomPipeName requires an argument that is a name of the pipe you want to use. Specify this argument and try again.</value>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/CommandLineParameterParserStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/CommandLineParameterParserStrings.resx
@@ -190,7 +190,7 @@ Valid formats are:
     <value>Cannot process the command because -ConfigurationName requires an argument that is a remote endpoint configuration name. Specify this argument and try again.</value>
   </data>
   <data name="MissingConfigurationFileArgument" xml:space="preserve">
-    <value>Cannot process the command because -ConfigurationFile requires an argument that is a session configuration (.pssc) file path name. Specify this argument and try again.</value>
+    <value>Cannot process the command because -ConfigurationFile requires an argument that is a session configuration (.pssc) file path. Specify this argument and try again.</value>
   </data>
   <data name="MissingCustomPipeNameArgument" xml:space="preserve">
     <value>Cannot process the command because -CustomPipeName requires an argument that is a name of the pipe you want to use. Specify this argument and try again.</value>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostStrings.resx
@@ -191,4 +191,7 @@ The current session does not support debugging; execution will continue.
   <data name="RunAsAdministrator" xml:space="preserve">
     <value>Run as Administrator</value>
   </data>
+  <data name="InvalidConfigurationParameters" xml:space="preserve"> 
+    <value>The ConfigurationName and ConfigurationFile options cannot be specified at the same time.  Both console options have been selected, either through the command line or policy setting.</value>
+  </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostStrings.resx
@@ -135,6 +135,9 @@
   <data name="ShellCannotBeStarted" xml:space="preserve">
     <value>The shell cannot be started. A failure occurred during initialization:</value>
   </data>
+  <data name="ShellCannotBeStartedWithConfigConflict" xml:space="preserve">
+    <value>The shell cannot be started. An InitialSessionState object has been provided along with a -ConfigurationFile argument. Both configuration directives cannot be used at the same time.</value>
+  </data>
   <data name="UnhandledExceptionShutdownMessage" xml:space="preserve">
     <value>An error has occurred that was not properly handled. Additional information is shown below. The PowerShell process will exit.</value>
   </data>
@@ -190,8 +193,5 @@ The current session does not support debugging; execution will continue.
   </data>
   <data name="RunAsAdministrator" xml:space="preserve">
     <value>Run as Administrator</value>
-  </data>
-  <data name="InvalidConfigurationParameters" xml:space="preserve"> 
-    <value>The ConfigurationName and ConfigurationFile options cannot be specified at the same time. Both console options have been selected, either through the command line or policy setting.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostStrings.resx
@@ -192,6 +192,6 @@ The current session does not support debugging; execution will continue.
     <value>Run as Administrator</value>
   </data>
   <data name="InvalidConfigurationParameters" xml:space="preserve"> 
-    <value>The ConfigurationName and ConfigurationFile options cannot be specified at the same time.  Both console options have been selected, either through the command line or policy setting.</value>
+    <value>The ConfigurationName and ConfigurationFile options cannot be specified at the same time. Both console options have been selected, either through the command line or policy setting.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -288,7 +288,7 @@ All parameters are case-insensitive.</value>
 
     Example: "pwsh -ConfigurationName AdminRoles"
 
--ConfigurationFile | -cf
+-ConfigurationFile
 
     Specifies a session configuration (.pssc) file path.  The configuration
     contained in the configuration file will be applied to the PowerShell

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -290,7 +290,7 @@ All parameters are case-insensitive.</value>
 
 -ConfigurationFile
 
-    Specifies a session configuration (.pssc) file path.  The configuration
+    Specifies a session configuration (.pssc) file path. The configuration
     contained in the configuration file will be applied to the PowerShell
     session.
 

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -288,6 +288,14 @@ All parameters are case-insensitive.</value>
 
     Example: "pwsh -ConfigurationName AdminRoles"
 
+-ConfigurationFile
+
+    Specifies a session configuration (.pssc) file path.  The configuration
+    contained in the configuration file will be applied to the PowerShell
+    session.
+
+    Example: "pwsh -ConfigurationFile "C:\ProgramData\PowerShell\MyConfig.pssc"
+
 -CustomPipeName
 
     Specifies the name to use for an additional IPC server (named pipe) used

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -288,7 +288,7 @@ All parameters are case-insensitive.</value>
 
     Example: "pwsh -ConfigurationName AdminRoles"
 
--ConfigurationFile
+-ConfigurationFile | -cf
 
     Specifies a session configuration (.pssc) file path.  The configuration
     contained in the configuration file will be applied to the PowerShell

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -1362,7 +1362,7 @@ namespace System.Management.Automation.Runspaces
                     StringUtil.Format(ConsoleInfoErrorStrings.ConfigurationFileDoesNotExist, path));
             }
 
-            if (!Path.GetExtension(path).Equals(".pssc", StringComparison.OrdinalIgnoreCase))
+            if (!path.EndsWith(".pssc", StringComparison.OrdinalIgnoreCase))
             {
                 throw new PSInvalidOperationException(
                     StringUtil.Format(ConsoleInfoErrorStrings.NotConfigurationFile, path));

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -1351,6 +1351,23 @@ namespace System.Management.Automation.Runspaces
             Func<string, bool> roleVerifier,
             bool validateFile)
         {
+            if (path is null)
+            {
+                throw new PSArgumentNullException(nameof(path));
+            }
+
+            if (!File.Exists(path))
+            {
+                throw new PSInvalidOperationException(
+                    StringUtil.Format(ConsoleInfoErrorStrings.ConfigurationFileDoesNotExist, path));
+            }
+
+            if (!Path.GetExtension(path).Equals(".pssc", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new PSInvalidOperationException(
+                    StringUtil.Format(ConsoleInfoErrorStrings.NotConfigurationFile, path));
+            }
+
             Remoting.DISCPowerShellConfiguration discConfiguration = new Remoting.DISCPowerShellConfiguration(path, roleVerifier, validateFile);
             return discConfiguration.GetInitialSessionState(null);
         }

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -1312,7 +1312,7 @@ namespace System.Management.Automation.Runspaces
         /// Creates an initial session state from a PSSC configuration file.
         /// </summary>
         /// <param name="path">The path to the PSSC session configuration file.</param>
-        /// <returns></returns>
+        /// <returns>InitialSessionState object.</returns>
         public static InitialSessionState CreateFromSessionConfigurationFile(string path)
         {
             return CreateFromSessionConfigurationFile(path, null);
@@ -1327,10 +1327,31 @@ namespace System.Management.Automation.Runspaces
         /// target session. If you have a WindowsPrincipal for a user, for example, create a Function that
         /// checks windowsPrincipal.IsInRole().
         /// </param>
-        /// <returns></returns>
-        public static InitialSessionState CreateFromSessionConfigurationFile(string path, Func<string, bool> roleVerifier)
+        /// <returns>InitialSessionState object.</returns>
+        public static InitialSessionState CreateFromSessionConfigurationFile(
+            string path,
+            Func<string, bool> roleVerifier)
         {
-            Remoting.DISCPowerShellConfiguration discConfiguration = new Remoting.DISCPowerShellConfiguration(path, roleVerifier);
+            return CreateFromSessionConfigurationFile(path, roleVerifier, validateFile: false);
+        }
+
+        /// <summary>
+        /// Creates an initial session state from a PSSC configuration file.
+        /// </summary>
+        /// <param name="path">The path to the PSSC session configuration file.</param>
+        /// <param name="roleVerifier">
+        /// The verifier that PowerShell should call to determine if groups in the Role entry apply to the
+        /// target session. If you have a WindowsPrincipal for a user, for example, create a Function that
+        /// checks windowsPrincipal.IsInRole().
+        /// </param>
+        /// <param name="validateFile">Validates the file contents for supported SessionState options.</param>
+        /// <returns>InitialSessionState object.</returns>
+        public static InitialSessionState CreateFromSessionConfigurationFile(
+            string path,
+            Func<string, bool> roleVerifier,
+            bool validateFile)
+        {
+            Remoting.DISCPowerShellConfiguration discConfiguration = new Remoting.DISCPowerShellConfiguration(path, roleVerifier, validateFile);
             return discConfiguration.GetInitialSessionState(null);
         }
 
@@ -5241,7 +5262,6 @@ end {
                 { "Enable-PSSessionConfiguration",     new SessionStateCmdletEntry("Enable-PSSessionConfiguration", typeof(EnablePSSessionConfigurationCommand), helpFile) },
                 { "Get-PSSessionCapability",           new SessionStateCmdletEntry("Get-PSSessionCapability", typeof(GetPSSessionCapabilityCommand), helpFile) },
                 { "Get-PSSessionConfiguration",        new SessionStateCmdletEntry("Get-PSSessionConfiguration", typeof(GetPSSessionConfigurationCommand), helpFile) },
-                { "New-PSSessionConfigurationFile",    new SessionStateCmdletEntry("New-PSSessionConfigurationFile", typeof(NewPSSessionConfigurationFileCommand), helpFile) },
                 { "Receive-PSSession",                 new SessionStateCmdletEntry("Receive-PSSession", typeof(ReceivePSSessionCommand), helpFile) },
                 { "Register-PSSessionConfiguration",   new SessionStateCmdletEntry("Register-PSSessionConfiguration", typeof(RegisterPSSessionConfigurationCommand), helpFile) },
                 { "Unregister-PSSessionConfiguration", new SessionStateCmdletEntry("Unregister-PSSessionConfiguration", typeof(UnregisterPSSessionConfigurationCommand), helpFile) },
@@ -5273,6 +5293,7 @@ end {
                 { "New-ModuleManifest",                new SessionStateCmdletEntry("New-ModuleManifest", typeof(NewModuleManifestCommand), helpFile) },
                 { "New-PSRoleCapabilityFile",          new SessionStateCmdletEntry("New-PSRoleCapabilityFile", typeof(NewPSRoleCapabilityFileCommand), helpFile) },
                 { "New-PSSession",                     new SessionStateCmdletEntry("New-PSSession", typeof(NewPSSessionCommand), helpFile) },
+                { "New-PSSessionConfigurationFile",    new SessionStateCmdletEntry("New-PSSessionConfigurationFile", typeof(NewPSSessionConfigurationFileCommand), helpFile) },
                 { "New-PSSessionOption",               new SessionStateCmdletEntry("New-PSSessionOption", typeof(NewPSSessionOptionCommand), helpFile) },
                 { "New-PSTransportOption",             new SessionStateCmdletEntry("New-PSTransportOption", typeof(NewPSTransportOptionCommand), helpFile) },
                 { "Out-Default",                       new SessionStateCmdletEntry("Out-Default", typeof(OutDefaultCommand), helpFile) },

--- a/src/System.Management.Automation/engine/remoting/commands/NewPSSessionConfigurationFile.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/NewPSSessionConfigurationFile.cs
@@ -15,7 +15,6 @@ using System.Text;
 
 namespace Microsoft.PowerShell.Commands
 {
-#if !UNIX
     /// <summary>
     /// New-PSSessionConfigurationFile command implementation
     ///
@@ -1126,7 +1125,6 @@ namespace Microsoft.PowerShell.Commands
 
         #endregion
     }
-#endif
 
     /// <summary>
     /// New-PSRoleCapabilityFile command implementation

--- a/src/System.Management.Automation/engine/remoting/fanin/InitialSessionStateProvider.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/InitialSessionStateProvider.cs
@@ -22,6 +22,8 @@ using Dbg = System.Management.Automation.Diagnostics;
 
 namespace System.Management.Automation.Remoting
 {
+    #region WSMan endpoint configuration
+
     /// <summary>
     /// This struct is used to represent contents from configuration xml. The
     /// XML is passed to plugins by WSMan API.
@@ -56,6 +58,8 @@ namespace System.Management.Automation.Remoting
 
         #endregion
 
+        #region Fields
+
         internal string StartupScript;
         // this field is used only by an Out-Of-Process (IPC) server process
         internal string InitializationScriptForOutOfProcessRunspace;
@@ -70,6 +74,10 @@ namespace System.Management.Automation.Remoting
         internal ApartmentState? ShellThreadApartmentState;
         internal PSSessionConfigurationData SessionConfigurationData;
         internal string ConfigFilePath;
+
+        #endregion
+
+        #region Methods
 
         /// <summary>
         /// Using optionName and optionValue updates the current object.
@@ -324,6 +332,8 @@ namespace System.Management.Automation.Remoting
             throw PSTraceSource.NewArgumentException("typeToLoad", RemotingErrorIdStrings.UnableToLoadType,
                     EndPointConfigurationTypeName, ConfigurationDataFromXML.INITPARAMETERSTOKEN);
         }
+
+        #endregion
     }
 
     /// <summary>
@@ -450,7 +460,8 @@ namespace System.Management.Automation.Remoting
                     ...
                   </InitializationParameters>
          */
-        internal static ConfigurationDataFromXML LoadEndPointConfiguration(string shellId,
+        internal static ConfigurationDataFromXML LoadEndPointConfiguration(
+            string shellId,
             string initializationParameters)
         {
             ConfigurationDataFromXML configData = null;
@@ -798,6 +809,8 @@ namespace System.Management.Automation.Remoting
     /// </summary>
     internal sealed class DefaultRemotePowerShellConfiguration : PSSessionConfiguration
     {
+        #region Method overrides
+
         /// <summary>
         /// </summary>
         /// <param name="senderInfo"></param>
@@ -852,9 +865,15 @@ namespace System.Management.Automation.Remoting
 
             return sessionState;
         }
+
+        #endregion
     }
 
-    #region Declarative Initial Session Configuration
+    #endregion
+
+    #region Declarative InitialSession Configuration
+
+    #region Supporting types
 
     /// <summary>
     /// Specifies type of initial session state to use. Valid values are Empty and Default.
@@ -897,6 +916,10 @@ namespace System.Management.Automation.Remoting
             this.ValidationCallback = callback;
         }
     }
+
+    #endregion
+
+    #region ConfigFileConstants
 
     /// <summary>
     /// Configuration file constants.
@@ -1355,6 +1378,8 @@ namespace System.Management.Automation.Remoting
         }
     }
 
+    #endregion
+
     #region DISC Utilities
 
     /// <summary>
@@ -1681,6 +1706,8 @@ namespace System.Management.Automation.Remoting
 
     #endregion
 
+    #region DISCPowerShellConfiguration
+
     /// <summary>
     /// Creates an initial session state based on the configuration language for PSSC files.
     /// </summary>
@@ -1706,7 +1733,11 @@ namespace System.Management.Automation.Remoting
         /// target session. If you have a WindowsPrincipal for a user, for example, create a Function that
         /// checks windowsPrincipal.IsInRole().
         /// </param>
-        internal DISCPowerShellConfiguration(string configFile, Func<string, bool> roleVerifier)
+        /// <param name="validateFile">Validate file for supported configuration options.</param>
+        internal DISCPowerShellConfiguration(
+            string configFile,
+            Func<string, bool> roleVerifier,
+            bool validateFile = false)
         {
             _configFile = configFile;
             if (roleVerifier == null)
@@ -1726,6 +1757,12 @@ namespace System.Management.Automation.Remoting
                     configFile, out scriptName);
 
                 _configHash = DISCUtils.LoadConfigFile(Runspace.DefaultRunspace.ExecutionContext, script);
+
+                if (validateFile)
+                {
+                    DISCFileValidation.ValidateContents(_configHash);
+                }
+
                 MergeRoleRulesIntoConfigHash(roleVerifier);
                 MergeRoleCapabilitiesIntoConfigHash();
 
@@ -2889,5 +2926,111 @@ namespace System.Management.Automation.Remoting
             return result;
         }
     }
+    #endregion
+
+    #region DISCFileValidation
+
+    internal static class DISCFileValidation
+    {
+        // Set of supported configuration options for a PowerShell InitialSessionState.
+#if UNIX
+        private static readonly HashSet<string> SupportedConfigOptions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "AliasDefinitions",
+            "AssembliesToLoad",
+            "Author",
+            "CompanyName",
+            "Copyright",
+            "Description",
+            "EnvironmentVariables",
+            "FormatsToProcess",
+            "FunctionDefinitions",
+            "GUID",
+            "LanguageMode",
+            "ModulesToImport",
+            "MountUserDrive",
+            "SchemaVersion",
+            "ScriptsToProcess",
+            "SessionType",
+            "TranscriptDirectory",
+            "TypesToProcess",
+            "UserDriveMaximumSize",
+            "VisibleAliases",
+            "VisibleCmdlets",
+            "VariableDefinitions",
+            "VisibleExternalCommands",
+            "VisibleFunctions",
+            "VisibleProviders"
+        };
+#else
+        private static readonly HashSet<string> SupportedConfigOptions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "AliasDefinitions",
+            "AssembliesToLoad",
+            "Author",
+            "CompanyName",
+            "Copyright",
+            "Description",
+            "EnvironmentVariables",
+            "ExecutionPolicy",
+            "FormatsToProcess",
+            "FunctionDefinitions",
+            "GUID",
+            "LanguageMode",
+            "ModulesToImport",
+            "MountUserDrive",
+            "SchemaVersion",
+            "ScriptsToProcess",
+            "SessionType",
+            "TranscriptDirectory",
+            "TypesToProcess",
+            "UserDriveMaximumSize",
+            "VisibleAliases",
+            "VisibleCmdlets",
+            "VariableDefinitions",
+            "VisibleExternalCommands",
+            "VisibleFunctions",
+            "VisibleProviders"
+        };
+#endif
+
+        // These are configuration options for WSMan (WinRM) endpoint configurations, that 
+        // appearand in .pssc files, but are not part of PowerShell InitialSessionState.
+        private static readonly HashSet<string> UnsupportedConfigOptions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "GroupManagedServiceAccount",
+            "PowerShellVersion",
+            "RequiredGroups",
+            "RoleDefinitions",
+            "RunAsVirtualAccount",
+            "RunAsVirtualAccountGroups"
+        };
+
+        internal static void ValidateContents(Hashtable configHash)
+        {
+            foreach (var key in configHash.Keys)
+            {
+                if (key is not string keyName)
+                {
+                    throw new PSInvalidOperationException(RemotingErrorIdStrings.DISCInvalidConfigKeyType);
+                }
+
+                if (UnsupportedConfigOptions.Contains(keyName))
+                {
+                    throw new PSInvalidOperationException(
+                        StringUtil.Format(RemotingErrorIdStrings.DISCUnsupportedConfigName, keyName));
+                }
+
+                if (!SupportedConfigOptions.Contains(keyName))
+                {
+                    throw new PSInvalidOperationException(
+                        StringUtil.Format(RemotingErrorIdStrings.DISCUnknownConfigName, keyName));
+                }
+            }
+        }
+    }
+
+    #endregion
+    
     #endregion
 }

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -1980,10 +1980,10 @@ namespace System.Management.Automation.Remoting.Client
                         break;
                     }
 
-                    if (data.StartsWith(System.Management.Automation.Remoting.Server.NamedPipeErrorTextWriter.ErrorPrefix, StringComparison.OrdinalIgnoreCase))
+                    if (data.StartsWith(System.Management.Automation.Remoting.Server.FormattedErrorTextWriter.ErrorPrefix, StringComparison.OrdinalIgnoreCase))
                     {
                         // Error message from the server.
-                        string errorData = data.Substring(System.Management.Automation.Remoting.Server.NamedPipeErrorTextWriter.ErrorPrefix.Length);
+                        string errorData = data.Substring(System.Management.Automation.Remoting.Server.FormattedErrorTextWriter.ErrorPrefix.Length);
                         HandleErrorDataReceived(errorData);
                     }
                     else
@@ -2592,6 +2592,12 @@ namespace System.Management.Automation.Remoting.Server
             _stdOutWriter = outWriter;
             _stdErrWriter = errWriter;
             _cmdTransportManagers = new Dictionary<Guid, OutOfProcessServerTransportManager>();
+
+            this.WSManTransportErrorOccured += (object sender, TransportErrorOccuredEventArgs e) => 
+            {
+                string msg = e.Exception.TransportMessage ?? e.Exception.InnerException?.Message ?? string.Empty;
+                _stdErrWriter.WriteLine(StringUtil.Format(RemotingErrorIdStrings.RemoteTransportError, msg));
+            };
         }
 
         #endregion

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManPlugin.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManPlugin.cs
@@ -306,10 +306,16 @@ namespace System.Management.Automation.Remoting
                     PSOpcode.Connect, PSTask.None,
                     PSKeyword.ManagedPlugin | PSKeyword.UseAlwaysAnalytic,
                     requestDetails.ToString(), senderInfo.UserInfo.Identity.Name, requestDetails.resourceUri);
-                ServerRemoteSession remoteShellSession = ServerRemoteSession.CreateServerRemoteSession(senderInfo,
-                requestDetails.resourceUri,
-                extraInfo,
-                serverTransportMgr);
+
+                ServerRemoteSession remoteShellSession = ServerRemoteSession.CreateServerRemoteSession(
+                    senderInfo: senderInfo,
+                    configurationProviderId: requestDetails.resourceUri,
+                    initializationParameters: extraInfo,
+                    transportManager: serverTransportMgr,
+                    initialCommand: null,       // Not used by WinRM endpoint.
+                    configurationName: null,    // Not used by WinRM endpoint, which has its own configuration.
+                    configurationFile: null,    // Same.
+                    initialLocation: null);     // Same.
 
                 if (remoteShellSession == null)
                 {

--- a/src/System.Management.Automation/engine/remoting/server/OutOfProcServerMediator.cs
+++ b/src/System.Management.Automation/engine/remoting/server/OutOfProcServerMediator.cs
@@ -300,6 +300,7 @@ namespace System.Management.Automation.Remoting.Server
 
         protected OutOfProcessServerSessionTransportManager CreateSessionTransportManager(
             string configurationName,
+            string configurationFile,
             PSRemotingCryptoHelperServer cryptoHelper,
             string workingDirectory)
         {
@@ -317,14 +318,20 @@ namespace System.Management.Automation.Remoting.Server
             senderInfo = new PSSenderInfo(userPrincipal, "http://localhost");
 #endif
 
-            OutOfProcessServerSessionTransportManager tm = new OutOfProcessServerSessionTransportManager(originalStdOut, originalStdErr, cryptoHelper);
+            var tm = new OutOfProcessServerSessionTransportManager(
+                originalStdOut,
+                originalStdErr,
+                cryptoHelper);
 
             ServerRemoteSession.CreateServerRemoteSession(
-                senderInfo,
-                _initialCommand,
-                tm,
-                configurationName,
-                workingDirectory);
+                senderInfo: senderInfo,
+                configurationProviderId: "Microsoft.PowerShell",
+                initializationParameters: string.Empty,
+                transportManager: tm,
+                initialCommand: _initialCommand,
+                configurationName: configurationName,
+                configurationFile: configurationFile,
+                initialLocation: workingDirectory);
 
             return tm;
         }
@@ -333,11 +340,16 @@ namespace System.Management.Automation.Remoting.Server
             string initialCommand,
             PSRemotingCryptoHelperServer cryptoHelper,
             string workingDirectory,
-            string configurationName)
+            string configurationName,
+            string configurationFile)
         {
             _initialCommand = initialCommand;
 
-            sessionTM = CreateSessionTransportManager(configurationName, cryptoHelper, workingDirectory);
+            sessionTM = CreateSessionTransportManager(
+                configurationName: configurationName,
+                configurationFile: configurationFile,
+                cryptoHelper: cryptoHelper,
+                workingDirectory: workingDirectory);
 
             try
             {
@@ -348,7 +360,11 @@ namespace System.Management.Automation.Remoting.Server
                     {
                         if (sessionTM == null)
                         {
-                            sessionTM = CreateSessionTransportManager(configurationName, cryptoHelper, workingDirectory);
+                            sessionTM = CreateSessionTransportManager(
+                                configurationName: configurationName,
+                                configurationFile: configurationFile,
+                                cryptoHelper: cryptoHelper,
+                                workingDirectory: workingDirectory);
                         }
                     }
 
@@ -432,7 +448,8 @@ namespace System.Management.Automation.Remoting.Server
         /// It will replace StdIn,StdOut and StdErr stream with TextWriter.Null. This is
         /// to make sure these streams are totally used by our Mediator.
         /// </summary>
-        private StdIOProcessMediator() : base(true)
+        /// <param name="combineErrOutStream">Redirects remoting errors to the Out stream.</param>
+        private StdIOProcessMediator(bool combineErrOutStream) : base(exitProcessOnError: true)
         {
             // Create input stream reader from Console standard input stream.
             // We don't use the provided Console.In TextReader because it can have
@@ -441,16 +458,23 @@ namespace System.Management.Automation.Remoting.Server
             // stream encoding.  This way the stream encoding is determined by the
             // stream BOM as needed.
             originalStdIn = new StreamReader(Console.OpenStandardInput(), true);
-            Console.SetIn(TextReader.Null);
 
-            // replacing StdOut with Null so that no other app messes with the
-            // original stream
+            // Remoting errors can optionally be written to stdErr or stdOut with
+            // special formatting.
             originalStdOut = new OutOfProcessTextWriter(Console.Out);
-            Console.SetOut(TextWriter.Null);
+            if (combineErrOutStream)
+            {
+                originalStdErr = new FormattedErrorTextWriter(Console.Out);
+            }
+            else
+            {
+                originalStdErr = new OutOfProcessTextWriter(Console.Error);
+            }
 
-            // replacing StdErr with Null so that no other app messes with the
-            // original stream
-            originalStdErr = new OutOfProcessTextWriter(Console.Error);
+            // Replacing StdIn, StdOut, StdErr with Null so that no other app messes with the
+            // original streams.
+            Console.SetIn(TextReader.Null);
+            Console.SetOut(TextWriter.Null);
             Console.SetError(TextWriter.Null);
         }
 
@@ -464,10 +488,14 @@ namespace System.Management.Automation.Remoting.Server
         /// <param name="initialCommand">Specifies the initialization script.</param>
         /// <param name="workingDirectory">Specifies the initial working directory. The working directory is set before the initial command.</param>
         /// <param name="configurationName">Specifies an optional configuration name that configures the endpoint session.</param>
+        /// <param name="configurationFile">Specifies an optional path to a configuration (.pssc) file for the session.</param>
+        /// <param name="combineErrOutStream">Specifies the option to write remoting errors to stdOut stream, with special formatting.</param>
         internal static void Run(
             string initialCommand,
             string workingDirectory,
-            string configurationName)
+            string configurationName,
+            string configurationFile,
+            bool combineErrOutStream)
         {
             lock (SyncObject)
             {
@@ -477,14 +505,15 @@ namespace System.Management.Automation.Remoting.Server
                     return;
                 }
 
-                s_singletonInstance = new StdIOProcessMediator();
+                s_singletonInstance = new StdIOProcessMediator(combineErrOutStream);
             }
 
             s_singletonInstance.Start(
                 initialCommand: initialCommand,
                 cryptoHelper: new PSRemotingCryptoHelperServer(),
                 workingDirectory: workingDirectory,
-                configurationName: configurationName);
+                configurationName: configurationName,
+                configurationFile: configurationFile);
         }
 
         #endregion
@@ -526,7 +555,7 @@ namespace System.Management.Automation.Remoting.Server
             // Create transport reader/writers from named pipe.
             originalStdIn = namedPipeServer.TextReader;
             originalStdOut = new OutOfProcessTextWriter(namedPipeServer.TextWriter);
-            originalStdErr = new NamedPipeErrorTextWriter(namedPipeServer.TextWriter);
+            originalStdErr = new FormattedErrorTextWriter(namedPipeServer.TextWriter);
 
 #if !UNIX
             // Flow impersonation as needed.
@@ -557,17 +586,18 @@ namespace System.Management.Automation.Remoting.Server
                 initialCommand: initialCommand,
                 cryptoHelper: new PSRemotingCryptoHelperServer(),
                 workingDirectory: null,
-                configurationName: namedPipeServer.ConfigurationName);
+                configurationName: namedPipeServer.ConfigurationName,
+                configurationFile: null);
         }
 
         #endregion
     }
 
-    internal sealed class NamedPipeErrorTextWriter : OutOfProcessTextWriter
+    internal sealed class FormattedErrorTextWriter : OutOfProcessTextWriter
     {
         #region Constructors
 
-        internal NamedPipeErrorTextWriter(
+        internal FormattedErrorTextWriter(
             TextWriter textWriter) : base(textWriter)
         { }
 
@@ -575,6 +605,8 @@ namespace System.Management.Automation.Remoting.Server
 
         #region Base class overrides
 
+        // Write error data to stream with 'ErrorPrefix' prefix that will
+        // be interpreted by the client.
         public override void WriteLine(string data)
         {
             string dataToWrite = (data != null) ? ErrorPrefix + data : null;
@@ -632,7 +664,8 @@ namespace System.Management.Automation.Remoting.Server
                 initialCommand: initialCommand,
                 cryptoHelper: new PSRemotingCryptoHelperServer(),
                 workingDirectory: null,
-                configurationName: configurationName);
+                configurationName: configurationName,
+                configurationFile: null);
         }
 
         #endregion

--- a/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
+++ b/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
@@ -89,6 +89,10 @@ namespace System.Management.Automation.Remoting
         // Creates a pushed remote runspace session created with this configuration name.
         private string _configurationName;
 
+        // Specifies an optional .pssc configuration file path for out-of-proc session use.
+        // The .pssc file is used to configure the runspace for the endpoint session.
+        private string _configurationFile;
+
         // Specifies an initial location of the powershell session.
         private string _initialLocation;
 
@@ -173,7 +177,9 @@ namespace System.Management.Automation.Remoting
         /// xml.
         /// </param>
         /// <param name="transportManager"></param>
+        /// <param name="initialCommand">Optional initial command used for OutOfProc sessions.</param>
         /// <param name="configurationName">Optional configuration endpoint name for OutOfProc sessions.</param>
+        /// <param name="configurationFile">Optional configuration file (.pssc) path for OutOfProc sessions.</param>
         /// <param name="initialLocation">Optional configuration initial location of the powershell session.</param>
         /// <returns></returns>
         /// <exception cref="InvalidOperationException">
@@ -192,8 +198,10 @@ namespace System.Management.Automation.Remoting
             string configurationProviderId,
             string initializationParameters,
             AbstractServerSessionTransportManager transportManager,
-            string configurationName = null,
-            string initialLocation = null)
+            string initialCommand,
+            string configurationName,
+            string configurationFile,
+            string initialLocation)
         {
             Dbg.Assert(
                 (senderInfo != null) && (senderInfo.UserInfo != null),
@@ -215,7 +223,9 @@ namespace System.Management.Automation.Remoting
                 initializationParameters,
                 transportManager)
             {
+                _initScriptForOutOfProcRS = initialCommand,
                 _configurationName = configurationName,
+                _configurationFile = configurationFile,
                 _initialLocation = initialLocation
             };
 
@@ -223,33 +233,6 @@ namespace System.Management.Automation.Remoting
             RemoteSessionStateMachineEventArgs startEventArg = new RemoteSessionStateMachineEventArgs(RemoteSessionEvent.CreateSession);
             result.SessionDataStructureHandler.StateMachine.RaiseEvent(startEventArg);
 
-            return result;
-        }
-
-        /// <summary>
-        /// Used by OutOfProcessServerMediator to create a remote session.
-        /// </summary>
-        /// <param name="senderInfo"></param>
-        /// <param name="initializationScriptForOutOfProcessRunspace"></param>
-        /// <param name="transportManager"></param>
-        /// <param name="configurationName"></param>
-        /// <param name="initialLocation"></param>
-        /// <returns></returns>
-        internal static ServerRemoteSession CreateServerRemoteSession(
-            PSSenderInfo senderInfo,
-            string initializationScriptForOutOfProcessRunspace,
-            AbstractServerSessionTransportManager transportManager,
-            string configurationName,
-            string initialLocation)
-        {
-            ServerRemoteSession result = CreateServerRemoteSession(
-                senderInfo,
-                "Microsoft.PowerShell",
-                string.Empty,
-                transportManager,
-                configurationName: configurationName,
-                initialLocation: initialLocation);
-            result._initScriptForOutOfProcRS = initializationScriptForOutOfProcessRunspace;
             return result;
         }
 
@@ -754,16 +737,13 @@ namespace System.Management.Automation.Remoting
             // Get Initial Session State from custom session config suppliers
             // like Exchange.
             ConfigurationDataFromXML configurationData =
-                PSSessionConfiguration.LoadEndPointConfiguration(_configProviderId,
-                    _initParameters);
+                PSSessionConfiguration.LoadEndPointConfiguration(_configProviderId, _initParameters);
             // used by Out-Of-Proc (IPC) runspace.
             configurationData.InitializationScriptForOutOfProcessRunspace = _initScriptForOutOfProcRS;
             // start with data from configuration XML and then override with data
             // from EndPointConfiguration type.
             _maxRecvdObjectSize = configurationData.MaxReceivedObjectSizeMB;
             _maxRecvdDataSizeCommand = configurationData.MaxReceivedCommandSizeMB;
-
-            DISCPowerShellConfiguration discProvider = null;
 
             if (string.IsNullOrEmpty(configurationData.ConfigFilePath))
             {
@@ -772,11 +752,8 @@ namespace System.Management.Automation.Remoting
             else
             {
                 System.Security.Principal.WindowsPrincipal windowsPrincipal = new System.Security.Principal.WindowsPrincipal(_senderInfo.UserInfo.WindowsIdentity);
-
                 Func<string, bool> validator = (role) => windowsPrincipal.IsInRole(role);
-
-                discProvider = new DISCPowerShellConfiguration(configurationData.ConfigFilePath, validator);
-                _sessionConfigProvider = discProvider;
+                _sessionConfigProvider = new DISCPowerShellConfiguration(configurationData.ConfigFilePath, validator);
             }
 
             // exchange of ApplicationArguments and ApplicationPrivateData is be done as early as possible
@@ -787,6 +764,7 @@ namespace System.Management.Automation.Remoting
 
             if (configurationData.SessionConfigurationData != null)
             {
+                // Use the provided WinRM endpoint runspace configuration information.
                 try
                 {
                     rsSessionStateToUse =
@@ -797,8 +775,21 @@ namespace System.Management.Automation.Remoting
                     rsSessionStateToUse = _sessionConfigProvider.GetInitialSessionState(_senderInfo);
                 }
             }
+            else if (!string.IsNullOrEmpty(_configurationFile))
+            {
+                // Use the optional _configurationFile parameter to create the endpoint runspace configuration.
+                // This parameter is only used by Out-Of-Proc transports (not WinRM transports).
+                var discConfiguration = new Remoting.DISCPowerShellConfiguration(
+                    configFile: _configurationFile,
+                    roleVerifier: null, 
+                    validateFile: true);
+                rsSessionStateToUse = discConfiguration.GetInitialSessionState(_senderInfo);
+            }
             else
             {
+                // Create a runspace configuration based on the provided PSSessionConfiguration provider.
+                // This can be either a 'default' configuration, or third party configuration PSSessionConfiguration provider object.
+                // So far, only Exchange provides a custom PSSessionConfiguration provider implementation.
                 rsSessionStateToUse = _sessionConfigProvider.GetInitialSessionState(_senderInfo);
             }
 

--- a/src/System.Management.Automation/resources/ConsoleInfoErrorStrings.resx
+++ b/src/System.Management.Automation/resources/ConsoleInfoErrorStrings.resx
@@ -234,4 +234,10 @@
   <data name="ExportConsoleCannotDeleteFile" xml:space="preserve">
     <value>The Save operation failed. Cannot remove the file {0}.</value>
   </data>
+  <data name="ConfigurationFileDoesNotExist" xml:space="preserve">
+    <value>The provided configuration file '{0}' does not exist.</value>
+  </data>
+  <data name="NotConfigurationFile" xml:space="preserve">
+    <value>The provided configuration file '{0}' must have a .pssc file extension.</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
+++ b/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
@@ -1705,4 +1705,13 @@ SSH client process terminated before connection could be established.</value>
   <data name="InvalidPSSessionArgument" xml:space="preserve">
     <value>The Runspace argument to Create must be a non-null RemoteRunspace object.</value>
   </data>
+  <data name="DISCInvalidConfigKeyType" xml:space="preserve">
+    <value>The session configuration hash table contains an invalid key type. Keys should be string types.</value>
+  </data>
+  <data name="DISCUnsupportedConfigName" xml:space="preserve">
+    <value>The session configuration file contains an unsupported configuration option: {0}. This is a remoting endpoint configuration option, that does not apply to PowerShell session state.</value>
+  </data>
+  <data name="DISCUnknownConfigName" xml:space="preserve">
+    <value>The session configuration file contains an unknown configuration option: {0}.</value>
+  </data>
 </root>

--- a/test/hosting/test_HostingBasic.cs
+++ b/test/hosting/test_HostingBasic.cs
@@ -183,6 +183,30 @@ namespace PowerShell.Hosting.SDK.Tests
             Assert.Equal(42, ret);
         }
 
+        /// <summary>
+        /// ConsoleShell cannot start with both InitialSessionState and -ConfigurationFile argument configurations specified.
+        /// </summary>
+        [Fact]
+        public static void TestConsoleShellConfigConflictError()
+        {
+            var iss = System.Management.Automation.Runspaces.InitialSessionState.CreateDefault2();
+            Exception ex = null;
+            try
+            {
+                ConsoleShell.Start(iss, "BannerText", string.Empty, new string[] { "-ConfigurationFile noneSuch" });
+            }
+            catch (Exception e)
+            {
+                ex = e;
+            }
+
+            Assert.True(ex != null);
+            if (ex != null)
+            {
+                Assert.Equal(ex.GetType().FullName, "Microsoft.PowerShell.ConsoleHost.ConsoleHostStartupException");
+            }
+        }
+
         [Fact]
         public static void TestBuiltInModules()
         {

--- a/test/hosting/test_HostingBasic.cs
+++ b/test/hosting/test_HostingBasic.cs
@@ -183,6 +183,7 @@ namespace PowerShell.Hosting.SDK.Tests
             Assert.Equal(42, ret);
         }
 
+        /* Test disabled because CommandLineParser is static and can only be intialized once (above in TestConsoleShellScenario)
         /// <summary>
         /// ConsoleShell cannot start with both InitialSessionState and -ConfigurationFile argument configurations specified.
         /// </summary>
@@ -190,22 +191,10 @@ namespace PowerShell.Hosting.SDK.Tests
         public static void TestConsoleShellConfigConflictError()
         {
             var iss = System.Management.Automation.Runspaces.InitialSessionState.CreateDefault2();
-            Exception ex = null;
-            try
-            {
-                ConsoleShell.Start(iss, "BannerText", string.Empty, new string[] { "-ConfigurationFile noneSuch" });
-            }
-            catch (Exception e)
-            {
-                ex = e;
-            }
-
-            Assert.True(ex != null);
-            if (ex != null)
-            {
-                Assert.Equal(ex.GetType().FullName, "Microsoft.PowerShell.ConsoleHost.ConsoleHostStartupException");
-            }
+            int ret = ConsoleShell.Start(iss, "BannerText", string.Empty, new string[] { @"-ConfigurationFile ""noneSuch""" });
+            Assert.Equal(70, ret);  // ExitCodeInitFailure.
         }
+        */
 
         [Fact]
         public static void TestBuiltInModules()

--- a/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
+++ b/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
@@ -375,7 +375,7 @@ Describe "Verify approved aliases list" -Tags "CI" {
 "Cmdlet",       "New-PSDrive",                      "",                                 $($FullCLR -or $CoreWindows -or $CoreUnix),     "",                     "",                     "Low"
 "Cmdlet",       "New-PSRoleCapabilityFile",         "",                                 $(             $CoreWindows -or $CoreUnix),     "",                     "",                     "None"
 "Cmdlet",       "New-PSSession",                    "",                                 $($FullCLR -or $CoreWindows -or $CoreUnix),     "",                     "",                     "None"
-"Cmdlet",       "New-PSSessionConfigurationFile",   "",                                 $($FullCLR -or $CoreWindows              ),     "",                     "",                     "None"
+"Cmdlet",       "New-PSSessionConfigurationFile",   "",                                 $($FullCLR -or $CoreWindows -or $CoreUnix),     "",                     "",                     "None"
 "Cmdlet",       "New-PSSessionOption",              "",                                 $($FullCLR -or $CoreWindows -or $CoreUnix),     "",                     "",                     "None"
 "Cmdlet",       "New-PSTransportOption",            "",                                 $($FullCLR -or $CoreWindows -or $CoreUnix),     "",                     "",                     "None"
 "Cmdlet",       "New-Service",                      "",                                 $($FullCLR -or $CoreWindows              ),     "",                     "",                     "Medium"

--- a/test/xUnit/csharp/test_CommandLineParser.cs
+++ b/test/xUnit/csharp/test_CommandLineParser.cs
@@ -24,6 +24,7 @@ namespace PSTests.Parallel
             Assert.False(cpp.AbortStartup);
             Assert.Empty(cpp.Args);
             Assert.Null(cpp.ConfigurationName);
+            Assert.Null(cpp.ConfigurationFile);
             Assert.Null(cpp.CustomPipeName);
             Assert.Null(cpp.ErrorMessage);
             Assert.Null(cpp.ExecutionPolicy);
@@ -434,6 +435,38 @@ namespace PSTests.Parallel
             Assert.False(cpp.ShowShortHelp);
             Assert.True(cpp.ShowBanner);
             Assert.Equal("qwerty", cpp.ConfigurationName);
+            Assert.Null(cpp.ErrorMessage);
+        }
+
+        [Theory]
+        [InlineData("-configurationfile")]
+        public static void TestParameter_ConfigurationFile_No_Name(params string[] commandLine)
+        {
+            var cpp = new CommandLineParameterParser();
+
+            cpp.Parse(commandLine);
+
+            Assert.True(cpp.AbortStartup);
+            Assert.True(cpp.NoExit);
+            Assert.False(cpp.ShowShortHelp);
+            Assert.False(cpp.ShowBanner);
+            Assert.Equal((uint)ConsoleHost.ExitCodeBadCommandLineParameter, cpp.ExitCode);
+            Assert.Equal(CommandLineParameterParserStrings.MissingConfigurationFileArgument, cpp.ErrorMessage);
+        }
+
+        [Theory]
+        [InlineData("-configurationfile", "qwerty")]
+        public static void TestParameter_ConfigurationFile_With_Name(params string[] commandLine)
+        {
+            var cpp = new CommandLineParameterParser();
+
+            cpp.Parse(commandLine);
+
+            Assert.False(cpp.AbortStartup);
+            Assert.True(cpp.NoExit);
+            Assert.False(cpp.ShowShortHelp);
+            Assert.True(cpp.ShowBanner);
+            Assert.Equal("qwerty", cpp.ConfigurationFile);
             Assert.Null(cpp.ErrorMessage);
         }
 

--- a/test/xUnit/csharp/test_CommandLineParser.cs
+++ b/test/xUnit/csharp/test_CommandLineParser.cs
@@ -440,6 +440,7 @@ namespace PSTests.Parallel
 
         [Theory]
         [InlineData("-configurationfile")]
+        [InlineData("-cf")]
         public static void TestParameter_ConfigurationFile_No_Name(params string[] commandLine)
         {
             var cpp = new CommandLineParameterParser();
@@ -456,6 +457,7 @@ namespace PSTests.Parallel
 
         [Theory]
         [InlineData("-configurationfile", "qwerty")]
+        [InlineData("-cf", "qwerty")]
         public static void TestParameter_ConfigurationFile_With_Name(params string[] commandLine)
         {
             var cpp = new CommandLineParameterParser();

--- a/test/xUnit/csharp/test_CommandLineParser.cs
+++ b/test/xUnit/csharp/test_CommandLineParser.cs
@@ -440,7 +440,6 @@ namespace PSTests.Parallel
 
         [Theory]
         [InlineData("-configurationfile")]
-        [InlineData("-cf")]
         public static void TestParameter_ConfigurationFile_No_Name(params string[] commandLine)
         {
             var cpp = new CommandLineParameterParser();
@@ -457,7 +456,6 @@ namespace PSTests.Parallel
 
         [Theory]
         [InlineData("-configurationfile", "qwerty")]
-        [InlineData("-cf", "qwerty")]
         public static void TestParameter_ConfigurationFile_With_Name(params string[] commandLine)
         {
             var cpp = new CommandLineParameterParser();


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR adds a new -ConfigurationFile command line parameter to pwsh.exe, that takes a path to a .pssc configuration file.
This is an implementation of [RFC](https://github.com/PowerShell/PowerShell-RFC/pull/320).

## PR Context

This new command line parameter will allow PowerShell interactive or server mode sessions to run in a session configured by the provided .pssc file.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
