### PR TITLE
Fix Test-Json not handling non-object types at root

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/TestJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/TestJsonCommand.cs
@@ -136,12 +136,11 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void ProcessRecord()
         {
-            JObject parsedJson = null;
             bool result = true;
 
             try
             {
-                parsedJson = JObject.Parse(Json);
+                var parsedJson = JToken.Parse(Json);
 
                 if (_jschema != null)
                 {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Test-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Test-Json.Tests.ps1
@@ -65,7 +65,7 @@ Describe "Test-Json" -Tags "CI" {
                 errorNode
             }
 "@
-}
+    }
 
     It "Missing JSON schema file doesn't exist" {
         Test-Path -LiteralPath $missingSchemaJsonPath | Should -BeFalse
@@ -151,5 +151,29 @@ Describe "Test-Json" -Tags "CI" {
         $errorVar.Count | Should -Be 2
         $errorVar[0].FullyQualifiedErrorId | Should -BeExactly "InvalidJsonAgainstSchema,Microsoft.PowerShell.Commands.TestJsonCommand"
         $errorVar[1].FullyQualifiedErrorId | Should -BeExactly "InvalidJsonAgainstSchema,Microsoft.PowerShell.Commands.TestJsonCommand"
+    }
+
+    It 'Test-Json recognizes non-object types: <name>' -TestCases @(
+        @{ name = 'number'; value = 1; expected = 'number' }
+        @{ name = '"true"'; value = '"true"'; expected = 'string' }
+        @{ name = 'true'; value = 'true'; expected = 'boolean' }
+        @{ name = '"false"'; value = '"false"'; expected = 'string' }
+        @{ name = 'false'; value = 'false'; expected = 'boolean' }
+        @{ name = '"null"'; value = '"null"'; expected = 'string' }
+        @{ name = 'null'; value = 'null'; expected = 'null' }
+        @{ name = 'string'; value = '"abc"'; expected = 'string' }
+        @{ name = 'array'; value = '[ 1, 2 ]'; expected = 'array' }
+    ) {
+        param ($name, $value, $expected)
+
+        # All JSON valid
+        Test-Json -Json $value | Should -BeTrue
+
+        # Exactly one type should match
+        $types = 'string', 'number', 'boolean', 'null', 'array', 'object'
+        $types | ?{
+            $schema = "{ 'type': '$_' }"
+            Test-Json -Json $value -Schema $schema -ErrorAction SilentlyContinue
+        } | Should -Be $expected
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Test-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Test-Json.Tests.ps1
@@ -171,7 +171,7 @@ Describe "Test-Json" -Tags "CI" {
 
         # Exactly one type should match
         $types = 'string', 'number', 'boolean', 'null', 'array', 'object'
-        $types | ?{
+        $types | Where-Object {
             $schema = "{ 'type': '$_' }"
             Test-Json -Json $value -Schema $schema -ErrorAction SilentlyContinue
         } | Should -Be $expected


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

`Test-Json` incorrectly parsed JSON as `JObject`, which failed if the root type was not an object, but array, string, number, etc. @mklement0 suggested to change it to `JToken` which matches all types, which I verified to be a one-line fix.

Fixes #11384

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

`Test-Json` currently fails if the root type is not an object, despite `ConvertFrom-Json` and `ConvertTo-Json` handling them without a problem. This leads to confusing case of `1 | ConvertTo-Json | Test-Json` failing with a non-specific error "Cannot parse JSON".

This bug is most apparent when trying to validate a [JSON schema](https://json-schema.org/) where the root is not a single object, but instead an array of objects. However, as in example above, it also impacts cases without schema, where someone might use `Test-Json` as a shorthand for putting `ConvertFrom-Json` in a try-catch, which is exactly how it should be used when you don't care about content, just whether it is valid.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
