### PR TITLE
Remove 1s minimum delay in Invoke-WebRequest for small files, and prevent file-download-error suppression.

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -314,7 +314,6 @@ namespace Microsoft.PowerShell.Commands
                     return true;  // Let all wrapped exceptions throw and be handled in calling layers
                 });
             }
-            }
         }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -296,7 +296,7 @@ namespace Microsoft.PowerShell.Commands
                     record.StatusDescription = StringUtil.Format(WebCmdletStrings.WriteRequestProgressStatus, output.Position);
                     cmdlet.WriteProgress(record);
 
-                    Task.Delay(1000).Wait(cancellationToken);
+                    copyTask.Wait(1000, cancellationToken);
                 }
                 while (!copyTask.IsCompleted && !cancellationToken.IsCancellationRequested);
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -307,9 +307,6 @@ namespace Microsoft.PowerShell.Commands
             catch (OperationCanceledException)
             {
             }
-            catch (AggregateException)
-            {
-            }
         }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -307,11 +307,11 @@ namespace Microsoft.PowerShell.Commands
             catch (OperationCanceledException)
             {
             }
-            catch (AggregateException ae)
+            catch (AggregateException ae) //// we should remove this suppression in next release, which would fix partial file downloads without proper error handling.
             {
                 ae.Handle((x) =>
                 {
-                    return true;  // Let all wrapped exceptions throw and be handled in calling layers
+                    return true;
                 });
             }
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -289,16 +289,14 @@ namespace Microsoft.PowerShell.Commands
                 ActivityId,
                 WebCmdletStrings.WriteRequestProgressActivity,
                 WebCmdletStrings.WriteRequestProgressStatus);
+
             try
             {
-                do
+                while (!copyTask.Wait(1000, cancellationToken))
                 {
                     record.StatusDescription = StringUtil.Format(WebCmdletStrings.WriteRequestProgressStatus, output.Position);
                     cmdlet.WriteProgress(record);
-
-                    copyTask.Wait(1000, cancellationToken);
                 }
-                while (!copyTask.IsCompleted && !cancellationToken.IsCancellationRequested);
 
                 if (copyTask.IsCompleted)
                 {
@@ -307,6 +305,9 @@ namespace Microsoft.PowerShell.Commands
                 }
             }
             catch (OperationCanceledException)
+            {
+            }
+            catch (AggregateException)
             {
             }
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -307,7 +307,7 @@ namespace Microsoft.PowerShell.Commands
             catch (OperationCanceledException)
             {
             }
-            catch (AggregateException)
+            catch (AggregateException ae)
             {
                 ae.Handle((x) =>
                 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -307,14 +307,6 @@ namespace Microsoft.PowerShell.Commands
             catch (OperationCanceledException)
             {
             }
-            catch (AggregateException ae)
-            {
-                // we should remove this suppression in next release, which would fix partial file downloads without proper error handling.
-                ae.Handle((x) =>
-                {
-                    return true;
-                });
-            }
         }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -307,8 +307,9 @@ namespace Microsoft.PowerShell.Commands
             catch (OperationCanceledException)
             {
             }
-            catch (AggregateException ae) //// we should remove this suppression in next release, which would fix partial file downloads without proper error handling.
+            catch (AggregateException ae)
             {
+                // we should remove this suppression in next release, which would fix partial file downloads without proper error handling.
                 ae.Handle((x) =>
                 {
                     return true;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -309,6 +309,11 @@ namespace Microsoft.PowerShell.Commands
             }
             catch (AggregateException)
             {
+                ae.Handle((x) =>
+                {
+                    return true;  // Let all wrapped exceptions throw and be handled in calling layers
+                });
+            }
             }
         }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -307,6 +307,9 @@ namespace Microsoft.PowerShell.Commands
             catch (OperationCanceledException)
             {
             }
+            catch (AggregateException)
+            {
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix https://github.com/PowerShell/PowerShell/issues/17893 

Both `Invoke-RestMethod` and `Invoke-WebRequest` showed 20x latency of 1000ms when downloading a web item via pscore 7, that typically takes ~60ms in ps 5, In `StreamHelper` there is a constant minimum delay of `1s` for any calls to `StreamHelper.WriteToStream`. This is not expected. 

If `Invoke-WebRequest` / `Invoke-RestMethod` are used in parallel and for large volume of items, the 1s delay adds up. 

We fix this issue by replacing `Task.Delay` check with `copyTask.Wait`. 

The change does take into consideration, 
- to exit immediately if copyTask succeeds. 
- to wait for 1s, for progress update, in case task takes longer. 
- to throw exception, in case task fails [although, I think this may not have the right parity with earlier code]

Fix https://github.com/PowerShell/PowerShell/issues/17931

We also fix the issue where failure in download results in partial file being saved, and exception being suppressed. 

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

Tested that perf improves after fix, locally, 
![image](https://user-images.githubusercontent.com/3484074/184528659-129f8d95-d267-4eca-a04b-74e8213a6c51.png)

Earlier, latency was as follows, 
![image](https://user-images.githubusercontent.com/3484074/184528909-ad5d9ed3-5548-4b8c-aea1-9626e6dbe5d3.png)


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
