### PR TITLE
Make `Out-String` and `Out-File` keep string input unchanged

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -552,7 +552,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 }
                 else
                 {
-                    _lo.WriteLine(rte.text);
+                    // Write out raw text without any changes to it.
+                    _lo.WriteRawText(rte.text);
                 }
 
                 return;

--- a/src/System.Management.Automation/FormatAndOutput/common/ILineOutput.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ILineOutput.cs
@@ -250,6 +250,13 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// </param>
         internal abstract void WriteLine(string s);
 
+        /// <summary>
+        /// Write a line of string as raw text to the output device, with no change to the string.
+        /// For example, keeping VT escape sequences intact in it.
+        /// </summary>
+        /// <param name="s">The raw text to be written to the device.</param>
+        internal virtual void WriteRawText(string s) => WriteLine(s);
+
         internal WriteStreamType WriteStream
         {
             get;
@@ -431,7 +438,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     /// Implementation of the ILineOutput interface accepting an instance of a
     /// TextWriter abstract class.
     /// </summary>
-    internal class TextWriterLineOutput : LineOutput
+    internal sealed class TextWriterLineOutput : LineOutput
     {
         #region ILineOutput methods
 
@@ -467,9 +474,17 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <param name="s"></param>
         internal override void WriteLine(string s)
         {
-            CheckStopProcessing();
+            WriteRawText(PSHostUserInterface.GetOutputString(s, isHost: false));
+        }
 
-            s = PSHostUserInterface.GetOutputString(s, isHost: false);
+        /// <summary>
+        /// Write a raw text by delegating to the writer underneath, with no change to the text.
+        /// For example, keeping VT escape sequences intact in it.
+        /// </summary>
+        /// <param name="s">The raw text to be written to the device.</param>
+        internal override void WriteRawText(string s)
+        {
+            CheckStopProcessing();
 
             if (_suppressNewline)
             {
@@ -480,6 +495,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 _writer.WriteLine(s);
             }
         }
+
         #endregion
 
         /// <summary>

--- a/test/powershell/engine/Formatting/ErrorView.Tests.ps1
+++ b/test/powershell/engine/Formatting/ErrorView.Tests.ps1
@@ -115,7 +115,8 @@ Describe 'Tests for $ErrorView' -Tag CI {
 
         It "Error shows for advanced function" {
             # need to have it virtually interactive so that InvocationInfo.MyCommand is empty
-            $e = '[cmdletbinding()]param()$pscmdlet.writeerror([System.Management.Automation.ErrorRecord]::new(([System.NotImplementedException]::new("myTest")),"stub","notimplemented","command"))' | pwsh -noprofile -file - 2>&1 | Out-String
+            $e = '[cmdletbinding()]param()$pscmdlet.writeerror([System.Management.Automation.ErrorRecord]::new(([System.NotImplementedException]::new("myTest")),"stub","notimplemented","command"))' | pwsh -noprofile -file - 2>&1
+            $e = $e | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] } | Out-String
             $e | Should -Not -BeNullOrEmpty
 
             # need to see if ANSI escape sequences are in the output as ANSI is disabled for CI

--- a/test/powershell/engine/Formatting/OutputRendering.Tests.ps1
+++ b/test/powershell/engine/Formatting/OutputRendering.Tests.ps1
@@ -39,7 +39,7 @@ Describe 'OutputRendering tests' {
         param($outputRendering, $ansi)
 
         $PSStyle.OutputRendering = $outputRendering
-        $out = "$($PSStyle.Foreground.Green)hello" | Out-String
+        $out = [pscustomobject] @{ key = "$($PSStyle.Foreground.Green)hello" } | Out-String
 
         if ($ansi) {
             $out | Should -BeLike "*`e*" -Because ($out | Format-Hex | Out-String)

--- a/test/powershell/engine/Formatting/PSStyle.Tests.ps1
+++ b/test/powershell/engine/Formatting/PSStyle.Tests.ps1
@@ -335,6 +335,31 @@ Describe 'Tests for $PSStyle automatic variable' {
             $PSStyle.OutputRendering = $oldRender
         }
     }
+
+    It "Comment based help works with `$PSStyle" {
+        $oldRender = $PSStyle.OutputRendering
+
+        function Test-PSStyle {
+            <#
+            .Description
+            Get-Function [31mdisplays[0m the name and syntax of all functions in the session.
+            #>
+        }
+
+        try {
+            $PSStyle.OutputRendering = 'Ansi'
+            (Get-Help Test-PSStyle | Out-String).Contains("`e[31mdisplays`e[0m") | Should -BeTrue
+
+            $PSStyle.OutputRendering = 'Host'
+            (Get-Help Test-PSStyle | Out-String).Contains("`e[31mdisplays`e[0m") | Should -BeFalse
+
+            $PSStyle.OutputRendering = 'PlainText'
+            (Get-Help Test-PSStyle | Out-String).Contains("`e[31mdisplays`e[0m") | Should -BeFalse
+        }
+        finally {
+            $PSStyle.OutputRendering = $oldRender
+        }
+    }
 }
 
 Describe 'Handle strings with escape sequences in formatting' {

--- a/test/powershell/engine/Formatting/PSStyle.Tests.ps1
+++ b/test/powershell/engine/Formatting/PSStyle.Tests.ps1
@@ -287,24 +287,21 @@ Describe 'Tests for $PSStyle automatic variable' {
         $strDec.ToString("PlainText") | Should -Be $word
     }
 
-    It "String intput to Out-String should be intact" {
+    It "String intput to Out-String should be intact with OutputRendering='<OutputRendering>'" -TestCases @(
+        @{ OutputRendering = 'Ansi'; ContainsAnsi = $true }
+        @{ OutputRendering = 'Host'; ContainsAnsi = $false }
+        @{ OutputRendering = 'PlainText'; ContainsAnsi = $false }
+    ) {
+        param($OutputRendering, $ContainsAnsi)
+
         $oldRender = $PSStyle.OutputRendering
         $testStr = "`e[31mABC`e[0m"
 
         try {
-            $PSStyle.OutputRendering = 'Ansi'
-            (Get-Verb -Verb Get | Out-String).Contains("`e[") | Should -BeTrue 
-            ($testStr | Out-String).Trim() | Should -BeExactly $testStr
-
-            $PSStyle.OutputRendering = 'Host'
-            ## For input that actually goes through formatting, Out-String should remove VT sequences from the formatting output.
-            (Get-Verb -Verb Get | Out-String).Contains("`e[") | Should -BeFalse
-            ## For string input, since no formatting is applied, Out-String should keep the string intact.
-            ($testStr | Out-String).Trim() | Should -BeExactly $testStr
-
-            $PSStyle.OutputRendering = 'PlainText'
-            ## For input that actually goes through formatting, Out-String should remove VT sequences from the formatting output.
-            (Get-Verb -Verb Get | Out-String).Contains("`e[") | Should -BeFalse
+            $PSStyle.OutputRendering = $OutputRendering
+            ## For input that actually goes through formatting, Out-String should remove VT sequences
+            ## from the formatting output based on the output rendering option that is in effect.
+            (Get-Verb -Verb Get | Out-String).Contains("`e[") | Should -Be $ContainsAnsi
             ## For string input, since no formatting is applied, Out-String should keep the string intact.
             ($testStr | Out-String).Trim() | Should -BeExactly $testStr
         }
@@ -313,30 +310,36 @@ Describe 'Tests for $PSStyle automatic variable' {
         }
     }
 
-    It "String input to Out-File should be intact" {
+    It "String input to Out-File should be intact with OutputRendering='<OutputRendering>'" -TestCases @(
+        @{ OutputRendering = 'Ansi'; }
+        @{ OutputRendering = 'Host'; }
+        @{ OutputRendering = 'PlainText'; }
+    ) {
+        param($OutputRendering)
+
         $oldRender = $PSStyle.OutputRendering
         $content = "Read-Host -Prompt '`e[33mEnter your device code`e[0m'"
         Set-Content -Path $TestDrive\test.ps1 -Value $content -Encoding utf8NoBOM
 
         try {
-            $PSStyle.OutputRendering = 'Ansi'
-            Get-Content $TestDrive\test.ps1 > $TestDrive\copy1.ps1
-            (Get-Content $TestDrive\copy1.ps1 -Raw).Trim() | Should -BeExactly $content
-
-            $PSStyle.OutputRendering = 'Host'
-            Get-Content $TestDrive\test.ps1 > $TestDrive\copy2.ps1
-            (Get-Content $TestDrive\copy2.ps1 -Raw).Trim() | Should -BeExactly $content
-
-            $PSStyle.OutputRendering = 'PlainText'
-            Get-Content $TestDrive\test.ps1 > $TestDrive\copy3.ps1
-            (Get-Content $TestDrive\copy3.ps1 -Raw).Trim() | Should -BeExactly $content
+            $PSStyle.OutputRendering = $OutputRendering
+            Get-Content $TestDrive\test.ps1 > $TestDrive\copy.ps1
+            (Get-Content $TestDrive\copy.ps1 -Raw).Trim() | Should -BeExactly $content
         }
         finally {
             $PSStyle.OutputRendering = $oldRender
+            Remove-Item $TestDrive\test.ps1 -Force
+            Remove-Item $TestDrive\copy.ps1 -Force
         }
     }
 
-    It "Comment based help works with `$PSStyle" {
+    It "Comment based help works with `$PSStyle when OutputRendering='<OutputRendering>'" -TestCases @(
+        @{ OutputRendering = 'Ansi'; ContainsAnsi = $true }
+        @{ OutputRendering = 'Host'; ContainsAnsi = $false }
+        @{ OutputRendering = 'PlainText'; ContainsAnsi = $false }
+    ) {
+        param($OutputRendering, $ContainsAnsi)
+
         $oldRender = $PSStyle.OutputRendering
 
         function Test-PSStyle {
@@ -347,14 +350,8 @@ Describe 'Tests for $PSStyle automatic variable' {
         }
 
         try {
-            $PSStyle.OutputRendering = 'Ansi'
-            (Get-Help Test-PSStyle | Out-String).Contains("`e[31mdisplays`e[0m") | Should -BeTrue
-
-            $PSStyle.OutputRendering = 'Host'
-            (Get-Help Test-PSStyle | Out-String).Contains("`e[31mdisplays`e[0m") | Should -BeFalse
-
-            $PSStyle.OutputRendering = 'PlainText'
-            (Get-Help Test-PSStyle | Out-String).Contains("`e[31mdisplays`e[0m") | Should -BeFalse
+            $PSStyle.OutputRendering = $OutputRendering
+            (Get-Help Test-PSStyle | Out-String).Contains("`e[31mdisplays`e[0m") | Should -Be $ContainsAnsi
         }
         finally {
             $PSStyle.OutputRendering = $oldRender


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #17452

The changes in this PR update the behavior of `Out-File` and `Out-String` regarding the `RenderingOutput` setting to be the following:
- when the input object is pure string, these 2 cmdlets keep the string input unchanged regardless of the `RenderingOutput` setting
- when the input object needs to have formatting views applied to it, these 2 cmdlets remove escape sequences from the formatting output strings based on the `RenderingOutput` setting.

This change is a breaking change to these 2 cmdlets' existing behavior regarding `RenderingOutput`.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/8892
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
