### PR TITLE
Fix accumulation of tags when testing manifest with wildcard export

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -3228,20 +3228,22 @@ namespace Microsoft.PowerShell.Commands
                 {
                     newManifestInfo.PrivateData = manifestInfo.PrivateData;
                 }
-
-                // Assign the PowerShellGet related properties from the module manifest
-                foreach (var tag in manifestInfo.Tags)
+                else
                 {
-                    newManifestInfo.AddToTags(tag);
+                    // Assign the PowerShellGet related properties from the module manifest
+                    foreach (var tag in manifestInfo.Tags)
+                    {
+                        newManifestInfo.AddToTags(tag);
+                    }
+
+                    newManifestInfo.ReleaseNotes = manifestInfo.ReleaseNotes;
+                    newManifestInfo.ProjectUri = manifestInfo.ProjectUri;
+                    newManifestInfo.LicenseUri = manifestInfo.LicenseUri;
+                    newManifestInfo.IconUri = manifestInfo.IconUri;
                 }
 
-                newManifestInfo.ReleaseNotes = manifestInfo.ReleaseNotes;
-                newManifestInfo.ProjectUri = manifestInfo.ProjectUri;
-                newManifestInfo.LicenseUri = manifestInfo.LicenseUri;
-                newManifestInfo.IconUri = manifestInfo.IconUri;
                 newManifestInfo.RepositorySourceLocation = manifestInfo.RepositorySourceLocation;
                 newManifestInfo.IsConsideredEditionCompatible = manifestInfo.IsConsideredEditionCompatible;
-
                 newManifestInfo.ExperimentalFeatures = manifestInfo.ExperimentalFeatures;
 
                 // If we are in module discovery, then fix the path.

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -6240,7 +6240,12 @@ namespace Microsoft.PowerShell.Commands
             }
 
             if (module != null)
-                return module.Clone();
+            {
+                var cachedModule = module.Clone();
+                // Create new Tags-list to break reference
+                cachedModule.ResetTags();
+                return cachedModule;
+            }
 
             // fake/empty manifestInfo for processing in (!loadElements) mode
             module = new PSModuleInfo(filename, null, null);

--- a/src/System.Management.Automation/engine/Modules/PSModuleInfo.cs
+++ b/src/System.Management.Automation/engine/Modules/PSModuleInfo.cs
@@ -400,11 +400,16 @@ namespace System.Management.Automation
             get { return _tags; }
         }
 
-        private readonly List<string> _tags = new List<string>();
+        private List<string> _tags = new List<string>();
 
         internal void AddToTags(string tag)
         {
             _tags.Add(tag);
+        }
+
+        internal void ResetTags()
+        {
+            _tags = new List<string>();
         }
 
         /// <summary>

--- a/test/powershell/engine/Module/TestModuleManifest.Tests.ps1
+++ b/test/powershell/engine/Module/TestModuleManifest.Tests.ps1
@@ -274,3 +274,24 @@ Describe "Test-ModuleManifest Performance bug followup" -tags "CI" {
         }
     }
 }
+
+Describe 'Testing module with wildcard export' -Tags 'CI' {
+    BeforeAll {
+        $modulePath = 'testdrive:/wildcardexport'
+        New-Item -ItemType Directory -Path $modulePath > $null
+    }
+
+    AfterAll {
+        Remove-Item -Recurse -Force -ErrorAction SilentlyContinue testdrive:/module
+    }
+
+    It 'PSModuleInfo does not accumulate tags' {
+        # https://github.com/PowerShell/PowerShell/issues/17694
+        New-Item -ItemType File -Path "$modulePath\tags.psm1" > $null
+        New-ModuleManifest -Path "$modulePath\tags.psd1" -RootModule 'tags.psm1' -FunctionsToExport '*' -Tags 'one'
+        $module = Test-ModuleManifest -Path "$modulePath\tags.psd1"
+        $module = Test-ModuleManifest -Path "$modulePath\tags.psd1"
+        $module.Tags | Should -HaveCount 1
+        $module.Tags | Should -BeExactly 'one'
+    }
+}


### PR DESCRIPTION
# PR Summary

Resets the `Tags`-list in `PSModuleInfo` that survives the shallow clone when getting moduleinfo from scriptanalysiscache.

## PR Context

Currently on repeated calls to `Test-ModuleManifest` for modules with wildcard-export, the module manifest will return duplicate tags which keep accumulating every time.

Fix #17694

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
