### PR TITLE
Improve type inference for $_

### DIFF
--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -1868,6 +1868,7 @@ namespace System.Management.Automation
                             }
                         }
                     }
+
                     parent = parent.Parent;
                 }
 

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -1904,7 +1904,7 @@ namespace System.Management.Automation
                             return;
                         }
 
-                        AddInferredTypesForDollarUnderbar(pipelineAst.PipelineElements[0], inferredTypes);
+                        AddInferredTypesForDollarUnderbar(pipelineAst.PipelineElements[previousCommandIndex], inferredTypes);
 
                         return;
                     }

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -1901,7 +1901,7 @@ namespace System.Management.Automation
                         foreach (TypeConstraintAst catchType in catchBlock.CatchTypes)
                         {
                             Type exceptionType = catchType.TypeName.GetReflectionType();
-                            if (exceptionType != null && typeof(Exception).IsAssignableFrom(exceptionType))
+                            if (typeof(Exception).IsAssignableFrom(exceptionType))
                             {
                                 inferredTypes.Add(new PSTypeName(typeof(ErrorRecord<>).MakeGenericType(exceptionType)));
                             }
@@ -1919,7 +1919,7 @@ namespace System.Management.Automation
                     if (trap.TrapType is not null)
                     {
                         Type exceptionType = trap.TrapType.TypeName.GetReflectionType();
-                        if (exceptionType is not null && typeof(Exception).IsAssignableFrom(exceptionType))
+                        if (typeof(Exception).IsAssignableFrom(exceptionType))
                         {
                             inferredTypes.Add(new PSTypeName(typeof(ErrorRecord<>).MakeGenericType(exceptionType)));
                         }

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -2057,7 +2057,7 @@ namespace System.Management.Automation
                         continue;
                     }
 
-                    if (typeof(IEnumerable).IsAssignableFrom(result.Type))
+                    if (result.Type != typeof(string) && typeof(IEnumerable).IsAssignableFrom(result.Type))
                     {
                         // We can't deduce much from IEnumerable, but we can if it's generic.
                         var enumerableInterfaces = result.Type.GetInterfaces();

--- a/test/powershell/engine/Api/TypeInference.Tests.ps1
+++ b/test/powershell/engine/Api/TypeInference.Tests.ps1
@@ -1079,7 +1079,7 @@ Describe "Type inference Tests" -tags "CI" {
         $res.Name | Should -Be System.Exception
     }
 
-        It 'Infers type of variable $_ in pipeline with more than one element' {
+    It 'Infers type of variable $_ in pipeline with more than one element' {
         $memberAst = { Get-Date | New-Guid | Select-Object -Property {$_} }.Ast.Find({ param($a) $a -is [System.Management.Automation.Language.VariableExpressionAst] }, $true)
         $res = [AstTypeInference]::InferTypeOf($memberAst)
 
@@ -1092,6 +1092,21 @@ Describe "Type inference Tests" -tags "CI" {
 
         $res | Should -HaveCount 1
         $res.Name | Should -Be System.TimeSpan
+    }
+
+    It 'Infers type of variable $_ in switch statement' {
+        $variableAst = {
+        switch ("Hello","World")
+        {
+            'Hello'
+            {
+                $_
+            }
+        } }.Ast.Find({ param($a) $a -is [System.Management.Automation.Language.VariableExpressionAst] }, $true)
+        $res = [AstTypeInference]::InferTypeOf($variableAst)
+
+        $res | Should -HaveCount 1
+        $res.Name | Should -Be System.String
     }
 
     It 'Does not infer string in pipeline as char' {

--- a/test/powershell/engine/Api/TypeInference.Tests.ps1
+++ b/test/powershell/engine/Api/TypeInference.Tests.ps1
@@ -1079,6 +1079,14 @@ Describe "Type inference Tests" -tags "CI" {
         $res.Name | Should -Be System.Exception
     }
 
+    It 'Infers type of variable $_ in pipeline with more than one element' {
+        $memberAst = { Get-Date | New-Guid | Select-Object -Property {$_} }.Ast.Find({ param($a) $a -is [System.Management.Automation.Language.VariableExpressionAst] }, $true)
+        $res = [AstTypeInference]::InferTypeOf($memberAst)
+
+        $res | Should -HaveCount 1
+        $res.Name | Should -Be System.Guid
+    }
+
     $catchClauseTypes = @(
         @{ Type = 'System.ArgumentException' }
         @{ Type = 'System.ArgumentNullException' }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Fixes the type inference for $_ in pipelines with more than 1 command by making it infer the type of the previous command of the expression rather than the first.

-Edit: Decided to make a full fix for $_ and also fix it when the scriptblock is inside an array of arguments like for Select-Object or Foreach-Object `ls | ForEach-Object -Process {$_.<Tab>},{$_.<Tab>}`  
Also fixes a scenario where a catch block is given invalid types so there's no completion for $_ inside the catch block.
Fixes: https://github.com/PowerShell/PowerShell/issues/17613
Edit2: The test failures helped me discover a different issue, strings are enumerated as chars by the type inference. This has now been fixed.

Full list of scenarios where $_ is now properly being inferred:

- Member invocation scriptblocks like `$Collection.Where({$_})`
- Scriptblocks used as command arguments like: `ls | where {$_}`
- Switch statements like: `switch ("hello") {'Hello'{$_}}`
- Catch statements like: `try{} catch {$_}`
- Trap statements like: `trap {$_}`

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
