### PR TITLE
Fix the definition of the `PDH_COUNTER_INFO` struct

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Diagnostics/PdhHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/PdhHelper.cs
@@ -267,28 +267,65 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
         // We only need dwType and lDefaultScale fields from this structure.
         // We access those fields directly. The struct is here for reference only.
         //
-        [StructLayout(LayoutKind.Explicit, CharSet = CharSet.Unicode)]
-        private struct PDH_COUNTER_INFO
+        [StructLayout(LayoutKind.Sequential)]
+        private unsafe struct PDH_COUNTER_INFO
         {
-            [FieldOffset(0)] public UInt32 dwLength;
-            [FieldOffset(4)] public UInt32 dwType;
-            [FieldOffset(8)] public UInt32 CVersion;
-            [FieldOffset(12)] public UInt32 CStatus;
-            [FieldOffset(16)] public UInt32 lScale;
-            [FieldOffset(20)] public UInt32 lDefaultScale;
-            [FieldOffset(24)] public IntPtr dwUserData;
-            [FieldOffset(32)] public IntPtr dwQueryUserData;
-            [FieldOffset(40)] public string szFullPath;
+            public uint dwLength;
+            public uint dwType;
+            public uint CVersion;
+            public uint CStatus;
+            public int lScale;
+            public int lDefaultScale;
+            public ulong dwUserData;
+            public ulong dwQueryUserData;
+            public ushort* szFullPath;
+            public _Anonymous_e__Union Anonymous;
+            public ushort* szExplainText;
+            public fixed uint DataBuffer[1];
 
-            [FieldOffset(48)] public string szMachineName;
-            [FieldOffset(56)] public string szObjectName;
-            [FieldOffset(64)] public string szInstanceName;
-            [FieldOffset(72)] public string szParentInstance;
-            [FieldOffset(80)] public UInt32 dwInstanceIndex;
-            [FieldOffset(88)] public string szCounterName;
+            [StructLayout(LayoutKind.Explicit)]
+            internal struct _Anonymous_e__Union
+            {
+                [FieldOffset(0)]
+                public PDH_DATA_ITEM_PATH_ELEMENTS_blittable DataItemPath;
 
-            [FieldOffset(96)] public string szExplainText;
-            [FieldOffset(104)] public IntPtr DataBuffer;
+                [FieldOffset(0)]
+                public PDH_COUNTER_PATH_ELEMENTS_blittable CounterPath;
+
+                [FieldOffset(0)]
+                public _Anonymous_e__Struct Anonymous;
+
+                [StructLayout(LayoutKind.Sequential)]
+                internal struct PDH_DATA_ITEM_PATH_ELEMENTS_blittable
+                {
+                    public ushort* szMachineName;
+                    public Guid ObjectGUID;
+                    public uint dwItemId;
+                    public ushort* szInstanceName;
+                }
+
+                [StructLayout(LayoutKind.Sequential)]
+                internal struct PDH_COUNTER_PATH_ELEMENTS_blittable
+                {
+                    public ushort* szMachineName;
+                    public ushort* szObjectName;
+                    public ushort* szInstanceName;
+                    public ushort* szParentInstance;
+                    public uint dwInstanceIndex;
+                    public ushort* szCounterName;
+                }
+
+                [StructLayout(LayoutKind.Sequential)]
+                internal struct _Anonymous_e__Struct
+                {
+                    public ushort* szMachineName;
+                    public ushort* szObjectName;
+                    public ushort* szInstanceName;
+                    public ushort* szParentInstance;
+                    public uint dwInstanceIndex;
+                    public ushort* szCounterName;
+                }
+            }
         }
 
         [DllImport("pdh.dll", CharSet = CharSet.Unicode)]
@@ -477,7 +514,7 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
                 {
                     PDH_COUNTER_INFO pdhCounterInfo = (PDH_COUNTER_INFO)Marshal.PtrToStructure(bufCounterInfo, typeof(PDH_COUNTER_INFO));
                     counterType = pdhCounterInfo.dwType;
-                    defaultScale = pdhCounterInfo.lDefaultScale;
+                    defaultScale = (uint)pdhCounterInfo.lDefaultScale;
                 }
             }
             finally

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/PdhHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/PdhHelper.cs
@@ -270,17 +270,17 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
         [StructLayout(LayoutKind.Sequential)]
         private unsafe struct PDH_COUNTER_INFO
         {
-            public uint dwLength;
-            public uint dwType;
+            public uint Length;
+            public uint Type;
             public uint CVersion;
             public uint CStatus;
-            public int lScale;
-            public int lDefaultScale;
-            public ulong dwUserData;
-            public ulong dwQueryUserData;
-            public ushort* szFullPath;
+            public int Scale;
+            public int DefaultScale;
+            public ulong UserData;
+            public ulong QueryUserData;
+            public ushort* FullPath;
             public _Anonymous_e__Union Anonymous;
-            public ushort* szExplainText;
+            public ushort* ExplainText;
             public fixed uint DataBuffer[1];
 
             [StructLayout(LayoutKind.Explicit)]
@@ -298,32 +298,32 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
                 [StructLayout(LayoutKind.Sequential)]
                 internal struct PDH_DATA_ITEM_PATH_ELEMENTS_blittable
                 {
-                    public ushort* szMachineName;
+                    public ushort* MachineName;
                     public Guid ObjectGUID;
-                    public uint dwItemId;
-                    public ushort* szInstanceName;
+                    public uint ItemId;
+                    public ushort* InstanceName;
                 }
 
                 [StructLayout(LayoutKind.Sequential)]
                 internal struct PDH_COUNTER_PATH_ELEMENTS_blittable
                 {
-                    public ushort* szMachineName;
-                    public ushort* szObjectName;
-                    public ushort* szInstanceName;
-                    public ushort* szParentInstance;
-                    public uint dwInstanceIndex;
-                    public ushort* szCounterName;
+                    public ushort* MachineName;
+                    public ushort* ObjectName;
+                    public ushort* InstanceName;
+                    public ushort* ParentInstance;
+                    public uint InstanceIndex;
+                    public ushort* CounterName;
                 }
 
                 [StructLayout(LayoutKind.Sequential)]
                 internal struct _Anonymous_e__Struct
                 {
-                    public ushort* szMachineName;
-                    public ushort* szObjectName;
-                    public ushort* szInstanceName;
-                    public ushort* szParentInstance;
-                    public uint dwInstanceIndex;
-                    public ushort* szCounterName;
+                    public ushort* MachineName;
+                    public ushort* ObjectName;
+                    public ushort* InstanceName;
+                    public ushort* ParentInstance;
+                    public uint InstanceIndex;
+                    public ushort* CounterName;
                 }
             }
         }
@@ -513,8 +513,8 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
                 if (res == PdhResults.PDH_CSTATUS_VALID_DATA && bufCounterInfo != IntPtr.Zero)
                 {
                     PDH_COUNTER_INFO pdhCounterInfo = (PDH_COUNTER_INFO)Marshal.PtrToStructure(bufCounterInfo, typeof(PDH_COUNTER_INFO));
-                    counterType = pdhCounterInfo.dwType;
-                    defaultScale = (uint)pdhCounterInfo.lDefaultScale;
+                    counterType = pdhCounterInfo.Type;
+                    defaultScale = (uint)pdhCounterInfo.DefaultScale;
                 }
             }
             finally


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes the crash from #13829

## PR Context

The definition is mostly generated via [dotnet/ClangSharp](https://github.com/dotnet/ClangSharp) and altered a little manually. It's a bit involved for a struct we only use two fields from but it's easy to include in full so if we end up needing more this makes it very easy.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
