### PR TITLE
Use discard where possible

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
@@ -2231,8 +2231,7 @@ $result
                 bool isIPAddress = false;
                 try
                 {
-                    IPAddress unused;
-                    isIPAddress = IPAddress.TryParse(nameToCheck, out unused);
+                    isIPAddress = IPAddress.TryParse(nameToCheck, out _);
                 }
                 catch (Exception)
                 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Update-TypeData.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Update-TypeData.cs
@@ -849,8 +849,7 @@ namespace Microsoft.PowerShell.Commands
                         }
                         else if (sste.FileName != null)
                         {
-                            bool unused;
-                            Context.TypeTable.Update(sste.FileName, sste.FileName, errors, Context.AuthorizationManager, Context.InitialSessionState.Host, out unused);
+                            Context.TypeTable.Update(sste.FileName, sste.FileName, errors, Context.AuthorizationManager, Context.InitialSessionState.Host, out _);
                         }
                         else
                         {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
@@ -2270,14 +2270,13 @@ namespace Microsoft.PowerShell
             c.X = (short)origin.X;
             c.Y = (short)origin.Y;
 
-            DWORD unused = 0;
             bool result =
                 NativeMethods.FillConsoleOutputCharacter(
                     consoleHandle.DangerousGetHandle(),
                     character,
                     (DWORD)numberToWrite,
                     c,
-                    out unused);
+                    out _);
             if (!result)
             {
                 int err = Marshal.GetLastWin32Error();
@@ -2324,14 +2323,13 @@ namespace Microsoft.PowerShell
             c.X = (short)origin.X;
             c.Y = (short)origin.Y;
 
-            DWORD unused = 0;
             bool result =
                 NativeMethods.FillConsoleOutputAttribute(
                     consoleHandle.DangerousGetHandle(),
                     attribute,
                     (DWORD)numberToWrite,
                     c,
-                    out unused);
+                    out _);
 
             if (!result)
             {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -2873,8 +2873,7 @@ namespace Microsoft.PowerShell
 
             private string EvaluatePrompt()
             {
-                Exception unused = null;
-                string promptString = _promptExec.ExecuteCommandAndGetResultAsString("prompt", out unused);
+                string promptString = _promptExec.ExecuteCommandAndGetResultAsString("prompt", out _);
 
                 if (string.IsNullOrEmpty(promptString))
                 {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostRawUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostRawUserInterface.cs
@@ -85,9 +85,8 @@ namespace Microsoft.PowerShell
                 GetBufferInfo(out bufferInfo);
 
                 ConsoleColor foreground;
-                ConsoleColor unused;
 
-                ConsoleControl.WORDToColor(bufferInfo.Attributes, out foreground, out unused);
+                ConsoleControl.WORDToColor(bufferInfo.Attributes, out foreground, out _);
                 return foreground;
             }
 
@@ -135,9 +134,8 @@ namespace Microsoft.PowerShell
                 GetBufferInfo(out bufferInfo);
 
                 ConsoleColor background;
-                ConsoleColor unused;
 
-                ConsoleControl.WORDToColor(bufferInfo.Attributes, out unused, out background);
+                ConsoleControl.WORDToColor(bufferInfo.Attributes, out _, out background);
                 return background;
             }
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -207,9 +207,8 @@ namespace Microsoft.PowerShell
             HandleThrowOnReadAndPrompt();
 
             // call our internal version such that it does not end input on a tab
-            ReadLineResult unused;
 
-            return ReadLine(false, string.Empty, out unused, true, true);
+            return ReadLine(false, string.Empty, out _, true, true);
         }
 
         /// <summary>
@@ -1209,8 +1208,7 @@ namespace Microsoft.PowerShell
         public override void WriteDebugLine(string message)
         {
             // don't lock here as WriteLine is already protected.
-            bool unused;
-            message = HostUtilities.RemoveGuidFromMessage(message, out unused);
+            message = HostUtilities.RemoveGuidFromMessage(message, out _);
 
             // We should write debug to error stream only if debug is redirected.)
             if (_parent.ErrorFormat == Serialization.DataFormat.XML)
@@ -1270,8 +1268,7 @@ namespace Microsoft.PowerShell
         public override void WriteVerboseLine(string message)
         {
             // don't lock here as WriteLine is already protected.
-            bool unused;
-            message = HostUtilities.RemoveGuidFromMessage(message, out unused);
+            message = HostUtilities.RemoveGuidFromMessage(message, out _);
 
             // NTRAID#Windows OS Bugs-1061752-2004/12/15-sburns should read a skin setting here...)
             if (_parent.ErrorFormat == Serialization.DataFormat.XML)
@@ -1314,8 +1311,7 @@ namespace Microsoft.PowerShell
         public override void WriteWarningLine(string message)
         {
             // don't lock here as WriteLine is already protected.
-            bool unused;
-            message = HostUtilities.RemoveGuidFromMessage(message, out unused);
+            message = HostUtilities.RemoveGuidFromMessage(message, out _);
 
             // NTRAID#Windows OS Bugs-1061752-2004/12/15-sburns should read a skin setting here...)
             if (_parent.ErrorFormat == Serialization.DataFormat.XML)

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/Executor.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/Executor.cs
@@ -510,9 +510,8 @@ namespace Microsoft.PowerShell
         /// </returns>
         internal bool? ExecuteCommandAndGetResultAsBool(string command)
         {
-            Exception unused = null;
 
-            bool? result = ExecuteCommandAndGetResultAsBool(command, out unused);
+            bool? result = ExecuteCommandAndGetResultAsBool(command, out _);
 
             return result;
         }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/Serialization.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/Serialization.cs
@@ -189,8 +189,7 @@ namespace Microsoft.PowerShell
                     return null;
 
                 case DataFormat.XML:
-                    string unused;
-                    o = _xmlDeserializer.Deserialize(out unused);
+                    o = _xmlDeserializer.Deserialize(out _);
                     break;
 
                 case DataFormat.Text:

--- a/src/System.Management.Automation/DscSupport/CimDSCParser.cs
+++ b/src/System.Management.Automation/DscSupport/CimDSCParser.cs
@@ -2148,8 +2148,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
                         {
                             try
                             {
-                                string unused;
-                                foundResources = ImportCimKeywordsFromModule(moduleInfo, resourceToImport, out unused);
+                                foundResources = ImportCimKeywordsFromModule(moduleInfo, resourceToImport, out _);
                             }
                             catch (Exception)
                             {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -564,8 +564,7 @@ namespace System.Management.Automation
                             //     {
                             //         DependsOn=@('[user]x',|)
                             //
-                            bool unused;
-                            result = GetResultForEnumPropertyValueOfDSCResource(completionContext, string.Empty, ref replacementIndex, ref replacementLength, out unused);
+                            result = GetResultForEnumPropertyValueOfDSCResource(completionContext, string.Empty, ref replacementIndex, ref replacementLength, out _);
                         }
 
                         break;
@@ -693,8 +692,7 @@ namespace System.Management.Automation
                                 //         DependsOn=@(|)
                                 //         DependsOn=(|
                                 //
-                                bool unused;
-                                result = GetResultForEnumPropertyValueOfDSCResource(completionContext, string.Empty, ref replacementIndex, ref replacementLength, out unused);
+                                result = GetResultForEnumPropertyValueOfDSCResource(completionContext, string.Empty, ref replacementIndex, ref replacementLength, out _);
                             }
 
                             break;
@@ -944,8 +942,7 @@ namespace System.Management.Automation
                                             break;
                                         }
 
-                                        bool unused;
-                                        result = GetResultForEnumPropertyValueOfDSCResource(completionContext, string.Empty, ref replacementIndex, ref replacementLength, out unused);
+                                        result = GetResultForEnumPropertyValueOfDSCResource(completionContext, string.Empty, ref replacementIndex, ref replacementLength, out _);
                                         break;
                                     }
                                 case TokenKind.Break:

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -6024,8 +6024,7 @@ namespace System.Management.Automation
                     .AddCommandWithPreferenceSetting("Microsoft.PowerShell.Utility\\Sort-Object")
                     .AddParameter("Property", new[] { "ResultType", "ListItemText" })
                     .AddParameter("Unique");
-                Exception unused;
-                var sortedResults = powerShellExecutionHelper.ExecuteCurrentPowerShell(out unused, results);
+                var sortedResults = powerShellExecutionHelper.ExecuteCurrentPowerShell(out _, results);
                 results.Clear();
                 results.AddRange(sortedResults.Select(static psobj => PSObject.Base(psobj) as CompletionResult));
             }

--- a/src/System.Management.Automation/engine/ExecutionContext.cs
+++ b/src/System.Management.Automation/engine/ExecutionContext.cs
@@ -379,8 +379,7 @@ namespace System.Management.Automation
             var baseValue = PSObject.Base(value);
             if (baseValue != null && baseValue != NullString.Value)
             {
-                object unused;
-                result = UntrustedObjects.TryGetValue(baseValue, out unused);
+                result = UntrustedObjects.TryGetValue(baseValue, out _);
             }
 
             return result;
@@ -1584,8 +1583,7 @@ namespace System.Management.Automation
             try
             {
                 Cmdlet currentRunningModuleCommand;
-                string unused;
-                if (IsModuleCommandCurrentlyRunning(out currentRunningModuleCommand, out unused))
+                if (IsModuleCommandCurrentlyRunning(out currentRunningModuleCommand, out _))
                 {
                     currentRunningModuleCommand.WriteError(errorRecord);
                 }

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -3535,8 +3535,7 @@ namespace System.Management.Automation.Runspaces
                             moduleName = sste.PSSnapIn.Name;
                         }
 
-                        bool unused;
-                        context.TypeTable.Update(moduleName, sste.FileName, errors, context.AuthorizationManager, context.EngineHostInterface, out unused);
+                        context.TypeTable.Update(moduleName, sste.FileName, errors, context.AuthorizationManager, context.EngineHostInterface, out _);
                     }
                 }
                 else if (sste.TypeTable != null)

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -721,7 +721,7 @@ namespace System.Management.Automation
             string moduleDirPath = Path.GetDirectoryName(modulePath);
 
             // The module itself may be in a versioned directory (case 3)
-            if (Version.TryParse(Path.GetFileName(moduleDirPath), out Version unused))
+            if (Version.TryParse(Path.GetFileName(moduleDirPath), out _))
             {
                 moduleDirPath = Path.GetDirectoryName(moduleDirPath);
             }

--- a/src/System.Management.Automation/engine/ScriptCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/ScriptCommandProcessor.cs
@@ -143,9 +143,8 @@ namespace System.Management.Automation
                     if (parameter.IsDashQuestion())
                     {
                         Dictionary<Ast, Token[]> scriptBlockTokenCache = new Dictionary<Ast, Token[]>();
-                        string unused;
                         HelpInfo helpInfo = _scriptBlock.GetHelpInfo(context: Context, commandInfo: CommandInfo,
-                            dontSearchOnRemoteComputer: false, scriptBlockTokenCache: scriptBlockTokenCache, helpFile: out unused, helpUriFromDotLink: out unused);
+                            dontSearchOnRemoteComputer: false, scriptBlockTokenCache: scriptBlockTokenCache, helpFile: out _, helpUriFromDotLink: out _);
                         if (helpInfo == null)
                         {
                             break;

--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -1434,8 +1434,7 @@ namespace System.Management.Automation
                                 return;
                             }
 
-                            int unUsedChildrenNotMatchingFilterCriteria = 0;
-                            ProcessPathItems(providerInstance, providerPath, recurse, depth, context, out unUsedChildrenNotMatchingFilterCriteria, ProcessMode.Enumerate);
+                            ProcessPathItems(providerInstance, providerPath, recurse, depth, context, out _, ProcessMode.Enumerate);
                         }
                     }
                     else
@@ -1496,12 +1495,11 @@ namespace System.Management.Automation
                 {
                     // Do the recursion manually so that we can apply the
                     // include and exclude filters
-                    int unUsedChildrenNotMatchingFilterCriteria = 0;
                     try
                     {
                         // Temeporary set literal path as false to apply filter
                         context.SuppressWildcardExpansion = false;
-                        ProcessPathItems(providerInstance, path, recurse, depth, context, out unUsedChildrenNotMatchingFilterCriteria, ProcessMode.Enumerate);
+                        ProcessPathItems(providerInstance, path, recurse, depth, context, out _, ProcessMode.Enumerate);
                     }
                     finally
                     {
@@ -4162,7 +4160,6 @@ namespace System.Management.Automation
 
             // Get the provider specific path for the destination
 
-            PSDriveInfo unusedDrive = null;
             ProviderInfo destinationProvider = null;
             Microsoft.PowerShell.Commands.CopyItemDynamicParameters dynamicParams = context.DynamicParameters as Microsoft.PowerShell.Commands.CopyItemDynamicParameters;
             bool destinationIsRemote = false;
@@ -4213,7 +4210,7 @@ namespace System.Management.Automation
                        copyPath,
                        context,
                        out destinationProvider,
-                       out unusedDrive);
+                       out _);
             }
             else
             {

--- a/src/System.Management.Automation/engine/SessionStateNavigation.cs
+++ b/src/System.Management.Automation/engine/SessionStateNavigation.cs
@@ -1458,7 +1458,6 @@ namespace System.Management.Automation
                     }
                     else
                     {
-                        PSDriveInfo unusedPSDriveInfo = null;
                         ProviderInfo destinationProvider = null;
 
                         CmdletProviderContext destinationContext = new CmdletProviderContext(this.ExecutionContext);
@@ -1472,7 +1471,7 @@ namespace System.Management.Automation
                                     providerDestinationPaths[0].Path,
                                     destinationContext,
                                     out destinationProvider,
-                                    out unusedPSDriveInfo);
+                                    out _);
                         }
                         else
                         {
@@ -1484,7 +1483,7 @@ namespace System.Management.Automation
                                     destination,
                                     destinationContext,
                                     out destinationProvider,
-                                    out unusedPSDriveInfo);
+                                    out _);
                         }
 
                         // Now verify the providers are the same.

--- a/src/System.Management.Automation/engine/SessionStateVariableAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateVariableAPIs.cs
@@ -352,8 +352,7 @@ namespace System.Management.Automation
                     // First get the provider for the path.
 
                     ProviderInfo providerInfo = null;
-                    string unused =
-                        this.Globber.GetProviderPath(variablePath.QualifiedName, out providerInfo);
+                    _ = this.Globber.GetProviderPath(variablePath.QualifiedName, out providerInfo);
 
                     throw NewProviderInvocationException(
                         "ProviderCannotBeUsedAsVariable",
@@ -368,8 +367,7 @@ namespace System.Management.Automation
                     // First get the provider for the path.
 
                     ProviderInfo providerInfo = null;
-                    string unused =
-                        this.Globber.GetProviderPath(variablePath.QualifiedName, out providerInfo);
+                    _ = this.Globber.GetProviderPath(variablePath.QualifiedName, out providerInfo);
 
                     throw NewProviderInvocationException(
                         "ProviderCannotBeUsedAsVariable",
@@ -407,8 +405,7 @@ namespace System.Management.Automation
                     // First get the provider for the path.
 
                     ProviderInfo providerInfo = null;
-                    string unused =
-                        this.Globber.GetProviderPath(variablePath.QualifiedName, out providerInfo);
+                    _ = this.Globber.GetProviderPath(variablePath.QualifiedName, out providerInfo);
 
                     throw NewProviderInvocationException(
                         "ProviderVariableSyntaxInvalid",
@@ -445,8 +442,7 @@ namespace System.Management.Automation
                 {
                     // First get the provider for the path.
                     ProviderInfo providerInfo = null;
-                    string unused =
-                        this.Globber.GetProviderPath(variablePath.QualifiedName, out providerInfo);
+                    _ = this.Globber.GetProviderPath(variablePath.QualifiedName, out providerInfo);
 
                     ProviderInvocationException providerException =
                         new ProviderInvocationException(
@@ -741,8 +737,7 @@ namespace System.Management.Automation
                         // First get the provider for the path.
 
                         ProviderInfo providerInfo = null;
-                        string unused =
-                            this.Globber.GetProviderPath(variablePath.QualifiedName, out providerInfo);
+                        _ = this.Globber.GetProviderPath(variablePath.QualifiedName, out providerInfo);
 
                         throw NewProviderInvocationException(
                             "ProviderCannotBeUsedAsVariable",
@@ -757,8 +752,7 @@ namespace System.Management.Automation
                         // First get the provider for the path.
 
                         ProviderInfo providerInfo = null;
-                        string unused =
-                            this.Globber.GetProviderPath(variablePath.QualifiedName, out providerInfo);
+                        _ = this.Globber.GetProviderPath(variablePath.QualifiedName, out providerInfo);
 
                         throw NewProviderInvocationException(
                             "ProviderCannotBeUsedAsVariable",
@@ -796,8 +790,7 @@ namespace System.Management.Automation
                         // First get the provider for the path.
 
                         ProviderInfo providerInfo = null;
-                        string unused =
-                            this.Globber.GetProviderPath(variablePath.QualifiedName, out providerInfo);
+                        _ = this.Globber.GetProviderPath(variablePath.QualifiedName, out providerInfo);
 
                         throw NewProviderInvocationException(
                             "ProviderVariableSyntaxInvalid",
@@ -835,8 +828,7 @@ namespace System.Management.Automation
                         // First get the provider for the path.
 
                         ProviderInfo providerInfo = null;
-                        string unused =
-                            this.Globber.GetProviderPath(variablePath.QualifiedName, out providerInfo);
+                        _ = this.Globber.GetProviderPath(variablePath.QualifiedName, out providerInfo);
 
                         ProviderInvocationException providerException =
                             new ProviderInvocationException(
@@ -1245,8 +1237,7 @@ namespace System.Management.Automation
                     // First get the provider for the path.
 
                     ProviderInfo providerInfo = null;
-                    string unused =
-                        this.Globber.GetProviderPath(variablePath.QualifiedName, out providerInfo);
+                    _ = this.Globber.GetProviderPath(variablePath.QualifiedName, out providerInfo);
 
                     throw NewProviderInvocationException(
                         "ProviderCannotBeUsedAsVariable",
@@ -1261,8 +1252,7 @@ namespace System.Management.Automation
                     // First get the provider for the path.
 
                     ProviderInfo providerInfo = null;
-                    string unused =
-                        this.Globber.GetProviderPath(variablePath.QualifiedName, out providerInfo);
+                    _ = this.Globber.GetProviderPath(variablePath.QualifiedName, out providerInfo);
 
                     throw NewProviderInvocationException(
                         "ProviderCannotBeUsedAsVariable",
@@ -1301,8 +1291,7 @@ namespace System.Management.Automation
                     // First get the provider for the path.
 
                     ProviderInfo providerInfo = null;
-                    string unused =
-                        this.Globber.GetProviderPath(variablePath.QualifiedName, out providerInfo);
+                    _ = this.Globber.GetProviderPath(variablePath.QualifiedName, out providerInfo);
 
                     throw NewProviderInvocationException(
                         "ProviderVariableSyntaxInvalid",
@@ -1325,8 +1314,7 @@ namespace System.Management.Automation
                     // First get the provider for the path.
 
                     ProviderInfo providerInfo = null;
-                    string unused =
-                        this.Globber.GetProviderPath(variablePath.QualifiedName, out providerInfo);
+                    _ = this.Globber.GetProviderPath(variablePath.QualifiedName, out providerInfo);
 
                     ProviderInvocationException providerException =
                         new ProviderInvocationException(

--- a/src/System.Management.Automation/engine/TypeTable.cs
+++ b/src/System.Management.Automation/engine/TypeTable.cs
@@ -3937,8 +3937,7 @@ namespace System.Management.Automation.Runspaces
                     throw PSTraceSource.NewArgumentException("typeFile", TypesXmlStrings.TypeFileNotRooted, typefile);
                 }
 
-                bool unused;
-                Initialize(string.Empty, typefile, errors, authorizationManager, host, out unused);
+                Initialize(string.Empty, typefile, errors, authorizationManager, host, out _);
                 _typeFileList.Add(typefile);
             }
 

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -6135,9 +6135,7 @@ namespace System.Management.Automation.Language
                 {
                     // We'll wrap the variable in a PSReference, but not the constant variables ($true, $false, $null) because those
                     // can't be changed.
-                    IEnumerable<PropertyInfo> unused1;
-                    bool unused2;
-                    var varType = varExpr.GetVariableType(this, out unused1, out unused2);
+                    var varType = varExpr.GetVariableType(this, out _, out _);
                     return Expression.Call(
                         CachedReflectionInfo.VariableOps_GetVariableAsRef,
                         Expression.Constant(varExpr.VariablePath),

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -280,8 +280,7 @@ namespace System.Management.Automation.Language
             var parser = new Parser();
             var tokenizer = parser._tokenizer;
             tokenizer.Initialize(null, typename, null);
-            Token unused;
-            var result = parser.TypeNameRule(allowAssemblyQualifiedNames: true, firstTypeNameToken: out unused);
+            var result = parser.TypeNameRule(allowAssemblyQualifiedNames: true, firstTypeNameToken: out _);
 
             SemanticChecks.CheckArrayTypeNameDepth(result, PositionUtilities.EmptyExtent, parser);
             if (!ignoreErrors && parser.ErrorList.Count > 0)
@@ -4265,11 +4264,10 @@ namespace System.Management.Automation.Language
                     this.SkipToken();
                     SkipNewlines();
                     ITypeName superClass;
-                    Token unused;
                     Token commaToken = null;
                     while (true)
                     {
-                        superClass = this.TypeNameRule(allowAssemblyQualifiedNames: false, firstTypeNameToken: out unused);
+                        superClass = this.TypeNameRule(allowAssemblyQualifiedNames: false, firstTypeNameToken: out _);
                         if (superClass == null)
                         {
                             ReportIncompleteInput(After(ExtentFromFirstOf(commaToken, colonToken)),
@@ -4750,8 +4748,7 @@ namespace System.Management.Automation.Language
                     this.SkipToken();
                     SkipNewlines();
                     ITypeName underlyingType;
-                    Token unused;
-                    underlyingType = this.TypeNameRule(allowAssemblyQualifiedNames: false, firstTypeNameToken: out unused);
+                    underlyingType = this.TypeNameRule(allowAssemblyQualifiedNames: false, firstTypeNameToken: out _);
                     if (underlyingType == null)
                     {
                         ReportIncompleteInput(

--- a/src/System.Management.Automation/engine/parser/VariableAnalysis.cs
+++ b/src/System.Management.Automation/engine/parser/VariableAnalysis.cs
@@ -185,8 +185,7 @@ namespace System.Management.Automation.Language
                         // valuetype because the parameter has no value yet.  For example:
                         //     & { param([System.Reflection.MemberTypes]$m) ($null -eq $m) }
 
-                        object unused;
-                        if (!Compiler.TryGetDefaultParameterValue(analysisDetails.Type, out unused))
+                        if (!Compiler.TryGetDefaultParameterValue(analysisDetails.Type, out _))
                         {
                             analysisDetails.LocalTupleIndex = VariableAnalysis.ForceDynamic;
                         }

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -1639,9 +1639,7 @@ namespace System.Management.Automation.Language
         private string GetWithInputHandlingForInvokeCommandImpl(Tuple<List<VariableExpressionAst>, string> usingVariablesTuple)
         {
             // do not add "$input |" to complex pipelines
-            string unused1;
-            string unused2;
-            var pipelineAst = GetSimplePipeline(false, out unused1, out unused2);
+            var pipelineAst = GetSimplePipeline(false, out _, out _);
             if (pipelineAst == null)
             {
                 return (usingVariablesTuple == null)

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -2089,9 +2089,7 @@ namespace System.Management.Automation.Language
 
         internal static object CopyInstanceMembersOfValueType<T>(T t, object boxedT) where T : struct
         {
-            PSMemberInfoInternalCollection<PSMemberInfo> unused1;
-            ConsolidatedString unused2;
-            if (PSObject.HasInstanceMembers(boxedT, out unused1) || PSObject.HasInstanceTypeName(boxedT, out unused2))
+            if (PSObject.HasInstanceMembers(boxedT, out _) || PSObject.HasInstanceTypeName(boxedT, out _))
             {
                 var psobj = PSObject.AsPSObject(boxedT);
                 return PSObject.Base(psobj.Copy());
@@ -5623,8 +5621,7 @@ namespace System.Management.Automation.Language
 
             canOptimize = false;
 
-            PSMemberInfo unused;
-            Diagnostics.Assert(!TryGetInstanceMember(target.Value, Name, out unused),
+            Diagnostics.Assert(!TryGetInstanceMember(target.Value, Name, out _),
                                 "shouldn't get here if there is an instance member");
 
             PSMemberInfo memberInfo = null;

--- a/src/System.Management.Automation/utils/PsUtils.cs
+++ b/src/System.Management.Automation/utils/PsUtils.cs
@@ -350,9 +350,7 @@ namespace System.Management.Automation
                     pe.Message);
             }
 
-            string unused1;
-            string unused2;
-            var pipeline = ast.GetSimplePipeline(false, out unused1, out unused2);
+            var pipeline = ast.GetSimplePipeline(false, out _, out _);
             if (pipeline != null)
             {
                 var hashtableAst = pipeline.GetPureExpression() as HashtableAst;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Most variables that I've found to be unused has been replaced with discards. See: https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/functional/discards
I simply searched for "unused" and looked through the results.
<!-- Summarize your PR between here and the checklist. -->

## PR Context
The link describes the advantages but the short version is that it makes intent clear and from what I understand, allows for slight memory optimizations by the compiler.
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [X] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
