### PR TITLE
Make `Out-String` and `Out-File` keep string input unchanged (#17455)

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -552,7 +552,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 }
                 else
                 {
-                    _lo.WriteLine(rte.text);
+                    // Write out raw text without any changes to it.
+                    _lo.WriteRawText(rte.text);
                 }
 
                 return;

--- a/src/System.Management.Automation/FormatAndOutput/common/ILineOutput.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ILineOutput.cs
@@ -195,6 +195,13 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// </param>
         internal abstract void WriteLine(string s);
 
+        /// <summary>
+        /// Write a line of string as raw text to the output device, with no change to the string.
+        /// For example, keeping VT escape sequences intact in it.
+        /// </summary>
+        /// <param name="s">The raw text to be written to the device.</param>
+        internal virtual void WriteRawText(string s) => WriteLine(s);
+
         internal WriteStreamType WriteStream
         {
             get;
@@ -376,7 +383,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     /// Implementation of the ILineOutput interface accepting an instance of a
     /// TextWriter abstract class.
     /// </summary>
-    internal class TextWriterLineOutput : LineOutput
+    internal sealed class TextWriterLineOutput : LineOutput
     {
         #region ILineOutput methods
 
@@ -412,9 +419,17 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <param name="s"></param>
         internal override void WriteLine(string s)
         {
-            CheckStopProcessing();
+            WriteRawText(PSHostUserInterface.GetOutputString(s, isHost: false));
+        }
 
-            s = PSHostUserInterface.GetOutputString(s, isHost: false);
+        /// <summary>
+        /// Write a raw text by delegating to the writer underneath, with no change to the text.
+        /// For example, keeping VT escape sequences intact in it.
+        /// </summary>
+        /// <param name="s">The raw text to be written to the device.</param>
+        internal override void WriteRawText(string s)
+        {
+            CheckStopProcessing();
 
             if (_suppressNewline)
             {
@@ -425,6 +440,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 _writer.WriteLine(s);
             }
         }
+
         #endregion
 
         /// <summary>

--- a/test/powershell/engine/Formatting/ErrorView.Tests.ps1
+++ b/test/powershell/engine/Formatting/ErrorView.Tests.ps1
@@ -115,7 +115,8 @@ Describe 'Tests for $ErrorView' -Tag CI {
 
         It "Error shows for advanced function" {
             # need to have it virtually interactive so that InvocationInfo.MyCommand is empty
-            $e = '[cmdletbinding()]param()$pscmdlet.writeerror([System.Management.Automation.ErrorRecord]::new(([System.NotImplementedException]::new("myTest")),"stub","notimplemented","command"))' | pwsh -noprofile -file - 2>&1 | Out-String
+            $e = '[cmdletbinding()]param()$pscmdlet.writeerror([System.Management.Automation.ErrorRecord]::new(([System.NotImplementedException]::new("myTest")),"stub","notimplemented","command"))' | pwsh -noprofile -file - 2>&1
+            $e = $e | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] } | Out-String
             $e | Should -Not -BeNullOrEmpty
 
             # need to see if ANSI escape sequences are in the output as ANSI is disabled for CI

--- a/test/powershell/engine/Formatting/OutputRendering.Tests.ps1
+++ b/test/powershell/engine/Formatting/OutputRendering.Tests.ps1
@@ -39,7 +39,7 @@ Describe 'OutputRendering tests' {
         param($outputRendering, $ansi)
 
         $PSStyle.OutputRendering = $outputRendering
-        $out = "$($PSStyle.Foreground.Green)hello" | Out-String
+        $out = [pscustomobject] @{ key = "$($PSStyle.Foreground.Green)hello" } | Out-String
 
         if ($ansi) {
             $out | Should -BeLike "*`e*" -Because ($out | Format-Hex | Out-String)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
