### PR TITLE
Add Milliseconds Parameter to New-TimeSpan

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewTimeSpanCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewTimeSpanCommand.cs
@@ -88,6 +88,12 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = "Time")]
         public int Seconds { get; set; }
 
+        /// <summary>
+        /// Allows the user to override the millisecond.
+        /// </summary>
+        [Parameter(ParameterSetName = "Time")]
+        public int Milliseconds { get; set; }
+
         #endregion
 
         #region methods
@@ -119,7 +125,7 @@ namespace Microsoft.PowerShell.Commands
                     break;
 
                 case "Time":
-                    result = new TimeSpan(Days, Hours, Minutes, Seconds);
+                    result = new TimeSpan(Days, Hours, Minutes, Seconds, Milliseconds);
                     break;
 
                 default:

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/New-TimeSpan.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/New-TimeSpan.Tests.ps1
@@ -3,12 +3,13 @@
 Describe "New-TimeSpan DRT Unit Tests" -Tags "CI" {
 
      It "Should works proper with new-timespan"{
-         $results =  New-TimeSpan -Days 10 -Hours 10 -Minutes 10 -Seconds 10
+         $results =  New-TimeSpan -Days 10 -Hours 10 -Minutes 10 -Seconds 10 -Milliseconds 10
          $results | Should -BeOfType System.Timespan
          $results.Days | Should -Be 10
          $results.Hours | Should -Be 10
          $results.Minutes | Should -Be 10
          $results.Seconds | Should -Be 10
+         $results.Milliseconds | Should -Be 10
     }
 }
 
@@ -20,29 +21,30 @@ Describe "New-TimeSpan" -Tags "CI" {
     }
 
     Context "Core Functionality Tests" {
-	New-Variable -Name testObject -Value $(New-TimeSpan -Days 2 -Hours 23 -Minutes 4 -Seconds 3) -Force
+	New-Variable -Name testObject -Value $(New-TimeSpan -Days 2 -Hours 23 -Minutes 4 -Seconds 3 -Milliseconds 2) -Force
 
 	$expectedOutput = @{ "Days"              = "2";
 			     "Hours"             = "23";
 			     "Minutes"           = "4";
 			     "Seconds"           = "3";
-			     "Milliseconds"      = "0";
-			     "Ticks"             = "2558430000000";
-			     "TotalDays"         = "2.96114583333333";
-			     "TotalHours"        = "71.0675";
-			     "TotalMinutes"      = "4264.05";
-			     "TotalSeconds"      = "255843";
-			     "TotalMilliseconds" = "255843000"
+			     "Milliseconds"      = "2";
+			     "Ticks"             = "2558430020000";
+			     "TotalDays"         = "2.96114585648148";
+			     "TotalHours"        = "71.0675005555556";
+			     "TotalMinutes"      = "4264.05003333333";
+			     "TotalSeconds"      = "255843.002";
+			     "TotalMilliseconds" = "255843002"
 			   }
 
 	$TEN_MILLION = 10000000
 
 	It "Should have expected values for time properties set during creation" {
-	    $testObject.Days    | Should -Be $expectedOutput["Days"]
-	    $testObject.Hours   | Should -Be $expectedOutput["Hours"]
-	    $testObject.Minutes | Should -Be $expectedOutput["Minutes"]
-	    $testObject.Seconds | Should -Be $expectedOutput["Seconds"]
-	    $testObject.Ticks   | Should -Be $expectedOutput["Ticks"]
+	    $testObject.Days         | Should -Be $expectedOutput["Days"]
+	    $testObject.Hours        | Should -Be $expectedOutput["Hours"]
+	    $testObject.Minutes      | Should -Be $expectedOutput["Minutes"]
+	    $testObject.Seconds      | Should -Be $expectedOutput["Seconds"]
+	    $testObject.Milliseconds | Should -Be $expectedOutput["Milliseconds"]
+	    $testObject.Ticks        | Should -Be $expectedOutput["Ticks"]
 	}
 
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR adds a parameter to the New-TimeSpan cmdlet and updates the tests associated with the cmdlet to accomadate testing the new parameter.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

The ability to set millisecond precision in a timespan structure could be beneficial where consumers of a timespan structure have millisecond resolution.  This was requested under issue #16486.

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/9005
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
