### PR TITLE
Fix test performance by stopping ongoing progress-bar

### DIFF
--- a/test/powershell/Language/Scripting/ActionPreference.Tests.ps1
+++ b/test/powershell/Language/Scripting/ActionPreference.Tests.ps1
@@ -384,18 +384,18 @@ Describe 'ActionPreference.Break tests' -Tag 'CI' {
                     Write-Debug -Message 'This is a debug message'
                     Write-Information -MessageData 'This is an information message'
                     Write-Progress -Activity 'This shows progress'
+                    Write-Progress -Activity 'This shows progress' -Completed
                 }
                 Test-Break -WarningAction Break -InformationAction Break *>$null
                 $WarningPreference = $VerbosePreference = $DebugPreference = $InformationPreference = $ProgressPreference = [System.Management.Automation.ActionPreference]::Break
                 Test-Break *>$null
             }
-
             $results = @(Test-Debugger -Scriptblock $testScript)
         }
 
-        It 'Should show 7 debugger commands were invoked' {
+        It 'Should show 8 debugger commands were invoked' {
             # When no debugger commands are provided, 'c' is invoked every time a breakpoint is hit
-            $results.Count | Should -Be 7
+            $results.Count | Should -Be 8
         }
 
         It 'Write-Warning should trigger a breakpoint from -WarningAction Break' {


### PR DESCRIPTION
# PR Summary

A progress-bar started in `ActionPreference.Tests.ps1` is never completed and causes the the progress-bar to be rendered for all remaining tests including other files, killing the performance.

## PR Context

![tests-progressactivity](https://user-images.githubusercontent.com/3436158/180603598-4f0a07e6-ba45-4a4b-b535-c31dadf2269e.gif)

Demo command: `Start-PSPester -SkipTestToolBuild -Path /workspaces/PowerShell/test/powershell/Language/Scripting/ActionPreference.Tests.ps1, /workspaces/PowerShell/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1`

Before change: 60-70s
After change: 16s

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
