### PR TITLE
Limit searching of `charset` attribute in `meta` tag for HTML to first 1024 characters in webcmdlets

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -434,7 +434,7 @@ namespace Microsoft.PowerShell.Commands
                     // check for a charset attribute on the meta element to override the default
                     // we only look within the first 1k characters as the meta tag is in the head
                     // tag which is at the start of the document
-                    Match match = s_metaexp.Match(content.Substring(0, 1024));
+                    Match match = s_metaexp.Match(content.Substring(0, Math.Min(content.Length, 1024)));
                     if (match.Success)
                     {
                         Encoding localEncoding = null;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -431,8 +431,10 @@ namespace Microsoft.PowerShell.Commands
             {
                 do
                 {
-                    // check for a charset attribute on the meta element to override the default.
-                    Match match = s_metaexp.Match(content);
+                    // check for a charset attribute on the meta element to override the default
+                    // we only look within the first 1k characters as the meta tag is in the head
+                    // tag which is at the start of the document
+                    Match match = s_metaexp.Match(content.Substring(0, 1024));
                     if (match.Success)
                     {
                         Encoding localEncoding = null;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

In the case of HTML content, the cmdlet searches for `<meta charset=...>` in the body to find the right encoding to use.  It uses a regex to do this, however, it applies it to the entire body (which can be quite large).  The `<meta>` tag exists in the `<head>` tag which is expected at the top of the document under `<html>`.  So the change here is to limit the search to just the first 1k characters.  It is possible (since HTML is pretty lenient) to have a bunch of HTML comment tags that pushes the `<meta>` tag much lower, but seems unlikely.  The encoding defaults to UTF-8 which is used by most websites anyways.

Tested manually against the repro in the issue which returns immediately after the payload is downloaded.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/17762

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
