### PR TITLE
Fix `Export-PSSession` to not throw error when a rooted path is specified for `-OutputModule`

### DIFF
--- a/src/System.Management.Automation/resources/PathUtilsStrings.resx
+++ b/src/System.Management.Automation/resources/PathUtilsStrings.resx
@@ -139,7 +139,7 @@
     <value>The directory '{0}' already exists.  Use the -Force parameter if you want to overwrite the directory and files within the directory.</value>
   </data>
   <data name="ExportPSSession_ErrorModuleNameOrPath" xml:space="preserve">
-    <value>The -OutputModule parameter does not resolve to a path, and a user module path cannot be found for the provided name.</value>
+    <value>The user module path does not exist, and hence a module folder cannot be created for the provided module name '{0}'.</value>
   </data>
   <data name="ExportPSSession_CannotCreateOutputDirectory" xml:space="preserve">
     <value>Cannot create the module {0} due to the following: {1}. Use a different argument for the -OutputModule parameter and retry.</value>

--- a/src/System.Management.Automation/utils/PathUtils.cs
+++ b/src/System.Management.Automation/utils/PathUtils.cs
@@ -366,18 +366,25 @@ namespace System.Management.Automation
 
                 if (string.IsNullOrEmpty(rootedPath))
                 {
-                    string personalModuleRoot = ModuleIntrinsics.GetPersonalModulePath();
-                    if (string.IsNullOrEmpty(personalModuleRoot))
+                    if (Path.IsPathRooted(moduleNameOrPath))
                     {
-                        cmdlet.ThrowTerminatingError(
-                            new ErrorRecord(
-                                new ArgumentException(PathUtilsStrings.ExportPSSession_ErrorModuleNameOrPath),
-                                "ExportPSSession_ErrorModuleNameOrPath",
-                                ErrorCategory.InvalidArgument,
-                                cmdlet));
+                        rootedPath = moduleNameOrPath;
                     }
+                    else
+                    {
+                        string personalModuleRoot = ModuleIntrinsics.GetPersonalModulePath();
+                        if (string.IsNullOrEmpty(personalModuleRoot))
+                        {
+                            cmdlet.ThrowTerminatingError(
+                                new ErrorRecord(
+                                    new ArgumentException(StringUtil.Format(PathUtilsStrings.ExportPSSession_ErrorModuleNameOrPath, moduleNameOrPath)),
+                                    "ExportPSSession_ErrorModuleNameOrPath",
+                                    ErrorCategory.InvalidArgument,
+                                    cmdlet));
+                        }
 
-                    rootedPath = Path.Combine(personalModuleRoot, moduleNameOrPath);
+                        rootedPath = Path.Combine(personalModuleRoot, moduleNameOrPath);
+                    }
                 }
 
                 directoryInfo = new DirectoryInfo(rootedPath);

--- a/src/System.Management.Automation/utils/PathUtils.cs
+++ b/src/System.Management.Automation/utils/PathUtils.cs
@@ -5,10 +5,9 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Management.Automation.Internal;
-using Microsoft.PowerShell.Commands;
 using System.Runtime.CompilerServices;
 using System.Text;
-
+using Microsoft.PowerShell.Commands;
 using Dbg = System.Management.Automation.Diagnostics;
 
 namespace System.Management.Automation

--- a/src/System.Management.Automation/utils/PathUtils.cs
+++ b/src/System.Management.Automation/utils/PathUtils.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Management.Automation.Internal;
+using Microsoft.PowerShell.Commands;
 using System.Runtime.CompilerServices;
 using System.Text;
 
@@ -357,7 +358,9 @@ namespace System.Management.Automation
             DirectoryInfo directoryInfo = null;
             try
             {
-                string rootedPath = Microsoft.PowerShell.Commands.ModuleCmdletBase.ResolveRootedFilePath(moduleNameOrPath, cmdlet.Context);
+                // Even if 'moduleNameOrPath' is a rooted path, 'ResolveRootedFilePath' may return null when the path doesn't exist yet,
+                // or when it contains wildcards but cannot be resolved to a single path.
+                string rootedPath = ModuleCmdletBase.ResolveRootedFilePath(moduleNameOrPath, cmdlet.Context);
                 if (string.IsNullOrEmpty(rootedPath) && moduleNameOrPath.StartsWith('.'))
                 {
                     PathInfo currentPath = cmdlet.CurrentProviderLocation(cmdlet.Context.ProviderNames.FileSystem);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The 7.0.10 release contains a commit for a potential security issue: https://github.com/PowerShell/PowerShell/commit/38e55e14adadda43503486baf2909b3341e26d7a#. Here is the announcement about it: https://github.com/PowerShell/Announcements/issues/31.

[This particular change](https://github.com/PowerShell/PowerShell/commit/38e55e14adadda43503486baf2909b3341e26d7a#diff-2bd22a7e60ca6872d2757b0f575d658af263bc63ade58368634bf01c3a4872e1R369-R378) from that commit caused a regression in Azure Function when running `Import-Module <module-name> -UseWindowsPowerShell`, where the user's module path doesn't exist. That command worked fine with the PowerShell 7.0.9 SDK but started to fail with the PowerShell 7.0.11 SDK.

The root cause is that when `Export-PSSession` is used by `Import-Module -UseWindowsPowerShell`, a rooted path is always specified to the `-OutputModule` parameter, so it doesn't matter whether the user's module path exists or not because it doesn't need it to identify the directory to use.

The fix is to use the specified rooted path directly. Actually, `Path.Combine(path1, path2)` will return `path2` if it's rooted.
The error message is also updated:

![image](https://user-images.githubusercontent.com/127450/178626411-ecd1bc81-8ea5-4d31-aeca-60a45c353b9f.png)


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
