### PR TITLE
Avoid binding positional parameters when completing parameter in front of value

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -553,7 +553,7 @@ namespace System.Management.Automation
                 commandAst = (CommandAst)dashAst.Parent;
                 partialName = string.Empty;
 
-                // If the user tries to tab complete a new parameter in front of a positional argument like: ls -<Tab> C:\
+                // If the user tries to tab complete a new parameter in front of a positional argument like: dir -<Tab> C:\
                 // the user may want to add the parameter name so we don't want to bind positional arguments
                 if (commandAst is not null)
                 {
@@ -561,10 +561,7 @@ namespace System.Management.Automation
                     {
                         if (element.Extent.StartOffset > context.TokenAtCursor.Extent.StartOffset)
                         {
-                            if (element is not CommandParameterAst)
-                            {
-                                bindPositionalParameters = false;
-                            }
+                            bindPositionalParameters = element is CommandParameterAst;
                             break;
                         }
                     }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -533,6 +533,7 @@ namespace System.Management.Automation
                 return result;
             }
 
+            bool bindPositionalParameters = true;
             if (parameterAst != null)
             {
                 // Parent must be a command
@@ -551,22 +552,21 @@ namespace System.Management.Automation
                 // Parent must be a command
                 commandAst = (CommandAst)dashAst.Parent;
                 partialName = string.Empty;
-            }
 
-            bool bindPositionalParameters = true;
-            // If the user tries to tab complete a new parameter in front of a positional argument like: ls -<Tab> C:\
-            // the user may want to add the parameter name so we don't want to bind positional arguments
-            if (commandAst is not null && string.Equals(context.TokenAtCursor?.Text, "-", StringComparison.OrdinalIgnoreCase))
-            {
-                foreach (var element in commandAst.CommandElements)
+                // If the user tries to tab complete a new parameter in front of a positional argument like: ls -<Tab> C:\
+                // the user may want to add the parameter name so we don't want to bind positional arguments
+                if (commandAst is not null)
                 {
-                    if (element.Extent.StartOffset > context.TokenAtCursor.Extent.StartOffset)
+                    foreach (var element in commandAst.CommandElements)
                     {
-                        if (element is not CommandParameterAst)
+                        if (element.Extent.StartOffset > context.TokenAtCursor.Extent.StartOffset)
                         {
-                            bindPositionalParameters = false;
+                            if (element is not CommandParameterAst)
+                            {
+                                bindPositionalParameters = false;
+                            }
+                            break;
                         }
-                        break;
                     }
                 }
             }

--- a/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
@@ -949,8 +949,9 @@ namespace System.Management.Automation.Language
         /// <param name="pipeArgumentType">Indicate the type of the piped-in argument.</param>
         /// <param name="paramAstAtCursor">The CommandParameterAst the cursor is pointing at.</param>
         /// <param name="bindingType">Indicates whether pseudo binding is for argument binding, argument completion, or parameter completion.</param>
+        /// <param name="bindPositional">Indicates if the pseudo binding should bind positional parameters</param>
         /// <returns>PseudoBindingInfo.</returns>
-        internal PseudoBindingInfo DoPseudoParameterBinding(CommandAst command, Type pipeArgumentType, CommandParameterAst paramAstAtCursor, BindingType bindingType)
+        internal PseudoBindingInfo DoPseudoParameterBinding(CommandAst command, Type pipeArgumentType, CommandParameterAst paramAstAtCursor, BindingType bindingType, bool bindPositional = true)
         {
             if (command == null)
             {
@@ -1008,12 +1009,15 @@ namespace System.Management.Automation.Language
                 unboundArguments = BindNamedParameters();
                 _bindingEffective = _currentParameterSetFlag != 0;
 
-                // positional binding
-                unboundArguments = BindPositionalParameter(
-                    unboundArguments,
-                    _currentParameterSetFlag,
-                    _defaultParameterSetFlag,
-                    bindingType);
+                if (bindPositional)
+                {
+                    // positional binding
+                    unboundArguments = BindPositionalParameter(
+                        unboundArguments,
+                        _currentParameterSetFlag,
+                        _defaultParameterSetFlag,
+                        bindingType);
+                }
 
                 // VFRA/pipeline binding if the given command is a binary cmdlet or a script cmdlet
                 if (!_function)

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -691,6 +691,13 @@ ConstructorTestClass(int i, bool b)
         $completionText -join ' ' | Should -BeExactly 'blg csv tsv'
     }
 
+    it 'Should include positionally bound parameters when completing in front of parameter value' {
+        $TestString = 'Get-ChildItem -^ $HOME'
+        $CursorIndex = $TestString.IndexOf('^')
+        $res = TabExpansion2 -inputScript $TestString.Remove($CursorIndex, 1) -cursorColumn $CursorIndex
+        $res.CompletionMatches.CompletionText | should -Contain "-Path"
+    }
+
     Context "Script name completion" {
         BeforeAll {
             Setup -f 'install-powershell.ps1' -Content ""

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -695,7 +695,7 @@ ConstructorTestClass(int i, bool b)
         $TestString = 'Get-ChildItem -^ $HOME'
         $CursorIndex = $TestString.IndexOf('^')
         $res = TabExpansion2 -inputScript $TestString.Remove($CursorIndex, 1) -cursorColumn $CursorIndex
-        $res.CompletionMatches.CompletionText | should -Contain "-Path"
+        $res.CompletionMatches.CompletionText | Should -Contain "-Path"
     }
 
     Context "Script name completion" {


### PR DESCRIPTION

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Fixes https://github.com/PowerShell/PowerShell/issues/7733
This prevents the pseudobinding from binding positional parameters if the cursor is in front of a positional value like: `Get-ChildItem -<Tab> $HOME`  
It only does this if the tokenAtCursor is a dash because the completion already handles it for partially written parameters like `Get-ChildItem -P<Tab> $Home`.  
This makes it easier for users to fix a script with a positional parameter that the user wants replaced with a named parameter.
<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
