### PR TITLE
Detect default runtime using dotnet --info in build.psm1

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -871,12 +871,16 @@ function New-PSOptions {
 
         try {
             $Info = dotnet --info
+            Write-Verbose "dotnet --info:`n${Info}"
 
+            $Architecture = Get-FirstMatch $Info '^\s*Architecture:\s+(\w+)$'
+            $Platform = Get-FirstMatch $Info '^\s*OS Platform:\s+(\w+)$'
             # We plan to release packages targeting win7-x64 and win7-x86 RIDs,
             # which supports all supported windows platforms.
             # So we, will change the RID to win7-<arch>
-            $Platform = Get-FirstMatch $Info '^\s*OS Platform:\s+(\w+)$' -replace 'windows', 'win7'
-            $Architecture = Get-FirstMatch $Info '^\s*Architecture:\s+(\w+)$'
+            $WindowsPlatform = $Architecture[0] -eq 'x' ? 'win7' : 'win'
+            $Platform = $Platform -replace 'windows', $WindowsPlatform
+
             $Runtime = "${Platform}-${Architecture}".ToLower()
         } catch {
             Write-Error $_

--- a/build.psm1
+++ b/build.psm1
@@ -880,6 +880,8 @@ function New-PSOptions {
             # So we, will change the RID to win7-<arch>
             $WindowsPlatform = $Architecture[0] -eq 'x' ? 'win7' : 'win'
             $Platform = $Platform -replace 'windows', $WindowsPlatform
+            # OSX historically reports as 'darwin'
+            $Platform = $Platform -replace 'darwin', 'osx'
 
             $Runtime = "${Platform}-${Architecture}".ToLower()
         } catch {

--- a/build.psm1
+++ b/build.psm1
@@ -862,11 +862,11 @@ function New-PSOptions {
 
     if (-not $Runtime) {
         function Get-FirstMatch($String, $Pattern) {
-            $Matches = @($String | Select-String $Pattern)
-            if (-not $Matches) {
+            $Selection = @($String | Select-String $Pattern)
+            if (-not $Selection) {
                 throw "Cannot match pattern: '${Pattern}'"
             }
-            $Matches[0].Matches.Groups[1].Value
+            $Selection[0].Matches.Groups[1].Value
         }
 
         try {

--- a/build.psm1
+++ b/build.psm1
@@ -2268,7 +2268,7 @@ function Start-DevPowerShell {
 
         # splatting for the win
         $startProcessArgs = @{
-            FilePath = "$BinDir\pwsh"
+            FilePath = Join-Path $BinDir 'pwsh'
         }
 
         if ($ArgumentList) {

--- a/build.psm1
+++ b/build.psm1
@@ -872,10 +872,8 @@ function New-PSOptions {
 
         switch ($Platform) {
             'Windows' {
-                # We plan to release packages targeting win7-x64 and win7-x86 RIDs,
-                # which supports all supported windows platforms.
-                # So we, will change the RID to win7-<arch>
-                # CI runs with PowerShell 5.0, which does not support ?:
+                # For x86 and x64 architectures, we use win7-x64 and win7-x86 RIDs.
+                # For arm and arm64 architectures, we use win-arm and win-arm64 RIDs.
                 $Platform = if ($Architecture[0] -eq 'x') { 'win7' } else { 'win' }
                 $Runtime = "${Platform}-${Architecture}"
             }

--- a/build.psm1
+++ b/build.psm1
@@ -891,9 +891,9 @@ function New-PSOptions {
 
         if (-not $Runtime) {
             Throw "Could not determine Runtime Identifier, please update dotnet"
+        } else {
+            Write-Verbose "Using runtime '$Runtime'"
         }
-
-        Write-Verbose "Using runtime '$Runtime'"
     }
 
     $PowerShellDir = if ($Runtime -like 'win*' -or ($Runtime -like 'fxdependent*' -and $environment.IsWindows)) {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

Change runtime detection when not provided with explicit `-Runtime` to always use `dotnet --info` and their `Platform OS` and `Architecture`,

Fixes #17801 

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

This fixes runtime detection on Linux, which previously always defaulted to `x64`, even on ARM. This meant that `Start-PSBuild` required explicit `-Runtime linux-arm64`, which `Start-DevPowerShell` did not work at all as it had no option of specifying runtime. Also simplifies Windows and OSX code, delegating detection work to `dotnet` who is the main consumer of `runtime` option anyways.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
