### PR TITLE
Enable searching for assemblies in GAC_Arm64 on Windows

### DIFF
--- a/src/System.Management.Automation/CoreCLR/CorePsAssemblyLoadContext.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsAssemblyLoadContext.cs
@@ -374,6 +374,8 @@ namespace System.Management.Automation
                        var gacName = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "GAC_Arm64" : "GAC_64";
                         _gacPath64 = Path.Join(_winDir, "Microsoft.NET", "assembly", gacName);
                     }
+
+                    gacBitnessAwarePath = _gacPath64;
                 }
                 else
                 {
@@ -381,9 +383,10 @@ namespace System.Management.Automation
                     {
                         _gacPath32 = Path.Join(_winDir, "Microsoft.NET", "assembly", "GAC_32");
                     }
+
+                    gacBitnessAwarePath = _gacPath32;
                 }
 
-                gacBitnessAwarePath = _gacPath64;
                 assemblyFound = FindInGac(gacBitnessAwarePath, assemblyName, out assemblyFilePath);
             }
 

--- a/src/System.Management.Automation/CoreCLR/CorePsAssemblyLoadContext.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsAssemblyLoadContext.cs
@@ -365,29 +365,25 @@ namespace System.Management.Automation
 
             if (!assemblyFound)
             {
-                string gacBitnessAwarePath = null;
+                string gacBitnessAwarePath;
 
                 if (Environment.Is64BitProcess)
                 {
                     if (string.IsNullOrEmpty(_gacPath64))
                     {
                        var gacName = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "GAC_Arm64" : "GAC_64";
-                        _gacPath64 = string.Create(CultureInfo.InvariantCulture, $"{_winDir}{dirSeparator}Microsoft.NET{dirSeparator}assembly{dirSeparator}{gacName}");
+                        _gacPath64 = Path.Join(_winDir, "Microsoft.NET", "assembly", gacName);
                     }
-
-                    gacBitnessAwarePath = _gacPath64;
                 }
                 else
                 {
                     if (string.IsNullOrEmpty(_gacPath32))
                     {
-                        // cache value of '_gacPath32' folder in member variable.
-                        _gacPath32 = $"{_winDir}{dirSeparator}Microsoft.NET{dirSeparator}assembly{dirSeparator}GAC_32";
+                        _gacPath32 = Path.Join(_winDir, "Microsoft.NET", "assembly", "GAC_32");
                     }
-
-                    gacBitnessAwarePath = _gacPath32;
                 }
 
+                gacBitnessAwarePath = _gacPath64;
                 assemblyFound = FindInGac(gacBitnessAwarePath, assemblyName, out assemblyFilePath);
             }
 

--- a/src/System.Management.Automation/CoreCLR/CorePsAssemblyLoadContext.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsAssemblyLoadContext.cs
@@ -372,7 +372,7 @@ namespace System.Management.Automation
                     if (string.IsNullOrEmpty(_gacPath64))
                     {
                        var gacName = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "GAC_Arm64": "GAC_64";
-                         gacPath64 = string.Create(CultureInfo.InvariantCulture, $"{_winDir}{dirSeparator}Microsoft.NET{dirSeparator}assembly{dirSeparator}{gacName}");
+                         _gacPath64 = string.Create(CultureInfo.InvariantCulture, $"{_winDir}{dirSeparator}Microsoft.NET{dirSeparator}assembly{dirSeparator}{gacName}");
                     }
 
                     gacBitnessAwarePath = _gacPath64;

--- a/src/System.Management.Automation/CoreCLR/CorePsAssemblyLoadContext.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsAssemblyLoadContext.cs
@@ -372,7 +372,7 @@ namespace System.Management.Automation
                     if (string.IsNullOrEmpty(_gacPath64))
                     {
                        var gacName = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "GAC_Arm64": "GAC_64";
-                         _gacPath64 = string.Create(CultureInfo.InvariantCulture, $"{_winDir}{dirSeparator}Microsoft.NET{dirSeparator}assembly{dirSeparator}{gacName}");
+                        _gacPath64 = string.Create(CultureInfo.InvariantCulture, $"{_winDir}{dirSeparator}Microsoft.NET{dirSeparator}assembly{dirSeparator}{gacName}");
                     }
 
                     gacBitnessAwarePath = _gacPath64;

--- a/src/System.Management.Automation/CoreCLR/CorePsAssemblyLoadContext.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsAssemblyLoadContext.cs
@@ -371,14 +371,8 @@ namespace System.Management.Automation
                 {
                     if (string.IsNullOrEmpty(_gacPath64))
                     {
-                        if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
-                        {
-                            _gacPath64 = $"{_winDir}{dirSeparator}Microsoft.NET{dirSeparator}assembly{dirSeparator}GAC_Arm64";
-                        }
-                        else
-                        {
-                            _gacPath64 = $"{_winDir}{dirSeparator}Microsoft.NET{dirSeparator}assembly{dirSeparator}GAC_64";
-                        }
+                       var gacName = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "GAC_Arm64": "GAC_64";
+                         _gacPath64 = string.Create(CultureInfo.InvariantCulture, $"{_winDir}{dirSeparator}Microsoft.NET{dirSeparator}assembly{dirSeparator}{gacName}";
                     }
 
                     gacBitnessAwarePath = _gacPath64;

--- a/src/System.Management.Automation/CoreCLR/CorePsAssemblyLoadContext.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsAssemblyLoadContext.cs
@@ -371,8 +371,14 @@ namespace System.Management.Automation
                 {
                     if (string.IsNullOrEmpty(_gacPath64))
                     {
-                        // cache value of '_gacPath64' folder in member variable.
-                        _gacPath64 = $"{_winDir}{dirSeparator}Microsoft.NET{dirSeparator}assembly{dirSeparator}GAC_64";
+                        if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+                        {
+                            _gacPath64 = $"{_winDir}{dirSeparator}Microsoft.NET{dirSeparator}assembly{dirSeparator}GAC_Arm64";
+                        }
+                        else
+                        {
+                            _gacPath64 = $"{_winDir}{dirSeparator}Microsoft.NET{dirSeparator}assembly{dirSeparator}GAC_64";
+                        }
                     }
 
                     gacBitnessAwarePath = _gacPath64;

--- a/src/System.Management.Automation/CoreCLR/CorePsAssemblyLoadContext.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsAssemblyLoadContext.cs
@@ -372,7 +372,7 @@ namespace System.Management.Automation
                     if (string.IsNullOrEmpty(_gacPath64))
                     {
                        var gacName = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "GAC_Arm64": "GAC_64";
-                         _gacPath64 = string.Create(CultureInfo.InvariantCulture, $"{_winDir}{dirSeparator}Microsoft.NET{dirSeparator}assembly{dirSeparator}{gacName}";
+                         gacPath64 = string.Create(CultureInfo.InvariantCulture, $"{_winDir}{dirSeparator}Microsoft.NET{dirSeparator}assembly{dirSeparator}{gacName}");
                     }
 
                     gacBitnessAwarePath = _gacPath64;

--- a/src/System.Management.Automation/CoreCLR/CorePsAssemblyLoadContext.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsAssemblyLoadContext.cs
@@ -371,7 +371,7 @@ namespace System.Management.Automation
                 {
                     if (string.IsNullOrEmpty(_gacPath64))
                     {
-                       var gacName = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "GAC_Arm64": "GAC_64";
+                       var gacName = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "GAC_Arm64" : "GAC_64";
                         _gacPath64 = string.Create(CultureInfo.InvariantCulture, $"{_winDir}{dirSeparator}Microsoft.NET{dirSeparator}assembly{dirSeparator}{gacName}");
                     }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The code to enable searching the GAC was limited to GAC_32 and GAC_64 which fails on Windows Arm64 systems.  Fix is to use GAC_Arm64 if pwsh is running as a Arm64 process.

Manually validated with PKI module with (requires admin):

```powershell
New-SelfSignedCertificate -DnsName "www.fabrikam.com", "www.contoso.com" -CertStoreLocation "cert:\LocalMachine\My"
```

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/17814

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
