### PR TITLE
Ensure error message resets the color

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1334,7 +1334,7 @@ namespace System.Management.Automation.Runspaces
                                         }
 
                                         if ($ErrorView -eq 'ConciseView') {
-                                            return $posmsg
+                                            return $posmsg + $PSStyle.Reset
                                         }
 
                                         $indent = 4
@@ -1363,8 +1363,10 @@ namespace System.Management.Automation.Runspaces
                                             $posmsg += $newline + $indentString
                                         }
 
+                                        $posmsg += $PSStyle.Reset
+
                                         if ($ErrorView -eq 'CategoryView') {
-                                            $err.CategoryInfo.GetMessage()
+                                            $err.CategoryInfo.GetMessage() + $PSStyle.Reset
                                         }
                                         elseif (! $err.ErrorDetails -or ! $err.ErrorDetails.Message) {
                                             $err.Exception.Message + $posmsg

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1065,6 +1065,7 @@ namespace System.Management.Automation.Runspaces
                         .AddScriptBlockExpressionBinding(@"
                                     Set-StrictMode -Off
                                     $newline = [Environment]::Newline
+                                    $reset = $Host.UI.SupportsVirtualTerminal ? $PSStyle.Reset : ''
 
                                     function Get-ConciseViewPositionMessage {
 
@@ -1334,7 +1335,7 @@ namespace System.Management.Automation.Runspaces
                                         }
 
                                         if ($ErrorView -eq 'ConciseView') {
-                                            return $posmsg + $PSStyle.Reset
+                                            return $posmsg + $reset
                                         }
 
                                         $indent = 4
@@ -1363,10 +1364,10 @@ namespace System.Management.Automation.Runspaces
                                             $posmsg += $newline + $indentString
                                         }
 
-                                        $posmsg += $PSStyle.Reset
+                                        $posmsg += $reset
 
                                         if ($ErrorView -eq 'CategoryView') {
-                                            $err.CategoryInfo.GetMessage() + $PSStyle.Reset
+                                            $err.CategoryInfo.GetMessage() + $reset
                                         }
                                         elseif (! $err.ErrorDetails -or ! $err.ErrorDetails.Message) {
                                             $err.Exception.Message + $posmsg


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Prior to this change, after writing the error message if your prompt doesn't set any colors, the error color (default red) would continue to write to output.

Looked at changing it so that the color resets at writeline() time but that didn't work correctly across multiple lines as they should all be red, but because lines expect color to be retained, they would show incorrectly.

Ultimately, decided that the error message itself should reset the color (which also means that all output needs to reset at the end rather than expecting PS or ConsoleHost to fix it).

Manually tested with ConciseView and NormalView using:

```powershell
write-error 1;"hello"
```

Where the error should be in red even if multiple lines, but `hello` should be default foreground/background color.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/17885

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
