### PR TITLE
Improve pseudo binding for dynamic parameters

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
@@ -1211,9 +1211,6 @@ namespace System.Management.Automation.Language
             bool implementsDynamicParameters = commandProcessor != null &&
                                                commandProcessor.CommandInfo.ImplementsDynamicParameters;
 
-            var argumentsToGetDynamicParameters = implementsDynamicParameters
-                                                      ? new List<object>(_commandElements.Count)
-                                                      : null;
             if (commandProcessor != null || scriptProcessor != null)
             {
                 // Pre-processing the arguments -- command arguments
@@ -1222,7 +1219,30 @@ namespace System.Management.Automation.Language
                     var parameter = _commandElements[commandIndex] as CommandParameterAst;
                     if (parameter != null)
                     {
-                        argumentsToGetDynamicParameters?.Add(parameter.Extent.Text);
+                        if (implementsDynamicParameters)
+                        {
+                            CommandParameterInternal paramToAdd;
+                            if (parameter.Argument is null)
+                            {
+                                paramToAdd = CommandParameterInternal.CreateParameter(parameter.ParameterName, parameter.Extent.Text);
+                            }
+                            else
+                            {
+                                object value;
+                                if (!SafeExprEvaluator.TrySafeEval(parameter.Argument, context, out value))
+                                {
+                                    value = parameter.Argument.Extent.Text;
+                                }
+                                paramToAdd = CommandParameterInternal.CreateParameterWithArgument(
+                                    parameterAst: null,
+                                    parameterName: parameter.ParameterName,
+                                    parameterText: parameter.Extent.Text,
+                                    argumentAst: null,
+                                    value: value,
+                                    spaceAfterParameter:false);
+                            }
+                            commandProcessor.AddParameter(paramToAdd);
+                        }
 
                         AstPair parameterArg = parameter.Argument != null
                             ? new AstPair(parameter)
@@ -1248,7 +1268,10 @@ namespace System.Management.Automation.Language
                         }
                         else if (_commandElements[commandIndex] is ExpressionAst expression)
                         {
-                            valueToAdd = expression.Extent.Text;
+                            if (!SafeExprEvaluator.TrySafeEval(expression, context, out valueToAdd))
+                            {
+                                valueToAdd = expression.Extent.Text;
+                            }
                             expressionToAdd = expression;
                         }
                         else
@@ -1256,7 +1279,11 @@ namespace System.Management.Automation.Language
                             continue;
                         }
 
-                        argumentsToGetDynamicParameters?.Add(valueToAdd);
+                        if (implementsDynamicParameters)
+                        {
+                            commandProcessor.AddParameter(CommandParameterInternal.CreateArgument(valueToAdd));
+                        }
+
                         _arguments.Add(new AstPair(null, expressionToAdd));
                     }
                 }
@@ -1267,7 +1294,6 @@ namespace System.Management.Automation.Language
                 _function = false;
                 if (implementsDynamicParameters)
                 {
-                    ParameterBinderController.AddArgumentsToCommandProcessor(commandProcessor, argumentsToGetDynamicParameters.ToArray());
                     bool retryWithNoArgs = false, alreadyRetried = false;
 
                     do

--- a/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
@@ -1240,7 +1240,7 @@ namespace System.Management.Automation.Language
                                     parameterText: parameter.Extent.Text,
                                     argumentAst: null,
                                     value: value,
-                                    spaceAfterParameter:false);
+                                    spaceAfterParameter: false);
                             }
 
                             commandProcessor.AddParameter(paramToAdd);

--- a/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
@@ -1233,6 +1233,7 @@ namespace System.Management.Automation.Language
                                 {
                                     value = parameter.Argument.Extent.Text;
                                 }
+
                                 paramToAdd = CommandParameterInternal.CreateParameterWithArgument(
                                     parameterAst: null,
                                     parameterName: parameter.ParameterName,
@@ -1241,6 +1242,7 @@ namespace System.Management.Automation.Language
                                     value: value,
                                     spaceAfterParameter:false);
                             }
+
                             commandProcessor.AddParameter(paramToAdd);
                         }
 
@@ -1272,6 +1274,7 @@ namespace System.Management.Automation.Language
                             {
                                 valueToAdd = expression.Extent.Text;
                             }
+
                             expressionToAdd = expression;
                         }
                         else

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -597,6 +597,11 @@ ConstructorTestClass(int i, bool b)
         $res.CompletionMatches[0].CompletionText | Should -BeExactly '-Directory'
     }
 
+    it 'Should complete dynamic parameters while providing values to non-string parameters' {
+        $res = TabExpansion2 -inputScript 'Get-Content -Path $HOME -Verbose:$false -'
+        $res.CompletionMatches.CompletionText | Should -Contain '-Raw'
+    }
+
     It 'Should enumerate types when completing member names for Select-Object' {
         $TestString = '"Hello","World" | select-object '
         $res = TabExpansion2 -inputScript $TestString


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Fixes https://github.com/PowerShell/PowerShell/issues/3984
When doing pseudo binding the parameters with the value specified inside the parameter like `-Param:Value`  and non-constant values like variables would be processed as raw text. Now it tries to safely evaluate the values and add the evaluated value to the parameters, allowing binding to work in more scenarios.

It still doesn't work with values that can't be evaluated like `Test-DynamicParameter -Param2 (Get-Credential) -<Tab>`. One could argue that would be by design since the dynamic parameter doesn't have a value but IMO it's still not an ideal user experience.
<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
