### PR TITLE
Fix Parent property on processes with complex name

### DIFF
--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -904,8 +904,8 @@ namespace System.Management.Automation
                             continue;
                         }
 
-                        string[] lineSplit = line.Split('\t', 3, StringSplitOptions.RemoveEmptyEntries);
-                        if (lineSplit.Length != 3)
+                        string[] lineSplit = line.Split('\t', 2, StringSplitOptions.RemoveEmptyEntries);
+                        if (lineSplit.Length != 2)
                         {
                             continue;
                         }

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -901,15 +901,20 @@ namespace System.Management.Automation
                     string line;
                     while ((line = sr.ReadLine()) != null)
                     {
-                        Match ppidMatch = Regex.Match(
-                            line,
-                            @"^PPid:\s+(\d+)$",
-                            RegexOptions.CultureInvariant | RegexOptions.IgnoreCase,
-                            matchTimeout);
-
-                        if (ppidMatch.Success)
+                        if (!line.StartsWith("PPid:\t", StringComparison.OrdinalIgnoreCase))
                         {
-                            return int.Parse(ppidMatch.Groups[1].Value);
+                            continue;
+                        }
+
+                        string[] lineSplit = line.Split('\t', 2, StringSplitOptions.RemoveEmptyEntries);
+                        if (lineSplit.Length != 2)
+                        {
+                            continue;
+                        }
+
+                        if (int.TryParse(lineSplit[1].Trim(), out var ppid))
+                        {
+                            return ppid;
                         }
                     }
 

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -904,8 +904,8 @@ namespace System.Management.Automation
                             continue;
                         }
 
-                        string[] lineSplit = line.Split('\t', 2, StringSplitOptions.RemoveEmptyEntries);
-                        if (lineSplit.Length != 2)
+                        string[] lineSplit = line.Split('\t', 3, StringSplitOptions.RemoveEmptyEntries);
+                        if (lineSplit.Length != 3)
                         {
                             continue;
                         }

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -6,7 +6,6 @@ using System.ComponentModel;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Management.Automation.Internal;
-using System.Text.RegularExpressions;
 using Microsoft.Win32;
 
 namespace System.Management.Automation
@@ -883,7 +882,6 @@ namespace System.Management.Automation
             public static int GetProcFSParentPid(int pid)
             {
                 const int invalidPid = -1;
-                TimeSpan matchTimeout = new(0, 0, 5);  // 5 Seconds
 
                 // read /proc/<pid>/status
                 // Row beginning with PPid: \d is the parent process id.

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
@@ -148,10 +148,11 @@ Describe "Process Parent property" -Tags "CI" {
 while true; do sleep 1; done
 '@
 
-        Set-Content -Path testdrive:/$commandName -Value $script
-        chmod +x (Resolve-Path -Path testdrive:/$commandName -Relative)
+        # Can't use testdrive: as unelevated user doesn't have perms in test in CI
+        Set-Content -Path /tmp/$commandName -Value $script
+        chmod +x (Resolve-Path -Path /tmp/$commandName -Relative)
         try {
-            $p = Start-Process -FilePath testdrive:/$commandName -PassThru
+            $p = Start-Process -FilePath /tmp/$commandName -PassThru
             $p.Parent.Id | Should -Be $pid
         } finally {
             $p | Stop-Process

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
@@ -22,7 +22,7 @@ Describe "Get-Process for admin" -Tags @('CI', 'RequireAdminOnWindows') {
             $pwshVersion.FileBuildPart | Should -BeExactly $PSVersionTable.PSVersion.Patch
             $gitCommitId = $PSVersionTable.GitCommitId
             if ($gitCommitId.StartsWith("v")) { $gitCommitId = $gitCommitId.Substring(1) }
-            $productVersion = $pwshVersion.ProductVersion.Replace(" Commits: ","-").Replace(" SHA: ","-g")
+            $productVersion = $pwshVersion.ProductVersion.Replace(" Commits: ", "-").Replace(" SHA: ", "-g")
             $productVersion | Should -Match $gitCommitId
         } else {
             $pwshVersion.FileVersion | Should -BeNullOrEmpty
@@ -46,7 +46,7 @@ Describe "Get-Process" -Tags "CI" {
         $idleProcessPid = 0
     }
     It "Should return a type of Object[] for Get-Process cmdlet" -Pending:$IsMacOS {
-        ,$ps | Should -BeOfType System.Object[]
+        , $ps | Should -BeOfType System.Object[]
     }
 
     It "Should have not empty Name flags set for Get-Process object" -Pending:$IsMacOS {
@@ -78,7 +78,7 @@ Describe "Get-Process" -Tags "CI" {
         (Get-Process -Id $PID).Id | Should -BeExactly $PID
     }
 
-    It "Should fail to run Get-Process with -IncludeUserName without admin" -Skip:(!$IsWindows)  {
+    It "Should fail to run Get-Process with -IncludeUserName without admin" -Skip:(!$IsWindows) {
         { Get-Process -IncludeUserName } | Should -Throw -ErrorId "IncludeUserNameRequiresElevation,Microsoft.PowerShell.Commands.GetProcessCommand"
     }
 
@@ -95,7 +95,7 @@ Describe "Get-Process" -Tags "CI" {
         { Get-Process -FileVersionInfo -ErrorAction Stop } | Should -Throw -ErrorId "CouldNotEnumerateFileVer,Microsoft.PowerShell.Commands.GetProcessCommand"
     }
 
-    It "Should return CommandLine property" -Skip:($IsMacOS)  {
+    It "Should return CommandLine property" -Skip:($IsMacOS) {
         $command = "(Get-Process -Id `$pid).CommandLine"
         $result = & "$PSHOME/pwsh" -NoProfile -NonInteractive -Command $command
         $result | Should -BeLike "*$command*"
@@ -105,19 +105,18 @@ Describe "Get-Process" -Tags "CI" {
 Describe "Get-Process Formatting" -Tags "Feature" {
     BeforeAll {
         $skip = $false
-        if ($IsWindows)
-        {
+        if ($IsWindows) {
             # on Windows skip this test until issue #11016 is resolved
             $skip = $true
         }
     }
 
     It "Should not have Handle in table format header" -Skip:$skip {
-        $types = "System.Diagnostics.Process","System.Diagnostics.Process#IncludeUserName"
+        $types = "System.Diagnostics.Process", "System.Diagnostics.Process#IncludeUserName"
 
         foreach ($type in $types) {
             $formatData = Get-FormatData -TypeName $type -PowerShellVersion $PSVersionTable.PSVersion
-            $tableControls = $formatData.FormatViewDefinition | Where-Object {$_.Control -is "System.Management.Automation.TableControl"}
+            $tableControls = $formatData.FormatViewDefinition | Where-Object { $_.Control -is "System.Management.Automation.TableControl" }
             foreach ($tableControl in $tableControls) {
                 $tableControl.Control.Headers.Label -match "Handle*" | Should -BeNullOrEmpty
                 # verify that rows without headers isn't the handlecount (as PowerShell will create a header that matches the property name)
@@ -137,6 +136,26 @@ Describe "Process Parent property" -Tags "CI" {
         # Bug. See https://github.com/PowerShell/PowerShell/issues/12908
         $powershellexe = (Get-Process -Id $PID).mainmodule.filename
         & $powershellexe -noprofile -command '(Get-Process -Id $PID).Parent.Id' | Should -Be $PID
+    }
+
+    It "Can find parent with spaces and parenthesis in the name on non-Windows" -Skip:($IsWindows) {
+        # Bug. See https://github.com/PowerShell/PowerShell/issues/12908
+        $commandName = 't ( e ( s ) t )'
+
+        $script = @'
+#!/bin/sh
+
+while true; do sleep 1; done
+'@
+
+        Set-Content -Path testdrive:/$commandName -Value $script
+        chmod +x (Resolve-Path -Path testdrive:/$commandName -Relative)
+        try {
+            $p = Start-Process -FilePath testdrive:/$commandName -PassThru
+            $p.Parent.Id | Should -Be $pid
+        } finally {
+            $p | Stop-Process
+        }
     }
 }
 


### PR DESCRIPTION
# PR Summary

Fix the `Parent` property to retrieve the parent process on Linux where
the process name has complex characters like a space or parenthesis.

## PR Context

Reads from `/proc/[pid]/status` rather than `/proc/[pid]/stat` on Linux to get the parent process id. The `status` file is nicer as each entry is on a newline and has a label making it easier to select the data required. This is an alternative approach to deal with process' with a space and parenthesis in the name avoiding the last index of logic or trying to correctly select the proper column in the `stat` file.

Fixes https://github.com/PowerShell/PowerShell/issues/12908
Fixes https://github.com/PowerShell/PowerShell/issues/17541

Alternative to https://github.com/PowerShell/PowerShell/pull/12925

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
