### PR TITLE
Fix #16929 do not show profile load time msg with new pwsh parameter

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -189,6 +189,7 @@ namespace Microsoft.PowerShell
             "outputformat",
             "removeworkingdirectorytrailingcharacter",
             "settingsfile",
+            "showprofileloadtime",
             "version",
             "windowstyle",
             "workingdirectory"
@@ -228,6 +229,7 @@ namespace Microsoft.PowerShell
             WindowStyle         = 0x01000000, // -WindowStyle | -w
             WorkingDirectory    = 0x02000000, // -WorkingDirectory | -wd
             ConfigurationFile   = 0x04000000, // -ConfigurationFile
+            ShowProfileLoadTime = 0x08000000, // -ShowProfileLoadTime
             // Enum values for specified ExecutionPolicy
             EPUnrestricted      = 0x0000000100000000, // ExecutionPolicy unrestricted
             EPRemoteSigned      = 0x0000000200000000, // ExecutionPolicy remote signed
@@ -460,6 +462,15 @@ namespace Microsoft.PowerShell
             {
                 AssertArgumentsParsed();
                 return _showExtendedHelp;
+            }
+        }
+
+        internal bool ShowProfileLoadTime
+        {
+            get
+            {
+                AssertArgumentsParsed();
+                return _showProfileLoadTime;
             }
         }
 
@@ -919,6 +930,11 @@ namespace Microsoft.PowerShell
                 {
                     _sshServerMode = true;
                     ParametersUsed |= ParameterBitmap.SSHServerMode;
+                }
+                else if (MatchSwitch(switchKey, "showprofileloadtime", "showprofileloadtime"))
+                {
+                    _showProfileLoadTime = true;
+                    ParametersUsed |= ParameterBitmap.ShowProfileLoadTime;
                 }
                 else if (MatchSwitch(switchKey, "interactive", "i"))
                 {
@@ -1496,6 +1512,7 @@ namespace Microsoft.PowerShell
         private bool _serverMode;
         private bool _namedPipeServerMode;
         private bool _sshServerMode;
+        private bool _showProfileLoadTime;
         private bool _showVersion;
         private string? _configurationFile;
         private string? _configurationName;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -186,10 +186,10 @@ namespace Microsoft.PowerShell
             "nologo",
             "noninteractive",
             "noprofile",
+            "noprofileloadtime",
             "outputformat",
             "removeworkingdirectorytrailingcharacter",
             "settingsfile",
-            "showprofileloadtime",
             "version",
             "windowstyle",
             "workingdirectory"
@@ -229,7 +229,7 @@ namespace Microsoft.PowerShell
             WindowStyle         = 0x01000000, // -WindowStyle | -w
             WorkingDirectory    = 0x02000000, // -WorkingDirectory | -wd
             ConfigurationFile   = 0x04000000, // -ConfigurationFile
-            ShowProfileLoadTime = 0x08000000, // -ShowProfileLoadTime
+            NoProfileLoadTime   = 0x08000000, // -NoProfileLoadTime
             // Enum values for specified ExecutionPolicy
             EPUnrestricted      = 0x0000000100000000, // ExecutionPolicy unrestricted
             EPRemoteSigned      = 0x0000000200000000, // ExecutionPolicy remote signed
@@ -465,12 +465,12 @@ namespace Microsoft.PowerShell
             }
         }
 
-        internal bool ShowProfileLoadTime
+        internal bool NoProfileLoadTime
         {
             get
             {
                 AssertArgumentsParsed();
-                return _showProfileLoadTime;
+                return _noProfileLoadTime;
             }
         }
 
@@ -931,10 +931,10 @@ namespace Microsoft.PowerShell
                     _sshServerMode = true;
                     ParametersUsed |= ParameterBitmap.SSHServerMode;
                 }
-                else if (MatchSwitch(switchKey, "showprofileloadtime", "showprofileloadtime"))
+                else if (MatchSwitch(switchKey, "noprofileloadtime", "noprofileloadtime"))
                 {
-                    _showProfileLoadTime = true;
-                    ParametersUsed |= ParameterBitmap.ShowProfileLoadTime;
+                    _noProfileLoadTime = true;
+                    ParametersUsed |= ParameterBitmap.NoProfileLoadTime;
                 }
                 else if (MatchSwitch(switchKey, "interactive", "i"))
                 {
@@ -1512,7 +1512,7 @@ namespace Microsoft.PowerShell
         private bool _serverMode;
         private bool _namedPipeServerMode;
         private bool _sshServerMode;
-        private bool _showProfileLoadTime;
+        private bool _noProfileLoadTime;
         private bool _showVersion;
         private string? _configurationFile;
         private string? _configurationName;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -1885,7 +1885,7 @@ namespace Microsoft.PowerShell
                     sw.Stop();
 
                     var profileLoadTimeInMs = sw.ElapsedMilliseconds;
-                    if (s_cpp.ShowProfileLoadTime)
+                    if (s_cpp.ShowBanner && !s_cpp.NoProfileLoadTime && profileLoadTimeInMs > 500)
                     {
                         Console.Error.WriteLine(ConsoleHostStrings.SlowProfileLoadingMessage, profileLoadTimeInMs);
                     }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -1885,7 +1885,7 @@ namespace Microsoft.PowerShell
                     sw.Stop();
 
                     var profileLoadTimeInMs = sw.ElapsedMilliseconds;
-                    if (profileLoadTimeInMs > 500 && s_cpp.ShowBanner)
+                    if (s_cpp.ShowProfileLoadTime)
                     {
                         Console.Error.WriteLine(ConsoleHostStrings.SlowProfileLoadingMessage, profileLoadTimeInMs);
                     }

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -149,8 +149,9 @@
                   [-EncodedCommand &lt;Base64EncodedCommand&gt;]
                   [-ExecutionPolicy &lt;ExecutionPolicy&gt;] [-InputFormat {Text | XML}]
                   [-Interactive] [-MTA] [-NoExit] [-NoLogo] [-NonInteractive] [-NoProfile]
-                  [-OutputFormat {Text | XML}] [-SettingsFile &lt;filePath&gt;] [-SSHServerMode] [-STA]
-                  [-Version] [-WindowStyle &lt;style&gt;] [-WorkingDirectory &lt;directoryPath&gt;]
+                  [-OutputFormat {Text | XML}] [-SettingsFile &lt;filePath&gt;] [-ShowProfileLoadTime]
+                  [-SSHServerMode] [-STA] [-Version] [-WindowStyle &lt;style&gt;] 
+                  [-WorkingDirectory &lt;directoryPath&gt;]
 
        pwsh[.exe] -h | -Help | -? | /?
 
@@ -420,6 +421,10 @@ All parameters are case-insensitive.</value>
     "-ConfigurationName" argument.
 
     Example: "pwsh -SettingsFile c:\myproject\powershell.config.json"
+
+-ShowProfileLoadTime
+
+    Displays the time taken to load the PowerShell profiles.    
 
 -SSHServerMode | -sshs
 

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -149,8 +149,9 @@
                   [-EncodedCommand &lt;Base64EncodedCommand&gt;]
                   [-ExecutionPolicy &lt;ExecutionPolicy&gt;] [-InputFormat {Text | XML}]
                   [-Interactive] [-MTA] [-NoExit] [-NoLogo] [-NonInteractive] [-NoProfile]
-                  [-OutputFormat {Text | XML}] [-SettingsFile &lt;filePath&gt;] [-ShowProfileLoadTime]
-                  [-SSHServerMode] [-STA] [-Version] [-WindowStyle &lt;style&gt;] 
+                  [-NoProfileLoadTime] [-OutputFormat {Text | XML}] 
+                  [-SettingsFile &lt;filePath&gt;] [-SSHServerMode] [-STA] 
+                  [-Version] [-WindowStyle &lt;style&gt;] 
                   [-WorkingDirectory &lt;directoryPath&gt;]
 
        pwsh[.exe] -h | -Help | -? | /?
@@ -400,6 +401,11 @@ All parameters are case-insensitive.</value>
 
     Does not load the PowerShell profiles.
 
+-NoProfileLoadTime
+
+    Hides the PowerShell profile load time text shown at startup when the load
+    time exceeds 500 milliseconds.
+
 -OutputFormat | -o | -of
 
     Determines how output from PowerShell is formatted. Valid values are "Text"
@@ -421,10 +427,6 @@ All parameters are case-insensitive.</value>
     "-ConfigurationName" argument.
 
     Example: "pwsh -SettingsFile c:\myproject\powershell.config.json"
-
--ShowProfileLoadTime
-
-    Displays the time taken to load the PowerShell profiles.    
 
 -SSHServerMode | -sshs
 

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -860,8 +860,9 @@ $powershell -c '[System.Management.Automation.Platform]::SelectProductNameForDir
 
     Context "Startup banner text tests" -Tag Slow {
         BeforeAll {
-            $outputPath = "Temp:\StartupBannerTest-Output-${Pid}.txt"
             $inputPath  = "Temp:\StartupBannerTest-Input.txt"
+            $outputPath = "Temp:\StartupBannerTest-Output-${Pid}.txt"
+            $errorPath = "Temp:\StartupBannerTest-Error-${Pid}.txt"
             "exit" > $inputPath
 
             # Not testing update notification banner text here
@@ -877,9 +878,9 @@ $powershell -c '[System.Management.Automation.Platform]::SelectProductNameForDir
 
             $spArgs = @{
                 FilePath = $powershell
-                ArgumentList = @("-NoProfile")
                 RedirectStandardInput = $inputPath
                 RedirectStandardOutput = $outputPath
+                RedirectStandardError = $errorPath
                 WorkingDirectory = $pwd
                 PassThru = $true
                 NoNewWindow = $true
@@ -892,13 +893,48 @@ $powershell -c '[System.Management.Automation.Platform]::SelectProductNameForDir
 
             Remove-Item $inputPath -Force -ErrorAction Ignore
             Remove-Item $outputPath -Force -ErrorAction Ignore
+            Remove-Item $errorPath -Force -ErrorAction Ignore
         }
         BeforeEach {
             Remove-Item $outputPath -Force -ErrorAction Ignore
+            Remove-Item $errorPath -Force -ErrorAction Ignore
         }
         It "Displays expected startup banner text by default" {
+            $spArgs["ArgumentList"] = @("-NoProfile")
             $process = Start-Process @spArgs
             Wait-UntilTrue -sb { $process.HasExited } -TimeoutInMilliseconds 5000 -IntervalInMilliseconds 250 | Should -BeTrue
+
+            $err = @(Get-Content $errorPath)
+            $err | Write-Warning
+            $err.Count | Should -Be 0
+
+            $out = @(Get-Content $outputPath)
+            $out.Count | Should -Be 2
+            $out[0] | Should -BeExactly "PowerShell $($PSVersionTable.GitCommitId)"
+            $out[1] | Should -MatchExactly $expectedPromptPattern
+        }
+        It "Displays the profile load time with -ShowProfileLoadTime" {
+            # This test requires loading profiles so it may not run well on a machine with profiles that generate errors.
+            $spArgs["ArgumentList"] = @("-ShowProfileLoadTime")
+            $process = Start-Process @spArgs
+            Wait-UntilTrue -sb { $process.HasExited } -TimeoutInMilliseconds 5000 -IntervalInMilliseconds 250 | Should -BeTrue
+
+            $err = @(Get-Content $errorPath)
+            $err.Count | Should -Be 1
+            $err[0] | Should -MatchExactly "Loading personal and system profiles took \d+ms\."
+
+            $out = @(Get-Content $outputPath)
+            $out.Count | Should -Be 2
+            $out[0] | Should -BeExactly "PowerShell $($PSVersionTable.GitCommitId)"
+            $out[1] | Should -MatchExactly $expectedPromptPattern
+        }
+        It "Displays no profile load time with -ShowProfileLoadTime and -NoProfile" {
+            $spArgs["ArgumentList"] = "-NoProfile", "-ShowProfileLoadTime"
+            $process = Start-Process @spArgs
+            Wait-UntilTrue -sb { $process.HasExited } -TimeoutInMilliseconds 5000 -IntervalInMilliseconds 250 | Should -BeTrue
+
+            $err = @(Get-Content $errorPath)
+            $err.Count | Should -Be 0
 
             $out = @(Get-Content $outputPath)
             $out.Count | Should -Be 2
@@ -906,9 +942,12 @@ $powershell -c '[System.Management.Automation.Platform]::SelectProductNameForDir
             $out[1] | Should -MatchExactly $expectedPromptPattern
         }
         It "Displays only the prompt with -NoLogo" {
-            $spArgs["ArgumentList"] += "-NoLogo"
+            $spArgs["ArgumentList"] = "-NoProfile", "-NoLogo"
             $process = Start-Process @spArgs
             Wait-UntilTrue -sb { $process.HasExited } -TimeoutInMilliseconds 5000 -IntervalInMilliseconds 250 | Should -BeTrue
+
+            $err = @(Get-Content $errorPath)
+            $err.Count | Should -Be 0
 
             $out = @(Get-Content $outputPath)
             $out.Count | Should -Be 1


### PR DESCRIPTION
This PR adds a new pwsh command line parameter to enable the display of the profile load time message.

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Changes the host to not display the profile load time by default.  A new pwsh command line switch `-ShowProfileLoadTime` was added to allow someone to show the profile load time regardless of the length of the load time.

```
Usage: pwsh[.exe] [-Login] [[-File] <filePath> [args]]
                  [-Command { - | <script-block> [-args <arg-array>]
                                | <string> [<CommandParameters>] } ]
                  [-ConfigurationName <string>] [-CustomPipeName <string>]
                  [-EncodedCommand <Base64EncodedCommand>]
                  [-ExecutionPolicy <ExecutionPolicy>] [-InputFormat {Text | XML}]
                  [-Interactive] [-MTA] [-NoExit] [-NoLogo] [-NonInteractive] [-NoProfile]
                  [-OutputFormat {Text | XML}] [-SettingsFile <filePath>] [-ShowProfileLoadTime]
                  [-SSHServerMode] [-STA] [-Version] [-WindowStyle <style>]
                  [-WorkingDirectory <directoryPath>]

       pwsh[.exe] -h | -Help | -? | /?
       
...

-ShowProfileLoadTime

    Displays the time taken to load the PowerShell profiles.

-SSHServerMode | -sshs
```

## PR Context

Addresses #16929 to further reduce the amount of default startup banner text.

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here --> I wasn't going to file an issue on https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_pwsh?view=powershell-7.2 until the PR gets a thumbs up.
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
