### PR TITLE
[WIP] Make named pipe IPC opt-in

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -190,6 +190,7 @@ namespace Microsoft.PowerShell
             "outputformat",
             "removeworkingdirectorytrailingcharacter",
             "settingsfile",
+            "startipclistener",
             "version",
             "windowstyle",
             "workingdirectory"
@@ -230,6 +231,7 @@ namespace Microsoft.PowerShell
             WorkingDirectory    = 0x02000000, // -WorkingDirectory | -wd
             ConfigurationFile   = 0x04000000, // -ConfigurationFile
             NoProfileLoadTime   = 0x08000000, // -NoProfileLoadTime
+            StartIPCListener    = 0x10000000, // -StartIPCListener | -startipc
             // Enum values for specified ExecutionPolicy
             EPUnrestricted      = 0x0000000100000000, // ExecutionPolicy unrestricted
             EPRemoteSigned      = 0x0000000200000000, // ExecutionPolicy remote signed
@@ -396,6 +398,15 @@ namespace Microsoft.PowerShell
                 {
                     _configurationName = value;
                 }
+            }
+        }
+
+        internal bool StartIPClistener
+        {
+            get
+            {
+                AssertArgumentsParsed();
+                return _startIPCListener;
             }
         }
 
@@ -940,6 +951,11 @@ namespace Microsoft.PowerShell
                 {
                     _noInteractive = false;
                     ParametersUsed |= ParameterBitmap.Interactive;
+                }
+                else if (MatchSwitch(switchKey, "startipclistener", "startipc"))
+                {
+                    _startIPCListener = true;
+                    ParametersUsed |= ParameterBitmap.StartIPCListener;
                 }
                 else if (MatchSwitch(switchKey, "configurationfile", "configurationfile"))
                 {
@@ -1514,6 +1530,7 @@ namespace Microsoft.PowerShell
         private bool _sshServerMode;
         private bool _noProfileLoadTime;
         private bool _showVersion;
+        private bool _startIPCListener;
         private string? _configurationFile;
         private string? _configurationName;
         private string? _error;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -200,6 +200,13 @@ namespace Microsoft.PowerShell
 #if !UNIX
                 TaskbarJumpList.CreateRunAsAdministratorJumpList();
 #endif
+
+                // Start IPC named pipe listener for this process, if requested.
+                if (s_cpp.StartIPClistener)
+                {
+                    Runspace.StartIPCListener();
+                }
+
                 // First check for and handle PowerShell running in a server mode.
                 if (s_cpp.ServerMode)
                 {

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -153,6 +153,7 @@
                   [-SettingsFile &lt;filePath&gt;] [-SSHServerMode] [-STA] 
                   [-Version] [-WindowStyle &lt;style&gt;] 
                   [-WorkingDirectory &lt;directoryPath&gt;]
+                  [-StartIPCListener] 
 
        pwsh[.exe] -h | -Help | -? | /?
 
@@ -453,6 +454,12 @@ All parameters are case-insensitive.</value>
     PowerShell file path is supported.
 
     To start PowerShell in your home directory, use: pwsh -WorkingDirectory ~
+
+-StartIPCListener | -startipc
+
+    Start PowerShell with the IPC (inter-process communication) listener
+    running, which can be used with Enter-PSHostProcess to attach to and
+    debug running PowerShell host processes.
 
 -Help, -?, /?
 

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -151,9 +151,9 @@
                   [-Interactive] [-MTA] [-NoExit] [-NoLogo] [-NonInteractive] [-NoProfile]
                   [-NoProfileLoadTime] [-OutputFormat {Text | XML}] 
                   [-SettingsFile &lt;filePath&gt;] [-SSHServerMode] [-STA] 
+                  [-StartIPCListener] 
                   [-Version] [-WindowStyle &lt;style&gt;] 
                   [-WorkingDirectory &lt;directoryPath&gt;]
-                  [-StartIPCListener] 
 
        pwsh[.exe] -h | -Help | -? | /?
 
@@ -439,6 +439,12 @@ All parameters are case-insensitive.</value>
     Start PowerShell using a single-threaded apartment. This is the default.
     This switch is only available on Windows.
 
+-StartIPCListener | -startipc
+
+    Start PowerShell with the IPC (inter-process communication) listener
+    running, which can be used with Enter-PSHostProcess to attach to and
+    debug running PowerShell host processes.
+
 -Version | -v
 
     Displays the version of PowerShell. Additional parameters are ignored.
@@ -454,12 +460,6 @@ All parameters are case-insensitive.</value>
     PowerShell file path is supported.
 
     To start PowerShell in your home directory, use: pwsh -WorkingDirectory ~
-
--StartIPCListener | -startipc
-
-    Start PowerShell with the IPC (inter-process communication) listener
-    running, which can be used with Enter-PSHostProcess to attach to and
-    debug running PowerShell host processes.
 
 -Help, -?, /?
 

--- a/src/System.Management.Automation/engine/hostifaces/Connection.cs
+++ b/src/System.Management.Automation/engine/hostifaces/Connection.cs
@@ -6,6 +6,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Management.Automation.Host;
 using System.Management.Automation.Internal;
+using System.Management.Automation.Remoting;
 using System.Runtime.Serialization;
 using System.Threading;
 
@@ -455,6 +456,7 @@ namespace System.Management.Automation.Runspaces
         #region Private Data
 
         private static int s_globalId;
+        private static RemoteSessionNamedPipeServer s_IPCNamedPipeServer;
         private readonly Stack<PowerShell> _runningPowerShells;
         private PowerShell _baseRunningPowerShell;
         private readonly object _syncObject;
@@ -1271,6 +1273,26 @@ namespace System.Management.Automation.Runspaces
         public static Runspace GetRunspace(RunspaceConnectionInfo connectionInfo, Guid sessionId, Guid? commandId, PSHost host, TypeTable typeTable)
         {
             return RemoteRunspace.GetRemoteRunspace(connectionInfo, sessionId, commandId, host, typeTable);
+        }
+
+        /// <summary>
+        /// Starts the IPC named pipe listener that allows other PowerShell sessions to connect
+        /// and debug this session. The connection is via a PowerShell remoting connection. The 
+        /// listener can only be started once per PowerShell session.
+        /// </summary>
+        /// <returns>
+        /// True if the listener was created and started, or false if the listener has already
+        /// been created.
+        /// </returns>
+        public static bool StartIPCListener()
+        {
+            if (s_IPCNamedPipeServer == null)
+            {
+                s_IPCNamedPipeServer = RemoteSessionNamedPipeServer.IPCNamedPipeServer;
+                return true;
+            }
+
+            return false;
         }
 
         #endregion

--- a/src/System.Management.Automation/engine/hostifaces/LocalConnection.cs
+++ b/src/System.Management.Automation/engine/hostifaces/LocalConnection.cs
@@ -68,6 +68,8 @@ namespace System.Management.Automation.Runspaces
         }
         #endregion constructors
 
+        #region Methods
+
         /// <summary>
         /// Private data to be used by applications built on top of PowerShell.
         ///
@@ -210,6 +212,8 @@ namespace System.Management.Automation.Runspaces
             // last to so that changes to the default MaximumHistorySize will be picked up.
             _history = new History(this.ExecutionContext);
         }
+
+        #endregion
 
         #region protected_methods
 
@@ -584,6 +588,8 @@ namespace System.Management.Automation.Runspaces
         }
 
         #endregion
+
+        #region Helpers
 
         /// <summary>
         /// Open the runspace.
@@ -1030,6 +1036,8 @@ namespace System.Management.Automation.Runspaces
             }
         }
 
+        #endregion
+
         #region SessionStateProxy
 
         protected override void DoSetVariable(string name, object value)
@@ -1303,11 +1311,6 @@ namespace System.Management.Automation.Runspaces
         [TraceSource("RunspaceInit", "Initialization code for Runspace")]
         private static readonly PSTraceSource s_runspaceInitTracer =
             PSTraceSource.GetTracer("RunspaceInit", "Initialization code for Runspace", false);
-
-        /// <summary>
-        /// This ensures all processes have a server/listener.
-        /// </summary>
-        private static readonly RemoteSessionNamedPipeServer s_IPCNamedPipeServer = RemoteSessionNamedPipeServer.IPCNamedPipeServer;
 
         #endregion private fields
     }

--- a/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
@@ -11,6 +11,7 @@ using System.Text;
 namespace System.Management.Automation.Runspaces
 {
     /// <summary>
+    /// Class for creating a PowerShell process.
     /// </summary>
     public sealed class PowerShellProcessInstance : IDisposable
     {
@@ -51,7 +52,14 @@ namespace System.Management.Automation.Runspaces
         /// <param name="initializationScript">Specifies a script that will be executed when the powershell process is initialized.</param>
         /// <param name="useWow64">Specifies if the powershell process will be 32-bit.</param>
         /// <param name="workingDirectory">Specifies the initial working directory for the new powershell process.</param>
-        public PowerShellProcessInstance(Version powerShellVersion, PSCredential credential, ScriptBlock initializationScript, bool useWow64, string workingDirectory)
+        /// <param name="startIPCListener">Specifies if the powershell process will start the IPC listener.</param>
+        public PowerShellProcessInstance(
+            Version powerShellVersion,
+            PSCredential credential,
+            ScriptBlock initializationScript,
+            bool useWow64,
+            string workingDirectory,
+            bool startIPCListener)
         {
             string exePath = PwshExePath;
             bool startingWindowsPowerShell51 = false;
@@ -113,6 +121,11 @@ namespace System.Management.Automation.Runspaces
             _startInfo.ArgumentList.Add("-NoLogo");
             _startInfo.ArgumentList.Add("-NoProfile");
 
+            if (startIPCListener)
+            {
+                _startInfo.ArgumentList.Add("-StartIPCListener");
+            }
+
             if (!string.IsNullOrWhiteSpace(workingDirectory) && !startingWindowsPowerShell51)
             {
                 _startInfo.ArgumentList.Add("-wd");
@@ -145,18 +158,42 @@ namespace System.Management.Automation.Runspaces
         /// <summary>
         /// Initializes a new instance of the <see cref="PowerShellProcessInstance"/> class. Initializes the underlying dotnet process class.
         /// </summary>
+        /// <param name="powerShellVersion">Specifies the version of powershell.</param>
+        /// <param name="credential">Specifies a user account credentials.</param>
+        /// <param name="initializationScript">Specifies a script that will be executed when the powershell process is initialized.</param>
+        /// <param name="useWow64">Specifies if the powershell process will be 32-bit.</param>
+        /// <param name="workingDirectory">Specifies the initial working directory for the new powershell process.</param>
+        public PowerShellProcessInstance(
+            Version powerShellVersion,
+            PSCredential credential,
+            ScriptBlock initializationScript,
+            bool useWow64,
+            string workingDirectory)
+            : this(powerShellVersion, credential, initializationScript, useWow64, workingDirectory, startIPCListener: false)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PowerShellProcessInstance"/> class. Initializes the underlying dotnet process class.
+        /// </summary>
         /// <param name="powerShellVersion"></param>
         /// <param name="credential"></param>
         /// <param name="initializationScript"></param>
         /// <param name="useWow64"></param>
-        public PowerShellProcessInstance(Version powerShellVersion, PSCredential credential, ScriptBlock initializationScript, bool useWow64) : this(powerShellVersion, credential, initializationScript, useWow64, workingDirectory: null)
+        public PowerShellProcessInstance(
+            Version powerShellVersion,
+            PSCredential credential,
+            ScriptBlock initializationScript,
+            bool useWow64)
+            : this(powerShellVersion, credential, initializationScript, useWow64, workingDirectory: null, startIPCListener: false)
         {
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PowerShellProcessInstance"/> class. Default initializes the underlying dotnet process class.
         /// </summary>
-        public PowerShellProcessInstance() : this(powerShellVersion: null, credential: null, initializationScript: null, useWow64: false, workingDirectory: null)
+        public PowerShellProcessInstance()
+        : this(powerShellVersion: null, credential: null, initializationScript: null, useWow64: false, workingDirectory: null, startIPCListener: false)
         {
         }
 

--- a/src/System.Management.Automation/engine/remoting/commands/StartJob.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/StartJob.cs
@@ -481,6 +481,12 @@ namespace Microsoft.PowerShell.Commands
         private ScriptBlock _initScript;
 
         /// <summary>
+        /// Gets or sets whether the job host process starts the PowerShell IPC listener.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter StartIPCListener { get; set; }
+
+        /// <summary>
         /// Gets or sets an initial working directory for the powershell background job.
         /// </summary>
         [Parameter]
@@ -664,6 +670,7 @@ namespace Microsoft.PowerShell.Commands
             connectionInfo.AuthenticationMechanism = this.Authentication;
             connectionInfo.PSVersion = this.PSVersion;
             connectionInfo.WorkingDirectory = this.WorkingDirectory;
+            connectionInfo.StartIPCListener = this.StartIPCListener;
 
             RemoteRunspace remoteRunspace = (RemoteRunspace)RunspaceFactory.CreateRunspace(connectionInfo, this.Host,
                         Utils.GetTypeTableFromExecutionContextTLS());

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -1580,6 +1580,11 @@ namespace System.Management.Automation.Runspaces
         public string WorkingDirectory { get; set; }
 
         /// <summary>
+        /// Gets or sets whether the child job process starts the PowerShell IPC listener.
+        /// </summary>
+        public bool StartIPCListener { get; set; }
+
+        /// <summary>
         /// Powershell version to execute the job in.
         /// </summary>
         public Version PSVersion { get; set; }
@@ -1659,6 +1664,7 @@ namespace System.Management.Automation.Runspaces
             result.AuthenticationMechanism = this.AuthenticationMechanism;
             result.InitializationScript = this.InitializationScript;
             result.WorkingDirectory = this.WorkingDirectory;
+            result.StartIPCListener = this.StartIPCListener;
             result.RunAs32 = this.RunAs32;
             result.PSVersion = this.PSVersion;
             result.Process = Process;

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -1580,7 +1580,7 @@ namespace System.Management.Automation.Runspaces
         public string WorkingDirectory { get; set; }
 
         /// <summary>
-        /// Gets or sets whether the child job process starts the PowerShell IPC listener.
+        /// Gets or sets a value indicating whether the child job process starts the PowerShell IPC listener.
         /// </summary>
         public bool StartIPCListener { get; set; }
 

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -1128,7 +1128,8 @@ namespace System.Management.Automation.Remoting.Client
                                                                                            _connectionInfo.Credential,
                                                                                            _connectionInfo.InitializationScript,
                                                                                            _connectionInfo.RunAs32,
-                                                                                           _connectionInfo.WorkingDirectory);
+                                                                                           _connectionInfo.WorkingDirectory,
+                                                                                           _connectionInfo.StartIPCListener);
                 if (_connectionInfo.Process != null)
                 {
                     _processCreated = false;

--- a/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
+++ b/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
@@ -1408,7 +1408,7 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
     <value>Multiple processes were found with this name {0}. Use the process Id to specify a single process to enter.</value>
   </data>
   <data name="EnterPSHostProcessNoPowerShell" xml:space="preserve">
-    <value>Cannot enter process with Id '{0}' because it has not loaded the PowerShell engine.</value>
+    <value>Cannot enter process with Id '{0}' because either it is not hosting PowerShell or it does not have a running PowerShell listener to connect to. Use -StartIPCListener switch to run PowerShell with the IPC listener running.</value>
   </data>
   <data name="EnterPSHostProcessNoProcessFoundWithId" xml:space="preserve">
     <value>No process was found with Id: {0}.</value>

--- a/test/powershell/Host/Logging.Tests.ps1
+++ b/test/powershell/Host/Logging.Tests.ps1
@@ -317,15 +317,14 @@ Path:.*
             $configFile = WriteLogSettings -LogId $logId
             $testPid = & $powershell -NoProfile -SettingsFile $configFile -Command '$PID'
 
-            Export-PSOsLog -After $after -LogPid $testPid -TimeoutInMilliseconds 30000 -IntervalInMilliseconds 3000 -MinimumCount 3 |
+            Export-PSOsLog -After $after -LogPid $testPid -TimeoutInMilliseconds 30000 -IntervalInMilliseconds 3000 -MinimumCount 2 |
                 Set-Content -Path $contentFile
             $items = @(Get-PSOsLog -Path $contentFile -Id $logId -After $after -TotalCount 3 -Verbose)
 
             $items | Should -Not -Be $null
-            $items.Count | Should -BeGreaterThan 2
+            $items.Count | Should -BeGreaterThan 1
             $items[0].EventId | Should -BeExactly 'Perftrack_ConsoleStartupStart:PowershellConsoleStartup.WinStart.Informational'
-            $items[1].EventId | Should -BeExactly 'NamedPipeIPC_ServerListenerStarted:NamedPipe.Open.Informational'
-            $items[2].EventId | Should -BeExactly 'Perftrack_ConsoleStartupStop:PowershellConsoleStartup.WinStop.Informational'
+            $items[1].EventId | Should -BeExactly 'Perftrack_ConsoleStartupStop:PowershellConsoleStartup.WinStop.Informational'
             # if there are more items than expected...
             if ($items.Count -gt 3)
             {

--- a/test/powershell/Host/Logging.Tests.ps1
+++ b/test/powershell/Host/Logging.Tests.ps1
@@ -178,12 +178,12 @@ Creating Scriptblock text \(1 of 1\):#012{0}(⏎|#012)*ScriptBlock ID: [0-9a-z\-
         $items | Should -Not -Be $null
         $items.Length | Should -BeGreaterThan 1
         $items[0].EventId | Should -BeExactly 'Perftrack_ConsoleStartupStart:PowershellConsoleStartup.WinStart.Informational'
-        $items[2].EventId | Should -BeExactly 'Perftrack_ConsoleStartupStop:PowershellConsoleStartup.WinStop.Informational'
+        $items[1].EventId | Should -BeExactly 'Perftrack_ConsoleStartupStop:PowershellConsoleStartup.WinStop.Informational'
         # if there are more items than expected...
-        if ($items.Length -gt 3)
+        if ($items.Length -gt 2)
         {
             # Force reporting of the first unexpected item to help diagnosis
-            $items[3] | Should -Be $null
+            $items[2] | Should -Be $null
         }
     }
 

--- a/test/powershell/Host/Logging.Tests.ps1
+++ b/test/powershell/Host/Logging.Tests.ps1
@@ -178,7 +178,6 @@ Creating Scriptblock text \(1 of 1\):#012{0}(⏎|#012)*ScriptBlock ID: [0-9a-z\-
         $items | Should -Not -Be $null
         $items.Length | Should -BeGreaterThan 1
         $items[0].EventId | Should -BeExactly 'Perftrack_ConsoleStartupStart:PowershellConsoleStartup.WinStart.Informational'
-        $items[1].EventId | Should -BeExactly 'NamedPipeIPC_ServerListenerStarted:NamedPipe.Open.Informational'
         $items[2].EventId | Should -BeExactly 'Perftrack_ConsoleStartupStop:PowershellConsoleStartup.WinStop.Informational'
         # if there are more items than expected...
         if ($items.Length -gt 3)

--- a/test/powershell/Host/Startup.Tests.ps1
+++ b/test/powershell/Host/Startup.Tests.ps1
@@ -65,7 +65,6 @@ Describe "Validate start of console host" -Tag CI {
                 'System.DirectoryServices.dll'
                 'System.Management.dll'
                 'System.Security.Claims.dll'
-                'System.Threading.Overlapped.dll'
             )
         }
         else {
@@ -84,7 +83,7 @@ Describe "Validate start of console host" -Tag CI {
             Remove-Item $profileDataFile -Force
         }
 
-        $loadedAssemblies = & "$PSHOME/pwsh" -noprofile -command '([System.AppDomain]::CurrentDomain.GetAssemblies()).manifestmodule | Where-Object { $_.Name -notlike "<*>" } | ForEach-Object { $_.Name }'
+        $loadedAssemblies = & "$PSHOME/pwsh" -noprofile -command "([System.AppDomain]::CurrentDomain.GetAssemblies()).manifestmodule | Where-Object { `$_.Name -notlike '<*>' } | ForEach-Object { `$_.Name }"
     }
 
     It "No new assemblies are loaded" {

--- a/test/powershell/Host/Startup.Tests.ps1
+++ b/test/powershell/Host/Startup.Tests.ps1
@@ -27,7 +27,6 @@ Describe "Validate start of console host" -Tag CI {
             'System.Diagnostics.Tracing.dll'
             'System.IO.FileSystem.AccessControl.dll'
             'System.IO.FileSystem.DriveInfo.dll'
-            'System.IO.Pipes.dll'
             'System.Linq.dll'
             'System.Linq.Expressions.dll'
             'System.Management.Automation.dll'
@@ -71,7 +70,6 @@ Describe "Validate start of console host" -Tag CI {
         }
         else {
             $allowedAssemblies += @(
-                'System.Net.Sockets.dll'
                 'System.Reflection.Emit.dll'
             )
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Enter-PSHostProcess.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Enter-PSHostProcess.Tests.ps1
@@ -65,6 +65,9 @@ Describe "Enter-PSHostProcess tests" -Tag Feature {
         BeforeAll {
             $oldColor = $env:NO_COLOR
             $env:NO_COLOR = 1
+
+            # Ensure this PowerShell process allows IPC connection.
+            [runspace]::StartIPCListener()
         }
 
         AfterAll {
@@ -79,7 +82,7 @@ Describe "Enter-PSHostProcess tests" -Tag Feature {
                 while ($true) {
                     Start-Sleep -Seconds 30 | Out-Null
                 }
-            }
+            } -StartIPCListener
 
             $pwshId = Wait-JobPid $pwshJob
         }
@@ -204,7 +207,7 @@ Describe "Enter-PSHostProcess tests" -Tag Feature {
                 [System.Management.Automation.Remoting.RemoteSessionNamedPipeServer]::CreateCustomNamedPipeServer($args[0])
                 $PID
                 while ($true) { Start-Sleep -Seconds 30 | Out-Null }
-            }
+            } -StartIPCListener
 
             $pwshId = Wait-JobPid $pwshJob
 

--- a/test/powershell/engine/Remoting/CustomConnection.Tests.ps1
+++ b/test/powershell/engine/Remoting/CustomConnection.Tests.ps1
@@ -5,7 +5,7 @@ $script:JobId = -1
 
 function Start-PwshProcess
 {
-    $job = Start-Job -ScriptBlock { Write-Output $PID; Start-Sleep -Seconds 300 }
+    $job = Start-Job -ScriptBlock { Write-Output $PID; Start-Sleep -Seconds 300 } -StartIPCListener
     $script:JobId = $job.Id
     $procId = -1
     $count = 0


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR makes the IPC named pipe listener, which currently always runs, opt-in.  This addresses issue #11599.

## PR Context

Since about PowerShell 5.0, every PowerShell session has a running IPC (inter-process communication) listener that allowed other PowerShell sessions on a local machine (with appropriate privileges) to attach to it and debug running script.  One downside to this is on non-Windows platforms where the created named pipe used for the connection does not always get cleaned up after the session process terminates.  Another drawback is that an extra listener thread always runs in a PowerShell session, that is rarely used.

The fix is to make the IPC listener thread opt-in, through both a new `-StartIPCListener` pwsh.exe parameter and a new `System.Management.Automation.Runspaces.Runspace.StartIPCListener()` API.  This makes debugging running script on other PowerShell sessions less convenient but still doable.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [x] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [x] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
