### PR TITLE
Support mapping foreground/background `ConsoleColor` values to VT escape sequences

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -315,8 +315,8 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>The matched line with matched text inverted.</returns>
         private string EmphasizeLine()
         {
-            string invertColorsVT100 = VTUtility.GetEscapeSequence(VTUtility.VT.Inverse);
-            string resetVT100 = VTUtility.GetEscapeSequence(VTUtility.VT.Reset);
+            string invertColorsVT100 = PSStyle.Instance.Reverse;
+            string resetVT100 = PSStyle.Instance.Reset;
 
             char[] chars = new char[(_matchIndexes.Count * (invertColorsVT100.Length + resetVT100.Length)) + Line.Length];
             int lineIndex = 0;

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -816,9 +816,7 @@ namespace System.Management.Automation.Runspaces
                                     $errorColor = $psstyle.Formatting.Error
                                 }
 
-                                $resetColor = [System.Management.Automation.VTUtility]::GetEscapeSequence(
-                                    [System.Management.Automation.VTUtility+VT]::Reset
-                                )
+                                $resetColor = $PSStyle.Reset
                             }
 
                             function Get-VT100Color([ConsoleColor] $color) {
@@ -826,7 +824,7 @@ namespace System.Management.Automation.Runspaces
                                     return ''
                                 }
 
-                                return [System.Management.Automation.VTUtility]::GetEscapeSequence($color)
+                                return [System.Management.Automation.VTUtility]::MapForegroundColorToEscapeSequence($color)
                             }
 
                             function Show-ErrorRecord($obj, [int]$indent = 0, [int]$depth = 1) {
@@ -1070,9 +1068,7 @@ namespace System.Management.Automation.Runspaces
 
                                         $resetColor = ''
                                         if ($Host.UI.SupportsVirtualTerminal -and ([string]::IsNullOrEmpty($env:__SuppressAnsiEscapeSequences))) {
-                                            $resetColor = [System.Management.Automation.VTUtility]::GetEscapeSequence(
-                                                [System.Management.Automation.VTUtility+VT]::Reset
-                                            )
+                                            $resetColor = $PSStyle.Reset
                                         }
 
                                         function Get-VT100Color([ConsoleColor] $color) {
@@ -1080,21 +1076,7 @@ namespace System.Management.Automation.Runspaces
                                                 return ''
                                             }
 
-                                            return [System.Management.Automation.VTUtility]::GetEscapeSequence($color)
-                                        }
-
-                                        # return length of string sans VT100 codes
-                                        function Get-RawStringLength($string) {
-                                            $vtCodes = ""`e[0m"", ""`e[2;30m"", ""`e[2;31m"", ""`e[2;32m"", ""`e[2;33m"", ""`e[2;34m"",
-                                                ""`e[2;35m"", ""`e[2;36m"", ""`e[2;37m"", ""`e[1;30m"", ""`e[1;31m"", ""`e[1;32m"",
-                                                ""`e[1;33m"", ""`e[1;34m"", ""`e[1;35m"", ""`e[1;36m"", ""`e[1;37m""
-
-                                            $newString = $string
-                                            foreach ($vtCode in $vtCodes) {
-                                                $newString = $newString.Replace($vtCode, '')
-                                            }
-
-                                            return $newString.Length
+                                            return [System.Management.Automation.VTUtility]::MapForegroundColorToEscapeSequence($color)
                                         }
 
                                         # returns a string cut to last whitespace
@@ -1217,7 +1199,7 @@ namespace System.Management.Automation.Runspaces
 
                                         # if rendering line information, break up the message if it's wider than the console
                                         if ($myinv -and $myinv.ScriptName -or $err.CategoryInfo.Category -eq 'ParserError') {
-                                            $prefixLength = Get-RawStringLength -string $prefix
+                                            $prefixLength = [System.Management.Automation.Internal.StringDecorated]::new($prefix).ContentLength
                                             $prefixVtLength = $prefix.Length - $prefixLength
 
                                             # replace newlines in message so it lines up correct

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -824,7 +824,7 @@ namespace System.Management.Automation.Runspaces
                                     return ''
                                 }
 
-                                return [System.Management.Automation.VTUtility]::MapForegroundColorToEscapeSequence($color)
+                                return [System.Management.Automation.PSStyle]::MapForegroundColorToEscapeSequence($color)
                             }
 
                             function Show-ErrorRecord($obj, [int]$indent = 0, [int]$depth = 1) {
@@ -1076,7 +1076,7 @@ namespace System.Management.Automation.Runspaces
                                                 return ''
                                             }
 
-                                            return [System.Management.Automation.VTUtility]::MapForegroundColorToEscapeSequence($color)
+                                            return [System.Management.Automation.PSStyle]::MapForegroundColorToEscapeSequence($color)
                                         }
 
                                         # returns a string cut to last whitespace

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -722,6 +722,116 @@ namespace System.Management.Automation
                 return s_psstyle;
             }
         }
+
+        /// <summary>
+        /// The map of background console colors to escape sequences.
+        /// </summary>
+        private static readonly string[] BackgroundColorMap =
+            {
+                "\x1b[40m", // Black
+                "\x1b[44m", // DarkBlue
+                "\x1b[42m", // DarkGreen
+                "\x1b[46m", // DarkCyan
+                "\x1b[41m", // DarkRed
+                "\x1b[45m", // DarkMagenta
+                "\x1b[43m", // DarkYellow
+                "\x1b[47m", // Gray
+                "\x1b[100m", // DarkGray
+                "\x1b[104m", // Blue
+                "\x1b[102m", // Green
+                "\x1b[106m", // Cyan
+                "\x1b[101m", // Red
+                "\x1b[105m", // Magenta
+                "\x1b[103m", // Yellow
+                "\x1b[107m", // White
+            };
+
+        /// <summary>
+        /// The map of foreground console colors to escape sequences.
+        /// </summary>
+        private static readonly string[] ForegroundColorMap =
+            {
+                "\x1b[30m", // Black
+                "\x1b[34m", // DarkBlue
+                "\x1b[32m", // DarkGreen
+                "\x1b[36m", // DarkCyan
+                "\x1b[31m", // DarkRed
+                "\x1b[35m", // DarkMagenta
+                "\x1b[33m", // DarkYellow
+                "\x1b[37m", // Gray
+                "\x1b[90m", // DarkGray
+                "\x1b[94m", // Blue
+                "\x1b[92m", // Green
+                "\x1b[96m", // Cyan
+                "\x1b[91m", // Red
+                "\x1b[95m", // Magenta
+                "\x1b[93m", // Yellow
+                "\x1b[97m", // White
+            };
+
+        /// <summary>
+        /// Return the VT escape sequence for a ConsoleColor.
+        /// </summary>
+        /// <param name="color">The <see cref="ConsoleColor"/> to be mapped from.</param>
+        /// <param name="isBackground">Whether or not it's a background color.</param>
+        /// <returns>The VT escape sequence representing the color. Or, an empty string if the passed-in color is invalid.</returns>
+        internal static string MapColorToEscapeSequence(ConsoleColor color, bool isBackground)
+        {
+            int index = (int)color;
+            if (index < 0 || index >= ForegroundColorMap.Length)
+            {
+                throw new ArgumentOutOfRangeException(paramName: nameof(color));
+            }
+
+            return (isBackground ? BackgroundColorMap : ForegroundColorMap)[index];
+        }
+
+        /// <summary>
+        /// Return the VT escape sequence for a foreground color.
+        /// </summary>
+        /// <param name="foregroundColor">The foreground color to be mapped from.</param>
+        /// <returns>The VT escape sequence representing the foreground color. Or, an empty string if the passed-in color is invalid.</returns>
+        public static string MapForegroundColorToEscapeSequence(ConsoleColor foregroundColor)
+            => MapColorToEscapeSequence(foregroundColor, isBackground: false);
+
+        /// <summary>
+        /// Return the VT escape sequence for a background color.
+        /// </summary>
+        /// <param name="backgroundColor">The background color to be mapped from.</param>
+        /// <returns>The VT escape sequence representing the background color. Or, an empty string if the passed-in color is invalid.</returns>
+        public static string MapBackgroundColorToEscapeSequence(ConsoleColor backgroundColor)
+            => MapColorToEscapeSequence(backgroundColor, isBackground: true);
+
+        /// <summary>
+        /// Return the VT escape sequence for a pair of foreground and background colors.
+        /// </summary>
+        /// <param name="foregroundColor">The foreground color of the color pair.</param>
+        /// <param name="backgroundColor">The background color of the color pair.</param>
+        /// <returns>The VT escape sequence representing the foreground and background color pair. Or, an empty string if either of the passed-in colors is invalid.</returns>
+        public static string MapColorPairToEscapeSequence(ConsoleColor foregroundColor, ConsoleColor backgroundColor)
+        {
+            int foreIndex = (int)foregroundColor;
+            int backIndex = (int)backgroundColor;
+
+            if (foreIndex < 0 || foreIndex >= ForegroundColorMap.Length)
+            {
+                throw new ArgumentOutOfRangeException(paramName: nameof(foregroundColor));
+            }
+
+            if (backIndex < 0 || backIndex >= ForegroundColorMap.Length)
+            {
+                throw new ArgumentOutOfRangeException(paramName: nameof(backgroundColor));
+            }
+
+            string foreground = ForegroundColorMap[foreIndex];
+            string background = BackgroundColorMap[backIndex];
+
+            return string.Concat(
+                foreground.AsSpan(start: 0, length: foreground.Length - 1),
+                ";".AsSpan(),
+                background.AsSpan(start: 2));
+        }
     }
+
     #endregion PSStyle
 }

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -155,6 +155,16 @@ namespace System.Management.Automation
 
                 return FromRgb(red, green, blue);
             }
+
+            /// <summary>
+            /// Return the VT escape sequence for a foreground color.
+            /// </summary>
+            /// <param name="color">The foreground color to be mapped from.</param>
+            /// <returns>The VT escape sequence representing the foreground color.</returns>
+            public string FromConsoleColor(ConsoleColor color)
+            {
+                return MapForegroundColorToEscapeSequence(color);
+            }
         }
 
         /// <summary>
@@ -269,6 +279,16 @@ namespace System.Management.Automation
                 red = (byte)(rgb & 0xFF);
 
                 return FromRgb(red, green, blue);
+            }
+
+            /// <summary>
+            /// Return the VT escape sequence for a background color.
+            /// </summary>
+            /// <param name="color">The background color to be mapped from.</param>
+            /// <returns>The VT escape sequence representing the background color.</returns>
+            public string FromConsoleColor(ConsoleColor color)
+            {
+                return MapBackgroundColorToEscapeSequence(color);
             }
         }
 
@@ -774,7 +794,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="color">The <see cref="ConsoleColor"/> to be mapped from.</param>
         /// <param name="isBackground">Whether or not it's a background color.</param>
-        /// <returns>The VT escape sequence representing the color. Or, an empty string if the passed-in color is invalid.</returns>
+        /// <returns>The VT escape sequence representing the color.</returns>
         internal static string MapColorToEscapeSequence(ConsoleColor color, bool isBackground)
         {
             int index = (int)color;
@@ -790,7 +810,7 @@ namespace System.Management.Automation
         /// Return the VT escape sequence for a foreground color.
         /// </summary>
         /// <param name="foregroundColor">The foreground color to be mapped from.</param>
-        /// <returns>The VT escape sequence representing the foreground color. Or, an empty string if the passed-in color is invalid.</returns>
+        /// <returns>The VT escape sequence representing the foreground color.</returns>
         public static string MapForegroundColorToEscapeSequence(ConsoleColor foregroundColor)
             => MapColorToEscapeSequence(foregroundColor, isBackground: false);
 
@@ -798,7 +818,7 @@ namespace System.Management.Automation
         /// Return the VT escape sequence for a background color.
         /// </summary>
         /// <param name="backgroundColor">The background color to be mapped from.</param>
-        /// <returns>The VT escape sequence representing the background color. Or, an empty string if the passed-in color is invalid.</returns>
+        /// <returns>The VT escape sequence representing the background color.</returns>
         public static string MapBackgroundColorToEscapeSequence(ConsoleColor backgroundColor)
             => MapColorToEscapeSequence(backgroundColor, isBackground: true);
 
@@ -807,7 +827,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="foregroundColor">The foreground color of the color pair.</param>
         /// <param name="backgroundColor">The background color of the color pair.</param>
-        /// <returns>The VT escape sequence representing the foreground and background color pair. Or, an empty string if either of the passed-in colors is invalid.</returns>
+        /// <returns>The VT escape sequence representing the foreground and background color pair.</returns>
         public static string MapColorPairToEscapeSequence(ConsoleColor foregroundColor, ConsoleColor backgroundColor)
         {
             int foreIndex = (int)foregroundColor;

--- a/src/System.Management.Automation/utils/VTUtils.cs
+++ b/src/System.Management.Automation/utils/VTUtils.cs
@@ -2,114 +2,84 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 
 namespace System.Management.Automation
 {
     /// <summary>
     /// Class to help with VT escape sequences.
     /// </summary>
-    public static class VTUtility
+    [Obsolete("This class is deprecated. Use 'System.Management.Automation.PSStyle' instead.", error: true)]
+    public sealed class VTUtility
     {
-        private static readonly string[] BackgroundColorMap =
-            {
-                "\x1b[40m", // Black
-                "\x1b[44m", // DarkBlue
-                "\x1b[42m", // DarkGreen
-                "\x1b[46m", // DarkCyan
-                "\x1b[41m", // DarkRed
-                "\x1b[45m", // DarkMagenta
-                "\x1b[43m", // DarkYellow
-                "\x1b[47m", // Gray
-                "\x1b[100m", // DarkGray
-                "\x1b[104m", // Blue
-                "\x1b[102m", // Green
-                "\x1b[106m", // Cyan
-                "\x1b[101m", // Red
-                "\x1b[105m", // Magenta
-                "\x1b[103m", // Yellow
-                "\x1b[107m", // White
-            };
+        /// <summary>
+        /// Available VT escape codes other than colors.
+        /// </summary>
+        public enum VT
+        {
+            /// <summary>Reset the text style.</summary>
+            Reset,
 
-        private static readonly string[] ForegroundColorMap =
-            {
-                "\x1b[30m", // Black
-                "\x1b[34m", // DarkBlue
-                "\x1b[32m", // DarkGreen
-                "\x1b[36m", // DarkCyan
-                "\x1b[31m", // DarkRed
-                "\x1b[35m", // DarkMagenta
-                "\x1b[33m", // DarkYellow
-                "\x1b[37m", // Gray
-                "\x1b[90m", // DarkGray
-                "\x1b[94m", // Blue
-                "\x1b[92m", // Green
-                "\x1b[96m", // Cyan
-                "\x1b[91m", // Red
-                "\x1b[95m", // Magenta
-                "\x1b[93m", // Yellow
-                "\x1b[97m", // White
-            };
+            /// <summary>Invert the foreground and background colors.</summary>
+            Inverse
+        }
+
+        private static readonly Dictionary<ConsoleColor, string> ForegroundColorMap = new Dictionary<ConsoleColor, string>
+        {
+            { ConsoleColor.Black, "\x1b[30m" },
+            { ConsoleColor.Gray, "\x1b[37m" },
+            { ConsoleColor.Red, "\x1b[91m" },
+            { ConsoleColor.Green, "\x1b[92m" },
+            { ConsoleColor.Yellow, "\x1b[93m" },
+            { ConsoleColor.Blue, "\x1b[94m" },
+            { ConsoleColor.Magenta, "\x1b[95m" },
+            { ConsoleColor.Cyan, "\x1b[96m" },
+            { ConsoleColor.White, "\x1b[97m" },
+            { ConsoleColor.DarkRed, "\x1b[31m" },
+            { ConsoleColor.DarkGreen, "\x1b[32m" },
+            { ConsoleColor.DarkYellow, "\x1b[33m" },
+            { ConsoleColor.DarkBlue, "\x1b[34m" },
+            { ConsoleColor.DarkMagenta, "\x1b[35m" },
+            { ConsoleColor.DarkCyan, "\x1b[36m" },
+            { ConsoleColor.DarkGray, "\x1b[90m" },
+        };
+
+        private static readonly Dictionary<VT, string> VTCodes = new Dictionary<VT, string>
+        {
+            { VT.Reset, "\x1b[0m" },
+            { VT.Inverse, "\x1b[7m" }
+        };
 
         /// <summary>
         /// Return the VT escape sequence for a ConsoleColor.
         /// </summary>
-        /// <param name="color">The <see cref="ConsoleColor"/> to be mapped from.</param>
-        /// <param name="isBackground">Whether or not it's a background color.</param>
-        /// <returns>The VT escape sequence representing the color. Or, an empty string if the passed-in color is invalid.</returns>
-        internal static string MapColorToEscapeSequence(ConsoleColor color, bool isBackground)
+        /// <param name="color">
+        /// The ConsoleColor to return the equivalent VT escape sequence.
+        /// </param>
+        /// <returns>
+        /// The requested VT escape sequence.
+        /// </returns>
+        public static string GetEscapeSequence(ConsoleColor color)
         {
-            int index = (int)color;
-            if (index < 0 || index >= ForegroundColorMap.Length)
-            {
-                // Return empty string if the passed-in console color is out of bound.
-                return string.Empty;
-            }
-
-            return (isBackground ? BackgroundColorMap : ForegroundColorMap)[index];
+            string value = string.Empty;
+            ForegroundColorMap.TryGetValue(color, out value);
+            return value;
         }
 
         /// <summary>
-        /// Return the VT escape sequence for a foreground color.
+        /// Return the VT escape sequence for a supported VT enum value.
         /// </summary>
-        /// <param name="foregroundColor">The foreground color to be mapped from.</param>
-        /// <returns>The VT escape sequence representing the foreground color. Or, an empty string if the passed-in color is invalid.</returns>
-        public static string MapForegroundColorToEscapeSequence(ConsoleColor foregroundColor)
-            => MapColorToEscapeSequence(foregroundColor, isBackground: false);
-
-        /// <summary>
-        /// Return the VT escape sequence for a background color.
-        /// </summary>
-        /// <param name="backgroundColor">The background color to be mapped from.</param>
-        /// <returns>The VT escape sequence representing the background color. Or, an empty string if the passed-in color is invalid.</returns>
-        public static string MapBackgroundColorToEscapeSequence(ConsoleColor backgroundColor)
-            => MapColorToEscapeSequence(backgroundColor, isBackground: true);
-
-        /// <summary>
-        /// Return the VT escape sequence for a pair of foreground and background colors.
-        /// </summary>
-        /// <param name="foregroundColor">The foreground color of the color pair.</param>
-        /// <param name="backgroundColor">The background color of the color pair.</param>
-        /// <returns>The VT escape sequence representing the foreground and background color pair. Or, an empty string if either of the passed-in colors is invalid.</returns>
-        public static string MapColorPairToEscapeSequence(ConsoleColor foregroundColor, ConsoleColor backgroundColor)
+        /// <param name="vt">
+        /// The VT code to return the VT escape sequence.
+        /// </param>
+        /// <returns>
+        /// The requested VT escape sequence.
+        /// </returns>
+        public static string GetEscapeSequence(VT vt)
         {
-            int foreIndex = (int)foregroundColor;
-            int backIndex = (int)backgroundColor;
-
-            if (foreIndex < 0 || backIndex < 0 ||
-                foreIndex >= ForegroundColorMap.Length ||
-                backIndex >= ForegroundColorMap.Length)
-            {
-                // Return empty string if either of the passed-in console colors is out of bound.
-                return string.Empty;
-            }
-
-            string foreground = ForegroundColorMap[foreIndex];
-            string background = BackgroundColorMap[backIndex];
-
-            return string.Concat(
-                foreground.AsSpan(start: 0, length: foreground.Length - 1),
-                ";".AsSpan(),
-                background.AsSpan(start: 2));
+            string value = string.Empty;
+            VTCodes.TryGetValue(vt, out value);
+            return value;
         }
     }
 }

--- a/src/System.Management.Automation/utils/VTUtils.cs
+++ b/src/System.Management.Automation/utils/VTUtils.cs
@@ -10,52 +10,58 @@ namespace System.Management.Automation
     /// </summary>
     public static class VTUtility
     {
-        private static readonly string[] BackgroundColorMap = {
-            "\x1b[40m", // Black
-            "\x1b[44m", // DarkBlue
-            "\x1b[42m", // DarkGreen
-            "\x1b[46m", // DarkCyan
-            "\x1b[41m", // DarkRed
-            "\x1b[45m", // DarkMagenta
-            "\x1b[43m", // DarkYellow
-            "\x1b[47m", // Gray
-            "\x1b[100m", // DarkGray
-            "\x1b[104m", // Blue
-            "\x1b[102m", // Green
-            "\x1b[106m", // Cyan
-            "\x1b[101m", // Red
-            "\x1b[105m", // Magenta
-            "\x1b[103m", // Yellow
-            "\x1b[107m", // White
-        };
+        private static readonly string[] BackgroundColorMap =
+            {
+                "\x1b[40m", // Black
+                "\x1b[44m", // DarkBlue
+                "\x1b[42m", // DarkGreen
+                "\x1b[46m", // DarkCyan
+                "\x1b[41m", // DarkRed
+                "\x1b[45m", // DarkMagenta
+                "\x1b[43m", // DarkYellow
+                "\x1b[47m", // Gray
+                "\x1b[100m", // DarkGray
+                "\x1b[104m", // Blue
+                "\x1b[102m", // Green
+                "\x1b[106m", // Cyan
+                "\x1b[101m", // Red
+                "\x1b[105m", // Magenta
+                "\x1b[103m", // Yellow
+                "\x1b[107m", // White
+            };
 
-        private static readonly string[] ForegroundColorMap = {
-            "\x1b[30m", // Black
-            "\x1b[34m", // DarkBlue
-            "\x1b[32m", // DarkGreen
-            "\x1b[36m", // DarkCyan
-            "\x1b[31m", // DarkRed
-            "\x1b[35m", // DarkMagenta
-            "\x1b[33m", // DarkYellow
-            "\x1b[37m", // Gray
-            "\x1b[90m", // DarkGray
-            "\x1b[94m", // Blue
-            "\x1b[92m", // Green
-            "\x1b[96m", // Cyan
-            "\x1b[91m", // Red
-            "\x1b[95m", // Magenta
-            "\x1b[93m", // Yellow
-            "\x1b[97m", // White
-        };
+        private static readonly string[] ForegroundColorMap =
+            {
+                "\x1b[30m", // Black
+                "\x1b[34m", // DarkBlue
+                "\x1b[32m", // DarkGreen
+                "\x1b[36m", // DarkCyan
+                "\x1b[31m", // DarkRed
+                "\x1b[35m", // DarkMagenta
+                "\x1b[33m", // DarkYellow
+                "\x1b[37m", // Gray
+                "\x1b[90m", // DarkGray
+                "\x1b[94m", // Blue
+                "\x1b[92m", // Green
+                "\x1b[96m", // Cyan
+                "\x1b[91m", // Red
+                "\x1b[95m", // Magenta
+                "\x1b[93m", // Yellow
+                "\x1b[97m", // White
+            };
 
         /// <summary>
         /// Return the VT escape sequence for a ConsoleColor.
         /// </summary>
+        /// <param name="color">The <see cref="ConsoleColor"/> to be mapped from.</param>
+        /// <param name="isBackground">Whether or not it's a background color.</param>
+        /// <returns>The VT escape sequence representing the color. Or, an empty string if the passed-in color is invalid.</returns>
         internal static string MapColorToEscapeSequence(ConsoleColor color, bool isBackground)
         {
             int index = (int)color;
             if (index < 0 || index >= ForegroundColorMap.Length)
             {
+                // Return empty string if the passed-in console color is out of bound.
                 return string.Empty;
             }
 
@@ -65,18 +71,25 @@ namespace System.Management.Automation
         /// <summary>
         /// Return the VT escape sequence for a foreground color.
         /// </summary>
+        /// <param name="foregroundColor">The foreground color to be mapped from.</param>
+        /// <returns>The VT escape sequence representing the foreground color. Or, an empty string if the passed-in color is invalid.</returns>
         public static string MapForegroundColorToEscapeSequence(ConsoleColor foregroundColor)
             => MapColorToEscapeSequence(foregroundColor, isBackground: false);
 
         /// <summary>
         /// Return the VT escape sequence for a background color.
         /// </summary>
+        /// <param name="backgroundColor">The background color to be mapped from.</param>
+        /// <returns>The VT escape sequence representing the background color. Or, an empty string if the passed-in color is invalid.</returns>
         public static string MapBackgroundColorToEscapeSequence(ConsoleColor backgroundColor)
             => MapColorToEscapeSequence(backgroundColor, isBackground: true);
 
         /// <summary>
         /// Return the VT escape sequence for a pair of foreground and background colors.
         /// </summary>
+        /// <param name="foregroundColor">The foreground color of the color pair.</param>
+        /// <param name="backgroundColor">The background color of the color pair.</param>
+        /// <returns>The VT escape sequence representing the foreground and background color pair. Or, an empty string if either of the passed-in colors is invalid.</returns>
         public static string MapColorPairToEscapeSequence(ConsoleColor foregroundColor, ConsoleColor backgroundColor)
         {
             int foreIndex = (int)foregroundColor;

--- a/src/System.Management.Automation/utils/VTUtils.cs
+++ b/src/System.Management.Automation/utils/VTUtils.cs
@@ -8,7 +8,7 @@ namespace System.Management.Automation
     /// <summary>
     /// Class to help with VT escape sequences.
     /// </summary>
-    public sealed class VTUtility
+    public static class VTUtility
     {
         private static readonly string[] BackgroundColorMap = {
             "\x1b[40m", // Black


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix: #17937

Update `PSStyle` to support mapping foreground/background `ConsoleColor` values to VT escape sequences, and mark the `VTUtility` class deprecated.

```
PS:11> [System.Management.Automation.PSStyle] | gm -Static

   TypeName: System.Management.Automation.PSStyle

Name                               MemberType Definition
----                               ---------- ----------
Equals                             Method     static bool Equals(System.Object objA, System.Object objB)
MapBackgroundColorToEscapeSequence Method     static string MapBackgroundColorToEscapeSequence(System.ConsoleColor backgroundColor)
MapColorPairToEscapeSequence       Method     static string MapColorPairToEscapeSequence(System.ConsoleColor foregroundColor, System.ConsoleColor ba…
MapForegroundColorToEscapeSequence Method     static string MapForegroundColorToEscapeSequence(System.ConsoleColor foregroundColor)
ReferenceEquals                    Method     static bool ReferenceEquals(System.Object objA, System.Object objB)
Instance                           Property   static System.Management.Automation.PSStyle Instance {get;}
```

## PR Context

Please see the detailed description in #17937 for the context.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] Public method documentation will be automatically refreshed when we do doc updates.
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
