### PR TITLE
Change class used for `Get-CimClass -Amended` parameter test

### DIFF
--- a/test/powershell/Modules/CimCmdlets/Get-CimClass.Tests.ps1
+++ b/test/powershell/Modules/CimCmdlets/Get-CimClass.Tests.ps1
@@ -29,7 +29,7 @@ Describe 'Get-CimClass' -Tags @("Feature") {
     }
 
     It 'can retrieve class amended qualifiers' -Pending:(-not $IsWindows) {
-        $a = Get-CimClass -Class 'Win32_PrinterConfiguration' -Amended
-        $a.CimClassProperties['Color'].Qualifiers.Item('Values').Value.Count | Should -Be 2
+        $a = Get-CimClass -Class 'Win32_LogicalDisk' -Amended
+        $a.CimClassProperties['DriveType'].Qualifiers.Item('Values').Value.Count | Should -Be 7
     }
 }


### PR DESCRIPTION
# PR Summary

Change class used for `Get-CimClass` cmdlet's `-Amended` parameter test: `Win32_PrinterConfiguration` for `Win32_LogicalDisk`.

## PR Context

It seems that `Win32_PrinterConfiguration` class isn't the best option for testing the `-Amended` parameter,
because the qualifiers collection for its properties contain Description, Values, etc., even if you don't use the `-Amended` parameter.

In contrast, such classes, like `Win32_LogicalDisk` and others don't contain aforementioned qualifiers when the `-Amended` parameter wasn't specified.


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
