### PR TITLE
Re-enable tests because the corresponding dotnet issues were fixed

### DIFF
--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -1106,8 +1106,7 @@ Describe 'Pwsh startup and PATH' -Tag CI {
 }
 
 Describe 'Console host name' -Tag CI {
-    It 'Name is pwsh' -Pending {
-        # waiting on https://github.com/dotnet/runtime/issues/33673
+    It 'Name is pwsh' {
         (Get-Process -Id $PID).Name | Should -BeExactly 'pwsh'
     }
 }

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -867,9 +867,7 @@ foo``u{2195}abc
             @{ Script = "0x12"; ExpectedValue = "18"; ExpectedType = [int] }
             @{ Script = "-0x12"; ExpectedValue = "-18"; ExpectedType = [int] }
 
-            # Disabling this because https://github.com/dotnet/runtime/issues/54251
-            # @{ Script = "0x80000000"; ExpectedValue = $([int32]::MinValue); ExpectedType = [int] }
-
+            @{ Script = "0x80000000"; ExpectedValue = $([int32]::MinValue); ExpectedType = [int] }
             @{ Script = "0x7fffffff"; ExpectedValue = $([int32]::MaxValue); ExpectedType = [int] }
             @{ Script = "0x100000000"; ExpectedValue = [int64]0x100000000; ExpectedType = [long] }
             @{ Script = "0xFF"; ExpectedValue = "255"; ExpectedType = [int] }
@@ -1053,9 +1051,7 @@ foo``u{2195}abc
             @{ Script = "0xFFFFu"; ExpectedValue = "65535"; ExpectedType = [uint] }
             @{ Script = "0xFFFFFFu"; ExpectedValue = "16777215"; ExpectedType = [uint] }
 
-            # Disabling this because https://github.com/dotnet/runtime/issues/54251
-            # @{ Script = "0xFFFFFFFFu"; ExpectedValue = "$([uint]::MaxValue)"; ExpectedType = [uint] }
-
+            @{ Script = "0xFFFFFFFFu"; ExpectedValue = "$([uint]::MaxValue)"; ExpectedType = [uint] }
             @{ Script = "0xFFFFFFFFFFu"; ExpectedValue = "1099511627775"; ExpectedType = [ulong] }
             @{ Script = "0xFFFFFFFFFFFFu"; ExpectedValue = "281474976710655"; ExpectedType = [ulong] }
             @{ Script = "0xFFFFFFFFFFFFFFu"; ExpectedValue = "72057594037927935"; ExpectedType = [ulong] }
@@ -1065,10 +1061,7 @@ foo``u{2195}abc
             @{ Script = "0b10u"; ExpectedValue = "2"; ExpectedType = [uint] }
             @{ Script = "0b11111111u"; ExpectedValue = "255"; ExpectedType = [uint] }
             @{ Script = "0b1111111111111111u"; ExpectedValue = "65535"; ExpectedType = [uint] }
-
-            # Disabling this because https://github.com/dotnet/runtime/issues/54251
-            # @{ Script = "0b11111111111111111111111111111111u"; ExpectedValue = "4294967295"; ExpectedType = [uint] }
-
+            @{ Script = "0b11111111111111111111111111111111u"; ExpectedValue = "4294967295"; ExpectedType = [uint] }
             @{ Script = "0b1111111111111111111111111111111111111111111111111111111111111111u"; ExpectedValue = "18446744073709551615"; ExpectedType = [ulong] }
             #Multipliers
             @{ Script = "1ukb"; ExpectedValue = "1024"; ExpectedType = [uint] }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -32,7 +32,8 @@ function GetExternalHostAddress([string]$HostName)
     }
 }
 
-# Adding RequireSudoOnUnix due to issue: https://github.com/dotnet/runtime/issues/66746
+# Adding RequireSudoOnUnix due to an intentional breaking change.
+# See https://github.com/dotnet/runtime/issues/66746
 Describe "Test-Connection" -tags "CI", "RequireSudoOnUnix" {
     BeforeAll {
         $hostName = [System.Net.Dns]::GetHostName()

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -2003,7 +2003,6 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
 
     Context "Denial of service" -Tag 'DOS' {
         It "Image Parsing" {
-            Set-ItResult -Pending -Because "The pathological regex runs fast due to https://github.com/dotnet/runtime/issues/33399.  Fixed in .NET 5 preview.2"
             $dosUri = Get-WebListenerUrl -Test 'Dos' -query @{
                 dosType='img'
                 dosLength='5000'

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -2003,6 +2003,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
 
     Context "Denial of service" -Tag 'DOS' {
         It "Image Parsing" {
+            Set-ItResult -Pending -Because "The pathological regex runs fast due to https://github.com/dotnet/runtime/issues/33399.  Fixed in .NET 5 preview.2"
             $dosUri = Get-WebListenerUrl -Test 'Dos' -query @{
                 dosType='img'
                 dosLength='5000'


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Re-enable tests because the corresponding dotnet issues were fixed.
