### PR TITLE
Filter completion for enum parameter against ValidateRange-attributes

### DIFF
--- a/src/System.Management.Automation/engine/Attributes.cs
+++ b/src/System.Management.Automation/engine/Attributes.cs
@@ -1313,26 +1313,24 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Returns a list containing only the elements that passed the attribute's validation.
+        /// Returns only the elements that passed the attribute's validation.
         /// </summary>
         /// <param name="elementsToValidate">The objects to validate.</param>
-        internal IList<T> GetValidatedElements<T>(IList<T> elementsToValidate)
+        internal IEnumerable GetValidatedElements(IEnumerable elementsToValidate)
         {
-            var result = new List<T>(elementsToValidate.Count);
             foreach (var el in elementsToValidate)
             {
                 try
                 {
                     ValidateElement(el);
-                    result.Add(el);
                 }
                 catch (ValidationMetadataException)
                 {
                     // Element was not in range - drop
+                    continue;
                 }
+                yield return el;
             }
-
-            return result;
         }
     }
 

--- a/src/System.Management.Automation/engine/Attributes.cs
+++ b/src/System.Management.Automation/engine/Attributes.cs
@@ -1329,6 +1329,7 @@ namespace System.Management.Automation
                     // Element was not in range - drop
                     continue;
                 }
+
                 yield return el;
             }
         }

--- a/src/System.Management.Automation/engine/Attributes.cs
+++ b/src/System.Management.Automation/engine/Attributes.cs
@@ -1312,18 +1312,26 @@ namespace System.Management.Automation
             return resultType;
         }
 
-        internal List<T> FilterElements<T>(IEnumerable<T> elements)
+        /// <summary>
+        /// Returns a list containing only the elements that passed the attribute's validation.
+        /// </summary>
+        /// <param name="elementsToValidate">The objects to validate.</param>
+        internal IList<T> GetValidatedElements<T>(IList<T> elementsToValidate)
         {
-            var result = new List<T>();
-            foreach (var value in elements)
+            var result = new List<T>(elementsToValidate.Count);
+            foreach (var el in elementsToValidate)
             {
                 try
                 {
-                    ValidateElement(value);
-                    result.Add(value);
+                    ValidateElement(el);
+                    result.Add(el);
                 }
-                catch { }
+                catch (ValidationMetadataException)
+                {
+                    // Element was not in range - drop
+                }
             }
+
             return result;
         }
     }

--- a/src/System.Management.Automation/engine/Attributes.cs
+++ b/src/System.Management.Automation/engine/Attributes.cs
@@ -1311,6 +1311,21 @@ namespace System.Management.Automation
 
             return resultType;
         }
+
+        internal List<T> FilterElements<T>(IEnumerable<T> elements)
+        {
+            var result = new List<T>();
+            foreach (var value in elements)
+            {
+                try
+                {
+                    ValidateElement(value);
+                    result.Add(value);
+                }
+                catch { }
+            }
+            return result;
+        }
     }
 
     /// <summary>

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -1770,13 +1770,13 @@ namespace System.Management.Automation
             {
                 RemoveLastNullCompletionResult(result);
 
-                var enumValues = parameterType.GetEnumValues().Cast<Enum>().ToList();
+                IList<Enum> enumValues = LanguagePrimitives.EnumSingleTypeConverter.GetEnumValues(parameterType).Cast<Enum>().ToList();
                 // Exclude values not accepted by ValidateRange-attributes
                 foreach (ValidateArgumentsAttribute att in parameter.Parameter.ValidationAttributes)
                 {
                     if (att is ValidateRangeAttribute rangeAtt)
                     {
-                        enumValues = rangeAtt.FilterElements(enumValues);
+                        enumValues = rangeAtt.GetValidatedElements(enumValues);
                     }
                 }
 
@@ -1786,18 +1786,19 @@ namespace System.Management.Automation
                 var pattern = WildcardPattern.Get(wordToComplete + "*", WildcardOptions.IgnoreCase);
                 var enumList = new List<string>();
 
-                foreach (string value in enumValues.ConvertAll(v => v.ToString()))
+                foreach (Enum value in enumValues)
                 {
-                    if (wordToComplete.Equals(value, StringComparison.OrdinalIgnoreCase))
+                    string name = value.ToString();
+                    if (wordToComplete.Equals(name, StringComparison.OrdinalIgnoreCase))
                     {
-                        string completionText = quote == string.Empty ? value : quote + value + quote;
-                        fullMatch = new CompletionResult(completionText, value, CompletionResultType.ParameterValue, value);
+                        string completionText = quote == string.Empty ? name : quote + name + quote;
+                        fullMatch = new CompletionResult(completionText, name, CompletionResultType.ParameterValue, name);
                         continue;
                     }
 
-                    if (pattern.IsMatch(value))
+                    if (pattern.IsMatch(name))
                     {
-                        enumList.Add(value);
+                        enumList.Add(name);
                     }
                 }
 

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -1771,6 +1771,7 @@ namespace System.Management.Automation
                 RemoveLastNullCompletionResult(result);
 
                 IEnumerable enumValues = LanguagePrimitives.EnumSingleTypeConverter.GetEnumValues(parameterType);
+
                 // Exclude values not accepted by ValidateRange-attributes
                 foreach (ValidateArgumentsAttribute att in parameter.Parameter.ValidationAttributes)
                 {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -1776,15 +1776,7 @@ namespace System.Management.Automation
                 {
                     if (att is ValidateRangeAttribute rangeAtt)
                     {
-                        for (int i = enumValues.Count - 1; i >= 0; i--)
-                        {
-                            // ValidateRangeAttribute ctor already validated MinRange/MaxRange not null and comparable type
-                            if (LanguagePrimitives.Compare(enumValues[i], rangeAtt.MaxRange) == 1
-                                || LanguagePrimitives.Compare(enumValues[i], rangeAtt.MinRange) == -1)
-                            {
-                                enumValues.RemoveAt(i);
-                            }
-                        }
+                        enumValues = rangeAtt.FilterElements(enumValues);
                     }
                 }
 

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -1770,7 +1770,7 @@ namespace System.Management.Automation
             {
                 RemoveLastNullCompletionResult(result);
 
-                IList<Enum> enumValues = LanguagePrimitives.EnumSingleTypeConverter.GetEnumValues(parameterType).Cast<Enum>().ToList();
+                IEnumerable enumValues = LanguagePrimitives.EnumSingleTypeConverter.GetEnumValues(parameterType);
                 // Exclude values not accepted by ValidateRange-attributes
                 foreach (ValidateArgumentsAttribute att in parameter.Parameter.ValidationAttributes)
                 {

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -2089,6 +2089,7 @@ namespace System.Management.Automation
             /// Returns all values for the provided enum type.
             /// </summary>
             /// <param name="enumType">The enum type to retrieve values from.</param>
+            /// <returns>Array of enum values for the specified type.</returns>
             internal static Array GetEnumValues(Type enumType)
                 => EnumSingleTypeConverter.GetEnumHashEntry(enumType).values;
 

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -2085,6 +2085,13 @@ namespace System.Management.Automation
                 return string.Join(CultureInfo.CurrentUICulture.TextInfo.ListSeparator, enumHashEntry.names);
             }
 
+            /// <summary>
+            /// Returns all values for the provided enum type.
+            /// </summary>
+            /// <param name="enumType">The enum type to retrieve values from.</param>
+            internal static Array GetEnumValues(Type enumType)
+                => EnumSingleTypeConverter.GetEnumHashEntry(enumType).values;
+
             public override object ConvertFrom(object sourceValue, Type destinationType, IFormatProvider formatProvider, bool ignoreCase)
             {
                 return EnumSingleTypeConverter.BaseConvertFrom(sourceValue, destinationType, formatProvider, ignoreCase, false);

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1347,7 +1347,7 @@ ConstructorTestClass(int i, bool b)
 
         It 'Tab completion for enum parameter is filtered against <Name>' -TestCases @(
             @{ Name = 'ValidateRange with enum-values'; Attribute = '[ValidateRange([System.ConsoleColor]::Blue, [System.ConsoleColor]::Cyan)]' }
-            @{ Name = 'ValidateRange with enum-values'; Attribute = '[ValidateRange(9, 11)]' }
+            @{ Name = 'ValidateRange with int-values'; Attribute = '[ValidateRange(9, 11)]' }
             @{ Name = 'multiple ValidateRange-attributes'; Attribute = '[ValidateRange([System.ConsoleColor]::Blue, [System.ConsoleColor]::Cyan)][ValidateRange([System.ConsoleColor]::Gray, [System.ConsoleColor]::Red)]' }
         ) {
             param($Name, $Attribute)
@@ -1359,6 +1359,15 @@ ConstructorTestClass(int i, bool b)
             $res.CompletionMatches[0].CompletionText | Should -BeExactly 'Blue'
             $res.CompletionMatches[1].CompletionText | Should -BeExactly 'Cyan'
             $res.CompletionMatches[2].CompletionText | Should -BeExactly 'Green'
+        }
+
+        It 'Tab completion for enum parameter is filtered with ValidateRange using rangekind' {
+            $functionDefinition = 'param ( [ValidateRange([System.Management.Automation.ValidateRangeKind]::NonPositive)][consolecolor]$color )' -f $Attribute
+            Set-Item -Path function:baz -Value $functionDefinition
+            $inputStr = 'baz -color '
+            $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
+            $res.CompletionMatches | Should -HaveCount 1
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly 'Black' # 0 = NonPositive
         }
 
         It "Test [CommandCompletion]::GetNextResult" {

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1345,8 +1345,14 @@ ConstructorTestClass(int i, bool b)
             $res.CompletionMatches[1].CompletionText | Should -BeExactly 'Configuration'
         }
 
-        It 'Tab completion for enum type parameter with ValidateRange is filtered' {
-            function baz ([ValidateRange([System.ConsoleColor]::Blue, [System.ConsoleColor]::Cyan)][consolecolor]$color) {}
+        It 'Tab completion for enum parameter is filtered against <Name>' -TestCases @(
+            @{ Name = 'ValidateRange with enum-values'; Attribute = '[ValidateRange([System.ConsoleColor]::Blue, [System.ConsoleColor]::Cyan)]' }
+            @{ Name = 'ValidateRange with enum-values'; Attribute = '[ValidateRange(9, 11)]' }
+            @{ Name = 'multiple ValidateRange-attributes'; Attribute = '[ValidateRange([System.ConsoleColor]::Blue, [System.ConsoleColor]::Cyan)][ValidateRange([System.ConsoleColor]::Gray, [System.ConsoleColor]::Red)]' }
+        ) {
+            param($Name, $Attribute)
+            $functionDefinition = 'param ( {0}[consolecolor]$color )' -f $Attribute
+            Set-Item -Path function:baz -Value $functionDefinition
             $inputStr = 'baz -color '
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
             $res.CompletionMatches | Should -HaveCount 3

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1345,6 +1345,16 @@ ConstructorTestClass(int i, bool b)
             $res.CompletionMatches[1].CompletionText | Should -BeExactly 'Configuration'
         }
 
+        It 'Tab completion for enum type parameter with ValidateRange is filtered' {
+            function baz ([ValidateRange([System.ConsoleColor]::Blue, [System.ConsoleColor]::Cyan)][consolecolor]$color) {}
+            $inputStr = 'baz -color '
+            $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
+            $res.CompletionMatches | Should -HaveCount 3
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly 'Blue'
+            $res.CompletionMatches[1].CompletionText | Should -BeExactly 'Cyan'
+            $res.CompletionMatches[2].CompletionText | Should -BeExactly 'Green'
+        }
+
         It "Test [CommandCompletion]::GetNextResult" {
             $inputStr = "Get-Command -Type Alias,c"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length


### PR DESCRIPTION
# PR Summary

Updates parameter completion for enums to exclude values not allowed by `ValidateRange`-attributes.

## PR Context

See [this comment](https://github.com/PowerShell/PowerShell/issues/17546#issuecomment-1165989939)

Fix #2849

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
