### PR TITLE
Allow commands to still be executed even if the current working directory no longer exists

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -1908,8 +1908,12 @@ namespace Microsoft.PowerShell.Commands
             }
             else
             {
-                // Working Directory not specified -> Assign Current Path.
-                startInfo.WorkingDirectory = PathUtils.ResolveFilePath(this.SessionState.Path.CurrentFileSystemLocation.Path, this, isLiteralPath: true);
+                // Working Directory not specified -> Assign Current Path, but only if it still exists
+                var currentDirectory = PathUtils.ResolveFilePath(this.SessionState.Path.CurrentFileSystemLocation.Path, this, isLiteralPath: true);
+                if (Directory.Exists(currentDirectory))
+                {
+                    startInfo.WorkingDirectory = currentDirectory;
+                }
             }
 
             if (this.ParameterSetName.Equals("Default"))

--- a/src/System.Management.Automation/engine/CommandPathSearch.cs
+++ b/src/System.Management.Automation/engine/CommandPathSearch.cs
@@ -110,7 +110,17 @@ namespace System.Management.Automation
                 sessionState.CurrentDrive.Provider.NameEquals(fileSystemProviderName) &&
                 sessionState.IsProviderLoaded(fileSystemProviderName);
 
-            string environmentCurrentDirectory = Directory.GetCurrentDirectory();
+            string? environmentCurrentDirectory = null;
+            
+            try
+            {
+                environmentCurrentDirectory = Directory.GetCurrentDirectory();
+            }
+            catch (FileNotFoundException)
+            {
+                // This can happen if the current working directory is deleted by another process on non-Windows
+                // In this case, we'll just ignore it and continue on with the current directory as null
+            }
 
             LocationGlobber pathResolver = _context.LocationGlobber;
 

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1378,8 +1378,8 @@ namespace System.Management.Automation
             string rawPath =
                 context.EngineSessionState.GetNamespaceCurrentLocation(
                     context.ProviderNames.FileSystem).ProviderPath;
-            
-            // only set this if the working directory still exists
+
+            // Only set this if the PowerShell's current working directory still exists.
             if (Directory.Exists(rawPath))
             {
                 startInfo.WorkingDirectory = WildcardPattern.Unescape(rawPath);

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1378,7 +1378,12 @@ namespace System.Management.Automation
             string rawPath =
                 context.EngineSessionState.GetNamespaceCurrentLocation(
                     context.ProviderNames.FileSystem).ProviderPath;
-            startInfo.WorkingDirectory = WildcardPattern.Unescape(rawPath);
+            
+            // only set this if the working directory still exists
+            if (Directory.Exists(rawPath))
+            {
+                startInfo.WorkingDirectory = WildcardPattern.Unescape(rawPath);
+            }
 
             return startInfo;
         }

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -51,6 +51,49 @@ Describe 'native commands with pipeline' -tags 'Feature' {
         Start-Sleep -Milliseconds 500
         (Get-Process 'yes' -ErrorAction Ignore).Count | Should -Be $yes
     }
+
+    It 'native command should still execute if the current working directory no longer exists' -Skip:($IsWindows) {
+        $wd = New-Item testdrive:/tmp -ItemType directory
+        $lock = New-Item testdrive:/lock -ItemType file
+        $script = @"
+            while (`$null -ne (Get-Item "$lock" -ErrorAction Ignore)) {
+                Start-Sleep -Seconds 1
+            }
+
+            try {
+                `$out = ps
+            }
+            catch {
+                `$null = Set-Content -Path "$testdrive/error" -Value (`$_ | Out-String)
+            }
+
+            `$null = Set-Content -Path "$testdrive/out" -Value `$out
+"@
+
+        $pwsh = Start-Process -FilePath "${PSHOME}/pwsh" -WorkingDirectory $wd -ArgumentList @('-noprofile','-command',$script)
+
+        Remove-Item -Path $wd -Force
+        Remove-Item $lock
+        $start = Get-Date
+
+        try {
+            while ($null -eq (Get-Item "$testdrive/error" -ErrorAction Ignore) -and $null -eq (Get-Item "$testdrive/out" -ErrorAction Ignore)) {
+                if (((Get-Date) - $start).TotalSeconds -gt 60) {
+                    throw "Timeout"
+                }
+
+                Start-Sleep -Seconds 1
+            }
+        }
+        finally {
+            $pwsh | Stop-Process -Force -ErrorAction Ignore
+        }
+
+        $err = Get-Item -Path "$testdrive/error" -ErrorAction Ignore
+        $err | Should -BeNullOrEmpty -Because $err
+        $out = Get-Item -Path "$testdrive/out" -ErrorAction Ignore
+        $out | Should -Not -BeNullOrEmpty
+    }
 }
 
 Describe "Native Command Processor" -tags "Feature" {

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -52,7 +52,12 @@ Describe 'native commands with pipeline' -tags 'Feature' {
         (Get-Process 'yes' -ErrorAction Ignore).Count | Should -Be $yes
     }
 
-    It 'native command should still execute if the current working directory no longer exists' -Skip:($IsWindows) {
+    It 'native command should still execute if the current working directory no longer exists with command: <command>' -Skip:($IsWindows) -TestCases @(
+        @{ command = 'ps' }
+        @{ command = 'start-process ps -nonewwindow'}
+    ){
+        param($command)
+
         $wd = New-Item testdrive:/tmp -ItemType directory
         $lock = New-Item testdrive:/lock -ItemType file
         $script = @"
@@ -61,7 +66,7 @@ Describe 'native commands with pipeline' -tags 'Feature' {
             }
 
             try {
-                `$out = ps
+                `$out = $command
             }
             catch {
                 `$null = Set-Content -Path "$testdrive/error" -Value (`$_ | Out-String)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

In the case where the current working directory is deleted, there are two places in the code that fail.  The CommandSearcher tries to search the current directory and an exception is thrown.  The change is to catch that exception and have the logic continue where current directory is null which is already handled.  After this, the NativeCommandProcessor always tries to set the native command process working directory to the current working directory which will fail and an exception is thrown.  So if the current working directory doesn't exist, don't set that property.  The default for this member is already an empty string.

This change makes pwsh work the same as bash.

## PR Context

Fix #2116

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
