### PR TITLE
Change `Get-ChildItem` to treat trailing slash in path as indicating a directory when used with `-Recurse`

### DIFF
--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -1324,7 +1324,7 @@ namespace System.Management.Automation
                 try
                 {
                     // If we're recursing, do some path fixups to match user
-                    // expectations only if the last part is a file and not a directory:
+                    // expectations, but only if the last part is a file and not a directory:
                     if (recurse && !path.EndsWith(Path.DirectorySeparatorChar) && !path.EndsWith(Path.AltDirectorySeparatorChar))
                     {
                         string childName = GetChildName(path, context);

--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -1324,8 +1324,8 @@ namespace System.Management.Automation
                 try
                 {
                     // If we're recursing, do some path fixups to match user
-                    // expectations:
-                    if (recurse)
+                    // expectations only if the last part is a file and not a directory:
+                    if (recurse && !path.EndsWith(Path.DirectorySeparatorChar) && !path.EndsWith(Path.AltDirectorySeparatorChar))
                     {
                         string childName = GetChildName(path, context);
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1380,6 +1380,14 @@ namespace Microsoft.PowerShell.Commands
             bool hidden = attributes.HasFlag(FileAttributes.Hidden);
             isContainer = attributes.HasFlag(FileAttributes.Directory);
 
+            // FileInfo allows for a file path to end in a trailing slash, but the resulting object
+            // is incomplete.  A trailing slash should indicate a directory.  So if the path ends in a
+            // trailing slash and is not a directory, return null
+            if (!isContainer && path.EndsWith(Path.DirectorySeparatorChar))
+            {
+                return null;
+            }
+
             FlagsExpression<FileAttributes> evaluator = null;
             FlagsExpression<FileAttributes> switchEvaluator = null;
             GetChildDynamicParameters fspDynamicParam = DynamicParameters as GetChildDynamicParameters;

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1373,10 +1373,7 @@ namespace Microsoft.PowerShell.Commands
             path = NormalizePath(path);
             FileInfo result = new FileInfo(path);
 
-            // FileInfo.Exists is always false for a directory path, so we check the attribute for existence.
             var attributes = result.Attributes;
-            if ((int)attributes == -1) { /* Path doesn't exist. */ return null; }
-
             bool hidden = attributes.HasFlag(FileAttributes.Hidden);
             isContainer = attributes.HasFlag(FileAttributes.Directory);
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -217,6 +217,17 @@ Describe "Get-ChildItem" -Tags "CI" {
         It "Should list the folder present when path length equal to MAX_PATH" {
             (Get-ChildItem -Path TestDrive:\$item_I -Recurse -Force).Name.Length | Should -BeGreaterThan 0
         }
+
+        It 'Trailing slash for -Path should treat it as a folder only when used with -recurse' {
+            $foo = New-Item -ItemType Directory -Path TestDrive:\foo
+            $foo2 = New-Item -ItemType Directory -Path TestDrive:\foo\foo
+            $bar = New-Item -ItemType File -Path TestDrive:\foo\bar
+            $bar2 = New-Item -ItemType File -Path TestDrive:\foo\foo\bar
+
+            { Get-ChildItem -Path testdrive:/foo/bar/ -Recurse -ErrorAction Stop } | Should -Throw -ErrorId 'ItemNotFound,Microsoft.PowerShell.Commands.GetChildItemCommand'
+            $barFiles = Get-ChildItem -Path testdrive:/foo/bar -Recurse
+            $barFiles.Count | Should -Be 2
+        }
     }
 
     Context 'Env: Provider' {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

If you run this command:

```powershell
get-childitem -path c:\foo\bar -recurse
```
and the subfolder `bar` does not exist and a subfolder called `b` doesn't exist, you get an incorrect error message:

```output
Get-ChildItem: Cannot find path 'C:\foo\b' because it does not exist.
```

The problem is that the code is trying to find the parent of bar, which should be `C:\foo\` but because of the trailing slash, it has an off-by-one error resulting in `c:\foo\b`.  It then tries to find this folder which results in the error message.  If by chance a folder `b` exists, then `Get-ChildItem` would traverse into that folder and return incorrect results.

The fix here is if the path ends in a trailing slash, then we treat the last part as indicating a directory and never a folder.  So we add checks for that and if "c:\foo\bar\" where a folder "bar" doesn't exist, you'll get the right error message with the path.

However, part of the fix works around an issue with .NET FileInfo::new() which happily accepts a path to a file with a trailing slash and returns an incomplete object.  Since this repros with .NET Framework, it seems unlikely to be changed (`Get-Item` demonstrates the behavior and is not changed in this PR) so I added code to fail if such an object is returned.

## PR Context

This issue was brought up in this thread: https://twitter.com/SBarizien/status/1549000209610510336

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
