### PR TITLE
Add completion for index expressions for dictionaries

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -505,7 +505,7 @@ namespace System.Management.Automation
                         }
                         else if (lastAst.Parent is IndexExpressionAst indexExpressionAst)
                         {
-                            // handles quoted string inside index expression like: $PSVersionTable["<Tab>"]
+                            // Handles quoted string inside index expression like: $PSVersionTable["<Tab>"]
                             completionContext.WordToComplete = (tokenAtCursor as StringToken).Value;
                             return CompletionCompleters.CompleteIndexExpression(completionContext, indexExpressionAst.Target);
                         }
@@ -759,7 +759,7 @@ namespace System.Management.Automation
                     case TokenKind.LBracket:
                         if (lastAst.Parent is IndexExpressionAst indexExpression)
                         {
-                            // handles index expression with cursor right after lbracket like: $PSVersionTable[<Tab>]
+                            // Handles index expression with cursor right after lbracket like: $PSVersionTable[<Tab>]
                             completionContext.WordToComplete = string.Empty;
                             result = CompletionCompleters.CompleteIndexExpression(completionContext, indexExpression.Target);
                             if (result.Count > 0)
@@ -921,7 +921,7 @@ namespace System.Management.Automation
                                 case TokenKind.LBracket:
                                     if (lastAst.Parent is IndexExpressionAst indexExpression)
                                     {
-                                        // handles index expression where cursor is on a new line after the lbracket like: $PSVersionTable[\n<Tab>]
+                                        // Handles index expression where cursor is on a new line after the lbracket like: $PSVersionTable[\n<Tab>]
                                         completionContext.WordToComplete = string.Empty;
                                         result = CompletionCompleters.CompleteIndexExpression(completionContext, indexExpression.Target);
                                     }
@@ -1000,7 +1000,7 @@ namespace System.Management.Automation
                                 case TokenKind.LBracket:
                                     if (lastAst.Parent is IndexExpressionAst indexExpression)
                                     {
-                                        // handles index expression with whitespace between lbracket and cursor like: $PSVersionTable[ <Tab>]
+                                        // Handles index expression with whitespace between lbracket and cursor like: $PSVersionTable[ <Tab>]
                                         completionContext.WordToComplete = string.Empty;
                                         result = CompletionCompleters.CompleteIndexExpression(completionContext, indexExpression.Target);
                                     }
@@ -2002,7 +2002,7 @@ namespace System.Management.Automation
                         if (cursorAst.Extent.EndOffset == tokenAtCursor.Extent.StartOffset)
                         {
                             if (cursorAst.Extent.EndLineNumber == tokenAtCursor.Extent.StartLineNumber &&
-                            cursorAst.Extent.EndColumnNumber == tokenAtCursor.Extent.StartColumnNumber)
+                                cursorAst.Extent.EndColumnNumber == tokenAtCursor.Extent.StartColumnNumber)
                             {
                                 if (tokenAtCursorText.IndexOfAny(Utils.Separators.Directory) == 0)
                                 {
@@ -2055,7 +2055,8 @@ namespace System.Management.Automation
                             {
                                 completionContext.WordToComplete = completionContext.WordToComplete.Remove(completionContext.WordToComplete.Length - 1);
                             }
-                            // handles index expression with unquoted word like: $PSVersionTable[psver<Tab>]
+
+                            // Handles index expression with unquoted word like: $PSVersionTable[psver<Tab>]
                             return CompletionCompleters.CompleteIndexExpression(completionContext, indexExpression.Target);
                         }
                     }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -503,6 +503,11 @@ namespace System.Management.Automation
                                 return completions;
                             }
                         }
+                        else if (lastAst.Parent is IndexExpressionAst indexExpressionAst)
+                        {
+                            completionContext.WordToComplete = (tokenAtCursor as StringToken).Value;
+                            return CompletionCompleters.CompleteIndexExpression(completionContext, indexExpressionAst.Target);
+                        }
 
                         result = GetResultForString(completionContext, ref replacementIndex, ref replacementLength, isQuotedString);
                         break;
@@ -750,6 +755,18 @@ namespace System.Management.Automation
                         result = CompletionCompleters.CompleteOperator(tokenAtCursor.Text);
                         break;
 
+                    case TokenKind.LBracket:
+                        if (lastAst.Parent is IndexExpressionAst indexExpression)
+                        {
+                            completionContext.WordToComplete = string.Empty;
+                            result = CompletionCompleters.CompleteIndexExpression(completionContext, indexExpression.Target);
+                            if (result.Count > 0)
+                            {
+                                replacementIndex++;
+                                replacementLength--;
+                            }
+                        }
+                        break;
                     default:
                         if ((tokenAtCursor.TokenFlags & TokenFlags.Keyword) != 0)
                         {
@@ -899,6 +916,13 @@ namespace System.Management.Automation
                                     }
 
                                     break;
+                                case TokenKind.LBracket:
+                                    if (lastAst.Parent is IndexExpressionAst indexExpression)
+                                    {
+                                        completionContext.WordToComplete = string.Empty;
+                                        result = CompletionCompleters.CompleteIndexExpression(completionContext, indexExpression.Target);
+                                    }
+                                    break;
                                 default:
                                     break;
                             }
@@ -968,6 +992,13 @@ namespace System.Management.Automation
                                     if (result is not null && result.Count > 0)
                                     {
                                         return result;
+                                    }
+                                    break;
+                                case TokenKind.LBracket:
+                                    if (lastAst.Parent is IndexExpressionAst indexExpression)
+                                    {
+                                        completionContext.WordToComplete = string.Empty;
+                                        result = CompletionCompleters.CompleteIndexExpression(completionContext, indexExpression.Target);
                                     }
                                     break;
                                 default:
@@ -1878,7 +1909,7 @@ namespace System.Management.Automation
             return results;
         }
 
-        private List<CompletionResult> GetResultForIdentifier(CompletionContext completionContext, ref int replacementIndex, ref int replacementLength, bool isQuotedString)
+        private static List<CompletionResult> GetResultForIdentifier(CompletionContext completionContext, ref int replacementIndex, ref int replacementLength, bool isQuotedString)
         {
             var tokenAtCursor = completionContext.TokenAtCursor;
             var lastAst = completionContext.RelatedAsts.Last();
@@ -1960,61 +1991,67 @@ namespace System.Management.Automation
                 // Handle completion for a path with variable, such as: $PSHOME\ty<tab>
                 if (completionContext.RelatedAsts.Count > 0 && completionContext.RelatedAsts[0] is ScriptBlockAst)
                 {
-                    Ast cursorAst = null;
-                    var cursorPosition = (InternalScriptPosition)_cursorPosition;
-                    int offsetBeforeCmdName = cursorPosition.Offset - tokenAtCursorText.Length;
-                    if (offsetBeforeCmdName >= 0)
-                    {
-                        var cursorBeforeCmdName = cursorPosition.CloneWithNewOffset(offsetBeforeCmdName);
-                        var scriptBlockAst = (ScriptBlockAst)completionContext.RelatedAsts[0];
-                        cursorAst = GetLastAstAtCursor(scriptBlockAst, cursorBeforeCmdName);
-                    }
+                    Ast cursorAst = completionContext.RelatedAsts[0].FindAll(ast => ast.Extent.EndOffset <= tokenAtCursor.Extent.StartOffset, true).LastOrDefault();
 
-                    if (cursorAst != null &&
-                        cursorAst.Extent.EndLineNumber == tokenAtCursor.Extent.StartLineNumber &&
-                        cursorAst.Extent.EndColumnNumber == tokenAtCursor.Extent.StartColumnNumber)
+                    if (cursorAst is not null)
                     {
-                        if (tokenAtCursorText.IndexOfAny(Utils.Separators.Directory) == 0)
+                        if (cursorAst.Extent.EndOffset == tokenAtCursor.Extent.StartOffset)
                         {
-                            string wordToComplete =
-                                CompletionCompleters.ConcatenateStringPathArguments(cursorAst as CommandElementAst, tokenAtCursorText, completionContext);
-                            if (wordToComplete != null)
+                            if (cursorAst.Extent.EndLineNumber == tokenAtCursor.Extent.StartLineNumber &&
+                            cursorAst.Extent.EndColumnNumber == tokenAtCursor.Extent.StartColumnNumber)
                             {
-                                completionContext.WordToComplete = wordToComplete;
-                                result = new List<CompletionResult>(CompletionCompleters.CompleteFilename(completionContext));
-                                if (result.Count > 0)
+                                if (tokenAtCursorText.IndexOfAny(Utils.Separators.Directory) == 0)
                                 {
-                                    replacementIndex = cursorAst.Extent.StartScriptPosition.Offset;
-                                    replacementLength += cursorAst.Extent.Text.Length;
+                                    string wordToComplete =
+                                        CompletionCompleters.ConcatenateStringPathArguments(cursorAst as CommandElementAst, tokenAtCursorText, completionContext);
+                                    if (wordToComplete != null)
+                                    {
+                                        completionContext.WordToComplete = wordToComplete;
+                                        result = new List<CompletionResult>(CompletionCompleters.CompleteFilename(completionContext));
+                                        if (result.Count > 0)
+                                        {
+                                            replacementIndex = cursorAst.Extent.StartScriptPosition.Offset;
+                                            replacementLength += cursorAst.Extent.Text.Length;
+                                        }
+
+                                        return result;
+                                    }
+                                    else
+                                    {
+                                        var variableAst = cursorAst as VariableExpressionAst;
+                                        string fullPath = variableAst != null
+                                            ? CompletionCompleters.CombineVariableWithPartialPath(
+                                                variableAst: variableAst,
+                                                extraText: tokenAtCursorText,
+                                                executionContext: completionContext.ExecutionContext)
+                                            : null;
+
+                                        if (fullPath == null) { return result; }
+
+                                        // Continue trying the filename/commandname completion for scenarios like this: $aa\d<tab>
+                                        completionContext.WordToComplete = fullPath;
+                                        replacementIndex = cursorAst.Extent.StartScriptPosition.Offset;
+                                        replacementLength += cursorAst.Extent.Text.Length;
+
+                                        completionContext.ReplacementIndex = replacementIndex;
+                                        completionContext.ReplacementLength = replacementLength;
+                                    }
                                 }
-
-                                return result;
-                            }
-                            else
-                            {
-                                var variableAst = cursorAst as VariableExpressionAst;
-                                string fullPath = variableAst != null
-                                    ? CompletionCompleters.CombineVariableWithPartialPath(
-                                        variableAst: variableAst,
-                                        extraText: tokenAtCursorText,
-                                        executionContext: completionContext.ExecutionContext)
-                                    : null;
-
-                                if (fullPath == null) { return result; }
-
-                                // Continue trying the filename/commandname completion for scenarios like this: $aa\d<tab>
-                                completionContext.WordToComplete = fullPath;
-                                replacementIndex = cursorAst.Extent.StartScriptPosition.Offset;
-                                replacementLength += cursorAst.Extent.Text.Length;
-
-                                completionContext.ReplacementIndex = replacementIndex;
-                                completionContext.ReplacementLength = replacementLength;
+                                // Continue trying the filename/commandname completion for scenarios like this: $aa[get-<tab>
+                                else if (cursorAst is not ErrorExpressionAst || cursorAst.Parent is not IndexExpressionAst)
+                                {
+                                    return result;
+                                }
                             }
                         }
-                        // Continue trying the filename/commandname completion for scenarios like this: $aa[get-<tab>
-                        else if (cursorAst is not ErrorExpressionAst || cursorAst.Parent is not IndexExpressionAst)
+
+                        if (cursorAst.Parent is IndexExpressionAst indexExpression && indexExpression.Index is ErrorExpressionAst)
                         {
-                            return result;
+                            if (completionContext.WordToComplete.EndsWith(']'))
+                            {
+                                completionContext.WordToComplete = completionContext.WordToComplete.Remove(completionContext.WordToComplete.Length - 1);
+                            }
+                            return CompletionCompleters.CompleteIndexExpression(completionContext, indexExpression.Target);
                         }
                     }
                 }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -505,6 +505,7 @@ namespace System.Management.Automation
                         }
                         else if (lastAst.Parent is IndexExpressionAst indexExpressionAst)
                         {
+                            // handles quoted string inside index expression like: $PSVersionTable["<Tab>"]
                             completionContext.WordToComplete = (tokenAtCursor as StringToken).Value;
                             return CompletionCompleters.CompleteIndexExpression(completionContext, indexExpressionAst.Target);
                         }
@@ -758,6 +759,7 @@ namespace System.Management.Automation
                     case TokenKind.LBracket:
                         if (lastAst.Parent is IndexExpressionAst indexExpression)
                         {
+                            // handles index expression with cursor right after lbracket like: $PSVersionTable[<Tab>]
                             completionContext.WordToComplete = string.Empty;
                             result = CompletionCompleters.CompleteIndexExpression(completionContext, indexExpression.Target);
                             if (result.Count > 0)
@@ -919,6 +921,7 @@ namespace System.Management.Automation
                                 case TokenKind.LBracket:
                                     if (lastAst.Parent is IndexExpressionAst indexExpression)
                                     {
+                                        // handles index expression where cursor is on a new line after the lbracket like: $PSVersionTable[\n<Tab>]
                                         completionContext.WordToComplete = string.Empty;
                                         result = CompletionCompleters.CompleteIndexExpression(completionContext, indexExpression.Target);
                                     }
@@ -997,6 +1000,7 @@ namespace System.Management.Automation
                                 case TokenKind.LBracket:
                                     if (lastAst.Parent is IndexExpressionAst indexExpression)
                                     {
+                                        // handles index expression with whitespace between lbracket and cursor like: $PSVersionTable[ <Tab>]
                                         completionContext.WordToComplete = string.Empty;
                                         result = CompletionCompleters.CompleteIndexExpression(completionContext, indexExpression.Target);
                                     }
@@ -2051,6 +2055,7 @@ namespace System.Management.Automation
                             {
                                 completionContext.WordToComplete = completionContext.WordToComplete.Remove(completionContext.WordToComplete.Length - 1);
                             }
+                            // handles index expression with unquoted word like: $PSVersionTable[psver<Tab>]
                             return CompletionCompleters.CompleteIndexExpression(completionContext, indexExpression.Target);
                         }
                     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Adds completion for accessing keys in hashtables through the index syntax like: `$PSVersionTable[PSver<Tab>` -> `$PSVersionTable['PSVersion'`
Also fixes an issue where tab completion for hashtable keys that are accessed through the member syntax doesn't get quoted when needed: `@{"Key with space" = "Hello"}.Key<Tab><Tab>` -> `@{"Key with space" = "Hello"}.'Key with space'`
<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
