### PR TITLE
Fix web cmdlets hang after network connectivity lost

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -291,7 +291,7 @@ namespace Microsoft.PowerShell.Commands
             // If the client loses network connectivity for over 1 minute, the task returned from 
             // 'CopyToAsync()' will never complete and therefore the loop below will be infinite.
             // Short explaination:
-            // - CopyToAsync() uses ReadAsync() in cycle until ReadAsync() read 0 bytes (it is EOF).
+            // - CopyToAsync() uses ReadAsync() in loop until ReadAsync() returns 0, indicating EOF.
             // - ReadAsync() read from network Socket.
             // - If network lost connectivity over 1 min the Socket lost connect to target service
             //   but OS never close the Socket (tested on Windows).

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -293,7 +293,7 @@ namespace Microsoft.PowerShell.Commands
             // Short explaination:
             // - CopyToAsync() uses ReadAsync() in loop until ReadAsync() returns 0, indicating EOF.
             // - ReadAsync() read from network Socket.
-            // - If network lost connectivity over 1 min the Socket lost connect to target service
+            // - If losing network connectivity for over 1 minute, the Socket will lose connect to target service
             //   but OS never close the Socket (tested on Windows).
             // - Then Socket never return anything, and thus ReadAsync() will be infinitely blocked on the Socket
             //   and CopyToAsync() task will be never completed.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -318,7 +318,8 @@ namespace Microsoft.PowerShell.Commands
 
                     if (previousLength != output.Length)
                     {
-                        // Reset cancelation timer only if we get an information from network on the interation.
+                        // Reset cancelation timer while information continues to flow from network.
+                        // Cancelation timer applies only during no network connectivity.
                         previousLength = output.Length;
                         cts.CancelAfter(timeout);
                     }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -288,8 +288,8 @@ namespace Microsoft.PowerShell.Commands
                 WebCmdletStrings.WriteRequestProgressActivity,
                 WebCmdletStrings.WriteRequestProgressStatus);
 
-            // If the client lost target service on ~1 min due to a lost of network connectivity
-            // the CopyToAsync() task will be never completed and cycle below will be infinite.
+            // If the client loses network connectivity for over 1 minute, the task returned from 
+            // 'CopyToAsync()' will never complete and therefore the loop below will be infinite.
             // Short explaination:
             // - CopyToAsync() uses ReadAsync() in cycle until ReadAsync() read 0 bytes (it is EOF).
             // - ReadAsync() read from network Socket.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -295,7 +295,7 @@ namespace Microsoft.PowerShell.Commands
             // - ReadAsync() read from network Socket.
             // - If network lost connectivity over 1 min the Socket lost connect to target service
             //   but OS never close the Socket (tested on Windows).
-            // - Then Socket never return an information, ReadAsync() will be infinitely blocked on the Socket
+            // - Then Socket never return anything, and thus ReadAsync() will be infinitely blocked on the Socket
             //   and CopyToAsync() task will be never completed.
             //
             // Since cancelation token in CopyToAsync() applies to whole CopyToAsync()


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Use cancelation timer to unblock web cmdlets after lost network connectivity with target service.

Tested manually.

## PR Context

Repro steps:
1. Start download a file
```powershell
Invoke-WebRequest https://github.com/PowerShell/PowerShell/releases/download/v7.3.0-preview.7/PowerShell-7.3.0-preview.7-win-x64.zip -OutFile C:\temp\PowerShell-7.3.0-preview.7-win-x64.zip -TimeoutSec 5
```
2. Turn off Wi-Fi Internet connection (or unplug cable from Internet router)
3. Wait ~1min (the cmdlet is not terminated after 5 sec)
4. Restore network connectivity
5. The cmdlet hangs infinitely (Ctrl-C works!)

It is not big issue for interactive session since user can press Ctrl-C but for script scenario this can block the script infinitely and it is already critical issue.

The root of this problem is that although HttpClient generates a special stream for getting Content, it does not extend Timeout to it. So we have to use a workaround.

With the fix the command from example above will be terminated after 5 sec beginning with network connectivity lost and write "Invoke-WebRequest: The operation was canceled." error to inform users that result file is corrupted.

![image](https://user-images.githubusercontent.com/22290914/187915491-67ec5c6f-8f49-40fb-89f8-b7ec3c67b221.png)

![image](https://user-images.githubusercontent.com/22290914/187915691-3e7779b1-96b5-4789-a768-b02670ca339d.png)

Notice, this doesn't change behavior if user press Ctrl-C - no error is written although I would expect it to write, but that's another issue.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
