### PR TITLE
Improve enumeration of inferred types in pipeline

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -5901,7 +5901,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Complete members against extension methods 'Where' and 'ForEach'
         /// </summary>
-        private static void CompleteExtensionMethods(string memberName, List<CompletionResult> results, bool addMethodparenthesis = true)
+        private static void CompleteExtensionMethods(string memberName, List<CompletionResult> results, bool addMethodParenthesis = true)
         {
             var pattern = WildcardPattern.Get(memberName, WildcardOptions.IgnoreCase);
             CompleteExtensionMethods(pattern, results, addMethodparenthesis);
@@ -5910,7 +5910,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Complete members against extension methods 'Where' and 'ForEach' based on the given pattern.
         /// </summary>
-        private static void CompleteExtensionMethods(WildcardPattern pattern, List<CompletionResult> results, bool addMethodparenthesis)
+        private static void CompleteExtensionMethods(WildcardPattern pattern, List<CompletionResult> results, bool addMethodParenthesis)
         {
             foreach (var member in s_extensionMethods)
             {
@@ -6046,7 +6046,7 @@ namespace System.Management.Automation
             Func<object, bool> filter,
             bool isStatic,
             HashSet<string> excludedMembers = null, 
-            bool addMethodparenthesis = true)
+            bool addMethodParenthesis = true)
         {
             bool extensionMethodsAdded = false;
             HashSet<string> typeNameUsed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -6088,7 +6088,7 @@ namespace System.Management.Automation
             }
         }
 
-        private static void AddInferredMember(object member, WildcardPattern memberNamePattern, List<CompletionResult> results, HashSet<string> excludedMembers, bool addMethodparenthesis)
+        private static void AddInferredMember(object member, WildcardPattern memberNamePattern, List<CompletionResult> results, HashSet<string> excludedMembers, bool addMethodParenthesis)
         {
             string memberName = null;
             bool isMethod = false;

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -3973,7 +3973,7 @@ namespace System.Management.Automation
                 }
 
                 Func<object, bool> filter = propertiesOnly ? IsPropertyMember : null;
-                CompleteMemberByInferredType(context.TypeInferenceContext, prevType, result, context.WordToComplete + "*", filter, isStatic: false, excludedMembers, addMethodparenthesis: false);
+                CompleteMemberByInferredType(context.TypeInferenceContext, prevType, result, context.WordToComplete + "*", filter, isStatic: false, excludedMembers, addMethodParenthesis: false);
             }
 
             result.Add(CompletionResult.Null);
@@ -5904,7 +5904,7 @@ namespace System.Management.Automation
         private static void CompleteExtensionMethods(string memberName, List<CompletionResult> results, bool addMethodParenthesis = true)
         {
             var pattern = WildcardPattern.Get(memberName, WildcardOptions.IgnoreCase);
-            CompleteExtensionMethods(pattern, results, addMethodparenthesis);
+            CompleteExtensionMethods(pattern, results, addMethodParenthesis);
         }
 
         /// <summary>
@@ -5916,7 +5916,7 @@ namespace System.Management.Automation
             {
                 if (pattern.IsMatch(member.Item1))
                 {
-                    string completionText = addMethodparenthesis ? $"{member.Item1}(" : member.Item1;
+                    string completionText = addMethodParenthesis ? $"{member.Item1}(" : member.Item1;
                     results.Add(new CompletionResult(completionText, member.Item1, CompletionResultType.Method, member.Item2));
                 }
             }
@@ -6062,7 +6062,7 @@ namespace System.Management.Automation
                 var members = context.GetMembersByInferredType(psTypeName, isStatic, filter);
                 foreach (var member in members)
                 {
-                    AddInferredMember(member, memberNamePattern, results, excludedMembers, addMethodparenthesis);
+                    AddInferredMember(member, memberNamePattern, results, excludedMembers, addMethodParenthesis);
                 }
 
                 // Check if we need to complete against the extension methods 'Where' and 'ForEach'
@@ -6070,7 +6070,7 @@ namespace System.Management.Automation
                 {
                     // Complete extension methods 'Where' and 'ForEach' for Enumerable types
                     extensionMethodsAdded = true;
-                    CompleteExtensionMethods(memberNamePattern, results, addMethodparenthesis);
+                    CompleteExtensionMethods(memberNamePattern, results, addMethodParenthesis);
                 }
             }
 
@@ -6160,7 +6160,7 @@ namespace System.Management.Automation
 
             var completionResultType = isMethod ? CompletionResultType.Method : CompletionResultType.Property;
             string completionText;
-            if (isMethod && addMethodparenthesis)
+            if (isMethod && addMethodParenthesis)
             {
                 completionText = $"{memberName}(";
             }

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -1288,7 +1288,7 @@ namespace System.Management.Automation
 
                 if (i > 0)
                 {
-                    inferredTypes.AddRange(InferTypes(parentPipeline.PipelineElements[i - 1]));
+                    inferredTypes.AddRange(GetInferredEnumeratedTypes(InferTypes(parentPipeline.PipelineElements[i - 1])));
                 }
             }
         }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -574,14 +574,14 @@ ConstructorTestClass(int i, bool b)
     It 'Should complete method name without starting parenthesis in foreach-object' {
         $TestString = '1..10 | ForEach-Object gettype'
         $res = TabExpansion2 -inputScript $TestString
-        $res.CompletionMatches[0].CompletionText | Should -BeExactly GetType
+        $res.CompletionMatches[0].CompletionText | Should -BeExactly 'GetType'
     }
 
     It 'Should enumerate types when completing member names for Select-Object' {
         $TestString = '"Hello","World" | select-object '
         $res = TabExpansion2 -inputScript $TestString
         $res | Should -HaveCount 1
-        $res.CompletionMatches[0].CompletionText | Should -BeExactly Length
+        $res.CompletionMatches[0].CompletionText | Should -BeExactly 'Length'
     }
 
     Context "Format cmdlet's View paramter completion" {

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -504,7 +504,7 @@ switch ($x)
 
     It 'ForEach-Object member completion results should include methods' {
         $res = TabExpansion2 -inputScript '1..10 | ForEach-Object -MemberName '
-        $res.CompletionMatches.CompletionText | Should -Contain "GetType("
+        $res.CompletionMatches.CompletionText | Should -Contain "GetType"
     }
 
     It 'Should not complete void instance members' {
@@ -569,12 +569,6 @@ ConstructorTestClass(int i, bool b)
         }
         $res = TabExpansion2 -inputScript $Script
         $res.CompletionMatches[0].CompletionText | Should -BeExactly '-Directory'
-    }
-
-    It 'Should complete method name without starting parenthesis in foreach-object' {
-        $TestString = '1..10 | ForEach-Object gettype'
-        $res = TabExpansion2 -inputScript $TestString
-        $res.CompletionMatches[0].CompletionText | Should -BeExactly 'GetType'
     }
 
     It 'Should enumerate types when completing member names for Select-Object' {

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -571,6 +571,19 @@ ConstructorTestClass(int i, bool b)
         $res.CompletionMatches[0].CompletionText | Should -BeExactly '-Directory'
     }
 
+    It 'Should complete method name without starting parenthesis in foreach-object' {
+        $TestString = '1..10 | ForEach-Object gettype'
+        $res = TabExpansion2 -inputScript $TestString
+        $res.CompletionMatches[0].CompletionText | Should -BeExactly GetType
+    }
+
+    It 'Should enumerate types when completing member names for Select-Object' {
+        $TestString = '"Hello","World" | select-object '
+        $res = TabExpansion2 -inputScript $TestString
+        $res | Should -HaveCount 1
+        $res.CompletionMatches[0].CompletionText | Should -BeExactly Length
+    }
+
     Context "Format cmdlet's View paramter completion" {
         BeforeAll {
             $viewDefinition = @'

--- a/test/powershell/engine/Api/TypeInference.Tests.ps1
+++ b/test/powershell/engine/Api/TypeInference.Tests.ps1
@@ -1342,6 +1342,12 @@ Describe "Type inference Tests" -tags "CI" {
         $res.Count | Should -Be 1
         $res.Name | Should -Be 'System.Security.AccessControl.AuthorizationRule'
     }
+
+    It 'Enumerates the inferred type after *-Object commands' {
+        $res = [AstTypeInference]::InferTypeOf( { (([System.Management.Automation.Language.Ast]$null).FindAll() | Select-Object -First 1) }.Ast)
+        $res.Count | Should -Be 1
+        $res.Name | Should -Be 'System.Management.Automation.Language.Ast'
+    }
 }
 
 Describe "AstTypeInference tests" -Tags CI {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Update the type inference for $_ so it uses the same enumeration as the foreach loop.  
Update the native member completion for the *-Object commands to enumerate the types of the input object.  
Update the member completion for foreach-object to not add the parenthesis when completing methods.
Update the type inference for Where, Sort and Select so the inferred type after these commands are enumerated.
<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
