### PR TITLE
Throw when too many parameter sets are defined

### DIFF
--- a/src/System.Management.Automation/engine/MergedCommandParameterMetadata.cs
+++ b/src/System.Management.Automation/engine/MergedCommandParameterMetadata.cs
@@ -164,6 +164,13 @@ namespace System.Management.Automation
         private uint _nextAvailableParameterSetIndex;
 
         /// <summary>
+        /// The maximum number of parameter sets allowed. Limit is set by the use
+        /// of a uint bitmask to store which parameter sets a parameter is included in.
+        /// See <see cref="ParameterSetSpecificMetadata.ParameterSetFlag"/>.
+        /// </summary>
+        private const uint MaxParameterSetCount = 32;
+
+        /// <summary>
         /// Gets the number of parameter sets that were declared for the command.
         /// </summary>
         internal int ParameterSetCount
@@ -228,7 +235,7 @@ namespace System.Management.Automation
                 // A parameter set name should only be added once
                 if (index == -1)
                 {
-                    if (_nextAvailableParameterSetIndex == 32)
+                    if (_nextAvailableParameterSetIndex >= MaxParameterSetCount)
                     {
                         // Don't let the parameter set index overflow
                         ParsingMetadataException parsingException =

--- a/src/System.Management.Automation/engine/MergedCommandParameterMetadata.cs
+++ b/src/System.Management.Automation/engine/MergedCommandParameterMetadata.cs
@@ -228,7 +228,7 @@ namespace System.Management.Automation
                 // A parameter set name should only be added once
                 if (index == -1)
                 {
-                    if (_nextAvailableParameterSetIndex == uint.MaxValue)
+                    if (_nextAvailableParameterSetIndex == 32)
                     {
                         // Don't let the parameter set index overflow
                         ParsingMetadataException parsingException =

--- a/test/powershell/Language/Scripting/ParameterBinding.Tests.ps1
+++ b/test/powershell/Language/Scripting/ParameterBinding.Tests.ps1
@@ -170,6 +170,21 @@ Describe "Tests for parameter binding" -Tags "CI" {
         ( get-foo -b b a c d ) -join ',' | Should -BeExactly 'a,c,d'
     }
 
+    It 'Too many parameter sets defined' {
+        $scriptblock = {
+            param($numSets=1)
+            $parameters = (1..($numSets) | ForEach-Object { "[Parameter(parametersetname='set$_')]`$a$_" }) -join ', '
+            $body = "param($parameters) 'worked'"
+            $sb = [scriptblock]::Create($body)
+            & $sb -a1 123
+        }
+
+        { & $scriptblock -numSets 32 } | Should -Not -Throw
+        & $scriptblock -numSets 32 | Should -Be 'worked'
+        { & $scriptblock -numSets 33 } | Should -Throw -ErrorId 'ParsingTooManyParameterSets'
+        { & $scriptblock -numSets 34 } | Should -Throw -ErrorId 'ParsingTooManyParameterSets'
+    }
+
     It 'Default parameter set with value from remaining arguments case 1' {
         function get-foo
         {

--- a/test/powershell/Language/Scripting/ParameterBinding.Tests.ps1
+++ b/test/powershell/Language/Scripting/ParameterBinding.Tests.ps1
@@ -174,15 +174,13 @@ Describe "Tests for parameter binding" -Tags "CI" {
         $scriptblock = {
             param($numSets=1)
             $parameters = (1..($numSets) | ForEach-Object { "[Parameter(parametersetname='set$_')]`$a$_" }) -join ', '
-            $body = "param($parameters) 'worked'"
+            $body = "param($parameters) 'working'"
             $sb = [scriptblock]::Create($body)
             & $sb -a1 123
         }
 
-        { & $scriptblock -numSets 32 } | Should -Not -Throw
-        & $scriptblock -numSets 32 | Should -Be 'worked'
+        & $scriptblock -numSets 32 | Should -Be 'working'
         { & $scriptblock -numSets 33 } | Should -Throw -ErrorId 'ParsingTooManyParameterSets'
-        { & $scriptblock -numSets 34 } | Should -Throw -ErrorId 'ParsingTooManyParameterSets'
     }
 
     It 'Default parameter set with value from remaining arguments case 1' {


### PR DESCRIPTION
# PR Summary

Fixes a bug that caused an exception for `ParsingTooManyParameterSets` to never be thrown when a command has more than 32 parameter sets.

## PR Context

Due to use of `uint` bitmask for parameter sets lookup, a maximum of 32 parameter sets are allowed in commands/scriptblocks. The intended exception when 33+ sets are defined was never thrown due to a bug, causing an index overflow that registers parameters in set 33 and higher in existing sets.

Fix #9372

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
