### PR TITLE
Check to be sure we're calling powershell before encoding a scriptblock.

### DIFF
--- a/experimental-feature-linux.json
+++ b/experimental-feature-linux.json
@@ -6,4 +6,5 @@
   "PSSubsystemPluginModel",
   "PSModuleAutoLoadSkipOfflineFiles",
   "PSFeedbackProvider"
+  "PSNativeScriptBlockArgument"
 ]

--- a/experimental-feature-windows.json
+++ b/experimental-feature-windows.json
@@ -6,4 +6,5 @@
   "PSSubsystemPluginModel",
   "PSModuleAutoLoadSkipOfflineFiles",
   "PSFeedbackProvider"
+  "PSNativeScriptBlockArgument"
 ]

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -26,6 +26,7 @@ namespace System.Management.Automation
         internal const string PSCustomTableHeaderLabelDecoration = "PSCustomTableHeaderLabelDecoration";
         internal const string PSFeedbackProvider = "PSFeedbackProvider";
         internal const string PSCommandWithArgs = "PSCommandWithArgs";
+        internal const string PSNativeScriptBlockArgumentFeatureName = "PSNativeScriptBlockArgument";
 
         #endregion
 
@@ -132,6 +133,9 @@ namespace System.Management.Automation
                 new ExperimentalFeature(
                     name: PSCommandWithArgs,
                     description: "Enable `-CommandWithArgs` parameter for pwsh"),
+                new ExperimentalFeature(
+                    name: PSNativeScriptBlockArgumentFeatureName,
+                    description: "Add support of passing ScriptBlock arguments unchanged to native commands"),
             };
 
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -290,9 +290,8 @@ namespace System.Management.Automation
                             string text = arg;
 
                             // handle a scriptblock here
-                            if (ExperimentalFeature.IsEnabled(ExperimentalFeature.PSNativeScriptBlockArgumentFeatureName) && parameter.ArgumentValue is ScriptBlock)
+                            if (ExperimentalFeature.IsEnabled(ExperimentalFeature.PSNativeScriptBlockArgumentFeatureName) && parameter.ArgumentValue is ScriptBlock sb)
                             {
-                                ScriptBlock sb = (ScriptBlock)parameter.ArgumentValue;
                                 text = sb.Ast.Extent.Text;
                             }
 
@@ -429,9 +428,8 @@ namespace System.Management.Automation
 
             if (!argExpanded)
             {
-                if (ExperimentalFeature.IsEnabled(ExperimentalFeature.PSNativeScriptBlockArgumentFeatureName) && parameter.ArgumentValue is ScriptBlock)
+                if (ExperimentalFeature.IsEnabled(ExperimentalFeature.PSNativeScriptBlockArgumentFeatureName) && parameter.ArgumentValue is ScriptBlock sb)
                 {
-                    ScriptBlock sb = (ScriptBlock)parameter.ArgumentValue;
                     _arguments.Append(sb.Ast.Extent.Text);
                     AddToArgumentList(parameter, sb.Ast.Extent.Text);
                 }

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -292,6 +292,7 @@ namespace System.Management.Automation
                             // handle a scriptblock here
                             if (ExperimentalFeature.IsEnabled(ExperimentalFeature.PSNativeScriptBlockArgumentFeatureName) && parameter.ArgumentValue is ScriptBlock sb)
                             {
+                                // use the extent for the argument rather than trying to construct an argument.
                                 text = sb.Ast.Extent.Text;
                             }
 
@@ -430,6 +431,8 @@ namespace System.Management.Automation
             {
                 if (ExperimentalFeature.IsEnabled(ExperimentalFeature.PSNativeScriptBlockArgumentFeatureName) && parameter.ArgumentValue is ScriptBlock sb)
                 {
+                    // This adds the extent text as a single argument, it is not broken up.
+                    // If the scriptblock is '{ get-date }' then the resulting single argument is '{ get-date }'.
                     _arguments.Append(sb.Ast.Extent.Text);
                     AddToArgumentList(parameter, sb.Ast.Extent.Text);
                 }

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -243,7 +243,7 @@ namespace System.Management.Automation
 
         // This is the list of PowerShell names.
         // It's used by the MiniShell to determine if a command is a PowerShell.
-        private static readonly IReadOnlySet<string>s_powerShellExecutableNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        private static readonly IReadOnlySet<string> s_powerShellExecutableNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "powershell.exe",
             "pwsh",
@@ -1645,7 +1645,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Returns true if native command is powershell or pwsh and the experimental feature is enabled.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>A bool indicating whether the native application is a powershell or variant.</returns>
         private bool CheckNativeAppIsNotPowerShell()
         {
             if (!ExperimentalFeature.IsEnabled(ExperimentalFeature.PSNativeScriptBlockArgumentFeatureName))
@@ -1657,8 +1657,10 @@ namespace System.Management.Automation
             // This will still miss the case where the command is a hard-link to pwsh.
             PSObject possibleLink = new PSObject(new FileInfo(Command.CommandInfo.Source));
             string resolvedPath = Microsoft.PowerShell.Commands.InternalSymbolicLinkLinkCodeMethods.ResolvedTarget(possibleLink);
+
             // get the name of the executable without the extension, this 
             string appName = System.IO.Path.GetFileName(resolvedPath);
+
             // This can be expanded to support other native commands which can handle an encoded scriptblock argument.
             if (s_powerShellExecutableNames.Contains(appName))
             {

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -411,6 +411,19 @@ Describe "Scriptblock passed as arguments to native executables" -tag @("CI") {
             $result[2] | Should -BeExactly 'Arg 2 is <{ get-date }>'
         }
 
+        It "a script block with fewer spaces and new line will be passed as is" {
+            if ($skipTest) {
+                Set-ItResult -skipped -Because $reason
+            }
+            $result = testexe -echoargs a b { get-date
+get-location }
+            $result.Count | Should -Be 4
+            $result[0] | Should -BeExactly 'Arg 0 is <a>'
+            $result[1] | Should -BeExactly 'Arg 1 is <b>'
+            $result[2] | Should -BeExactly 'Arg 2 is <{ get-date'
+            $result[3] | Should -BeExactly 'get-location }>'
+        }
+
         It "a script block with a space and new line will be passed as is" {
             if ($skipTest) {
                 Set-ItResult -skipped -Because $reason

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -411,6 +411,19 @@ Describe "Scriptblock passed as arguments to native executables" -tag @("CI") {
             $result[2] | Should -BeExactly 'Arg 2 is <{ get-date }>'
         }
 
+        It "a script block with a space and new line will be passed as is" {
+            if ($skipTest) {
+                Set-ItResult -skipped -Because $reason
+            }
+            $result = testexe -echoargs a b { get-date
+            get-location }
+            $result.Count | Should -Be 4
+            $result[0] | Should -BeExactly 'Arg 0 is <a>'
+            $result[1] | Should -BeExactly 'Arg 1 is <b>'
+            $result[2] | Should -BeExactly 'Arg 2 is <{ get-date'
+            $result[3] | Should -BeExactly '            get-location }>'
+        }
+
         It "multiple scriptblocks will be passed as is." {
             if ($skipTest) {
                 Set-ItResult -skipped -Because $reason


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Currently, if we see something that appears to be a script block, we will base64 encode the contents of the scriptblock and then add a couple of additional parameters and then call it. However, many applications can accept parameter values that look like a scriptblock, but are not. This PR attempts to provide an improved experience where we will only base64 encode a scriptblock if we are calling powershell/pwsh.
This will alleviate the need for quoting commands like:
`msiexec /p "msipatch.msp;msipatch2.msp" /n {00000001-0002-0000-0000-624474736554} /qb`.

Arguments will be passed as follows:

```powershell
PS> testexe -echoargs a b {get-date}
Arg 0 is <a>
Arg 1 is <b>
Arg 2 is <{get-date}>
```

This is a breaking change, but any currently implemented work-arounds should not need alteration. Because we check for a specific command name, other stand-alone _native_ applications which currently handle a scriptblock arguments (and implements the other constructed parameters) will likely have generate an error. The command name lookup is flexible enough so the list can be expanded (or even made dynamic). This PR looks only for powershell/pwsh.

Another design choice was to not break up a scriptblock into multiple arguments based on whitespace. This would be fairly fragile as it would not correct to just break up on whitespace as embedded quotes, etc, would be broken as well. 

<!-- Summarize your PR between here and the checklist. -->

## PR Context

This is a fix for issue #5187

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [x] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [x] Experimental feature name(s): PSNativeScriptBlockArgument
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
