### PR TITLE
Completion null-annotation

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CommandCompletion.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CommandCompletion.cs
@@ -14,6 +14,8 @@ using System.Text.RegularExpressions;
 using Microsoft.PowerShell.Telemetry.Internal;
 #endif
 
+#nullable enable
+
 namespace System.Management.Automation
 {
     /// <summary>
@@ -91,7 +93,7 @@ namespace System.Management.Automation
         /// <param name="cursorIndex">The index of the cursor in the input.</param>
         /// <param name="options">Optional options to configure how completion is performed.</param>
         /// <returns></returns>
-        public static CommandCompletion CompleteInput(string input, int cursorIndex, Hashtable options)
+        public static CommandCompletion CompleteInput(string input, int cursorIndex, Hashtable? options)
         {
             if (input == null)
             {
@@ -209,7 +211,7 @@ namespace System.Management.Automation
         /// <param name="powershell">The powershell to use to invoke the script function TabExpansion2.</param>
         /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "powershell")]
-        public static CommandCompletion CompleteInput(Ast ast, Token[] tokens, IScriptPosition cursorPosition, Hashtable options, PowerShell powershell)
+        public static CommandCompletion CompleteInput(Ast ast, Token[] tokens, IScriptPosition cursorPosition, Hashtable? options, PowerShell powershell)
         {
             if (ast == null)
             {
@@ -288,9 +290,9 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="forward">True if we should move forward through the list, false if backwards.</param>
         /// <returns>The next completion result, or null if no results.</returns>
-        public CompletionResult GetNextResult(bool forward)
+        public CompletionResult? GetNextResult(bool forward)
         {
-            CompletionResult result = null;
+            CompletionResult? result = null;
             var count = CompletionMatches.Count;
             if (count > 0)
             {
@@ -322,7 +324,7 @@ namespace System.Management.Automation
         /// <param name="options">Optional parameter that specifies configurable options for completion.</param>
         /// <param name="debugger">Current debugger.</param>
         /// <returns>A collection of completions with the replacement start and length.</returns>
-        internal static CommandCompletion CompleteInputInDebugger(string input, int cursorIndex, Hashtable options, Debugger debugger)
+        internal static CommandCompletion CompleteInputInDebugger(string input, int cursorIndex, Hashtable? options, Debugger debugger)
         {
             if (input == null)
             {
@@ -356,7 +358,7 @@ namespace System.Management.Automation
         /// <param name="options">Optional options to configure how completion is performed.</param>
         /// <param name="debugger">Current debugger.</param>
         /// <returns>Command completion.</returns>
-        internal static CommandCompletion CompleteInputInDebugger(Ast ast, Token[] tokens, IScriptPosition cursorPosition, Hashtable options, Debugger debugger)
+        internal static CommandCompletion CompleteInputInDebugger(Ast ast, Token[] tokens, IScriptPosition cursorPosition, Hashtable? options, Debugger debugger)
         {
             if (ast == null)
             {
@@ -436,7 +438,7 @@ namespace System.Management.Automation
             }
         }
 
-        private static CommandCompletion CallScriptWithStringParameterSet(string input, int cursorIndex, Hashtable options, PowerShell powershell)
+        private static CommandCompletion CallScriptWithStringParameterSet(string input, int cursorIndex, Hashtable? options, PowerShell powershell)
         {
             try
             {
@@ -472,7 +474,7 @@ namespace System.Management.Automation
             return s_emptyCommandCompletion;
         }
 
-        private static CommandCompletion CallScriptWithAstParameterSet(Ast ast, Token[] tokens, IScriptPosition cursorPosition, Hashtable options, PowerShell powershell)
+        private static CommandCompletion CallScriptWithAstParameterSet(Ast ast, Token[] tokens, IScriptPosition cursorPosition, Hashtable? options, PowerShell powershell)
         {
             try
             {
@@ -510,7 +512,7 @@ namespace System.Management.Automation
         }
 
         // This is the start of the real implementation of autocomplete/intellisense/tab completion
-        private static CommandCompletion CompleteInputImpl(Ast ast, Token[] tokens, IScriptPosition positionOfCursor, Hashtable options)
+        private static CommandCompletion CompleteInputImpl(Ast ast, Token[] tokens, IScriptPosition positionOfCursor, Hashtable? options)
         {
 #if LEGACYTELEMETRY
             // We could start collecting telemetry at a later date.
@@ -526,7 +528,7 @@ namespace System.Management.Automation
                 // the built-in version, so we should continue to use theirs.
                 int replacementIndex = -1;
                 int replacementLength = -1;
-                List<CompletionResult> results = null;
+                List<CompletionResult>? results = null;
 
                 if (NeedToInvokeLegacyTabExpansion(powershell))
                 {
@@ -625,9 +627,9 @@ namespace System.Management.Automation
             return false;
         }
 
-        private static List<CompletionResult> InvokeLegacyTabExpansion(PowerShell powershell, string input, int cursorIndex, bool remoteToWin7, out int replacementIndex, out int replacementLength)
+        private static List<CompletionResult>? InvokeLegacyTabExpansion(PowerShell powershell, string input, int cursorIndex, bool remoteToWin7, out int replacementIndex, out int replacementLength)
         {
-            List<CompletionResult> results = null;
+            List<CompletionResult>? results = null;
 
             var legacyInput = (cursorIndex != input.Length) ? input.Substring(0, cursorIndex) : input;
             char quote;
@@ -771,7 +773,7 @@ namespace System.Management.Automation
                     {
                         PSObject command = commands[i];
                         string cmdletFullName = CmdletInfo.GetFullName(command);
-                        cmdlets[i] = new CommandAndName(command, PSSnapinQualifiedName.GetInstance(cmdletFullName));
+                        cmdlets[i] = new CommandAndName(command, PSSnapinQualifiedName.GetInstance(cmdletFullName)!);
                     }
 
                     if (isSnapinSpecified)
@@ -804,11 +806,11 @@ namespace System.Management.Automation
                 }
 
                 string toolTip;
-                string displayName = SafeGetProperty<string>(commandAndName.Command, "Name");
+                string displayName = SafeGetProperty<string>(commandAndName.Command, "Name")!;
 
                 if (commandType.Value == CommandTypes.Cmdlet || commandType.Value == CommandTypes.Application)
                 {
-                    toolTip = SafeGetProperty<string>(commandAndName.Command, "Definition");
+                    toolTip = SafeGetProperty<string>(commandAndName.Command, "Definition")!;
                 }
                 else
                 {
@@ -889,8 +891,8 @@ namespace System.Management.Automation
                 bool isProviderDirectPath = lastWord.StartsWith(@"\\", StringComparison.Ordinal) ||
                                             lastWord.StartsWith("//", StringComparison.Ordinal);
 
-                List<PathItemAndConvertedPath> s1 = null;
-                List<PathItemAndConvertedPath> s2 = null;
+                List<PathItemAndConvertedPath>? s1 = null;
+                List<PathItemAndConvertedPath>? s2 = null;
 
                 if (containsGlobChars && !isLastWordEmpty)
                 {
@@ -908,7 +910,7 @@ namespace System.Management.Automation
                             shouldFullyQualifyPaths);
                 }
 
-                IEnumerable<PathItemAndConvertedPath> combinedMatches = CombineMatchSets(s1, s2);
+                IEnumerable<PathItemAndConvertedPath>? combinedMatches = CombineMatchSets(s1, s2);
 
                 if (combinedMatches != null)
                 {
@@ -921,7 +923,7 @@ namespace System.Management.Automation
                         completionText = AddQuoteIfNecessary(completionText, quote, completingAtStartOfLine);
 
                         bool? isContainer = SafeGetProperty<bool?>(combinedMatch.Item, "PSIsContainer");
-                        string childName = SafeGetProperty<string>(combinedMatch.Item, "PSChildName");
+                        string? childName = SafeGetProperty<string>(combinedMatch.Item, "PSChildName");
                         string toolTip = PowerShellExecutionHelper.SafeToString(combinedMatch.ConvertedPath);
 
                         if (isContainer != null && childName != null && toolTip != null)
@@ -955,7 +957,7 @@ namespace System.Management.Automation
                 return completionText;
             }
 
-            private static IEnumerable<PathItemAndConvertedPath> CombineMatchSets(List<PathItemAndConvertedPath> s1, List<PathItemAndConvertedPath> s2)
+            private static IEnumerable<PathItemAndConvertedPath>? CombineMatchSets(List<PathItemAndConvertedPath>? s1, List<PathItemAndConvertedPath>? s2)
             {
                 if (s1 == null || s1.Count < 1)
                 {
@@ -1003,26 +1005,26 @@ namespace System.Management.Automation
                 return result;
             }
 
-            private static T SafeGetProperty<T>(PSObject psObject, string propertyName)
+            private static T? SafeGetProperty<T>(PSObject? psObject, string propertyName)
             {
                 if (psObject == null)
                 {
                     return default(T);
                 }
 
-                PSPropertyInfo property = psObject.Properties[propertyName];
+                PSPropertyInfo? property = psObject.Properties[propertyName];
                 if (property == null)
                 {
                     return default(T);
                 }
 
-                object propertyValue = property.Value;
+                object? propertyValue = property.Value;
                 if (propertyValue == null)
                 {
                     return default(T);
                 }
 
-                T returnValue;
+                T? returnValue;
                 if (LanguagePrimitives.TryConvertTo(propertyValue, out returnValue))
                 {
                     return returnValue;
@@ -1065,7 +1067,7 @@ namespace System.Management.Automation
                 }
             }
 
-            private static List<PathItemAndConvertedPath> PSv2FindMatches(PowerShellExecutionHelper helper, string path, bool shouldFullyQualifyPaths)
+            private static List<PathItemAndConvertedPath>? PSv2FindMatches(PowerShellExecutionHelper helper, string path, bool shouldFullyQualifyPaths)
             {
                 Diagnostics.Assert(!string.IsNullOrEmpty(path), "path should have a value");
                 var result = new List<PathItemAndConvertedPath>();
@@ -1100,9 +1102,9 @@ namespace System.Management.Automation
                     var pathsArray = t.BaseObject as IList;
                     if (pathsArray != null && pathsArray.Count == 3)
                     {
-                        object objectPath = pathsArray[0];
-                        PSObject item = pathsArray[1] as PSObject;
-                        object convertedPath = pathsArray[1];
+                        object? objectPath = pathsArray[0];
+                        PSObject? item = pathsArray[1] as PSObject;
+                        object? convertedPath = pathsArray[1];
 
                         if (objectPath == null || item == null || convertedPath == null)
                         {
@@ -1241,7 +1243,7 @@ namespace System.Management.Automation
                     }
                 }
 
-                string result = new string(_wordBuffer, 0, _wordBufferIndex);
+                string result = new string(_wordBuffer!, 0, _wordBufferIndex);
 
                 closingQuote = inSingleQuote ? '\'' : inDoubleQuote ? '"' : '\0';
                 replacementIndexOut = ReplacementIndex;
@@ -1309,7 +1311,7 @@ namespace System.Management.Automation
             }
 
             private readonly string _sentence;
-            private char[] _wordBuffer;
+            private char[]? _wordBuffer;
             private int _wordBufferIndex;
             private int _replacementIndex;
             private int _sentenceIndex;

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -77,6 +77,8 @@ namespace System.Management.Automation
 
         internal ExecutionContext ExecutionContext { get; }
 
+        internal bool HasPseudoBindingInfo => _pseudoBindingInfo is not null;
+
         internal PseudoBindingInfo PseudoBindingInfo 
         { 
             get => _pseudoBindingInfo ??  throw new InvalidOperationException($"Accessing property '{nameof(PseudoBindingInfo)}' on CompletionContext without first setting it.");

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -11,29 +11,59 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Management.Automation.Subsystem;
 using System.Management.Automation.Subsystem.DSC;
+using System.Diagnostics.CodeAnalysis;
+
+#nullable enable
 
 namespace System.Management.Automation
 {
     internal class CompletionContext
     {
-        internal List<Ast> RelatedAsts { get; set; }
+        public CompletionContext(string wordToComplete, PowerShellExecutionHelper helper, ExecutionContext executionContext)
+        {
+            WordToComplete = wordToComplete;
+            Helper = helper;
+            ExecutionContext = executionContext;
+            RelatedAsts = Array.Empty<Ast>();
+            CursorPosition = new EmptyScriptPosition();
+            CustomArgumentCompleters = executionContext.CustomArgumentCompleters;
+            NativeArgumentCompleters = executionContext.NativeArgumentCompleters;            
+        }
+
+        public CompletionContext(Hashtable options, IScriptPosition cursorPosition, Token? tokenAtCursor, Token? tokenBeforeCursor, List<Ast> relatedAsts, int replacementIndex, ExecutionContext executionContext, TypeInferenceContext typeInferenceContext)
+        {
+            WordToComplete = string.Empty;
+            Options = options;
+            CursorPosition = cursorPosition;
+            TokenAtCursor = tokenAtCursor;
+            TokenBeforeCursor = tokenBeforeCursor;
+            RelatedAsts = relatedAsts;
+            ReplacementIndex = replacementIndex;
+            ExecutionContext = executionContext;
+            _typeInferenceContext = typeInferenceContext;
+            Helper = typeInferenceContext.Helper;
+            CustomArgumentCompleters = executionContext.CustomArgumentCompleters;
+            NativeArgumentCompleters = executionContext.NativeArgumentCompleters;
+        }
+
+        internal IList<Ast> RelatedAsts { get; }
 
         // Only one of TokenAtCursor or TokenBeforeCursor is set
         // This is how we can tell if we're trying to complete part of something (like a member)
         // or complete an argument, where TokenBeforeCursor could be a parameter name.
-        internal Token TokenAtCursor { get; set; }
+        internal Token? TokenAtCursor { get; }
 
-        internal Token TokenBeforeCursor { get; set; }
+        internal Token? TokenBeforeCursor { get; }
 
-        internal IScriptPosition CursorPosition { get; set; }
+        internal IScriptPosition CursorPosition { get;  }
 
-        internal PowerShellExecutionHelper Helper { get; set; }
+        internal PowerShellExecutionHelper Helper { get; }
 
-        internal Hashtable Options { get; set; }
+        internal Hashtable? Options { get; set; }
 
-        internal Dictionary<string, ScriptBlock> CustomArgumentCompleters { get; set; }
+        internal Dictionary<string, ScriptBlock> CustomArgumentCompleters { get; }
 
-        internal Dictionary<string, ScriptBlock> NativeArgumentCompleters { get; set; }
+        internal Dictionary<string, ScriptBlock> NativeArgumentCompleters { get; }
 
         internal string WordToComplete { get; set; }
 
@@ -41,11 +71,11 @@ namespace System.Management.Automation
 
         internal int ReplacementLength { get; set; }
 
-        internal ExecutionContext ExecutionContext { get; set; }
+        internal ExecutionContext ExecutionContext { get; }
 
-        internal PseudoBindingInfo PseudoBindingInfo { get; set; }
+        internal PseudoBindingInfo? PseudoBindingInfo { get; set; }
 
-        internal TypeInferenceContext TypeInferenceContext { get; set; }
+        internal TypeInferenceContext TypeInferenceContext => _typeInferenceContext ?? throw new InvalidOperationException($"Accessing property {nameof(TypeInferenceContext)} on CompletionContext created without it.");
 
         internal bool GetOption(string option, bool @default)
         {
@@ -56,6 +86,8 @@ namespace System.Management.Automation
 
             return LanguagePrimitives.ConvertTo<bool>(Options[option]);
         }
+
+        private readonly TypeInferenceContext? _typeInferenceContext;
     }
 
     internal class CompletionAnalysis
@@ -110,7 +142,7 @@ namespace System.Management.Automation
 
         internal readonly struct AstAnalysisContext
         {
-            internal AstAnalysisContext(Token tokenAtCursor, Token tokenBeforeCursor, List<Ast> relatedAsts, int replacementIndex)
+            internal AstAnalysisContext(Token? tokenAtCursor, Token? tokenBeforeCursor, List<Ast> relatedAsts, int replacementIndex)
             {
                 TokenAtCursor = tokenAtCursor;
                 TokenBeforeCursor = tokenBeforeCursor;
@@ -118,8 +150,8 @@ namespace System.Management.Automation
                 ReplacementIndex = replacementIndex;
             }
 
-            internal readonly Token TokenAtCursor;
-            internal readonly Token TokenBeforeCursor;
+            internal readonly Token? TokenAtCursor;
+            internal readonly Token? TokenBeforeCursor;
             internal readonly List<Ast> RelatedAsts;
             internal readonly int ReplacementIndex;
         }
@@ -129,8 +161,8 @@ namespace System.Management.Automation
             bool adjustLineAndColumn = false;
             IScriptPosition positionForAstSearch = cursor;
 
-            Token tokenBeforeCursor = null;
-            Token tokenAtCursor = InterstingTokenAtCursorOrDefault(inputTokens, cursor);
+            Token? tokenBeforeCursor = null;
+            Token? tokenAtCursor = InterstingTokenAtCursorOrDefault(inputTokens, cursor);
             if (tokenAtCursor == null)
             {
                 tokenBeforeCursor = InterstingTokenBeforeCursorOrDefault(inputTokens, cursor);
@@ -190,23 +222,10 @@ namespace System.Management.Automation
 
             ExecutionContext executionContext = typeInferenceContext.ExecutionContext;
 
-            return new CompletionContext
-            {
-                Options = _options,
-                CursorPosition = _cursorPosition,
-                TokenAtCursor = astContext.TokenAtCursor,
-                TokenBeforeCursor = astContext.TokenBeforeCursor,
-                RelatedAsts = astContext.RelatedAsts,
-                ReplacementIndex = astContext.ReplacementIndex,
-                ExecutionContext = executionContext,
-                TypeInferenceContext = typeInferenceContext,
-                Helper = typeInferenceContext.Helper,
-                CustomArgumentCompleters = executionContext.CustomArgumentCompleters,
-                NativeArgumentCompleters = executionContext.NativeArgumentCompleters,
-            };
+            return new CompletionContext(_options, _cursorPosition, astContext.TokenAtCursor, astContext.TokenBeforeCursor, astContext.RelatedAsts, astContext.ReplacementIndex, executionContext, typeInferenceContext);         
         }
 
-        private static Token InterstingTokenAtCursorOrDefault(IReadOnlyList<Token> tokens, IScriptPosition cursorPosition)
+        private static Token? InterstingTokenAtCursorOrDefault(IReadOnlyList<Token> tokens, IScriptPosition cursorPosition)
         {
             for (int i = tokens.Count - 1; i >= 0; --i)
             {
@@ -220,7 +239,7 @@ namespace System.Management.Automation
             return null;
         }
 
-        private static Token InterstingTokenBeforeCursorOrDefault(IReadOnlyList<Token> tokens, IScriptPosition cursorPosition)
+        private static Token? InterstingTokenBeforeCursorOrDefault(IReadOnlyList<Token> tokens, IScriptPosition cursorPosition)
         {
             for (int i = tokens.Count - 1; i >= 0; --i)
             {
@@ -234,7 +253,7 @@ namespace System.Management.Automation
             return null;
         }
 
-        private static Ast GetLastAstAtCursor(ScriptBlockAst scriptBlockAst, IScriptPosition cursorPosition)
+        private static Ast? GetLastAstAtCursor(ScriptBlockAst scriptBlockAst, IScriptPosition cursorPosition)
         {
             var asts = AstSearcher.FindAll(scriptBlockAst, ast => IsCursorRightAfterExtent(cursorPosition, ast.Extent), searchNestedScriptBlocks: true);
             return asts.LastOrDefault();
@@ -245,9 +264,9 @@ namespace System.Management.Automation
         /// <summary>
         /// Check if we should complete file names for "switch -file"
         /// </summary>
-        private static bool CompleteAgainstSwitchFile(Ast lastAst, Token tokenBeforeCursor)
+        private static bool CompleteAgainstSwitchFile(Ast lastAst, Token? tokenBeforeCursor)
         {
-            Tuple<Token, Ast> fileConditionTuple;
+            Tuple<Token, Ast>? fileConditionTuple;
 
             var errorStatement = lastAst as ErrorStatementAst;
             if (errorStatement != null && errorStatement.Flags != null && errorStatement.Kind != null && tokenBeforeCursor != null &&
@@ -293,7 +312,7 @@ namespace System.Management.Automation
             return false;
         }
 
-        private static bool CompleteAgainstStatementFlags(Ast scriptAst, Ast lastAst, Token token, out TokenKind kind)
+        private static bool CompleteAgainstStatementFlags(Ast? scriptAst, Ast? lastAst, Token? token, out TokenKind kind)
         {
             kind = TokenKind.Unknown;
 
@@ -317,7 +336,7 @@ namespace System.Management.Automation
             {
                 var asts = AstSearcher.FindAll(scriptBlockAst, ast => IsCursorAfterExtent(token.Extent.StartScriptPosition, ast.Extent), searchNestedScriptBlocks: true);
 
-                Ast last = asts.LastOrDefault();
+                Ast? last = asts.LastOrDefault();
                 errorStatement = null;
 
                 while (last != null)
@@ -334,7 +353,7 @@ namespace System.Management.Automation
                     {
                         case TokenKind.Switch:
 
-                            Tuple<Token, Ast> value;
+                            Tuple<Token, Ast>? value;
                             if (errorStatement.Flags != null && errorStatement.Flags.TryGetValue(Parser.VERBATIM_ARGUMENT, out value))
                             {
                                 if (IsTokenTheSame(value.Item1, token))
@@ -371,7 +390,7 @@ namespace System.Management.Automation
 
         #endregion Special Cases
 
-        internal List<CompletionResult> GetResults(PowerShell powerShell, out int replacementIndex, out int replacementLength)
+        internal List<CompletionResult>? GetResults(PowerShell powerShell, out int replacementIndex, out int replacementLength)
         {
             var completionContext = CreateCompletionContext(powerShell);
 
@@ -396,14 +415,14 @@ namespace System.Management.Automation
             }
         }
 
-        internal List<CompletionResult> GetResultHelper(CompletionContext completionContext, out int replacementIndex, out int replacementLength, bool isQuotedString)
+        internal List<CompletionResult>? GetResultHelper(CompletionContext completionContext, out int replacementIndex, out int replacementLength, bool isQuotedString)
         {
             replacementIndex = -1;
             replacementLength = -1;
 
             var tokenAtCursor = completionContext.TokenAtCursor;
             var lastAst = completionContext.RelatedAsts.Last();
-            List<CompletionResult> result = null;
+            List<CompletionResult>? result = null;
             if (tokenAtCursor != null)
             {
                 replacementIndex = tokenAtCursor.Extent.StartScriptPosition.Offset;
@@ -498,7 +517,7 @@ namespace System.Management.Automation
                             && lastAst.Parent.Parent is AssignmentStatementAst assignmentAst)
                         {
                             // Handle scenarios like `$ErrorActionPreference = '<tab>`
-                            if (TryGetCompletionsForVariableAssignment(completionContext, assignmentAst, out List<CompletionResult> completions))
+                            if (TryGetCompletionsForVariableAssignment(completionContext, assignmentAst, out List<CompletionResult>? completions))
                             {
                                 return completions;
                             }
@@ -604,7 +623,7 @@ namespace System.Management.Automation
                             && lastAst.Parent.Parent is AssignmentStatementAst assignmentAst2)
                         {
                             // Handle scenarios like '[ValidateSet(11,22)][int]$i = 11; $i = 2<tab>'
-                            if (TryGetCompletionsForVariableAssignment(completionContext, assignmentAst2, out List<CompletionResult> completions))
+                            if (TryGetCompletionsForVariableAssignment(completionContext, assignmentAst2, out List<CompletionResult>? completions))
                             {
                                 result = completions;
                             }
@@ -644,8 +663,8 @@ namespace System.Management.Automation
 
                     case TokenKind.DynamicKeyword:
                         {
-                            DynamicKeywordStatementAst keywordAst;
-                            ConfigurationDefinitionAst configureAst = GetAncestorConfigurationAstAndKeywordAst(
+                            DynamicKeywordStatementAst? keywordAst;
+                            ConfigurationDefinitionAst? configureAst = GetAncestorConfigurationAstAndKeywordAst(
                                 completionContext.CursorPosition, lastAst, out keywordAst);
                             Diagnostics.Assert(configureAst != null, "ConfigurationDefinitionAst should never be null");
                             bool matched = false;
@@ -674,7 +693,7 @@ namespace System.Management.Automation
                                 completionContext.ReplacementLength = replacementLength = 0;
 
                                 // Handle scenarios like '$ErrorActionPreference =<tab>'
-                                if (TryGetCompletionsForVariableAssignment(completionContext, assignmentAst2, out List<CompletionResult> completions))
+                                if (TryGetCompletionsForVariableAssignment(completionContext, assignmentAst2, out List<CompletionResult>? completions))
                                 {
                                     return completions;
                                 }
@@ -794,7 +813,7 @@ namespace System.Management.Automation
                     //         DependsOn=zzz
                     //         |
                     //
-                    isLineContinuationBeforeCursor = completionContext.TokenBeforeCursor.Kind == TokenKind.LineContinuation;
+                    isLineContinuationBeforeCursor = tokenBeforeCursor.Kind == TokenKind.LineContinuation;
                 }
 
                 bool skipAutoCompleteForCommandCall = isCursorLineEmpty && !isLineContinuationBeforeCursor;
@@ -866,8 +885,8 @@ namespace System.Management.Automation
                         result = GetResultForHashtable(completionContext);
                         if (result == null || result.Count == 0)
                         {
-                            DynamicKeywordStatementAst keywordAst;
-                            ConfigurationDefinitionAst configAst = GetAncestorConfigurationAstAndKeywordAst(cursor, lastAst, out keywordAst);
+                            DynamicKeywordStatementAst? keywordAst;
+                            ConfigurationDefinitionAst? configAst = GetAncestorConfigurationAstAndKeywordAst(cursor, lastAst, out keywordAst);
                             if (configAst != null)
                             {
                                 bool matched;
@@ -880,7 +899,7 @@ namespace System.Management.Automation
                         // <Tab>
                         if ((result is null || result.Count == 0) && tokenBeforeCursor is not null)
                         {
-                            switch (completionContext.TokenBeforeCursor.Kind)
+                            switch (tokenBeforeCursor.Kind)
                             {
                                
                                 case TokenKind.Dot:
@@ -888,7 +907,7 @@ namespace System.Management.Automation
                                 case TokenKind.QuestionDot:
                                     replacementIndex = cursor.Offset;
                                     replacementLength = 0;
-                                    result = CompletionCompleters.CompleteMember(completionContext, @static: completionContext.TokenBeforeCursor.Kind == TokenKind.ColonColon, ref replacementLength);
+                                    result = CompletionCompleters.CompleteMember(completionContext, @static: tokenBeforeCursor.Kind == TokenKind.ColonColon, ref replacementLength);
                                     break;
 
                                 case TokenKind.LParen:
@@ -1010,7 +1029,7 @@ namespace System.Management.Automation
             if (result == null || result.Count == 0)
             {
                 var typeAst = completionContext.RelatedAsts.OfType<TypeExpressionAst>().FirstOrDefault();
-                TypeName typeNameToComplete = null;
+                TypeName? typeNameToComplete = null;
                 if (typeAst != null)
                 {
                     typeNameToComplete = FindTypeNameToComplete(typeAst.TypeName, _cursorPosition);
@@ -1069,9 +1088,9 @@ namespace System.Management.Automation
         }
 
         // Helper method to auto complete hashtable key
-        private static List<CompletionResult> GetResultForHashtable(CompletionContext completionContext)
+        private static List<CompletionResult>? GetResultForHashtable(CompletionContext completionContext)
         {
-            Ast lastRelatedAst = null;
+            Ast? lastRelatedAst = null;
             var cursorPosition = completionContext.CursorPosition;
 
             // Enumeration is used over the LastAst pattern because empty lines following a key-value pair will set LastAst to the value.
@@ -1112,7 +1131,7 @@ namespace System.Management.Automation
 
                 if (cursorIsWithinOrOnSameLineAsKeypair)
                 {
-                    var tokenBeforeOrAtCursor = completionContext.TokenBeforeCursor ?? completionContext.TokenAtCursor;
+                    var tokenBeforeOrAtCursor = completionContext.TokenBeforeCursor ?? completionContext.TokenAtCursor!;
                     if (tokenBeforeOrAtCursor.Kind != TokenKind.Semi)
                     {
                         return null;
@@ -1141,7 +1160,7 @@ namespace System.Management.Automation
             return false;
         }
 
-        internal static TypeName FindTypeNameToComplete(ITypeName type, IScriptPosition cursor)
+        internal static TypeName? FindTypeNameToComplete(ITypeName type, IScriptPosition cursor)
         {
             var typeName = type as TypeName;
             if (typeName != null)
@@ -1195,12 +1214,12 @@ namespace System.Management.Automation
             return stringToComplete;
         }
 
-        private static Tuple<ExpressionAst, StatementAst> GetHashEntryContainsCursor(
+        private static Tuple<ExpressionAst, StatementAst>? GetHashEntryContainsCursor(
             IScriptPosition cursor,
             HashtableAst hashTableAst,
             bool isCursorInString)
         {
-            Tuple<ExpressionAst, StatementAst> keyValuePairWithCursor = null;
+            Tuple<ExpressionAst, StatementAst>? keyValuePairWithCursor = null;
             foreach (var kvp in hashTableAst.KeyValuePairs)
             {
                 if (IsCursorWithinOrJustAfterExtent(cursor, kvp.Item2.Extent))
@@ -1255,10 +1274,10 @@ namespace System.Management.Automation
 
         // Pulls the variable out of an assignment's LHS expression
         // Also brings back the innermost type constraint if there is one
-        private static VariableExpressionAst GetVariableFromExpressionAst(
+        private static VariableExpressionAst? GetVariableFromExpressionAst(
             ExpressionAst expression,
-            ref Type typeConstraint,
-            ref ValidateSetAttribute setConstraint)
+            ref Type? typeConstraint,
+            ref ValidateSetAttribute? setConstraint)
         {
             switch (expression)
             {
@@ -1295,8 +1314,8 @@ namespace System.Management.Automation
         private static bool TryGetTypeConstraintOnVariable(
             CompletionContext completionContext,
             string variableName,
-            out Type typeConstraint,
-            out ValidateSetAttribute setConstraint)
+            out Type? typeConstraint,
+            out ValidateSetAttribute? setConstraint)
         {
             typeConstraint = null;
             setConstraint = null;
@@ -1328,9 +1347,9 @@ namespace System.Management.Automation
         private static bool TryGetCompletionsForVariableAssignment(
             CompletionContext completionContext,
             AssignmentStatementAst assignmentAst,
-            out List<CompletionResult> completions)
+            [NotNullWhen(returnValue: true)] out List<CompletionResult>? completions)
         {
-            bool TryGetResultForEnum(Type typeConstraint, CompletionContext completionContext, out List<CompletionResult> completions)
+            bool TryGetResultForEnum(Type? typeConstraint, CompletionContext completionContext, [NotNullWhen(returnValue: true)] out List<CompletionResult>? completions)
             {
                 completions = null;
 
@@ -1343,7 +1362,7 @@ namespace System.Management.Automation
                 return false;
             }
 
-            bool TryGetResultForSet(Type typeConstraint, ValidateSetAttribute setConstraint, CompletionContext completionContext1, out List<CompletionResult> completions)
+            bool TryGetResultForSet(Type? typeConstraint, ValidateSetAttribute? setConstraint, CompletionContext completionContext1, [NotNullWhen(returnValue: true)] out List<CompletionResult>? completions)
             {
                 completions = null;
 
@@ -1359,9 +1378,9 @@ namespace System.Management.Automation
             completions = null;
 
             // Try to get the variable from the assignment, plus any type constraint on it
-            Type typeConstraint = null;
-            ValidateSetAttribute setConstraint = null;
-            VariableExpressionAst variableAst = GetVariableFromExpressionAst(assignmentAst.Left, ref typeConstraint, ref setConstraint);
+            Type? typeConstraint = null;
+            ValidateSetAttribute? setConstraint = null;
+            VariableExpressionAst? variableAst = GetVariableFromExpressionAst(assignmentAst.Left, ref typeConstraint, ref setConstraint);
 
             if (variableAst == null)
             {
@@ -1404,7 +1423,7 @@ namespace System.Management.Automation
         }
 
         private static List<CompletionResult> GetResultForSet(
-            Type typeConstraint,
+            Type? typeConstraint,
             IList<string> validValues,
             CompletionContext completionContext)
         {
@@ -1434,7 +1453,7 @@ namespace System.Management.Automation
                 stringToComplete = completionContext.TokenAtCursor.Text;
             }
 
-            IEnumerable<string> matchedResults = null;
+            IEnumerable<string>matchedResults;
 
             if (!string.IsNullOrEmpty(stringToComplete))
             {
@@ -1486,7 +1505,7 @@ namespace System.Management.Automation
             return GetMatchedResults(allNames, completionContext);
         }
 
-        private static List<CompletionResult> GetResultForEnumPropertyValueOfDSCResource(
+        private static List<CompletionResult>? GetResultForEnumPropertyValueOfDSCResource(
             CompletionContext completionContext,
             string stringToComplete,
             ref int replacementIndex,
@@ -1495,7 +1514,7 @@ namespace System.Management.Automation
         {
             shouldContinue = true;
             bool isCursorInString = completionContext.TokenAtCursor is StringToken;
-            List<CompletionResult> result = null;
+            List<CompletionResult>? result = null;
             var lastAst = completionContext.RelatedAsts.Last();
             Ast lastChildofHashtableAst;
             var hashTableAst = Ast.GetAncestorHashtableAst(lastAst, out lastChildofHashtableAst);
@@ -1513,11 +1532,11 @@ namespace System.Management.Automation
                         var propertyNameAst = keyValuePairWithCursor.Item1 as StringConstantExpressionAst;
                         if (propertyNameAst != null)
                         {
-                            DynamicKeywordProperty property;
+                            DynamicKeywordProperty? property;
                             if (keywordAst.Keyword.Properties.TryGetValue(propertyNameAst.Value, out property))
                             {
-                                List<string> existingValues = null;
-                                WildcardPattern wildcardPattern = null;
+                                List<string>? existingValues = null;
+                                WildcardPattern? wildcardPattern = null;
                                 bool isDependsOnProperty = string.Equals(property.Name, @"DependsOn", StringComparison.OrdinalIgnoreCase);
                                 bool hasNewLine = false;
                                 string stringQuote = (completionContext.TokenAtCursor is StringExpandableToken) ? "\"" : "'";
@@ -1571,8 +1590,8 @@ namespace System.Management.Automation
                                 Diagnostics.Assert(isCursorInString || (!hasNewLine), "hasNoQuote and hasNewLine cannot be true at the same time");
                                 if (property.ValueMap != null && property.ValueMap.Count > 0)
                                 {
-                                    IEnumerable<string> orderedValues = property.ValueMap.Keys.OrderBy(static x => x).Where(v => !existingValues.Contains(v, StringComparer.OrdinalIgnoreCase));
-                                    var matchedResults = orderedValues.Where(v => wildcardPattern.IsMatch(v));
+                                    IEnumerable<string> orderedValues = property.ValueMap.Keys.OrderBy(static x => x).Where(v => !existingValues!.Contains(v, StringComparer.OrdinalIgnoreCase));
+                                    var matchedResults = orderedValues.Where(v => wildcardPattern!.IsMatch(v));
                                     if (matchedResults == null || !matchedResults.Any())
                                     {
                                         // Fallback to all allowed values
@@ -1584,7 +1603,7 @@ namespace System.Management.Automation
                                         string completionText = isCursorInString ? value : stringQuote + value + stringQuote;
                                         if (hasNewLine)
                                             completionText += stringQuote;
-                                        result.Add(new CompletionResult(
+                                        result!.Add(new CompletionResult(
                                             completionText,
                                             value,
                                             CompletionResultType.Text,
@@ -1614,7 +1633,7 @@ namespace System.Management.Automation
                                                         sb.Append(']');
                                                         sb.Append(dynamicKeywordAst.ElementName);
                                                         var resource = sb.ToString();
-                                                        if (!existingValues.Contains(resource, StringComparer.OrdinalIgnoreCase) &&
+                                                        if (!existingValues!.Contains(resource, StringComparer.OrdinalIgnoreCase) &&
                                                             !allResources.Contains(resource, StringComparer.OrdinalIgnoreCase))
                                                         {
                                                             allResources.Add(resource);
@@ -1623,7 +1642,7 @@ namespace System.Management.Automation
                                                 }
                                             }
 
-                                            var matchedResults = allResources.Where(r => wildcardPattern.IsMatch(r));
+                                            var matchedResults = allResources.Where(r => wildcardPattern!.IsMatch(r));
                                             if (matchedResults == null || !matchedResults.Any())
                                             {
                                                 // Fallback to all allowed values
@@ -1635,7 +1654,7 @@ namespace System.Management.Automation
                                                 string completionText = isCursorInString ? resource : stringQuote + resource + stringQuote;
                                                 if (hasNewLine)
                                                     completionText += stringQuote;
-                                                result.Add(new CompletionResult(
+                                                result!.Add(new CompletionResult(
                                                     completionText,
                                                     resource,
                                                     CompletionResultType.Text,
@@ -1653,7 +1672,7 @@ namespace System.Management.Automation
             return result;
         }
 
-        private List<CompletionResult> GetResultForString(CompletionContext completionContext, ref int replacementIndex, ref int replacementLength, bool isQuotedString)
+        private List<CompletionResult>? GetResultForString(CompletionContext completionContext, ref int replacementIndex, ref int replacementLength, bool isQuotedString)
         {
             // When it's the content of a quoted string, we only handle variable/member completion
             if (isQuotedString) { return null; }
@@ -1661,14 +1680,14 @@ namespace System.Management.Automation
             var tokenAtCursor = completionContext.TokenAtCursor;
             var lastAst = completionContext.RelatedAsts.Last();
 
-            List<CompletionResult> result = null;
+            List<CompletionResult>? result = null;
             var expandableString = lastAst as ExpandableStringExpressionAst;
             var constantString = lastAst as StringConstantExpressionAst;
             if (constantString == null && expandableString == null) { return null; }
 
-            string strValue = constantString != null ? constantString.Value : expandableString.Value;
-            StringConstantType strType = constantString != null ? constantString.StringConstantType : expandableString.StringConstantType;
-            string subInput = null;
+            string strValue = constantString != null ? constantString.Value : expandableString!.Value;
+            StringConstantType strType = constantString != null ? constantString.StringConstantType : expandableString!.StringConstantType;
+            string? subInput = null;
 
             bool shouldContinue;
             result = GetResultForEnumPropertyValueOfDSCResource(completionContext, strValue, ref replacementIndex, ref replacementLength, out shouldContinue);
@@ -1693,7 +1712,7 @@ namespace System.Management.Automation
             // Handle variable/member completion
             if (subInput != null)
             {
-                int stringStartIndex = tokenAtCursor.Extent.StartScriptPosition.Offset;
+                int stringStartIndex = tokenAtCursor!.Extent.StartScriptPosition.Offset;
                 int cursorIndexInString = _cursorPosition.Offset - stringStartIndex - 1;
                 if (cursorIndexInString >= strValue.Length)
                     cursorIndexInString = strValue.Length;
@@ -1773,12 +1792,12 @@ namespace System.Management.Automation
         /// <param name="ast"></param>
         /// <param name="keywordAst"></param>
         /// <returns></returns>
-        private static ConfigurationDefinitionAst GetAncestorConfigurationAstAndKeywordAst(
+        private static ConfigurationDefinitionAst? GetAncestorConfigurationAstAndKeywordAst(
             IScriptPosition cursorPosition,
             Ast ast,
-            out DynamicKeywordStatementAst keywordAst)
+            out DynamicKeywordStatementAst? keywordAst)
         {
-            ConfigurationDefinitionAst configureAst = Ast.GetAncestorConfigurationDefinitionAstAndDynamicKeywordStatementAst(ast, out keywordAst);
+            ConfigurationDefinitionAst? configureAst = Ast.GetAncestorConfigurationDefinitionAstAndDynamicKeywordStatementAst(ast, out keywordAst);
             // Find the configuration statement contains current cursor
             // Note: cursorPosition.Offset < configureAst.Extent.EndOffset means cursor locates inside the configuration
             //       cursorPosition.Offset = configureAst.Extent.EndOffset means cursor locates at the end of the configuration
@@ -1809,13 +1828,13 @@ namespace System.Management.Automation
         /// <param name="keywordAst"></param>
         /// <param name="matched"></param>
         /// <returns></returns>
-        private static List<CompletionResult> GetResultForIdentifierInConfiguration(
+        private static List<CompletionResult>? GetResultForIdentifierInConfiguration(
             CompletionContext completionContext,
             ConfigurationDefinitionAst configureAst,
-            DynamicKeywordStatementAst keywordAst,
+            DynamicKeywordStatementAst? keywordAst,
             out bool matched)
         {
-            List<CompletionResult> results = null;
+            List<CompletionResult>? results = null;
             matched = false;
 
             IEnumerable<DynamicKeyword> keywords = configureAst.DefinedKeywords.Where(
@@ -1852,7 +1871,7 @@ namespace System.Management.Automation
                 foreach (var keyword in matchedResults)
                 {
                     string usageString = string.Empty;
-                    ICrossPlatformDsc dscSubsystem = SubsystemManager.GetSubsystem<ICrossPlatformDsc>();
+                    ICrossPlatformDsc? dscSubsystem = SubsystemManager.GetSubsystem<ICrossPlatformDsc>();
                     if (dscSubsystem != null)
                     {
                         usageString = dscSubsystem.GetDSCResourceUsageString(keyword);
@@ -1878,12 +1897,12 @@ namespace System.Management.Automation
             return results;
         }
 
-        private List<CompletionResult> GetResultForIdentifier(CompletionContext completionContext, ref int replacementIndex, ref int replacementLength, bool isQuotedString)
+        private List<CompletionResult>? GetResultForIdentifier(CompletionContext completionContext, ref int replacementIndex, ref int replacementLength, bool isQuotedString)
         {
-            var tokenAtCursor = completionContext.TokenAtCursor;
+            var tokenAtCursor = completionContext.TokenAtCursor!;
             var lastAst = completionContext.RelatedAsts.Last();
 
-            List<CompletionResult> result = null;
+            List<CompletionResult>? result = null;
             var tokenAtCursorText = tokenAtCursor.Text;
             completionContext.WordToComplete = tokenAtCursorText;
 
@@ -1902,7 +1921,7 @@ namespace System.Management.Automation
                 }
                 else
                 {
-                    UsingStatementAst usingState = strConst.Parent as UsingStatementAst;
+                    UsingStatementAst? usingState = strConst.Parent as UsingStatementAst;
                     if (usingState != null)
                     {
                         completionContext.ReplacementIndex = strConst.Extent.StartOffset;
@@ -1946,7 +1965,7 @@ namespace System.Management.Automation
                     }
                 }
             }
-            if (completionContext.TokenAtCursor.TokenFlags == TokenFlags.MemberName)
+            if (tokenAtCursor.TokenFlags == TokenFlags.MemberName)
             {
                 result = GetResultForAttributeArgument(completionContext, ref replacementIndex, ref replacementLength);
                 if (result is not null)
@@ -1960,7 +1979,7 @@ namespace System.Management.Automation
                 // Handle completion for a path with variable, such as: $PSHOME\ty<tab>
                 if (completionContext.RelatedAsts.Count > 0 && completionContext.RelatedAsts[0] is ScriptBlockAst)
                 {
-                    Ast cursorAst = null;
+                    Ast? cursorAst = null;
                     var cursorPosition = (InternalScriptPosition)_cursorPosition;
                     int offsetBeforeCmdName = cursorPosition.Offset - tokenAtCursorText.Length;
                     if (offsetBeforeCmdName >= 0)
@@ -1993,7 +2012,7 @@ namespace System.Management.Automation
                             else
                             {
                                 var variableAst = cursorAst as VariableExpressionAst;
-                                string fullPath = variableAst != null
+                                string? fullPath = variableAst != null
                                     ? CompletionCompleters.CombineVariableWithPartialPath(
                                         variableAst: variableAst,
                                         extraText: tokenAtCursorText,
@@ -2028,7 +2047,7 @@ namespace System.Management.Automation
                 {
                     try
                     {
-                        string expandedString = null;
+                        string? expandedString = null;
                         var expandableStringAst = new ExpandableStringExpressionAst(strConst.Extent, strConst.Value, StringConstantType.BareWord);
                         if (CompletionCompleters.IsPathSafelyExpandable(expandableStringAst: expandableStringAst,
                                                                         extraText: string.Empty,
@@ -2051,10 +2070,10 @@ namespace System.Management.Automation
                 //
                 // Handle completion of DSC resources within Configuration
                 //
-                DynamicKeywordStatementAst keywordAst;
-                ConfigurationDefinitionAst configureAst = GetAncestorConfigurationAstAndKeywordAst(completionContext.CursorPosition, lastAst, out keywordAst);
+                DynamicKeywordStatementAst? keywordAst;
+                ConfigurationDefinitionAst? configureAst = GetAncestorConfigurationAstAndKeywordAst(completionContext.CursorPosition, lastAst, out keywordAst);
                 bool matched = false;
-                List<CompletionResult> keywordResult = null;
+                List<CompletionResult>? keywordResult = null;
                 if (configureAst != null)
                 {
                     // Current token is within ConfigurationDefinitionAst or DynamicKeywordStatementAst
@@ -2075,7 +2094,7 @@ namespace System.Management.Automation
                 {
                     result.InsertRange(0, keywordResult);
                 }
-                else if (!matched && keywordResult != null && commandNameResult.Count == 0)
+                else if (!matched && keywordResult != null && commandNameResult?.Count == 0)
                 {
                     result.AddRange(keywordResult);
                 }
@@ -2260,13 +2279,13 @@ namespace System.Management.Automation
             return result;
         }
 
-        private static List<CompletionResult> GetResultForAttributeArgument(CompletionContext completionContext, ref int replacementIndex, ref int replacementLength)
+        private static List<CompletionResult>? GetResultForAttributeArgument(CompletionContext completionContext, ref int replacementIndex, ref int replacementLength)
         {
             // Attribute member arguments
-            Type attributeType = null;
+            Type? attributeType = null;
             string argName = string.Empty;
-            Ast argAst = completionContext.RelatedAsts.Find(static ast => ast is NamedAttributeArgumentAst);
-            AttributeAst attAst;
+            Ast? argAst = completionContext.RelatedAsts.FirstOrDefault(static ast => ast is NamedAttributeArgumentAst);
+            AttributeAst? attAst;
             if (argAst is NamedAttributeArgumentAst namedArgAst)
             {
                 attAst = (AttributeAst)namedArgAst.Parent;
@@ -2277,7 +2296,7 @@ namespace System.Management.Automation
             }
             else
             {
-                Ast astAtt = completionContext.RelatedAsts.Find(static ast => ast is AttributeAst);
+                Ast? astAtt = completionContext.RelatedAsts.FirstOrDefault(static ast => ast is AttributeAst);
                 attAst = astAtt as AttributeAst;
                 if (attAst is not null)
                 {
@@ -2289,7 +2308,7 @@ namespace System.Management.Automation
             {
                 int cursorPosition = completionContext.CursorPosition.Offset;
                 var existingArguments = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                foreach (var namedArgument in attAst.NamedArguments)
+                foreach (var namedArgument in attAst!.NamedArguments)
                 {
                     if (cursorPosition < namedArgument.Extent.StartOffset || cursorPosition > namedArgument.Extent.EndOffset)
                     {
@@ -2373,7 +2392,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Complete loop labels after labeled control flow statements such as Break and Continue.
         /// </summary>
-        private static List<CompletionResult> CompleteLoopLabel(CompletionContext completionContext)
+        private static List<CompletionResult>? CompleteLoopLabel(CompletionContext completionContext)
         {
             var result = new List<CompletionResult>();
             foreach (Ast ast in completionContext.RelatedAsts)

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -74,7 +74,8 @@ namespace System.Management.Automation
 
             var helper = new PowerShellExecutionHelper(PowerShell.Create(RunspaceMode.CurrentRunspace));
             var executionContext = helper.CurrentPowerShell.Runspace.ExecutionContext;
-            return CompleteCommand(new CompletionContext { WordToComplete = commandName, Helper = helper, ExecutionContext = executionContext }, moduleName, commandTypes);
+            return CompleteCommand(new CompletionContext(wordToComplete: commandName, helper, executionContext), moduleName, commandTypes);
+            
         }
 
         internal static List<CompletionResult> CompleteCommand(CompletionContext context)
@@ -4288,7 +4289,7 @@ namespace System.Management.Automation
 
             var helper = new PowerShellExecutionHelper(PowerShell.Create(RunspaceMode.CurrentRunspace));
             var executionContext = helper.CurrentPowerShell.Runspace.ExecutionContext;
-            return CompleteFilename(new CompletionContext { WordToComplete = fileName, Helper = helper, ExecutionContext = executionContext });
+            return CompleteFilename(new CompletionContext(wordToComplete: fileName, helper, executionContext));
         }
 
         internal static IEnumerable<CompletionResult> CompleteFilename(CompletionContext context)
@@ -4754,7 +4755,7 @@ namespace System.Management.Automation
 
             var helper = new PowerShellExecutionHelper(PowerShell.Create(RunspaceMode.CurrentRunspace));
             var executionContext = helper.CurrentPowerShell.Runspace.ExecutionContext;
-            return CompleteVariable(new CompletionContext { WordToComplete = variableName, Helper = helper, ExecutionContext = executionContext });
+            return CompleteVariable(new CompletionContext(wordToComplete: variableName, helper, executionContext));
         }
 
         private static readonly string[] s_variableScopes = new string[] { "Global:", "Local:", "Script:", "Private:" };
@@ -5404,7 +5405,7 @@ namespace System.Management.Automation
                 replacementIndex = context.TokenAtCursor.Extent.StartOffset + lineKeyword.Index;
                 replacementLength = lineKeyword.Value.Length;
 
-                var validKeywords = new HashSet<String>(s_commentHelpKeywords.Keys, StringComparer.OrdinalIgnoreCase);
+                var validKeywords = new HashSet<string>(s_commentHelpKeywords.Keys, StringComparer.OrdinalIgnoreCase);
                 foreach (Match keyword in usedKeywords)
                 {
                     if (keyword == lineKeyword || s_commentHelpAllowedDuplicateKeywords.Contains(keyword.Value))
@@ -6731,7 +6732,7 @@ namespace System.Management.Automation
 
             var helper = new PowerShellExecutionHelper(powershell);
             var executionContext = helper.CurrentPowerShell.Runspace.ExecutionContext;
-            return CompleteType(new CompletionContext { WordToComplete = typeName, Helper = helper, ExecutionContext = executionContext });
+            return CompleteType(new CompletionContext(wordToComplete: typeName, helper, executionContext));
         }
 
         internal static List<CompletionResult> CompleteType(CompletionContext context, string prefix = "", string suffix = "")

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -1390,9 +1390,11 @@ namespace System.Management.Automation
             ArgumentLocation argLocation,
             CommandAst commandAst)
         {
-            List<CompletionResult> result = new List<CompletionResult>();
+            Debug.Assert(context.HasPseudoBindingInfo);
+            
+            List<CompletionResult> result = new List<CompletionResult>();                        
 
-            PseudoBindingInfo bindingInfo = context.PseudoBindingInfo!;
+            PseudoBindingInfo bindingInfo = context.PseudoBindingInfo;
             if (argLocation.IsPositional)
             {
                 CompletePositionalArgument(
@@ -1444,7 +1446,7 @@ namespace System.Management.Automation
             ArgumentLocation argLocation,
             CommandAst commandAst)
         {
-            PseudoBindingInfo bindingInfo = context.PseudoBindingInfo!;
+            PseudoBindingInfo bindingInfo = context.PseudoBindingInfo;
             Diagnostics.Assert(bindingInfo.InfoType.Equals(PseudoBindingInfoType.PseudoBindingSucceed), "Caller needs to make sure the pseudo binding was successful");
             List<CompletionResult> result = new List<CompletionResult>();
 
@@ -2373,7 +2375,7 @@ namespace System.Management.Automation
         private static Hashtable GetBoundArgumentsAsHashtable(CompletionContext context)
         {
             var result = new Hashtable(StringComparer.OrdinalIgnoreCase);
-            if (context.PseudoBindingInfo != null)
+            if (context.HasPseudoBindingInfo)
             {
                 var boundArguments = context.PseudoBindingInfo.BoundArguments;
                 if (boundArguments != null)

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Data;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
@@ -26,6 +27,8 @@ using Microsoft.PowerShell.Cim;
 using Microsoft.PowerShell.Commands;
 using Microsoft.PowerShell.Commands.Internal.Format;
 
+#nullable enable
+
 namespace System.Management.Automation
 {
     /// <summary>
@@ -37,7 +40,7 @@ namespace System.Management.Automation
             AppDomain.CurrentDomain.AssemblyLoad += UpdateTypeCacheOnAssemblyLoad;
         }
 
-        private static void UpdateTypeCacheOnAssemblyLoad(object sender, AssemblyLoadEventArgs args)
+        private static void UpdateTypeCacheOnAssemblyLoad(object? sender, AssemblyLoadEventArgs args)
         {
             // Just null out the cache - we'll rebuild it the next time someone tries to complete a type.
             // We could rebuild it now, but we could be loading multiple assemblies (e.g. dependent assemblies)
@@ -51,7 +54,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="commandName"></param>
         /// <returns></returns>
-        public static IEnumerable<CompletionResult> CompleteCommand(string commandName)
+        public static IEnumerable<CompletionResult>? CompleteCommand(string commandName)
         {
             return CompleteCommand(commandName, null);
         }
@@ -63,7 +66,7 @@ namespace System.Management.Automation
         /// <param name="commandTypes"></param>
         /// <returns></returns>
         [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
-        public static IEnumerable<CompletionResult> CompleteCommand(string commandName, string moduleName, CommandTypes commandTypes = CommandTypes.All)
+        public static IEnumerable<CompletionResult>? CompleteCommand(string commandName, string? moduleName, CommandTypes commandTypes = CommandTypes.All)
         {
             var runspace = Runspace.DefaultRunspace;
             if (runspace == null)
@@ -78,25 +81,25 @@ namespace System.Management.Automation
             
         }
 
-        internal static List<CompletionResult> CompleteCommand(CompletionContext context)
+        internal static List<CompletionResult>? CompleteCommand(CompletionContext context)
         {
             return CompleteCommand(context, null);
         }
 
-        private static List<CompletionResult> CompleteCommand(CompletionContext context, string moduleName, CommandTypes types = CommandTypes.All)
+        private static List<CompletionResult>? CompleteCommand(CompletionContext context, string? moduleName, CommandTypes types = CommandTypes.All)
         {
             var addAmpersandIfNecessary = IsAmpersandNeeded(context, false);
 
             string commandName = context.WordToComplete;
             string quote = HandleDoubleAndSingleQuote(ref commandName);
 
-            List<CompletionResult> commandResults = null;
+            List<CompletionResult>? commandResults = null;
 
             if (commandName.IndexOfAny(Utils.Separators.DirectoryOrDrive) == -1)
             {
                 // The name to complete is neither module qualified nor is it a relative/rooted file path.
 
-                Ast lastAst = null;
+                Ast? lastAst = null;
                 if (context.RelatedAsts != null && context.RelatedAsts.Count > 0)
                 {
                     lastAst = context.RelatedAsts.Last();
@@ -191,7 +194,7 @@ namespace System.Management.Automation
                     commandInfos = context.Helper.ExecuteCurrentPowerShell(out exceptionThrown);
                 }
 
-                List<CompletionResult> completionResults = null;
+                List<CompletionResult>? completionResults = null;
 
                 if (commandInfos != null && commandInfos.Count > 1)
                 {
@@ -267,7 +270,7 @@ namespace System.Management.Automation
             return new CompletionResult(name, listItem, CompletionResultType.Command, syntax);
         }
 
-        internal static List<CompletionResult> MakeCommandsUnique(IEnumerable<PSObject> commandInfoPsObjs, bool includeModulePrefix, bool addAmpersandIfNecessary, string quote)
+        internal static List<CompletionResult> MakeCommandsUnique(IEnumerable<PSObject>? commandInfoPsObjs, bool includeModulePrefix, bool addAmpersandIfNecessary, string quote)
         {
             List<CompletionResult> results = new List<CompletionResult>();
             if (commandInfoPsObjs == null || !commandInfoPsObjs.Any())
@@ -279,7 +282,7 @@ namespace System.Management.Automation
             foreach (var psobj in commandInfoPsObjs)
             {
                 object baseObj = PSObject.Base(psobj);
-                string name = null;
+                string? name = null;
 
                 var commandInfo = baseObj as CommandInfo;
                 if (commandInfo != null)
@@ -308,7 +311,7 @@ namespace System.Management.Automation
                     if (name == null) { continue; }
                 }
 
-                object value;
+                object? value;
                 if (!commandTable.TryGetValue(name, out value))
                 {
                     commandTable.Add(name, baseObj);
@@ -328,7 +331,7 @@ namespace System.Management.Automation
                 }
             }
 
-            List<CompletionResult> endResults = null;
+            List<CompletionResult>? endResults = null;
             foreach (var keyValuePair in commandTable)
             {
                 var commandList = keyValuePair.Value as List<object>;
@@ -486,14 +489,14 @@ namespace System.Management.Automation
 
         internal static List<CompletionResult> CompleteCommandParameter(CompletionContext context)
         {
-            string partialName = null;
+            string? partialName = null;
             bool withColon = false;
-            CommandAst commandAst = null;
+            CommandAst? commandAst = null;
             List<CompletionResult> result = new List<CompletionResult>();
 
             // Find the parameter ast, it will be near or at the end
-            CommandParameterAst parameterAst = null;
-            DynamicKeywordStatementAst keywordAst = null;
+            CommandParameterAst? parameterAst = null;
+            DynamicKeywordStatementAst? keywordAst = null;
             for (int i = context.RelatedAsts.Count - 1; i >= 0; i--)
             {
                 if (keywordAst == null)
@@ -515,7 +518,7 @@ namespace System.Management.Automation
                 var lastAst = context.RelatedAsts.Last();
                 var wordToMatch = string.Concat(context.WordToComplete.AsSpan(1), "*");
                 var pattern = WildcardPattern.Get(wordToMatch, WildcardOptions.IgnoreCase);
-                var parameterNames = keywordAst.CommandElements.Where(static ast => ast is CommandParameterAst).Select(static ast => (ast as CommandParameterAst).ParameterName);
+                var parameterNames = keywordAst.CommandElements.OfType<CommandParameterAst>().Select(static ast => ast.ParameterName);
                 foreach (var parameterName in s_parameterNamesOfImportDSCResource)
                 {
                     if (pattern.IsMatch(parameterName) && !parameterNames.Contains(parameterName, StringComparer.OrdinalIgnoreCase))
@@ -554,7 +557,7 @@ namespace System.Management.Automation
                 partialName = string.Empty;
             }
 
-            PseudoBindingInfo pseudoBinding = new PseudoParameterBinder()
+            PseudoBindingInfo? pseudoBinding = new PseudoParameterBinder()
                                                 .DoPseudoParameterBinding(commandAst, null, parameterAst, PseudoParameterBinder.BindingType.ParameterCompletion);
             // The command cannot be found or it's not a cmdlet, not a script cmdlet, not a function.
             // Try completing as if it the parameter is a command argument for native command completion.
@@ -571,7 +574,7 @@ namespace System.Management.Automation
                     break;
                 case PseudoBindingInfoType.PseudoBindingSucceed:
                     // The command is a cmdlet or script cmdlet. Binding succeeded.
-                    result = GetParameterCompletionResults(partialName, pseudoBinding, parameterAst, withColon);
+                    result = GetParameterCompletionResults(partialName, pseudoBinding, parameterAst!, withColon);
                     break;
             }
 
@@ -648,7 +651,7 @@ namespace System.Management.Automation
             }
 
             // The parameter should be bound in the pseudo binding during the named binding
-            string matchedParameterName = null;
+            string? matchedParameterName = null;
             foreach (KeyValuePair<string, AstParameterArgumentPair> entry in bindingInfo.BoundArguments)
             {
                 switch (entry.Value.ParameterArgumentType)
@@ -833,12 +836,12 @@ namespace System.Management.Automation
 
         internal static List<CompletionResult> CompleteCommandArgument(CompletionContext context)
         {
-            CommandAst commandAst = null;
+            CommandAst? commandAst = null;
             List<CompletionResult> result = new List<CompletionResult>();
 
             // Find the expression ast. It should be at the end if there is one
-            ExpressionAst expressionAst = null;
-            MemberExpressionAst secondToLastMemberAst = null;
+            ExpressionAst? expressionAst = null;
+            MemberExpressionAst? secondToLastMemberAst = null;
             Ast lastAst = context.RelatedAsts.Last();
 
             expressionAst = lastAst as ExpressionAst;
@@ -868,7 +871,7 @@ namespace System.Management.Automation
                                 break;
                         }
 
-                        CommandElementAst secondToLastAst = null;
+                        CommandElementAst? secondToLastAst = null;
                         if (index > 1)
                         {
                             secondToLastAst = commandAst.CommandElements[index - 1];
@@ -891,12 +894,12 @@ namespace System.Management.Automation
                             {
                                 var fullPath = ConcatenateStringPathArguments(secondToLastAst, partialPathAst.Value, context);
                                 expressionAst = secondToLastStringConstantAst != null
-                                                    ? (ExpressionAst)secondToLastStringConstantAst
-                                                    : (ExpressionAst)secondToLastExpandableStringAst;
+                                                    ? secondToLastStringConstantAst
+                                                    : secondToLastExpandableStringAst;
 
                                 context.ReplacementIndex = ((InternalScriptPosition)secondToLastAst.Extent.StartScriptPosition).Offset;
                                 context.ReplacementLength += ((InternalScriptPosition)secondToLastAst.Extent.EndScriptPosition).Offset - context.ReplacementIndex;
-                                context.WordToComplete = fullPath;
+                                context.WordToComplete = fullPath!;
                                 // context.CursorPosition = secondToLastAst.Extent.StartScriptPosition;
                             }
                             else if (secondToLastArrayAst != null)
@@ -908,7 +911,7 @@ namespace System.Management.Automation
                                 {
                                     expressionAst = secondToLastArrayAst;
 
-                                    context.ReplacementIndex = ((InternalScriptPosition)lastArrayElement.Extent.StartScriptPosition).Offset;
+                                    context.ReplacementIndex = ((InternalScriptPosition)lastArrayElement!.Extent.StartScriptPosition).Offset;
                                     context.ReplacementLength += ((InternalScriptPosition)lastArrayElement.Extent.EndScriptPosition).Offset - context.ReplacementIndex;
                                     context.WordToComplete = fullPath;
                                 }
@@ -936,7 +939,7 @@ namespace System.Management.Automation
                                         {
                                             expressionAst = arrayArgAst;
 
-                                            context.ReplacementIndex = ((InternalScriptPosition)lastArrayElement.Extent.StartScriptPosition).Offset;
+                                            context.ReplacementIndex = ((InternalScriptPosition)lastArrayElement!.Extent.StartScriptPosition).Offset;
                                             context.ReplacementLength += ((InternalScriptPosition)lastArrayElement.Extent.EndScriptPosition).Offset - context.ReplacementIndex;
                                             context.WordToComplete = fullPath;
                                         }
@@ -1025,7 +1028,7 @@ namespace System.Management.Automation
 
                 if (pseudoBinding.AllParsedArguments != null && pseudoBinding.AllParsedArguments.Count > 0)
                 {
-                    ArgumentLocation argLocation;
+                    ArgumentLocation? argLocation;
                     bool treatAsExpression = false;
 
                     if (expressionAst != null)
@@ -1045,12 +1048,12 @@ namespace System.Management.Automation
                     if (treatAsExpression)
                     {
                         argLocation = FindTargetArgumentLocation(
-                            pseudoBinding.AllParsedArguments, expressionAst);
+                            pseudoBinding.AllParsedArguments, expressionAst!);
                     }
                     else
                     {
                         argLocation = FindTargetArgumentLocation(
-                            pseudoBinding.AllParsedArguments, context.TokenAtCursor ?? context.TokenBeforeCursor);
+                            pseudoBinding.AllParsedArguments, context.TokenAtCursor ?? context.TokenBeforeCursor!);
                     }
 
                     if (argLocation != null)
@@ -1073,7 +1076,7 @@ namespace System.Management.Automation
                 if (!parsedArgumentsProvidesMatch)
                 {
                     int index = 0;
-                    CommandElementAst prevElem = null;
+                    CommandElementAst? prevElem = null;
                     if (expressionAst != null)
                     {
                         foreach (CommandElementAst eleAst in commandAst.CommandElements)
@@ -1086,7 +1089,7 @@ namespace System.Management.Automation
                     }
                     else
                     {
-                        var token = context.TokenAtCursor ?? context.TokenBeforeCursor;
+                        var token = context.TokenAtCursor ?? context.TokenBeforeCursor!;
                         foreach (CommandElementAst eleAst in commandAst.CommandElements)
                         {
                             if (eleAst.Extent.StartOffset > token.Extent.EndOffset)
@@ -1189,7 +1192,7 @@ namespace System.Management.Automation
                 finally
                 {
                     if (clearLiteralPathsKey)
-                        context.Options.Remove("LiteralPaths");
+                        context.Options!.Remove("LiteralPaths");
                 }
             }
 
@@ -1287,7 +1290,7 @@ namespace System.Management.Automation
                         finally
                         {
                             if (clearLiteralPathKey)
-                                context.Options.Remove("LiteralPaths");
+                                context.Options!.Remove("LiteralPaths");
                         }
                     }
                 }
@@ -1327,7 +1330,7 @@ namespace System.Management.Automation
                 finally
                 {
                     if (clearLiteralPathKey)
-                        context.Options.Remove("LiteralPaths");
+                        context.Options!.Remove("LiteralPaths");
                 }
 
                 // The word to complete contains a dash and it's not the first character. We try command names in this case.
@@ -1341,8 +1344,8 @@ namespace System.Management.Automation
 
             return result;
         }
-
-        internal static string ConcatenateStringPathArguments(CommandElementAst stringAst, string partialPath, CompletionContext completionContext)
+        
+        internal static string? ConcatenateStringPathArguments(CommandElementAst? stringAst, string partialPath, CompletionContext completionContext)
         {
             var constantPathAst = stringAst as StringConstantExpressionAst;
             if (constantPathAst != null)
@@ -1365,7 +1368,7 @@ namespace System.Management.Automation
             else
             {
                 var expandablePathAst = stringAst as ExpandableStringExpressionAst;
-                string fullPath = null;
+                string? fullPath = null;
                 if (expandablePathAst != null &&
                     IsPathSafelyExpandable(expandableStringAst: expandablePathAst,
                                            extraText: partialPath,
@@ -1389,7 +1392,7 @@ namespace System.Management.Automation
         {
             List<CompletionResult> result = new List<CompletionResult>();
 
-            PseudoBindingInfo bindingInfo = context.PseudoBindingInfo;
+            PseudoBindingInfo bindingInfo = context.PseudoBindingInfo!;
             if (argLocation.IsPositional)
             {
                 CompletePositionalArgument(
@@ -1441,14 +1444,14 @@ namespace System.Management.Automation
             ArgumentLocation argLocation,
             CommandAst commandAst)
         {
-            PseudoBindingInfo bindingInfo = context.PseudoBindingInfo;
+            PseudoBindingInfo bindingInfo = context.PseudoBindingInfo!;
             Diagnostics.Assert(bindingInfo.InfoType.Equals(PseudoBindingInfoType.PseudoBindingSucceed), "Caller needs to make sure the pseudo binding was successful");
             List<CompletionResult> result = new List<CompletionResult>();
 
             if (argLocation.IsPositional && argLocation.Argument == null)
             {
-                AstPair lastPositionalArg;
-                AstParameterArgumentPair targetPositionalArg =
+                AstPair? lastPositionalArg;
+                AstParameterArgumentPair? targetPositionalArg =
                     FindTargetPositionalArgument(
                         bindingInfo.AllParsedArguments,
                         argLocation.Position,
@@ -1569,12 +1572,12 @@ namespace System.Management.Automation
             uint defaultParameterSetFlag,
             uint validParameterSetFlags,
             int position,
-            Dictionary<string, AstParameterArgumentPair> boundArguments = null)
+            Dictionary<string, AstParameterArgumentPair>? boundArguments = null)
         {
             bool isProcessedAsPositional = false;
             bool isDefaultParameterSetValid = defaultParameterSetFlag != 0 &&
                                               (defaultParameterSetFlag & validParameterSetFlags) != 0;
-            MergedCompiledCommandParameter positionalParam = null;
+            MergedCompiledCommandParameter? positionalParam = null;
 
             foreach (MergedCompiledCommandParameter param in parameters)
             {
@@ -1674,14 +1677,14 @@ namespace System.Management.Automation
             CompletionContext context,
             List<CompletionResult> result,
             MergedCompiledCommandParameter parameter,
-            Dictionary<string, AstParameterArgumentPair> boundArguments = null)
+            Dictionary<string, AstParameterArgumentPair>? boundArguments = null)
         {
-            CompletionResult fullMatch = null;
+            CompletionResult? fullMatch = null;
             Type parameterType = GetEffectiveParameterType(parameter.Parameter.Type);
 
             if (parameterType.IsArray)
             {
-                parameterType = parameterType.GetElementType();
+                parameterType = parameterType.GetElementType()!;
             }
 
             foreach (ValidateArgumentsAttribute att in parameter.Parameter.ValidationAttributes)
@@ -1813,7 +1816,7 @@ namespace System.Management.Automation
         }
 
         private static IEnumerable<PSTypeName> NativeCommandArgumentCompletion_InferTypesOfArgument(
-            Dictionary<string, AstParameterArgumentPair> boundArguments,
+            Dictionary<string, AstParameterArgumentPair>? boundArguments,
             CommandAst commandAst,
             CompletionContext context,
             string parameterName)
@@ -1823,13 +1826,13 @@ namespace System.Management.Automation
                 yield break;
             }
 
-            AstParameterArgumentPair astParameterArgumentPair;
+            AstParameterArgumentPair? astParameterArgumentPair;
             if (!boundArguments.TryGetValue(parameterName, out astParameterArgumentPair))
             {
                 yield break;
             }
 
-            Ast argumentAst = null;
+            Ast? argumentAst = null;
             switch (astParameterArgumentPair.ParameterArgumentType)
             {
                 case AstParameterArgumentType.AstPair:
@@ -1870,17 +1873,17 @@ namespace System.Management.Automation
                 yield break;
             }
 
-            ExpressionAst argumentExpressionAst = argumentAst as ExpressionAst;
+            ExpressionAst? argumentExpressionAst = argumentAst as ExpressionAst;
             if (argumentExpressionAst == null)
             {
-                CommandExpressionAst argumentCommandExpressionAst = argumentAst as CommandExpressionAst;
+                CommandExpressionAst? argumentCommandExpressionAst = argumentAst as CommandExpressionAst;
                 if (argumentCommandExpressionAst != null)
                 {
                     argumentExpressionAst = argumentCommandExpressionAst.Expression;
                 }
             }
 
-            object argumentValue;
+            object? argumentValue;
             if (argumentExpressionAst != null && SafeExprEvaluator.TrySafeEval(argumentExpressionAst, context.ExecutionContext, out argumentValue))
             {
                 if (argumentValue != null)
@@ -1917,7 +1920,7 @@ namespace System.Management.Automation
         }
 
         internal static IList<string> NativeCommandArgumentCompletion_ExtractSecondaryArgument(
-            Dictionary<string, AstParameterArgumentPair> boundArguments,
+            Dictionary<string, AstParameterArgumentPair>? boundArguments,
             string parameterName)
         {
             List<string> result = new List<string>();
@@ -1927,7 +1930,7 @@ namespace System.Management.Automation
                 return result;
             }
 
-            AstParameterArgumentPair argumentValue;
+            AstParameterArgumentPair? argumentValue;
             if (!boundArguments.TryGetValue(parameterName, out argumentValue))
             {
                 return result;
@@ -1997,7 +2000,7 @@ namespace System.Management.Automation
             List<CompletionResult> result,
             CommandAst commandAst,
             CompletionContext context,
-            Dictionary<string, AstParameterArgumentPair> boundArguments = null)
+            Dictionary<string, AstParameterArgumentPair>? boundArguments = null)
         {
             string parameterName = parameter.Name;
 
@@ -2015,7 +2018,7 @@ namespace System.Management.Automation
 
             string parameterFullName = $"{actualCommandName}:{parameterName}";
 
-            ScriptBlock customCompleter = GetCustomArgumentCompleter(
+            ScriptBlock? customCompleter = GetCustomArgumentCompleter(
                 "CustomArgumentCompleters",
                 new[] { parameterFullName, parameterName },
                 context);
@@ -2168,7 +2171,7 @@ namespace System.Management.Automation
                 case "Get-Module":
                     {
                         bool loadedModulesOnly = boundArguments == null || !boundArguments.ContainsKey("ListAvailable");
-                        bool skipEditionCheck = !loadedModulesOnly && boundArguments.ContainsKey("SkipEditionCheck");
+                        bool skipEditionCheck = !loadedModulesOnly && boundArguments!.ContainsKey("SkipEditionCheck");
                         NativeCompletionModuleCommands(context, parameterName, result, loadedModulesOnly, skipEditionCheck: skipEditionCheck);
                         break;
                     }
@@ -2349,8 +2352,8 @@ namespace System.Management.Automation
                             break;
                         }
 
-                        HashSet<string> excludedValues = null;
-                        if (parameterName.Equals("Property", StringComparison.OrdinalIgnoreCase) && boundArguments["Property"] is AstPair pair)
+                        HashSet<string>? excludedValues = null;
+                        if (parameterName.Equals("Property", StringComparison.OrdinalIgnoreCase) && boundArguments?["Property"] is AstPair pair)
                         {
                             excludedValues = GetParameterValues(pair, context.CursorPosition.Offset);
                         }
@@ -2384,7 +2387,7 @@ namespace System.Management.Automation
                             var exprAst = parameterAst != null
                                               ? parameterAst.Argument
                                               : astPair.Argument as ExpressionAst;
-                            object value;
+                            object? value;
                             if (exprAst != null && SafeExprEvaluator.TrySafeEval(exprAst, context.ExecutionContext, out value))
                             {
                                 result[boundArgument.Key] = value;
@@ -2410,12 +2413,12 @@ namespace System.Management.Automation
             return result;
         }
 
-        private static ScriptBlock GetCustomArgumentCompleter(
+        private static ScriptBlock? GetCustomArgumentCompleter(
             string optionKey,
             IEnumerable<string> keys,
             CompletionContext context)
         {
-            ScriptBlock scriptBlock;
+            ScriptBlock? scriptBlock;
             var options = context.Options;
             if (options != null)
             {
@@ -2478,7 +2481,7 @@ namespace System.Management.Automation
             object[] argumentsToCompleter,
             List<CompletionResult> result)
         {
-            Collection<PSObject> customResults = null;
+            Collection<PSObject>? customResults = null;
             try
             {
                 customResults = scriptBlock.Invoke(argumentsToCompleter);
@@ -2523,16 +2526,16 @@ namespace System.Management.Automation
 
         private static void NativeCompletionCimCommands(
             string parameter,
-            Dictionary<string, AstParameterArgumentPair> boundArguments,
+            Dictionary<string, AstParameterArgumentPair>? boundArguments,
             List<CompletionResult> result,
             CommandAst commandAst,
             CompletionContext context,
-            HashSet<string> excludedValues,
+            HashSet<string>? excludedValues,
             string commandName)
         {
             if (boundArguments != null)
             {
-                AstParameterArgumentPair astParameterArgumentPair;
+                AstParameterArgumentPair? astParameterArgumentPair;
                 if ((boundArguments.TryGetValue("ComputerName", out astParameterArgumentPair)
                      || boundArguments.TryGetValue("CimSession", out astParameterArgumentPair))
                     && astParameterArgumentPair != null)
@@ -2557,7 +2560,7 @@ namespace System.Management.Automation
                 return;
             }
 
-            string pseudoboundCimNamespace = NativeCommandArgumentCompletion_ExtractSecondaryArgument(boundArguments, "Namespace").FirstOrDefault();
+            string? pseudoboundCimNamespace = NativeCommandArgumentCompletion_ExtractSecondaryArgument(boundArguments, "Namespace").FirstOrDefault();
             if (parameter.Equals("ClassName", StringComparison.OrdinalIgnoreCase))
             {
                 NativeCompletionCimClassName(pseudoboundCimNamespace, result, context);
@@ -2566,8 +2569,8 @@ namespace System.Management.Automation
             }
 
             bool gotInstance = false;
-            IEnumerable<PSTypeName> cimClassTypeNames = null;
-            string pseudoboundClassName = NativeCommandArgumentCompletion_ExtractSecondaryArgument(boundArguments, "ClassName").FirstOrDefault();
+            IEnumerable<PSTypeName>? cimClassTypeNames = null;
+            string? pseudoboundClassName = NativeCommandArgumentCompletion_ExtractSecondaryArgument(boundArguments, "ClassName").FirstOrDefault();
             if (pseudoboundClassName != null)
             {
                 gotInstance = false;
@@ -2597,7 +2600,7 @@ namespace System.Management.Automation
                         }
                         else if (parameter.Equals("Arguments", StringComparison.OrdinalIgnoreCase))
                         {
-                            string pseudoboundMethodName = NativeCommandArgumentCompletion_ExtractSecondaryArgument(boundArguments, "MethodName").FirstOrDefault();
+                            string? pseudoboundMethodName = NativeCommandArgumentCompletion_ExtractSecondaryArgument(boundArguments, "MethodName").FirstOrDefault();
                             NativeCompletionCimMethodArgumentName(pseudoboundCimNamespace, pseudoboundClassName, pseudoboundMethodName, excludedValues, result, context);
                         }
                         else if (parameter.Equals("Property", StringComparison.OrdinalIgnoreCase))
@@ -2616,7 +2619,7 @@ namespace System.Management.Automation
             new ConcurrentDictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase);
 
         private static IEnumerable<string> NativeCompletionCimAssociationResultClassName_GetResultClassNames(
-            string cimNamespaceOfSource,
+            string? cimNamespaceOfSource,
             string cimClassNameOfSource)
         {
             StringBuilder safeClassName = new StringBuilder();
@@ -2748,10 +2751,10 @@ namespace System.Management.Automation
         }
 
         private static void NativeCompletionCimMethodArgumentName(
-            string pseudoboundNamespace,
-            string pseudoboundClassName,
-            string pseudoboundMethodName,
-            HashSet<string> excludedParameters,
+            string? pseudoboundNamespace,
+            string? pseudoboundClassName,
+            string? pseudoboundMethodName,
+            HashSet<string>? excludedParameters,
             List<CompletionResult> result,
             CompletionContext context)
         {
@@ -2788,10 +2791,10 @@ namespace System.Management.Automation
         }
 
         private static void NativeCompletionCimPropertyName(
-            string pseudoboundNamespace,
-            string pseudoboundClassName,
+            string? pseudoboundNamespace,
+            string? pseudoboundClassName,
             bool includeReadOnly,
-            HashSet<string> excludedProperties,
+            HashSet<string>? excludedProperties,
             List<CompletionResult> result,
             CompletionContext context)
         {
@@ -2844,7 +2847,7 @@ namespace System.Management.Automation
         }
 
         private static void NativeCompletionCimClassName(
-            string pseudoBoundNamespace,
+            string? pseudoBoundNamespace,
             List<CompletionResult> result,
             CompletionContext context)
         {
@@ -2942,7 +2945,7 @@ namespace System.Management.Automation
             result.AddRange(namespaceResults.OrderBy(static x => x.ListItemText, StringComparer.OrdinalIgnoreCase));
         }
 
-        private static void NativeCompletionGetCommand(CompletionContext context, string moduleName, string paramName, List<CompletionResult> result)
+        private static void NativeCompletionGetCommand(CompletionContext context, string? moduleName, string paramName, List<CompletionResult> result)
         {
             if (!string.IsNullOrEmpty(paramName) && paramName.Equals("Name", StringComparison.OrdinalIgnoreCase))
             {
@@ -3437,7 +3440,7 @@ namespace System.Management.Automation
             result.Add(CompletionResult.Null);
         }
 
-        private static void NativeCompletionDriveCommands(CompletionContext context, string psProvider, string paramName, List<CompletionResult> result)
+        private static void NativeCompletionDriveCommands(CompletionContext context, string? psProvider, string paramName, List<CompletionResult> result)
         {
             if (string.IsNullOrEmpty(paramName) || !paramName.Equals("Name", StringComparison.OrdinalIgnoreCase))
                 return;
@@ -3763,7 +3766,7 @@ namespace System.Management.Automation
             finally
             {
                 if (clearLiteralPath)
-                    context.Options.Remove("LiteralPaths");
+                    context.Options!.Remove("LiteralPaths");
             }
 
             result.Add(CompletionResult.Null);
@@ -3865,7 +3868,7 @@ namespace System.Management.Automation
                 finally
                 {
                     if (clearLiteralPath)
-                        context.Options.Remove("LiteralPaths");
+                        context.Options!.Remove("LiteralPaths");
                 }
 
                 result.Add(CompletionResult.Null);
@@ -3900,13 +3903,13 @@ namespace System.Management.Automation
             finally
             {
                 if (clearLiteralPath)
-                    context.Options.Remove("LiteralPaths");
+                    context.Options!.Remove("LiteralPaths");
             }
 
             result.Add(CompletionResult.Null);
         }
 
-        private static IEnumerable<PSTypeName> GetInferenceTypes(CompletionContext context, CommandAst commandAst)
+        private static IEnumerable<PSTypeName>? GetInferenceTypes(CompletionContext context, CommandAst commandAst)
         {
             // Command is something like where-object/foreach-object/format-list/etc. where there is a parameter that is a property name
             // and we want member names based on the input object, which is either the parameter InputObject, or comes from the pipeline.
@@ -3924,11 +3927,11 @@ namespace System.Management.Automation
                 }
             }
 
-            IEnumerable<PSTypeName> prevType = null;
+            IEnumerable<PSTypeName>? prevType = null;
             if (i == 0)
             {
                 // based on a type of the argument which is binded to 'InputObject' parameter.
-                AstParameterArgumentPair pair;
+                AstParameterArgumentPair? pair;
                 if (!context.PseudoBindingInfo.BoundArguments.TryGetValue("InputObject", out pair)
                     || !pair.ArgumentSpecified)
                 {
@@ -3952,12 +3955,12 @@ namespace System.Management.Automation
             return prevType;
         }
 
-        private static void NativeCompletionMemberName(CompletionContext context, List<CompletionResult> result, CommandAst commandAst, AstParameterArgumentPair parameterInfo, bool propertiesOnly = true)
+        private static void NativeCompletionMemberName(CompletionContext context, List<CompletionResult> result, CommandAst commandAst, AstParameterArgumentPair? parameterInfo, bool propertiesOnly = true)
         {
             IEnumerable<PSTypeName> prevType = GetInferenceTypes(context, commandAst);
             if (prevType is not null)
             {
-                HashSet<string> excludedMembers = null;
+                HashSet<string>? excludedMembers = null;
                 if (parameterInfo is AstPair pair)
                 {
                     excludedMembers = GetParameterValues(pair, context.CursorPosition.Offset);
@@ -3987,12 +3990,12 @@ namespace System.Management.Automation
 
         private static void NativeCompletionFormatViewName(
             CompletionContext context,
-            Dictionary<string, AstParameterArgumentPair> boundArguments,
+            Dictionary<string, AstParameterArgumentPair>? boundArguments,
             List<CompletionResult> result,
             CommandAst commandAst,
             string commandName)
         {
-            IEnumerable<PSTypeName> prevType = NativeCommandArgumentCompletion_InferTypesOfArgument(boundArguments, commandAst, context, "InputObject");
+            IEnumerable<PSTypeName>? prevType = NativeCommandArgumentCompletion_InferTypesOfArgument(boundArguments, commandAst, context, "InputObject");
 
             if (prevType is not null)
             {
@@ -4020,7 +4023,7 @@ namespace System.Management.Automation
             if (wordToComplete.Contains('['))
             {
                 var cursor = (InternalScriptPosition)context.CursorPosition;
-                cursor = cursor.CloneWithNewOffset(cursor.Offset - context.TokenAtCursor.Extent.StartOffset - (isQuoted ? 1 : 0));
+                cursor = cursor.CloneWithNewOffset(cursor.Offset - context.TokenAtCursor!.Extent.StartOffset - (isQuoted ? 1 : 0));
                 var fullTypeName = Parser.ScanType(wordToComplete, ignoreErrors: true);
                 var typeNameToComplete = CompletionAnalysis.FindTypeNameToComplete(fullTypeName, cursor);
                 if (typeNameToComplete == null)
@@ -4085,7 +4088,7 @@ namespace System.Management.Automation
         /// If the command line after the [tab] will not be truncated, the return value could be non-null: Get-Cmdlet [tab] abc
         /// If the command line after the [tab] is truncated, the return value will always be null
         /// </returns>
-        private static AstPair FindTargetPositionalArgument(Collection<AstParameterArgumentPair> parsedArguments, int position, out AstPair lastPositionalArgument)
+        private static AstPair? FindTargetPositionalArgument(Collection<AstParameterArgumentPair> parsedArguments, int position, out AstPair? lastPositionalArgument)
         {
             int index = 0;
             lastPositionalArgument = null;
@@ -4110,7 +4113,7 @@ namespace System.Management.Automation
         private static ArgumentLocation FindTargetArgumentLocation(Collection<AstParameterArgumentPair> parsedArguments, Token token)
         {
             int position = 0;
-            AstParameterArgumentPair prevArg = null;
+            AstParameterArgumentPair? prevArg = null;
             foreach (AstParameterArgumentPair pair in parsedArguments)
             {
                 switch (pair.ParameterArgumentType)
@@ -4132,7 +4135,7 @@ namespace System.Management.Automation
                                 {
                                     // case 1: Get-Cmdlet -Param <tab> abc
                                     // case 2: dir -Path .\abc.txt, <tab> -File
-                                    return new ArgumentLocation() { Argument = arg, IsPositional = false, Position = -1 };
+                                    return new ArgumentLocation(arg);
                                 }
                             }
                             else
@@ -4179,12 +4182,12 @@ namespace System.Management.Automation
         /// <param name="prev">The argument that is right before the 'tab' location.</param>
         /// <param name="position">The number of positional arguments before the 'tab' location.</param>
         /// <returns></returns>
-        private static ArgumentLocation GenerateArgumentLocation(AstParameterArgumentPair prev, int position)
+        private static ArgumentLocation GenerateArgumentLocation(AstParameterArgumentPair? prev, int position)
         {
             // Tab is typed before the first argument
             if (prev == null)
             {
-                return new ArgumentLocation() { Argument = null, IsPositional = true, Position = 0 };
+                return new ArgumentLocation(position: 0);
             }
 
             switch (prev.ParameterArgumentType)
@@ -4192,14 +4195,13 @@ namespace System.Management.Automation
                 case AstParameterArgumentType.AstPair:
                 case AstParameterArgumentType.Switch:
                     if (!prev.ParameterSpecified)
-                        return new ArgumentLocation() { Argument = null, IsPositional = true, Position = position };
+                        return new ArgumentLocation(position);
 
                     return prev.Parameter.Extent.Text.EndsWith(':')
-                        ? new ArgumentLocation() { Argument = prev, IsPositional = false, Position = -1 }
-
-                        : new ArgumentLocation() { Argument = null, IsPositional = true, Position = position };
+                        ? new ArgumentLocation(previousArgument: prev)
+                        : new ArgumentLocation(position);
                 case AstParameterArgumentType.Fake:
-                    return new ArgumentLocation() { Argument = prev, IsPositional = false, Position = -1 };
+                    return new ArgumentLocation(previousArgument: prev);
                 default:
                     Diagnostics.Assert(false, "parsed arguments should not contain AstArray and PipeObject");
                     return null;
@@ -4212,7 +4214,7 @@ namespace System.Management.Automation
         /// <param name="parsedArguments"></param>
         /// <param name="expAst"></param>
         /// <returns></returns>
-        private static ArgumentLocation FindTargetArgumentLocation(Collection<AstParameterArgumentPair> parsedArguments, ExpressionAst expAst)
+        private static ArgumentLocation? FindTargetArgumentLocation(Collection<AstParameterArgumentPair> parsedArguments, ExpressionAst expAst)
         {
             Diagnostics.Assert(expAst != null, "Caller needs to make sure expAst is not null");
             int position = 0;
@@ -4228,14 +4230,14 @@ namespace System.Management.Automation
 
                             if (arg.ParameterContainsArgument && arg.Argument == expAst)
                             {
-                                return new ArgumentLocation() { IsPositional = false, Position = -1, Argument = arg };
+                                return new ArgumentLocation(arg);
                             }
 
                             if (arg.Argument.GetHashCode() == expAst.GetHashCode())
                             {
                                 return arg.ParameterSpecified ?
-                                    new ArgumentLocation() { IsPositional = false, Position = -1, Argument = arg } :
-                                    new ArgumentLocation() { IsPositional = true, Position = position, Argument = arg };
+                                    new ArgumentLocation(arg) :
+                                    new ArgumentLocation(arg, position);
                             }
 
                             if (!arg.ParameterSpecified)
@@ -4262,11 +4264,48 @@ namespace System.Management.Automation
 
         private sealed class ArgumentLocation
         {
-            internal bool IsPositional { get; set; }
+            /// <summary>
+            /// Initializes a new instance of an <see cref="ArgumentLocation"/> that is non-positional.
+            /// </summary>
+            /// <param name="previousArgument"></param>
+            public ArgumentLocation(AstParameterArgumentPair previousArgument)
+            {
+                Argument = previousArgument;
+                Position = -1;
+                IsPositional = false;
+            }
 
-            internal int Position { get; set; }
+            /// <summary>
+            /// Initializes a new instance of an <see cref="ArgumentLocation"/> from a position.
+            /// </summary>
+            /// <param name="position">The number of positional arguments before the 'tab' location.</param>
+            public ArgumentLocation(int position)
+            {
+                Debug.Assert(position >= 0);
+                Position = position;
+                IsPositional = position > -1;
+            }
 
-            internal AstParameterArgumentPair Argument { get; set; }
+            /// <summary>
+            /// Initializes a new instance of an <see cref="ArgumentLocation"/> with a previousArgument and a position.
+            /// </summary>
+            /// <param name="previousArgument"></param>
+            /// <param name="position"></param>
+            public ArgumentLocation(AstParameterArgumentPair previousArgument, int position)
+            {
+                Debug.Assert(position > -1);
+                Position = position;
+                IsPositional = position > -1;
+                Argument = previousArgument;
+            }
+
+            [MemberNotNullWhen(returnValue: false, nameof(Argument))]
+            internal bool IsPositional { get; }
+
+            internal int Position { get; }
+
+            [DisallowNull]
+            internal AstParameterArgumentPair? Argument { get;  set; }
         }
 
         #endregion Command Arguments
@@ -4298,7 +4337,7 @@ namespace System.Management.Automation
         }
 
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
-        internal static IEnumerable<CompletionResult> CompleteFilename(CompletionContext context, bool containerOnly, HashSet<string> extension)
+        internal static IEnumerable<CompletionResult> CompleteFilename(CompletionContext context, bool containerOnly, HashSet<string>? extension)
         {
             var wordToComplete = context.WordToComplete;
             var quote = HandleDoubleAndSingleQuote(ref wordToComplete);
@@ -4345,7 +4384,7 @@ namespace System.Management.Automation
                     wordToComplete = WildcardPattern.Escape(wordToComplete, Utils.Separators.StarOrQuestion);
                 }
 
-                if (!defaultRelative && wordToComplete.Length >= 2 && wordToComplete[1] == ':' && char.IsLetter(wordToComplete[0]) && executionContext != null)
+                if (!defaultRelative && wordToComplete.Length >= 2 && wordToComplete[1] == ':' && char.IsLetter(wordToComplete[0]))
                 {
                     // We don't actually need the drive, but the drive must be "mounted" in PowerShell before completion
                     // can succeed.  This call will mount the drive if it wasn't already.
@@ -4402,7 +4441,7 @@ namespace System.Management.Automation
 
                         if (psobjs.Count > 0 && !LocationGlobber.StringContainsGlobCharacters(wordToComplete))
                         {
-                            string leaf = null;
+                            string? leaf = null;
                             string pathWithoutProvider = wordContainsProviderId
                                     ? wordToComplete.Substring(wordToComplete.IndexOf(':') + 2)
                                     : wordToComplete;
@@ -4416,7 +4455,7 @@ namespace System.Management.Automation
                             }
 
                             var notHiddenEntries = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                            string providerPath = null;
+                            string? providerPath = null;
 
                             foreach (dynamic entry in psobjs)
                             {
@@ -4442,7 +4481,7 @@ namespace System.Management.Automation
                                 // ProviderPath should be absolute path for FileSystem entries
                                 if (!string.IsNullOrEmpty(parentPath))
                                 {
-                                    string[] entries = null;
+                                    string[]? entries = null;
                                     try
                                     {
                                         entries = Directory.GetFileSystemEntries(parentPath, leaf, _enumerationOptions);
@@ -4507,7 +4546,7 @@ namespace System.Management.Automation
                     foreach (PSObject psobj in sortedPsobjs)
                     {
                         object baseObj = PSObject.Base(psobj);
-                        string path = null, providerPath = null;
+                        string? path = null, providerPath = null;
 
                         // Get the path, the PSObject could be:
                         // 1. a PathInfo object -- results of Resolve-Path
@@ -4608,7 +4647,7 @@ namespace System.Management.Automation
                             completionText = quote + completionText + quote;
                         }
 
-                        if (isFileSystem)
+                        if (isFileSystem && providerPath is not null)
                         {
                             // Use .NET APIs directly to reduce the time overhead
                             var isContainer = Directory.Exists(providerPath);
@@ -4641,7 +4680,7 @@ namespace System.Management.Automation
                                     .AddCommandWithPreferenceSetting("Microsoft.PowerShell.Management\\Convert-Path")
                                     .AddParameter("LiteralPath", item.PSPath);
                                 var tooltips = powerShellExecutionHelper.ExecuteCurrentPowerShell(out exceptionThrown);
-                                string tooltip = null, listItemText = item.PSChildName;
+                                string? tooltip = null, listItemText = item.PSChildName;
                                 if (tooltips != null && tooltips.Count == 1)
                                 {
                                     tooltip = PSObject.Base(tooltips[0]) as string;
@@ -4727,7 +4766,7 @@ namespace System.Management.Automation
 #endif
         }
 
-        private static bool CheckFileExtension(string path, HashSet<string> extension)
+        private static bool CheckFileExtension(string path, HashSet<string>? extension)
         {
             if (extension == null || extension.Count == 0)
                 return true;
@@ -4772,7 +4811,7 @@ namespace System.Management.Automation
             var wordToComplete = context.WordToComplete;
             var colon = wordToComplete.IndexOf(':');
 
-            var lastAst = context.RelatedAsts?.Last();
+            var lastAst = context.RelatedAsts?.LastOrDefault();
             var variableAst = lastAst as VariableExpressionAst;
             var prefix = variableAst != null && variableAst.Splatted ? "@" : "$";
 
@@ -4782,7 +4821,7 @@ namespace System.Management.Automation
             if (lastAst != null)
             {
                 Ast parent = lastAst.Parent;
-                var findVariablesVisitor = new FindVariablesVisitor { CompletionVariableAst = lastAst };
+                var findVariablesVisitor = new FindVariablesVisitor(completionVariableAst: lastAst);
                 while (parent != null)
                 {
                     if (parent is IParameterMetadataProvider)
@@ -4796,10 +4835,10 @@ namespace System.Management.Automation
 
                 foreach (Tuple<string, Ast> varAst in findVariablesVisitor.VariableSources)
                 {
-                    Ast astTarget = null;
-                    string userPath = null;
+                    Ast? astTarget = null;
+                    string? userPath = null;
 
-                    VariableExpressionAst variableDefinitionAst = varAst.Item2 as VariableExpressionAst;
+                    VariableExpressionAst? variableDefinitionAst = varAst.Item2 as VariableExpressionAst;
                     if (variableDefinitionAst != null)
                     {
                         userPath = varAst.Item1;
@@ -4807,7 +4846,7 @@ namespace System.Management.Automation
                     }
                     else
                     {
-                        CommandAst commandParameterAst = varAst.Item2 as CommandAst;
+                        CommandAst? commandParameterAst = varAst.Item2 as CommandAst;
                         if (commandParameterAst != null)
                         {
                             userPath = varAst.Item1;
@@ -4856,7 +4895,7 @@ namespace System.Management.Automation
                             var commandAst = ast as CommandAst;
                             if (commandAst != null)
                             {
-                                PSTypeName discoveredType = AstTypeInference.InferTypeOf(ast, context.TypeInferenceContext, TypeInferenceRuntimePermissions.AllowSafeEval).FirstOrDefault<PSTypeName>();
+                                PSTypeName? discoveredType = AstTypeInference.InferTypeOf(ast, context.TypeInferenceContext, TypeInferenceRuntimePermissions.AllowSafeEval).FirstOrDefault<PSTypeName>();
                                 if (discoveredType != null)
                                 {
                                     tooltip = StringUtil.Format("[{0}]${1}", discoveredType.Name, userPath);
@@ -5022,7 +5061,12 @@ namespace System.Management.Automation
 
         private sealed class FindVariablesVisitor : AstVisitor
         {
-            internal Ast Top;
+            public FindVariablesVisitor(Ast completionVariableAst)
+            {                
+                CompletionVariableAst = completionVariableAst;
+            }
+
+            internal Ast? Top;
             internal Ast CompletionVariableAst;
             internal readonly List<Tuple<string, Ast>> VariableSources = new List<Tuple<string, Ast>>();
 
@@ -5050,7 +5094,7 @@ namespace System.Management.Automation
                     StaticBindingResult bindingResult = StaticParameterBinder.BindCommand(commandAst, false, desiredParameters);
                     if (bindingResult != null)
                     {
-                        ParameterBindingResult parameterBindingResult;
+                        ParameterBindingResult? parameterBindingResult;
 
                         foreach (string commandVariableParameter in desiredParameters)
                         {
@@ -5090,7 +5134,7 @@ namespace System.Management.Automation
             {
                 if (member.FieldType.Equals(typeof(string)))
                 {
-                    result.Add((string)member.GetValue(null));
+                    result.Add((string)member.GetValue(null)!);
                 }
             }
 
@@ -5101,7 +5145,7 @@ namespace System.Management.Automation
 
         #region Comments
 
-        internal static List<CompletionResult> CompleteComment(CompletionContext context, ref int replacementIndex, ref int replacementLength)
+        internal static List<CompletionResult>? CompleteComment(CompletionContext context, ref int replacementIndex, ref int replacementLength)
         {
             if (context.WordToComplete.StartsWith("<#", StringComparison.Ordinal))
             {
@@ -5373,21 +5417,22 @@ namespace System.Management.Automation
             ' ',
         };
 
-        private static List<CompletionResult> CompleteCommentHelp(CompletionContext context, ref int replacementIndex, ref int replacementLength)
+        private static List<CompletionResult>? CompleteCommentHelp(CompletionContext context, ref int replacementIndex, ref int replacementLength)
         {
             // Finds comment keywords like ".DESCRIPTION"
-            MatchCollection usedKeywords = Regex.Matches(context.TokenAtCursor.Text, @"(?<=^\s*\.)\w*", RegexOptions.Multiline);
+            Token tokenAtCursor = context.TokenAtCursor!;
+            MatchCollection usedKeywords = Regex.Matches(tokenAtCursor.Text, @"(?<=^\s*\.)\w*", RegexOptions.Multiline);
             if (usedKeywords.Count == 0)
             {
                 return null;
             }
 
             // Last keyword at or before the cursor
-            Match lineKeyword = null;
+            Match? lineKeyword = null;
             for (int i = usedKeywords.Count - 1; i >= 0; i--)
             {
                 Match keyword = usedKeywords[i];
-                if (context.CursorPosition.Offset >= keyword.Index + context.TokenAtCursor.Extent.StartOffset)
+                if (context.CursorPosition.Offset >= keyword.Index + tokenAtCursor.Extent.StartOffset)
                 {
                     lineKeyword = keyword;
                     break;
@@ -5400,9 +5445,9 @@ namespace System.Management.Automation
             }
 
             // Cursor is within or at the start/end of the keyword
-            if (context.CursorPosition.Offset <= lineKeyword.Index + lineKeyword.Length + context.TokenAtCursor.Extent.StartOffset)
+            if (context.CursorPosition.Offset <= lineKeyword.Index + lineKeyword.Length + tokenAtCursor.Extent.StartOffset)
             {
-                replacementIndex = context.TokenAtCursor.Extent.StartOffset + lineKeyword.Index;
+                replacementIndex = tokenAtCursor.Extent.StartOffset + lineKeyword.Index;
                 replacementLength = lineKeyword.Value.Length;
 
                 var validKeywords = new HashSet<string>(s_commentHelpKeywords.Keys, StringComparer.OrdinalIgnoreCase);
@@ -5430,7 +5475,7 @@ namespace System.Management.Automation
 
             // Finds the argument for the keyword (any characters following the keyword, ignoring leading/trailing whitespace). For example "C:\New folder"
             Match keywordArgument = Regex.Match(context.CursorPosition.Line, @"(?<=^\s*\.\w+\s+)\S.*(?<=\S)");
-            int lineStartIndex = lineKeyword.Index - context.CursorPosition.Line.IndexOf(lineKeyword.Value) + context.TokenAtCursor.Extent.StartOffset;
+            int lineStartIndex = lineKeyword.Index - context.CursorPosition.Line.IndexOf(lineKeyword.Value) + tokenAtCursor.Extent.StartOffset;
             int argumentIndex = keywordArgument.Success ? keywordArgument.Index : context.CursorPosition.ColumnNumber - 1;
 
             replacementIndex = lineStartIndex + argumentIndex;
@@ -5443,11 +5488,11 @@ namespace System.Management.Automation
 
             if (lineKeyword.Value.Equals("FORWARDHELPTARGETNAME", StringComparison.OrdinalIgnoreCase))
             {
-                var result = new List<CompletionResult>(CompleteCommand(keywordArgument.Value, "*", CommandTypes.All));
-                return result.Count > 0 ? result : null;
+                var result = CompleteCommand(keywordArgument.Value, "*", CommandTypes.All)?.ToList();
+                return result?.Count > 0 ? result : null;
             }
 
-            if (lineKeyword.Value.Equals("FORWARDHELPCATEGORY", StringComparison.OrdinalIgnoreCase))
+            if (lineKeyword.Value.Equals("FORWARDHELPCATEGORY", StringComparison.OrdinalIgnoreCase)) 
             {
                 var result = new List<CompletionResult>();
                 foreach (string category in s_commentHelpForwardCategories)
@@ -5474,8 +5519,8 @@ namespace System.Management.Automation
             if (lineKeyword.Value.Equals("EXTERNALHELP", StringComparison.OrdinalIgnoreCase))
             {
                 context.WordToComplete = keywordArgument.Value;
-                var result = new List<CompletionResult>(CompleteFilename(context, containerOnly: false, (new HashSet<string>() { ".xml" })));
-                return result.Count > 0 ? result : null;
+                var result = CompleteFilename(context, containerOnly: false, (new HashSet<string>() { ".xml" }))?.ToList();
+                return result?.Count > 0 ? result : null;
             }
 
             return null;
@@ -5523,18 +5568,19 @@ namespace System.Management.Automation
             "All"
         };
 
-        private static FunctionDefinitionAst GetCommentHelpFunctionTarget(CompletionContext context)
+        private static FunctionDefinitionAst? GetCommentHelpFunctionTarget(CompletionContext context)
         {
-            if (context.TokenAtCursor.Kind != TokenKind.Comment)
+            Token tokenAtCursor = context.TokenAtCursor!;
+            if (tokenAtCursor.Kind != TokenKind.Comment)
             {
                 return null;
             }
 
             Ast lastAst = context.RelatedAsts[^1];
-            Ast firstAstAfterComment = lastAst.Find(ast => ast.Extent.StartOffset >= context.TokenAtCursor.Extent.EndOffset && ast is not NamedBlockAst, searchNestedScriptBlocks: false);
+            Ast firstAstAfterComment = lastAst.Find(ast => ast.Extent.StartOffset >= context.TokenAtCursor.Extent.EndOffset, searchNestedScriptBlocks: false);
 
             // Comment-based help can apply to a following function definition if it starts within 2 lines
-            int commentEndLine = context.TokenAtCursor.Extent.EndLineNumber + 2;
+            int commentEndLine = tokenAtCursor.Extent.EndLineNumber + 2;
 
             if (lastAst is NamedBlockAst)
             {
@@ -5573,11 +5619,11 @@ namespace System.Management.Automation
             return null;
         }
 
-        private static List<CompletionResult> CompleteCommentParameterValue(CompletionContext context, string wordToComplete)
+        private static List<CompletionResult>? CompleteCommentParameterValue(CompletionContext context, string wordToComplete)
         {
-            FunctionDefinitionAst foundFunction = GetCommentHelpFunctionTarget(context);
+            FunctionDefinitionAst? foundFunction = GetCommentHelpFunctionTarget(context);
 
-            ReadOnlyCollection<ParameterAst> foundParameters = null;
+            ReadOnlyCollection<ParameterAst>? foundParameters = null;
             if (foundFunction is not null)
             {
                 foundParameters = foundFunction.Parameters ?? foundFunction.Body.ParamBlock?.Parameters;
@@ -5602,7 +5648,7 @@ namespace System.Management.Automation
                 }
             }
 
-            MatchCollection usedParameters = Regex.Matches(context.TokenAtCursor.Text, @"(?<=^\s*\.parameter\s+)\w.*(?<=\S)", RegexOptions.Multiline | RegexOptions.IgnoreCase);
+            MatchCollection usedParameters = Regex.Matches(context.TokenAtCursor!.Text, @"(?<=^\s*\.parameter\s+)\w.*(?<=\S)", RegexOptions.Multiline | RegexOptions.IgnoreCase);
             foreach (Match parameter in usedParameters)
             {
                 if (wordToComplete.Equals(parameter.Value, StringComparison.OrdinalIgnoreCase))
@@ -5650,8 +5696,8 @@ namespace System.Management.Automation
             var results = new List<CompletionResult>();
             var lastAst = context.RelatedAsts.Last();
             var memberName = "*";
-            Ast memberNameCandidateAst = null;
-            ExpressionAst targetExpr = null;
+            Ast? memberNameCandidateAst = null;
+            ExpressionAst? targetExpr = null;
 
             if (lastAst is MemberExpressionAst LastAstAsMemberExpression)
             {
@@ -5752,7 +5798,7 @@ namespace System.Management.Automation
                     targetExpr = parentAsMemberExpression.Expression;
                 }
             }
-            else if (lastAst.Parent is BinaryExpressionAst binaryExpression && context.TokenAtCursor.Kind.Equals(TokenKind.Multiply))
+            else if (lastAst.Parent is BinaryExpressionAst binaryExpression && context.TokenAtCursor!.Kind.Equals(TokenKind.Multiply))
             {
                 if (binaryExpression.Left is MemberExpressionAst memberExpression)
                 {
@@ -5771,7 +5817,7 @@ namespace System.Management.Automation
                 //     'RandomString'.<tab>
                 //     { }
                 // }
-                Ast astBeforeMemberAccessToken = null;
+                Ast? astBeforeMemberAccessToken = null;
                 for (int i = errorStatement.Bodies.Count - 1; i >= 0; i--)
                 {
                     astBeforeMemberAccessToken = errorStatement.Bodies[i];
@@ -5803,7 +5849,7 @@ namespace System.Management.Automation
 
             if (results.Count == 0)
             {
-                PSTypeName[] inferredTypes = null;
+                PSTypeName[]? inferredTypes = null;
 
                 if (@static)
                 {
@@ -5945,7 +5991,7 @@ namespace System.Management.Automation
                 return;
             }
 
-            Type controlBodyType = commandName switch
+            Type? controlBodyType = commandName switch
             {
                 "Format-Table" => typeof(TableControlBody),
                 "Format-List" => typeof(ListControlBody),
@@ -5989,7 +6035,7 @@ namespace System.Management.Automation
             }
         }
 
-        internal static void CompleteMemberByInferredType(TypeInferenceContext context, IEnumerable<PSTypeName> inferredTypes, List<CompletionResult> results, string memberName, Func<object, bool> filter, bool isStatic, HashSet<string> excludedMembers = null)
+        internal static void CompleteMemberByInferredType(TypeInferenceContext context, IEnumerable<PSTypeName> inferredTypes, List<CompletionResult> results, string memberName, Func<object, bool>? filter, bool isStatic, HashSet<string>? excludedMembers = null)
         {
             bool extensionMethodsAdded = false;
             HashSet<string> typeNameUsed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -6028,15 +6074,15 @@ namespace System.Management.Automation
                 Exception unused;
                 var sortedResults = powerShellExecutionHelper.ExecuteCurrentPowerShell(out unused, results);
                 results.Clear();
-                results.AddRange(sortedResults.Select(static psobj => PSObject.Base(psobj) as CompletionResult));
+                results.AddRange(sortedResults.Select(static psobj => (CompletionResult)PSObject.Base(psobj)));
             }
         }
 
-        private static void AddInferredMember(object member, WildcardPattern memberNamePattern, List<CompletionResult> results, HashSet<string> excludedMembers)
+        private static void AddInferredMember(object member, WildcardPattern memberNamePattern, List<CompletionResult> results, HashSet<string>? excludedMembers)
         {
-            string memberName = null;
+            string? memberName = null;
             bool isMethod = false;
-            Func<string> getToolTip = null;
+            Func<string>? getToolTip = null;
             var propertyInfo = member as PropertyInfo;
             if (propertyInfo != null)
             {
@@ -6066,7 +6112,7 @@ namespace System.Management.Automation
             {
                 memberName = psMemberInfo.Name;
                 isMethod = member is PSMethodInfo;
-                getToolTip = psMemberInfo.ToString;
+                getToolTip = psMemberInfo.ToString!;
             }
 
             var cimProperty = member as CimPropertyDeclaration;
@@ -6105,7 +6151,7 @@ namespace System.Management.Automation
             var completionResultType = isMethod ? CompletionResultType.Method : CompletionResultType.Property;
             var completionText = isMethod ? memberName + "(" : memberName;
 
-            results.Add(new CompletionResult(completionText, memberName, completionResultType, getToolTip()));
+            results.Add(new CompletionResult(completionText, memberName, completionResultType, getToolTip!()));
         }
 
         private static string GetCimPropertyToString(CimPropertyDeclaration cimProperty)
@@ -6201,7 +6247,7 @@ namespace System.Management.Automation
         {
             internal abstract CompletionResult GetCompletionResult(string keyMatched, string prefix, string suffix);
 
-            internal abstract CompletionResult GetCompletionResult(string keyMatched, string prefix, string suffix, string namespaceToRemove);
+            internal abstract CompletionResult GetCompletionResult(string keyMatched, string prefix, string suffix, string? namespaceToRemove);
 
             internal static string RemoveBackTick(string typeName)
             {
@@ -6219,10 +6265,15 @@ namespace System.Management.Automation
         /// </summary>
         private class TypeCompletionInStringFormat : TypeCompletionBase
         {
+            public TypeCompletionInStringFormat(string fullTypeName)
+            {
+                FullTypeName = fullTypeName;
+            }
+
             /// <summary>
             /// Get the full type name of the type represented by this instance.
             /// </summary>
-            internal string FullTypeName;
+            internal string FullTypeName { get; }
 
             /// <summary>
             /// Get the short type name of the type represented by this instance.
@@ -6244,7 +6295,7 @@ namespace System.Management.Automation
                 }
             }
 
-            private string _shortTypeName;
+            private string? _shortTypeName;
 
             /// <summary>
             /// Get the namespace of the type represented by this instance.
@@ -6263,7 +6314,7 @@ namespace System.Management.Automation
                 }
             }
 
-            private string _namespace;
+            private string? _namespace;
 
             /// <summary>
             /// Construct the CompletionResult based on the information of this instance.
@@ -6276,7 +6327,7 @@ namespace System.Management.Automation
             /// <summary>
             /// Construct the CompletionResult based on the information of this instance.
             /// </summary>
-            internal override CompletionResult GetCompletionResult(string keyMatched, string prefix, string suffix, string namespaceToRemove)
+            internal override CompletionResult GetCompletionResult(string keyMatched, string prefix, string suffix, string? namespaceToRemove)
             {
                 string completion = string.IsNullOrEmpty(namespaceToRemove)
                                         ? FullTypeName
@@ -6318,6 +6369,10 @@ namespace System.Management.Automation
 
             private int _genericArgumentCount = 0;
 
+            public GenericTypeCompletionInStringFormat(string fullTypeName) : base(fullTypeName)
+            {
+            }
+
             /// <summary>
             /// Construct the CompletionResult based on the information of this instance.
             /// </summary>
@@ -6329,7 +6384,7 @@ namespace System.Management.Automation
             /// <summary>
             /// Construct the CompletionResult based on the information of this instance.
             /// </summary>
-            internal override CompletionResult GetCompletionResult(string keyMatched, string prefix, string suffix, string namespaceToRemove)
+            internal override CompletionResult GetCompletionResult(string keyMatched, string prefix, string suffix, string? namespaceToRemove)
             {
                 string fullNameWithoutBacktip = RemoveBackTick(FullTypeName);
                 string completion = string.IsNullOrEmpty(namespaceToRemove)
@@ -6364,6 +6419,11 @@ namespace System.Management.Automation
         {
             internal Type Type;
 
+            public TypeCompletion(Type type)
+            {
+                Type = type;
+            }
+
             protected string GetTooltipPrefix()
             {
                 if (typeof(Delegate).IsAssignableFrom(Type))
@@ -6385,7 +6445,7 @@ namespace System.Management.Automation
                 return GetCompletionResult(keyMatched, prefix, suffix, null);
             }
 
-            internal override CompletionResult GetCompletionResult(string keyMatched, string prefix, string suffix, string namespaceToRemove)
+            internal override CompletionResult GetCompletionResult(string keyMatched, string prefix, string suffix, string? namespaceToRemove)
             {
                 string completion = ToStringCodeMethods.Type(Type, false, keyMatched);
 
@@ -6394,7 +6454,7 @@ namespace System.Management.Automation
                 // probably didn't want the accelerator.
                 if (keyMatched.Contains('.') && !completion.Contains('.'))
                 {
-                    completion = Type.FullName;
+                    completion = Type.FullName!;
                 }
 
                 if (!string.IsNullOrEmpty(namespaceToRemove) && completion.Equals(Type.FullName, StringComparison.OrdinalIgnoreCase))
@@ -6415,14 +6475,18 @@ namespace System.Management.Automation
         /// </summary>
         private sealed class GenericTypeCompletion : TypeCompletion
         {
+            public GenericTypeCompletion(Type type) : base(type)
+            {
+            }
+
             internal override CompletionResult GetCompletionResult(string keyMatched, string prefix, string suffix)
             {
                 return GetCompletionResult(keyMatched, prefix, suffix, null);
             }
 
-            internal override CompletionResult GetCompletionResult(string keyMatched, string prefix, string suffix, string namespaceToRemove)
+            internal override CompletionResult GetCompletionResult(string keyMatched, string prefix, string suffix, string? namespaceToRemove)
             {
-                string fullNameWithoutBacktip = RemoveBackTick(Type.FullName);
+                string fullNameWithoutBacktip = RemoveBackTick(Type.FullName!);
                 string completion = string.IsNullOrEmpty(namespaceToRemove)
                                         ? fullNameWithoutBacktip
                                         : fullNameWithoutBacktip.Substring(namespaceToRemove.Length + 1);
@@ -6454,6 +6518,11 @@ namespace System.Management.Automation
         {
             internal string Namespace;
 
+            public NamespaceCompletion(string @namespace)
+            {
+                Namespace = @namespace;
+            }
+
             internal override CompletionResult GetCompletionResult(string keyMatched, string prefix, string suffix)
             {
                 var listItemText = Namespace;
@@ -6466,7 +6535,7 @@ namespace System.Management.Automation
                 return new CompletionResult(prefix + Namespace + suffix, listItemText, CompletionResultType.Namespace, "Namespace " + Namespace);
             }
 
-            internal override CompletionResult GetCompletionResult(string keyMatched, string prefix, string suffix, string namespaceToRemove)
+            internal override CompletionResult GetCompletionResult(string keyMatched, string prefix, string suffix, string? namespaceToRemove)
             {
                 return GetCompletionResult(keyMatched, prefix, suffix);
             }
@@ -6477,9 +6546,20 @@ namespace System.Management.Automation
             // The Key is the string we'll be searching on.  It could complete to various things.
             internal string Key;
             internal List<TypeCompletionBase> Completions = new List<TypeCompletionBase>();
+
+            public TypeCompletionMapping(string key)
+            {
+                Key = key;
+            }
+
+            public TypeCompletionMapping(string key, TypeCompletionBase typeCompletionInstance)
+                : this(key)
+            {                
+                Completions.Add(typeCompletionInstance);
+            }
         }
 
-        private static TypeCompletionMapping[][] s_typeCache;
+        private static TypeCompletionMapping[][]? s_typeCache;
 
         private static TypeCompletionMapping[][] InitializeTypeCache()
         {
@@ -6488,8 +6568,8 @@ namespace System.Management.Automation
             var entries = new Dictionary<string, TypeCompletionMapping>(StringComparer.OrdinalIgnoreCase);
             foreach (var type in TypeAccelerators.Get)
             {
-                TypeCompletionMapping entry;
-                var typeCompletionInstance = new TypeCompletion { Type = type.Value };
+                TypeCompletionMapping? entry;
+                var typeCompletionInstance = new TypeCompletion(type.Value);
 
                 if (entries.TryGetValue(type.Key, out entry))
                 {
@@ -6515,15 +6595,15 @@ namespace System.Management.Automation
                 }
                 else
                 {
-                    entries.Add(type.Key, new TypeCompletionMapping { Key = type.Key, Completions = { typeCompletionInstance } });
+                    entries.Add(type.Key, new TypeCompletionMapping(type.Key, typeCompletionInstance));
                 }
 
                 // If the full type name has already been included, then we know for sure that the short type name has also been included.
-                string fullTypeName = type.Value.FullName;
+                string fullTypeName = type.Value.FullName!;
                 if (entries.ContainsKey(fullTypeName)) { continue; }
 
                 // Otherwise, add the mapping from full type name to the type
-                entries.Add(fullTypeName, new TypeCompletionMapping { Key = fullTypeName, Completions = { typeCompletionInstance } });
+                entries.Add(fullTypeName, new TypeCompletionMapping(key: fullTypeName, typeCompletionInstance));
 
                 // If the short type name is the same as the accelerator name, then skip it to avoid duplication.
                 string shortTypeName = type.Value.Name;
@@ -6534,7 +6614,7 @@ namespace System.Management.Automation
                 // are in the TypeAccelerator cache.
                 if (!entries.TryGetValue(shortTypeName, out entry))
                 {
-                    entry = new TypeCompletionMapping { Key = shortTypeName };
+                    entry = new TypeCompletionMapping(key: shortTypeName);
                     entries.Add(shortTypeName, entry);
                 }
 
@@ -6549,7 +6629,7 @@ namespace System.Management.Automation
             // Populate the type completion cache using the namespace-qualified type names.
             foreach (string fullTypeName in ClrFacade.AvailableDotNetTypeNames)
             {
-                var typeCompInString = new TypeCompletionInStringFormat { FullTypeName = fullTypeName };
+                var typeCompInString = new TypeCompletionInStringFormat(fullTypeName);
                 HandleNamespace(entries, typeCompInString.Namespace);
                 HandleType(entries, fullTypeName, typeCompInString.ShortTypeName, null);
             }
@@ -6597,7 +6677,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="entryCache">The TypeCompletionMapping dictionary.</param>
         /// <param name="namespace">The namespace.</param>
-        private static void HandleNamespace(Dictionary<string, TypeCompletionMapping> entryCache, string @namespace)
+        private static void HandleNamespace(Dictionary<string, TypeCompletionMapping> entryCache, string? @namespace)
         {
             if (string.IsNullOrEmpty(@namespace))
             {
@@ -6612,19 +6692,15 @@ namespace System.Management.Automation
                                         ? @namespace.Substring(0, dotIndex)
                                         : @namespace;
 
-                TypeCompletionMapping entry;
+                TypeCompletionMapping? entry;
                 if (!entryCache.TryGetValue(subNamespace, out entry))
                 {
-                    entry = new TypeCompletionMapping
-                    {
-                        Key = subNamespace,
-                        Completions = { new NamespaceCompletion { Namespace = subNamespace } }
-                    };
+                    entry = new TypeCompletionMapping(key: subNamespace, typeCompletionInstance: new NamespaceCompletion(@namespace: subNamespace));                    
                     entryCache.Add(subNamespace, entry);
                 }
                 else if (!entry.Completions.OfType<NamespaceCompletion>().Any())
                 {
-                    entry.Completions.Add(new NamespaceCompletion { Namespace = subNamespace });
+                    entry.Completions.Add(new NamespaceCompletion(@namespace: subNamespace));
                 }
             }
         }
@@ -6636,11 +6712,11 @@ namespace System.Management.Automation
         /// <param name="fullTypeName">The full type name.</param>
         /// <param name="shortTypeName">The short type name.</param>
         /// <param name="actualType">The actual type object. It may be null if we are handling type information from the CoreCLR TypeCatalog.</param>
-        private static void HandleType(Dictionary<string, TypeCompletionMapping> entryCache, string fullTypeName, string shortTypeName, Type actualType)
+        private static void HandleType(Dictionary<string, TypeCompletionMapping> entryCache, string? fullTypeName, string shortTypeName, Type? actualType)
         {
             if (string.IsNullOrEmpty(fullTypeName)) { return; }
 
-            TypeCompletionBase typeCompletionBase = null;
+            TypeCompletionBase? typeCompletionBase = null;
             var backtick = fullTypeName.LastIndexOf('`');
             var plusChar = fullTypeName.LastIndexOf('+');
 
@@ -6653,9 +6729,8 @@ namespace System.Management.Automation
                 if (isNested) { return; }
 
                 typeCompletionBase = actualType != null
-                                         ? (TypeCompletionBase)new GenericTypeCompletion { Type = actualType }
-
-                                         : new GenericTypeCompletionInStringFormat { FullTypeName = fullTypeName };
+                                         ? (TypeCompletionBase)new GenericTypeCompletion(actualType)
+                                         : new GenericTypeCompletionInStringFormat(fullTypeName);
 
                 // Remove the backtick, we only want 1 generic in our results for types like Func or Action.
                 fullTypeName = fullTypeName.Substring(0, backtick);
@@ -6664,28 +6739,23 @@ namespace System.Management.Automation
             else
             {
                 typeCompletionBase = actualType != null
-                                         ? (TypeCompletionBase)new TypeCompletion { Type = actualType }
-
-                                         : new TypeCompletionInStringFormat { FullTypeName = fullTypeName };
+                                         ? (TypeCompletionBase)new TypeCompletion(actualType)
+                                         : new TypeCompletionInStringFormat(fullTypeName);
             }
 
             // If the full type name has already been included, then we know for sure that the short type
             // name and the accelerator type names (if there are any) have also been included.
-            TypeCompletionMapping entry;
+            TypeCompletionMapping? entry;
             if (!entryCache.TryGetValue(fullTypeName, out entry))
             {
-                entry = new TypeCompletionMapping
-                {
-                    Key = fullTypeName,
-                    Completions = { typeCompletionBase }
-                };
+                entry = new TypeCompletionMapping(fullTypeName, typeCompletionBase);                
                 entryCache.Add(fullTypeName, entry);
 
                 // Add a new mapping entry, or put the TypeCompletion instance in the existing mapping entry of the shortTypeName.
                 // For example, this may happen to System.ServiceProcess.TimeoutException when System.TimeoutException is already in the cache.
                 if (!entryCache.TryGetValue(shortTypeName, out entry))
                 {
-                    entry = new TypeCompletionMapping { Key = shortTypeName };
+                    entry = new TypeCompletionMapping(shortTypeName);
                     entryCache.Add(shortTypeName, entry);
                 }
 
@@ -6754,7 +6824,7 @@ namespace System.Management.Automation
             {
                 foreach (var completion in entry.Completions)
                 {
-                    string namespaceToRemove = GetNamespaceToRemove(context, completion);
+                    string? namespaceToRemove = GetNamespaceToRemove(context, completion);
                     var completionResult = completion.GetCompletionResult(entry.Key, prefix, suffix, namespaceToRemove);
 
                     // We might get the same completion result twice. For example, the type cache has:
@@ -6792,7 +6862,7 @@ namespace System.Management.Automation
             return results;
         }
 
-        private static string GetNamespaceToRemove(CompletionContext context, TypeCompletionBase completion)
+        private static string? GetNamespaceToRemove(CompletionContext context, TypeCompletionBase completion)
         {
             if (completion is NamespaceCompletion || context.RelatedAsts == null || context.RelatedAsts.Count == 0)
             {
@@ -6800,7 +6870,7 @@ namespace System.Management.Automation
             }
 
             var typeCompletion = completion as TypeCompletion;
-            string typeNameSpace = typeCompletion != null
+            string? typeNameSpace = typeCompletion != null
                                        ? typeCompletion.Type.Namespace
                                        : ((TypeCompletionInStringFormat)completion).Namespace;
 
@@ -6873,7 +6943,7 @@ namespace System.Management.Automation
 
         #region Statement Parameters
 
-        internal static List<CompletionResult> CompleteStatementFlags(TokenKind kind, string wordToComplete)
+        internal static List<CompletionResult>? CompleteStatementFlags(TokenKind kind, string wordToComplete)
         {
             switch (kind)
             {
@@ -6891,7 +6961,7 @@ namespace System.Management.Automation
                     var pattern = WildcardPattern.Get(wordToComplete + "*", WildcardOptions.IgnoreCase);
                     var enumList = new List<string>();
                     var result = new List<CompletionResult>();
-                    CompletionResult fullMatch = null;
+                    CompletionResult? fullMatch = null;
 
                     foreach (string value in enumArray)
                     {
@@ -6950,13 +7020,13 @@ namespace System.Management.Automation
         /// <param name="ast"></param>
         /// <param name="hashtableAst"></param>
         /// <returns></returns>
-        internal static List<CompletionResult> CompleteHashtableKeyForDynamicKeyword(
+        internal static List<CompletionResult>? CompleteHashtableKeyForDynamicKeyword(
             CompletionContext completionContext,
             DynamicKeywordStatementAst ast,
             HashtableAst hashtableAst)
         {
             Diagnostics.Assert(ast.Keyword != null, "DynamicKeywordStatementAst.Keyword can never be null");
-            List<CompletionResult> results = null;
+            List<CompletionResult>? results = null;
             var dynamicKeywordProperties = ast.Keyword.Properties;
             var memberPattern = completionContext.WordToComplete + "*";
 
@@ -7016,7 +7086,7 @@ namespace System.Management.Automation
             return results;
         }
 
-        internal static List<CompletionResult> CompleteHashtableKey(CompletionContext completionContext, HashtableAst hashtableAst)
+        internal static List<CompletionResult>? CompleteHashtableKey(CompletionContext completionContext, HashtableAst hashtableAst)
         {
             int cursorOffset = completionContext.CursorPosition.Offset;
             string wordToComplete = completionContext.WordToComplete;
@@ -7098,7 +7168,7 @@ namespace System.Management.Automation
                     return null;
                 }
 
-                string parameterName = null;
+                string? parameterName = null;
                 foreach (var boundArg in binding.BoundArguments)
                 {
                     var astPair = boundArg.Value as AstPair;
@@ -7256,7 +7326,7 @@ namespace System.Management.Automation
             return null;
         }
 
-        private static List<CompletionResult> GetSpecialHashTableKeyMembers(HashSet<string> excludedKeys, string wordToComplete, params string[] keys)
+        private static List<CompletionResult>? GetSpecialHashTableKeyMembers(HashSet<string> excludedKeys, string wordToComplete, params string[] keys)
         {
             var result = new List<CompletionResult>();
             foreach (string key in keys)
@@ -7279,7 +7349,7 @@ namespace System.Management.Automation
 
         #region Helpers
 
-        internal static bool IsPathSafelyExpandable(ExpandableStringExpressionAst expandableStringAst, string extraText, ExecutionContext executionContext, out string expandedString)
+        internal static bool IsPathSafelyExpandable(ExpandableStringExpressionAst expandableStringAst, string extraText, ExecutionContext executionContext, [NotNullWhen(returnValue: true)] out string? expandedString)
         {
             expandedString = null;
             // Expand the string if its type is DoubleQuoted or BareWord
@@ -7296,7 +7366,7 @@ namespace System.Management.Automation
             {
                 if (!(nestedAst is VariableExpressionAst variableAst)) { return false; }
 
-                string strValue = CombineVariableWithPartialPath(variableAst, null, executionContext);
+                string? strValue = CombineVariableWithPartialPath(variableAst, null, executionContext);
                 if (strValue != null)
                 {
                     varValues.Add(strValue);
@@ -7314,7 +7384,7 @@ namespace System.Management.Automation
             return true;
         }
 
-        internal static string CombineVariableWithPartialPath(VariableExpressionAst variableAst, string extraText, ExecutionContext executionContext)
+        internal static string? CombineVariableWithPartialPath(VariableExpressionAst variableAst, string? extraText, ExecutionContext executionContext)
         {
             var varPath = variableAst.VariablePath;
             if (!varPath.IsVariable && !varPath.DriveName.Equals("env", StringComparison.OrdinalIgnoreCase))
@@ -7331,7 +7401,7 @@ namespace System.Management.Automation
             try
             {
                 // We check the strict mode inside GetVariableValue
-                object value = VariableOps.GetVariableValue(varPath, executionContext, variableAst);
+                object? value = VariableOps.GetVariableValue(varPath, executionContext, variableAst);
                 var strValue = (value == null) ? string.Empty : value as string;
 
                 if (strValue == null)
@@ -7405,7 +7475,7 @@ namespace System.Management.Automation
             CompletionContext context,
             List<CompletionResult> results)
         {
-            object value;
+            object? value;
             if (SafeExprEvaluator.TrySafeEval(targetExpr, context.ExecutionContext, out value) && value != null)
             {
                 if (targetExpr is ArrayExpressionAst && value is not object[])
@@ -7467,7 +7537,7 @@ namespace System.Management.Automation
                         completionText += '(';
                     }
 
-                    string tooltip = memberInfo.ToString();
+                    string tooltip = memberInfo.ToString()!;
                     if (tooltip.Contains("),", StringComparison.Ordinal))
                     {
                         var overloads = tooltip.Split("),", StringSplitOptions.RemoveEmptyEntries);
@@ -7601,7 +7671,7 @@ namespace System.Management.Automation
         /// <param name="completionContext"></param>
         /// <returns>
         /// Indicate whether the "LiteralPaths" option needs to be removed after operation
-        /// </returns>
+        /// </returns>        
         private static bool TurnOnLiteralPathOption(CompletionContext completionContext)
         {
             bool clearLiteralPathsKey = false;
@@ -7629,9 +7699,9 @@ namespace System.Management.Automation
         /// <returns></returns>
         internal static bool IsAmpersandNeeded(CompletionContext context, bool defaultChoice)
         {
-            if (context.RelatedAsts != null && !string.IsNullOrEmpty(context.WordToComplete))
+            var lastAst = context.RelatedAsts.LastOrDefault();
+            if (lastAst != null && !string.IsNullOrEmpty(context.WordToComplete))
             {
-                var lastAst = context.RelatedAsts.Last();
                 var parent = lastAst.Parent as CommandAst;
 
                 if (parent != null && parent.CommandElements.Count == 1 &&
@@ -7651,7 +7721,7 @@ namespace System.Management.Automation
 
         private sealed class ItemPathComparer : IComparer<PSObject>
         {
-            public int Compare(PSObject x, PSObject y)
+            public int Compare(PSObject? x, PSObject? y)
             {
                 var xPathInfo = PSObject.Base(x) as PathInfo;
                 var xFileInfo = PSObject.Base(x) as IO.FileSystemInfo;
@@ -7661,7 +7731,7 @@ namespace System.Management.Automation
                 var yFileInfo = PSObject.Base(y) as IO.FileSystemInfo;
                 var yPathStr = PSObject.Base(y) as string;
 
-                string xPath = null, yPath = null;
+                string? xPath = null, yPath = null;
 
                 if (xPathInfo != null)
                     xPath = xPathInfo.ProviderPath;
@@ -7686,10 +7756,10 @@ namespace System.Management.Automation
 
         private sealed class CommandNameComparer : IComparer<PSObject>
         {
-            public int Compare(PSObject x, PSObject y)
+            public int Compare(PSObject? x, PSObject? y)
             {
-                string xName = null;
-                string yName = null;
+                string? xName = null;
+                string? yName = null;
 
                 object xObj = PSObject.Base(x);
                 object yObj = PSObject.Base(y);
@@ -7718,7 +7788,7 @@ namespace System.Management.Automation
     /// </summary>
     internal class SafeExprEvaluator : ICustomAstVisitor2
     {
-        internal static bool TrySafeEval(ExpressionAst ast, ExecutionContext executionContext, out object value)
+        internal static bool TrySafeEval(ExpressionAst ast, ExecutionContext executionContext, [NotNullWhen(returnValue:true)] out object? value)
         {
             if (!(bool)ast.Accept(new SafeExprEvaluator()))
             {
@@ -7982,7 +8052,7 @@ namespace System.Management.Automation
         {
             if (commandAst.Parent is not PipelineAst pipelineAst)
             {
-                return null;
+                return Array.Empty<CompletionResult>();
             }
 
             int i;
@@ -8002,7 +8072,7 @@ namespace System.Management.Automation
                 var pseudoBinding = new PseudoParameterBinder().DoPseudoParameterBinding(commandAst, null, parameterAst, PseudoParameterBinder.BindingType.ParameterCompletion);
                 if (!pseudoBinding.BoundArguments.TryGetValue(_parameterNameOfInput, out var pair) || !pair.ArgumentSpecified)
                 {
-                    return null;
+                    return Array.Empty<CompletionResult>();
                 }
 
                 if (pair is AstPair astPair && astPair.Argument != null)
@@ -8010,7 +8080,7 @@ namespace System.Management.Automation
                     prevType = AstTypeInference.InferTypeOf(astPair.Argument, typeInferenceContext, TypeInferenceRuntimePermissions.AllowSafeEval);
                 }
 
-                return null;
+                return Array.Empty<CompletionResult>();
             }
             else
             {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -3957,7 +3957,7 @@ namespace System.Management.Automation
 
         private static void NativeCompletionMemberName(CompletionContext context, List<CompletionResult> result, CommandAst commandAst, AstParameterArgumentPair? parameterInfo, bool propertiesOnly = true)
         {
-            IEnumerable<PSTypeName> prevType = GetInferenceTypes(context, commandAst);
+            IEnumerable<PSTypeName>? prevType = GetInferenceTypes(context, commandAst);
             if (prevType is not null)
             {
                 HashSet<string>? excludedMembers = null;
@@ -3966,7 +3966,7 @@ namespace System.Management.Automation
                     excludedMembers = GetParameterValues(pair, context.CursorPosition.Offset);
                 }
 
-                Func<object, bool> filter = propertiesOnly ? IsPropertyMember : null;
+                Func<object, bool>? filter = propertiesOnly ? IsPropertyMember : null;
                 CompleteMemberByInferredType(context.TypeInferenceContext, prevType, result, context.WordToComplete + "*", filter, isStatic: false, excludedMembers);
             }
 
@@ -5577,7 +5577,7 @@ namespace System.Management.Automation
             }
 
             Ast lastAst = context.RelatedAsts[^1];
-            Ast firstAstAfterComment = lastAst.Find(ast => ast.Extent.StartOffset >= context.TokenAtCursor.Extent.EndOffset, searchNestedScriptBlocks: false);
+            Ast firstAstAfterComment = lastAst.Find(ast => ast.Extent.StartOffset >= tokenAtCursor.Extent.EndOffset, searchNestedScriptBlocks: false);
 
             // Comment-based help can apply to a following function definition if it starts within 2 lines
             int commentEndLine = tokenAtCursor.Extent.EndLineNumber + 2;
@@ -5864,7 +5864,7 @@ namespace System.Management.Automation
                     inferredTypes = AstTypeInference.InferTypeOf(targetExpr, context.TypeInferenceContext, TypeInferenceRuntimePermissions.AllowSafeEval).ToArray();
                 }
 
-                if (!@static && inferredTypes.Length == 1 && inferredTypes[0].Name.Equals("System.Void", StringComparison.OrdinalIgnoreCase))
+                if (!@static && inferredTypes!.Length == 1 && inferredTypes[0].Name.Equals("System.Void", StringComparison.OrdinalIgnoreCase))
                 {
                     return results;
                 }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionResult.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionResult.cs
@@ -3,6 +3,8 @@
 
 using System;
 
+#nullable enable
+
 namespace System.Management.Automation
 {
     /// <summary>
@@ -210,6 +212,10 @@ namespace System.Management.Automation
         /// This can be used in argument completion, to indicate that the completion attempt has gone through the
         /// native command argument completion methods.
         /// </remarks>
-        private CompletionResult() { }
+        private CompletionResult() {
+            _completionText = null!;
+            _listItemText = null!;
+            _toolTip = null!;
+        }
     }
 }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionResult.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionResult.cs
@@ -212,7 +212,8 @@ namespace System.Management.Automation
         /// This can be used in argument completion, to indicate that the completion attempt has gone through the
         /// native command argument completion methods.
         /// </remarks>
-        private CompletionResult() {
+        private CompletionResult() 
+		{
             _completionText = null!;
             _listItemText = null!;
             _toolTip = null!;

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1018,7 +1018,7 @@ ConstructorTestClass(int i, bool b)
                 ## if $PSHOME contains a space tabcompletion adds ' around the path
                 @{ inputStr = 'cd $PSHOME\Modu'; expected = if($PSHOME.Contains(' ')) { "'$(Join-Path $PSHOME 'Modules')'" } else { Join-Path $PSHOME 'Modules' }; setup = $null }
                 @{ inputStr = 'cd "$PSHOME\Modu"'; expected = "`"$(Join-Path $PSHOME 'Modules')`""; setup = $null }
-                @{ inputStr = '$PSHOME\System.Management.Au'; expected = if($PSHOME.Contains(' ')) { "`& '$(Join-Path $PSHOME 'System.Management.Automation.dll')'" }  else { Join-Path $PSHOME 'System.Management.Automation.dll'}; Setup = $null }
+                @{ inputStr = '$PSHOME\System.Management.Au'; expected = if($PSHOME.Contains(' ')) { "`& '$(Join-Path $PSHOME 'System.Management.Automation.dll')'" }  else { Join-Path $PSHOME 'System.Management.Automation.dll'; Setup = $null }}
                 @{ inputStr = '"$PSHOME\System.Management.Au"'; expected = "`"$(Join-Path $PSHOME 'System.Management.Automation.dll')`""; setup = $null }
                 @{ inputStr = '& "$PSHOME\System.Management.Au"'; expected = "`"$(Join-Path $PSHOME 'System.Management.Automation.dll')`""; setup = $null }
                 ## tab completion AST-based tests

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1018,7 +1018,7 @@ ConstructorTestClass(int i, bool b)
                 ## if $PSHOME contains a space tabcompletion adds ' around the path
                 @{ inputStr = 'cd $PSHOME\Modu'; expected = if($PSHOME.Contains(' ')) { "'$(Join-Path $PSHOME 'Modules')'" } else { Join-Path $PSHOME 'Modules' }; setup = $null }
                 @{ inputStr = 'cd "$PSHOME\Modu"'; expected = "`"$(Join-Path $PSHOME 'Modules')`""; setup = $null }
-                @{ inputStr = '$PSHOME\System.Management.Au'; expected = if($PSHOME.Contains(' ')) { "`& '$(Join-Path $PSHOME 'System.Management.Automation.dll')'" }  else { Join-Path $PSHOME 'System.Management.Automation.dll'; Setup = $null }}
+                @{ inputStr = '$PSHOME\System.Management.Au'; expected = if($PSHOME.Contains(' ')) { "`& '$(Join-Path $PSHOME 'System.Management.Automation.dll')'" }  else { Join-Path $PSHOME 'System.Management.Automation.dll'}; Setup = $null }
                 @{ inputStr = '"$PSHOME\System.Management.Au"'; expected = "`"$(Join-Path $PSHOME 'System.Management.Automation.dll')`""; setup = $null }
                 @{ inputStr = '& "$PSHOME\System.Management.Au"'; expected = "`"$(Join-Path $PSHOME 'System.Management.Automation.dll')`""; setup = $null }
                 ## tab completion AST-based tests


### PR DESCRIPTION
# PR Summary

Nullable annotations, and a few select rewrites to clarify nullability, for
CommandCompletion.cs    
CompletionAnalysis.cs   
CompletionCompleters.cs 
CompletionResult.cs     

## PR Context

Before doing the work on IArgumentCompletion2, it makes sense to have a better view of the current workings with regard to nullability.


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
