### PR TITLE
Remove potential ANSI escape sequences in strings before using in `Out-GridView`

### DIFF
--- a/src/Microsoft.Management.UI.Internal/commandHelpers/OutGridView.cs
+++ b/src/Microsoft.Management.UI.Internal/commandHelpers/OutGridView.cs
@@ -502,7 +502,7 @@ namespace Microsoft.Management.UI.Internal
                             {
                                 if (property.Value is string)
                                 {
-                                    StringDecorated decoratedString = new StringDecorated((string)property.Value);
+                                    StringDecorated decoratedString = new StringDecorated(property.Value as string);
                                     property.Value = decoratedString.ToString(OutputRendering.PlainText);
                                 }
                             }

--- a/src/Microsoft.Management.UI.Internal/commandHelpers/OutGridView.cs
+++ b/src/Microsoft.Management.UI.Internal/commandHelpers/OutGridView.cs
@@ -500,9 +500,9 @@ namespace Microsoft.Management.UI.Internal
                             // Remove any potential ANSI decoration
                             foreach (var property in value.Properties)
                             {
-                                if (property.Value is string)
+                                if (property.Value is string str)
                                 {
-                                    StringDecorated decoratedString = new StringDecorated(property.Value as string);
+                                    StringDecorated decoratedString = new StringDecorated(str);
                                     property.Value = decoratedString.ToString(OutputRendering.PlainText);
                                 }
                             }

--- a/src/Microsoft.Management.UI.Internal/commandHelpers/OutGridView.cs
+++ b/src/Microsoft.Management.UI.Internal/commandHelpers/OutGridView.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Management.Automation;
+using System.Management.Automation.Internal;
 using System.Threading;
 using System.Windows;
 using System.Windows.Automation;
@@ -496,6 +497,16 @@ namespace Microsoft.Management.UI.Internal
                     {
                         try
                         {
+                            // Remove any potential ANSI decoration
+                            foreach (var property in value.Properties)
+                            {
+                                if (property.Value is string)
+                                {
+                                    StringDecorated decoratedString = new StringDecorated((string)property.Value);
+                                    property.Value = decoratedString.ToString(OutputRendering.PlainText);
+                                }
+                            }
+
                             this.listItems.Add(value);
                         }
                         catch (Exception e)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

`Out-GridView` specifically uses the formatted output so that it resembles what you'd see in `Format-Table`.  This means that any ANSI that is included would be in the strings in `Out-GridView` even though WPF doesn't know how to render them.

The fix is as objects are being sent to `Out-GridView`, we use the `StringDecorated` class to remove known ANSI escape sequences so they are just plaintext.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/17636

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
