### PR TITLE
Add test for default LanguageMode using remoting

### DIFF
--- a/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
+++ b/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
@@ -338,5 +338,14 @@ Describe "Remoting loopback tests" -Tags @('CI', 'RequireAdminOnWindows') {
             $session | Remove-PSSession -ErrorAction Ignore
         }
     }
-}
 
+    It 'Language Mode is FullLanguage by default' {
+        $session = New-RemoteSession -ConfigurationName $endPoint
+        try {
+            $result = Invoke-Command -Session $session -ScriptBlock { $ExecutionContext.SessionState.LanguageMode }
+            $result | Should -Be ([System.Management.Automation.PSLanguageMode]::FullLanguage)
+        } finally {
+            $session | Remove-PSSession -ErrorAction Ignore
+        }
+    }
+}


### PR DESCRIPTION
# PR Summary

Adds a test for Windows that LanguageMode is `FullLanguage` by default.

## PR Context

Fix #1413

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
