### PR TITLE
Fix enum-ranges for ValidateRange in proxy commands

### DIFF
--- a/src/System.Management.Automation/engine/TypeMetadata.cs
+++ b/src/System.Management.Automation/engine/TypeMetadata.cs
@@ -761,6 +761,7 @@ namespace System.Management.Automation
         private const string AliasesFormat = @"{0}[Alias({1})]";
         private const string ValidateLengthFormat = @"{0}[ValidateLength({1}, {2})]";
         private const string ValidateRangeRangeKindFormat = @"{0}[ValidateRange([System.Management.Automation.ValidateRangeKind]::{1})]";
+        private const string ValidateRangeEnumFormat = @"{0}[ValidateRange([{3}]::{1}, [{3}]::{2})]";
         private const string ValidateRangeFloatFormat = @"{0}[ValidateRange({1:R}, {2:R})]";
         private const string ValidateRangeFormat = @"{0}[ValidateRange({1}, {2})]";
         private const string ValidatePatternFormat = "{0}[ValidatePattern('{1}')]";
@@ -931,6 +932,10 @@ namespace System.Management.Automation
                     {
                         format = ValidateRangeFloatFormat;
                     }
+                    else if (rangeType.IsEnum)
+                    {
+                        format = ValidateRangeEnumFormat;
+                    }
                     else
                     {
                         format = ValidateRangeFormat;
@@ -941,7 +946,8 @@ namespace System.Management.Automation
                         format,
                         prefix,
                         validRangeAttrib.MinRange,
-                        validRangeAttrib.MaxRange);
+                        validRangeAttrib.MaxRange,
+                        rangeType.FullName);
                     return result;
                 }
             }

--- a/test/powershell/engine/Basic/ProxyCommand.tests.ps1
+++ b/test/powershell/engine/Basic/ProxyCommand.tests.ps1
@@ -7,6 +7,7 @@ Describe 'ProxyCommand Tests' -Tag 'CI' {
             @{ Name = 'ValidateLengthAttribute';                         ParamBlock = '[ValidateLength(1, 10)][int]${Parameter}' }
             @{ Name = 'ValidateRangeAttribute with Minimum and Maximum'; ParamBlock = '[ValidateRange(1, 10)][int]${Parameter}' }
             @{ Name = 'ValidateRangeAttribute with RangeKind';           ParamBlock = '[ValidateRange([System.Management.Automation.ValidateRangeKind]::Positive)][int]${Parameter}' }
+            @{ Name = 'ValidateRangeAttribute with Enum';                ParamBlock = '[ValidateRange([Microsoft.PowerShell.ExecutionPolicy]::Unrestricted, [Microsoft.PowerShell.ExecutionPolicy]::Undefined)][Microsoft.PowerShell.ExecutionPolicy]${Parameter}' }
             @{ Name = 'AllowNullAttribute';                              ParamBlock = '[AllowNull()][int]${Parameter}' }
             @{ Name = 'AllowEmptyStringAttribute';                       ParamBlock = '[AllowEmptyString()][int]${Parameter}' }
             @{ Name = 'AllowEmptyCollectionAttribute';                   ParamBlock = '[AllowEmptyCollection()][int]${Parameter}' }

--- a/test/powershell/engine/Basic/ProxyCommand.tests.ps1
+++ b/test/powershell/engine/Basic/ProxyCommand.tests.ps1
@@ -7,7 +7,6 @@ Describe 'ProxyCommand Tests' -Tag 'CI' {
             @{ Name = 'ValidateLengthAttribute';                         ParamBlock = '[ValidateLength(1, 10)][int]${Parameter}' }
             @{ Name = 'ValidateRangeAttribute with Minimum and Maximum'; ParamBlock = '[ValidateRange(1, 10)][int]${Parameter}' }
             @{ Name = 'ValidateRangeAttribute with RangeKind';           ParamBlock = '[ValidateRange([System.Management.Automation.ValidateRangeKind]::Positive)][int]${Parameter}' }
-            @{ Name = 'ValidateRangeAttribute with Enum';                ParamBlock = '[ValidateRange([Microsoft.PowerShell.ExecutionPolicy]::Unrestricted, [Microsoft.PowerShell.ExecutionPolicy]::Undefined)][Microsoft.PowerShell.ExecutionPolicy]${Parameter}' }
             @{ Name = 'AllowNullAttribute';                              ParamBlock = '[AllowNull()][int]${Parameter}' }
             @{ Name = 'AllowEmptyStringAttribute';                       ParamBlock = '[AllowEmptyString()][int]${Parameter}' }
             @{ Name = 'AllowEmptyCollectionAttribute';                   ParamBlock = '[AllowEmptyCollection()][int]${Parameter}' }
@@ -17,6 +16,24 @@ Describe 'ProxyCommand Tests' -Tag 'CI' {
             @{ Name = 'ValidateNotNullOrEmptyAttribute';                 ParamBlock = '[ValidateNotNullOrEmpty()][int]${Parameter}' }
             @{ Name = 'ValidateSetAttribute with explicit set';          ParamBlock = '[ValidateSet(''1'',''10'')][int]${Parameter}' }
             @{ Name = 'PSTypeNameAttribute';                             ParamBlock = '[PSTypeName(''TypeName'')][int]${Parameter}' }
+        )
+
+        $validateRangeEnumTestCases = @(
+            @{
+                Name       = 'Enum min and Enum max';
+                ParamBlock = '[ValidateRange([Microsoft.PowerShell.ExecutionPolicy]::Unrestricted, [Microsoft.PowerShell.ExecutionPolicy]::Undefined)][Microsoft.PowerShell.ExecutionPolicy]${Parameter}'
+                Expected   = '[ValidateRange([Microsoft.PowerShell.ExecutionPolicy]::Unrestricted, [Microsoft.PowerShell.ExecutionPolicy]::Undefined)][Microsoft.PowerShell.ExecutionPolicy]${Parameter}'
+            },
+            @{
+                Name       = 'Enum min and int max';
+                ParamBlock = '[ValidateRange([Microsoft.PowerShell.ExecutionPolicy]::Unrestricted, 5)][Microsoft.PowerShell.ExecutionPolicy]${Parameter}'
+                Expected   = '[ValidateRange(0, 5)][Microsoft.PowerShell.ExecutionPolicy]${Parameter}'
+            }
+            @{
+                Name       = 'int min and Enum max';
+                ParamBlock = '[ValidateRange(0, [Microsoft.PowerShell.ExecutionPolicy]::Undefined)][Microsoft.PowerShell.ExecutionPolicy]${Parameter}'
+                Expected   = '[ValidateRange(0, 5)][Microsoft.PowerShell.ExecutionPolicy]${Parameter}'
+            }
         )
     }
 
@@ -40,6 +57,24 @@ Describe 'ProxyCommand Tests' -Tag 'CI' {
             $generatedParamBlock = $generatedParamBlock -split '\r?\n' -replace '^ *' -join ''
 
             $generatedParamBlock | Should -Be $ParamBlock
+        }
+
+        It 'Generates a param block when ValidateRangeAttribute is used with <Name>' -TestCases $validateRangeEnumTestCases {
+            param (
+                $Name,
+                $ParamBlock,
+                $Expected
+            )
+
+            $functionDefinition = 'param ( {0} )' -f $ParamBlock
+            Set-Item -Path function:testProxyCommandFunction -Value $functionDefinition
+
+            $generatedParamBlock = [System.Management.Automation.ProxyCommand]::GetParamBlock(
+                (Get-Command testProxyCommandFunction)
+            )
+            $generatedParamBlock = $generatedParamBlock -split '\r?\n' -replace '^ *' -join ''
+
+            $generatedParamBlock | Should -Be $Expected
         }
 
         It 'Generates a param block when ValidateScriptAttribute is used' {


### PR DESCRIPTION
# PR Summary

In proxy commands, `ValidateRange`-attributes using enum-values as MinRange\MaxRange arguments will be generated properly.

## PR Context

Enum-values used as MinRange\MaxRange in `ValidateRangeAttribute` are currently generated as unquoted strings in proxy commands. This causes an exception when trying to execute the proxy command.

```powershell
# after PR, this will be generated properly
[ValidateRange([MyEnum]::Low, [MyEnum]::High)]

# these are unaffected, not forgotten
# if min OR max are int, then both are converted to int in the CommandMetadata, so they already work as expected in proxys
[ValidateRange(0, [MyEnum]::High)]
[ValidateRange([MyEnum]::Low, 1000)]
```

Fix #17546 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
