### PR TITLE
Implemented ScriptBlock support for ValidateSet

### DIFF
--- a/src/System.Management.Automation/engine/Attributes.cs
+++ b/src/System.Management.Automation/engine/Attributes.cs
@@ -1595,7 +1595,6 @@ namespace System.Management.Automation
         // Cached valid values.
         private string[] _validValues;
         private readonly int _validValuesCacheExpiration;
-        
         /// <summary>
         /// Initializes a new instance of the <see cref="CachedValidValuesGeneratorBase"/> class.
         /// </summary>

--- a/src/System.Management.Automation/engine/Attributes.cs
+++ b/src/System.Management.Automation/engine/Attributes.cs
@@ -1690,6 +1690,7 @@ namespace System.Management.Automation
                 {
                     return _validValues;
                 }
+
                 if (validValuesScript is not null)
                 {
                     var validValuesFromScript = new List<string>();

--- a/src/System.Management.Automation/engine/Attributes.cs
+++ b/src/System.Management.Automation/engine/Attributes.cs
@@ -1655,7 +1655,7 @@ namespace System.Management.Automation
         // of 'validValuesGenerator'.
         private readonly string[] _validValues;
         private readonly IValidateSetValuesGenerator validValuesGenerator = null;
-        private readonly ScriptBlock validValuesScript = null;
+        private readonly ScriptBlock validValuesScript;
         // The valid values generator cache works across 'ValidateSetAttribute' instances.
         private static readonly ConcurrentDictionary<Type, IValidateSetValuesGenerator> s_ValidValuesGeneratorCache =
             new ConcurrentDictionary<Type, IValidateSetValuesGenerator>();

--- a/src/System.Management.Automation/engine/Attributes.cs
+++ b/src/System.Management.Automation/engine/Attributes.cs
@@ -1701,7 +1701,7 @@ namespace System.Management.Automation
 
                     foreach (var customResult in customResults)
                     {
-                        var resultAsString = customResult.BaseObject as string;
+                        var resultAsString = LanguagePrimitives.ConvertTo<string>(customResult);
                         if (resultAsString != null)
                         {
                             validValuesFromScript.Add(resultAsString);

--- a/src/System.Management.Automation/engine/Attributes.cs
+++ b/src/System.Management.Automation/engine/Attributes.cs
@@ -1708,11 +1708,14 @@ namespace System.Management.Automation
                             validValuesFromScript.Add(resultAsString);
                             continue;
                         }
+
                         var resultToString = customResult.ToString();
                         validValuesFromScript.Add(resultToString);
                     }
+
                     return validValuesFromScript;
                 }
+
                 var validValuesLocal = validValuesGenerator.GetValidValues();
 
                 if (validValuesLocal == null)

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -1645,6 +1645,10 @@ namespace System.Management.Automation.Language
                         typeof(System.Management.Automation.IValidateSetValuesGenerator).FullName);
                 }
             }
+            else if (ast.PositionalArguments.Count == 1 && ast.PositionalArguments[0] is ScriptBlockExpressionAst scriptBlockAst)
+            {
+                result = new ValidateSetAttribute(scriptBlockAst.ScriptBlock.GetScriptBlock());
+            }
             else
             {
                 // 'ValidateSet("value1","value2", IgnoreCase=$false)' is supported in scripts.

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1096,6 +1096,15 @@ switch ($x)
             $res.CompletionMatches[1].CompletionText | Should -BeExactly 'dog'
         }
 
+        It "Tab completion for validateSet attribute with ScriptBlock" {
+            function foo { param([ValidateSet({'cat','dog'})]$p) }
+            $inputStr = "foo "
+            $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
+            $res.CompletionMatches | Should -HaveCount 2
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly 'cat'
+            $res.CompletionMatches[1].CompletionText | Should -BeExactly 'dog'
+        }
+
         It "Tab completion for validateSet attribute takes precedence over enums" {
             function foo { param([ValidateSet('DarkBlue','DarkCyan')][ConsoleColor]$p) }
             $inputStr = "foo "


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Implements #8651

Adds constructor to ValidateSetAttribute that accepts a ScriptBlock. 

Adds logic that evaluates the ScriptBlock when ValidValues is accessed

Adds logic to Compiler.cs that detects the presence of a ScriptBlock and uses the new constructor

Adds test to TabCompletion.Tests.ps1 to verify functionality

## PR Context

I would like to be able to have dynamic parameter values self-contained in a function definition.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
