### PR TITLE
Use null propagation operator in Utility module

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -429,10 +429,7 @@ namespace Microsoft.PowerShell.Commands
                     _readOnlyFileInfo.Attributes |= FileAttributes.ReadOnly;
             }
 
-            if (_helper != null)
-            {
-                _helper.Dispose();
-            }
+            _helper?.Dispose();
         }
 
         private void ReconcilePreexistingPropertyNames()

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
@@ -170,10 +170,7 @@ namespace System.Management.Automation
         internal void Stop()
         {
             CustomInternalSerializer serializer = _serializer;
-            if (serializer != null)
-            {
-                serializer.Stop();
-            }
+            serializer?.Stop();
         }
 
         #endregion

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/DebugRunspaceCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/DebugRunspaceCommand.cs
@@ -236,10 +236,7 @@ namespace Microsoft.PowerShell.Commands
 
             // Unblock the data collection.
             PSDataCollection<PSStreamObject> debugCollection = _debugBlockingCollection;
-            if (debugCollection != null)
-            {
-                debugCollection.Complete();
-            }
+            debugCollection?.Complete();
 
             // Unblock any new command wait.
             _newRunningScriptEvent.Set();
@@ -334,9 +331,8 @@ namespace Microsoft.PowerShell.Commands
         private void AddDataEventHandlers()
         {
             // Create new collection objects.
-            if (_debugBlockingCollection != null) { _debugBlockingCollection.Dispose(); }
-
-            if (_debugAccumulateCollection != null) { _debugAccumulateCollection.Dispose(); }
+            _debugBlockingCollection?.Dispose();
+            _debugAccumulateCollection?.Dispose();
 
             _debugBlockingCollection = new PSDataCollection<PSStreamObject>();
             _debugBlockingCollection.BlockingEnumerator = true;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ExportAliasCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ExportAliasCommand.cs
@@ -291,8 +291,7 @@ namespace Microsoft.PowerShell.Commands
                         line = GetAliasLine(alias, "set-alias -Name:\"{0}\" -Value:\"{1}\" -Description:\"{2}\" -Option:\"{3}\"");
                     }
 
-                    if (writer != null)
-                        writer.WriteLine(line);
+                    writer?.WriteLine(line);
 
                     if (PassThru)
                     {
@@ -302,8 +301,7 @@ namespace Microsoft.PowerShell.Commands
             }
             finally
             {
-                if (writer != null)
-                    writer.Dispose();
+                writer?.Dispose();
                 // reset the read-only attribute
                 if (readOnlyFileInfo != null)
                     readOnlyFileInfo.Attributes |= FileAttributes.ReadOnly;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutWindowProxy.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutWindowProxy.cs
@@ -230,13 +230,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        internal void BlockUntilClosed()
-        {
-            if (_closedEvent != null)
-            {
-                _closedEvent.WaitOne();
-            }
-        }
+        internal void BlockUntilClosed() => _closedEvent?.WaitOne();
 
         /// <summary>
         /// Implements IDisposable logic.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowMarkdownCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowMarkdownCommand.cs
@@ -224,10 +224,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void EndProcessing()
         {
-            if (_powerShell != null)
-            {
-                _powerShell.Dispose();
-            }
+            _powerShell?.Dispose();
         }
     }
 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/StartSleepCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/StartSleepCommand.cs
@@ -91,10 +91,7 @@ namespace Microsoft.PowerShell.Commands
                 }
             }
 
-            if (_waitHandle != null)
-            {
-                _waitHandle.WaitOne(milliSecondsToSleep, true);
-            }
+            _waitHandle?.WaitOne(milliSecondsToSleep, true);
         }
 
         /// <summary>
@@ -150,10 +147,7 @@ namespace Microsoft.PowerShell.Commands
             lock (_syncObject)
             {
                 _stopping = true;
-                if (_waitHandle != null)
-                {
-                    _waitHandle.Set();
-                }
+                _waitHandle?.Set();
             }
         }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Update-TypeData.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Update-TypeData.cs
@@ -1160,10 +1160,7 @@ namespace Microsoft.PowerShell.Commands
                     indicesToRemove.Sort();
                     for (int i = indicesToRemove.Count - 1; i >= 0; i--)
                     {
-                        if (Context.InitialSessionState != null)
-                        {
-                            Context.InitialSessionState.Types.RemoveItem(indicesToRemove[i]);
-                        }
+                        Context.InitialSessionState?.Types.RemoveItem(indicesToRemove[i]);
                     }
 
                     try

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1578,10 +1578,7 @@ namespace Microsoft.PowerShell.Commands
                                     }
                                     finally
                                     {
-                                        if (reader != null)
-                                        {
-                                            reader.Dispose();
-                                        }
+                                        reader?.Dispose();
                                     }
 
                                     if (!string.IsNullOrEmpty(detailMsg))
@@ -1657,13 +1654,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Implementing ^C, after start the BeginGetResponse.
         /// </summary>
-        protected override void StopProcessing()
-        {
-            if (_cancelToken != null)
-            {
-                _cancelToken.Cancel();
-            }
-        }
+        protected override void StopProcessing() => _cancelToken?.Cancel();
 
         #endregion Overrides
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/XmlCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/XmlCommands.cs
@@ -453,8 +453,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 CreateMemoryStream();
 
-                if (_serializer != null)
-                    _serializer.SerializeAsStream(InputObject);
+                _serializer?.SerializeAsStream(InputObject);
 
                 if (_serializer != null)
                 {
@@ -472,8 +471,7 @@ namespace Microsoft.PowerShell.Commands
             }
             else
             {
-                if (_serializer != null)
-                    _serializer.Serialize(InputObject);
+                _serializer?.Serialize(InputObject);
             }
         }
 
@@ -801,13 +799,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        internal void Stop()
-        {
-            if (_deserializer != null)
-            {
-                _deserializer.Stop();
-            }
-        }
+        internal void Stop() => _deserializer?.Stop();
     }
 
     #region Select-Xml

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/TraceExpressionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/TraceExpressionCommand.cs
@@ -249,13 +249,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Ensures that the sub-pipeline we created gets stopped as well.
         /// </summary>
-        protected override void StopProcessing()
-        {
-            if (_pipeline != null)
-            {
-                _pipeline.Stop();
-            }
-        }
+        protected override void StopProcessing() => _pipeline?.Stop();
 
         #endregion Cmdlet code
 


### PR DESCRIPTION
# PR Summary

Replace if not null-checks with null propagation operator to solve IDE0031 with .NET Preview 7.

## PR Context

Related to #17769

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
