### PR TITLE
Fix Update-Help failing silently with implicit non-US culture.

### DIFF
--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1573,6 +1573,7 @@ namespace System.Management.Automation.Internal
         internal static bool UseDebugAmsiImplementation;
         internal static bool BypassAppLockerPolicyCaching;
         internal static bool BypassOnlineHelpRetrieval;
+        internal static bool ThrowHelpCultureNotSupported;
         internal static bool ForcePromptForChoiceDefaultOption;
         internal static bool NoPromptForPassword;
         internal static bool ForceFormatListFixedLabelWidth;
@@ -1612,10 +1613,6 @@ namespace System.Management.Automation.Internal
         internal static bool OneDriveTestOn;
         internal static bool OneDriveTestRecurseOn;
         internal static string OneDriveTestSymlinkName = "link-Beta";
-
-        // Update-Help
-        internal static CultureInfo UpdateHelpCurrentUICulture;
-        internal static bool UpdateHelpThrowHelpCultureNotSupported;
 
         /// <summary>This member is used for internal test purposes.</summary>
         public static void SetTestHook(string property, object value)

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1613,6 +1613,10 @@ namespace System.Management.Automation.Internal
         internal static bool OneDriveTestRecurseOn;
         internal static string OneDriveTestSymlinkName = "link-Beta";
 
+        // Update-Help
+        internal static CultureInfo UpdateHelpCurrentUICulture;
+        internal static bool UpdateHelpThrowHelpCultureNotSupported;
+
         /// <summary>This member is used for internal test purposes.</summary>
         public static void SetTestHook(string property, object value)
         {

--- a/src/System.Management.Automation/help/UpdatableHelpCommandBase.cs
+++ b/src/System.Management.Automation/help/UpdatableHelpCommandBase.cs
@@ -562,7 +562,7 @@ namespace Microsoft.PowerShell.Commands
                         else
                         {
                             // Hold first exception, it will be displayed if fallback chain fails
-                            WriteVerbose(e.FullyQualifiedErrorId); // TODO: better message
+                            WriteVerbose(StringUtil.Format(HelpDisplayStrings.HelpCultureNotSupportedFallback, e.Message));
                             implicitCultureNotSupported ??= e;
                         }
                     }

--- a/src/System.Management.Automation/help/UpdatableHelpCommandBase.cs
+++ b/src/System.Management.Automation/help/UpdatableHelpCommandBase.cs
@@ -509,6 +509,7 @@ namespace Microsoft.PowerShell.Commands
             // Win8: 572882 When the system locale is English and the UI is JPN,
             // running "update-help" still downs English help content.
             var cultures = _language ?? _helpSystem.GetCurrentUICulture();
+            UpdatableHelpSystemException implicitCultureNotSupported = null;
 
             foreach (string culture in cultures)
             {
@@ -558,6 +559,12 @@ namespace Microsoft.PowerShell.Commands
                             // Display the error message only if we are not using the fallback chain
                             ProcessException(module.ModuleName, culture, e);
                         }
+                        else
+                        {
+                            // Hold first exception, it will be displayed if fallback chain fails
+                            WriteVerbose(e.FullyQualifiedErrorId); // TODO: better message
+                            implicitCultureNotSupported ??= e;
+                        }
                     }
                     else
                     {
@@ -581,12 +588,18 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
 
-                // If -Language is not specified, we only install
+                // If -UICulture is not specified, we only install
                 // one culture from the fallback chain
                 if (_language == null && installed)
                 {
-                    break;
+                    return;
                 }
+            }
+
+            // If the exception is not null and did not return early, then all of the fallback chain failed
+            if (implicitCultureNotSupported != null)
+            {
+                ProcessException(module.ModuleName, cultures.First(), implicitCultureNotSupported);
             }
         }
 

--- a/src/System.Management.Automation/help/UpdatableHelpSystem.cs
+++ b/src/System.Management.Automation/help/UpdatableHelpSystem.cs
@@ -293,6 +293,7 @@ namespace System.Management.Automation.Help
         internal IEnumerable<string> GetCurrentUICulture()
         {
             CultureInfo culture = CultureInfo.CurrentUICulture;
+
             while (culture != null)
             {
                 if (string.IsNullOrEmpty(culture.Name))

--- a/src/System.Management.Automation/help/UpdatableHelpSystem.cs
+++ b/src/System.Management.Automation/help/UpdatableHelpSystem.cs
@@ -294,6 +294,11 @@ namespace System.Management.Automation.Help
         {
             CultureInfo culture = CultureInfo.CurrentUICulture;
 
+            // Allow mocking implicit culture in tests
+            if (InternalTestHooks.UpdateHelpCurrentUICulture != null) {
+                culture = InternalTestHooks.UpdateHelpCurrentUICulture;
+            }
+
             while (culture != null)
             {
                 if (string.IsNullOrEmpty(culture.Name))

--- a/src/System.Management.Automation/help/UpdatableHelpSystem.cs
+++ b/src/System.Management.Automation/help/UpdatableHelpSystem.cs
@@ -293,12 +293,6 @@ namespace System.Management.Automation.Help
         internal IEnumerable<string> GetCurrentUICulture()
         {
             CultureInfo culture = CultureInfo.CurrentUICulture;
-
-            // Allow mocking implicit culture in tests
-            if (InternalTestHooks.UpdateHelpCurrentUICulture != null) {
-                culture = InternalTestHooks.UpdateHelpCurrentUICulture;
-            }
-
             while (culture != null)
             {
                 if (string.IsNullOrEmpty(culture.Name))

--- a/src/System.Management.Automation/help/UpdateHelpCommand.cs
+++ b/src/System.Management.Automation/help/UpdateHelpCommand.cs
@@ -215,11 +215,11 @@ namespace Microsoft.PowerShell.Commands
         internal override bool ProcessModuleWithCulture(UpdatableHelpModuleInfo module, string culture)
         {
             // Simulate culture not found
-            if (InternalTestHooks.UpdateHelpThrowHelpCultureNotSupported) {
+            if (InternalTestHooks.ThrowHelpCultureNotSupported)
+            {
                 // TODO: unify with Base.IsUpdateNecessary to ensure exact same exception thrown
                 throw new UpdatableHelpSystemException("HelpCultureNotSupported",
-                    StringUtil.Format(HelpDisplayStrings.HelpCultureNotSupported,
-                    InternalTestHooks.UpdateHelpCurrentUICulture, "test-TEST"),
+                    StringUtil.Format(HelpDisplayStrings.HelpCultureNotSupported, culture, "en-US"),
                     ErrorCategory.InvalidOperation, null, null);
             }
 

--- a/src/System.Management.Automation/help/UpdateHelpCommand.cs
+++ b/src/System.Management.Automation/help/UpdateHelpCommand.cs
@@ -214,6 +214,15 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>True if the module has been processed, false if not.</returns>
         internal override bool ProcessModuleWithCulture(UpdatableHelpModuleInfo module, string culture)
         {
+            // Simulate culture not found
+            if (InternalTestHooks.UpdateHelpThrowHelpCultureNotSupported) {
+                // TODO: unify with Base.IsUpdateNecessary to ensure exact same exception thrown
+                throw new UpdatableHelpSystemException("HelpCultureNotSupported",
+                    StringUtil.Format(HelpDisplayStrings.HelpCultureNotSupported,
+                    InternalTestHooks.UpdateHelpCurrentUICulture, "test-TEST"),
+                    ErrorCategory.InvalidOperation, null, null);
+            }
+
             UpdatableHelpInfo currentHelpInfo = null;
             UpdatableHelpInfo newHelpInfo = null;
             string helpInfoUri = null;

--- a/src/System.Management.Automation/help/UpdateHelpCommand.cs
+++ b/src/System.Management.Automation/help/UpdateHelpCommand.cs
@@ -217,7 +217,6 @@ namespace Microsoft.PowerShell.Commands
             // Simulate culture not found
             if (InternalTestHooks.ThrowHelpCultureNotSupported)
             {
-                // TODO: unify with Base.IsUpdateNecessary to ensure exact same exception thrown
                 throw new UpdatableHelpSystemException("HelpCultureNotSupported",
                     StringUtil.Format(HelpDisplayStrings.HelpCultureNotSupported, culture, "en-US"),
                     ErrorCategory.InvalidOperation, null, null);

--- a/src/System.Management.Automation/resources/HelpDisplayStrings.resx
+++ b/src/System.Management.Automation/resources/HelpDisplayStrings.resx
@@ -306,6 +306,10 @@
   <data name="HelpCultureNotSupported" xml:space="preserve">
     <value>The specified culture is not supported: {0}. Specify a culture from the following list: {{{1}}}.</value>
   </data>
+  <data name="HelpCultureNotSupportedFallback" xml:space="preserve">
+    <value>Postponing error and trying fallback cultures, will show as error if none of fallbacks are supported:
+{0}</value>
+  </data>
   <data name="ModuleBaseMustExist" xml:space="preserve">
     <value>The ModuleBase directory cannot be found. Verify the directory and try again.</value>
   </data>

--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -30,7 +30,8 @@ function UpdateHelpFromLocalContentPath {
         throw "Unable to find help content at '$helpContentPath'"
     }
 
-    Update-Help -Module $ModuleName -SourcePath $helpContentPath -Force -ErrorAction Stop -Scope $Scope
+    # Test files are 'en-US', set explicit culture so test does not help on non-US systems
+    Update-Help -Module $ModuleName -SourcePath $helpContentPath -UICulture 'en-US' -Force -ErrorAction Stop -Scope $Scope
 }
 
 function GetCurrentUserHelpRoot {

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -444,7 +444,8 @@ Describe "Validate 'Update-Help' shows 'HelpCultureNotSupported' when thrown" -T
 
     It 'Shows error if help culture does not match: <name>' -TestCases @(
         @{ 'name' = 'implicit culture'; 'culture' = $null }
-        @{ 'name' = 'explicit culture'; 'culture' = 'en-GB' }
+        @{ 'name' = 'explicit culture en-GB'; 'culture' = 'en-GB' }
+        @{ 'name' = 'explicit culture de-DE'; 'culture' = 'de-DE' }
     ) {
         param ($name, $culture)
         # Cannot pass null, have to splat to skip argument entirely
@@ -452,8 +453,12 @@ Describe "Validate 'Update-Help' shows 'HelpCultureNotSupported' when thrown" -T
         $cultureUsed = $culture ?? (Get-Culture)
 
         $ErrorVariable = $null
-        Update-Help @cultureArg -ErrorVariable ErrorVariable -ErrorAction SilentlyContinue
+        $VerboseOutput = New-TemporaryFile
+        Update-Help @cultureArg -ErrorVariable ErrorVariable -ErrorAction SilentlyContinue -Verbose 4>$VerboseOutput
         $ErrorVariable | Should -Match "No UI culture was found that matches the following pattern: ${cultureUsed}"
+        if (-not $culture) {
+            Get-Content -Raw $VerboseOutput | Should -Match 'Postponing error and trying fallback cultures'
+        }
     }
 }
 

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -434,6 +434,23 @@ Describe "Validate Update-Help -SourcePath for all PowerShell modules for user s
     RunUpdateHelpTests -Tag "Feature" -useSourcePath -Scope 'CurrentUser'
 }
 
+Describe "Validate 'Update-Help' without arguments on non-US systems" -Tags @('Feature') {
+    BeforeAll {
+        [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('UpdateHelpCurrentUICulture', [System.Globalization.CultureInfo] 'en-GB')
+        [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('UpdateHelpThrowHelpCultureNotSupported', $true)
+    }
+    AfterAll {
+        [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('UpdateHelpCurrentUICulture', $null)
+        [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('UpdateHelpThrowHelpCultureNotSupported', $false)
+    }
+
+    It 'Fails if downloaded culture does not match implicit one' {
+        $ErrorVariable = $null
+        Update-Help -ErrorVariable ErrorVariable -ErrorAction SilentlyContinue
+        $ErrorVariable | Should -Not -BeNullOrEmpty
+    }
+}
+
 Describe "Validate 'Save-Help -DestinationPath for one PowerShell modules." -Tags @('CI', 'RequireAdminOnWindows') {
     BeforeAll {
         $SavedProgressPreference = $ProgressPreference


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

`HelpCultureNotSupported` is caught and ignored with implicit culture (`-UICulture` not given explicitly, defaults to system) to allow trying again with culture's parents. It does not however check if there are any more fallbacks, so all errors of this type are completely silenced. I store first error of this type, then show it if none of the fallbacks succeed,

Fixes #17696 

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

`Update-Help` with implcit culture fails silently on non-US systems (`en-GB` in my case), with no feedback on what is wrong even when using `-Verbose`. With this fix, the user is shown the same error as with explicit `-UICulture (Get-UICulture)`, which clearly describes what they should do:

```powershell
Update-Help: Failed to update Help for the module(s) '...' with UI culture(s) {en-GB} : No UI culture was found that matches the following pattern: en-GB. Verify the pattern and then try the command again..
English-US help content is available and can be installed using: Update-Help -UICulture en-US.
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: [Docs issue #9072](https://github.com/MicrosoftDocs/PowerShell-Docs/issues/9072)
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
