### PR TITLE
Fix formatting to act appropriately when the style of table header or list label is empty string

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/ListWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ListWriter.cs
@@ -227,6 +227,10 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             // The padding to use in the lines after the first.
             string headPadding = null;
 
+            // The VT style used for the list label.
+            string style = PSStyle.Instance.Formatting.FormatAccent;
+            string reset = PSStyle.Instance.Reset;
+
             // display the string collection
             for (int k = 0; k < sc.Count; k++)
             {
@@ -235,18 +239,21 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
                 if (k == 0)
                 {
-                    if (string.IsNullOrWhiteSpace(prependString))
+                    if (string.IsNullOrWhiteSpace(prependString) || style == string.Empty)
                     {
-                        // Sometimes 'prependString' is just padding white spaces.
-                        // We don't need to add formatting escape sequences in such a case.
+                        // - Sometimes 'prependString' is just padding white spaces, and we don't
+                        //   need to add formatting escape sequences in such a case.
+                        // - Otherwise, if the style is an empty string, then the user has chosen
+                        //   to not apply a style to the list label.
                         _cachedBuilder.Append(prependString).Append(str);
                     }
                     else
                     {
+                        // Apply the style to the list label.
                         _cachedBuilder
-                            .Append(PSStyle.Instance.Formatting.FormatAccent)
+                            .Append(style)
                             .Append(prependString)
-                            .Append(PSStyle.Instance.Reset)
+                            .Append(reset)
                             .Append(str);
                     }
                 }
@@ -257,9 +264,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     _cachedBuilder.Append(headPadding).Append(str);
                 }
 
-                if (str.Contains(ValueStringDecorated.ESC) && !str.EndsWith(PSStyle.Instance.Reset))
+                if (str.Contains(ValueStringDecorated.ESC) && !str.EndsWith(reset))
                 {
-                    _cachedBuilder.Append(PSStyle.Instance.Reset);
+                    _cachedBuilder.Append(reset);
                 }
 
                 lo.WriteLine(_cachedBuilder.ToString());

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -698,6 +698,11 @@ namespace System.Management.Automation
 
         private static string ValidateNoContent(string text)
         {
+            if (text is null)
+            {
+                throw new ArgumentNullException(nameof(text));
+            }
+
             var decorartedString = new ValueStringDecorated(text);
             if (decorartedString.ContentLength > 0)
             {

--- a/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
@@ -151,9 +151,12 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             }
             else if (_header != null)
             {
+                string style = PSStyle.Instance.Formatting.TableHeader;
+                string reset = PSStyle.Instance.Reset;
+
                 foreach (string line in _header)
                 {
-                    lo.WriteLine(PSStyle.Instance.Formatting.TableHeader + line + PSStyle.Instance.Reset);
+                    lo.WriteLine(style == string.Empty ? line : style + line + reset);
                 }
 
                 return _header.Count;
@@ -226,6 +229,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 }
             }
 
+            string style = PSStyle.Instance.Formatting.TableHeader;
+            string reset = PSStyle.Instance.Reset;
+
             if (multiLine)
             {
                 foreach (string line in GenerateTableRow(values, currentAlignment, lo.DisplayCells))
@@ -233,7 +239,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     generatedRows?.Add(line);
                     if (isHeader)
                     {
-                        lo.WriteLine(PSStyle.Instance.Formatting.TableHeader + line + PSStyle.Instance.Reset);
+                        lo.WriteLine(style == string.Empty ? line : style + line + reset);
                     }
                     else
                     {
@@ -247,7 +253,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 generatedRows?.Add(line);
                 if (isHeader)
                 {
-                    lo.WriteLine(PSStyle.Instance.Formatting.TableHeader + line + PSStyle.Instance.Reset);
+                    lo.WriteLine(style == string.Empty ? line : style + line + reset);
                 }
                 else
                 {

--- a/test/powershell/engine/Formatting/PSStyle.Tests.ps1
+++ b/test/powershell/engine/Formatting/PSStyle.Tests.ps1
@@ -151,6 +151,22 @@ Describe 'Tests for $PSStyle automatic variable' {
         }
     }
 
+    It '$PSStyle.Formatting.FormatAccent is ignored when it''s set to be an empty string' {
+        $old = $PSStyle.Formatting.FormatAccent
+        $oldRender = $PSStyle.OutputRendering
+
+        try {
+            $PSStyle.OutputRendering = 'Ansi'
+            $PSStyle.Formatting.FormatAccent = ''
+            $out = $PSVersionTable | Format-List | Out-String
+            $out.Contains("`e[") | Should -BeFalse
+        }
+        finally {
+            $PSStyle.OutputRendering = $oldRender
+            $PSStyle.Formatting.FormatAccent = $old
+        }
+    }
+
     It '$PSStyle.Formatting.TableHeader is applied to Format-Table' {
         $old = $PSStyle.Formatting.TableHeader
         $oldRender = $PSStyle.OutputRendering
@@ -160,6 +176,22 @@ Describe 'Tests for $PSStyle automatic variable' {
             $PSStyle.Formatting.TableHeader = $PSStyle.Foreground.Blue + $PSStyle.Background.White + $PSStyle.Bold
             $out = $PSVersionTable | Format-Table | Out-String
             $out | Should -BeLike "*$($PSStyle.Formatting.TableHeader.Replace('[',"``["))*"
+        }
+        finally {
+            $PSStyle.OutputRendering = $oldRender
+            $PSStyle.Formatting.TableHeader = $old
+        }
+    }
+
+    It '$PSStyle.Formatting.TableHeader is ignored when it''s set to be an empty string' {
+        $old = $PSStyle.Formatting.TableHeader
+        $oldRender = $PSStyle.OutputRendering
+
+        try {
+            $PSStyle.OutputRendering = 'Ansi'
+            $PSStyle.Formatting.TableHeader = ''
+            $out = $PSVersionTable | Format-Table | Out-String
+            $out.Contains("`e[") | Should -BeFalse
         }
         finally {
             $PSStyle.OutputRendering = $oldRender


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix formatting to act appropriately when the style of table header or list label is empty string.
Before: The `reset` VT sequence is always appended.
After: Append `reset` VT sequence only if the style VT sequence is not an empty string.

Also fix a Null Ref exception when setting the format styles.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
